### PR TITLE
feat(dnd): add dnd to preview

### DIFF
--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -1,3 +1,4 @@
+import { type IsomerComponent } from '@opengovsg/isomer-components'
 import React, {
   createContext,
   useState,
@@ -5,15 +6,15 @@ import React, {
   useMemo,
   type PropsWithChildren,
 } from 'react'
-import { type Block, type DrawerState } from '~/types/editorDrawer'
+import { type DrawerState } from '~/types/editorDrawer'
 
 export interface DrawerContextType {
   drawerState: DrawerState
   setDrawerState: (state: DrawerState) => void
-  pageState: Block[]
-  setPageState: (state: Block[]) => void
-  editorState: Block[]
-  setEditorState: (state: Block[]) => void
+  pageState: IsomerComponent[]
+  setPageState: (state: IsomerComponent[]) => void
+  editorState: IsomerComponent[]
+  setEditorState: (state: IsomerComponent[]) => void
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -22,9 +23,9 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
     state: 'root',
   })
   // Current saved state of page
-  const [pageState, setPageState] = useState<Block[]>([])
+  const [pageState, setPageState] = useState<IsomerComponent[]>([])
   // Current edit view of page
-  const [editorState, setEditorState] = useState<Block[]>([])
+  const [editorState, setEditorState] = useState<IsomerComponent[]>([])
 
   const value = useMemo(
     () => ({

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -1,18 +1,6 @@
-import { Text, VStack, HStack, Box, Divider, Spacer } from '@chakra-ui/react'
-import { useEffect, useState } from 'react'
-import {
-  DragDropContext,
-  Droppable,
-  Draggable,
-  DropResult,
-} from '@hello-pangea/dnd'
-import { MdOutlineDragIndicator } from 'react-icons/md'
-import { BsPlus } from 'react-icons/bs'
-import { Button } from '@opengovsg/design-system-react'
-import RootStateDrawer from './RootStateDrawer'
-import { type DrawerState } from '~/types/editorDrawer'
 import { useEditorDrawerContext } from '~/contexts/EditorDrawerContext'
 import ComponentSelector from '~/components/PageEditor/ComponentSelector'
+import RootStateDrawer from './RootStateDrawer'
 import TipTapComponent from './TipTapComponent'
 import ComplexEditorStateDrawer from './ComplexEditorStateDrawer'
 

--- a/apps/studio/src/features/editing-experience/components/Preview.tsx
+++ b/apps/studio/src/features/editing-experience/components/Preview.tsx
@@ -10,7 +10,7 @@ export interface PreviewProps {
     version: string
     layout: string
     page: any
-    content: IsomerPageSchema['content']
+    content: IsomerComponent
   }
 }
 

--- a/apps/studio/src/features/editing-experience/components/Preview.tsx
+++ b/apps/studio/src/features/editing-experience/components/Preview.tsx
@@ -1,21 +1,10 @@
 import {
-  type IsomerComponent,
   type IsomerPageSchema,
   RenderEngine,
 } from '@opengovsg/isomer-components'
 import { trpc } from '~/utils/trpc'
 
-export interface PreviewProps {
-  schema?: {
-    version: string
-    layout: string
-    page: any
-    content: IsomerComponent[]
-  }
-}
-
-export default function Preview({ schema }: PreviewProps) {
-  const renderSchema = schema!
+export default function Preview({ layout, content, page }: IsomerPageSchema) {
   const [{ theme, isGovernment, sitemap, name }] =
     trpc.site.getConfig.useSuspenseQuery({ id: 1 })
   const [{ content: footer }] = trpc.site.getFooter.useSuspenseQuery({
@@ -42,14 +31,10 @@ export default function Preview({ schema }: PreviewProps) {
         footerItems: footer,
       }}
       // @ts-expect-error blah
-      layout={renderSchema.layout}
-      page={{
-        ...renderSchema.page,
-        permalink: '/',
-        lastModified: new Date().toISOString(),
-      }}
+      layout={layout}
       // TODO: remove this cast and add validation
-      content={renderSchema.content}
+      content={content}
+      page={page}
     />
   )
 }

--- a/apps/studio/src/features/editing-experience/components/Preview.tsx
+++ b/apps/studio/src/features/editing-experience/components/Preview.tsx
@@ -10,7 +10,7 @@ export interface PreviewProps {
     version: string
     layout: string
     page: any
-    content: IsomerComponent
+    content: IsomerComponent[]
   }
 }
 
@@ -23,9 +23,6 @@ export default function Preview({ schema }: PreviewProps) {
   })
   const [{ content: navbar }] = trpc.site.getNavbar.useSuspenseQuery({
     id: 1,
-  })
-  const [{ content: page }] = trpc.page.readPageAndBlob.useSuspenseQuery({
-    pageId: 1,
   })
 
   return (
@@ -52,7 +49,7 @@ export default function Preview({ schema }: PreviewProps) {
         lastModified: new Date().toISOString(),
       }}
       // TODO: remove this cast and add validation
-      content={page.content}
+      content={renderSchema.content}
     />
   )
 }

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -68,8 +68,9 @@ export default function RootStateDrawer() {
                 <Box w="100%">
                   {pageState.map((block, index) => (
                     <Draggable
-                      key={block.id}
-                      draggableId={block.id}
+                      // TODO: Determine key + draggable id
+                      key={index}
+                      draggableId={`${block.type}-${index}`}
                       index={index}
                     >
                       {(provided) => (
@@ -97,7 +98,7 @@ export default function RootStateDrawer() {
                               }}
                             />
                             <Text px="3" fontWeight={500}>
-                              {block.text}
+                              {block.type}
                             </Text>
                           </HStack>
                           <Divider />

--- a/apps/studio/src/pages/dashboard/edit/index.tsx
+++ b/apps/studio/src/pages/dashboard/edit/index.tsx
@@ -10,71 +10,9 @@ import { trpc } from '~/utils/trpc'
 
 const ISOMER_SCHEMA_URI = 'https://schema.isomer.gov.sg/next/0.1.0.json'
 
-const placeholder = {
-  version: '0.1.0',
-  layout: 'homepage',
-  page: {
-    title: 'Home',
-  },
-  content: [
-    {
-      type: 'hero',
-      variant: 'gradient',
-      alignment: 'left',
-      backgroundColor: 'black',
-      title: 'Ministry of Trade and Industry',
-      subtitle:
-        'A leading global city of enterprise and talent, a vibrant nation of innovation and opportunity',
-      buttonLabel: 'Main CTA',
-      buttonUrl: '/',
-      secondaryButtonLabel: 'Sub CTA',
-      secondaryButtonUrl: '/',
-      backgroundUrl: 'https://ohno.isomer.gov.sg/images/hero-banner.png',
-    },
-    {
-      type: 'infobar',
-      title: 'This is an infobar',
-      description: 'This is the description that goes into the Infobar section',
-    },
-    {
-      type: 'infopic',
-      title: 'This is an infopic',
-      description: 'This is the description for the infopic component',
-      imageSrc: 'https://placehold.co/600x400',
-    },
-    {
-      type: 'keystatistics',
-      statistics: [
-        {
-          label: 'Average all nighters pulled in a typical calendar month',
-          value: '3',
-        },
-        {
-          label: 'Growth in tasks assigned Q4 2024 (YoY)',
-          value: '+12.2%',
-        },
-        {
-          label: 'Creative blocks met per single evening',
-          value: '89',
-        },
-        {
-          value: '4.0',
-          label: 'Number of lies in this stat block',
-        },
-      ],
-      variant: 'top',
-      title: 'Irrationality in numbers',
-    },
-  ],
-}
-
 const EditPage: NextPageWithLayout = () => {
-  const [, setEditedSchema] = useState<any>(placeholder)
-  const [, setIsJSONValid] = useState(true)
-
-  const [isCopied, setIsCopied] = useState(false)
-  const [, setJsonSchema] = useState<any>(null)
-  const [validate, setValidate] = useState<any>(null)
+  const [, setJsonSchema] = useState(null)
+  const [validate, setValidate] = useState(null)
 
   const { setDrawerState, pageState, setPageState, setEditorState } =
     useEditorDrawerContext()
@@ -83,6 +21,7 @@ const EditPage: NextPageWithLayout = () => {
     pageId: 1,
   })
 
+  // TODO: should be a get query
   const loadSchema = async () => {
     await fetch(ISOMER_SCHEMA_URI)
       .then((response) => response.json())
@@ -95,53 +34,11 @@ const EditPage: NextPageWithLayout = () => {
       })
   }
 
-  const handleEditorChange = (value: any) => {
-    setEditorState(value)
-
-    try {
-      const parsedJson = JSON.parse(value)
-
-      if (validate === null) {
-        console.log('Schema not loaded yet')
-        return
-      }
-
-      if (validate(parsedJson)) {
-        setIsJSONValid(true)
-        setEditedSchema(parsedJson)
-      } else {
-        setIsJSONValid(false)
-        console.log('JSON is invalid', validate.errors)
-      }
-    } catch (e) {
-      setIsJSONValid(false)
-      console.log(e)
-    }
-  }
-
   useEffect(() => {
     if (validate === null) {
       loadSchema()
     }
-
-    const saved = localStorage.getItem('editorValue')
-
-    if (saved) {
-      handleEditorChange(saved)
-    }
-
-    const savedNew = localStorage.getItem('newEditorValue')
-
-    if (savedNew) {
-      handleNewEditorChange(saved)
-    }
   }, [validate])
-
-  useEffect(() => {
-    if (isCopied) {
-      setTimeout(() => setIsCopied(false), 3000)
-    }
-  }, [isCopied])
 
   useEffect(() => {
     setDrawerState({
@@ -165,13 +62,9 @@ const EditPage: NextPageWithLayout = () => {
       </GridItem>
       {/* TODO: Implement preview */}
       <GridItem colSpan={2} overflow="scroll">
-        <Preview
-          schema={{
-            content: pageState,
-            version: page.version,
-            layout: page.layout,
-          }}
-        />
+        {/* TODO: the version here should be obtained from the schema  */}
+        {/* and not from the page */}
+        <Preview {...page} content={pageState} />
       </GridItem>
     </Grid>
   )

--- a/apps/studio/src/pages/dashboard/edit/index.tsx
+++ b/apps/studio/src/pages/dashboard/edit/index.tsx
@@ -69,32 +69,16 @@ const placeholder = {
 }
 
 const EditPage: NextPageWithLayout = () => {
-  const [isEditorOpen, setIsEditorOpen] = useState(true)
-  const [editedSchema, setEditedSchema] = useState<any>(placeholder)
-  const [isJSONValid, setIsJSONValid] = useState(true)
-  const [isNewEditor, setIsNewEditor] = useState(false)
+  const [, setEditedSchema] = useState<any>(placeholder)
+  const [, setIsJSONValid] = useState(true)
 
   const [isCopied, setIsCopied] = useState(false)
-  const [jsonSchema, setJsonSchema] = useState<any>(null)
+  const [, setJsonSchema] = useState<any>(null)
   const [validate, setValidate] = useState<any>(null)
 
-  const {
-    drawerState,
-    setDrawerState,
-    pageState,
-    setPageState,
-    editorState,
-    setEditorState,
-  } = useEditorDrawerContext()
+  const { setDrawerState, pageState, setPageState, setEditorState } =
+    useEditorDrawerContext()
 
-  const [{ theme, isGovernment, sitemap, name }] =
-    trpc.site.getConfig.useSuspenseQuery({ id: 1 })
-  const [{ content: footer }] = trpc.site.getFooter.useSuspenseQuery({
-    id: 1,
-  })
-  const [{ content: navbar }] = trpc.site.getNavbar.useSuspenseQuery({
-    id: 1,
-  })
   const [{ content: page }] = trpc.page.readPageAndBlob.useSuspenseQuery({
     pageId: 1,
   })
@@ -109,6 +93,30 @@ const EditPage: NextPageWithLayout = () => {
         setJsonSchema(schema)
         setValidate(() => validateFn)
       })
+  }
+
+  const handleEditorChange = (value: any) => {
+    setEditorState(value)
+
+    try {
+      const parsedJson = JSON.parse(value)
+
+      if (validate === null) {
+        console.log('Schema not loaded yet')
+        return
+      }
+
+      if (validate(parsedJson)) {
+        setIsJSONValid(true)
+        setEditedSchema(parsedJson)
+      } else {
+        setIsJSONValid(false)
+        console.log('JSON is invalid', validate.errors)
+      }
+    } catch (e) {
+      setIsJSONValid(false)
+      console.log(e)
+    }
   }
 
   useEffect(() => {
@@ -134,54 +142,6 @@ const EditPage: NextPageWithLayout = () => {
       setTimeout(() => setIsCopied(false), 3000)
     }
   }, [isCopied])
-
-  const handleEditorChange = (value: any) => {
-    setEditorState(value)
-    localStorage.setItem('editorValue', value)
-
-    try {
-      const parsedJson = JSON.parse(value)
-
-      if (validate === null) {
-        console.log('Schema not loaded yet')
-        return
-      }
-
-      if (validate(parsedJson)) {
-        setIsJSONValid(true)
-        setEditedSchema(parsedJson)
-      } else {
-        setIsJSONValid(false)
-        console.log('JSON is invalid', validate.errors)
-      }
-    } catch (e) {
-      setIsJSONValid(false)
-      console.log(e)
-    }
-  }
-
-  const handleNewEditorChange = (value: any) => {
-    setEditorState(value)
-    localStorage.setItem('newEditorValue', value)
-
-    try {
-      if (validate === null) {
-        console.log('Schema not loaded yet')
-        return
-      }
-
-      if (validate(value)) {
-        setIsJSONValid(true)
-        setEditedSchema(value)
-      } else {
-        setIsJSONValid(false)
-        console.log('JSON is invalid', validate.errors)
-      }
-    } catch (e) {
-      setIsJSONValid(false)
-      console.log(e)
-    }
-  }
 
   useEffect(() => {
     setDrawerState({

--- a/apps/studio/src/pages/dashboard/edit/index.tsx
+++ b/apps/studio/src/pages/dashboard/edit/index.tsx
@@ -180,7 +180,7 @@ const EditPage: NextPageWithLayout = () => {
     ]
     setEditorState(blocks)
     setPageState(blocks)
-  }, [])
+  }, [setDrawerState, setEditorState, setPageState])
 
   return (
     <Grid

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -1,4 +1,3 @@
-import { type IsomerPageSchema } from '@opengovsg/isomer-components'
 import { protectedProcedure, router } from '~/server/trpc'
 import {
   createPageSchema,
@@ -24,10 +23,9 @@ export const pageRouter = router({
     .input(getEditPageSchema)
     .query(async ({ input, ctx }) => {
       const { pageId } = input
-      // const page = await getFullPageById(pageId)
       const page = await getFullPageById(pageId)
       const pageName: string = page.name
-      const siteMeta = getSiteConfig(page.siteId)
+      const siteMeta = await getSiteConfig(page.siteId)
       const navbar = await getNavBar(page.siteId)
       const footer = await getFooter(page.siteId)
       const { content } = page

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1,10 +1,5 @@
 import { db } from '../database'
-import {
-  type Page,
-  type Footer,
-  type Navbar,
-  type UpdateBlobProps,
-} from './resource.types'
+import { type Page, type Footer, type Navbar } from './resource.types'
 
 export const getPages = () => {
   return (
@@ -46,7 +41,7 @@ export const getPageById = (id: number) => {
 }
 
 export const updatePageById = (
-  page: Partial<Omit<Page, 'id' | 'blobId'>> & { id: string },
+  page: Partial<Omit<Page, 'id'>> & { id: number },
 ) => {
   const { id, ...rest } = page
   return db.transaction().execute((tx) => {
@@ -58,7 +53,7 @@ export const updatePageById = (
   })
 }
 
-export const updateBlobById = (props: UpdateBlobProps) => {
+export const updateBlobById = (props: { id: number; content: Page }) => {
   const { id, content } = props
   return db.transaction().execute((tx) => {
     return (

--- a/apps/studio/src/server/modules/resource/resource.types.ts
+++ b/apps/studio/src/server/modules/resource/resource.types.ts
@@ -1,4 +1,16 @@
-import { type IsomerSiteProps } from '@opengovsg/isomer-components'
+import {
+  type IsomerPageSchema,
+  type IsomerSiteProps,
+} from '@opengovsg/isomer-components'
+import { type Resource } from 'prisma/generated/generatedTypes'
+import { type SetRequired } from 'type-fest'
+
+export type PageContent = Omit<
+  IsomerPageSchema,
+  'layout' | 'LinkComponent' | 'ScriptComponent'
+>
+
+export type Page = SetRequired<Resource, 'blobId'>
 
 export type Navbar = { items: IsomerSiteProps['navBarItems'] }
 

--- a/apps/studio/src/types/editorDrawer.ts
+++ b/apps/studio/src/types/editorDrawer.ts
@@ -1,8 +1,3 @@
-export type Block = {
-  text: string
-  id: string
-}
-
 export type RootDrawerState = {
   state: 'root'
 }


### PR DESCRIPTION
## Problem
we want to have drag and drop functionality to re-arrange blocks easily

Closes ISOM-1170.

## Solution
- at present, there are a few stateful variables (multiple calls of `useState` for managing old/new editor state) 
- to have a single centralised place to manage them, i've streamlined them into `editorState/setEditorState` from the `useEditorDrawerContext`
- then, i hooked up this state to the `onDragEnd` call for dnd. 
- the feedback loop is then:
    - i drag something and drop
    - on drag end triggers
    - new state is derived post-drag
    - this new state is saved into `editorState`
    - new state is fed into `Preview`, which triggers a re-render

## Notes
- i'm not quite sure what the `old/newEditorState` is (i've removed both of them) 
- not quite sure what `isCopied` etc is too

## Screenshots/video

https://github.com/opengovsg/isomer/assets/44049504/a3c5d543-c12d-402f-8b7e-0718b08c7969

