### PR TITLE
[TEMPLATE] fix: restyle breadcrumb to reduce visual clutter

### DIFF
--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -4,21 +4,22 @@ import type { BreadcrumbProps } from "~/interfaces"
 
 const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
   return (
-    <div className="flex flex-row flex-wrap gap-1">
+    <div className="flex flex-row flex-wrap gap-2">
       {links.map((link, index) => {
         const isLast = index === links.length - 1
         return (
-          <div
-            key={index}
-            className="flex flex-row items-center gap-1 text-content-medium"
-          >
+          <div key={index} className="flex flex-row items-center gap-1">
             <LinkComponent
               href={link.url}
-              className="underline underline-offset-2 hover:text-hyperlink-hover active:text-hyperlink"
+              className={`text-sm underline decoration-transparent underline-offset-2 transition duration-150 ease-in hover:decoration-inherit active:text-hyperlink ${
+                isLast ? "font-medium text-gray-700" : "text-gray-600"
+              }`}
             >
               {link.title}
             </LinkComponent>
-            {!isLast && <MdChevronRight className="h-auto min-w-6" />}
+            {!isLast && (
+              <MdChevronRight className="h-auto min-w-6 text-gray-400" />
+            )}
           </div>
         )
       })}


### PR DESCRIPTION
## Problem

breadcrumbs were previously messy with every link underlined.
<img width="580" alt="image" src="https://github.com/user-attachments/assets/0492e634-9c03-4080-9fb2-adeeffbeb218">

Closes [ISOM-1256](https://linear.app/ogp/issue/ISOM-1256/restyling-breadcrumbs)

## Solution

Restyled as per [Figma](https://www.figma.com/design/rsKQdmtyoOWawyAv1LkJJK/(New%2C-WIP)-Isomer-Next-Component-Library?node-id=424-2944)
<img width="925" alt="image" src="https://github.com/user-attachments/assets/35a443ad-7975-471f-a95c-fbc052fc3713">

From Storybook:
<img width="442" alt="image" src="https://github.com/user-attachments/assets/9b50ea5a-005f-4e65-9367-64a6dc25166b">

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x ] No - this PR is backwards compatible
