### PR TITLE
feat: do not assign CODEOWNERS as reviewers for dependabot PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,7 @@
 * @opengovsg/isomer-engineers
+
+# Don't automatically assign reviewers on PRs that only modify these files.
+# As they have no owner listed, these files are not owned by anyone.
+# Mostly to avoid dependabot noise
+package.json
+package-lock.json


### PR DESCRIPTION
Super annoying spam every night due to dependabot. By adding the package.json and package-lock.json rules to codeowners, those files will be marked as ownerless and thus no email spam from dependabot PRs.
