### PR TITLE
fix(infopic): style fixes for infopic variants

### DIFF
--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
@@ -20,27 +20,28 @@ const Template: StoryFn<InfopicProps> = (args) => <InfoPic {...args} />
 export const SideBySide = Template.bind({})
 SideBySide.args = {
   sectionIndex: 0,
-  title:
-    "Explore your great neighbourhood with us can’t stretch all the way so this needs a max width",
+  variant: "side-by-side",
+  title: "Lemon. Think small.",
   description:
-    "They will try to close the door on you, just open it. Lion! The other day the grass was brown, now it’s green because I ain’t give up. Never surrender.",
+    "Our little car isn't so much of a novelty anymore. An ode to Ogilvy.",
   imageAlt: "alt",
-  imageSrc: "https://placehold.co/200x200",
-  buttonLabel: "Primary CTA",
+  imageSrc:
+    "https://images.unsplash.com/photo-1581235720704-06d3acfcb36f?q=80&w=3795&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  buttonLabel: "Buy one",
   buttonUrl: "https://www.google.com",
 }
 
 export const SideBySideRightVariant = Template.bind({})
 SideBySideRightVariant.args = {
   sectionIndex: 0,
+  variant: "side-by-side",
   isTextOnRight: true,
-  title:
-    "Explore your great neighbourhood with us can’t stretch all the way so this needs a max width",
+  title: "Meet Simone Yi Ting Tan",
   description:
-    "They will try to close the door on you, just open it. Lion! The other day the grass was brown, now it’s green because I ain’t give up. Never surrender.",
+    "Simone is our Management Associate from batch 2024. Simone is currently on her third rotation in the Energy Trading department.",
   imageAlt: "alt",
-  imageSrc: "https://placehold.co/200x200",
-  buttonLabel: "Primary CTA",
+  imageSrc: "https://placehold.co/400x300",
+  buttonLabel: "Simone's Journey",
   buttonUrl: "https://www.google.com",
 }
 
@@ -53,7 +54,7 @@ SidePart.args = {
   description:
     "They will try to close the door on you, just open it. Lion! The other day the grass was brown, now it’s green because I ain’t give up. Never surrender.",
   imageAlt: "alt",
-  imageSrc: "https://placehold.co/200x200",
+  imageSrc: "https://placehold.co/1000x200",
   buttonLabel: "Primary CTA",
   buttonUrl: "https://www.google.com",
 }

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -12,11 +12,9 @@ const TextComponent = ({
   className?: string
 }) => {
   return (
-    <div className={`flex flex-col gap-10 ${className ?? ""}`}>
+    <div className={`flex flex-col gap-6 ${className ?? ""}`}>
       <div className="flex flex-col gap-4 sm:gap-6">
-        <h1 className="text-2xl font-semibold text-content sm:text-4xl">
-          {title}
-        </h1>
+        <h1 className="text-2xl font-bold text-content sm:text-4xl">{title}</h1>
         {description && (
           <p className="text-sm text-content sm:text-lg">{description}</p>
         )}
@@ -38,11 +36,13 @@ const ImageComponent = ({
   className?: string
 }) => {
   return (
-    <div className={`aspect-h-1 aspect-w-1 overflow-hidden ${className ?? ""}`}>
+    <div
+      className={`aspect-h-1 aspect-w-1 my-auto overflow-hidden ${className ?? ""}`}
+    >
       <img
         src={src}
         alt={alt}
-        className="h-full max-h-[22.5rem] w-full object-cover object-center object-center lg:max-h-[38.75rem]"
+        className="max-h-[22.5rem] w-full object-cover object-center lg:max-h-[38.75rem]"
       />
     </div>
   )
@@ -60,33 +60,33 @@ const SideBySideInfoPic = ({
   return (
     <>
       {/* Mobile-Tablet */}
-      <div className="lg:hidden">
+      <div className="md:hidden">
         <div
-          className={`${ComponentContent} flex flex-col gap-14 py-16 sm:px-14 sm:py-24`}
+          className={`${ComponentContent} flex flex-col gap-10 py-16 sm:px-14 sm:py-12`}
         >
+          <ImageComponent src={src} alt={alt} className="rounded-xl" />
           <TextComponent
             title={title}
             description={description}
             buttonLabel={button}
             buttonUrl={url}
           />
-          <ImageComponent src={src} alt={alt} />
         </div>
       </div>
       {/* Desktop */}
-      <div className="hidden lg:block">
+      <div className="hidden md:block">
         <div
           className={`${ComponentContent} flex ${
             isTextOnRight ? "flex-row" : "flex-row-reverse"
-          } gap-14 py-24`}
+          } gap-16 py-24`}
         >
-          <ImageComponent src={src} alt={alt} className="w-1/3" />
+          <ImageComponent src={src} alt={alt} className="w-1/2 rounded-xl" />
           <TextComponent
             title={title}
             description={description}
             buttonLabel={button}
             buttonUrl={url}
-            className="w-2/3"
+            className="w-1/2 justify-center"
           />
         </div>
       </div>
@@ -125,13 +125,15 @@ const SidePartInfoPic = ({
           className={`flex ${isTextOnRight ? "flex-row" : "flex-row-reverse"}`}
         >
           <ImageComponent src={src} alt={alt} className="w-1/2" />
-          <div className="my-auto w-1/2 py-24 pl-10">
+          <div
+            className={`my-auto flex w-1/2 py-24 ${isTextOnRight ? "justify-start pl-24" : "justify-end pr-24"} `}
+          >
             <TextComponent
               title={title}
               description={description}
               buttonLabel={button}
               buttonUrl={url}
-              className="max-w-screen-sm"
+              className="max-w-[33.75rem]"
             />
           </div>
         </div>

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -133,7 +133,7 @@ const SidePartInfoPic = ({
               description={description}
               buttonLabel={button}
               buttonUrl={url}
-              className="max-w-[33.75rem]"
+              className="max-w-[30.25rem]"
             />
           </div>
         </div>


### PR DESCRIPTION
## Problem

- Previously, the two infopic variants were the same. Updated the 2nd infopic variant to use within content pages and added some styling changes to match [designs here](https://www.figma.com/design/rsKQdmtyoOWawyAv1LkJJK/Isomer-Next-Component-Library?node-id=1-10)

## Before & After Screenshots

"Side by Side" variant has a border radius and is for content page usage
![image](https://github.com/opengovsg/isomer-next/assets/139780851/3fc58e11-a3e3-4736-af13-5a88db1e3b22)

"Side Part" variant is for homepage usage
![image](https://github.com/opengovsg/isomer-next/assets/139780851/0e7013af-8fab-4f23-b3e8-a193ed484fa6)