### PR TITLE
fix(infocards): styling and a11y fix for infocards

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - main
-  
+
 # List of jobs
 jobs:
   chromatic:
@@ -39,7 +39,7 @@ jobs:
               - 'packages/components/tailwind.config.js'
 
       - name: Set environment variable to run Chromatic build
-        if: ${{ github.event_name == 'push' && steps.filter.outputs.components == 'true' }}
+        if: ${{ steps.filter.outputs.components == 'true' }}
         run: echo "ISOMER_RUN_CHROMATIC_BUILD=true" >> $GITHUB_ENV
 
       # This extra step is not in the original chromatic workflow.

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -26,7 +26,8 @@ Default.args = {
   variant: "top",
   cards: [
     {
-      title: "Testing for a card with a long line length that spans across two lines or more",
+      title:
+        "Testing for a card with a long line length that spans across two lines or more",
       description:
         "Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile.",
       imageUrl: "https://placehold.co/200x300",
@@ -37,7 +38,7 @@ Default.args = {
     {
       title: "Card with short title",
       description:
-      "In the labyrinthine expanse of Zandoria, an enigmatic government wields authority through a web of intricate bureaucracy and omnipresent surveillance, shaping the lives of its denizens with meticulous precision and unyielding control.",
+        "In the labyrinthine expanse of Zandoria, an enigmatic government wields authority through a web of intricate bureaucracy and omnipresent surveillance, shaping the lives of its denizens with meticulous precision and unyielding control.",
       imageUrl: "https://placehold.co/200x300",
       imageAlt: "alt text",
       buttonLabel: "Explore with us",
@@ -46,7 +47,7 @@ Default.args = {
     {
       title: "Committee of Supply (COS) 2024",
       description:
-      "In the kingdom of Veridonia, the government operates as a benevolent monarchy, guided by ancient traditions and the wisdom of its sovereign. Its policies prioritize the welfare of its subjects, fostering prosperity and unity throughout the realm.",
+        "In the kingdom of Veridonia, the government operates as a benevolent monarchy, guided by ancient traditions and the wisdom of its sovereign. Its policies prioritize the welfare of its subjects, fostering prosperity and unity throughout the realm.",
       imageUrl: "https://placehold.co/200x300",
       imageAlt: "alt text",
       buttonLabel: "Explore with us",

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
   variant: "top",
   cards: [
     {
-      title: "A yummy, tipsy evening at Duxton",
+      title: "Testing for a card with a long line length that spans across two lines or more",
       description:
         "Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile.",
       imageUrl: "https://placehold.co/200x300",
@@ -35,16 +35,18 @@ Default.args = {
       url: "https://www.google.com",
     },
     {
-      title: "A yummy, tipsy evening at Duxton",
+      title: "Card with short title",
       description:
-        "Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile. Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile. Explore Duxton with us and leave with a full belly, tipsy mind, and a happy smile.",
+      "In the labyrinthine expanse of Zandoria, an enigmatic government wields authority through a web of intricate bureaucracy and omnipresent surveillance, shaping the lives of its denizens with meticulous precision and unyielding control.",
       imageUrl: "https://placehold.co/200x300",
       imageAlt: "alt text",
       buttonLabel: "Explore with us",
       url: "/",
     },
     {
-      title: "A yummy, tipsy evening at Duxton",
+      title: "Committee of Supply (COS) 2024",
+      description:
+      "In the kingdom of Veridonia, the government operates as a benevolent monarchy, guided by ancient traditions and the wisdom of its sovereign. Its policies prioritize the welfare of its subjects, fostering prosperity and unity throughout the realm.",
       imageUrl: "https://placehold.co/200x300",
       imageAlt: "alt text",
       buttonLabel: "Explore with us",

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -12,10 +12,12 @@ const TitleSection = ({
   className?: string
 }) => {
   return (
-    <div className={`flex max-w-3xl flex-col gap-8 self-start ${className}`}>
+    <div
+      className={`flex max-w-3xl flex-col gap-8 self-start pb-8 sm:pb-12 ${className}`}
+    >
       <h3 className="text-heading-03 text-content-strong">{title}</h3>
       {subtitle && (
-        <p className="text-sm text-content sm:text-lg">{subtitle}</p>
+        <p className="text-content text-sm sm:text-lg">{subtitle}</p>
       )}
     </div>
   )
@@ -26,7 +28,7 @@ const InfoCards = ({ cards, title, subtitle, variant }: InfoCardsProps) => {
     <section>
       {variant === "side" ? (
         <div
-          className={`${ComponentContent} mx-auto flex flex-col items-center gap-12 py-12 lg:flex-row lg:py-24`}
+          className={`${ComponentContent} mx-auto flex flex-col items-center py-12 lg:flex-row lg:py-24`}
         >
           <TitleSection
             title={title}
@@ -64,11 +66,11 @@ const InfoCards = ({ cards, title, subtitle, variant }: InfoCardsProps) => {
         </div>
       ) : (
         <div
-          className={`${ComponentContent} mx-auto flex flex-col items-center gap-12 py-12 lg:py-24`}
+          className={`${ComponentContent} mx-auto flex flex-col items-center py-12 lg:py-24`}
         >
           <TitleSection title={title} subtitle={subtitle} />
           <div
-            className={`grid grid-cols-1 gap-8 sm:max-lg:hidden lg:grid-cols-3`}
+            className={`grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3`}
           >
             {cards.map((card) => (
               <Card
@@ -79,19 +81,6 @@ const InfoCards = ({ cards, title, subtitle, variant }: InfoCardsProps) => {
                 imageAlt={card.imageAlt}
                 buttonLabel={card.buttonLabel}
                 variant="vertical"
-              ></Card>
-            ))}
-          </div>
-          <div className={`hidden grid-cols-1 gap-8 sm:max-lg:grid`}>
-            {cards.map((card) => (
-              <Card
-                title={card.title}
-                url={card.url}
-                imageUrl={card.imageUrl}
-                description={card.description}
-                imageAlt={card.imageAlt}
-                buttonLabel={card.buttonLabel}
-                variant="horizontal"
               ></Card>
             ))}
           </div>

--- a/packages/components/src/templates/next/components/internal/Card.tsx
+++ b/packages/components/src/templates/next/components/internal/Card.tsx
@@ -31,11 +31,13 @@ const TextComponent = ({
   text,
   buttonLabel,
   className,
+  url,
 }: {
   text: SingleCardProps["description"]
   title: SingleCardProps["title"]
   buttonLabel: SingleCardProps["buttonLabel"]
   className?: string
+  url: string
 }) => {
   return (
     <div
@@ -43,19 +45,30 @@ const TextComponent = ({
     >
       <div className="flex flex-col gap-3">
         {title && (
-          <h4 className="text-heading-04 text-content-strong">{title}</h4>
+          <h4 className="text-heading-04 text-content-strong line-clamp-2">
+            {title}
+          </h4>
         )}
         {text && (
-          <p className="grow text-left text-base text-content sm:text-lg">
+          <p className="text-content line-clamp-4 grow text-left text-base sm:text-lg">
             {text}
           </p>
         )}
       </div>
       {buttonLabel && (
-        <div className="flex items-center gap-1">
-          <p className="text-button-link-01 text-interaction-link">
+        <div className={`flex items-center gap-1`}>
+          <a
+            href={url}
+            target={url.startsWith("http") ? "_blank" : undefined}
+            rel={
+              url.startsWith("http")
+                ? "noopener noreferrer nofollow"
+                : undefined
+            }
+            className="text-interaction-link text-button-link-01 after:absolute after:inset-0"
+          >
             {buttonLabel}
-          </p>
+          </a>
           <BiRightArrowAlt className="h-auto w-6 flex-shrink-0" />
         </div>
       )}
@@ -74,13 +87,10 @@ const Card = ({
   variant,
 }: CardProps) => {
   return (
-    <a
-      className={`flex ${
+    <div
+      className={`relative flex ${
         variant === "horizontal" ? "flex-row" : "flex-col"
-      }  gap-1 border border-divider-medium ${className}`}
-      href={url}
-      target={url.startsWith("http") ? "_blank" : undefined}
-      rel={url.startsWith("http") ? "noopener noreferrer nofollow" : undefined}
+      }  border-divider-medium gap-1 rounded-md border hover:opacity-90 ${className}`}
     >
       {variant === "horizontal" ? (
         <>
@@ -94,6 +104,7 @@ const Card = ({
             title={title}
             buttonLabel={buttonLabel}
             className="h-full w-1/2"
+            url={url}
           />
         </>
       ) : (
@@ -103,10 +114,15 @@ const Card = ({
             alt={imageAlt || title}
             className="h-52"
           />
-          <TextComponent text={text} title={title} buttonLabel={buttonLabel} />
+          <TextComponent
+            text={text}
+            title={title}
+            buttonLabel={buttonLabel}
+            url={url}
+          />
         </>
       )}
-    </a>
+    </div>
   )
 }
 

--- a/packages/components/src/templates/next/components/internal/Card.tsx
+++ b/packages/components/src/templates/next/components/internal/Card.tsx
@@ -41,7 +41,7 @@ const TextComponent = ({
 }) => {
   return (
     <div
-      className={`flex flex-grow flex-col justify-between gap-6 px-5 py-6 sm:p-7 ${className}`}
+      className={`flex flex-grow flex-col justify-between gap-6 px-5 py-6 sm:p-5 ${className}`}
     >
       <div className="flex flex-col gap-3">
         {title && (

--- a/packages/components/src/templates/next/components/internal/Card.tsx
+++ b/packages/components/src/templates/next/components/internal/Card.tsx
@@ -50,7 +50,7 @@ const TextComponent = ({
           </h4>
         )}
         {text && (
-          <p className="text-content line-clamp-4 grow text-left text-base sm:text-lg">
+          <p className="text-content line-clamp-4 grow text-left	text-base sm:text-lg">
             {text}
           </p>
         )}
@@ -65,7 +65,7 @@ const TextComponent = ({
                 ? "noopener noreferrer nofollow"
                 : undefined
             }
-            className="text-interaction-link text-button-link-01 after:absolute after:inset-0"
+            className="text-button-link-01 text-interaction-link after:absolute after:inset-0"
           >
             {buttonLabel}
           </a>
@@ -90,7 +90,7 @@ const Card = ({
     <div
       className={`relative flex ${
         variant === "horizontal" ? "flex-row" : "flex-col"
-      }  border-divider-medium gap-1 rounded-md border hover:opacity-90 ${className}`}
+      } border-divider-medium gap-1 rounded-md border hover:opacity-80 ${className}`}
     >
       {variant === "horizontal" ? (
         <>


### PR DESCRIPTION
## Problem

Styling fixes and one a11y fix for infocards

## Solution

1. Removed gap-12, changed to pb-12 (pb-8 for <sm) below title area instead (gap-12 was causing an extra left padding when there is no title)
2. Removed horizontal card variant from the Default info cards layout. Instead, at md-lg range, cards collapse to a 2-col layout. This is after trying out designs at different viewports; turns out vertical variant still fits.
3. Added border-radius of 6px
5. Hover state opacity 80% 
6. <a> is inside the card content instead of the whole card. Whole card is still clickable (ref: [Cards](https://inclusive-components.design/cards/))
7. Fixed image height to h-52
8. Scaled down padding in the text section
9. Added line-clamp for title and paragraph.

## Before & After Screenshots

**BEFORE**:

<img width="1175" alt="image" src="https://github.com/isomerpages/isomer-components/assets/139780851/0e0ec225-aa1e-495e-9a09-ea5572173f59">

<img width="832" alt="image" src="https://github.com/isomerpages/isomer-components/assets/139780851/8364b318-6432-496d-8bba-059964cc26f7">

**AFTER**:

at w=800px, cards collapse to 2 columns
<img width="819" alt="image" src="https://github.com/isomerpages/isomer-components/assets/139780851/eed737df-910e-4fe0-b038-318d3428de08">

when body text is too long:
<img width="415" alt="image" src="https://github.com/isomerpages/isomer-components/assets/139780851/6ad4a10c-884a-47d6-af95-b43d33fe1661">
