### PR TITLE
fix: decouple template package.json for building sites

### DIFF
--- a/tooling/build/scripts/preBuild.sh
+++ b/tooling/build/scripts/preBuild.sh
@@ -6,8 +6,8 @@ set -x
 # Download package.json and package-lock.json files from central repo #
 #######################################################################
 
-curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/template/package.json -o package.json
-curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/template/package-lock.json -o package-lock.json
+# curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/template/package.json -o package.json
+# curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/template/package-lock.json -o package-lock.json
 curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/template/tailwind.config.js -o tailwind.config.js
 
 #######################


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Now it is not possible to build the next sites because we have a dependency on the `@isomer/eslint-config` and other stuff.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Decouple this dependency for the time being, since the CodeBuild process we will be using in the future will use the entire monorepo.