### PR TITLE
fix(style): style updates for stats block

### DIFF
--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -37,7 +37,7 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
       >
         <h2
           className={`w-full text-2xl font-medium text-content ${
-            variant === "side" ? "lg:w-1/3" : ""
+            variant === "side" ? "lg:w-1/3" : "md:max-w-[47.5rem]"
           }`}
         >
           {title}

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -31,21 +31,21 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
   return (
     <section>
       <div
-        className={`${ComponentContent} flex flex-col gap-10 py-12 xs:py-24 ${
+        className={`${ComponentContent} flex flex-col gap-16 py-12 xs:py-24 lg:gap-24 ${
           variant === "side" ? "lg:flex-row lg:gap-16" : ""
         }`}
       >
         <h2
-          className={`w-full text-2xl font-semibold text-content xs:text-4xl xs:leading-[2.75rem] ${
+          className={`w-full text-2xl font-medium text-content ${
             variant === "side" ? "lg:w-1/3" : ""
           }`}
         >
           {title}
         </h2>
-        <div className="flex flex-col flex-wrap gap-10 md:flex-row">
+        <div className="flex flex-col flex-wrap justify-center gap-8 md:flex-row">
           {statistics.slice(0, maxItems).map(({ label, value }) => (
             <div
-              className={`flex grow flex-col gap-3 ${
+              className={`flex grow flex-col gap-3 text-center ${
                 ITEM_WIDTHS[variant][Math.min(maxItems, statistics.length)]
               }`}
             >

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -42,7 +42,7 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
         >
           {title}
         </h2>
-        <div className="flex flex-col flex-wrap justify-center gap-8 md:flex-row">
+        <div className="flex flex-col flex-wrap justify-center gap-x-8 gap-y-10 md:flex-row">
           {statistics.slice(0, maxItems).map(({ label, value }) => (
             <div
               className={`flex grow flex-col gap-3 text-center ${


### PR DESCRIPTION
## Problem

- Larger gap between block title and stats
- Adjust max-width of title in large screens
- Center-align stats
- Smaller title to give more visual importance to statistics
- Add larger row gap

Adjusted to meet [style changes documented on Figma](https://www.figma.com/design/rsKQdmtyoOWawyAv1LkJJK/Isomer-Next-Component-Library?node-id=1-28)

## Before & After Screenshots

**BEFORE**:

Stats block title was visually competing with the individual stats; gap between title and stats is too narrow
![image](https://github.com/opengovsg/isomer-next/assets/139780851/16ec07cd-0aa9-4a01-bfb0-9a2057fb02a3)

**AFTER**:
![image](https://github.com/opengovsg/isomer-next/assets/139780851/df341b59-cf7f-44ca-91b2-fed8a822c7db)
