### PR TITLE
feat: add types to JSON columns in prisma schema

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -107,6 +107,7 @@
     "pg": "^8.12.0",
     "pino": "^9.2.0",
     "pino-pretty": "^11.2.1",
+    "prisma-json-types-generator": "^3.0.4",
     "prisma-kysely": "^1.8.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -10,17 +10,29 @@ export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
 export interface Blob {
   id: GeneratedAlways<number>
-  content: unknown
+  /**
+   * @kyselyType(PrismaJson.BlobJsonContent)
+   * [BlobJsonContent]
+   */
+  content: PrismaJson.BlobJsonContent
 }
 export interface Footer {
   id: GeneratedAlways<number>
   siteId: number
-  content: unknown
+  /**
+   * @kyselyType(PrismaJson.FooterJsonContent)
+   * [FooterJsonContent]
+   */
+  content: PrismaJson.FooterJsonContent
 }
 export interface Navbar {
   id: GeneratedAlways<number>
   siteId: number
-  content: unknown
+  /**
+   * @kyselyType(PrismaJson.NavbarJsonContent)
+   * [NavbarJsonContent]
+   */
+  content: PrismaJson.NavbarJsonContent
 }
 export interface Permission {
   id: GeneratedAlways<number>
@@ -41,7 +53,11 @@ export interface Resource {
 export interface Site {
   id: GeneratedAlways<number>
   name: string
-  config: unknown
+  /**
+   * @kyselyType(PrismaJson.SiteJsonConfig)
+   * [SiteJsonConfig]
+   */
+  config: PrismaJson.SiteJsonConfig
 }
 export interface SiteMember {
   userId: string

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -10,6 +10,13 @@ generator client {
   provider = "prisma-client-js"
 }
 
+/// Always after the prisma-client-js generator
+/// Generates types for the JSON columns
+/// The relevant types are declared in a separate prisma/types.ts file.
+generator json {
+  provider = "prisma-json-types-generator"
+}
+
 generator kysely {
   provider     = "prisma-kysely"
   readOnlyIds  = true
@@ -89,27 +96,37 @@ model Site {
   // This is currently put as `Json` for ease of extensibility
   // when we lock in what we actually want for site-wide config, 
   // we should put this in our db table.
+  /// @kyselyType(PrismaJson.SiteJsonConfig)
+  /// [SiteJsonConfig]
   config      Json
   navbar      Navbar?
   footer      Footer?
 }
 
 model Navbar {
-  id      Int  @id @default(autoincrement())
-  siteId  Int  @unique
-  site    Site @relation(fields: [siteId], references: [id])
+  id     Int  @id @default(autoincrement())
+  siteId Int  @unique
+  site   Site @relation(fields: [siteId], references: [id])
+
+  /// @kyselyType(PrismaJson.NavbarJsonContent)
+  /// [NavbarJsonContent]
   content Json
 }
 
 model Footer {
-  id      Int  @id @default(autoincrement())
-  siteId  Int  @unique
-  site    Site @relation(fields: [siteId], references: [id])
+  id     Int  @id @default(autoincrement())
+  siteId Int  @unique
+  site   Site @relation(fields: [siteId], references: [id])
+
+  /// @kyselyType(PrismaJson.FooterJsonContent)
+  /// [FooterJsonContent]
   content Json
 }
 
 model Blob {
   id      Int  @id @default(autoincrement())
+  /// @kyselyType(PrismaJson.BlobJsonContent)
+  /// [BlobJsonContent]
   content Json
 
   mainResource  Resource? @relation("MainBlob")

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -3,17 +3,10 @@
  *
  * @link https://www.prisma.io/docs/guides/database/seed-database
  */
-import {
-  type IsomerGeneratedSiteProps,
-  type IsomerSiteConfigProps,
-  type IsomerSitemap,
-} from "@opengovsg/isomer-components"
+import type { IsomerSchema, IsomerSitemap } from "@opengovsg/isomer-components"
 import cuid2 from "@paralleldrive/cuid2"
 
-import {
-  type Footer,
-  type Navbar,
-} from "~/server/modules/resource/resource.types"
+import type { Navbar } from "~/server/modules/resource/resource.types"
 import { db } from "../src/server/modules/database"
 
 const MOCK_PHONE_NUMBER = "123456789"
@@ -29,7 +22,7 @@ const ISOMER_ADMINS = [
   "hanpu",
 ]
 
-const PAGE_BLOB = {
+const PAGE_BLOB: IsomerSchema = {
   version: "0.1.0",
   layout: "homepage",
   page: {
@@ -40,7 +33,6 @@ const PAGE_BLOB = {
       type: "hero",
       variant: "gradient",
       alignment: "left",
-      backgroundColor: "black",
       title: "Ministry of Trade and Industry",
       subtitle:
         "A leading global city of enterprise and talent, a vibrant nation of innovation and opportunity",
@@ -172,11 +164,7 @@ async function main() {
         siteName: "MTI",
         logoUrl: "",
         search: undefined,
-        // TODO: Remove siteMap as it is a generated field
-        siteMap,
         isGovernment: true,
-      } satisfies IsomerSiteConfigProps & {
-        siteMap: IsomerGeneratedSiteProps["siteMap"]
       },
     })
     .returning("id")
@@ -192,7 +180,7 @@ async function main() {
         privacyStatementLink: "/privacy",
         termsOfUseLink: "/terms-of-use",
         siteNavItems: FOOTER_ITEMS,
-      } satisfies Footer,
+      },
     })
     .execute()
 
@@ -200,7 +188,7 @@ async function main() {
     .insertInto("Navbar")
     .values({
       siteId,
-      content: { items: NAV_BAR_ITEMS } satisfies Navbar,
+      content: NAV_BAR_ITEMS,
     })
     .execute()
 

--- a/apps/studio/prisma/types.ts
+++ b/apps/studio/prisma/types.ts
@@ -1,0 +1,23 @@
+/**
+ * This type file is used by prisma-json-types-generator to generate typecasts for
+ * Json columns in the database to use in the applications.
+ * This is further used by the `kysely` and `kysely-prisma` libraries to generate
+ * types for the query builder.
+ */
+
+import type {
+  IsomerPageSchemaType as _IsomerPageSchemaType,
+  IsomerSchema as _IsomerSchema,
+  IsomerSiteConfigProps as _IsomerSiteConfigProps,
+  IsomerSiteWideComponentsProps as _IsomerSiteWideComponentsProps,
+} from "@opengovsg/isomer-components"
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace PrismaJson {
+    type SiteJsonConfig = _IsomerSiteConfigProps
+    type BlobJsonContent = _IsomerSchema
+    type NavbarJsonContent = _IsomerSiteWideComponentsProps["navBarItems"]
+    type FooterJsonContent = _IsomerSiteWideComponentsProps["footerItems"]
+  }
+}

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -1,6 +1,6 @@
 import type { UseDisclosureReturn } from "@chakra-ui/react"
-import type { z } from "zod"
 import { useEffect } from "react"
+import { useRouter } from "next/router"
 import {
   FormControl,
   FormHelperText,
@@ -23,6 +23,7 @@ import {
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
 import { Controller } from "react-hook-form"
+import { z } from "zod"
 
 import { useZodForm } from "~/lib/form"
 import {
@@ -50,10 +51,17 @@ const clientCreatePageSchema = createPageSchema.omit({
 
 type ClientCreatePageSchema = z.input<typeof clientCreatePageSchema>
 
+const pageCreateQuerySchema = z.object({
+  siteId: z.coerce.number(),
+  resourceId: z.coerce.number().optional(),
+})
+
 export const PageCreateModal = ({
   isOpen,
   onClose,
 }: PageCreateModalProps): JSX.Element => {
+  const { query } = useRouter()
+  const { siteId, resourceId } = pageCreateQuerySchema.parse(query)
   const { mutate, isLoading } = trpc.page.createPage.useMutation({
     onSuccess: onClose,
     // TOOD: Error handling
@@ -63,8 +71,8 @@ export const PageCreateModal = ({
     mutate({
       ...values,
       // TODO: Add siteId to the form
-      siteId: 1,
-      folderId: 1,
+      siteId,
+      folderId: resourceId,
     })
   }
 

--- a/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageCreateModal.tsx
@@ -1,4 +1,5 @@
 import type { UseDisclosureReturn } from "@chakra-ui/react"
+import type { z } from "zod"
 import { useEffect } from "react"
 import { useRouter } from "next/router"
 import {
@@ -23,7 +24,6 @@ import {
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
 import { Controller } from "react-hook-form"
-import { z } from "zod"
 
 import { useZodForm } from "~/lib/form"
 import {
@@ -33,7 +33,11 @@ import {
 } from "~/schemas/page"
 import { trpc } from "~/utils/trpc"
 
-type PageCreateModalProps = Pick<UseDisclosureReturn, "isOpen" | "onClose">
+interface PageCreateModalProps
+  extends Pick<UseDisclosureReturn, "isOpen" | "onClose"> {
+  siteId: number
+  folderId?: number
+}
 
 const generatePageUrl = (value: string) => {
   return (
@@ -51,17 +55,12 @@ const clientCreatePageSchema = createPageSchema.omit({
 
 type ClientCreatePageSchema = z.input<typeof clientCreatePageSchema>
 
-const pageCreateQuerySchema = z.object({
-  siteId: z.coerce.number(),
-  resourceId: z.coerce.number().optional(),
-})
-
 export const PageCreateModal = ({
   isOpen,
   onClose,
+  siteId,
+  folderId,
 }: PageCreateModalProps): JSX.Element => {
-  const { query } = useRouter()
-  const { siteId, resourceId } = pageCreateQuerySchema.parse(query)
   const { mutate, isLoading } = trpc.page.createPage.useMutation({
     onSuccess: onClose,
     // TOOD: Error handling
@@ -70,9 +69,8 @@ export const PageCreateModal = ({
   const submitCallback = (values: ClientCreatePageSchema) => {
     mutate({
       ...values,
-      // TODO: Add siteId to the form
       siteId,
-      folderId: resourceId,
+      folderId,
     })
   }
 

--- a/apps/studio/src/features/editing-experience/components/Preview.tsx
+++ b/apps/studio/src/features/editing-experience/components/Preview.tsx
@@ -27,7 +27,7 @@ export default function Preview(props: IsomerSchema) {
         isGovernment,
         environment: "production",
         lastUpdated: "3 Apr 2024",
-        navBarItems: navbar.items,
+        navBarItems: navbar,
         footerItems: footer,
       }}
     />

--- a/apps/studio/src/hooks/useQueryParse.ts
+++ b/apps/studio/src/hooks/useQueryParse.ts
@@ -1,0 +1,8 @@
+import type { ZodTypeAny } from "zod"
+import { useRouter } from "next/router"
+
+export const useQueryParse = <T extends ZodTypeAny>(schema: T) => {
+  const { query } = useRouter()
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return schema.parse(query) as T["_output"]
+}

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -10,12 +10,18 @@ import {
 } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
+import { z } from "zod"
 
 import { MenuItem } from "~/components/Menu"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import PageCreateModal from "~/features/editing-experience/components/PageCreateModal"
+import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminCmsSidebarLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
+
+const sitePageSchema = z.object({
+  siteId: z.coerce.number(),
+})
 
 const SitePage: NextPageWithLayout = () => {
   const {
@@ -23,6 +29,9 @@ const SitePage: NextPageWithLayout = () => {
     onOpen: onPageCreateModalOpen,
     onClose: onPageCreateModalClose,
   } = useDisclosure()
+
+  const { siteId } = useQueryParse(sitePageSchema)
+
   return (
     <>
       <VStack w="100%" p="1.75rem" gap="1rem">
@@ -62,6 +71,7 @@ const SitePage: NextPageWithLayout = () => {
       <PageCreateModal
         isOpen={isPageCreateModalOpen}
         onClose={onPageCreateModalClose}
+        siteId={siteId}
       />
     </>
   )

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,11 +1,18 @@
 import { useEffect } from "react"
 import { Grid, GridItem } from "@chakra-ui/react"
+import { z } from "zod"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
 import Preview from "~/features/editing-experience/components/Preview"
+import { useQueryParse } from "~/hooks/useQueryParse"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
+
+const editPageSchema = z.object({
+  pageId: z.coerce.number(),
+  siteId: z.coerce.number(),
+})
 
 function EditPage(): JSX.Element {
   const {
@@ -14,9 +21,11 @@ function EditPage(): JSX.Element {
     setPageState,
     setSnapshot: setEditorState,
   } = useEditorDrawerContext()
+  const { pageId, siteId } = useQueryParse(editPageSchema)
 
   const [{ content: page }] = trpc.page.readPageAndBlob.useSuspenseQuery({
-    pageId: 1,
+    pageId,
+    siteId,
   })
 
   useEffect(() => {

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -1,25 +1,15 @@
+import { ISOMER_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
 import { z } from "zod"
 
-const PAGE_LAYOUTS = ["content"] as const
+const LAYOUT_VALUES = [...Object.values(ISOMER_PAGE_LAYOUTS)]
+type LayoutValues = (typeof LAYOUT_VALUES)[number]
 
 export const MAX_TITLE_LENGTH = 150
 export const MAX_PAGE_URL_LENGTH = 250
 
 export const getEditPageSchema = z.object({
   pageId: z.number().min(1),
-})
-
-export const updatePageSchema = getEditPageSchema.extend({
-  // NOTE: We allow both to be empty now,
-  // in which case this is a no-op.
-  // We are ok w/ this because it doesn't
-  // incur any db writes
-  parentId: z.number().min(1).optional(),
-  pageName: z.string().min(1).optional(),
-})
-
-export const updatePageBlobSchema = getEditPageSchema.extend({
-  content: z.string(),
+  siteId: z.number().min(1),
 })
 
 export const createPageSchema = z.object({
@@ -43,8 +33,9 @@ export const createPageSchema = z.object({
     .max(MAX_PAGE_URL_LENGTH, {
       message: `Page URL should be shorter than ${MAX_PAGE_URL_LENGTH} characters.`,
     }),
-  // TODO: add the actual layouts in here
-  layout: z.enum(PAGE_LAYOUTS).default("content"),
+  layout: z
+    .enum<string, [LayoutValues]>(LAYOUT_VALUES as [LayoutValues])
+    .default("content"),
   siteId: z.number().min(1),
   // NOTE: implies that top level pages are allowed
   folderId: z.number().min(1).optional(),

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1,8 +1,8 @@
-import type { SelectExpression } from "kysely"
 import { type DB } from "~prisma/generated/generatedTypes"
+import { SelectExpression } from "kysely"
 
 import { db } from "../database"
-import { type Footer, type Navbar, type Page } from "./resource.types"
+import { type Page } from "./resource.types"
 
 // Specify the default columns to return from the Resource table
 const defaultResourceSelect: SelectExpression<DB, "Resource">[] = [
@@ -90,19 +90,12 @@ export const updatePageById = (
   })
 }
 
-// NOTE: This id here is the page id
-export const updateBlobById = async (props: {
+export const updateBlobById = (props: {
   id: number
-  content: string
+  content: PrismaJson.BlobJsonContent
 }) => {
   const { id, content } = props
-  return db.transaction().execute(async (tx) => {
-    const page = await tx
-      .selectFrom("Resource")
-      .where("Resource.id", "=", id)
-      .select("draftBlobId")
-      .executeTakeFirstOrThrow()
-
+  return db.transaction().execute((tx) => {
     return (
       tx
         .updateTable("Blob")
@@ -124,7 +117,7 @@ export const getNavBar = async (siteId: number) => {
     // NOTE: Throwing here is acceptable because each site should have a navbar
     .executeTakeFirstOrThrow()
 
-  return { ...rest, content: content as Navbar }
+  return { ...rest, content }
 }
 
 export const getFooter = async (siteId: number) => {
@@ -135,7 +128,7 @@ export const getFooter = async (siteId: number) => {
     // NOTE: Throwing here is acceptable because each site should have a footer
     .executeTakeFirstOrThrow()
 
-  return { ...rest, content: content as Footer }
+  return { ...rest, content }
 }
 
 export const moveResource = async (

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1,5 +1,5 @@
+import type { SelectExpression } from "kysely"
 import { type DB } from "~prisma/generated/generatedTypes"
-import { SelectExpression } from "kysely"
 
 import { db } from "../database"
 import { type Page } from "./resource.types"
@@ -50,28 +50,44 @@ export const getFolders = () =>
     .execute()
 
 // NOTE: Base method for retrieving a resource - no distinction made on whether `blobId` exists
-const getByResourceId = (id: number) =>
-  db.selectFrom("Resource").where("Resource.id", "=", id)
+const getById = ({
+  resourceId,
+  siteId,
+}: {
+  resourceId: number
+  siteId: number
+}) =>
+  db
+    .selectFrom("Resource")
+    .where("Resource.id", "=", resourceId)
+    .where("siteId", "=", siteId)
 
 // NOTE: Throw here to fail early if our invariant that a page has a `blobId` is violated
-export const getFullPageById = async (id: number) => {
+export const getFullPageById = async (args: {
+  resourceId: number
+  siteId: number
+}) => {
   // Check if draft blob exists and return that preferentially
-  const draftBlob = await getByResourceId(id)
+  const draftBlob = await getById(args)
     .where("Resource.draftBlobId", "is not", null)
     .innerJoin("Blob", "Resource.draftBlobId", "Blob.id")
     .select(defaultResourceWithBlobSelect)
     .executeTakeFirst()
-  if (draftBlob) return draftBlob
+  if (draftBlob) {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore excessive deep type instantiaton
+    return draftBlob
+  }
 
-  return getByResourceId(id)
+  return getById(args)
     .where("Resource.mainBlobId", "is not", null)
     .innerJoin("Blob", "Resource.mainBlobId", "Blob.id")
     .select(defaultResourceWithBlobSelect)
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
 }
 
-export const getPageById = (id: number) => {
-  return getByResourceId(id)
+export const getPageById = (args: { resourceId: number; siteId: number }) => {
+  return getById(args)
     .where("type", "is", "Page")
     .select(defaultResourceSelect)
     .executeTakeFirstOrThrow()
@@ -95,17 +111,17 @@ export const updateBlobById = (props: {
   content: PrismaJson.BlobJsonContent
 }) => {
   const { id, content } = props
-  return db.transaction().execute((tx) => {
-    return (
-      tx
-        .updateTable("Blob")
-        .innerJoin("Resource", "Resource.id", "id")
-        // NOTE: This works because a page has a 1-1 relation with a blob
-        .set({ content })
-        .where("Resource.id", "=", id)
-        .executeTakeFirstOrThrow()
-    )
-  })
+  return (
+    db
+      .updateTable("Blob")
+      .innerJoin("Resource", "Resource.id", "id")
+      // NOTE: This works because a page has a 1-1 relation with a blob
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore excessive deep type instantiaton
+      .set({ content })
+      .where("Resource.id", "=", id)
+      .executeTakeFirstOrThrow()
+  )
 }
 
 // TODO: should be selecting from new table

--- a/apps/studio/src/stories/Page/SitePage.stories.tsx
+++ b/apps/studio/src/stories/Page/SitePage.stories.tsx
@@ -13,6 +13,13 @@ const meta: Meta<typeof SitePage> = {
     msw: {
       handlers: [meHandlers.me(), pageHandlers.list.default()],
     },
+    nextjs: {
+      router: {
+        query: {
+          siteId: "1",
+        },
+      },
+    },
   },
   decorators: [],
 }

--- a/apps/studio/tests/msw/handlers/site.ts
+++ b/apps/studio/tests/msw/handlers/site.ts
@@ -33,19 +33,6 @@ const defaultFooter = {
   siteId: 1,
 }
 
-const defaultNavbar = {
-  content: {
-    items: [
-      {
-        name: "Home",
-        url: "/",
-      },
-    ] satisfies IsomerSiteWideComponentsProps["navBarItems"],
-  },
-  id: 1,
-  siteId: 1,
-}
-
 const defaultConfigGetQuery = () => {
   return trpcMsw.site.getConfig.query(() => defaultSiteConfig)
 }
@@ -55,7 +42,54 @@ const defaultFooterGetQuery = () => {
 }
 
 const defaultNavbarGetQuery = () => {
-  return trpcMsw.site.getNavbar.query(() => defaultNavbar)
+  return trpcMsw.site.getNavbar.query(() => {
+    return {
+      id: 1,
+      siteId: 1,
+      content: [
+        {
+          url: "/item-one",
+          name: "Expandable nav item",
+          items: [
+            {
+              url: "/item-one/pa-network-one",
+              name: "PA's network one",
+              description:
+                "Click here and brace yourself for mild disappointment.",
+            },
+            {
+              url: "/item-one/pa-network-two",
+              name: "PA's network two",
+              description:
+                "Click here and brace yourself for mild disappointment.",
+            },
+            {
+              url: "/item-one/pa-network-three",
+              name: "PA's network three",
+            },
+            {
+              url: "/item-one/pa-network-four",
+              name: "PA's network four",
+              description:
+                "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+            },
+            {
+              url: "/item-one/pa-network-five",
+              name: "PA's network five",
+              description:
+                "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+            },
+            {
+              url: "/item-one/pa-network-six",
+              name: "PA's network six",
+              description:
+                "Click here and brace yourself for mild disappointment.",
+            },
+          ],
+        },
+      ],
+    }
+  })
 }
 
 export const siteHandlers = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "pg": "^8.12.0",
         "pino": "^9.2.0",
         "pino-pretty": "^11.2.1",
+        "prisma-json-types-generator": "^3.0.4",
         "prisma-kysely": "^1.8.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -7391,14 +7392,12 @@
     "node_modules/@prisma/debug": {
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.16.2.tgz",
-      "integrity": "sha512-ItzB4nR4O8eLzuJiuP3WwUJfoIvewMHqpGCad+64gvThcKEVOtaUza9AEJo2DPqAOa/AWkFyK54oM4WwHeew+A==",
-      "devOptional": true
+      "integrity": "sha512-ItzB4nR4O8eLzuJiuP3WwUJfoIvewMHqpGCad+64gvThcKEVOtaUza9AEJo2DPqAOa/AWkFyK54oM4WwHeew+A=="
     },
     "node_modules/@prisma/engines": {
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.16.2.tgz",
       "integrity": "sha512-qUxwMtrwoG3byd4PbX6T7EjHJ8AUhzTuwniOGkh/hIznBfcE2QQnGakyEq4VnwNuttMqvh/GgPFapHQ3lCuRHg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/debug": "5.16.2",
@@ -7410,14 +7409,12 @@
     "node_modules/@prisma/engines-version": {
       "version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303.tgz",
-      "integrity": "sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw==",
-      "devOptional": true
+      "integrity": "sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw=="
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.16.2.tgz",
       "integrity": "sha512-sq51lfHKfH2jjYSjBtMjP+AznFqOJzXpqmq6B9auWrlTJrMgZ7lPyhWUW7VU7LsQU48/TJ+DZeIz8s9bMYvcHg==",
-      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "5.16.2",
         "@prisma/engines-version": "5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303",
@@ -7473,7 +7470,6 @@
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.16.2.tgz",
       "integrity": "sha512-cXiHPgNLNyj22vLouPVNegklpRL/iX2jxTeap5GRO3DmCoVyIHmJAV1CgUMUJhHlcol9yYy7EHvsnXTDJ/PKEA==",
-      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "5.16.2"
       }
@@ -27667,7 +27663,6 @@
       "version": "5.16.2",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.16.2.tgz",
       "integrity": "sha512-rFV/xoBR2hBGGlu4LPLQd4U8WVA+tSAmYyFWGPRVfj+xg7N4kiZV4lSk38htSpF+/IuHKzlrbh4SFk8Z18cI8A==",
-      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "5.16.2"
@@ -27678,6 +27673,46 @@
       "engines": {
         "node": ">=16.13"
       }
+    },
+    "node_modules/prisma-json-types-generator": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/prisma-json-types-generator/-/prisma-json-types-generator-3.0.4.tgz",
+      "integrity": "sha512-W53OpjBdGZxCsYv7MlUX69d7TPA9lEsQbDf9ddF0J93FX5EvaIRDMexdFPe0KTxiuquGvZTDJgeNXb3gIqEhJw==",
+      "dependencies": {
+        "@prisma/generator-helper": "5.9.1",
+        "tslib": "2.6.2"
+      },
+      "bin": {
+        "prisma-json-types-generator": "index.js"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "funding": {
+        "url": "https://github.com/ArthurFiorette/prisma-json-types-generator?sponsor=1"
+      },
+      "peerDependencies": {
+        "prisma": "^5.1",
+        "typescript": "^5.1"
+      }
+    },
+    "node_modules/prisma-json-types-generator/node_modules/@prisma/debug": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.9.1.tgz",
+      "integrity": "sha512-yAHFSFCg8KVoL0oRUno3m60GAjsUKYUDkQ+9BA2X2JfVR3kRVSJFc/GpQ2fSORi4pSHZR9orfM4UC9OVXIFFTA=="
+    },
+    "node_modules/prisma-json-types-generator/node_modules/@prisma/generator-helper": {
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@prisma/generator-helper/-/generator-helper-5.9.1.tgz",
+      "integrity": "sha512-WMdEUPpPYxUGruRQM6e6IVTWXFjt1hHdF/m2TO7pWxhPo7/ZeoTOF9fH8JsvVSV78DYLOQkx9osjFLXZu447Kw==",
+      "dependencies": {
+        "@prisma/debug": "5.9.1"
+      }
+    },
+    "node_modules/prisma-json-types-generator/node_modules/tslib": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/prisma-kysely": {
       "version": "1.8.0",

--- a/packages/components/src/engine/index.ts
+++ b/packages/components/src/engine/index.ts
@@ -1,3 +1,3 @@
 export { RenderEngine } from "./render"
 export { getMetadata, getRobotsTxt, getSitemapXml } from "./metadata"
-export type * from "~/types"
+export * from "~/types"


### PR DESCRIPTION
### TL;DR

Added the `prisma-json-types-generator` module to the project and associated it with the JSON columns in the Prisma schema. This enables the usage of strongly typed JSON columns in the database.

### What changed?

- Added `prisma-json-types-generator` version `^3.0.4` to `package.json` and `package-lock.json`.
- Updated `schema.prisma` to include a new generator for `prisma-json-types-generator`.
- Added type annotations for JSON fields in various models.
- Created a new `types.ts` file to define types for the JSON columns.
- Updated various parts of the codebase to use the new strongly typed JSON fields.

### How to test?

1. Install the new dependencies by running `npm install`.
2. Verify that the Prisma client is generated with the new JSON types by running `npx prisma generate`.
3. Run the existing tests to ensure that no functionality is broken.
4. Perform manual testing on forms that deal with JSON fields to ensure they are working correctly.

### Why make this change?

This change enhances type safety and developer experience by enabling strongly typed JSON columns in the database. It also prepares the project for more advanced features that rely on typed JSON data.

---