### PR TITLE
fix(infocols): design fixes, more icon support

### DIFF
--- a/packages/components/src/common/icons.ts
+++ b/packages/components/src/common/icons.ts
@@ -1,23 +1,21 @@
 import { IconType } from "react-icons"
-import { BiRightArrowAlt } from "react-icons/bi"
-import { LiaChartBar } from "react-icons/lia"
 import {
-  HiOutlineDocumentReport,
-  HiOutlinePresentationChartLine,
-  HiOutlineUsers,
-  HiOutlineOfficeBuilding,
-  HiOutlineSparkles,
-  HiOutlineGlobeAlt,
-} from "react-icons/hi"
+  BiRightArrowAlt,
+  BiBuildings,
+  BiChart,
+  BiGlobe,
+  BiGroup,
+  BiStar,
+  BiBarChartAlt2,
+} from "react-icons/bi"
 
 export const SUPPORTED_ICON_NAMES = [
   "right-arrow",
   "bar-chart",
-  "doc-report",
   "line-chart",
   "users",
   "office-building",
-  "sparkles",
+  "stars",
   "globe",
 ] as const
 
@@ -27,11 +25,10 @@ export type SupportedIconType = IconType
 export const SUPPORTED_ICONS_MAP: Record<SupportedIconName, SupportedIconType> =
   {
     "right-arrow": BiRightArrowAlt,
-    "bar-chart": LiaChartBar,
-    "doc-report": HiOutlineDocumentReport,
-    "line-chart": HiOutlinePresentationChartLine,
-    users: HiOutlineUsers,
-    "office-building": HiOutlineOfficeBuilding,
-    sparkles: HiOutlineSparkles,
-    globe: HiOutlineGlobeAlt,
+    "bar-chart": BiBarChartAlt2,
+    "line-chart": BiChart,
+    users: BiGroup,
+    "office-building": BiBuildings,
+    stars: BiStar,
+    globe: BiGlobe,
   }

--- a/packages/components/src/common/icons.ts
+++ b/packages/components/src/common/icons.ts
@@ -1,8 +1,25 @@
 import { IconType } from "react-icons"
 import { BiRightArrowAlt } from "react-icons/bi"
 import { LiaChartBar } from "react-icons/lia"
+import {
+  HiOutlineDocumentReport,
+  HiOutlinePresentationChartLine,
+  HiOutlineUsers,
+  HiOutlineOfficeBuilding,
+  HiOutlineSparkles,
+  HiOutlineGlobeAlt,
+} from "react-icons/hi"
 
-export const SUPPORTED_ICON_NAMES = ["right-arrow", "bar-chart"] as const
+export const SUPPORTED_ICON_NAMES = [
+  "right-arrow",
+  "bar-chart",
+  "doc-report",
+  "line-chart",
+  "users",
+  "office-building",
+  "sparkles",
+  "globe",
+] as const
 
 export type SupportedIconName = (typeof SUPPORTED_ICON_NAMES)[number]
 // TODO: use union types to support more icon libraries apart from react-icons
@@ -11,4 +28,10 @@ export const SUPPORTED_ICONS_MAP: Record<SupportedIconName, SupportedIconType> =
   {
     "right-arrow": BiRightArrowAlt,
     "bar-chart": LiaChartBar,
+    "doc-report": HiOutlineDocumentReport,
+    "line-chart": HiOutlinePresentationChartLine,
+    users: HiOutlineUsers,
+    "office-building": HiOutlineOfficeBuilding,
+    sparkles: HiOutlineSparkles,
+    globe: HiOutlineGlobeAlt,
   }

--- a/packages/components/src/interfaces/complex/Button.ts
+++ b/packages/components/src/interfaces/complex/Button.ts
@@ -7,12 +7,16 @@ export type ButtonColorScheme = (typeof BUTTON_COLOR_SCHEMES)[number]
 export const BUTTON_VARIANTS = ["solid", "outline", "ghost", "link"] as const
 export type ButtonVariant = (typeof BUTTON_VARIANTS)[number]
 
