### PR TITLE
Rudimentary endpoint for getting a folder/site's content

### DIFF
--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -13,8 +13,7 @@ export const createFolderSchema = z.object({
   parentFolderId: z.string().nullable(),
 })
 
-export const readFolderOrTopLevelFolderSchema = z.object({
-    // Null resourceId indicates reading of top level folder in a site.
-    siteId: z.string(),
-    resourceId: z.string().nullable()
+export const readFolderSchema = z.object({
+  siteId: z.string(),
+  resourceId: z.string(),
 })

--- a/apps/studio/src/server/modules/_app.ts
+++ b/apps/studio/src/server/modules/_app.ts
@@ -5,12 +5,14 @@ import { publicProcedure, router } from '../trpc'
 import { meRouter } from './me/me.router'
 import { authRouter } from './auth/auth.router'
 import { pageRouter } from './page/page.router'
+import { folderRouter } from './folder/folder.router'
 
 export const appRouter = router({
   healthcheck: publicProcedure.query(() => 'yay!'),
   me: meRouter,
   auth: authRouter,
   page: pageRouter,
+  folder: folderRouter,
 })
 
 export type AppRouter = typeof appRouter

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -47,8 +47,9 @@ export const folderRouter = router({
             id: c.id,
             name: c.name,
             type: 'page',
-            lastEditedDate: new Date(),
-            lastEditedUser: 'Coming Soon',
+            lastEditDate: new Date(),
+            lastEditUser: 'Coming Soon',
+            permalink: '/placeholder',
           }
         }
         return {
@@ -57,6 +58,7 @@ export const folderRouter = router({
           type: 'folder',
           lastEditDate: 'folder',
           lastEditUser: 'Coming Soon',
+          permalink: '/placeholder',
         }
       })
 

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,9 +1,6 @@
 /* eslint-disable import/prefer-default-export */
 import { protectedProcedure, router } from '~/server/trpc'
-import {
-  createFolderSchema,
-  readFolderOrTopLevelFolderSchema,
-} from '~/schemas/folder'
+import { createFolderSchema, readFolderSchema } from '~/schemas/folder'
 
 export const folderRouter = router({
   create: protectedProcedure
@@ -11,61 +8,23 @@ export const folderRouter = router({
     .mutation(async ({ ctx, input }) => {
       return { folderId: '' }
     }),
-  readFolderOrTopLevelFolder: protectedProcedure
-    .input(readFolderOrTopLevelFolderSchema)
+  readFolder: protectedProcedure
+    .input(readFolderSchema)
     .query(async ({ ctx, input }) => {
       // Things that aren't working yet:
       // 0. Perm checking
       // 1. Last Edited user and time
       // 2. Page status(draft, published)
-      if (input.resourceId) {
-        // Non-root level lookup
-        const folderResult = await ctx.db
-          .selectFrom('Resource')
-          .select(['name', 'parentId'])
-          .where('id', '=', input.resourceId)
-          .executeTakeFirstOrThrow()
-        const childrenResult = await ctx.db
-          .selectFrom('Resource')
-          .select(['id', 'name', 'blobId'])
-          .where('parentId', '=', input.resourceId)
-          .execute()
-        const children = childrenResult.map((c) => {
-          if (c.blobId) {
-            return {
-              id: c.id,
-              name: c.name,
-              type: 'page',
-              lastEditDate: new Date(0),
-              lastEditUser: 'Coming Soon',
-              permalink: '/placeholder',
-              status: 'published',
-            }
-          }
-          return {
-            id: c.id,
-            name: c.name,
-            type: 'folder',
-            lastEditDate: 'folder',
-            lastEditUser: 'Coming Soon',
-            permalink: '/placeholder',
-            status: 'folder',
-          }
-        })
 
-        const { parentId } = folderResult
-        const folderName = folderResult.name
-
-        return {
-          folderName,
-          children,
-          parentId,
-        }
-      }
+      const folderResult = await ctx.db
+        .selectFrom('Resource')
+        .select(['name', 'parentId'])
+        .where('id', '=', input.resourceId)
+        .executeTakeFirstOrThrow()
       const childrenResult = await ctx.db
         .selectFrom('Resource')
         .select(['id', 'name', 'blobId'])
-        .where('parentId', 'is', null)
+        .where('parentId', '=', input.resourceId)
         .execute()
       const children = childrenResult.map((c) => {
         if (c.blobId) {
@@ -89,8 +48,9 @@ export const folderRouter = router({
           status: 'folder',
         }
       })
-      const parentId = null
-      const folderName = 'Root-level Site Folder'
+
+      const { parentId } = folderResult
+      const folderName = folderResult.name
 
       return {
         folderName,

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -18,12 +18,12 @@ export const folderRouter = router({
 
       const folderResult = await ctx.db
         .selectFrom('Resource')
-        .select(['name', 'parentId'])
+        .selectAll('Resource')
         .where('id', '=', input.resourceId)
         .executeTakeFirstOrThrow()
       const childrenResult = await ctx.db
         .selectFrom('Resource')
-        .select(['id', 'name', 'blobId'])
+        .selectAll('Resource')
         .where('parentId', '=', input.resourceId)
         .execute()
       const children = childrenResult.map((c) => {
@@ -42,10 +42,7 @@ export const folderRouter = router({
           id: c.id,
           name: c.name,
           type: 'folder',
-          lastEditDate: 'folder',
-          lastEditUser: 'Coming Soon',
           permalink: '/placeholder',
-          status: 'folder',
         }
       })
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [ISOM-1194](https://linear.app/ogp/issue/ISOM-1194/create-api-to-return-the-sites-pages), partially. This is just a simple endpoint that allows for testing of the site dashboard page with DB data. It is missing the following things which I have also added to a new ticket 1203(not linking it as linear might pick up on it): 

1. Currently, no permission checking is done.
2. Since there is no decided solution for storing page status, whether it's published or draft, this is not working yet(just returns published for now)
3. Similar to the above, there is no current decided solution for where the last edited information(datetime and user) is stored. Potentially, this could be stored as the diffs between edits, or somewhere in the db. Dummy data is fielded for this at the moment.

Lastly, in the future, since we are treating both folders and pages as resources, this could be integrated with the router for pages.

## Solution

<!-- How did you solve the problem? -->
Modifies the current folder router's readFolderOrTopLevelFolder procedure(tRPC).

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible
