### PR TITLE
fix(styling): minor design fixes for components

### DIFF
--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -4,10 +4,10 @@ import { Prose } from "../../native"
 
 const Accordion = ({ summary, details }: AccordionProps) => {
   return (
-    <details className="border-y border-divider-medium hover:cursor-pointer has-[+_details]:border-b-0 [&_>_summary]:open:font-semibold [&_>_summary_>_svg]:open:rotate-180">
-      <summary className="text-paragraph-01 my-[0.125rem] flex list-none flex-row gap-3 px-4 py-5 text-content outline-none focus:ring-2 focus:ring-focus-outline focus:ring-offset-0">
+    <details className="border-divider-medium border-y hover:cursor-pointer has-[+_details]:border-b-0 [&_>_summary_>_svg]:open:rotate-180">
+      <summary className="text-paragraph-01 text-content my-[0.125rem] flex list-none flex-row items-center gap-3 px-4 py-5 font-medium outline-none">
         {summary}
-        <BiChevronDown className="mb-auto ml-auto min-w-6 text-2xl transition-all duration-200 ease-in-out" />
+        <BiChevronDown className="ml-auto min-w-6 text-2xl transition-all duration-200 ease-in-out" />
       </summary>
 
       <div className="mb-4 ml-4 mr-6 mt-2">

--- a/packages/components/src/templates/next/components/complex/Button/Button.tsx
+++ b/packages/components/src/templates/next/components/complex/Button/Button.tsx
@@ -3,7 +3,7 @@ import type { ButtonColorScheme } from "~/interfaces/complex/Button"
 import { SUPPORTED_ICONS_MAP } from "~/common/icons"
 
 const Label = ({ label }: Pick<ButtonProps, "label">) => (
-  <span className="text-md text-center font-medium leading-tight">{label}</span>
+  <span className="text-center text-lg font-medium leading-tight">{label}</span>
 )
 
 const RightIcon = ({ rightIcon }: Pick<ButtonProps, "rightIcon">) => {
@@ -32,7 +32,7 @@ const BaseButton = ({
       rel={href.startsWith("http") ? "noopener noreferrer nofollow" : undefined}
       type="button"
       className={`${className} inline-flex w-fit items-center gap-1 rounded ${
-        isLinkVariant ? "h-fit" : "px-4 py-3"
+        isLinkVariant ? "h-fit" : "px-5 py-3"
       } `}
     >
       <Label label={label} />

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -15,7 +15,7 @@ const TitleSection = ({
     <div
       className={`flex max-w-3xl flex-col gap-8 self-start pb-8 sm:pb-12 ${className}`}
     >
-      <h3 className="text-heading-03 text-content-strong">{title}</h3>
+      <h2 className="text-heading-03 text-content-strong">{title}</h2>
       {subtitle && (
         <p className="text-content text-sm sm:text-lg">{subtitle}</p>
       )}

--- a/packages/components/src/templates/next/components/internal/Card.tsx
+++ b/packages/components/src/templates/next/components/internal/Card.tsx
@@ -50,7 +50,7 @@ const TextComponent = ({
           </h4>
         )}
         {text && (
-          <p className="text-content line-clamp-4 grow text-left	text-base sm:text-lg">
+          <p className="text-content line-clamp-4 grow text-left text-base sm:text-lg">
             {text}
           </p>
         )}
@@ -65,7 +65,7 @@ const TextComponent = ({
                 ? "noopener noreferrer nofollow"
                 : undefined
             }
-            className="text-button-link-01 text-interaction-link after:absolute after:inset-0"
+            className="text-interaction-link font-medium after:absolute after:inset-0"
           >
             {buttonLabel}
           </a>
@@ -90,7 +90,7 @@ const Card = ({
     <div
       className={`relative flex ${
         variant === "horizontal" ? "flex-row" : "flex-col"
-      } border-divider-medium gap-1 rounded-md border hover:opacity-80 ${className}`}
+      } outline-divider-medium gap-1 rounded-md outline hover:opacity-80 ${className}`}
     >
       {variant === "horizontal" ? (
         <>


### PR DESCRIPTION
Adding minor design fixes to single PR because most of these are one-liners per component:

- **Accordion** had focus state which was appearing on active state, removed (focus state is for keyboard manipulation)
- **Button** y-padding needs to be larger
- **Infocards** should use h2 tag (like all other blocks) instead of h3 
- **Infocards** should use outline instead of border

The linter may have caused reordering of classnames