### PR TITLE
fix(styling): spacing updates for paragraph, headings

### DIFF
--- a/packages/components/src/presets/next.ts
+++ b/packages/components/src/presets/next.ts
@@ -122,8 +122,8 @@ export default {
           fontWeight: "600",
           letterSpacing: theme("letterSpacing.tight"),
           "@media (min-width: 1024px)": {
-            fontSize: "3rem",
-            lineHeight: "3.625rem",
+            fontSize: "2.7rem",
+            lineHeight: "3.2rem",
           },
         },
 

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -10,7 +10,7 @@ export const BaseParagraph = ({
 
   return (
     <p
-      className={`[&:not(:first-child)]:mt-6 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:text-hyperlink [&_a]:underline visited:[&_a]:text-purple-600 hover:[&_a]:text-hyperlink-hover ${className}`}
+      className={`[&_a]:text-hyperlink hover:[&_a]:text-hyperlink-hover [&:not(:first-child)]:mt-6 sm:[&:not(:first-child)]:mt-7 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:underline visited:[&_a]:text-purple-600 ${className}`}
       dangerouslySetInnerHTML={{ __html: sanitizedContent }}
       id={id}
     />

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -10,7 +10,7 @@ export const BaseParagraph = ({
 
   return (
     <p
-      className={`[&_a]:text-hyperlink hover:[&_a]:text-hyperlink-hover [&:not(:first-child)]:mt-6 sm:[&:not(:first-child)]:mt-7 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:underline visited:[&_a]:text-purple-600 ${className}`}
+      className={`[&_a]:text-hyperlink hover:[&_a]:text-hyperlink-hover [&:not(:first-child)]:mt-6 sm:[&:not(:first-child)]:mt-7 [&:not(:last-child)]:mb-6 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:underline visited:[&_a]:text-purple-600 ${className}`}
       dangerouslySetInnerHTML={{ __html: sanitizedContent }}
       id={id}
     />

--- a/packages/components/src/templates/next/components/native/Heading/Heading.tsx
+++ b/packages/components/src/templates/next/components/native/Heading/Heading.tsx
@@ -6,7 +6,7 @@ const Heading = ({ id, content, level }: Omit<HeadingProps, "type">) => {
     return (
       <h2
         id={id}
-        className="text-heading-02 text-content [&:not(:first-child)]:mt-36"
+        className="text-heading-02 text-content [&:not(:first-child)]:mt-24"
       >
         {getTextAsHtml(content)}
       </h2>
@@ -16,7 +16,7 @@ const Heading = ({ id, content, level }: Omit<HeadingProps, "type">) => {
     return (
       <h3
         id={id}
-        className="text-heading-03 text-content [&:not(:first-child)]:mt-16"
+        className="text-heading-03 text-content [&:not(:first-child)]:mt-14"
       >
         {getTextAsHtml(content)}
       </h3>

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1591,6 +1591,15 @@ SmallTable.args = {
       content: [{ type: "text", text: "Checklist for sheer irrationality" }],
     },
     {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "In the realm of human cognition, irrationality often reigns supreme, defying the logic that ostensibly governs our decisions and actions.",
+        },
+      ],
+    },
+    {
       type: "heading",
       id: "section1",
       level: 3,
@@ -1794,6 +1803,26 @@ SmallTable.args = {
     {
       type: "paragraph",
       content: [{ type: "text", text: "This is yet another paragraph" }],
+    },
+    {
+      type: "heading",
+      id: "section3",
+      level: 3,
+      content: [
+        {
+          type: "text",
+          text: "Test this is a long heading that comes right before a h4",
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "What if got some small text here like the section below this is going to explain blah blah",
+        },
+      ],
     },
     {
       type: "heading",

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1835,7 +1835,16 @@ SmallTable.args = {
       content: [
         {
           type: "text",
-          text: "In the realm of human cognition, irrationality often reigns supreme, defying the logic that ostensibly governs our decisions and actions. It manifests in myriad ways, from the subtle biases that influence our perceptions to the outright contradictions that confound our rational minds. We find ourselves ensnared in cognitive dissonance, grappling with conflicting beliefs and emotions that lead us astray from the path of reason. Despite our best intentions, we succumb to the allure of irrationality, surrendering to the whims of impulse and emotion. Our choices become a tangled web of contradictions, driven by instinct rather than careful deliberation. We cling to superstitions and fallacies, seeking comfort in the irrationality that offers solace amidst life's uncertainties. It is a paradoxical dance, where the irrational often masquerades as wisdom, leading us down paths fraught with confusion and folly. Yet, in embracing our irrationality, we find a peculiar sort of freedom, liberated from the constraints of logic and reason. We navigate the world with a blend of intuition and irrationality, embracing the chaos that defines the human experience. And so, in the tapestry of existence, irrationality weaves its intricate threads, adding depth and complexity to the fabric of our lives.",
+          text: "In the realm of human cognition, irrationality often reigns supreme, defying the logic that ostensibly governs our decisions and actions. It manifests in myriad ways, from the subtle biases that influence our perceptions to the outright contradictions that confound our rational minds. We find ourselves ensnared in cognitive dissonance, grappling with conflicting beliefs and emotions that lead us astray from the path of reason.",
+        },
+      ],
+    },
+    {
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Despite our best intentions, we succumb to the allure of irrationality, surrendering to the whims of impulse and emotion. Our choices become a tangled web of contradictions, driven by instinct rather than careful deliberation. We cling to superstitions and fallacies, seeking comfort in the irrationality that offers solace amidst life's uncertainties. It is a paradoxical dance, where the irrational often masquerades as wisdom, leading us down paths fraught with confusion and folly. Yet, in embracing our irrationality, we find a peculiar sort of freedom, liberated from the constraints of logic and reason. We navigate the world with a blend of intuition and irrationality, embracing the chaos that defines the human experience. And so, in the tapestry of existence, irrationality weaves its intricate threads, adding depth and complexity to the fabric of our lives.",
         },
       ],
     },


### PR DESCRIPTION
Previously, spacing between headings / paragraphs were either too big or missing, causing janky views on content pages:

<img width="811" alt="image" src="https://github.com/opengovsg/isomer/assets/139780851/8276ca04-304f-4951-ac2c-69fc4706df58">

Also, the "h2" styles on content pages were very big.

This PR includes updates to:

- heading-02 size is smaller
- between-paragraph gap is larger for more whitespace
- some headings have a smaller margin-top
- paragraphs have a margin-bottom so that accordions / tables that follow it aren't too close.