### PR TITLE
chore: update report vulnerability link

### DIFF
--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -194,7 +194,7 @@ const LegalSection = ({
           {isGovernment && (
             <FooterItem
               title="Report Vulnerability"
-              url="https://tech.gov.sg/report_vulnerability"
+              url="https://tech.gov.sg/report-vulnerability"
               LinkComponent={LinkComponent}
             />
           )}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

GovTech has updated their report vulnerability link since they have migrated to Isomer Classic.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Updated the link to point to https://www.tech.gov.sg/report-vulnerability
