### PR TITLE
fix(style): article layout design fixes

### DIFF
--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -11,34 +11,27 @@ const ArticlePageHeader = ({
   LinkComponent,
 }: ArticlePageHeaderProps) => {
   return (
-    <div className="mx-auto w-full max-w-[960px]">
-      <div className="my-8 lg:my-16">
+    <div className="mx-auto w-full">
+      <div className="my-16">
         <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
       </div>
 
-      <div className="mb-3 text-lg text-content-medium">{category}</div>
+      <div className="mb-3 text-base font-medium text-gray-600">{category}</div>
 
-      <div className="flex max-w-[660px] flex-col gap-9">
-        <h1 className="text-[2.375rem] font-semibold leading-[2.75rem] text-content-strong lg:text-5xl lg:leading-[3.625rem]">
+      <div className="flex flex-col gap-5">
+        <h1 className="text-content-strong text-3xl font-semibold tracking-tight lg:text-4xl">
           {title}
         </h1>
+        <p className="text-sm text-gray-800">{date}</p>
 
-        <p className="text-xl leading-8 text-content-strong">{date}</p>
-
-        <div className="bg-utility-neutral px-3 py-[1.125rem]">
+        <div className="text-xl tracking-tight text-gray-500 md:text-2xl">
           {summary.length === 1 ? (
-            <BaseParagraph
-              content={summary[0]}
-              className="text-paragraph-01 text-content"
-            />
+            <BaseParagraph content={summary[0]} />
           ) : (
             <ul className="list-disc ps-7">
               {summary.map((item) => (
                 <li key={Math.random()} className="pl-0.5 [&_p]:inline">
-                  <BaseParagraph
-                    content={item}
-                    className="text-paragraph-01 text-content"
-                  />
+                  <BaseParagraph content={item} />
                 </li>
               ))}
             </ul>

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -91,26 +91,31 @@ Default.args = {
   },
   page: {
     title:
-      "Man sentenced to 24 months' imprisonment for smuggling 34.7 kg of rhinoceros horns",
+      "Singapore's Spectacular Citizens' Festival: a Celebration of Unity and Diversity",
     permalink:
       "/newsroom/news/man-sentenced-to-24-months-imprisonment-for-smuggling-34-7-kg-of-rhinoceros-horns",
     lastModified: "2024-05-02T14:12:57.160Z",
-    category: "NParks Happenings",
+    category: "Citizen Engagement",
     date: "1 May 2024",
     articlePageHeader: {
       summary: [
-        "20 pieces of rhinoceros horns were found in two pieces of transit baggage bound for Laos.",
-        "The 34.7 kg seizure is the largest seizure of rhinoceros horns in Singapore to date.",
+        "Singapore is preparing to host its inaugural Citizens' Festival in Marina Boulevard.",
+        "The festival aims to unite Singaporeans of all backgrounds through cultural showcases, food markets, live music, and wellness activities.",
       ],
     },
   },
   content: [
     {
+      type: "image",
+      src: "https://images.unsplash.com/photo-1570441262582-a2d4b9a916a5?q=80&w=2948&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+      alt: "A man is serving food out of a blue food",
+    },
+    {
       type: "paragraph",
       content: [
         {
           type: "text",
-          text: "South African Gumede Sthembiso Joel, 33, was sentenced to 24 months’ imprisonment today after pleading guilty to two charges under the Endangered Species (Import and Export) Act [1] (“ESA”) for transiting in Singapore with rhinoceros horns without a valid permit. This is the heaviest sentence meted out in Singapore to date for a case involving the smuggling of wildlife parts.",
+          text: "Singapore - In a bid to foster community spirit and celebrate the rich tapestry of its diverse population, Singapore is gearing up to host its first-ever Citizens' Festival. This unprecedented event promises to be a dazzling extravaganza filled with entertainment, cultural showcases, and gastronomic delights.",
         },
       ],
     },
@@ -119,7 +124,16 @@ Default.args = {
       content: [
         {
           type: "text",
-          text: "On 4 October 2022, the National Parks Board (NParks) seized 20 pieces of rhinoceros horns that were being smuggled through Singapore Changi Airport. Airport security and NParks’ K9 Unit detected and inspected two pieces of baggage (“Boxes”) and found 34.7 kg of rhinoceros horns, which would have an estimated wholesale value of approximately S$1,200,140.79 (US$843,210) as of 4 October 2022. The accused, who was travelling from South Africa to the Lao People’s Democratic Republic through Singapore, was immediately arrested and the rhinoceros horns were seized by NParks.",
+          text: "One of the highlights of the festival is the Cultural Village, where visitors can immerse themselves in the sights, sounds, and flavors of Singapore's various ethnic communities. From traditional Malay dance performances to Chinese calligraphy demonstrations and Indian culinary workshops, attendees will have the opportunity to gain a deeper appreciation for the country's multicultural heritage.",
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "This is a Chat-GPT4 generated article for visual testing purposes.",
         },
       ],
     },

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -23,7 +23,7 @@ const ArticleLayout = ({
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >
-      <div className="mx-auto flex max-w-container flex-col gap-20 px-6 md:px-10">
+      <div className="mx-auto flex max-w-[47.8rem] flex-col gap-20 px-6 md:px-10">
         <ArticlePageHeader
           {...page.articlePageHeader}
           breadcrumb={breadcrumb}
@@ -33,9 +33,7 @@ const ArticleLayout = ({
           LinkComponent={LinkComponent}
         />
 
-        <hr className="border-divider-medium" />
-
-        <div className="mx-auto w-full max-w-[960px] gap-10 pb-16">
+        <div className="mx-auto w-full gap-10 pb-20">
           <div className="w-full overflow-x-auto lg:max-w-[660px]">
             {renderPageContent({ content, LinkComponent })}
           </div>


### PR DESCRIPTION
Article layout was looking jank

Key changes:
- Smaller title font size
- Removed box around summary
- Summary font colour is lighter
- Removed divider
- Adjusted some spacing

After images:
<img width="862" alt="image" src="https://github.com/opengovsg/isomer/assets/139780851/6b34424a-184e-4ce6-9235-14c86ed54b0c">
<img width="385" alt="image" src="https://github.com/opengovsg/isomer/assets/139780851/6f687454-ee57-46fb-95a5-3d97a639f200">
