### PR TITLE
fix(styling): collections layout design cleanup

### DIFF
--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -30,7 +30,7 @@ const ArticleTextComponent = ({
       <div className={`flex flex-col gap-3`}>
         <div className="flex flex-col gap-1 sm:flex-row sm:gap-2">
           <p className="text-caption-01 text-content-medium">{lastUpdated}</p>
-          <p className="text-caption-01 hidden text-content-medium sm:block">
+          <p className="text-caption-01 text-content-medium hidden sm:block">
             |
           </p>
           <p className="text-caption-01 text-content-strong">{category}</p>
@@ -38,7 +38,7 @@ const ArticleTextComponent = ({
         <h4 className="text-heading-04 line-clamp-3 sm:line-clamp-2">
           {title}
         </h4>
-        <p className="text-paragraph-02 line-clamp-3 text-content-medium sm:line-clamp-2">
+        <p className="text-paragraph-02 text-content-medium line-clamp-3 sm:line-clamp-2">
           {description}
         </p>
       </div>
@@ -61,7 +61,7 @@ const FileTextComponent = ({
       <div className={`flex flex-col gap-3`}>
         <div className="flex flex-col gap-1 sm:flex-row sm:gap-2">
           <p className="text-caption-01 text-content-medium">{lastUpdated}</p>
-          <p className="text-caption-01 hidden text-content-medium sm:block">
+          <p className="text-caption-01 text-content-medium hidden sm:block">
             |
           </p>
           <p className="text-caption-01 text-content-strong">{category}</p>
@@ -69,7 +69,7 @@ const FileTextComponent = ({
         <h4 className="text-heading-04 line-clamp-3 sm:line-clamp-2">
           {`(${fileDetails.type.toUpperCase()}) ${title}`}
         </h4>
-        <p className="text-paragraph-02 line-clamp-3 text-content-medium sm:line-clamp-2">
+        <p className="text-paragraph-02 text-content-medium line-clamp-3 sm:line-clamp-2">
           {description}
         </p>
       </div>
@@ -93,7 +93,7 @@ const ArticleCard = ({
 }: Omit<ArticleCardProps | LinkCardProps, "type">) => {
   return (
     <LinkComponent href={url}>
-      <div className="flex flex-col gap-6 border-y border-divider-medium px-3 py-6 text-content hover:text-hyperlink-hover sm:flex-row sm:px-6">
+      <div className="border-divider-medium text-content hover:text-hyperlink-hover flex flex-col gap-6 border-y py-6 sm:flex-row">
         <ArticleTextComponent
           lastUpdated={lastUpdated}
           category={category}
@@ -117,7 +117,7 @@ const FileCard = ({
 }: Omit<FileCardProps, "type">) => {
   return (
     <a href={url}>
-      <div className="flex flex-col gap-6 border-y border-divider-medium px-3 py-6 text-content hover:text-hyperlink-hover sm:flex-row sm:px-6">
+      <div className="border-divider-medium text-content hover:text-hyperlink-hover flex flex-col gap-6 border-y py-6 sm:flex-row">
         <FileTextComponent
           lastUpdated={lastUpdated}
           category={category}

--- a/packages/components/src/templates/next/components/internal/CollectionSearch/CollectionSearch.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionSearch/CollectionSearch.tsx
@@ -10,10 +10,10 @@ const CollectionSearch = ({
     <label className="relative block">
       <span className="sr-only">{placeholder}</span>
       <span className="absolute inset-y-0 left-0 flex items-center pl-4">
-        <BiSearch className="h-5 w-5 fill-interaction-support-placeholder" />
+        <BiSearch className="fill-interaction-support-placeholder h-5 w-5" />
       </span>
       <input
-        className="w-full rounded py-3 pl-[3.25rem] ring-1 ring-divider-medium placeholder:text-interaction-support-placeholder focus:ring-2 focus:ring-focus-outline active:bg-interaction-main-subtle-hover active:ring-2 active:ring-focus-outline"
+        className="ring-divider-medium placeholder:text-interaction-support-placeholder focus:ring-focus-outline active:bg-interaction-main-subtle-hover active:ring-focus-outline w-full rounded-lg py-4 pl-[3.25rem] focus:ring-2 active:ring-2"
         placeholder={placeholder}
         type="text"
         name="search"

--- a/packages/components/src/templates/next/components/internal/CollectionSort/CollectionSort.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionSort/CollectionSort.tsx
@@ -47,11 +47,10 @@ const CollectionSort = ({
   return (
     <div className="relative">
       <div className="flex flex-col gap-2">
-        <p className="text-paragraph-02 text-content-strong">Sort by</p>
         <button
           className={`flex justify-between gap-6 rounded-[4px] border px-4 py-2.5 ${
             showSortOptions
-              ? "border-focus-outline outline outline-1 outline-focus-outline"
+              ? "border-focus-outline outline-focus-outline outline outline-1"
               : "border-divider-medium"
           }`}
           aria-label={
@@ -73,8 +72,8 @@ const CollectionSort = ({
           {SortOptions.map((option) => (
             <button
               key={option}
-              className={`flex w-full items-center justify-between rounded-[4px] px-4 py-2.5 text-left hover:bg-interaction-main-subtle-hover ${
-                option === selectedSortOption && "border-2 border-focus-outline"
+              className={`hover:bg-interaction-main-subtle-hover flex w-full items-center justify-between rounded-[4px] px-4 py-2.5 text-left ${
+                option === selectedSortOption && "border-focus-outline border-2"
               }`}
               onClick={() => {
                 setSortBy(SortOptionToConfigMap[option].sortBy)

--- a/packages/components/src/templates/next/components/internal/Filter/Filter.tsx
+++ b/packages/components/src/templates/next/components/internal/Filter/Filter.tsx
@@ -18,27 +18,25 @@ const Filter = ({
   }
 
   return (
-    <div className="flex flex-col divide-y divide-divider-medium last:border-b last:border-b-divider-medium">
-      <h5 className="text-heading-05 py-4 text-content">Filter by</h5>
+    <div className="divide-divider-medium last:border-b-divider-medium flex flex-col divide-y last:border-b">
+      <h5 className="py-5 text-xl font-semibold">Filter by</h5>
       {filters.map(({ id, label, items }) => (
         <div className="py-4" key={id}>
           <button
             className="flex w-full flex-row"
             onClick={() => updateFilterToggle(id)}
           >
-            <h5 className="text-paragraph-01 font-medium text-content-medium">
-              {label}
-            </h5>
+            <h5 className="text-content-medium text-lg">{label}</h5>
             <div className="flex-1"></div>
             <BiChevronDown
-              className={`text-2xl text-content-medium transition-all duration-300 ease-in-out ${
+              className={`text-content-medium text-2xl transition-all duration-300 ease-in-out ${
                 showFilter[id] ? "rotate-180" : "rotate-0"
               }`}
             />
           </button>
 
           <div
-            className={`flex w-full flex-col gap-3 pt-4 text-content-medium ${
+            className={`text-content-medium flex w-full flex-col gap-3 pt-4 ${
               showFilter[id] ? "block" : "hidden"
             }`}
           >
@@ -46,11 +44,11 @@ const Filter = ({
               <label
                 key={itemId}
                 htmlFor={itemId}
-                className="flex w-full flex-row rounded px-1 py-2 align-middle hover:bg-interaction-main-subtle-hover has-[:focus]:ring-2 has-[:focus]:ring-focus-outline"
+                className="hover:bg-interaction-main-subtle-hover has-[:focus]:ring-focus-outline flex w-full flex-row rounded px-1 py-2 align-middle has-[:focus]:ring-2"
               >
                 <input
                   type="checkbox"
-                  className="h-6 w-6 rounded border-2 border-divider-medium text-interaction-main focus:ring-0 group-focus:ring-2 group-focus:ring-focus-outline"
+                  className="border-divider-medium text-interaction-main group-focus:ring-focus-outline h-6 w-6 rounded border-2 focus:ring-0 group-focus:ring-2"
                   id={itemId}
                   name={itemId}
                   checked={

--- a/packages/components/src/templates/next/components/internal/LocalSearchInputBox/LocalSearchInputBox.tsx
+++ b/packages/components/src/templates/next/components/internal/LocalSearchInputBox/LocalSearchInputBox.tsx
@@ -10,7 +10,7 @@ const LocalSearchInputBox = ({
         type="search"
         name="q"
         placeholder="Search this site"
-        className="block w-full border border-divider-medium px-4 py-2 focus:border-site-primary focus:outline-none focus:ring-site-primary"
+        className="border-divider-medium focus:border-site-primary focus:ring-site-primary block w-full border px-4 py-2 focus:outline-none"
       />
 
       <button type="submit" aria-label="Search this site">

--- a/packages/components/src/templates/next/components/internal/Pagination/Pagination.tsx
+++ b/packages/components/src/templates/next/components/internal/Pagination/Pagination.tsx
@@ -13,7 +13,7 @@ export const Pagination = ({
     <nav className="grid w-full grid-cols-4" aria-label="Pagination">
       {/* Previous button */}
       <button
-        className="flex cursor-pointer flex-row gap-1 p-1 align-middle hover:bg-interaction-main-subtle-hover disabled:cursor-not-allowed disabled:text-interaction-sub disabled:hover:bg-transparent"
+        className="hover:bg-interaction-main-subtle-hover flex cursor-pointer flex-row gap-1 justify-self-end p-1 align-middle disabled:cursor-not-allowed disabled:text-neutral-400 disabled:hover:bg-transparent"
         aria-label="Previous page"
         disabled={currPage <= 1}
         onClick={() => {
@@ -23,17 +23,17 @@ export const Pagination = ({
         }}
       >
         <BiLeftArrowAlt className="my-auto text-2xl" />
-        <p className="hidden text-lg underline xs:inline">Previous</p>
+        <p className="xs:inline hidden text-lg underline">Previous</p>
       </button>
 
       {/* Page number */}
-      <p className="col-span-2 my-auto justify-self-center xs:text-xl xs:leading-8">
+      <p className="xs:text-lg xs:leading-8 col-span-2 my-auto justify-self-center">
         Page {currPage} of {totalPages}
       </p>
 
       {/* Next button */}
       <button
-        className="flex cursor-pointer flex-row gap-1 justify-self-end p-1 align-middle hover:bg-interaction-main-subtle-hover disabled:cursor-not-allowed disabled:text-interaction-sub disabled:hover:bg-transparent"
+        className="hover:bg-interaction-main-subtle-hover flex cursor-pointer flex-row gap-1 justify-self-start p-1 align-middle disabled:cursor-not-allowed disabled:text-neutral-400 disabled:hover:bg-transparent sm:justify-self-end"
         aria-label="Next page"
         disabled={currPage >= totalPages}
         onClick={() => {
@@ -42,7 +42,7 @@ export const Pagination = ({
           }
         }}
       >
-        <p className="hidden text-lg underline xs:inline">Next</p>
+        <p className="xs:inline hidden text-lg underline">Next</p>
         <BiRightArrowAlt className="my-auto text-2xl" />
       </button>
     </nav>

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -260,15 +260,15 @@ const CollectionClient = ({
   )
 
   return (
-    <div className="mx-auto my-20 flex max-w-container flex-col items-center gap-16 px-6 py-16 md:px-10">
-      <div className="flex w-full flex-col gap-12">
-        <h1 className="text-heading-01 flex flex-col gap-16 text-content-strong">
+    <div className="max-w-container mx-auto my-16 flex flex-col items-start gap-16 px-6 md:px-10">
+      <div className="flex max-w-[47.8rem] flex-col gap-12">
+        <h1 className="text-heading-01 text-content-strong flex flex-col gap-16">
           {title}
         </h1>
         <p className="text-paragraph-01 text-content">{subtitle}</p>
       </div>
 
-      <div className="mx-auto w-full sm:w-3/4">
+      <div className="mx-auto w-full">
         <CollectionSearch
           placeholder={`Search for ${page.title.toLowerCase()}`}
           search={searchValue}
@@ -277,7 +277,7 @@ const CollectionClient = ({
       </div>
 
       <div className="flex w-full flex-col justify-between gap-10 lg:flex-row">
-        <div className="w-full lg:w-1/5 xl:w-1/6">
+        <div className="w-full lg:w-1/4">
           <Filter
             filters={filters}
             appliedFilters={appliedFilters}
@@ -291,10 +291,10 @@ const CollectionClient = ({
             }
           />
         </div>
-        <div className="flex w-full flex-col gap-6 lg:w-4/5 xl:w-5/6">
-          <div className="flex w-full flex-wrap items-start justify-between gap-6 sm:flex-nowrap">
+        <div className="flex w-full flex-col gap-4 lg:w-3/4">
+          <div className="flex w-full flex-wrap items-end justify-between gap-6 sm:flex-nowrap">
             <div className="flex h-full w-full flex-col gap-3">
-              <p className="text-paragraph-01 mt-auto text-content">
+              <p className="text-content mt-auto text-base">
                 {appliedFilters.length > 0 || searchValue !== ""
                   ? `${filteredItems.length} search ${
                       filteredItems.length === 1 ? "result" : "results"
@@ -309,7 +309,7 @@ const CollectionClient = ({
                   </>
                 )}
               </p>
-
+              {/* Commenting out applied filter display temporarily
               {appliedFilters.length > 0 && (
                 <div className="flex flex-row flex-wrap gap-3">
                   {getAppliedFiltersWithLabels(filters, appliedFilters).map(
@@ -329,7 +329,7 @@ const CollectionClient = ({
                     ),
                   )}
                 </div>
-              )}
+              )}*/}
             </div>
             <div className="w-full shrink-0 sm:w-[260px]">
               <CollectionSort
@@ -351,12 +351,12 @@ const CollectionClient = ({
               ))}
 
             {paginatedItems.length === 0 && searchValue !== "" && (
-              <div className="m-auto flex flex-col gap-3 text-center">
+              <div className="my-20 flex flex-col gap-3 text-center lg:m-auto">
                 <p className="text-paragraph-01">
                   We couldn’t find articles that match your search.
                 </p>
                 <button
-                  className="mx-auto w-fit text-lg font-semibold text-hyperlink hover:text-hyperlink-hover"
+                  className="text-hyperlink hover:text-hyperlink-hover text-md mx-auto w-fit font-semibold lg:text-lg"
                   onClick={() => {
                     setSearchValue("")
                     setAppliedFilters([])


### PR DESCRIPTION
A temporary design cleanup for the Collections layout. **This layout will be going through redesigns soon**, so this cleanup is just to iron out alignment issues to make more presentable, notably:

- Temporarily hide selected filters (it's been commented out)
- Pagination: fix issue where left-arrow was really small and alignment issue
- Vertical alignment of "Filter by" and Results so that the horizontal lines don't look janky
- Filters was taking up too little width, adjusted to take up more space (1/4 in larger screens)
- Search bar is thicker for visual balance
- Page title and subtitle take up limited width, to follow other page layouts & best practices
- Fix missing gap above empty results copy in mobile

Before:
<img width="1444" alt="image" src="https://github.com/opengovsg/isomer/assets/139780851/a21828f8-0aca-4c7f-b0a3-1d3057e0833b">

After:
<img width="1437" alt="image" src="https://github.com/opengovsg/isomer/assets/139780851/83f759e4-61af-4cf1-b974-497c701b718c">

Mobile:
<img width="380" alt="image" src="https://github.com/opengovsg/isomer/assets/139780851/692819b3-d3dd-4a56-818e-cf28270012b5">
