### PR TITLE
fix: enable unsafe-eval for user test

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -10,6 +10,7 @@ TODO: Removing this CSP first
   //   // For displaying images from R2
   //   env.R2_PUBLIC_HOSTNAME ? `https://${env.R2_PUBLIC_HOSTNAME}` : ''
   // };
+  // script-src 'self' ${env.NODE_ENV === "production" ? "" : "'unsafe-eval'"};
 */
 
 // TODO: Stricten the CSP for images
@@ -22,7 +23,7 @@ const ContentSecurityPolicy = `
   img-src * data:;
   frame-src 'self';
   object-src 'none';
-  script-src 'self' ${env.NODE_ENV === "production" ? "" : "'unsafe-eval'"};
+  script-src 'self' 'unsafe-eval';
   style-src 'self' https: 'unsafe-inline';
   connect-src 'self' https://schema.isomer.gov.sg https://browser-intake-datadoghq.com https://*.browser-intake-datadoghq.com https://vitals.vercel-insights.com/v1/vitals ${
     // For POSTing presigned URLs to R2 storage.


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Ajv compilation to create the validation function requires `unsafe-eval` to be enabled for `script-src`.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Enable `unsafe-eval` for script-src for the time being, so that we can proceed with user testing.
    - Ref: https://ajv.js.org/security.html#content-security-policy