### PR TITLE
feat: introduce JSONForms nested object renderer

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -4,6 +4,7 @@ export const JSON_FORMS_RANKING = {
   DropdownControl: 2,
   IntegerControl: 4,
   TextControl: 1,
+  ObjectControl: 2,
   OneOfControl: 3,
   ProseControl: 2,
   RadioControl: 3,

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -13,6 +13,8 @@ import {
   jsonFormsDropdownControlTester,
   JsonFormsIntegerControl,
   jsonFormsIntegerControlTester,
+  JsonFormsObjectControl,
+  jsonFormsObjectControlTester,
   JsonFormsOneOfControl,
   jsonFormsOneOfControlTester,
   JsonFormsProseControl,
@@ -26,6 +28,7 @@ import {
 } from './renderers'
 
 const renderers: JsonFormsRendererRegistryEntry[] = [
+  { tester: jsonFormsObjectControlTester, renderer: JsonFormsObjectControl },
   { tester: jsonFormsArrayControlTester, renderer: JsonFormsArrayControl },
   { tester: jsonFormsBooleanControlTester, renderer: JsonFormsBooleanControl },
   {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
@@ -1,0 +1,61 @@
+import {
+  Generate,
+  findUISchema,
+  isObjectControl,
+  rankWith,
+  type RankedTester,
+  type StatePropsOfControlWithDetail,
+} from '@jsonforms/core'
+import { JsonFormsDispatch, withJsonFormsDetailProps } from '@jsonforms/react'
+import { useMemo } from 'react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
+
+export const jsonFormsObjectControlTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.ObjectControl,
+  isObjectControl,
+)
+
+export function JsonFormsObjectControl({
+  path,
+  visible,
+  renderers,
+  cells,
+  schema,
+  enabled,
+  uischema,
+  uischemas,
+  rootSchema,
+}: StatePropsOfControlWithDetail) {
+  const detailUiSchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas || [],
+        schema,
+        uischema.scope,
+        path,
+        () =>
+          Generate.uiSchema(schema, 'VerticalLayout', undefined, rootSchema),
+        uischema,
+        rootSchema,
+      ),
+    [uischemas, schema, uischema, path, rootSchema],
+  )
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <JsonFormsDispatch
+      visible={visible}
+      enabled={enabled}
+      schema={schema}
+      uischema={detailUiSchema}
+      path={path}
+      renderers={renderers}
+      cells={cells}
+    />
+  )
+}
+
+export default withJsonFormsDetailProps(JsonFormsObjectControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -15,6 +15,10 @@ export {
   jsonFormsIntegerControlTester,
 } from './JsonFormsIntegerControl'
 export {
+  default as JsonFormsObjectControl,
+  jsonFormsObjectControlTester,
+} from './JsonFormsObjectControl'
+export {
   default as JsonFormsOneOfControl,
   jsonFormsOneOfControlTester,
 } from './JsonFormsOneOfControl'

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
@@ -26,8 +26,9 @@ export function JsonFormsVerticalLayoutRenderer({
 
   return (
     <VStack spacing={2}>
-      {elements.map((element) => (
-        <Box key={path} w="100%">
+      {elements.map((element, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Box key={`${path}-${index}`} w="100%">
           <JsonFormsDispatch
             uischema={element}
             schema={schema}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We do not have a nested object renderer, which makes us unable to render the hero dropdown fields (since it is a nested object within each of the hero variants).

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Added an object renderer to render nested objects specifically. ([Reference here](https://github.com/eclipsesource/jsonforms/blob/master/packages/material-renderers/src/complex/MaterialObjectRenderer.tsx))

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![Screenshot 2024-06-28 at 10 23 57](https://github.com/opengovsg/isomer/assets/27919917/376f6627-bec4-4c49-a576-fa1971d22234)

**AFTER**:

<!-- [insert screenshot here] -->

![Screenshot 2024-06-28 at 10 21 57](https://github.com/opengovsg/isomer/assets/27919917/106fb74c-3e29-4bf2-b59b-00679a2ca661)