### PR TITLE
chore: remove props only used in classic from schema

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -35,8 +35,6 @@ export const SingleCardSchema = Type.Object({
 export const InfoCardsSchema = Type.Object(
   {
     type: Type.Literal("infocards", { default: "infocards" }),
-    // TODO: Remove this property, only used in classic theme
-    sectionIdx: Type.Optional(Type.Number()),
     variant: Type.Union([Type.Literal("side"), Type.Literal("top")], {
       title: "Infocards variant",
       description: "The variant of the infocards component to use",
@@ -66,4 +64,6 @@ export const InfoCardsSchema = Type.Object(
 )
 
 export type SingleCardProps = Static<typeof SingleCardSchema>
-export type InfoCardsProps = Static<typeof InfoCardsSchema>
+export type InfoCardsProps = Static<typeof InfoCardsSchema> & {
+  sectionIdx?: number // TODO: Remove this property, only used in classic theme
+}

--- a/packages/components/src/interfaces/complex/InfoCols.ts
+++ b/packages/components/src/interfaces/complex/InfoCols.ts
@@ -41,8 +41,6 @@ export const InfoBoxSchema = Type.Object({
 export const InfoColsSchema = Type.Object(
   {
     type: Type.Literal("infocols", { default: "infocols" }),
-    // TODO: Remove this property, only used in classic theme
-    sectionIdx: Type.Optional(Type.Number()),
     title: Type.String({
       title: "Infocols title",
       description: "The title of the Infocols component",
@@ -84,5 +82,6 @@ export const InfoColsSchema = Type.Object(
 )
 
 export type InfoColsProps = Static<typeof InfoColsSchema> & {
+  sectionIdx?: number // TODO: Remove this property, only used in classic theme
   LinkComponent?: any // Next.js link
 }

--- a/packages/components/src/interfaces/complex/Infobar.ts
+++ b/packages/components/src/interfaces/complex/Infobar.ts
@@ -4,18 +4,10 @@ import { Type } from "@sinclair/typebox"
 export const InfobarSchema = Type.Object(
   {
     type: Type.Literal("infobar", { default: "infobar" }),
-    // TODO: Remove this property, only used in classic theme
-    sectionIdx: Type.Optional(Type.Number()),
     title: Type.String({
       title: "Infobar title",
       description: "The title of the infobar",
     }),
-    subtitle: Type.Optional(
-      Type.String({
-        title: "Infobar subtitle",
-        description: "The subtitle of the infobar",
-      }),
-    ),
     description: Type.Optional(
       Type.String({
         title: "Infobar content",
@@ -53,5 +45,7 @@ export const InfobarSchema = Type.Object(
 )
 
 export type InfobarProps = Static<typeof InfobarSchema> & {
+  sectionIdx?: number // TODO: Remove this property, only used in classic theme
+  subtitle?: string // Subtitle that is only used in the classic theme
   LinkComponent?: any // Next.js link
 }

--- a/packages/components/src/interfaces/complex/Infopic.ts
+++ b/packages/components/src/interfaces/complex/Infopic.ts
@@ -4,18 +4,10 @@ import { Type } from "@sinclair/typebox"
 export const InfopicSchema = Type.Object(
   {
     type: Type.Literal("infopic", { default: "infopic" }),
-    // TODO: Remove this property, only used in classic theme
-    sectionIndex: Type.Optional(Type.Number()),
     title: Type.String({
       title: "Infopic title",
       description: "The title of the Infopic component",
     }),
-    subtitle: Type.Optional(
-      Type.String({
-        title: "Infopic subtitle",
-        description: "The subtitle of the Infopic component",
-      }),
-    ),
     description: Type.Optional(
       Type.String({
         title: "Infopic description",
@@ -65,4 +57,7 @@ export const InfopicSchema = Type.Object(
   },
 )
 
-export type InfopicProps = Static<typeof InfopicSchema>
+export type InfopicProps = Static<typeof InfopicSchema> & {
+  sectionIndex?: number // TODO: Remove this property, only used in classic theme
+  subtitle?: string // Subtitle that is only used in the classic theme
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some props appear on the form editor but do not affect how it is rendered on the preview, which can be confusing to the user.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Remove all the props that are only currently used in the classic theme from the schema, so it does not get rendered on the form builder inside Studio.