### PR TITLE
feat: introduce sub-component dnd custom renderer

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -1,6 +1,6 @@
 // Rankings are adapted from JSONForms' Material Renderers package
 export const JSON_FORMS_RANKING = {
-  ArrayControl: 3,
+  ArrayControl: 4,
   BooleanControl: 2,
   DropdownControl: 2,
   IntegerControl: 4,

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,12 +1,48 @@
-import { Box } from "@chakra-ui/react"
+import { Box, Heading, HStack, Icon } from "@chakra-ui/react"
+import { IconButton } from "@opengovsg/design-system-react"
+import { BiDollar, BiX } from "react-icons/bi"
 
 import FormBuilder from "./form-builder/FormBuilder"
 
 export default function ComplexEditorStateDrawer(): JSX.Element {
   return (
-    <Box p={4}>
-      <h1>Complex Editor State Drawer</h1>
-      <FormBuilder component="infocards" />
+    <Box position="relative" h="100%" w="100%">
+      <Box
+        bgColor="base.canvas.default"
+        borderBottomColor="base.divider.medium"
+        borderBottomWidth="1px"
+        px="2rem"
+        py="1.25rem"
+      >
+        <HStack justifyContent="space-between" w="100%">
+          <HStack spacing={3}>
+            <Icon
+              as={BiDollar}
+              fontSize="1.5rem"
+              p="0.25rem"
+              bgColor="slate.100"
+              textColor="blue.600"
+              borderRadius="base"
+            />
+            <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+              {/* TODO: Replace this with the actual component name */}
+              Edit Infocols
+            </Heading>
+          </HStack>
+          <IconButton
+            icon={<Icon as={BiX} />}
+            variant="clear"
+            colorScheme="sub"
+            size="sm"
+            p="0.625rem"
+            onClick={() => console.log("Close drawer")}
+            aria-label="Close drawer"
+          />
+        </HStack>
+      </Box>
+      <Box px="2rem" py="1.5rem">
+        <FormBuilder component="infocols" />
+      </Box>
     </Box>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/DraggableDrawerButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/DraggableDrawerButton.tsx
@@ -1,0 +1,91 @@
+import type {
+  DraggableProvidedDraggableProps,
+  DraggableProvidedDragHandleProps,
+} from "@hello-pangea/dnd"
+import type {
+  OwnPropsOfMasterListItem,
+  StatePropsOfMasterItem,
+} from "@jsonforms/core"
+import { Box, forwardRef, HStack, Icon, Text } from "@chakra-ui/react"
+import { withJsonFormsMasterListItemProps } from "@jsonforms/react"
+import { BiGridVertical } from "react-icons/bi"
+
+interface DraggableDrawerButtonProps extends OwnPropsOfMasterListItem {
+  ref: React.Ref<HTMLDivElement>
+  draggableProps: DraggableProvidedDraggableProps
+  dragHandleProps: DraggableProvidedDragHandleProps | null
+  setSelectedIndex: (selectedIndex?: number) => void
+}
+
+const DraggableDrawerButtonText = withJsonFormsMasterListItemProps(
+  ({ childLabel, index }: StatePropsOfMasterItem) => (
+    <Text
+      textStyle="subhead-2"
+      textColor="base.content.strong"
+      textAlign="start"
+    >
+      {childLabel || `Item ${index + 1}`}
+    </Text>
+  ),
+)
+
+const DraggableDrawerButton = forwardRef(
+  (
+    {
+      draggableProps,
+      dragHandleProps,
+      setSelectedIndex,
+      index,
+      ...rest
+    }: DraggableDrawerButtonProps,
+    ref,
+  ) => {
+    return (
+      <Box
+        my="0.375rem"
+        borderWidth="1px"
+        borderColor="base.divider.medium"
+        borderRadius="lg"
+        w="100%"
+        bgColor="utility.ui"
+        transitionProperty="background-color"
+        transitionDuration="0.2s"
+        _hover={{
+          bgColor: "interaction.main-subtle.default",
+        }}
+        _active={{
+          bgColor: "interaction.main-subtle.default",
+          borderColor: "base.content.brand",
+          outline: "1px solid",
+          outlineColor: "base.content.brand",
+        }}
+        ref={ref}
+        {...draggableProps}
+      >
+        <HStack spacing={0}>
+          <Box
+            cursor="grab"
+            pl="0.5rem"
+            pr="0.25rem"
+            py="0.75rem"
+            {...dragHandleProps}
+          >
+            <Icon as={BiGridVertical} fontSize="1.5rem" color="slate.300" />
+          </Box>
+          <Box
+            as="button"
+            onClick={() => setSelectedIndex(index)}
+            pl="0.25rem"
+            pr="1rem"
+            py="0.75rem"
+            w="100%"
+          >
+            <DraggableDrawerButtonText {...rest} index={index} />
+          </Box>
+        </HStack>
+      </Box>
+    )
+  },
+)
+
+export default DraggableDrawerButton

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
@@ -1,44 +1,299 @@
-import type { ArrayLayoutProps, RankedTester } from "@jsonforms/core"
-import { Box, Heading } from "@chakra-ui/react"
+import type { DropResult } from "@hello-pangea/dnd"
+import type {
+  ArrayLayoutProps,
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+  JsonSchema,
+  RankedTester,
+  UISchemaElement,
+} from "@jsonforms/core"
+import { useCallback, useMemo, useState } from "react"
 import {
+  Box,
+  Flex,
+  Heading,
+  HStack,
+  Icon,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
+import {
+  composePaths,
   createDefaultValue,
+  findUISchema,
   isObjectArrayControl,
   rankWith,
+  Resolve,
 } from "@jsonforms/core"
-import { withJsonFormsArrayLayoutProps } from "@jsonforms/react"
-import { Button } from "@opengovsg/design-system-react"
+import {
+  JsonFormsDispatch,
+  withJsonFormsArrayLayoutProps,
+} from "@jsonforms/react"
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import { BiX } from "react-icons/bi"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import DraggableDrawerButton from "./DraggableDrawerButton"
 
 export const jsonFormsArrayControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.ArrayControl,
   isObjectArrayControl,
 )
 
-export function JsonFormsArrayControl({
+interface ComplexEditorNestedDrawerProps {
+  renderers?: JsonFormsRendererRegistryEntry[]
+  cells?: JsonFormsCellRendererRegistryEntry[]
+  visible: boolean
+  schema: JsonSchema
+  uischema: UISchemaElement
+  path: string
+  label: string
+  setSelectedIndex: (selectedIndex?: number) => void
+}
+
+function ComplexEditorNestedDrawer({
+  renderers,
+  cells,
+  visible,
+  schema,
+  uischema,
   path,
   label,
+  setSelectedIndex,
+}: ComplexEditorNestedDrawerProps) {
+  return (
+    <VStack
+      spacing={5}
+      position="absolute"
+      top={0}
+      left={0}
+      px="2rem"
+      py="1.5rem"
+      bgColor="grey.50"
+      w="100%"
+      h="100%"
+    >
+      <HStack justifyContent="space-between" w="100%">
+        <Heading as="h3" size="sm" variant="subhead-1" fontWeight="medium">
+          Edit {label}
+        </Heading>
+        <IconButton
+          icon={<Icon as={BiX} />}
+          variant="clear"
+          colorScheme="sub"
+          size="sm"
+          p="0.625rem"
+          onClick={() => setSelectedIndex()}
+          aria-label="Close drawer"
+        />
+      </HStack>
+
+      <Box w="100%" h="100%">
+        <JsonFormsDispatch
+          renderers={renderers}
+          cells={cells}
+          visible={visible}
+          schema={schema}
+          uischema={uischema}
+          path={path}
+        />
+      </Box>
+    </VStack>
+  )
+}
+
+export function JsonFormsArrayControl({
+  data,
+  path,
+  visible,
+  enabled,
+  label,
   addItem,
+  removeItems,
+  moveUp,
+  moveDown,
+  minItems,
   schema,
   rootSchema,
+  renderers,
+  cells,
+  uischemas,
+  uischema,
+  translations,
 }: ArrayLayoutProps) {
+  const [selectedIndex, setSelectedIndex] = useState<number>()
+  const { maxItems } = Resolve.schema(rootSchema, uischema.scope, rootSchema)
+  const handleRemoveItem = useCallback(
+    (path: string, index: number) => () => {
+      if (selectedIndex === undefined || !removeItems) {
+        return
+      }
+
+      removeItems(path, [index])()
+
+      if (selectedIndex === index) {
+        setSelectedIndex(undefined)
+      } else if (selectedIndex > index) {
+        setSelectedIndex(selectedIndex - 1)
+      }
+    },
+    [removeItems, selectedIndex],
+  )
+  const handleMoveItem = useCallback(
+    (path: string, originalIndex: number, newIndex: number) => {
+      if (originalIndex === newIndex || !moveDown || !moveUp) {
+        return
+      }
+
+      if (originalIndex < newIndex) {
+        for (let i = originalIndex; i < newIndex; i++) {
+          moveDown(path, i)()
+        }
+      } else {
+        for (let i = originalIndex; i > newIndex; i--) {
+          moveUp(path, i)()
+        }
+      }
+    },
+    [moveUp, moveDown],
+  )
+
+  const childUiSchema = useMemo(
+    () =>
+      findUISchema(
+        uischemas ?? [],
+        schema,
+        uischema.scope,
+        path,
+        undefined,
+        uischema,
+        rootSchema,
+      ),
+    [uischemas, schema, uischema, path, rootSchema],
+  )
+  const onDragEnd = (result: DropResult) => {
+    if (!result.destination) {
+      return
+    }
+    const originalIndex = result.source.index
+    const newIndex = result.destination.index
+    handleMoveItem(path, originalIndex, newIndex)
+  }
+
   return (
-    <Box py={2}>
-      <Heading as="h3" size="sm" variant="subhead-1">
+    <VStack py={2} spacing="0.375rem">
+      <Heading
+        as="h3"
+        size="sm"
+        variant="subhead-1"
+        fontWeight="medium"
+        w="100%"
+      >
         {label}
       </Heading>
 
-      <p>Placeholder for drag-and-drop of objects</p>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <Droppable droppableId="blocks">
+          {({ droppableProps, innerRef, placeholder }) => (
+            <VStack
+              {...droppableProps}
+              align="baseline"
+              w="100%"
+              h="100%"
+              spacing={0}
+              ref={innerRef}
+            >
+              {data === 0 && (
+                <Flex
+                  alignItems="center"
+                  flexDir="column"
+                  px="1.5rem"
+                  p="3.75rem"
+                  justifyContent="center"
+                  w="100%"
+                >
+                  <Text
+                    textStyle="subhead-1"
+                    textColor="base.content.default"
+                    textAlign="center"
+                  >
+                    Items you add will appear here
+                  </Text>
+                </Flex>
+              )}
 
-      <Button
-        onClick={addItem(path, createDefaultValue(schema, rootSchema))}
-        mt={3}
-        w="100%"
-        variant="outline"
-      >
-        Add item
-      </Button>
-    </Box>
+              {[...Array(data).keys()].map((index) => {
+                const childPath = composePaths(path, `${index}`)
+
+                return (
+                  <Draggable
+                    key={childPath}
+                    draggableId={childPath}
+                    index={index}
+                  >
+                    {({ draggableProps, dragHandleProps, innerRef }) => (
+                      <DraggableDrawerButton
+                        draggableProps={draggableProps}
+                        dragHandleProps={dragHandleProps}
+                        ref={innerRef}
+                        index={index}
+                        path={path}
+                        schema={schema}
+                        enabled={enabled}
+                        handleSelect={() => () => undefined}
+                        removeItem={handleRemoveItem}
+                        selected={selectedIndex === index}
+                        key={index}
+                        uischema={childUiSchema}
+                        childLabelProp={undefined}
+                        translations={translations}
+                        setSelectedIndex={setSelectedIndex}
+                      />
+                    )}
+                  </Draggable>
+                )
+              })}
+
+              {placeholder}
+            </VStack>
+          )}
+        </Droppable>
+      </DragDropContext>
+
+      {selectedIndex !== undefined && (
+        <ComplexEditorNestedDrawer
+          renderers={renderers}
+          cells={cells}
+          visible={visible}
+          schema={schema}
+          uischema={childUiSchema}
+          path={composePaths(path, `${selectedIndex}`)}
+          label={label}
+          setSelectedIndex={setSelectedIndex}
+        />
+      )}
+
+      {selectedIndex === undefined ? (
+        <Button
+          onClick={addItem(path, createDefaultValue(schema, rootSchema))}
+          w="100%"
+          variant="outline"
+          isDisabled={maxItems !== undefined && data >= maxItems}
+        >
+          Add item
+        </Button>
+      ) : (
+        <Button
+          onClick={handleRemoveItem(path, selectedIndex)}
+          variant="clear"
+          colorScheme="critical"
+          isDisabled={minItems !== undefined && data <= minItems}
+        >
+          Remove item
+        </Button>
+      )}
+    </VStack>
   )
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1219.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Enhance the existing array custom renderer to handle drag-and-drop of sub-components.
    - Implementation was referenced from [JSONForm's MaterialListWithDetailRenderer](https://github.com/eclipsesource/jsonforms/blob/master/packages/material-renderers/src/additional/ListWithDetailMasterItem.tsx), especially regarding how they obtain the appropriate child label to display.

## Screenshots

<!-- [insert screenshot here] -->
<img width="464" alt="Screenshot 2024-07-12 at 16 14 59" src="https://github.com/user-attachments/assets/ddebc21e-26ef-41e6-8ff0-055b1d9fc379">
<img width="474" alt="Screenshot 2024-07-12 at 16 15 16" src="https://github.com/user-attachments/assets/c4f75557-9a01-422a-8844-78eea2727d34">
