### PR TITLE
fix(styling): stats block styling updates

### DIFF
--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -37,7 +37,7 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
       >
         <h2
           className={`w-full text-2xl font-medium text-content ${
-            variant === "side" ? "lg:w-1/3" : ""
+            variant === "side" ? "lg:w-1/3" : "md:max-w-[47.5rem]"
           }`}
         >
           {title}

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -31,21 +31,21 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
   return (
     <section>
       <div
-        className={`${ComponentContent} flex flex-col gap-10 py-12 xs:py-24 ${
+        className={`${ComponentContent} flex flex-col gap-16 py-12 xs:py-24 lg:gap-24 ${
           variant === "side" ? "lg:flex-row lg:gap-16" : ""
         }`}
       >
         <h2
-          className={`w-full text-2xl font-semibold text-content xs:text-4xl xs:leading-[2.75rem] ${
+          className={`w-full text-2xl font-medium text-content ${
             variant === "side" ? "lg:w-1/3" : ""
           }`}
         >
           {title}
         </h2>
-        <div className="flex flex-col flex-wrap gap-10 md:flex-row">
+        <div className="flex flex-col flex-wrap justify-center gap-8 md:flex-row">
           {statistics.slice(0, maxItems).map(({ label, value }) => (
             <div
-              className={`flex grow flex-col gap-3 ${
+              className={`flex grow flex-col gap-3 text-center ${
                 ITEM_WIDTHS[variant][Math.min(maxItems, statistics.length)]
               }`}
             >

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -29,35 +29,33 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
   const maxItems = variant === "side" ? 3 : 4
 
   return (
-    <section>
-      <div
-        className={`${ComponentContent} flex flex-col gap-16 py-12 xs:py-24 lg:gap-24 ${
-          variant === "side" ? "lg:flex-row lg:gap-16" : ""
+    <div
+      className={`${ComponentContent} xs:py-24 flex flex-col gap-16 py-12 lg:gap-24 ${
+        variant === "side" ? "lg:flex-row lg:gap-16" : ""
+      }`}
+    >
+      <h2
+        className={`text-content w-full text-2xl font-semibold sm:text-4xl ${
+          variant === "side" ? "lg:w-1/3" : "md:max-w-[47.5rem]"
         }`}
       >
-        <h2
-          className={`w-full text-2xl font-medium text-content ${
-            variant === "side" ? "lg:w-1/3" : "md:max-w-[47.5rem]"
-          }`}
-        >
-          {title}
-        </h2>
-        <div className="flex flex-col flex-wrap justify-center gap-x-8 gap-y-10 md:flex-row">
-          {statistics.slice(0, maxItems).map(({ label, value }) => (
-            <div
-              className={`flex grow flex-col gap-3 text-center ${
-                ITEM_WIDTHS[variant][Math.min(maxItems, statistics.length)]
-              }`}
-            >
-              <h3 className="text-pretty text-4xl font-semibold leading-[2.75rem] text-content-strong xs:text-5xl xs:leading-[3.5rem]">
-                {value.slice(0, MAX_CHAR_LIMIT)}
-              </h3>
-              <p className="text-sm text-content-medium">{label}</p>
-            </div>
-          ))}
-        </div>
+        {title}
+      </h2>
+      <div className="flex flex-col flex-wrap justify-center gap-x-8 gap-y-10 md:flex-row">
+        {statistics.slice(0, maxItems).map(({ label, value }) => (
+          <div
+            className={`flex grow flex-col gap-3 text-center ${
+              ITEM_WIDTHS[variant][Math.min(maxItems, statistics.length)]
+            }`}
+          >
+            <h3 className="text-content-strong xs:text-5xl xs:leading-[3.5rem] text-pretty text-4xl font-semibold leading-[2.75rem]">
+              {value.slice(0, MAX_CHAR_LIMIT)}
+            </h3>
+            <p className="text-sm font-medium text-neutral-500">{label}</p>
+          </div>
+        ))}
       </div>
-    </section>
+    </div>
   )
 }
 

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -42,7 +42,7 @@ const KeyStatistics = ({ variant, title, statistics }: KeyStatisticsProps) => {
         >
           {title}
         </h2>
-        <div className="flex flex-col flex-wrap justify-center gap-8 md:flex-row">
+        <div className="flex flex-col flex-wrap justify-center gap-x-8 gap-y-10 md:flex-row">
           {statistics.slice(0, maxItems).map(({ label, value }) => (
             <div
               className={`flex grow flex-col gap-3 text-center ${


### PR DESCRIPTION
Tweaks to stats block:
- row gap between title and stats
- adjust max-width
- adjust title size