### PR TITLE
feat: add placeholders for array, oneOf and prose inputs

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -1,0 +1,11 @@
+export const JSON_FORMS_RANKING = {
+  ArrayControl: 3,
+  BooleanControl: 2,
+  DropdownControl: 2,
+  IntegerControl: 4,
+  TextControl: 1,
+  OneOfControl: 3,
+  ProseControl: 2,
+  RadioControl: 3,
+  VerticalLayoutRenderer: 1,
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -5,12 +5,18 @@ import { useState } from 'react'
 import IsomerSchema from '../../data/0.1.0.json'
 
 import {
+  JsonFormsArrayControl,
+  jsonFormsArrayControlTester,
   JsonFormsBooleanControl,
   jsonFormsBooleanControlTester,
   JsonFormsDropdownControl,
   jsonFormsDropdownControlTester,
   JsonFormsIntegerControl,
   jsonFormsIntegerControlTester,
+  JsonFormsOneOfControl,
+  jsonFormsOneOfControlTester,
+  JsonFormsProseControl,
+  jsonFormsProseControlTester,
   JsonFormsRadioControl,
   jsonFormsRadioControlTester,
   JsonFormsTextControl,
@@ -20,6 +26,7 @@ import {
 } from './renderers'
 
 const renderers: JsonFormsRendererRegistryEntry[] = [
+  { tester: jsonFormsArrayControlTester, renderer: JsonFormsArrayControl },
   { tester: jsonFormsBooleanControlTester, renderer: JsonFormsBooleanControl },
   {
     tester: jsonFormsDropdownControlTester,
@@ -27,6 +34,8 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
   },
   { tester: jsonFormsIntegerControlTester, renderer: JsonFormsIntegerControl },
   { tester: jsonFormsTextControlTester, renderer: JsonFormsTextControl },
+  { tester: jsonFormsOneOfControlTester, renderer: JsonFormsOneOfControl },
+  { tester: jsonFormsProseControlTester, renderer: JsonFormsProseControl },
   { tester: jsonFormsRadioControlTester, renderer: JsonFormsRadioControl },
   {
     tester: jsonFormsVerticalLayoutTester,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
@@ -1,0 +1,44 @@
+import { Box, Heading } from '@chakra-ui/react'
+import {
+  createDefaultValue,
+  isObjectArrayControl,
+  rankWith,
+  type ArrayLayoutProps,
+  type RankedTester,
+} from '@jsonforms/core'
+import { withJsonFormsArrayLayoutProps } from '@jsonforms/react'
+import { Button } from '@opengovsg/design-system-react'
+
+export const jsonFormsArrayControlTester: RankedTester = rankWith(
+  3,
+  isObjectArrayControl,
+)
+
+export function JsonFormsArrayControl({
+  path,
+  label,
+  addItem,
+  schema,
+  rootSchema,
+}: ArrayLayoutProps) {
+  return (
+    <Box py={2}>
+      <Heading as="h3" size="sm" variant="subhead-1">
+        {label}
+      </Heading>
+
+      <p>Placeholder for drag-and-drop of objects</p>
+
+      <Button
+        onClick={addItem(path, createDefaultValue(schema, rootSchema))}
+        mt={3}
+        w="100%"
+        variant="outline"
+      >
+        Add item
+      </Button>
+    </Box>
+  )
+}
+
+export default withJsonFormsArrayLayoutProps(JsonFormsArrayControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
@@ -8,9 +8,10 @@ import {
 } from '@jsonforms/core'
 import { withJsonFormsArrayLayoutProps } from '@jsonforms/react'
 import { Button } from '@opengovsg/design-system-react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsArrayControlTester: RankedTester = rankWith(
-  3,
+  JSON_FORMS_RANKING.ArrayControl,
   isObjectArrayControl,
 )
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -11,9 +11,10 @@ import {
   FormLabel,
   Switch,
 } from '@opengovsg/design-system-react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsBooleanControlTester: RankedTester = rankWith(
-  2,
+  JSON_FORMS_RANKING.BooleanControl,
   isBooleanControl,
 )
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDropdownControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDropdownControl.tsx
@@ -23,10 +23,11 @@ export function JsonFormsDropdownControl({
   description,
   required,
   options,
+  schema,
 }: ControlProps & OwnPropsOfEnum) {
   const [dropdownValue, setDropdownValue] = useState(data || '')
 
-  if (!options) {
+  if (!options || (options.length === 1 && !!schema.default)) {
     return null
   }
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDropdownControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDropdownControl.tsx
@@ -9,9 +9,10 @@ import {
 import { withJsonFormsEnumProps } from '@jsonforms/react'
 import { FormLabel, SingleSelect } from '@opengovsg/design-system-react'
 import { useState } from 'react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsDropdownControlTester: RankedTester = rankWith(
-  2,
+  JSON_FORMS_RANKING.DropdownControl,
   isEnumControl,
 )
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
@@ -22,9 +22,10 @@ import {
   FormLabel,
   NumberInput,
 } from '@opengovsg/design-system-react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsIntegerControlTester: RankedTester = rankWith(
-  4,
+  JSON_FORMS_RANKING.IntegerControl,
   and(
     uiTypeIs('Control'),
     or(schemaTypeIs('integer'), schemaTypeIs('number')),

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsOneOfControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsOneOfControl.tsx
@@ -1,0 +1,74 @@
+import { Box, FormControl } from '@chakra-ui/react'
+import {
+  createCombinatorRenderInfos,
+  isOneOfControl,
+  rankWith,
+  type CombinatorRendererProps,
+  type RankedTester,
+} from '@jsonforms/core'
+import { JsonFormsDispatch, withJsonFormsOneOfProps } from '@jsonforms/react'
+import { FormLabel, SingleSelect } from '@opengovsg/design-system-react'
+import { useState } from 'react'
+
+export const jsonFormsOneOfControlTester: RankedTester = rankWith(
+  3,
+  isOneOfControl,
+)
+
+export function JsonFormsOneOfControl({
+  schema,
+  path,
+  renderers,
+  cells,
+  rootSchema,
+  uischema,
+  uischemas,
+  label,
+  description,
+}: CombinatorRendererProps) {
+  const oneOfRenderInfos = createCombinatorRenderInfos(
+    schema.oneOf || [],
+    rootSchema,
+    'oneOf',
+    uischema,
+    path,
+    uischemas,
+  )
+  const variants = oneOfRenderInfos.map((oneOfRenderInfo) => ({
+    label: oneOfRenderInfo.label,
+    value: oneOfRenderInfo.label,
+  }))
+
+  const [variant, setVariant] = useState(oneOfRenderInfos[0]?.label || '')
+
+  return (
+    <Box py={2}>
+      <FormControl isRequired>
+        <FormLabel description={description}>{label}</FormLabel>
+        <SingleSelect
+          value={variant}
+          name={label}
+          items={variants}
+          isClearable={false}
+          onChange={setVariant}
+        />
+      </FormControl>
+
+      {oneOfRenderInfos.map(
+        (oneOfRenderInfo) =>
+          variant === oneOfRenderInfo.label && (
+            <JsonFormsDispatch
+              key={oneOfRenderInfo.label}
+              uischema={oneOfRenderInfo.uischema}
+              schema={oneOfRenderInfo.schema}
+              path={path}
+              renderers={renderers}
+              cells={cells}
+            />
+          ),
+      )}
+    </Box>
+  )
+}
+
+export default withJsonFormsOneOfProps(JsonFormsOneOfControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsOneOfControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsOneOfControl.tsx
@@ -9,9 +9,10 @@ import {
 import { JsonFormsDispatch, withJsonFormsOneOfProps } from '@jsonforms/react'
 import { FormLabel, SingleSelect } from '@opengovsg/design-system-react'
 import { useState } from 'react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsOneOfControlTester: RankedTester = rankWith(
-  3,
+  JSON_FORMS_RANKING.OneOfControl,
   isOneOfControl,
 )
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
@@ -8,9 +8,10 @@ import {
 } from '@jsonforms/core'
 import { withJsonFormsControlProps } from '@jsonforms/react'
 import { FormLabel, Textarea } from '@opengovsg/design-system-react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsProseControlTester: RankedTester = rankWith(
-  2,
+  JSON_FORMS_RANKING.ProseControl,
   schemaMatches(
     (schema) => hasType(schema, 'array') && schema.format === 'prose',
   ),

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
@@ -1,0 +1,42 @@
+import { Box, FormControl } from '@chakra-ui/react'
+import {
+  hasType,
+  rankWith,
+  schemaMatches,
+  type ControlProps,
+  type RankedTester,
+} from '@jsonforms/core'
+import { withJsonFormsControlProps } from '@jsonforms/react'
+import { FormLabel, Textarea } from '@opengovsg/design-system-react'
+
+export const jsonFormsProseControlTester: RankedTester = rankWith(
+  2,
+  schemaMatches(
+    (schema) => hasType(schema, 'array') && schema.format === 'prose',
+  ),
+)
+
+// TODO: Replace this with the Tiptap editor
+export function JsonFormsProseControl({
+  data,
+  label,
+  handleChange,
+  path,
+  description,
+  required,
+}: ControlProps) {
+  return (
+    <Box py={2}>
+      <FormControl isRequired={required}>
+        <FormLabel description={description}>{label}</FormLabel>
+        <Textarea
+          value={data || ''}
+          onChange={(e) => handleChange(path, e.target.value)}
+          placeholder={label}
+        />
+      </FormControl>
+    </Box>
+  )
+}
+
+export default withJsonFormsControlProps(JsonFormsProseControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsRadioControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsRadioControl.tsx
@@ -10,9 +10,10 @@ import {
 } from '@jsonforms/core'
 import { withJsonFormsEnumProps } from '@jsonforms/react'
 import { FormLabel, Radio } from '@opengovsg/design-system-react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsRadioControlTester: RankedTester = rankWith(
-  3,
+  JSON_FORMS_RANKING.RadioControl,
   and(
     isEnumControl,
     schemaMatches((schema) => schema.format === 'radio'),

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
@@ -7,9 +7,10 @@ import {
 } from '@jsonforms/core'
 import { withJsonFormsControlProps } from '@jsonforms/react'
 import { FormLabel, Input } from '@opengovsg/design-system-react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsTextControlTester: RankedTester = rankWith(
-  1,
+  JSON_FORMS_RANKING.TextControl,
   isStringControl,
 )
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -1,4 +1,8 @@
 export {
+  default as JsonFormsArrayControl,
+  jsonFormsArrayControlTester,
+} from './JsonFormsArrayControl'
+export {
   default as JsonFormsBooleanControl,
   jsonFormsBooleanControlTester,
 } from './JsonFormsBooleanControl'
@@ -10,6 +14,14 @@ export {
   default as JsonFormsIntegerControl,
   jsonFormsIntegerControlTester,
 } from './JsonFormsIntegerControl'
+export {
+  default as JsonFormsOneOfControl,
+  jsonFormsOneOfControlTester,
+} from './JsonFormsOneOfControl'
+export {
+  default as JsonFormsProseControl,
+  jsonFormsProseControlTester,
+} from './JsonFormsProseControl'
 export {
   default as JsonFormsRadioControl,
   jsonFormsRadioControlTester,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
@@ -7,9 +7,10 @@ import {
   type RankedTester,
 } from '@jsonforms/core'
 import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
 
 export const jsonFormsVerticalLayoutTester: RankedTester = rankWith(
-  1,
+  JSON_FORMS_RANKING.VerticalLayoutRenderer,
   uiTypeIs('VerticalLayout'),
 )
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The JSONForms implementation do not support the array, oneOf and prose inputs.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add placeholders for these types of inputs. Full implementation will come in subsequent PRs.