### PR TITLE
ISOM-1258: add-site-and-move-procedures

### DIFF
--- a/apps/studio/src/schemas/site.ts
+++ b/apps/studio/src/schemas/site.ts
@@ -4,7 +4,11 @@ export const getConfigSchema = z.object({
   id: z.number().min(1),
 })
 
+export const getNotificationSchema = z.object({
+  siteId: z.number().min(1),
+})
+
 export const setNotificationSchema = z.object({
-  id: z.number().min(1),
-  notificationStr: z.string(),
+  siteId: z.number().min(1),
+  notification: z.string(),
 })

--- a/apps/studio/src/schemas/site.ts
+++ b/apps/studio/src/schemas/site.ts
@@ -10,5 +10,5 @@ export const getNotificationSchema = z.object({
 
 export const setNotificationSchema = z.object({
   siteId: z.number().min(1),
-  notification: z.string(),
+  notification: z.string().min(1),
 })

--- a/apps/studio/src/schemas/site.ts
+++ b/apps/studio/src/schemas/site.ts
@@ -3,3 +3,8 @@ import { z } from "zod"
 export const getConfigSchema = z.object({
   id: z.number().min(1),
 })
+
+export const setNotificationSchema = z.object({
+  id: z.number().min(1),
+  notificationStr: z.string(),
+})

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -90,3 +90,16 @@ export const getFooter = async (siteId: number) => {
 
   return { ...rest, content: content as Footer }
 }
+
+export const moveResource = async (
+  siteId: number,
+  resourceId: number,
+  newParentId: number | null,
+) => {
+  return db
+    .updateTable("Resource")
+    .set({ parentId: newParentId })
+    .where("siteId", "=", siteId)
+    .where("id", "=", resourceId)
+    .executeTakeFirstOrThrow()
+}

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -1,7 +1,15 @@
-import { getConfigSchema, setNotificationSchema } from "~/schemas/site"
+import {
+  getConfigSchema,
+  getNotificationSchema,
+  setNotificationSchema,
+} from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
 import { getFooter, getNavBar } from "../resource/resource.service"
-import { getSiteConfig, setSiteNotification } from "./site.service"
+import {
+  getNotification,
+  getSiteConfig,
+  setSiteNotification,
+} from "./site.service"
 
 export const siteRouter = router({
   getConfig: protectedProcedure
@@ -22,11 +30,18 @@ export const siteRouter = router({
       const { id } = input
       return getNavBar(id)
     }),
+  getNotification: protectedProcedure
+    .input(getNotificationSchema)
+    .query(async ({ input }) => {
+      const { siteId } = input
+      const notification = await getNotification(siteId)
+      return notification
+    }),
   setNotification: protectedProcedure
     .input(setNotificationSchema)
     .mutation(async ({ input, ctx }) => {
-      const { id, notificationStr } = input
-      await setSiteNotification(id, notificationStr)
+      const { siteId, notification } = input
+      await setSiteNotification(siteId, notification)
       return input
     }),
 })

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -1,7 +1,7 @@
-import { getConfigSchema } from "~/schemas/site"
+import { getConfigSchema, setNotificationSchema } from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
 import { getFooter, getNavBar } from "../resource/resource.service"
-import { getSiteConfig } from "./site.service"
+import { getSiteConfig, setSiteNotification } from "./site.service"
 
 export const siteRouter = router({
   getConfig: protectedProcedure
@@ -21,5 +21,12 @@ export const siteRouter = router({
     .query(async ({ input }) => {
       const { id } = input
       return getNavBar(id)
+    }),
+  setNotification: protectedProcedure
+    .input(setNotificationSchema)
+    .mutation(async ({ input, ctx }) => {
+      const { id, notificationStr } = input
+      await setSiteNotification(id, notificationStr)
+      return input
     }),
 })

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -39,16 +39,25 @@ export const setSiteConfig = async (
     .where("id", "=", siteId)
     .executeTakeFirstOrThrow()
 }
+export const getNotification = async (siteId: number) => {
+  const result = await db
+    .selectFrom("Site")
+    .select(sql`config ->> 'notification'`.as("notification"))
+    .where("id", "=", siteId)
+    .executeTakeFirstOrThrow()
+
+  return result.notification
+}
 
 // TODO: Should triger immediate re-publish of site
 export const setSiteNotification = async (
   siteId: number,
-  notificationStr: string,
+  notification: string,
 ) => {
   return db
     .updateTable("Site")
     .set({
-      config: sql`jsonb_set(config, '{"notification"}', to_jsonb(${notificationStr}::text))`,
+      config: sql`jsonb_set(config, '{"notification"}', to_jsonb(${notification}::text))`,
     })
     .where("id", "=", siteId)
     .executeTakeFirstOrThrow()

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -28,6 +28,7 @@ export const getSiteConfig = async (siteId: number) => {
 }
 
 // Note: This overwrites the full site config
+// TODO: Should triger immediate re-publish of site
 export const setSiteConfig = async (
   siteId: number,
   config: IsomerSiteConfigProps,
@@ -39,6 +40,7 @@ export const setSiteConfig = async (
     .executeTakeFirstOrThrow()
 }
 
+// TODO: Should triger immediate re-publish of site
 export const setSiteNotification = async (
   siteId: number,
   notificationStr: string,

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -3,7 +3,7 @@ import {
   type IsomerSiteConfigProps,
 } from "@opengovsg/isomer-components"
 
-import { db } from "../database"
+import { db, sql } from "../database"
 
 export const getSiteConfig = async (siteId: number) => {
   const { config, name } = await db
@@ -25,4 +25,29 @@ export const getSiteConfig = async (siteId: number) => {
     sitemap,
     name,
   }
+}
+
+// Note: This overwrites the full site config
+export const setSiteConfig = async (
+  siteId: number,
+  config: IsomerSiteConfigProps,
+) => {
+  return db
+    .updateTable("Site")
+    .set({ config })
+    .where("id", "=", siteId)
+    .executeTakeFirstOrThrow()
+}
+
+export const setSiteNotification = async (
+  siteId: number,
+  notificationStr: string,
+) => {
+  return db
+    .updateTable("Site")
+    .set({
+      config: sql`jsonb_set(config, '{"notification"}', to_jsonb(${notificationStr}::text))`,
+    })
+    .where("id", "=", siteId)
+    .executeTakeFirstOrThrow()
 }


### PR DESCRIPTION
## Problem

Currently, no procedure catering for move of resource and setting site configs.
Closes [insert issue #]

## Solution

Adds procedures to move resources (single), and set site config (override fully) and set site notification (minimum requirement of site settings).

TODO: changes in site configs should trigger a immediate publish

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible
