### PR TITLE
feat: ref all native components and use getComponentSchema

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -1,8 +1,8 @@
-import type { IsomerComplexComponentProps } from "@opengovsg/isomer-components"
+import type { IsomerComponentTypes } from "@opengovsg/isomer-components"
 import { useState } from "react"
 import { type JsonFormsRendererRegistryEntry } from "@jsonforms/core"
 import { JsonForms } from "@jsonforms/react"
-import { IsomerComplexComponentsMap } from "@opengovsg/isomer-components"
+import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 
 import {
@@ -57,13 +57,13 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
 ]
 
 export interface FormBuilderProps {
-  component: IsomerComplexComponentProps["type"]
+  component: IsomerComponentTypes
 }
 
 export default function FormBuilder({
   component,
 }: FormBuilderProps): JSX.Element {
-  const subSchema = IsomerComplexComponentsMap[component]
+  const subSchema = getComponentSchema(component)
   const [formData, setFormData] = useState({})
 
   return (

--- a/packages/components/src/engine/index.ts
+++ b/packages/components/src/engine/index.ts
@@ -1,3 +1,3 @@
 export { RenderEngine } from "./render"
 export { getMetadata, getRobotsTxt, getSitemapXml } from "./metadata"
-export * from "~/types"
+export type * from "~/types"

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./engine"
-export { IsomerPageSchema as schema } from "./types/schema"
+export * from "./schemas"
 export * from "./presets"

--- a/packages/components/src/interfaces/native/Heading.ts
+++ b/packages/components/src/interfaces/native/Heading.ts
@@ -29,6 +29,7 @@ export const HeadingSchema = Type.Object(
     content: Type.Array(TextSchema),
   },
   {
+    $id: "components-native-heading",
     title: "Heading component",
     description: "A heading element that defines a title for a section",
   },

--- a/packages/components/src/interfaces/native/ListItem.ts
+++ b/packages/components/src/interfaces/native/ListItem.ts
@@ -32,6 +32,7 @@ export const listItemSchemaBuilder = <T extends TSchema, U extends TSchema>(
       ),
     },
     {
+      $id: "components-native-listItem",
       title: "List item component",
       description:
         "A list item that can contain paragraphs or nested ordered lists and unordered lists",

--- a/packages/components/src/interfaces/native/Prose.ts
+++ b/packages/components/src/interfaces/native/Prose.ts
@@ -13,12 +13,12 @@ export const ProseSchema = Type.Object({
   content: Type.Optional(
     Type.Array(
       Type.Union([
-        DividerSchema,
-        HeadingSchema,
-        OrderedListSchema,
-        ParagraphSchema,
-        TableSchema,
-        UnorderedListSchema,
+        Type.Ref(DividerSchema),
+        Type.Ref(HeadingSchema),
+        Type.Ref(OrderedListSchema),
+        Type.Ref(ParagraphSchema),
+        Type.Ref(TableSchema),
+        Type.Ref(UnorderedListSchema),
       ]),
       {
         title: "Content block",

--- a/packages/components/src/interfaces/native/Table.ts
+++ b/packages/components/src/interfaces/native/Table.ts
@@ -117,6 +117,7 @@ export const TableSchema = Type.Object(
     ),
   },
   {
+    $id: "components-native-table",
     title: "Table component",
   },
 )

--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -1,5 +1,3 @@
-import type { TSchema } from "@sinclair/typebox"
-
 import {
   AccordionSchema,
   ButtonSchema,

--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -1,0 +1,46 @@
+import type { TSchema } from "@sinclair/typebox"
+
+import {
+  AccordionSchema,
+  ButtonSchema,
+  CalloutSchema,
+  DividerSchema,
+  HeadingSchema,
+  HeroSchema,
+  IframeSchema,
+  ImageSchema,
+  InfobarSchema,
+  InfoCardsSchema,
+  InfoColsSchema,
+  InfopicSchema,
+  KeyStatisticsSchema,
+  OrderedListSchema,
+  ParagraphSchema,
+  ProseSchema,
+  TableSchema,
+  UnorderedListSchema,
+} from "~/interfaces"
+
+export const IsomerComplexComponentsMap = {
+  accordion: AccordionSchema,
+  button: ButtonSchema,
+  callout: CalloutSchema,
+  hero: HeroSchema,
+  iframe: IframeSchema,
+  image: ImageSchema,
+  infobar: InfobarSchema,
+  infocards: InfoCardsSchema,
+  infocols: InfoColsSchema,
+  infopic: InfopicSchema,
+  keystatistics: KeyStatisticsSchema,
+}
+
+export const IsomerNativeComponentsMap = {
+  prose: ProseSchema,
+  divider: DividerSchema,
+  heading: HeadingSchema,
+  orderedList: OrderedListSchema,
+  paragraph: ParagraphSchema,
+  table: TableSchema,
+  unorderedList: UnorderedListSchema,
+}

--- a/packages/components/src/schemas/index.ts
+++ b/packages/components/src/schemas/index.ts
@@ -1,0 +1,1 @@
+export { getComponentSchema, schema } from "./main"

--- a/packages/components/src/schemas/main.ts
+++ b/packages/components/src/schemas/main.ts
@@ -1,0 +1,36 @@
+import type { TSchema } from "@sinclair/typebox"
+
+import type { IsomerComponentTypes } from "~/types"
+import { IsomerPageSchema } from "~/types"
+import {
+  IsomerComplexComponentsMap,
+  IsomerNativeComponentsMap,
+} from "./components"
+
+const definitions = {
+  components: {
+    complex: IsomerComplexComponentsMap,
+    native: IsomerNativeComponentsMap,
+  },
+}
+
+export const schema: TSchema = {
+  $schema: "http://json-schema.org/draft-07/schema#",
+  title: "Isomer Next Page JSON",
+  ...IsomerPageSchema,
+  ...definitions,
+}
+
+export const getComponentSchema = (
+  component: IsomerComponentTypes,
+): TSchema => {
+  const componentSchema =
+    component === "prose"
+      ? IsomerNativeComponentsMap.prose
+      : IsomerComplexComponentsMap[component]
+
+  return {
+    ...componentSchema,
+    ...definitions,
+  }
+}

--- a/packages/components/src/schemas/main.ts
+++ b/packages/components/src/schemas/main.ts
@@ -16,7 +16,7 @@ const definitions = {
 
 export const schema: TSchema = {
   $schema: "http://json-schema.org/draft-07/schema#",
-  title: "Isomer Next Page JSON",
+  title: "Isomer Next Page Schema",
   ...IsomerPageSchema,
   ...definitions,
 }

--- a/packages/components/src/types/components.ts
+++ b/packages/components/src/types/components.ts
@@ -2,55 +2,17 @@ import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
 import {
-  AccordionSchema,
-  ButtonSchema,
-  CalloutSchema,
-  HeroSchema,
-  IframeSchema,
-  ImageSchema,
-  InfobarSchema,
-  InfoCardsSchema,
-  InfoColsSchema,
-  InfopicSchema,
-  KeyStatisticsSchema,
-  ProseSchema,
-} from "~/interfaces"
-
-export const IsomerComplexComponentsMap = {
-  accordion: AccordionSchema,
-  button: ButtonSchema,
-  callout: CalloutSchema,
-  hero: HeroSchema,
-  iframe: IframeSchema,
-  image: ImageSchema,
-  infobar: InfobarSchema,
-  infocards: InfoCardsSchema,
-  infocols: InfoColsSchema,
-  infopic: InfopicSchema,
-  keystatistics: KeyStatisticsSchema,
-}
-
-export const IsomerNativeComponentsMap = {
-  prose: ProseSchema,
-}
-
-export const IsomerComplexComponentsSchemas = Type.Union(
-  Object.values(IsomerComplexComponentsMap),
-)
-
-export const IsomerNativeComponentsSchemas = Type.Union(
-  Object.values(IsomerNativeComponentsMap),
-)
+  IsomerComplexComponentsMap,
+  IsomerNativeComponentsMap,
+} from "~/schemas/components"
 
 export const IsomerComponentsSchemas = Type.Union([
-  IsomerComplexComponentsSchemas,
-  IsomerNativeComponentsSchemas,
+  ...Object.values(IsomerComplexComponentsMap),
+  IsomerNativeComponentsMap.prose,
 ])
 
-export type IsomerComplexComponentProps = Static<
-  typeof IsomerComplexComponentsSchemas
->
-export type IsomerNativeComponentProps = Static<
-  typeof IsomerNativeComponentsSchemas
->
 export type IsomerComponent = Static<typeof IsomerComponentsSchemas>
+
+export type IsomerComponentTypes =
+  | keyof typeof IsomerComplexComponentsMap
+  | "prose"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

For some reason builds could work before without using refs, but now it doesn't. It is now time to settle the schemas once and for all.

Concretely, the problem is that the schema (after removal of all the Type.Ref) kept running into issues because of duplicate `$id` definitions. This is because the same component can be referenced multiple times by different components, especially the native ones.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Make all native components be Type.Ref'd.
- Introduce `getComponentSchema` as the main entry point for component consumers to consume the underlying JSON schemas.
    - This method ensures that all native components are referenced using Type.Ref, then we separately maintain a definitions list which contains the actual definition for those `$id`.
    - This ensures that the `$id` is defined only once in sub-schemas that require them.