### PR TITLE
feat: introduce JSONForms group layout renderer

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -8,5 +8,6 @@ export const JSON_FORMS_RANKING = {
   OneOfControl: 3,
   ProseControl: 2,
   RadioControl: 3,
+  GroupLayoutRenderer: 1,
   VerticalLayoutRenderer: 1,
 }

--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -1,3 +1,4 @@
+// Rankings are adapted from JSONForms' Material Renderers package
 export const JSON_FORMS_RANKING = {
   ArrayControl: 3,
   BooleanControl: 2,

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -6,22 +6,24 @@ import IsomerSchema from '../../data/0.1.0.json'
 
 import {
   JsonFormsArrayControl,
-  jsonFormsArrayControlTester,
   JsonFormsBooleanControl,
-  jsonFormsBooleanControlTester,
   JsonFormsDropdownControl,
-  jsonFormsDropdownControlTester,
   JsonFormsIntegerControl,
-  jsonFormsIntegerControlTester,
   JsonFormsObjectControl,
-  jsonFormsObjectControlTester,
   JsonFormsOneOfControl,
-  jsonFormsOneOfControlTester,
   JsonFormsProseControl,
-  jsonFormsProseControlTester,
   JsonFormsRadioControl,
-  jsonFormsRadioControlTester,
   JsonFormsTextControl,
+  jsonFormsArrayControlTester,
+  jsonFormsBooleanControlTester,
+  jsonFormsDropdownControlTester,
+  jsonFormsGroupLayoutRenderer,
+  jsonFormsGroupLayoutTester,
+  jsonFormsIntegerControlTester,
+  jsonFormsObjectControlTester,
+  jsonFormsOneOfControlTester,
+  jsonFormsProseControlTester,
+  jsonFormsRadioControlTester,
   jsonFormsTextControlTester,
   jsonFormsVerticalLayoutRenderer,
   jsonFormsVerticalLayoutTester,
@@ -41,6 +43,10 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
   { tester: jsonFormsProseControlTester, renderer: JsonFormsProseControl },
   { tester: jsonFormsRadioControlTester, renderer: JsonFormsRadioControl },
   {
+    tester: jsonFormsGroupLayoutTester,
+    renderer: jsonFormsGroupLayoutRenderer,
+  },
+  {
     tester: jsonFormsVerticalLayoutTester,
     renderer: jsonFormsVerticalLayoutRenderer,
   },
@@ -56,7 +62,7 @@ export default function FormBuilder({
   const { properties, ...rest } = IsomerSchema.components.complex[component]
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { type, ...props } = properties
-  const newSchema = {
+  const schema = {
     ...rest,
     properties: props,
     components: IsomerSchema.components,
@@ -66,7 +72,7 @@ export default function FormBuilder({
 
   return (
     <JsonForms
-      schema={newSchema}
+      schema={schema}
       data={formData}
       renderers={renderers}
       onChange={({ data }) => {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
@@ -1,0 +1,92 @@
+import { Box, Divider, Heading, VStack } from '@chakra-ui/react'
+import {
+  or,
+  rankWith,
+  schemaMatches,
+  uiTypeIs,
+  type GroupLayout,
+  type LayoutProps,
+  type RankedTester,
+} from '@jsonforms/core'
+import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react'
+import React from 'react'
+import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
+
+export const jsonFormsGroupLayoutTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.GroupLayoutRenderer,
+  or(
+    uiTypeIs('Group'),
+    schemaMatches((schema) =>
+      Object.prototype.hasOwnProperty.call(schema, 'group'),
+    ),
+  ),
+)
+
+const GroupComponent = React.memo(function GroupComponent({
+  visible,
+  enabled,
+  uischema,
+  label,
+  schema,
+  path,
+  renderers,
+  cells,
+}: LayoutProps) {
+  const { elements } = uischema as GroupLayout
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <VStack spacing={4}>
+      <Divider borderColor="base.divider.strong" />
+      <Box w="100%">
+        <Heading as="h3" size="sm">
+          {label}
+        </Heading>
+      </Box>
+      {elements.map((element, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <Box key={`${path}-${index}`} w="100%">
+          <JsonFormsDispatch
+            uischema={element}
+            schema={schema}
+            path={path}
+            enabled={enabled}
+            renderers={renderers}
+            cells={cells}
+          />
+        </Box>
+      ))}
+    </VStack>
+  )
+})
+
+export function JsonFormsGroupLayoutRenderer({
+  uischema,
+  schema,
+  path,
+  visible,
+  enabled,
+  renderers,
+  cells,
+  direction,
+  label,
+}: LayoutProps) {
+  return (
+    <GroupComponent
+      schema={schema}
+      path={path}
+      direction={direction}
+      visible={visible}
+      enabled={enabled}
+      uischema={uischema}
+      renderers={renderers}
+      cells={cells}
+      label={label}
+    />
+  )
+}
+
+export default withJsonFormsLayoutProps(JsonFormsGroupLayoutRenderer)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
@@ -1,10 +1,7 @@
 import { Box, Divider, Heading, VStack } from '@chakra-ui/react'
 import {
-  or,
   rankWith,
-  schemaMatches,
   uiTypeIs,
-  type GroupLayout,
   type LayoutProps,
   type RankedTester,
 } from '@jsonforms/core'

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
@@ -11,15 +11,11 @@ import {
 import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react'
 import React from 'react'
 import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
+import { isGroupLayout } from '~/types/schema'
 
 export const jsonFormsGroupLayoutTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.GroupLayoutRenderer,
-  or(
-    uiTypeIs('Group'),
-    schemaMatches((schema) =>
-      Object.prototype.hasOwnProperty.call(schema, 'group'),
-    ),
-  ),
+  uiTypeIs('Group'),
 )
 
 const GroupComponent = React.memo(function GroupComponent({
@@ -32,7 +28,10 @@ const GroupComponent = React.memo(function GroupComponent({
   renderers,
   cells,
 }: LayoutProps) {
-  const { elements } = uischema as GroupLayout
+  // Note: We have to perform this check here due to inaccuracies in JSONForms'
+  // type definitions.
+  // Ref: https://github.com/eclipsesource/jsonforms/blob/c3cead71d08ff11837bdeb5fbea66e5313137218/packages/material-renderers/src/layouts/MaterialGroupLayout.tsx#L52
+  const elements = isGroupLayout(uischema) ? uischema.elements : []
 
   if (!visible) {
     return null

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
@@ -1,18 +1,87 @@
 import { Box, VStack } from '@chakra-ui/react'
 import {
-  type VerticalLayout,
   rankWith,
   uiTypeIs,
   type LayoutProps,
   type RankedTester,
+  type UISchemaElement,
+  type VerticalLayout,
 } from '@jsonforms/core'
 import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react'
 import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
+import { type IsomerJsonSchema } from '~/types/schema'
+
+interface UISchemaElementWithScope extends UISchemaElement {
+  scope?: string
+  label?: string
+  elements?: UISchemaElementWithScope[]
+}
 
 export const jsonFormsVerticalLayoutTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.VerticalLayoutRenderer,
   uiTypeIs('VerticalLayout'),
 )
+
+function getUiSchemaWithGroup(
+  jsonSchema: IsomerJsonSchema,
+  uiSchema: UISchemaElementWithScope[],
+) {
+  const { groups } = jsonSchema
+  const groupMap = new Map<string, string[]>()
+
+  if (!groups) {
+    return uiSchema
+  }
+
+  // Identify all the properties that have groups
+  groups.forEach(({ label, fields }) => {
+    groupMap.set(label, fields)
+  })
+
+  const propertiesNotInGroup = Object.keys(jsonSchema.properties || {}).filter(
+    (property) => !groups.some(({ fields }) => fields.includes(property)),
+  )
+
+  const tempUiSchema = [...uiSchema]
+  const newUiSchema: UISchemaElementWithScope[] = []
+
+  // Iterate through the UI schema and combine properties that belong to the
+  // same group, while preserving the original order of the schema
+  tempUiSchema.forEach((element) => {
+    if (
+      element.scope === undefined ||
+      propertiesNotInGroup.includes(element.scope.split('/').pop() || '')
+    ) {
+      newUiSchema.push(element)
+      return
+    }
+
+    const group = groups.find(({ fields }) =>
+      fields.includes(element.scope?.split('/').pop() || ''),
+    )
+
+    if (group) {
+      const { label } = group
+      const groupFields = groupMap.get(label) || []
+      const groupElements = uiSchema.filter((el) =>
+        groupFields.includes(el.scope?.split('/').pop() || ''),
+      )
+
+      newUiSchema.push({
+        type: 'Group',
+        label,
+        elements: groupElements,
+      })
+
+      groupElements.forEach((el) => {
+        const index = tempUiSchema.indexOf(el)
+        tempUiSchema.splice(index, 1)
+      })
+    }
+  })
+
+  return newUiSchema
+}
 
 export function JsonFormsVerticalLayoutRenderer({
   uischema,
@@ -23,10 +92,14 @@ export function JsonFormsVerticalLayoutRenderer({
   cells,
 }: LayoutProps) {
   const { elements } = uischema as VerticalLayout
+  const newElements = getUiSchemaWithGroup(
+    schema as IsomerJsonSchema,
+    elements as UISchemaElementWithScope[],
+  )
 
   return (
     <VStack spacing={2}>
-      {elements.map((element, index) => (
+      {newElements.map((element, index) => (
         // eslint-disable-next-line react/no-array-index-key
         <Box key={`${path}-${index}`} w="100%">
           <JsonFormsDispatch

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
@@ -5,13 +5,12 @@ import {
   type LayoutProps,
   type RankedTester,
   type UISchemaElement,
-  type VerticalLayout,
 } from '@jsonforms/core'
 import { JsonFormsDispatch, withJsonFormsLayoutProps } from '@jsonforms/react'
 import { JSON_FORMS_RANKING } from '~/constants/formBuilder'
-import { type IsomerJsonSchema } from '~/types/schema'
+import { isVerticalLayout, type IsomerJsonSchema } from '~/types/schema'
 
-interface UISchemaElementWithScope extends UISchemaElement {
+type UISchemaElementWithScope = UISchemaElement & {
   scope?: string
   label?: string
   elements?: UISchemaElementWithScope[]
@@ -89,11 +88,11 @@ export function JsonFormsVerticalLayoutRenderer({
   renderers,
   cells,
 }: LayoutProps) {
-  const { elements } = uischema as VerticalLayout
-  const newElements = getUiSchemaWithGroup(
-    schema as IsomerJsonSchema,
-    elements as UISchemaElementWithScope[],
-  )
+  // Note: We have to perform this check here due to inaccuracies in JSONForms'
+  // type definitions.
+  // Ref: https://github.com/eclipsesource/jsonforms/blob/c3cead71d08ff11837bdeb5fbea66e5313137218/packages/material-renderers/src/layouts/MaterialVerticalLayout.tsx#L57
+  const elements = isVerticalLayout(uischema) ? uischema.elements : []
+  const newElements = getUiSchemaWithGroup(schema, elements)
 
   return (
     <VStack spacing={2}>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
@@ -27,16 +27,14 @@ function getUiSchemaWithGroup(
   uiSchema: UISchemaElementWithScope[],
 ) {
   const { groups } = jsonSchema
-  const groupMap = new Map<string, string[]>()
 
   if (!groups) {
     return uiSchema
   }
 
-  // Identify all the properties that have groups
-  groups.forEach(({ label, fields }) => {
-    groupMap.set(label, fields)
-  })
+  const groupMap = new Map<string, string[]>(
+    new Map(groups.map(({ label, fields }) => [label, fields])),
+  )
 
   const propertiesNotInGroup = Object.keys(jsonSchema.properties || {}).filter(
     (property) => !groups.some(({ fields }) => fields.includes(property)),

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/index.ts
@@ -1,4 +1,8 @@
 export {
+  default as jsonFormsGroupLayoutRenderer,
+  jsonFormsGroupLayoutTester,
+} from './JsonFormsGroupLayout'
+export {
   default as jsonFormsVerticalLayoutRenderer,
   jsonFormsVerticalLayoutTester,
 } from './JsonFormsVerticalLayout'

--- a/apps/studio/src/features/editing-experience/data/0.1.0.json
+++ b/apps/studio/src/features/editing-experience/data/0.1.0.json
@@ -970,6 +970,16 @@
         "type": "object",
         "title": "Hero side variant",
         "required": ["variant", "title", "backgroundUrl"],
+        "groups": [
+          {
+            "label": "Primary call-to-action",
+            "fields": ["buttonLabel", "buttonUrl"]
+          },
+          {
+            "label": "Secondary call-to-action",
+            "fields": ["secondaryButtonLabel", "secondaryButtonUrl"]
+          }
+        ],
         "properties": {
           "variant": {
             "type": "string",

--- a/apps/studio/src/types/schema.ts
+++ b/apps/studio/src/types/schema.ts
@@ -1,0 +1,8 @@
+import { type JsonSchema7 } from '@jsonforms/core'
+
+export interface IsomerJsonSchema extends JsonSchema7 {
+  groups?: Array<{
+    label: string
+    fields: string[]
+  }>
+}

--- a/apps/studio/src/types/schema.ts
+++ b/apps/studio/src/types/schema.ts
@@ -1,8 +1,25 @@
-import { type JsonSchema7 } from '@jsonforms/core'
+import {
+  type GroupLayout,
+  type JsonSchema,
+  type UISchemaElement,
+  type VerticalLayout,
+} from '@jsonforms/core'
 
-export interface IsomerJsonSchema extends JsonSchema7 {
+export type IsomerJsonSchema = JsonSchema & {
   groups?: Array<{
     label: string
     fields: string[]
   }>
+}
+
+export function isGroupLayout(
+  uischema: UISchemaElement,
+): uischema is GroupLayout {
+  return uischema.type === 'Group' && 'elements' in uischema
+}
+
+export function isVerticalLayout(
+  uischema: UISchemaElement,
+): uischema is VerticalLayout {
+  return uischema.type === 'VerticalLayout' && 'elements' in uischema
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We don't have a group layout renderer yet, so we are not able to group similar fields together.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Introduce a new group layout renderer so that we can group similar fields together and apply a header to them.

## Screenshots

<img width="853" alt="Screenshot 2024-07-01 at 10 22 46" src="https://github.com/opengovsg/isomer/assets/27919917/f9b9a1f9-c591-4170-9bc5-a87d2777cbdf">