### PR TITLE
chore: add default blocks contents

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -19,15 +19,143 @@ export const DEFAULT_BLOCKS: Record<
       },
     ],
   },
-  accordion: undefined,
-  button: undefined,
-  callout: undefined,
+  accordion: {
+    type: "accordion",
+    summary: "Title for the accordion item",
+    details: {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Enter content for the accordion here.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  button: {
+    type: "button",
+    label: "Button label",
+    href: "/button-url",
+    colorScheme: "black",
+    variant: "solid",
+    size: "base",
+    rightIcon: "right-arrow",
+  },
+  callout: {
+    type: "callout",
+    variant: "info",
+    content: {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Callout content",
+            },
+          ],
+        },
+      ],
+    },
+  },
   hero: undefined,
-  iframe: undefined,
-  image: undefined,
-  infobar: undefined,
-  infocards: undefined,
-  infocols: undefined,
-  infopic: undefined,
-  keystatistics: undefined,
+  iframe: {
+    type: "iframe",
+    title: "YouTube embed",
+    content:
+      '<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ?si=ggGGn4uvFWAIelWD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
+  },
+  image: {
+    type: "image",
+    src: "/images/1.png",
+    alt: "Add your alt text here",
+  },
+  infobar: {
+    type: "infobar",
+    title: "This is the main title",
+    description: "This is an optional description",
+  },
+  infocards: {
+    type: "infocards",
+    variant: "top",
+    title: "This is an optional title of the Infocards component",
+    subtitle: "This is an optional subtitle for the Infocards component",
+    cards: [
+      {
+        title: "This is the first card",
+        url: "https://www.google.com",
+        imageUrl: "https://placehold.co/200x200",
+        imageAlt: "This is the alt text",
+      },
+      {
+        title: "This is the second card",
+        url: "https://www.google.com",
+        imageUrl: "https://placehold.co/400x200",
+        imageAlt: "This is the alt text",
+      },
+      {
+        title: "This is the third card",
+        url: "https://www.google.com",
+        imageUrl: "https://placehold.co/500x200",
+        imageAlt: "This is the alt text",
+      },
+    ],
+  },
+  infocols: {
+    type: "infocols",
+    title: "This is the main title of the InfoCols component",
+    subtitle: "This is an optional subtitle for the InfoCols component.",
+    infoBoxes: [
+      {
+        title: "This is the title of the first column",
+        description: "You can also add additional description here",
+        icon: "office-building",
+      },
+      {
+        title: "This is the title of the second column",
+        description: "You can also add additional description here",
+        icon: "stars",
+      },
+      {
+        title: "This is the title of the third column",
+        description: "You can also add additional description here",
+        icon: "globe",
+      },
+    ],
+  },
+  infopic: {
+    type: "infopic",
+    title: "This is an infopic",
+    description: "This is the description for the infopic component",
+    imageSrc: "https://placehold.co/600x400",
+  },
+  keystatistics: {
+    type: "keystatistics",
+    variant: "top",
+    title: "Irrationality in numbers",
+    statistics: [
+      {
+        label: "Average all nighters pulled in a typical calendar month",
+        value: "3",
+      },
+      {
+        label: "Growth in tasks assigned Q4 2024 (YoY)",
+        value: "+12.2%",
+      },
+      {
+        label: "Creative blocks met per single evening",
+        value: "89",
+      },
+      {
+        value: "4.0",
+        label: "Number of lies in this stat block",
+      },
+    ],
+  },
 }

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -8,17 +8,16 @@ import ComplexEditorStateDrawer from "./ComplexEditorStateDrawer"
 import RootStateDrawer from "./RootStateDrawer"
 import TipTapComponent from "./TipTapComponent"
 
+const proseSchema = getComponentSchema("prose")
+const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
+const validate = ajv.compile<ProseProps>(proseSchema)
+
 export function EditPageDrawer() {
   const {
     previewPageState,
     drawerState: currState,
     currActiveIdx,
   } = useEditorDrawerContext()
-
-  const proseSchema = getComponentSchema("prose")
-
-  const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
-  const validate = ajv.compile<ProseProps>(proseSchema)
 
   const inferAsProse = (
     component?: (typeof previewPageState)[number],

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -17,7 +17,7 @@ export function EditPageDrawer() {
 
   const proseSchema = getComponentSchema("prose")
 
-  const ajv = new Ajv({ allErrors: true, strict: false })
+  const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
   const validate = ajv.compile<ProseProps>(proseSchema)
 
   const inferAsProse = (

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -55,6 +55,7 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
     renderer: jsonFormsVerticalLayoutRenderer,
   },
 ]
+const ajv = new Ajv({ strict: false, logger: false })
 
 export default function FormBuilder(): JSX.Element {
   const {
@@ -76,7 +77,6 @@ export default function FormBuilder(): JSX.Element {
 
   const subSchema = getComponentSchema(component.type)
   const data = previewPageState[currActiveIdx]
-  const ajv = new Ajv({ strict: false, logger: false })
   const validateFn = ajv.compile<IsomerComponent>(subSchema)
 
   return (

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -76,7 +76,7 @@ export default function FormBuilder(): JSX.Element {
 
   const subSchema = getComponentSchema(component.type)
   const data = previewPageState[currActiveIdx]
-  const ajv = new Ajv({ strict: false })
+  const ajv = new Ajv({ strict: false, logger: false })
   const validateFn = ajv.compile<IsomerComponent>(subSchema)
 
   return (
@@ -91,7 +91,7 @@ export default function FormBuilder(): JSX.Element {
           setPreviewPageState(newPageState)
         }
       }}
-      ajv={new Ajv({ strict: false })}
+      ajv={ajv}
     />
   )
 }

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -16,7 +16,7 @@ import {
 import { getSiteConfig } from "../site/site.service"
 import { createDefaultPage } from "./page.service"
 
-const ajv = new Ajv({ allErrors: true, strict: false })
+const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
 const schemaValidator = ajv.compile<IsomerSchema>(schema)
 
 // TODO: Need to do validation like checking for existence of the page


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The default blocks contents are currently set to undefined.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add default block contents for all the blocks except for the hero component.
- Also set logger to false for Ajv since we don't use it for debugging (and it is very noisy).