### PR TITLE
feat(CreatePageModal): add form validation and expected behaviour for modal

### DIFF
--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.stories.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { userEvent, within } from "@storybook/test"
+
+import PageCreateModal from "./PageCreateModal"
+
+const meta: Meta<typeof PageCreateModal> = {
+  title: "Components/PageCreateModal",
+  component: PageCreateModal,
+  decorators: [],
+  args: {
+    isOpen: true,
+    onClose: () => console.log("onClose"),
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {},
+}
+
+export const AutogeneratePageUrl: Story = {
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement.ownerDocument.body)
+    const inputElement = screen.getByText(/page title/i)
+    await userEvent.type(inputElement, "My_new page WITH w@eird characters!")
+  },
+}

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -24,7 +24,11 @@ import {
 import { Controller } from "react-hook-form"
 
 import { useZodForm } from "~/lib/form"
-import { createPageSchema } from "~/schemas/page"
+import {
+  createPageSchema,
+  MAX_PAGE_URL_LENGTH,
+  MAX_TITLE_LENGTH,
+} from "~/schemas/page"
 
 type PageCreateModalProps = Pick<UseDisclosureReturn, "isOpen" | "onClose">
 
@@ -42,9 +46,6 @@ export const PageCreateModal = ({
   isOpen,
   onClose,
 }: PageCreateModalProps): JSX.Element => {
-  const MAX_TITLE_LENGTH = 100
-  const MAX_PAGE_URL_LENGTH = 150
-
   const {
     register,
     handleSubmit,

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -123,10 +123,9 @@ export const PageCreateModal = ({
                           onChange(
                             e.target.value
                               .toLowerCase()
-                              // Replace spacebar with hyphen for UX
                               // TODO(ISOM-1187): Add storybook snapshot test
-                              .replace(/\s/g, "-")
-                              .replace(/[^a-z0-9\-]/g, ""),
+                              // Replace non-alphanum characters with hyphen for UX
+                              .replace(/[^a-z0-9]/g, "-"),
                           )
                         }}
                       />

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -164,7 +164,6 @@ const PageCreateModalContent = ({
 
               <Input
                 placeholder="This is a title for your new page"
-                id="title"
                 {...register("pageTitle")}
               />
               {errors.pageTitle?.message ? (

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -38,7 +38,6 @@ const generatePageUrl = (value: string) => {
   return (
     value
       .toLowerCase()
-      // TODO(ISOM-1187): Add storybook snapshot test
       // Replace non-alphanum characters with hyphen for UX
       .replace(/[^a-z0-9]/g, "-")
   )
@@ -143,9 +142,9 @@ const PageCreateModalContent = ({
   })
   return (
     <ModalContent>
+      <ModalCloseButton isDisabled={isLoading} />
       <ModalHeader color="base.content.strong">
         Tell us about your new page
-        <ModalCloseButton isDisabled={isLoading} />
       </ModalHeader>
       <form onSubmit={handleCreatePage}>
         <ModalBody>

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -1,4 +1,5 @@
 import type { UseDisclosureReturn } from "@chakra-ui/react"
+import type { z } from "zod"
 import { useEffect } from "react"
 import {
   FormControl,
@@ -43,10 +44,60 @@ const generatePageUrl = (value: string) => {
   )
 }
 
+const clientCreatePageSchema = createPageSchema.omit({
+  siteId: true,
+  folderId: true,
+})
+
+type ClientCreatePageSchema = z.input<typeof clientCreatePageSchema>
+
 export const PageCreateModal = ({
   isOpen,
   onClose,
 }: PageCreateModalProps): JSX.Element => {
+  const { mutate, isLoading } = trpc.page.createPage.useMutation({
+    onSuccess: onClose,
+    // TOOD: Error handling
+  })
+
+  const submitCallback = (values: ClientCreatePageSchema) => {
+    mutate({
+      ...values,
+      // TODO: Add siteId to the form
+      siteId: 1,
+      folderId: 1,
+    })
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      closeOnOverlayClick={!isLoading}
+      closeOnEsc={!isLoading}
+    >
+      <ModalOverlay />
+      <PageCreateModalContent
+        key={String(isOpen)}
+        onSubmit={submitCallback}
+        isLoading={isLoading}
+        onClose={onClose}
+      />
+    </Modal>
+  )
+}
+
+export default PageCreateModal
+
+const PageCreateModalContent = ({
+  onSubmit,
+  isLoading,
+  onClose,
+}: {
+  onSubmit: (values: ClientCreatePageSchema) => void
+  isLoading: boolean
+  onClose: () => void
+}) => {
   const {
     register,
     handleSubmit,
@@ -68,10 +119,7 @@ export const PageCreateModal = ({
 
   const [title, url] = watch(["pageTitle", "pageUrl"])
 
-  const { mutate, isLoading } = trpc.page.createPage.useMutation()
-
   /**
-   * To nip broken links from the bud, the ideal interaction for this is:
    * As user edits the Page title, Page URL is updated as an hyphenated form of the page title.
    * If user edits Page URL, the “syncing” stops.
    *
@@ -82,131 +130,110 @@ export const PageCreateModal = ({
    * 5. starts typing new page title B -> page url syncs w new page title B
    */
   useEffect(() => {
+    // This allows the syncing to happen only when the page title is not dirty
+    // Dirty means user has changed the value AND the value is not the same as the default value of "".
+    // Once the value has been cleared, dirty state will reset.
     if (!getFieldState("pageUrl").isDirty) {
       setValue("pageUrl", generatePageUrl(title))
     }
   }, [getFieldState, setValue, title])
 
   const handleCreatePage = handleSubmit((values) => {
-    mutate({
-      ...values,
-      // TODO: Add siteId to the form
-      siteId: 1,
-      folderId: 1,
-    })
+    onSubmit(values)
   })
-
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      closeOnOverlayClick={!isLoading}
-      closeOnEsc={!isLoading}
-    >
-      <ModalCloseButton disabled={isLoading} isDisabled={isLoading} />
-      <ModalOverlay />
-      <ModalContent>
-        <ModalHeader color="base.content.strong">
-          Tell us about your new page
-        </ModalHeader>
-        <ModalCloseButton />
-        <form onSubmit={handleCreatePage}>
-          <ModalBody>
-            <Stack gap={"1.5em"}>
-              <Text fontSize="md" color="base.content.default">
-                You can change these later.
-              </Text>
-              {/* Section 1: Page Title */}
-              <FormControl
-                isInvalid={!!errors.pageTitle}
-                isReadOnly={isLoading}
-              >
-                <FormLabel color="base.content.strong">
-                  Page title
-                  <FormHelperText color="base.content.default">
-                    Title should be descriptive
-                  </FormHelperText>
-                </FormLabel>
+    <ModalContent>
+      <ModalHeader color="base.content.strong">
+        Tell us about your new page
+        <ModalCloseButton isDisabled={isLoading} />
+      </ModalHeader>
+      <form onSubmit={handleCreatePage}>
+        <ModalBody>
+          <Stack gap={"1.5em"}>
+            <Text fontSize="md" color="base.content.default">
+              You can change these later.
+            </Text>
+            {/* Section 1: Page Title */}
+            <FormControl isInvalid={!!errors.pageTitle} isReadOnly={isLoading}>
+              <FormLabel color="base.content.strong">
+                Page title
+                <FormHelperText color="base.content.default">
+                  Title should be descriptive
+                </FormHelperText>
+              </FormLabel>
 
-                <Input
-                  placeholder="This is a title for your new page"
-                  id="title"
-                  {...register("pageTitle")}
+              <Input
+                placeholder="This is a title for your new page"
+                id="title"
+                {...register("pageTitle")}
+              />
+              {errors.pageTitle?.message ? (
+                <FormErrorMessage>{errors.pageTitle.message}</FormErrorMessage>
+              ) : (
+                <FormHelperText mt={"0.5em"} color="base.content.medium">
+                  {MAX_TITLE_LENGTH - title.length} characters left
+                </FormHelperText>
+              )}
+            </FormControl>
+
+            {/* Section 2: Page URL */}
+            <FormControl isInvalid={!!errors.pageUrl} isReadOnly={isLoading}>
+              <FormLabel>
+                Page URL
+                <FormHelperText>URL should be short and simple</FormHelperText>
+              </FormLabel>
+              <InputGroup>
+                <InputLeftAddon
+                  bg="interaction.support.disabled"
+                  color="base.divider.strong"
+                >
+                  your-site.gov.sg/
+                </InputLeftAddon>
+                <Controller
+                  control={control}
+                  name="pageUrl"
+                  render={({ field: { onChange, ...field } }) => (
+                    <Input
+                      {...field}
+                      onChange={(e) => {
+                        onChange(generatePageUrl(e.target.value))
+                      }}
+                    />
+                  )}
                 />
-                {errors.pageTitle?.message ? (
-                  <FormErrorMessage>
-                    {errors.pageTitle.message}
-                  </FormErrorMessage>
-                ) : (
-                  <FormHelperText mt={"0.5em"} color="base.content.medium">
-                    {MAX_TITLE_LENGTH - title.length} characters left
-                  </FormHelperText>
-                )}
-              </FormControl>
+              </InputGroup>
 
-              {/* Section 2: Page URL */}
-              <FormControl isInvalid={!!errors.pageUrl} isReadOnly={isLoading}>
-                <FormLabel>
-                  Page URL
-                  <FormHelperText>
-                    URL should be short and simple
-                  </FormHelperText>
-                </FormLabel>
-                <InputGroup>
-                  <InputLeftAddon
-                    bg="interaction.support.disabled"
-                    color="base.divider.strong"
-                  >
-                    your-site.gov.sg/
-                  </InputLeftAddon>
-                  <Controller
-                    control={control}
-                    name="pageUrl"
-                    render={({ field: { onChange, ...field } }) => (
-                      <Input
-                        {...field}
-                        onChange={(e) => {
-                          onChange(generatePageUrl(e.target.value))
-                        }}
-                      />
-                    )}
-                  />
-                </InputGroup>
+              {errors.pageUrl?.message ? (
+                <FormErrorMessage>{errors.pageUrl.message}</FormErrorMessage>
+              ) : (
+                <FormHelperText mt={"0.5em"} color="base.content.medium">
+                  {MAX_PAGE_URL_LENGTH - url.length} characters left
+                </FormHelperText>
+              )}
+            </FormControl>
+          </Stack>
+        </ModalBody>
 
-                {errors.pageUrl?.message ? (
-                  <FormErrorMessage>{errors.pageUrl.message}</FormErrorMessage>
-                ) : (
-                  <FormHelperText mt={"0.5em"} color="base.content.medium">
-                    {MAX_PAGE_URL_LENGTH - url.length} characters left
-                  </FormHelperText>
-                )}
-              </FormControl>
-            </Stack>
-          </ModalBody>
-
-          <ModalFooter>
-            <Button
-              variant="link"
-              mr={5}
-              onClick={onClose}
-              isDisabled={isLoading}
-              fontWeight={500}
-              color={"base.content.strong"}
-            >
-              Cancel
-            </Button>
-            <Button
-              bgColor="interaction.main.default"
-              type="submit"
-              isLoading={isLoading}
-            >
-              Create page
-            </Button>
-          </ModalFooter>
-        </form>
-      </ModalContent>
-    </Modal>
+        <ModalFooter>
+          <Button
+            variant="link"
+            mr={5}
+            onClick={onClose}
+            isDisabled={isLoading}
+            fontWeight={500}
+            color={"base.content.strong"}
+          >
+            Cancel
+          </Button>
+          <Button
+            bgColor="interaction.main.default"
+            type="submit"
+            isLoading={isLoading}
+          >
+            Create page
+          </Button>
+        </ModalFooter>
+      </form>
+    </ModalContent>
   )
 }
-
-export default PageCreateModal

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -36,7 +36,8 @@ export const createPageSchema = z.object({
       required_error: "Enter a URL for this page.",
     })
     // TODO(ISOM-1187): Add tests for this regex, to ensure frontend is synchronized with backend
-    .regex(/^[a-z0-9\-]+$/, {
+    // Using `*` instead of `+` to allow empty strings, so the correct required error message is shown instead of the regex error message.
+    .regex(/^[a-z0-9\-]*$/, {
       message: "Only lowercase alphanumeric characters and hyphens are allowed",
     })
     .min(1, { message: "Enter a URL for this page" })

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -35,7 +35,6 @@ export const createPageSchema = z.object({
     .string({
       required_error: "Enter a URL for this page.",
     })
-    // TODO(ISOM-1187): Add tests for this regex, to ensure frontend is synchronized with backend
     // Using `*` instead of `+` to allow empty strings, so the correct required error message is shown instead of the regex error message.
     .regex(/^[a-z0-9\-]*$/, {
       message: "Only lowercase alphanumeric characters and hyphens are allowed",

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -25,7 +25,7 @@ export const createPageSchema = z.object({
       required_error: "Enter a title for this page",
     })
     .min(1, { message: "Minimum length should be 1" })
-    .max(100, { message: "Maximum length should be 100" }),
+    .max(150, { message: "Maximum length should be 150" }),
   pageUrl: z
     .string({
       required_error: "Enter a valid URL for this page.",
@@ -35,7 +35,7 @@ export const createPageSchema = z.object({
       message: "Only lowercase alphanumeric characters and hyphens are allowed",
     })
     .min(1, { message: "Minimum length should be 1" })
-    .max(150, { message: "Maximum length should be 150" }),
+    .max(250, { message: "Maximum length should be 250" }),
   // TODO: add the actual layouts in here
   layout: z.enum(PAGE_LAYOUTS).default("content"),
   siteId: z.number().min(1),

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -2,6 +2,9 @@ import { z } from "zod"
 
 const PAGE_LAYOUTS = ["content"] as const
 
+export const MAX_TITLE_LENGTH = 150
+export const MAX_PAGE_URL_LENGTH = 250
+
 export const getEditPageSchema = z.object({
   pageId: z.number().min(1),
 })
@@ -25,7 +28,9 @@ export const createPageSchema = z.object({
       required_error: "Enter a title for this page",
     })
     .min(1, { message: "Enter a title for this page" })
-    .max(150, { message: "Page title should be shorter than 150 characters." }),
+    .max(MAX_TITLE_LENGTH, {
+      message: `Page title should be shorter than ${MAX_TITLE_LENGTH} characters.`,
+    }),
   pageUrl: z
     .string({
       required_error: "Enter a URL for this page.",
@@ -35,7 +40,9 @@ export const createPageSchema = z.object({
       message: "Only lowercase alphanumeric characters and hyphens are allowed",
     })
     .min(1, { message: "Enter a URL for this page" })
-    .max(250, { message: "Page URL should be shorter than 250 characters." }),
+    .max(MAX_PAGE_URL_LENGTH, {
+      message: `Page URL should be shorter than ${MAX_PAGE_URL_LENGTH} characters.`,
+    }),
   // TODO: add the actual layouts in here
   layout: z.enum(PAGE_LAYOUTS).default("content"),
   siteId: z.number().min(1),

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -20,8 +20,22 @@ export const updatePageBlobSchema = getEditPageSchema.extend({
 })
 
 export const createPageSchema = z.object({
-  pageName: z.string(),
-  pageTitle: z.string(),
+  pageTitle: z
+    .string({
+      required_error: "Enter a title for this page",
+    })
+    .min(1, { message: "Minimum length should be 1" })
+    .max(100, { message: "Maximum length should be 100" }),
+  pageUrl: z
+    .string({
+      required_error: "Enter a valid URL for this page.",
+    })
+    // TODO(ISOM-1187): Add tests for this regex, to ensure frontend is synchronized with backend
+    .regex(/^[a-z0-9\-]+$/, {
+      message: "Only lowercase alphanumeric characters and hyphens are allowed",
+    })
+    .min(1, { message: "Minimum length should be 1" })
+    .max(150, { message: "Maximum length should be 150" }),
   // TODO: add the actual layouts in here
   layout: z.enum(PAGE_LAYOUTS).default("content"),
   siteId: z.number().min(1),

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -24,18 +24,18 @@ export const createPageSchema = z.object({
     .string({
       required_error: "Enter a title for this page",
     })
-    .min(1, { message: "Minimum length should be 1" })
-    .max(150, { message: "Maximum length should be 150" }),
+    .min(1, { message: "Enter a title for this page" })
+    .max(150, { message: "Page title should be shorter than 150 characters." }),
   pageUrl: z
     .string({
-      required_error: "Enter a valid URL for this page.",
+      required_error: "Enter a URL for this page.",
     })
     // TODO(ISOM-1187): Add tests for this regex, to ensure frontend is synchronized with backend
     .regex(/^[a-z0-9\-]+$/, {
       message: "Only lowercase alphanumeric characters and hyphens are allowed",
     })
-    .min(1, { message: "Minimum length should be 1" })
-    .max(250, { message: "Maximum length should be 250" }),
+    .min(1, { message: "Enter a URL for this page" })
+    .max(250, { message: "Page URL should be shorter than 250 characters." }),
   // TODO: add the actual layouts in here
   layout: z.enum(PAGE_LAYOUTS).default("content"),
   siteId: z.number().min(1),

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -57,8 +57,10 @@ export const pageRouter = router({
       return input
     }),
 
-  createPage: pageProcedure.input(createPageSchema).query(({ input, ctx }) => {
-    return { pageId: "" }
-  }),
+  createPage: pageProcedure
+    .input(createPageSchema)
+    .mutation(({ input, ctx }) => {
+      return { pageId: "" }
+    }),
   // TODO: Delete page stuff here
 })

--- a/apps/studio/src/theme/components/Modal.ts
+++ b/apps/studio/src/theme/components/Modal.ts
@@ -1,6 +1,7 @@
 import { modalAnatomy as parts } from "@chakra-ui/anatomy"
 import { createMultiStyleConfigHelpers, defineStyle } from "@chakra-ui/react"
 
+// eslint-disable-next-line @typescript-eslint/unbound-method
 const { definePartsStyle, defineMultiStyleConfig } =
   createMultiStyleConfigHelpers(parts.keys)
 
@@ -17,6 +18,26 @@ const baseStyle = definePartsStyle((props) => ({
   dialog: baseStyleDialog(props),
 }))
 
+const sizes = {
+  md: definePartsStyle(() => {
+    return {
+      header: {
+        pl: "2rem",
+        pr: "5rem", // accommodate close button
+      },
+    }
+  }),
+  full: definePartsStyle(() => {
+    return {
+      header: {
+        p: "1.5rem",
+        pr: "5rem", // accommodate close button
+      },
+    }
+  }),
+}
+
 export const Modal = defineMultiStyleConfig({
   baseStyle,
+  sizes,
 })


### PR DESCRIPTION
Closes ISOM-1248

#### TL;DR

Update PageCreateModal component with the expected page URL generation behavior and form validation.

#### What changed?

- Created `PageCreateModal.stories.tsx` for Storybook configurations
- Added form validation using Zod schemas
- Enhanced Page URL generation logic
- Updated Chakra UI modal theme configuration

#### How to test?

1. Open the Storybook interface.
2. Navigate to `Components/PageCreateModal` stories.
3. Verify that the PageCreateModal component renders correctly.
4. Test the form validation and URL generation.

#### Why make this change?

This change adds the necessary modal component for creating new pages within the application, improving the user experience for adding pages.

---
