### PR TITLE
feat: wire up all page states in editing experience

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -29,7 +29,6 @@ import {
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { type DrawerState } from "~/types/editorDrawer"
-import { trpc } from "~/utils/trpc"
 import { DEFAULT_BLOCKS } from "./constants"
 import { type SectionType } from "./types"
 
@@ -100,10 +99,10 @@ function BlockItem({
 function ComponentSelector() {
   const {
     setCurrActiveIdx,
-    pageState,
+    savedPageState,
     setDrawerState,
-    setPageState,
-    setSnapshot,
+    setSavedPageState,
+    setPreviewPageState,
   } = useEditorDrawerContext()
   const onProceed = (sectionType: SectionType) => {
     // TODO: add new section to page/editor state
@@ -116,12 +115,12 @@ function ComponentSelector() {
       DEFAULT_BLOCKS[sectionType]
 
     const nextPageState = !!newComponent
-      ? [...pageState, newComponent]
-      : pageState
-    setPageState(nextPageState)
+      ? [...savedPageState, newComponent]
+      : savedPageState
+    setSavedPageState(nextPageState)
     setDrawerState({ state: nextState })
     setCurrActiveIdx(nextPageState.length - 1)
-    setSnapshot(pageState)
+    setPreviewPageState(nextPageState)
   }
 
   return (

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -9,10 +9,10 @@ export interface DrawerContextType {
   setCurrActiveIdx: (currActiveIdx: number) => void
   drawerState: DrawerState
   setDrawerState: (state: DrawerState) => void
-  pageState: IsomerComponent[]
-  setPageState: Dispatch<SetStateAction<IsomerComponent[]>>
-  snapshot: IsomerComponent[]
-  setSnapshot: (state: IsomerComponent[]) => void
+  savedPageState: IsomerComponent[]
+  setSavedPageState: Dispatch<SetStateAction<IsomerComponent[]>>
+  previewPageState: IsomerComponent[]
+  setPreviewPageState: Dispatch<SetStateAction<IsomerComponent[]>>
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -20,12 +20,14 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
   const [drawerState, setDrawerState] = useState<DrawerState>({
     state: "root",
   })
+  // Index of the current block being edited
+  const [currActiveIdx, setCurrActiveIdx] = useState<number>(-1)
   // Current saved state of page
-  const [pageState, setPageState] = useState<IsomerComponent[]>([])
-  // Current edit view of page
-  const [snapshot, setSnapshot] = useState<IsomerComponent[]>([])
-  // Isomer page schema
-  const [currActiveIdx, setCurrActiveIdx] = useState(0)
+  const [savedPageState, setSavedPageState] = useState<IsomerComponent[]>([])
+  // State of the page to render in the preview
+  const [previewPageState, setPreviewPageState] = useState<IsomerComponent[]>(
+    [],
+  )
 
   return (
     <EditorDrawerContext.Provider
@@ -34,10 +36,10 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
         setCurrActiveIdx,
         drawerState,
         setDrawerState,
-        pageState,
-        setPageState,
-        snapshot,
-        setSnapshot,
+        savedPageState,
+        setSavedPageState,
+        previewPageState,
+        setPreviewPageState,
       }}
     >
       {children}

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -4,6 +4,7 @@ import { BiDollar, BiX } from "react-icons/bi"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import FormBuilder from "./form-builder/FormBuilder"
+import { getComponentSchema } from "@opengovsg/isomer-components"
 
 export default function ComplexEditorStateDrawer(): JSX.Element {
   const {
@@ -25,6 +26,8 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     return <></>
   }
 
+  const { title } = getComponentSchema(component.type)
+
   return (
     <Box position="relative" h="100%" w="100%">
       <Box
@@ -45,8 +48,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
               borderRadius="base"
             />
             <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-              Edit{" "}
-              {component.type.charAt(0).toUpperCase() + component.type.slice(1)}
+              Edit {title}
             </Heading>
           </HStack>
           <IconButton

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -7,19 +7,19 @@ import FormBuilder from "./form-builder/FormBuilder"
 
 export default function ComplexEditorStateDrawer(): JSX.Element {
   const {
+    currActiveIdx,
     setDrawerState,
     savedPageState,
     setSavedPageState,
     previewPageState,
     setPreviewPageState,
-    blockIndex,
   } = useEditorDrawerContext()
 
-  if (blockIndex === -1 || blockIndex > savedPageState.length) {
+  if (currActiveIdx === -1 || currActiveIdx > savedPageState.length) {
     return <></>
   }
 
-  const component = savedPageState[blockIndex]
+  const component = savedPageState[currActiveIdx]
 
   if (!component) {
     return <></>

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,10 +1,10 @@
 import { Box, Heading, HStack, Icon } from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
+import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiDollar, BiX } from "react-icons/bi"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import FormBuilder from "./form-builder/FormBuilder"
-import { getComponentSchema } from "@opengovsg/isomer-components"
 
 export default function ComplexEditorStateDrawer(): JSX.Element {
   const {

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,10 +1,30 @@
 import { Box, Heading, HStack, Icon } from "@chakra-ui/react"
-import { IconButton } from "@opengovsg/design-system-react"
+import { Button, IconButton } from "@opengovsg/design-system-react"
 import { BiDollar, BiX } from "react-icons/bi"
 
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import FormBuilder from "./form-builder/FormBuilder"
 
 export default function ComplexEditorStateDrawer(): JSX.Element {
+  const {
+    setDrawerState,
+    savedPageState,
+    setSavedPageState,
+    previewPageState,
+    setPreviewPageState,
+    blockIndex,
+  } = useEditorDrawerContext()
+
+  if (blockIndex === -1 || blockIndex > savedPageState.length) {
+    return <></>
+  }
+
+  const component = savedPageState[blockIndex]
+
+  if (!component) {
+    return <></>
+  }
+
   return (
     <Box position="relative" h="100%" w="100%">
       <Box
@@ -25,8 +45,8 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
               borderRadius="base"
             />
             <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-              {/* TODO: Replace this with the actual component name */}
-              Edit Infocols
+              Edit{" "}
+              {component.type.charAt(0).toUpperCase() + component.type.slice(1)}
             </Heading>
           </HStack>
           <IconButton
@@ -35,13 +55,27 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
             colorScheme="sub"
             size="sm"
             p="0.625rem"
-            onClick={() => console.log("Close drawer")}
+            onClick={() => {
+              setPreviewPageState(savedPageState)
+              setDrawerState({ state: "root" })
+            }}
             aria-label="Close drawer"
           />
         </HStack>
       </Box>
       <Box px="2rem" py="1.5rem">
-        <FormBuilder component="infocols" />
+        <FormBuilder />
+      </Box>
+      <Box px="2rem" pb="1.5rem">
+        <Button
+          w="100%"
+          onClick={() => {
+            setDrawerState({ state: "root" })
+            setSavedPageState(previewPageState)
+          }}
+        >
+          Save
+        </Button>
       </Box>
     </Box>
   )

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -46,6 +46,7 @@ export function EditPageDrawer() {
     case "complexEditor":
       return <ComplexEditorStateDrawer />
     default:
+      const _: never = currState
       return <h1>Edit Page Drawer</h1>
   }
 }

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -10,7 +10,7 @@ import TipTapComponent from "./TipTapComponent"
 
 export function EditPageDrawer() {
   const {
-    pageState,
+    previewPageState,
     drawerState: currState,
     currActiveIdx,
   } = useEditorDrawerContext()
@@ -20,7 +20,9 @@ export function EditPageDrawer() {
   const ajv = new Ajv({ allErrors: true, strict: false })
   const validate = ajv.compile<ProseProps>(proseSchema)
 
-  const inferAsProse = (component?: (typeof pageState)[number]): ProseProps => {
+  const inferAsProse = (
+    component?: (typeof previewPageState)[number],
+  ): ProseProps => {
     if (!component) {
       throw new Error(`Expected component of type prose but got undefined`)
     }
@@ -40,7 +42,7 @@ export function EditPageDrawer() {
     case "addBlock":
       return <ComponentSelector />
     case "nativeEditor": {
-      const component = pageState[currActiveIdx]
+      const component = previewPageState[currActiveIdx]
       return <TipTapComponent content={inferAsProse(component)} />
     }
     case "complexEditor":

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -4,29 +4,30 @@ import {
   Button,
   Divider,
   HStack,
+  Icon,
   Spacer,
   Text,
   VStack,
 } from "@chakra-ui/react"
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
 import { BsPlus } from "react-icons/bs"
-import { MdOutlineDragIndicator } from "react-icons/md"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { BiGridVertical } from "react-icons/bi"
 
 export default function RootStateDrawer() {
   const {
     setDrawerState,
-    pageState,
-    setPageState,
-    setSnapshot: setEditorState,
     setCurrActiveIdx,
+    savedPageState,
+    setSavedPageState,
+    setPreviewPageState,
   } = useEditorDrawerContext()
 
   const onDragEnd = (result: DropResult) => {
     if (!result.destination) return
 
-    const updatedBlocks = Array.from(pageState)
+    const updatedBlocks = Array.from(savedPageState)
     // Remove block at source index
     const [movedBlock] = updatedBlocks.splice(result.source.index, 1)
     if (movedBlock) {
@@ -34,7 +35,8 @@ export default function RootStateDrawer() {
       updatedBlocks.splice(result.destination.index, 0, movedBlock)
     }
 
-    setPageState(updatedBlocks)
+    setPreviewPageState(updatedBlocks)
+    setSavedPageState(updatedBlocks)
   }
 
   return (
@@ -69,7 +71,7 @@ export default function RootStateDrawer() {
                   Custom blocks
                 </Text>
                 <Box w="100%">
-                  {pageState.map((block, index) => (
+                  {savedPageState.map((block, index) => (
                     <Draggable
                       // TODO: Determine key + draggable id
                       key={index}
@@ -84,11 +86,10 @@ export default function RootStateDrawer() {
                             setCurrActiveIdx(index)
                             // TODO: we should automatically do this probably?
                             const nextState =
-                              pageState[index]?.type === "prose"
+                              savedPageState[index]?.type === "prose"
                                 ? "nativeEditor"
                                 : "complexEditor"
                             // NOTE: SNAPSHOT
-                            setEditorState(pageState)
                             setDrawerState({ state: nextState })
                           }}
                         >
@@ -100,12 +101,10 @@ export default function RootStateDrawer() {
                             {...provided.draggableProps}
                             {...provided.dragHandleProps}
                           >
-                            <MdOutlineDragIndicator
-                              style={{
-                                marginLeft: "0.75rem",
-                                width: "1.5rem",
-                                height: "1.5rem",
-                              }}
+                            <Icon
+                              as={BiGridVertical}
+                              fontSize="1.5rem"
+                              ml="0.75rem"
                             />
                             <Text px="3" fontWeight={500}>
                               {block.type}

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -12,6 +12,7 @@ import {
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
 import { BiGridVertical } from "react-icons/bi"
 import { BsPlus } from "react-icons/bs"
+import { getComponentSchema } from "@opengovsg/isomer-components"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 
@@ -107,7 +108,7 @@ export default function RootStateDrawer() {
                               ml="0.75rem"
                             />
                             <Text px="3" fontWeight={500}>
-                              {block.type}
+                              {getComponentSchema(block.type).title}
                             </Text>
                           </HStack>
                           <Divider />

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -10,9 +10,9 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
+import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiGridVertical } from "react-icons/bi"
 import { BsPlus } from "react-icons/bs"
-import { getComponentSchema } from "@opengovsg/isomer-components"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -10,10 +10,10 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
+import { BiGridVertical } from "react-icons/bi"
 import { BsPlus } from "react-icons/bs"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import { BiGridVertical } from "react-icons/bi"
 
 export default function RootStateDrawer() {
   const {

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -37,13 +37,19 @@ interface TipTapComponentProps {
 }
 
 function TipTapComponent({ content }: TipTapComponentProps) {
-  const { setDrawerState, setPageState, currActiveIdx, snapshot } =
-    useEditorDrawerContext()
+  const {
+    setDrawerState,
+    savedPageState,
+    setSavedPageState,
+    previewPageState,
+    setPreviewPageState,
+    currActiveIdx,
+  } = useEditorDrawerContext()
 
   const updatePageState = (editorContent: JSONContent) => {
     // TODO: actual validation
     const content = editorContent as ProseProps
-    setPageState((oldState) => {
+    setPreviewPageState((oldState) => {
       // TODO: performance - this is a full clone
       // of the object, which is expensive
       const newState = cloneDeep(oldState)
@@ -129,8 +135,8 @@ function TipTapComponent({ content }: TipTapComponentProps) {
           aria-label="Close add component"
           icon={<BiX />}
           onClick={() => {
-            setPageState(snapshot)
             setDrawerState({ state: "root" })
+            setPreviewPageState(savedPageState)
           }}
         />
       </Flex>
@@ -176,9 +182,8 @@ function TipTapComponent({ content }: TipTapComponentProps) {
       >
         <Button
           onClick={() => {
-            const jsonContent = editor.getJSON()
-            updatePageState(jsonContent)
             setDrawerState({ state: "root" })
+            setSavedPageState(previewPageState)
           }}
         >
           Save

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -1,6 +1,6 @@
+import type { IsomerComponent } from "@opengovsg/isomer-components"
 import { type JsonFormsRendererRegistryEntry } from "@jsonforms/core"
 import { JsonForms } from "@jsonforms/react"
-import type { IsomerComponent } from "@opengovsg/isomer-components"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -57,21 +57,25 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
 ]
 
 export default function FormBuilder(): JSX.Element {
-  const { savedPageState, previewPageState, setPreviewPageState, blockIndex } =
-    useEditorDrawerContext()
+  const {
+    savedPageState,
+    previewPageState,
+    setPreviewPageState,
+    currActiveIdx,
+  } = useEditorDrawerContext()
 
-  if (blockIndex === -1 || blockIndex > savedPageState.length) {
+  if (currActiveIdx === -1 || currActiveIdx > savedPageState.length) {
     return <></>
   }
 
-  const component = savedPageState[blockIndex]
+  const component = savedPageState[currActiveIdx]
 
   if (!component) {
     return <></>
   }
 
   const subSchema = getComponentSchema(component.type)
-  const data = previewPageState[blockIndex]
+  const data = previewPageState[currActiveIdx]
   const ajv = new Ajv({ strict: false })
   const validateFn = ajv.compile<IsomerComponent>(subSchema)
 
@@ -83,7 +87,7 @@ export default function FormBuilder(): JSX.Element {
       onChange={({ data }) => {
         if (validateFn(data)) {
           const newPageState = [...savedPageState]
-          newPageState[blockIndex] = data
+          newPageState[currActiveIdx] = data
           setPreviewPageState(newPageState)
         }
       }}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
@@ -123,7 +123,11 @@ export function JsonFormsArrayControl({
   translations,
 }: ArrayLayoutProps) {
   const [selectedIndex, setSelectedIndex] = useState<number>()
-  const { maxItems } = Resolve.schema(rootSchema, uischema.scope, rootSchema)
+  const resolvedSchema = Resolve.schema(rootSchema, uischema.scope, rootSchema)
+  const maxItems =
+    // NOTE: resolvedSchema can potentially be undefined
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    resolvedSchema !== undefined ? resolvedSchema.maxItems : undefined
   const handleRemoveItem = useCallback(
     (path: string, index: number) => () => {
       if (selectedIndex === undefined || !removeItems) {

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -17,9 +17,9 @@ const editPageSchema = z.object({
 function EditPage(): JSX.Element {
   const {
     setDrawerState,
-    pageState,
-    setPageState,
-    setSnapshot: setEditorState,
+    previewPageState,
+    setSavedPageState,
+    setPreviewPageState,
   } = useEditorDrawerContext()
   const { pageId, siteId } = useQueryParse(editPageSchema)
 
@@ -33,8 +33,9 @@ function EditPage(): JSX.Element {
       state: "root",
     })
     const blocks = page.content
-    setPageState(blocks)
-  }, [page.content, setDrawerState, setEditorState, setPageState])
+    setSavedPageState(blocks)
+    setPreviewPageState(blocks)
+  }, [page.content, setDrawerState, setPreviewPageState, setSavedPageState])
 
   return (
     <Grid
@@ -51,7 +52,7 @@ function EditPage(): JSX.Element {
       <GridItem colSpan={2} overflow="scroll">
         {/* TODO: the version here should be obtained from the schema  */}
         {/* and not from the page */}
-        <Preview {...page} version="0.1.0" content={pageState} />
+        <Preview {...page} version="0.1.0" content={previewPageState} />
       </GridItem>
     </Grid>
   )

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -1,3 +1,4 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { schema } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import Ajv from "ajv"
@@ -16,7 +17,7 @@ import { getSiteConfig } from "../site/site.service"
 import { createDefaultPage } from "./page.service"
 
 const ajv = new Ajv({ allErrors: true, strict: false })
-const schemaValidator = ajv.compile(schema)
+const schemaValidator = ajv.compile<IsomerSchema>(schema)
 
 // TODO: Need to do validation like checking for existence of the page
 // and whether the user has write-access to said page: replace protectorProcedure in this with the new procedure


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The various page states have not yet been wired up.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Wire up all the page states so the editing flow is more complete.
- What is NOT done/not working:
    - Adding of new blocks (will do in a separate PR, because need to adjust the schema to set default values)
    - Editing hero component (I think the schema is slightly incorrect, may update this PR later or do separately).