### PR TITLE
chore: lint files, remove extra package-lock.json

### DIFF
--- a/packages/studio/package-lock.json
+++ b/packages/studio/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "studio",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/tooling/build/amplify/create-app.js
+++ b/tooling/build/amplify/create-app.js
@@ -3,7 +3,7 @@ const {
   CreateAppCommand,
   CreateBranchCommand,
   StartJobCommand,
-} = require("@aws-sdk/client-amplify");
+} = require("@aws-sdk/client-amplify")
 
 const AMPLIFY_BUILD_SPEC = `
 version: 1
@@ -12,10 +12,10 @@ frontend:
     preBuild:
       commands:
         - rm -rf node_modules && rm -rf .next
-        - curl https://raw.githubusercontent.com/opengovsg/isomer-next/main/tooling/build/scripts/preBuild.sh | bash
+        - curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/build/scripts/preBuild.sh | bash
     build:
       commands:
-        - curl https://raw.githubusercontent.com/opengovsg/isomer-next/main/tooling/build/scripts/build.sh | bash
+        - curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/build/scripts/build.sh | bash
   artifacts:
     baseDirectory: out
     files:
@@ -24,12 +24,13 @@ frontend:
 #     paths:
 #       - .next/cache/**/*
 #       - node_modules/**/*
-`;
+`
 
-const amplifyClient = new AmplifyClient({ region: "ap-southeast-1" });
+const amplifyClient = new AmplifyClient({ region: "ap-southeast-1" })
 
 const createApp = async (appName) => {
-  let appId = "";
+  console.log("Creating app:", appName)
+  let appId = ""
 
   const params = new CreateAppCommand({
     name: appName,
@@ -40,12 +41,12 @@ const createApp = async (appName) => {
       NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT: "staging",
     },
     customRules: [{ source: "/<*>", target: "/404.html", status: "404" }],
-  });
+  })
 
   await amplifyClient
     .send(params)
     .then((appInfo) => {
-      appId = appInfo.app?.appId;
+      appId = appInfo.app?.appId
 
       const mainBranchParams = new CreateBranchCommand({
         appId,
@@ -55,9 +56,9 @@ const createApp = async (appName) => {
         environmentVariables: {
           NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT: "production",
         },
-      });
+      })
 
-      return amplifyClient.send(mainBranchParams);
+      return amplifyClient.send(mainBranchParams)
     })
     .then(() =>
       amplifyClient.send(
@@ -66,8 +67,8 @@ const createApp = async (appName) => {
           branchName: "staging",
           framework: "Next.js - SSG",
           enableAutoBuild: true,
-        })
-      )
+        }),
+      ),
     )
     .then(() =>
       amplifyClient.send(
@@ -75,8 +76,8 @@ const createApp = async (appName) => {
           appId,
           branchName: "main",
           jobType: "RELEASE",
-        })
-      )
+        }),
+      ),
     )
     .then(() =>
       amplifyClient.send(
@@ -84,9 +85,25 @@ const createApp = async (appName) => {
           appId,
           branchName: "staging",
           jobType: "RELEASE",
-        })
-      )
-    );
-};
+        }),
+      ),
+    )
+}
 
-createApp("mti-corp");
+const main = async () => {
+  const apps = [
+    "moh-hpp-next",
+    "moh-healthwatch-next",
+    "moh-hcsa-next",
+    "moh-ifeelyoung-next",
+    "moh-biosafety-next",
+    "moh-dc-next",
+    "moh-prepare-next",
+  ]
+
+  for (const app of apps) {
+    await createApp(app)
+  }
+}
+
+main()

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -1,80 +1,80 @@
-import config from "@/data/config.json";
-import footer from "@/data/footer.json";
-import navbar from "@/data/navbar.json";
-import sitemap from "@/sitemap.json";
+import config from "@/data/config.json"
+import footer from "@/data/footer.json"
+import navbar from "@/data/navbar.json"
+import sitemap from "@/sitemap.json"
 import {
   RenderEngine,
   getMetadata,
   getSitemapXml,
   type IsomerPageSchema,
-} from "@opengovsg/isomer-components";
-import type { Metadata, ResolvingMetadata } from "next";
-import Link from "next/link";
+} from "@opengovsg/isomer-components"
+import type { Metadata, ResolvingMetadata } from "next"
+import Link from "next/link"
 
 interface DynamicPageProps {
   params: {
-    permalink: string[];
-  };
+    permalink: string[]
+  }
 }
 
-const timeNow = new Date();
+const timeNow = new Date()
 const lastUpdated =
   timeNow.getDate().toString().padStart(2, "0") +
   " " +
   timeNow.toLocaleString("default", { month: "short" }) +
   " " +
-  timeNow.getFullYear();
+  timeNow.getFullYear()
 
 const getSchema = async (
-  permalink: DynamicPageProps["params"]["permalink"]
+  permalink: DynamicPageProps["params"]["permalink"],
 ) => {
   if (permalink && permalink.length > 0 && typeof permalink !== "string") {
-    const joinedPermalink = permalink.join("/");
+    const joinedPermalink = permalink.join("/")
 
     const schema = (await import(`@/schema/${joinedPermalink}.json`).then(
-      (module) => module.default
-    )) as IsomerPageSchema;
+      (module) => module.default,
+    )) as IsomerPageSchema
 
     const lastModified =
       // @ts-expect-error blah
       getSitemapXml(sitemap).find(
-        ({ url }) => permalink.join("/") === url.replace(/^\//, "")
-      )?.lastModified || new Date().toISOString();
+        ({ url }) => permalink.join("/") === url.replace(/^\//, ""),
+      )?.lastModified || new Date().toISOString()
 
-    schema.page.permalink = "/" + joinedPermalink;
-    schema.page.lastModified = lastModified;
+    schema.page.permalink = "/" + joinedPermalink
+    schema.page.lastModified = lastModified
 
-    return schema;
+    return schema
   }
 
   const schema = (await import(`@/schema/index.json`).then(
-    (module) => module.default
-  )) as IsomerPageSchema;
+    (module) => module.default,
+  )) as IsomerPageSchema
 
   const lastModified =
     // @ts-expect-error blah
     getSitemapXml(sitemap).find(({ url }) => url === "/")?.lastModified ||
-    new Date().toISOString();
+    new Date().toISOString()
 
-  schema.page.permalink = "/";
-  schema.page.lastModified = lastModified;
+  schema.page.permalink = "/"
+  schema.page.lastModified = lastModified
 
-  return schema;
-};
+  return schema
+}
 
 export const generateStaticParams = () => {
   // @ts-expect-error blah
   return getSitemapXml(sitemap).map(({ url }) => ({
     permalink: url.replace(/^\//, "").split("/"),
-  }));
-};
+  }))
+}
 
 export const generateMetadata = async (
   { params }: DynamicPageProps,
-  parent: ResolvingMetadata
+  parent: ResolvingMetadata,
 ): Promise<Metadata> => {
-  const { permalink } = params;
-  const schema = await getSchema(permalink);
+  const { permalink } = params
+  const schema = await getSchema(permalink)
   schema.site = {
     ...config.site,
     environment: process.env.NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT,
@@ -84,13 +84,13 @@ export const generateMetadata = async (
     // @ts-expect-error blah
     footerItems: footer,
     lastUpdated,
-  };
-  return getMetadata(schema);
-};
+  }
+  return getMetadata(schema)
+}
 
 const Page = async ({ params }: DynamicPageProps) => {
-  const { permalink } = params;
-  const renderSchema = await getSchema(permalink);
+  const { permalink } = params
+  const renderSchema = await getSchema(permalink)
 
   return (
     <>
@@ -112,7 +112,7 @@ const Page = async ({ params }: DynamicPageProps) => {
         LinkComponent={Link}
       />
     </>
-  );
-};
+  )
+}
 
-export default Page;
+export default Page

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -1,20 +1,20 @@
-import config from "@/data/config.json";
-import "@/styles/globals.css";
-import type { Metadata } from "next";
+import config from "@/data/config.json"
+import "@/styles/globals.css"
+import type { Metadata } from "next"
 
 export const metadata: Metadata = {
   title: {
     template: "%s | " + config.site.siteName,
     default: config.site.siteName,
   },
-};
+}
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en" data-theme={config.site.theme || "isomer-next"}>
       <body>{children}</body>
     </html>
-  );
-};
+  )
+}
 
-export default RootLayout;
+export default RootLayout

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -1,34 +1,34 @@
-import config from "@/data/config.json";
-import footer from "@/data/footer.json";
-import navbar from "@/data/navbar.json";
-import sitemap from "@/sitemap.json";
+import config from "@/data/config.json"
+import footer from "@/data/footer.json"
+import navbar from "@/data/navbar.json"
+import sitemap from "@/sitemap.json"
 import {
   RenderEngine,
   getMetadata,
   type IsomerPageSchema,
-} from "@opengovsg/isomer-components";
-import type { Metadata, ResolvingMetadata } from "next";
-import Link from "next/link";
+} from "@opengovsg/isomer-components"
+import type { Metadata, ResolvingMetadata } from "next"
+import Link from "next/link"
 
-const PAGE_TITLE = "404: Page not found";
-const PAGE_DESCRIPTION = "The page that you are accessing does not exist";
-const PAGE_SCHEMA_VERSION = "0.1.0";
+const PAGE_TITLE = "404: Page not found"
+const PAGE_DESCRIPTION = "The page that you are accessing does not exist"
+const PAGE_SCHEMA_VERSION = "0.1.0"
 
-const timeNow = new Date();
+const timeNow = new Date()
 const lastUpdated =
   timeNow.getDate().toString().padStart(2, "0") +
   " " +
   timeNow.toLocaleString("default", { month: "short" }) +
   " " +
-  timeNow.getFullYear();
+  timeNow.getFullYear()
 
 export const generateMetadata = async (
   props: never,
-  parent: ResolvingMetadata
+  parent: ResolvingMetadata,
 ): Promise<Metadata> => {
   const schema = (await import(`@/schema/index.json`).then(
-    (module) => module.default
-  )) as IsomerPageSchema;
+    (module) => module.default,
+  )) as IsomerPageSchema
   schema.site = {
     ...config.site,
     environment: process.env.NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT,
@@ -38,12 +38,12 @@ export const generateMetadata = async (
     // @ts-expect-error blah
     footerItems: footer,
     lastUpdated,
-  };
-  schema.page.permalink = "/404.html";
-  schema.page.title = PAGE_TITLE;
-  schema.page.description = PAGE_DESCRIPTION;
-  return getMetadata(schema);
-};
+  }
+  schema.page.permalink = "/404.html"
+  schema.page.title = PAGE_TITLE
+  schema.page.description = PAGE_DESCRIPTION
+  return getMetadata(schema)
+}
 
 const NotFound = () => {
   return (
@@ -70,7 +70,7 @@ const NotFound = () => {
         LinkComponent={Link}
       />
     </>
-  );
-};
+  )
+}
 
-export default NotFound;
+export default NotFound

--- a/tooling/template/app/robots.ts
+++ b/tooling/template/app/robots.ts
@@ -1,16 +1,16 @@
-import config from "@/data/config.json";
-import footer from "@/data/footer.json";
-import navbar from "@/data/navbar.json";
-import { getRobotsTxt } from "@opengovsg/isomer-components";
-import type { MetadataRoute } from "next";
+import config from "@/data/config.json"
+import footer from "@/data/footer.json"
+import navbar from "@/data/navbar.json"
+import { getRobotsTxt } from "@opengovsg/isomer-components"
+import type { MetadataRoute } from "next"
 
-const timeNow = new Date();
+const timeNow = new Date()
 const lastUpdated =
   timeNow.getDate().toString().padStart(2, "0") +
   " " +
   timeNow.toLocaleString("default", { month: "short" }) +
   " " +
-  timeNow.getFullYear();
+  timeNow.getFullYear()
 
 export default function robots(): MetadataRoute.Robots {
   return getRobotsTxt({
@@ -21,5 +21,5 @@ export default function robots(): MetadataRoute.Robots {
       footerItems: footer,
       lastUpdated,
     },
-  });
+  })
 }

--- a/tooling/template/app/sitemap.ts
+++ b/tooling/template/app/sitemap.ts
@@ -1,8 +1,8 @@
-import sitemapJson from "@/sitemap.json";
-import { getSitemapXml } from "@opengovsg/isomer-components";
-import type { MetadataRoute } from "next";
+import sitemapJson from "@/sitemap.json"
+import { getSitemapXml } from "@opengovsg/isomer-components"
+import type { MetadataRoute } from "next"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   // @ts-expect-error blah
-  return getSitemapXml(sitemapJson);
+  return getSitemapXml(sitemapJson)
 }

--- a/tooling/template/tailwind.config.js
+++ b/tooling/template/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
-import siteConfig from "./data/config.json";
-import { NextPreset } from "@opengovsg/isomer-components";
+import siteConfig from "./data/config.json"
+import { NextPreset } from "@opengovsg/isomer-components"
 
 const config = {
   content: [
@@ -24,6 +24,6 @@ const config = {
       },
     },
   },
-};
+}
 
-export default config;
+export default config


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The base template wasn't linted before, there was a lingering package-lock.json file in `packages/studio` and the create-app.js file can only create one app at a time.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Lint all the files inside the base template folder.
- Remove the package-lock.json file from the `packages/studio` folder, this has already been replaced by `apps/studio/package-lock.json`.
- Update the `create-app.js` file to allow creating multiple apps at one go.