### PR TITLE
feat: breakdown site-wide props types

### DIFF
--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -3,12 +3,15 @@
  *
  * @link https://www.prisma.io/docs/guides/database/seed-database
  */
-import { type SiteConfig } from '~/server/modules/site/site.types'
 import {
   type Navbar,
   type Footer,
 } from '~/server/modules/resource/resource.types'
-import { type IsomerSitemap } from '@opengovsg/isomer-components'
+import {
+  IsomerGeneratedSiteProps,
+  IsomerSiteConfigProps,
+  type IsomerSitemap,
+} from '@opengovsg/isomer-components'
 import { db } from '../src/server/modules/database'
 
 const NAV_BAR_ITEMS: Navbar['items'] = [
@@ -88,7 +91,7 @@ async function main() {
         siteName: 'MTI',
         logoUrl: '',
         search: undefined,
-        lastUpdated: '',
+        // TODO: Remove siteMap as it is a generated field
         siteMap: {
           title: 'Home',
           permalink: '/',
@@ -98,7 +101,9 @@ async function main() {
           lastModified: '',
         } satisfies IsomerSitemap,
         isGovernment: true,
-      } satisfies SiteConfig,
+      } satisfies IsomerSiteConfigProps & {
+        siteMap: IsomerGeneratedSiteProps['siteMap']
+      },
     })
     .returning('id')
     .executeTakeFirstOrThrow()

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -4,14 +4,14 @@
  * @link https://www.prisma.io/docs/guides/database/seed-database
  */
 import {
+  type IsomerGeneratedSiteProps,
+  type IsomerSiteConfigProps,
+  type IsomerSitemap,
+} from '@opengovsg/isomer-components'
+import {
   type Navbar,
   type Footer,
 } from '~/server/modules/resource/resource.types'
-import {
-  IsomerGeneratedSiteProps,
-  IsomerSiteConfigProps,
-  type IsomerSitemap,
-} from '@opengovsg/isomer-components'
 import { db } from '../src/server/modules/database'
 
 const NAV_BAR_ITEMS: Navbar['items'] = [

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -1,5 +1,8 @@
+import {
+  type IsomerGeneratedSiteProps,
+  type IsomerSiteConfigProps,
+} from '@opengovsg/isomer-components'
 import { db } from '../database'
-import { type SiteConfig } from './site.types'
 
 export const getSiteConfig = async (siteId: number) => {
   const { config, name } = await db
@@ -10,7 +13,10 @@ export const getSiteConfig = async (siteId: number) => {
 
   // TODO: add JSON parsing + validation
   // at present, this is stored at JSONB inside our db.
-  const { theme, isGovernment, sitemap } = config as SiteConfig
+  // TODO: remove siteMap as it is a generated field
+  const { theme, isGovernment, sitemap } = config as IsomerSiteConfigProps & {
+    sitemap: IsomerGeneratedSiteProps['siteMap']
+  }
 
   return {
     theme,

--- a/apps/studio/src/server/modules/site/site.types.ts
+++ b/apps/studio/src/server/modules/site/site.types.ts
@@ -1,3 +1,0 @@
-import { type IsomerSiteProps } from '@opengovsg/isomer-components'
-
-export type SiteConfig = Omit<IsomerSiteProps, 'navBarItems' | 'footerItems'>

--- a/packages/components/src/types/index.ts
+++ b/packages/components/src/types/index.ts
@@ -1,5 +1,5 @@
 export type { IsomerComponent } from "./components"
 export type * from "./page"
 export type * from "./schema"
-export type { IsomerSiteProps } from "./site"
+export type * from "./site"
 export type { IsomerSitemap } from "./sitemap"

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -2,19 +2,29 @@ import type { NavbarProps } from "~/interfaces"
 import type { SiteConfigFooterProps } from "~/interfaces/internal/Footer"
 import type { IsomerSitemap } from "./sitemap"
 
-export interface IsomerSiteProps {
+export interface IsomerGeneratedSiteProps {
+  siteMap: IsomerSitemap
+  environment?: string
+  lastUpdated: string
+}
+
+export interface IsomerSiteWideComponentsProps {
+  navBarItems: NavbarProps["items"]
+  footerItems: SiteConfigFooterProps
+}
+
+export interface IsomerSiteConfigProps {
   siteName: string
   url?: string
   agencyName?: string
-  siteMap: IsomerSitemap
   theme: "isomer-classic" | "isomer-next"
   logoUrl: string
   isGovernment?: boolean
-  environment?: string
   favicon?: string
-  lastUpdated: string
   search: NavbarProps["search"]
-  navBarItems: NavbarProps["items"]
-  footerItems: SiteConfigFooterProps
   notification?: string
 }
+
+export type IsomerSiteProps = IsomerGeneratedSiteProps &
+  IsomerSiteWideComponentsProps &
+  IsomerSiteConfigProps


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The producer (components) does not differentiate the site-wide props that are generated or user-defined.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The `IsomerSiteProps` are broken down into types that are generated and user-defined, so that consumers know how to differentiate between them.