+export const BUTTON_SIZES = ["base", "sm"] as const
+export type ButtonSize = (typeof BUTTON_SIZES)[number]
+
 export interface ButtonProps {
   type: "button"
   label: string
   href: string
   colorScheme?: ButtonColorScheme
   variant?: ButtonVariant
+  size?: ButtonSize
   rounded?: boolean
   leftIcon?: SupportedIconName
   rightIcon?: SupportedIconName

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
@@ -21,7 +21,8 @@ export const Default = Template.bind({})
 Default.args = {
   sectionIdx: 0,
   title: "MTI Highlights",
-  subtitle: "Key initiatives from the Ministry of Trade and Industry",
+  subtitle:
+    "These are some of the things we are working on. As a ministry, we focus on delivering value to the members of public.",
   infoBoxes: [
     {
       title: "Committee of Supply (COS) 2023",

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
@@ -28,7 +28,7 @@ Default.args = {
       description: "Building a Vibrant Economy, Nurturing Enterprises",
       buttonLabel: "Our plan",
       buttonUrl: "/faq",
-      icon: "doc-report",
+      icon: "bar-chart",
     },
     {
       title:
@@ -60,7 +60,7 @@ Default.args = {
       description: "23 roadmaps to drive industry transformation",
       buttonLabel: "See how we can help",
       buttonUrl: "/faq",
-      icon: "sparkles",
+      icon: "stars",
     },
     {
       title: "Pro-Enterprise Panel (PEP)",

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
@@ -20,50 +20,55 @@ const Template: StoryFn<InfoColsProps> = (args) => <InfoCols {...args} />
 export const Default = Template.bind({})
 Default.args = {
   sectionIdx: 0,
-  title: "Highlights",
-  subtitle: "Some of the things that we are working on",
+  title: "MTI Highlights",
+  subtitle: "Key initiatives from the Ministry of Trade and Industry",
   infoBoxes: [
     {
       title: "Committee of Supply (COS) 2023",
       description: "Building a Vibrant Economy, Nurturing Enterprises",
+      buttonLabel: "Our plan",
+      buttonUrl: "/faq",
+      icon: "doc-report",
+    },
+    {
+      title:
+        "Launch of the Manpower for Strategic Economic Priorities (M-SEP) scheme to support firms’ expansion plans",
+      description:
+        "Supporting businesses that contribute to Singapore's strategic economic priorities.",
+      buttonLabel: "Learn about scheme",
+      buttonUrl: "https://google.com",
+      icon: "line-chart",
+    },
+    {
+      title: "Partnerships",
+      description:
+        "Multilateral collaborations to strengthen regional cooperation and build capabilities.",
       buttonLabel: "Read article",
       buttonUrl: "/faq",
-      icon: "bar-chart",
+      icon: "users",
     },
     {
-      title: "Committee of Supply (COS) 2023",
-      description: "Building a Vibrant Economy, Nurturing Enterprises",
-      buttonLabel: "Read article",
+      title: "Digital Economy Agreements",
+      description:
+        "Digital trade rules and digital economy collaborations between two or more economies.",
+      buttonLabel: "About the agreement",
       buttonUrl: "https://google.com",
-      icon: "bar-chart",
+      icon: "globe",
     },
     {
-      title: "Committee of Supply (COS) 2023",
-      description: "Building a Vibrant Economy, Nurturing Enterprises",
-      buttonLabel: "Read article",
+      title: "Industry Transformation Maps",
+      description: "23 roadmaps to drive industry transformation",
+      buttonLabel: "See how we can help",
       buttonUrl: "/faq",
-      icon: "bar-chart",
+      icon: "sparkles",
     },
     {
-      title: "Committee of Supply (COS) 2023",
-      description: "Building a Vibrant Economy, Nurturing Enterprises",
-      buttonLabel: "Read article",
+      title: "Pro-Enterprise Panel (PEP)",
+      description:
+        "A pro-enterprise environment that facilitates the growth of businesses",
+      buttonLabel: "Get support",
       buttonUrl: "https://google.com",
-      icon: "bar-chart",
-    },
-    {
-      title: "Committee of Supply (COS) 2023",
-      description: "Building a Vibrant Economy, Nurturing Enterprises",
-      buttonLabel: "Read article",
-      buttonUrl: "/faq",
-      icon: "bar-chart",
-    },
-    {
-      title: "Committee of Supply (COS) 2023",
-      description: "Building a Vibrant Economy, Nurturing Enterprises",
-      buttonLabel: "Read article",
-      buttonUrl: "https://google.com",
-      icon: "bar-chart",
+      icon: "office-building",
     },
   ],
 }

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -17,8 +17,8 @@ const InfoBoxIcon = ({ icon }: { icon?: SupportedIconName }) => {
   if (!icon) return null
   const Icon = SUPPORTED_ICONS_MAP[icon]
   return (
-    <div>
-      <Icon className="h-auto w-10 text-site-primary" />
+    <div className="rounded-lg bg-site-primary-100 p-2">
+      <Icon className="h-auto w-6 text-site-primary" />
     </div>
   )
 }
@@ -28,7 +28,7 @@ const InfoBoxes = ({
   LinkComponent,
 }: Pick<InfoColsProps, "infoBoxes" | "LinkComponent">) => {
   return (
-    <div className="grid grid-cols-1 gap-x-8 gap-y-12 md:grid-cols-2 xl:grid-cols-3">
+    <div className="grid grid-cols-1 gap-x-28 gap-y-20 md:grid-cols-2 xl:grid-cols-3">
       {infoBoxes.map((infoBox, idx) => (
         <div key={idx} className="flex flex-col items-start gap-5 text-left">
           <InfoBoxIcon icon={infoBox.icon} />
@@ -67,7 +67,7 @@ const InfoCols = ({
   return (
     <section className={bgColor}>
       <div className={`${ComponentContent} py-24`}>
-        <div className="flex flex-col gap-12">
+        <div className="flex flex-col gap-24">
           <InfoColsHeader title={title} subtitle={subtitle} />
           <InfoBoxes infoBoxes={infoBoxes} LinkComponent={LinkComponent} />
         </div>

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -7,9 +7,15 @@ const InfoColsHeader = ({
   title,
   subtitle,
 }: Pick<InfoColsProps, "title" | "subtitle">) => (
-  <div className="flex w-full flex-col items-start gap-7 text-left">
-    <h2 className="text-heading-03 text-content-strong">{title}</h2>
-    {subtitle && <p className="text-paragraph-02 text-content">{subtitle}</p>}
+  <div className="flex w-full max-w-[47.5rem] flex-col items-start gap-7 text-left">
+    <h2 className="text-2xl font-semibold text-content-strong sm:text-4xl">
+      {title}
+    </h2>
+    {subtitle && (
+      <p className="text-sm text-content text-paragraph-02 sm:text-lg">
+        {subtitle}
+      </p>
+    )}
   </div>
 )
 
@@ -34,10 +40,10 @@ const InfoBoxes = ({
           <InfoBoxIcon icon={infoBox.icon} />
           <div className="flex flex-col items-start gap-4 text-left">
             <div className="flex flex-col items-start gap-4 text-content-strong">
-              <h3 className="text-heading-04 text-content-strong">
+              <h3 className="line-clamp-2 text-lg font-semibold text-content-strong sm:text-2xl">
                 {infoBox.title}
               </h3>
-              <p className="text-paragraph-02 text-content">
+              <p className="line-clamp-4 text-sm text-content sm:text-lg">
                 {infoBox.description}
               </p>
             </div>


### PR DESCRIPTION
## Problem

Design changes to infocols
- Row-gap 5rem
- Col-gap 7rem
- Add background behind icon
- Gap below block title 6rem

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ x] No - this PR is backwards compatible

## Before & After Screenshots

**BEFORE**:

<img width="1245" alt="image" src="https://github.com/isomerpages/isomer-components/assets/139780851/f8d923ec-9456-445d-8c47-c516f3c2df8e">

**AFTER**:

<img width="1448" alt="image" src="https://github.com/isomerpages/isomer-components/assets/139780851/5bfbb9c1-74bb-42bd-bc7d-ae72fb81fd22">