### PR TITLE
chore: rename keys from kebab-case to camelCase

### DIFF
--- a/docs/next/0.1.0.json
+++ b/docs/next/0.1.0.json
@@ -32,7 +32,7 @@
     }
   ],
   "definitions": {
-    "content-components": {
+    "contentComponents": {
       "type": "array",
       "minItems": 1,
       "items": {
@@ -51,6 +51,9 @@
           },
           {
             "$ref": "#/components/complex/iframe"
+          },
+          {
+            "$ref": "#/components/complex/image"
           },
           {
             "$ref": "#/components/complex/infobar"
@@ -74,9 +77,6 @@
             "$ref": "#/components/native/heading"
           },
           {
-            "$ref": "#/components/native/image"
-          },
-          {
             "$ref": "#/components/native/orderedlist"
           },
           {
@@ -91,7 +91,7 @@
         ]
       }
     },
-    "page-metadata": {
+    "pageMetadata": {
       "type": "object",
       "required": ["title"],
       "properties": {
@@ -125,14 +125,14 @@
         "page": {
           "allOf": [
             {
-              "$ref": "#/definitions/page-metadata"
+              "$ref": "#/definitions/pageMetadata"
             }
           ]
         },
         "content": {
           "type": "array",
           "title": "Page content",
-          "$ref": "#/definitions/content-components"
+          "$ref": "#/definitions/contentComponents"
         }
       }
     },
@@ -149,14 +149,14 @@
         "page": {
           "allOf": [
             {
-              "$ref": "#/definitions/page-metadata"
+              "$ref": "#/definitions/pageMetadata"
             },
             {
               "type": "object",
               "required": ["contentPageHeader"],
               "properties": {
                 "contentPageHeader": {
-                  "$ref": "#/components/internal/contentpageheader"
+                  "$ref": "#/components/internal/contentPageHeader"
                 }
               }
             }
@@ -165,7 +165,7 @@
         "content": {
           "type": "array",
           "title": "Page content",
-          "$ref": "#/definitions/content-components"
+          "$ref": "#/definitions/contentComponents"
         }
       }
     },
@@ -182,7 +182,7 @@
         "page": {
           "allOf": [
             {
-              "$ref": "#/definitions/page-metadata"
+              "$ref": "#/definitions/pageMetadata"
             },
             {
               "type": "object",
@@ -232,7 +232,7 @@
         "page": {
           "allOf": [
             {
-              "$ref": "#/definitions/page-metadata"
+              "$ref": "#/definitions/pageMetadata"
             },
             {
               "type": "object",
@@ -248,10 +248,10 @@
                   "title": "Date of the article"
                 },
                 "image": {
-                  "$ref": "#/components/internal/image-collection-card"
+                  "$ref": "#/components/internal/imageCollectionCard"
                 },
                 "articlePageHeader": {
-                  "$ref": "#/components/internal/articlepageheader"
+                  "$ref": "#/components/internal/articlePageHeader"
                 }
               }
             }
@@ -260,7 +260,7 @@
         "content": {
           "type": "array",
           "title": "Page content",
-          "$ref": "#/definitions/content-components"
+          "$ref": "#/definitions/contentComponents"
         }
       }
     },
@@ -277,7 +277,7 @@
         "page": {
           "allOf": [
             {
-              "$ref": "#/definitions/page-metadata"
+              "$ref": "#/definitions/pageMetadata"
             },
             {
               "required": ["ref", "category", "date"],
@@ -297,7 +297,7 @@
                   "title": "Date of the file item"
                 },
                 "image": {
-                  "$ref": "#/components/internal/image-collection-card"
+                  "$ref": "#/components/internal/imageCollectionCard"
                 }
               }
             }
@@ -329,7 +329,7 @@
         "page": {
           "allOf": [
             {
-              "$ref": "#/definitions/page-metadata"
+              "$ref": "#/definitions/pageMetadata"
             },
             {
               "required": ["ref", "category", "date"],
@@ -349,7 +349,7 @@
                   "title": "Date of the link item"
                 },
                 "image": {
-                  "$ref": "#/components/internal/image-collection-card"
+                  "$ref": "#/components/internal/imageCollectionCard"
                 }
               }
             }
@@ -395,13 +395,13 @@
             "items": {
               "anyOf": [
                 {
+                  "$ref": "#/components/complex/image"
+                },
+                {
                   "$ref": "#/components/native/divider"
                 },
                 {
                   "$ref": "#/components/native/heading"
-                },
-                {
-                  "$ref": "#/components/native/image"
                 },
                 {
                   "$ref": "#/components/native/orderedlist"
@@ -496,13 +496,13 @@
             "items": {
               "anyOf": [
                 {
+                  "$ref": "#/components/complex/image"
+                },
+                {
                   "$ref": "#/components/native/divider"
                 },
                 {
                   "$ref": "#/components/native/heading"
-                },
-                {
-                  "$ref": "#/components/native/image"
                 },
                 {
                   "$ref": "#/components/native/orderedlist"
@@ -535,28 +535,28 @@
         },
         "oneOf": [
           {
-            "$ref": "#/components/internal/hero-side"
+            "$ref": "#/components/internal/heroSide"
           },
           {
-            "$ref": "#/components/internal/hero-image"
+            "$ref": "#/components/internal/heroImage"
           },
           {
-            "$ref": "#/components/internal/hero-floating"
+            "$ref": "#/components/internal/heroFloating"
           },
           {
-            "$ref": "#/components/internal/hero-center"
+            "$ref": "#/components/internal/heroCenter"
           },
           {
-            "$ref": "#/components/internal/hero-gradient"
+            "$ref": "#/components/internal/heroGradient"
           },
           {
-            "$ref": "#/components/internal/hero-split"
+            "$ref": "#/components/internal/heroSplit"
           },
           {
-            "$ref": "#/components/internal/hero-copyled"
+            "$ref": "#/components/internal/heroCopyled"
           },
           {
-            "$ref": "#/components/internal/hero-floatingimage"
+            "$ref": "#/components/internal/heroFloatingImage"
           }
         ]
       },
@@ -580,6 +580,40 @@
             "type": "string",
             "title": "Iframe content",
             "description": "The full iframe embed code to display, should only contain the <iframe> tag"
+          }
+        }
+      },
+      "image": {
+        "type": "object",
+        "title": "Image component",
+        "required": ["type", "src", "alt"],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["image"],
+            "default": "image"
+          },
+          "src": {
+            "type": "string",
+            "title": "Image URL",
+            "description": "The URL to the image to display"
+          },
+          "alt": {
+            "type": "string",
+            "title": "Image alt text",
+            "description": "The alt text for the image"
+          },
+          "width": {
+            "type": "number",
+            "title": "Image width",
+            "description": "The width of the image",
+            "exclusiveMinimum": 0,
+            "maximum": 100
+          },
+          "href": {
+            "type": "string",
+            "title": "URL Link",
+            "description": "The URL to link the image to"
           }
         }
       },
@@ -879,7 +913,7 @@
       }
     },
     "internal": {
-      "articlepageheader": {
+      "articlePageHeader": {
         "type": "object",
         "title": "Article page header",
         "description": "The article page header is used to display the title, summary, breadcrumbs, category and date of an article page.",
@@ -895,7 +929,7 @@
           }
         }
       },
