### PR TITLE
Fix turbo json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,9 +1,11 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env", "tsconfig.json"],
-  "pipeline": {
+  "globalEnv": ["NODE_ENV"],
+  "tasks": {
     "build": {
-      "outputs": [".next/**", "!.next/cache/**"]
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "clean": {},
     "dev": {

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "globalDependencies": ["**/.env", "tsconfig.json"],
   "globalEnv": ["NODE_ENV"],
-  "tasks": {
+  "pipeline": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]


### PR DESCRIPTION
## Problem

Current turbo.json missed out the dependency we have on the isomer-components package. Hence, this causes `turbo build` to fail.

## Solution

Add the `^build` so that turbo will build the packages by starting with the one that has no internal dependencies and walk its way up the tree. Can go through https://turbo.build/repo/docs/reference/configuration for more info.

Also adds some minor changes to add `dist` as a output for caching purpose, and globalEnv configs.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible
