### PR TITLE
feat: update codeowners to ignore all package[-lock] files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 # Don't automatically assign reviewers on PRs that only modify these files.
 # As they have no owner listed, these files are not owned by anyone.
 # Mostly to avoid dependabot noise
-package.json
-package-lock.json
+**/package.json
+**/package-lock.json


### PR DESCRIPTION
### TL;DR

Updated the `.github/CODEOWNERS` file to more generally exclude `package.json` and `package-lock.json` files from requiring code review to avoid noise, especially from dependabot.

### What changed?

- Modified the `CODEOWNERS` file to use the pattern `**/package.json` and `**/package-lock.json` instead of directly specifying the files.

### How to test?
Pray and hope dependabot PRs stop requesting @opengovsg/isomer-engineers to review.

### Why make this change?

To reduce the noise from unnecessary code review requests for changes that typically don't require human review, like automated dependency updates from dependabot.