-      "contentpageheader": {
+      "contentPageHeader": {
         "type": "object",
         "title": "Content page header",
         "description": "The content page header is used to display the title, summary, and breadcrumbs of a content page.",
@@ -918,7 +952,7 @@
           }
         }
       },
-      "hero-side": {
+      "heroSide": {
         "type": "object",
         "title": "Hero side variant",
         "required": ["variant", "title", "backgroundUrl"],
@@ -977,7 +1011,7 @@
             "enum": ["sm", "md"]
           },
           "dropdown": {
-            "$ref": "#/components/internal/hero-dropdown"
+            "$ref": "#/components/internal/heroDropdown"
           },
           "backgroundUrl": {
             "type": "string",
@@ -985,11 +1019,11 @@
             "description": "The URL to the background image"
           },
           "keyHighlights": {
-            "$ref": "#/components/internal/hero-key-highlights"
+            "$ref": "#/components/internal/heroKeyHighlights"
           }
         }
       },
-      "hero-image": {
+      "heroImage": {
         "type": "object",
         "title": "Hero image variant",
         "required": ["image", "backgroundUrl"],
@@ -1005,14 +1039,14 @@
             "description": "The URL to the background image"
           },
           "keyHighlights": {
-            "$ref": "#/components/internal/hero-key-highlights"
+            "$ref": "#/components/internal/heroKeyHighlights"
           },
           "dropdown": {
-            "$ref": "#/components/internal/hero-dropdown"
+            "$ref": "#/components/internal/heroDropdown"
           }
         }
       },
-      "hero-floating": {
+      "heroFloating": {
         "type": "object",
         "title": "Hero floating variant",
         "required": ["variant", "title", "backgroundUrl"],
@@ -1071,7 +1105,7 @@
             "enum": ["sm", "md"]
           },
           "dropdown": {
-            "$ref": "#/components/internal/hero-dropdown"
+            "$ref": "#/components/internal/heroDropdown"
           },
           "backgroundUrl": {
             "type": "string",
@@ -1079,11 +1113,11 @@
             "description": "The URL to the background image"
           },
           "keyHighlights": {
-            "$ref": "#/components/internal/hero-key-highlights"
+            "$ref": "#/components/internal/heroKeyHighlights"
           }
         }
       },
-      "hero-center": {
+      "heroCenter": {
         "type": "object",
         "title": "Hero center variant",
         "required": ["variant", "title", "backgroundUrl"],
@@ -1129,14 +1163,14 @@
             "description": "The URL to the background image"
           },
           "keyHighlights": {
-            "$ref": "#/components/internal/hero-key-highlights"
+            "$ref": "#/components/internal/heroKeyHighlights"
           },
           "dropdown": {
-            "$ref": "#/components/internal/hero-dropdown"
+            "$ref": "#/components/internal/heroDropdown"
           }
         }
       },
-      "hero-gradient": {
+      "heroGradient": {
         "type": "object",
         "title": "Hero gradient variant",
         "required": ["variant", "title", "backgroundUrl"],
@@ -1189,7 +1223,7 @@
           }
         }
       },
-      "hero-split": {
+      "heroSplit": {
         "type": "object",
         "title": "Hero split variant",
         "required": ["variant", "title", "backgroundUrl"],
@@ -1248,7 +1282,7 @@
           }
         }
       },
-      "hero-copyled": {
+      "heroCopyled": {
         "type": "object",
         "title": "Hero copy-led variant",
         "required": ["variant", "title"],
@@ -1295,7 +1329,7 @@
           }
         }
       },
-      "hero-floatingimage": {
+      "heroFloatingImage": {
         "type": "object",
         "title": "Hero floating image variant",
         "required": ["variant", "title", "backgroundUrl"],
@@ -1342,7 +1376,7 @@
           }
         }
       },
-      "hero-dropdown": {
+      "heroDropdown": {
         "type": "object",
         "title": "Hero dropdown component",
         "required": ["options"],
@@ -1374,7 +1408,7 @@
           }
         }
       },
-      "hero-key-highlights": {
+      "heroKeyHighlights": {
         "type": "array",
         "title": "Hero key highlights component",
         "required": ["title", "url"],
@@ -1401,7 +1435,7 @@
           }
         }
       },
-      "image-collection-card": {
+      "imageCollectionCard": {
         "type": "object",
         "title": "Image for collection card",
         "description": "An optional image to include in the collection card.",
@@ -1454,40 +1488,6 @@
             "title": "Heading level",
             "description": "The level of the heading to use",
             "enum": [2, 3, 4, 5, 6]
-          }
-        }
-      },
-      "image": {
-        "type": "object",
-        "title": "Image component",
-        "required": ["type", "src", "alt"],
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": ["image"],
-            "default": "image"
-          },
-          "src": {
-            "type": "string",
-            "title": "Image URL",
-            "description": "The URL to the image to display"
-          },
-          "alt": {
-            "type": "string",
-            "title": "Image alt text",
-            "description": "The alt text for the image"
-          },
-          "width": {
-            "type": "number",
-            "title": "Image width",
-            "description": "The width of the image",
-            "exclusiveMinimum": 0,
-            "maximum": 100
-          },
-          "href": {
-            "type": "string",
-            "title": "URL Link",
-            "description": "The URL to link the image to"
           }
         }
       },
@@ -1601,7 +1601,7 @@
                     "title": "Table header cells",
                     "minItems": 1,
                     "items": {
-                      "$ref": "#/components/native/table-header-cell"
+                      "$ref": "#/components/native/tableHeaderCell"
                     }
                   }
                 }
@@ -1624,7 +1624,7 @@
                       "title": "Table header cells",
                       "minItems": 1,
                       "items": {
-                        "$ref": "#/components/native/table-header-cell"
+                        "$ref": "#/components/native/tableHeaderCell"
                       }
                     }
                   }
@@ -1644,7 +1644,7 @@
                       "title": "Table cells",
                       "minItems": 1,
                       "items": {
-                        "$ref": "#/components/native/table-cell"
+                        "$ref": "#/components/native/tableCell"
                       }
                     }
                   }
@@ -1654,7 +1654,7 @@
           }
         }
       },
-      "table-cell": {
+      "tableCell": {
         "type": "object",
         "title": "Table cell",
         "required": ["type", "content"],
@@ -1672,10 +1672,10 @@
             "items": {
               "anyOf": [
                 {
-                  "$ref": "#/components/native/divider"
+                  "$ref": "#/components/complex/image"
                 },
                 {
-                  "$ref": "#/components/native/image"
+                  "$ref": "#/components/native/divider"
                 },
                 {
                   "$ref": "#/components/native/paragraph"
@@ -1703,7 +1703,7 @@
           }
         }
       },
-      "table-header-cell": {
+      "tableHeaderCell": {
         "type": "object",
         "title": "Table header cell",
         "required": ["type", "content"],


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1196.
Closes ISOM-1197.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Moved image component from native to complex component
- Renamed keys that were using kebab-case to camelCase

**Notes**:

- No changes are needed on mti-corp or other repos as the changes are only internally referenced by the schema. The page schemas uses the `type` key which were not renamed.
- **FOR FEEDBACK**: Decided to keep component names (referenced by the page schemas) to be lowercase (i.e. `unorderedlist` instead of `unorderedList`) for simplicity. Let me know if this approach is sane or we should use camelCase as much as possible.