### PR TITLE
ISOM-1142: feat(modal): page create modal with validations

### DIFF
--- a/apps/studio/src/components/features/editing-experience/PageCreateModal.tsx
+++ b/apps/studio/src/components/features/editing-experience/PageCreateModal.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useState } from 'react'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  InputGroup,
+  InputLeftAddon,
+  Text,
+  Stack,
+  Box,
+} from '@chakra-ui/react'
+import {
+  Button,
+  FormErrorMessage,
+  ModalCloseButton,
+} from '@opengovsg/design-system-react'
+import { useForm, SubmitHandler } from 'react-hook-form'
+interface PageCreateModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+type PageCreateFormFields = {
+  title: string
+  url: string
+}
+
+/* TODO: Can extract these out to a constants file if can be reused */
+const ERROR_MESSAGES = {
+  MIN_LENGTH: 'Minimum length should be 1',
+  MAX_LENGTH: (max: number) => `Maximum length should be ${max}`,
+  TITLE: {
+    REQUIRED: 'Enter a title for this page',
+  },
+  URL: {
+    REQUIRED: 'Enter a URL for this page.',
+  },
+}
+
+export const PageCreateModal = ({
+  isOpen,
+  onClose,
+}: PageCreateModalProps): JSX.Element => {
+  const MAX_TITLE_LENGTH = 100
+  const MAX_PAGE_URL_LENGTH = 150
+  const [titleLen, setTitleLen] = useState(0)
+  const [pageUrlLen, setPageUrlLen] = useState(0)
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<PageCreateFormFields>()
+
+  const watchAllFields = watch()
+  console.log(watchAllFields)
+  console.log(`errors`, errors)
+  useEffect(() => {
+    setTitleLen(watchAllFields.title?.length || 0)
+    setPageUrlLen(watchAllFields.url?.length || 0)
+  }, [watchAllFields])
+
+  /* TODO: When integrating with BE */
+  const onSubmit: SubmitHandler<PageCreateFormFields> = (data) =>
+    console.log(data)
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalCloseButton />
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader color="base.content.strong">
+          Tell us about your new page
+        </ModalHeader>
+        <ModalCloseButton />
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <ModalBody>
+            <Stack gap={'1.5em'}>
+              <Text fontSize="md" color="base.content.default">
+                You can change these later.
+              </Text>
+              {/* Section 1: Page Title */}
+              <FormControl isInvalid={!!errors.title}>
+                <FormLabel color="base.content.strong">
+                  Page title
+                  <FormHelperText color="base.content.default">
+                    Title should be descriptive
+                  </FormHelperText>
+                </FormLabel>
+
+                <Input
+                  type="text"
+                  placeholder="This is a title for your new page"
+                  id="title"
+                  {...register('title', {
+                    required: ERROR_MESSAGES.TITLE.REQUIRED,
+                    validate: (value) =>
+                      value.trim().length !== 0 ||
+                      ERROR_MESSAGES.TITLE.REQUIRED,
+                    minLength: {
+                      value: 1,
+                      message: ERROR_MESSAGES.MIN_LENGTH,
+                    },
+                    maxLength: {
+                      value: MAX_TITLE_LENGTH,
+                      message: ERROR_MESSAGES.MAX_LENGTH(MAX_TITLE_LENGTH),
+                    },
+                  })}
+                  isInvalid={!!errors.title}
+                />
+                {errors.title && errors.title.message ? (
+                  <FormErrorMessage>{errors.title.message}</FormErrorMessage>
+                ) : (
+                  <FormHelperText mt={'0.5em'} color="base.content.medium">
+                    {MAX_TITLE_LENGTH - titleLen} characters left
+                  </FormHelperText>
+                )}
+              </FormControl>
+
+              {/* Section 2: Page URL */}
+              <FormControl isInvalid={!!errors.url}>
+                <FormLabel>
+                  Page URL
+                  <FormHelperText>
+                    URL should be short and simple
+                  </FormHelperText>
+                </FormLabel>
+                <InputGroup>
+                  <InputLeftAddon
+                    bgColor="interaction.support.disabled"
+                    color="base.divider.strong"
+                  >
+                    your-site.gov.sg/
+                  </InputLeftAddon>
+                  <Input
+                    type="tel"
+                    defaultValue={'hello-world'}
+                    color="base.content.default"
+                    {...register('url', {
+                      required: ERROR_MESSAGES.URL.REQUIRED,
+                      minLength: {
+                        value: 1,
+                        message: ERROR_MESSAGES.MIN_LENGTH,
+                      },
+                      maxLength: {
+                        value: MAX_PAGE_URL_LENGTH,
+                        message: ERROR_MESSAGES.MAX_LENGTH(MAX_PAGE_URL_LENGTH),
+                      },
+                    })}
+                    isInvalid={!!errors.url}
+                  />
+                </InputGroup>
+
+                {errors.url && errors.url.message ? (
+                  <FormErrorMessage>{errors.url.message}</FormErrorMessage>
+                ) : (
+                  <FormHelperText mt={'0.5em'} color="base.content.medium">
+                    {MAX_PAGE_URL_LENGTH - pageUrlLen} characters left
+                  </FormHelperText>
+                )}
+              </FormControl>
+            </Stack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button
+              variant="link"
+              mr={5}
+              onClick={onClose}
+              fontWeight={500}
+              color={'base.content.strong'}
+            >
+              Cancel
+            </Button>
+            <Button bgColor="interaction.main.default" type="submit">
+              Create page
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default PageCreateModal

--- a/apps/studio/src/features/editing-experience/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/PageCreateModal.tsx
@@ -61,8 +61,7 @@ export const PageCreateModal = ({
   } = useForm<PageCreateFormFields>()
 
   const watchAllFields = watch()
-  console.log(watchAllFields)
-  console.log(`errors`, errors)
+
   useEffect(() => {
     setTitleLen(watchAllFields.title?.length || 0)
     setPageUrlLen(watchAllFields.url?.length || 0)

--- a/apps/studio/src/pages/dashboard/index.tsx
+++ b/apps/studio/src/pages/dashboard/index.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure } from '@chakra-ui/react'
 import { Button } from '@opengovsg/design-system-react'
-import PageCreateModal from '~/components/features/editing-experience/PageCreateModal'
+import PageCreateModal from '~/features/editing-experience/PageCreateModal'
 
 export default function Dashboard() {
   const { isOpen, onOpen, onClose } = useDisclosure()

--- a/apps/studio/src/pages/dashboard/index.tsx
+++ b/apps/studio/src/pages/dashboard/index.tsx
@@ -1,0 +1,17 @@
+import { useDisclosure } from '@chakra-ui/react'
+import { Button } from '@opengovsg/design-system-react'
+import PageCreateModal from '~/components/features/editing-experience/PageCreateModal'
+
+export default function Dashboard() {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
+  return (
+    <div>
+      {/* TODO: Dashboard layout */}
+      <h1>DASHBOARD</h1>
+
+      <Button onClick={onOpen}>Create new page</Button>
+      <PageCreateModal isOpen={isOpen} onClose={onClose} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

We need to allow users to create new pages on Studio.

Closes ISOM-1142

## Solution

Implement Chakra modal with react-hook-form validations.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

## Before & After Screenshots

**AFTER**:
![Screenshot 2024-06-05 at 1 55 14 PM](https://github.com/opengovsg/isomer/assets/5507822/232f92b3-7150-40a5-95df-47a385550698)

## Tests
- [ ] Ensure the fields display a dynamic counter of how chars are left
- [ ] Ensure validation for each field for min length of 1
- [ ] Ensure validation  max length of 100 chars for title
- [ ] Ensure validation of 150 chars for url
