### PR TITLE
fix: add content type header middleware

### DIFF
--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -94,10 +94,7 @@ const loggerWithVersionMiddleware = loggerMiddleware.unstable_pipe(
 )
 
 const contentTypeHeaderMiddleware = t.middleware(async ({ ctx, next }) => {
-  if (
-    ctx.req.body &&
-    !ctx.req.headers['content-type']?.startsWith('application/json')
-  ) {
+  if (ctx.req.body && ctx.req.headers['content-type'] !== 'application/json') {
     throw new TRPCError({
       code: 'BAD_REQUEST',
       message: 'Invalid Content-Type',

--- a/apps/studio/tests/integration/helpers/iron-session.ts
+++ b/apps/studio/tests/integration/helpers/iron-session.ts
@@ -55,7 +55,16 @@ export const createMockRequest = (
 ): Context => {
   const innerContext = createContextInner({ session })
 
-  const { req, res } = createMocks(reqOptions, resOptions)
+  const { req, res } = createMocks(
+    {
+      ...reqOptions,
+      headers: {
+        'content-type': 'application/json', // will always be application/json
+        ...reqOptions.headers,
+      },
+    },
+    resOptions,
+  )
 
   return {
     ...innerContext,


### PR DESCRIPTION
This PR fixes an issue with Cross-Site Request Forgery (CSRF) protection. While actions that change the application’s state require JSON data in the POST body, the request's content type is not validated. This allows an attacker to craft a cross-site request that the server would accept, leading to a state change in the application.

Currently, because the session cookies do not have the SameSite attribute explicitly set to None, the browser prevents the exploitation of this CSRF vulnerability. However, an XSS on the subdomain could allow the exploitation of this vulnerability.

The fix to this issue is to allow only application/json as a valid content type, to mitigate the risk of CSRF.