### PR TITLE
fix: ajv type errors

### DIFF
--- a/packages/components/src/schemas/main.ts
+++ b/packages/components/src/schemas/main.ts
@@ -1,4 +1,5 @@
 import type { TSchema } from "@sinclair/typebox"
+import { Type } from "@sinclair/typebox"
 
 import type { IsomerComponentTypes } from "~/types"
 import { IsomerPageSchema } from "~/types"
@@ -26,7 +27,7 @@ export const getComponentSchema = (
 ): TSchema => {
   const componentSchema =
     component === "prose"
-      ? IsomerNativeComponentsMap.prose
+      ? Type.Ref(IsomerNativeComponentsMap.prose)
       : IsomerComplexComponentsMap[component]
 
   return {

--- a/packages/components/src/types/components.ts
+++ b/packages/components/src/types/components.ts
@@ -8,7 +8,7 @@ import {
 
 export const IsomerComponentsSchemas = Type.Union([
   ...Object.values(IsomerComplexComponentsMap),
-  IsomerNativeComponentsMap.prose,
+  Type.Ref(IsomerNativeComponentsMap.prose),
 ])
 
 export type IsomerComponent = Static<typeof IsomerComponentsSchemas>


### PR DESCRIPTION
### TL;DR

This pull request updates the components schema references to use `Type.Ref` from `@sinclair/typebox` and removes the unused 'docs' workspace from the package-lock.json file.

### What changed?

- Updated schema references in components to use `Type.Ref` from `@sinclair/typebox`.
- Removed the 'docs' workspace entry in the package-lock.json file.

### How to test?
No runtime error when navigating to a site dashboard
