### PR TITLE
ISOM-1147: feat: read folder dto

### DIFF
--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const getFolderSchema = z.object({
+    // Could pass a null resourceId for the root level folder?
+    siteId: z.string(),
+    resourceId: z.string().nullable()
+})

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
-export const getFolderSchema = z.object({
-    // Could pass a null resourceId for the root level folder?
+export const readFolderOrTopLevelFolder = z.object({
+    // Null resourceId indicates reading of top level folder in a site.
     siteId: z.string(),
     resourceId: z.string().nullable()
 })

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-export const readFolderOrTopLevelFolder = z.object({
+export const readFolderOrTopLevelFolderSchema = z.object({
     // Null resourceId indicates reading of top level folder in a site.
     siteId: z.string(),
     resourceId: z.string().nullable()

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,9 +1,9 @@
-import { readFolderOrTopLevelFolder } from "~/schemas/folder";
+import { readFolderOrTopLevelFolderSchema } from "~/schemas/folder";
 import { protectedProcedure, router } from '~/server/trpc'
 
 
 export const folderRouter = router({
-    readFolderOrTopLevelFolder: protectedProcedure.input(readFolderOrTopLevelFolder).query(async ({ input, ctx }) => {     
+    readFolderOrTopLevelFolder: protectedProcedure.input(readFolderOrTopLevelFolderSchema).query(async ({ input, ctx }) => {     
         // TODO: Fill these in later
         const folderName: string = ""
         const children: {id: string, name: string, type: 'page' | 'folder'}[] = []

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,0 +1,17 @@
+import { getFolderSchema } from "~/schemas/folder";
+import { protectedProcedure, router } from '~/server/trpc'
+
+
+export const folderRouter = router({
+    readFolder: protectedProcedure.input(getFolderSchema).query(async ({ input, ctx }) => {     
+        // TODO: Fill these in later
+        const folderName: string = ""
+        const children: {id: string, name: string, type: 'page' | 'folder'}[] = []
+        // Not sure if a backpointer is needed here
+        const parentId: string = ""
+        return {
+            folderName, children, parentId
+        }
+    })
+
+})

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,9 +1,9 @@
-import { getFolderSchema } from "~/schemas/folder";
+import { readFolderOrTopLevelFolder } from "~/schemas/folder";
 import { protectedProcedure, router } from '~/server/trpc'
 
 
 export const folderRouter = router({
-    readFolder: protectedProcedure.input(getFolderSchema).query(async ({ input, ctx }) => {     
+    readFolderOrTopLevelFolder: protectedProcedure.input(readFolderOrTopLevelFolder).query(async ({ input, ctx }) => {     
         // TODO: Fill these in later
         const folderName: string = ""
         const children: {id: string, name: string, type: 'page' | 'folder'}[] = []

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,9 @@
         "apps/*",
         "packages/*"
       ],
+      "dependencies": {
+        "zod": "^3.23.8"
+      },
       "devDependencies": {
         "turbo": "^1.13.3"
       }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "license": "ISC",
   "devDependencies": {
     "turbo": "^1.13.3"
+  },
+  "dependencies": {
+    "zod": "^3.23.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   "license": "ISC",
   "devDependencies": {
     "turbo": "^1.13.3"
-  },
-  "dependencies": {
-    "zod": "^3.23.8"
   }
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [ISOM-1147](https://linear.app/ogp/issue/ISOM-1147/create-dto-for-read-folder)
Adds dto for BE<>FE for reading of folder, used in features like display folder contents.

## Solution

- FE to BE schema requires siteId and resourceId for the folder. Assumptions made is that resourceId could be null if we want to retrieve root level folder for the particular site, but may have to look at this again.
- BE to FE scheme is in folder.router, distinction made between child folder and child pages.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible
