### PR TITLE
fix: remove null types from page content

### DIFF
--- a/packages/components/src/types/schema.ts
+++ b/packages/components/src/types/schema.ts
@@ -50,7 +50,7 @@ export const ArticlePageSchema = Type.Object({
 export const CollectionPageSchema = Type.Object({
   layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Collection),
   page: CollectionPageMetaSchema,
-  content: Type.Array(Type.Null(), {
+  content: Type.Array(IsomerComponentsSchemas, {
     title: "Page content",
     description:
       "This should be empty for collection pages, make sure to remove any items here.",
@@ -79,7 +79,7 @@ export const HomePageSchema = Type.Object({
 export const FileRefSchema = Type.Object({
   layout: Type.Literal(ISOMER_PAGE_LAYOUTS.File),
   page: FileRefMetaSchema,
-  content: Type.Array(Type.Null(), {
+  content: Type.Array(IsomerComponentsSchemas, {
     title: "Page content",
     description:
       "This should be empty for file pages, make sure to remove any items here.",
@@ -92,7 +92,7 @@ export const FileRefSchema = Type.Object({
 export const LinkRefSchema = Type.Object({
   layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Link),
   page: LinkRefMetaSchema,
-  content: Type.Array(Type.Null(), {
+  content: Type.Array(IsomerComponentsSchemas, {
     title: "Page content",
     description:
       "This should be empty for link pages, make sure to remove any items here.",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `Type.Null` is too strongly typed, causing developer grief.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Change all instances of `Type.Null` into `IsomerComponentsSchemas` to standardise with the other page schemas. We still enforce that it is an empty array via the `minItems` and `maxItems` props.