### PR TITLE
fix(trpc): remove batching

### DIFF
--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -12,7 +12,7 @@ import {
   type ReactRenderer,
 } from "@storybook/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import { httpBatchLink } from "@trpc/client"
+import { httpLink } from "@trpc/client"
 import { createTRPCReact } from "@trpc/react-query"
 import { format } from "date-fns/format"
 import { merge } from "lodash"
@@ -65,7 +65,7 @@ const SetupDecorator: Decorator = (story) => {
   )
   const [trpcClient] = useState(() =>
     trpc.createClient({
-      links: [httpBatchLink({ url: "" })],
+      links: [httpLink({ url: "" })],
       transformer: superjson,
     }),
   )

--- a/apps/studio/src/pages/api/trpc/[trpc].ts
+++ b/apps/studio/src/pages/api/trpc/[trpc].ts
@@ -24,7 +24,7 @@ export default trpcNext.createNextApiHandler({
    * Enable query batching
    */
   batching: {
-    enabled: true,
+    enabled: false,
   },
   /**
    * @link https://trpc.io/docs/caching#api-response-caching

--- a/apps/studio/src/utils/trpc.ts
+++ b/apps/studio/src/utils/trpc.ts
@@ -1,6 +1,6 @@
 import type { TRPCLink } from "@trpc/client"
 import { type NextPageContext } from "next"
-import { httpBatchLink, loggerLink, TRPCClientError } from "@trpc/client"
+import { httpLink, loggerLink, TRPCClientError } from "@trpc/client"
 import { createTRPCNext } from "@trpc/next"
 import { type inferRouterInputs, type inferRouterOutputs } from "@trpc/server"
 import { observable } from "@trpc/server/observable"
@@ -154,7 +154,7 @@ export const trpc = createTRPCNext<
             process.env.NODE_ENV === "development" ||
             (opts.direction === "down" && opts.result instanceof Error),
         }),
-        httpBatchLink({
+        httpLink({
           url: `${getBaseUrl()}/api/trpc`,
           /**
            * Provide a function that will invoke the current global


### PR DESCRIPTION
## Problem

Batching using trpc v10 in a dockerised environement is not production ready. 

For ref, can refer to egazette finding: GTA-35-004 WP1/WP2: Potential DoS Risk through TRPC batching (Medium)

Ideally, this would be solved by checking the total number of batching calls that were made, and it there was more than x number of calls that were made, the server should return a `TOO_MANY_REQUESTS`. However, this will logic will have tight coupling with the implementation with trpc. This will take a hit in latency, and if eng feels this is not worth the tradeoff, can treat this as throw away code but must be confident in hand-rolling own implmentation, since [TRPC](https://opengovproducts.slack.com/archives/C0774ABT2J2/p1719827474185169?thread_ts=1719579080.985729&cid=C0774ABT2J2) is applying decodeURIComponent to the path before splitting it.

Do note, that once v11 becomes a stable branch, then there is a cleaner solution to [this](https://github.com/trpc/trpc/issues/5825#issuecomment-2186406219). v11 coming out soon (they say beta is production ready but my confidence level is low). suggest merging this code for vapt then throw away moment v11 is stable. 

