### PR TITLE
Alexander/isom 1156 create add new block drawer state

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -1,4 +1,13 @@
-import { Flex, Text, VStack, Wrap } from '@chakra-ui/react'
+import {
+  Flex,
+  Popover,
+  PopoverArrow,
+  PopoverContent,
+  PopoverTrigger,
+  Text,
+  VStack,
+  Wrap,
+} from '@chakra-ui/react'
 import { Button, IconButton } from '@opengovsg/design-system-react'
 import { IconType } from 'react-icons'
 import {
@@ -44,26 +53,42 @@ const BlockItem = ({
   label,
   onProceed,
   sectionType,
+  description,
 }: {
   icon: IconType
   label: string
   onProceed: (sectionType: SectionType) => void
   sectionType: SectionType
+  description: string
 }) => {
   return (
-    <Button
-      m="0.75rem"
-      w="6rem"
-      h="6rem"
-      variant="clear"
-      colorScheme="neutral"
-      onClick={() => onProceed(sectionType)}
-    >
-      <VStack gap="0.5rem" color="base.content.default">
-        <Icon size="1.25rem" />
-        <Text textStyle={'caption-1'}>{label}</Text>
-      </VStack>
-    </Button>
+    <Popover trigger="hover" placement="right">
+      <PopoverTrigger>
+        <Button
+          m="0.75rem"
+          w="6rem"
+          h="6rem"
+          variant="clear"
+          colorScheme="neutral"
+          onClick={() => onProceed(sectionType)}
+        >
+          <VStack gap="0.5rem" color="base.content.default">
+            <Icon size="1.25rem" />
+            <Text textStyle={'caption-1'}>{label}</Text>
+          </VStack>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <VStack p="1.5rem" alignItems={'start'} gap="0.75rem">
+          <Flex alignItems={'center'} gap="0.5rem">
+            <Icon size="1.25rem" />
+            <Text textStyle={'subhead-2'}>{label}</Text>
+          </Flex>
+          <Text textStyle="body-2">{description}</Text>
+        </VStack>
+      </PopoverContent>
+    </Popover>
   )
 }
 
@@ -110,12 +135,14 @@ const ComponentSelector = ({ onClose, onProceed }: ComponentSelectorProps) => {
               icon={BiText}
               onProceed={onProceed}
               sectionType="paragraph"
-            />
+              description="Add text to your page - lists, headings, paragraph, and links."
+            ></BlockItem>
             <BlockItem
               label="Image"
               icon={BiImage}
               onProceed={onProceed}
               sectionType="image"
+              description="TODO"
             />
           </BlockList>
         </Section>
@@ -127,24 +154,28 @@ const ComponentSelector = ({ onClose, onProceed }: ComponentSelectorProps) => {
               icon={BiDollar}
               onProceed={onProceed}
               sectionType="statistics"
+              description="TODO"
             />
             <BlockItem
               label="Callout"
               icon={BiSolidQuoteAltLeft}
               onProceed={onProceed}
               sectionType="callout"
+              description="TODO"
             />
             <BlockItem
               label="Text with button"
               icon={BiSolidHandUp}
               onProceed={onProceed}
               sectionType="textWithButton"
+              description="TODO"
             />
             <BlockItem
               label="Text with image"
               icon={BiImages}
               onProceed={onProceed}
               sectionType="textWithImage"
+              description="TODO"
             />
           </BlockList>
         </Section>
@@ -156,24 +187,28 @@ const ComponentSelector = ({ onClose, onProceed }: ComponentSelectorProps) => {
               icon={BiCard}
               onProceed={onProceed}
               sectionType="cards"
+              description="TODO"
             />
             <BlockItem
               label="Columns"
               icon={BiColumns}
               onProceed={onProceed}
               sectionType="columns"
+              description="TODO"
             />
             <BlockItem
               label="Accordion"
               icon={BiExpandVertical}
               onProceed={onProceed}
               sectionType="accordion"
+              description="TODO"
             />
             <BlockItem
               label="Divider"
               icon={BiRuler}
               onProceed={onProceed}
               sectionType="divider"
+              description="TODO"
             />
           </BlockList>
         </Section>
@@ -185,18 +220,21 @@ const ComponentSelector = ({ onClose, onProceed }: ComponentSelectorProps) => {
               icon={BiMovie}
               onProceed={onProceed}
               sectionType="youtube"
+              description="TODO"
             />
             <BlockItem
               label="Google Maps"
               icon={BiMap}
               onProceed={onProceed}
               sectionType="googleMaps"
+              description="TODO"
             />
             <BlockItem
               label="FormSG"
               icon={BiQuestionMark}
               onProceed={onProceed}
               sectionType="formsg"
+              description="TODO"
             />
           </BlockList>
         </Section>

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -216,7 +216,7 @@ const ComponentSelector = ({ onClose, onProceed }: ComponentSelectorProps) => {
           <SectionTitle title="External Content" />
           <BlockList>
             <BlockItem
-              label="Youtube"
+              label="YouTube"
               icon={BiMovie}
               onProceed={onProceed}
               sectionType="youtube"

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -1,0 +1,208 @@
+import { Flex, Text, VStack, Wrap } from '@chakra-ui/react'
+import { Button, IconButton } from '@opengovsg/design-system-react'
+import { IconType } from 'react-icons'
+import {
+  BiCard,
+  BiColumns,
+  BiDollar,
+  BiExpandVertical,
+  BiImage,
+  BiImages,
+  BiMap,
+  BiMovie,
+  BiQuestionMark,
+  BiRuler,
+  BiSolidHandUp,
+  BiSolidQuoteAltLeft,
+  BiText,
+  BiX,
+} from 'react-icons/bi'
+import { SectionType } from './types'
+
+const Section = ({ children }: React.PropsWithChildren) => {
+  return (
+    <VStack gap="0.5rem" alignItems={'start'}>
+      {children}
+    </VStack>
+  )
+}
+
+const SectionTitle = ({ title }: { title: string }) => {
+  return (
+    <Text textStyle={'subhead-3'} textColor="base.content.medium">
+      {title}
+    </Text>
+  )
+}
+
+const BlockList = ({ children }: React.PropsWithChildren) => {
+  return <Wrap spacing="0">{children}</Wrap>
+}
+
+const BlockItem = ({
+  icon: Icon,
+  label,
+  onProceed,
+  sectionType,
+}: {
+  icon: IconType
+  label: string
+  onProceed: (sectionType: SectionType) => void
+  sectionType: SectionType
+}) => {
+  return (
+    <Button
+      m="0.75rem"
+      w="6rem"
+      h="6rem"
+      variant="clear"
+      colorScheme="neutral"
+      onClick={() => onProceed(sectionType)}
+    >
+      <VStack gap="0.5rem" color="base.content.default">
+        <Icon size="1.25rem" />
+        <Text textStyle={'caption-1'}>{label}</Text>
+      </VStack>
+    </Button>
+  )
+}
+
+interface ComponentSelectorProps {
+  onClose: () => void
+  onProceed: (sectionType: SectionType) => void
+}
+
+const ComponentSelector = ({ onClose, onProceed }: ComponentSelectorProps) => {
+  return (
+    <VStack w="full" gap="0">
+      <Flex
+        w="full"
+        py="1.25rem"
+        px="2rem"
+        alignItems={'center'}
+        justifyContent={'space-between'}
+        borderBottom={'solid'}
+        borderWidth={'1px'}
+        borderColor={'base.divider.medium'}
+      >
+        <VStack alignItems={'start'}>
+          <Text as={'h5'} textStyle={'h5'}>
+            Add a new block
+          </Text>
+          <Text textStyle={'body-2'}>Click a block to add to the page</Text>
+        </VStack>
+        <IconButton
+          size="lg"
+          variant="clear"
+          colorScheme="neutral"
+          color="interaction.sub.default"
+          aria-label="Close add component"
+          icon={<BiX />}
+          onClick={onClose}
+        />
+      </Flex>
+      <VStack p="2rem" w="full" gap="1.25rem" alignItems={'start'}>
+        <Section>
+          <SectionTitle title="Basic Building Blocks" />
+          <BlockList>
+            <BlockItem
+              label="Paragraph"
+              icon={BiText}
+              onProceed={onProceed}
+              sectionType="paragraph"
+            />
+            <BlockItem
+              label="Image"
+              icon={BiImage}
+              onProceed={onProceed}
+              sectionType="image"
+            />
+          </BlockList>
+        </Section>
+        <Section>
+          <SectionTitle title="Highlight Important Information" />
+          <BlockList>
+            <BlockItem
+              label="Statistics"
+              icon={BiDollar}
+              onProceed={onProceed}
+              sectionType="statistics"
+            />
+            <BlockItem
+              label="Callout"
+              icon={BiSolidQuoteAltLeft}
+              onProceed={onProceed}
+              sectionType="callout"
+            />
+            <BlockItem
+              label="Text with button"
+              icon={BiSolidHandUp}
+              onProceed={onProceed}
+              sectionType="textWithButton"
+            />
+            <BlockItem
+              label="Text with image"
+              icon={BiImages}
+              onProceed={onProceed}
+              sectionType="textWithImage"
+            />
+          </BlockList>
+        </Section>
+        <Section>
+          <SectionTitle title="Organise Content" />
+          <BlockList>
+            <BlockItem
+              label="Cards"
+              icon={BiCard}
+              onProceed={onProceed}
+              sectionType="cards"
+            />
+            <BlockItem
+              label="Columns"
+              icon={BiColumns}
+              onProceed={onProceed}
+              sectionType="columns"
+            />
+            <BlockItem
+              label="Accordion"
+              icon={BiExpandVertical}
+              onProceed={onProceed}
+              sectionType="accordion"
+            />
+            <BlockItem
+              label="Divider"
+              icon={BiRuler}
+              onProceed={onProceed}
+              sectionType="divider"
+            />
+          </BlockList>
+        </Section>
+        <Section>
+          <SectionTitle title="External Content" />
+          <BlockList>
+            <BlockItem
+              label="Youtube"
+              icon={BiMovie}
+              onProceed={onProceed}
+              sectionType="youtube"
+            />
+            <BlockItem
+              label="Google Maps"
+              icon={BiMap}
+              onProceed={onProceed}
+              sectionType="googleMaps"
+            />
+            <BlockItem
+              label="FormSG"
+              icon={BiQuestionMark}
+              onProceed={onProceed}
+              sectionType="formsg"
+            />
+          </BlockList>
+        </Section>
+      </VStack>
+    </VStack>
+  )
+}
+
+export default ComponentSelector

--- a/apps/studio/src/components/PageEditor/Editor.tsx
+++ b/apps/studio/src/components/PageEditor/Editor.tsx
@@ -66,32 +66,6 @@ const Editor = ({ jsonSchema, editorValue, onChange }: any) => {
       onClose={() => console.log('close')}
       onProceed={(componentType) => console.log(componentType)}
     />
-    // <Box>
-    //   <ThemeProvider theme={jsonFormsTheme}>
-    //     <CssBaseline />
-    //     <Box
-    //       padding="0.5rem"
-    //       overflowY={'auto'}
-    //       maxH="full"
-    //       css={{
-    //         '& div': {
-    //           maxWidth: '100% !important', // Setting max-w-full with high specificity
-    //         },
-    //         '& div.MuiTabs-flexContainer': {
-    //           overflowX: 'auto',
-    //         },
-    //       }}
-    //     >
-    //       <JsonForms
-    //         schema={jsonSchema}
-    //         data={editorValue}
-    //         renderers={renderers}
-    //         cells={materialCells}
-    //         onChange={({ data }) => onChange(data)}
-    //       />
-    //     </Box>
-    //   </ThemeProvider>
-    // </Box>
   )
 }
 

--- a/apps/studio/src/components/PageEditor/Editor.tsx
+++ b/apps/studio/src/components/PageEditor/Editor.tsx
@@ -11,6 +11,7 @@ import MainTiptapEditor from './MainTipTapEditor'
 import { ThemeProvider, CssBaseline } from '@mui/material'
 import { createTheme } from '@mui/material/styles'
 import { Box } from '@chakra-ui/react'
+import ComponentSelector from './ComponentSelector'
 
 const jsonFormsTheme = createTheme()
 
@@ -61,32 +62,36 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
 
 const Editor = ({ jsonSchema, editorValue, onChange }: any) => {
   return (
-    <Box>
-      <ThemeProvider theme={jsonFormsTheme}>
-        <CssBaseline />
-        <Box
-          padding="0.5rem"
-          overflowY={'auto'}
-          maxH="full"
-          css={{
-            '& div': {
-              maxWidth: '100% !important', // Setting max-w-full with high specificity
-            },
-            '& div.MuiTabs-flexContainer': {
-              overflowX: 'auto',
-            },
-          }}
-        >
-          <JsonForms
-            schema={jsonSchema}
-            data={editorValue}
-            renderers={renderers}
-            cells={materialCells}
-            onChange={({ data }) => onChange(data)}
-          />
-        </Box>
-      </ThemeProvider>
-    </Box>
+    <ComponentSelector
+      onClose={() => console.log('close')}
+      onProceed={(componentType) => console.log(componentType)}
+    />
+    // <Box>
+    //   <ThemeProvider theme={jsonFormsTheme}>
+    //     <CssBaseline />
+    //     <Box
+    //       padding="0.5rem"
+    //       overflowY={'auto'}
+    //       maxH="full"
+    //       css={{
+    //         '& div': {
+    //           maxWidth: '100% !important', // Setting max-w-full with high specificity
+    //         },
+    //         '& div.MuiTabs-flexContainer': {
+    //           overflowX: 'auto',
+    //         },
+    //       }}
+    //     >
+    //       <JsonForms
+    //         schema={jsonSchema}
+    //         data={editorValue}
+    //         renderers={renderers}
+    //         cells={materialCells}
+    //         onChange={({ data }) => onChange(data)}
+    //       />
+    //     </Box>
+    //   </ThemeProvider>
+    // </Box>
   )
 }
 

--- a/apps/studio/src/components/PageEditor/types.ts
+++ b/apps/studio/src/components/PageEditor/types.ts
@@ -4,3 +4,18 @@ export interface CustomRendererProps {
   handleChange(path: string, value: any): void
   path: string
 }
+
+export type SectionType =
+  | 'paragraph'
+  | 'image'
+  | 'statistics'
+  | 'callout'
+  | 'textWithButton'
+  | 'textWithImage'
+  | 'cards'
+  | 'columns'
+  | 'accordion'
+  | 'divider'
+  | 'youtube'
+  | 'googleMaps'
+  | 'formsg'


### PR DESCRIPTION
## Problem
This PR introduces the block drawer state. The popover state for each block is currently WIP, pending design - the text will be added in a future PR.

<img width="756" alt="Screenshot 2024-06-18 at 12 06 08 PM" src="https://github.com/opengovsg/isomer/assets/22111124/27752adf-6730-457c-8933-518f816ff01a">

Reference: [figma](https://www.figma.com/design/g7LnLn4IUcUC9dYxgsHEJM/IsomerCMS-V2-(working-title%3A-%22Isomer-Studio%22)?node-id=5727-31436&m=dev)
