### PR TITLE
chore: fix schema for generated index page

### DIFF
--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -119,27 +119,32 @@ const processDanglingDirectory = async (fullPath, relativePath, name) => {
   const children = await getSiteMapChildrenEntries(fullPath, relativePath)
   // TODO: Improve the content for generated index pages
   const listOfChildPages = {
-    type: "unorderedList",
-    content: children.map((child) => ({
-      type: "listItem",
-      content: [
-        {
-          type: "paragraph",
+    type: "prose",
+    content: [
+      {
+        type: "unorderedList",
+        content: children.map((child) => ({
+          type: "listItem",
           content: [
             {
-              type: "text",
-              marks: [
+              type: "paragraph",
+              content: [
                 {
-                  type: "link",
-                  href: child.permalink,
+                  type: "text",
+                  marks: [
+                    {
+                      type: "link",
+                      href: child.permalink,
+                    },
+                  ],
+                  text: child.title,
                 },
               ],
-              text: child.title,
             },
           ],
-        },
-      ],
-    })),
+        })),
+      }
+    ]
   }
 
   const pageName = name.replace(/-/g, " ")


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The schema was updated, so the auto-generated index page did not conform with the new schema.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fix the schema of the auto-generated index page, so it is now within a Prose block.