### PR TITLE
fix: update breadcrumb display

### DIFF
--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -5,23 +5,19 @@ const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
   return (
     <div className="flex flex-row flex-wrap gap-1">
       {links.map((link, index) => {
-        const isCurr = index === links.length - 1
+        const isLast = index === links.length - 1
         return (
           <div
             key={index}
-            className="flex flex-row items-center gap-1 text-content-medium"
+            className="text-content-medium flex flex-row items-center gap-1"
           >
-            {isCurr ? (
-              <p className="font-semibold text-content">{link.title}</p>
-            ) : (
-              <LinkComponent
-                href={link.url}
-                className="underline underline-offset-2 hover:text-hyperlink-hover active:text-hyperlink"
-              >
-                {link.title}
-              </LinkComponent>
-            )}
-            {!isCurr && <MdChevronRight className="h-auto min-w-6" />}
+            <LinkComponent
+              href={link.url}
+              className="hover:text-hyperlink-hover active:text-hyperlink underline underline-offset-2"
+            >
+              {link.title}
+            </LinkComponent>
+            {!isLast && <MdChevronRight className="h-auto min-w-6" />}
           </div>
         )
       })}

--- a/packages/components/src/utils/getBreadcrumbFromSiteMap.ts
+++ b/packages/components/src/utils/getBreadcrumbFromSiteMap.ts
@@ -7,14 +7,14 @@ export const getBreadcrumbFromSiteMap = (
   sitemap: IsomerSitemap,
   permalink: string[],
 ): BreadcrumbProps => {
-  const breadcrumb = []
+  const breadcrumb = [
+    {
+      title: "Home",
+      url: "/",
+    },
+  ]
   let node = sitemap
   let currentPath = ""
-
-  breadcrumb.push({
-    title: "Home",
-    url: "/",
-  })
 
   for (const pathSegment of permalink.slice(0, -1)) {
     currentPath += "/" + pathSegment

--- a/packages/components/src/utils/getBreadcrumbFromSiteMap.ts
+++ b/packages/components/src/utils/getBreadcrumbFromSiteMap.ts
@@ -11,7 +11,12 @@ export const getBreadcrumbFromSiteMap = (
   let node = sitemap
   let currentPath = ""
 
-  for (const pathSegment of permalink) {
+  breadcrumb.push({
+    title: "Home",
+    url: "/",
+  })
+
+  for (const pathSegment of permalink.slice(0, -1)) {
     currentPath += "/" + pathSegment
     const nextNode = node.children?.find(
       (node) => node.permalink === currentPath,


### PR DESCRIPTION
Update breadcrumb design for three main changes:

- "Home" should be displayed
- Better to not display current page; after doing some competitive analysis, seems like it's rare to show the current page and it serves zero user value as well, especially since we always show the page title top and center. It also messes up the Article layout a bit especially when the current page title is very long
- Last menu in crumbs should not have chevron trailing after it