### PR TITLE
chore: remove render for fallthrough

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -12,4 +12,5 @@ export const JSON_FORMS_RANKING = {
   RadioControl: 3,
   GroupLayoutRenderer: 1,
   VerticalLayoutRenderer: 1,
+  Catchall: 99999999999
 }

--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -12,5 +12,5 @@ export const JSON_FORMS_RANKING = {
   RadioControl: 3,
   GroupLayoutRenderer: 1,
   VerticalLayoutRenderer: 1,
-  Catchall: 99999999999
+  Catchall: -99999999999,
 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -1,6 +1,6 @@
 import type { JsonFormsRendererRegistryEntry } from "@jsonforms/core"
 import type { IsomerComponent } from "@opengovsg/isomer-components"
-import { and, or, rankWith, schemaTypeIs } from "@jsonforms/core"
+import { rankWith } from "@jsonforms/core"
 import { JsonForms } from "@jsonforms/react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -1,9 +1,11 @@
+import type { JsonFormsRendererRegistryEntry } from "@jsonforms/core"
 import type { IsomerComponent } from "@opengovsg/isomer-components"
-import { and, or, rankWith, schemaTypeIs, type JsonFormsRendererRegistryEntry } from "@jsonforms/core"
+import { and, or, rankWith, schemaTypeIs } from "@jsonforms/core"
 import { JsonForms } from "@jsonforms/react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import {
   JsonFormsAllOfControl,
@@ -31,7 +33,6 @@ import {
   jsonFormsVerticalLayoutRenderer,
   jsonFormsVerticalLayoutTester,
 } from "./renderers"
-import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
 const renderers: JsonFormsRendererRegistryEntry[] = [
   { tester: jsonFormsObjectControlTester, renderer: JsonFormsObjectControl },
@@ -60,17 +61,11 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
     renderer: jsonFormsVerticalLayoutRenderer,
   },
   {
-    // NOTE: If we fall through all our previous testers, 
+    // NOTE: If we fall through all our previous testers,
     // we render null so that the users don't get visual noise
-    tester: rankWith(
-      JSON_FORMS_RANKING.Catchall,
-      // NOTE: This is just for UAT for `sectionIdx` but we might want to make this a general case
-      and(
-        or(schemaTypeIs("integer"), schemaTypeIs("number")),
-      ),
-    ),
-    renderer: () => null
-  }
+    tester: rankWith(JSON_FORMS_RANKING.Catchall, () => true),
+    renderer: () => null,
+  },
 ]
 const ajv = new Ajv({ strict: false, logger: false })
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -1,5 +1,5 @@
 import type { IsomerComponent } from "@opengovsg/isomer-components"
-import { type JsonFormsRendererRegistryEntry } from "@jsonforms/core"
+import { and, or, rankWith, schemaTypeIs, type JsonFormsRendererRegistryEntry } from "@jsonforms/core"
 import { JsonForms } from "@jsonforms/react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
@@ -31,6 +31,7 @@ import {
   jsonFormsVerticalLayoutRenderer,
   jsonFormsVerticalLayoutTester,
 } from "./renderers"
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
 const renderers: JsonFormsRendererRegistryEntry[] = [
   { tester: jsonFormsObjectControlTester, renderer: JsonFormsObjectControl },
@@ -54,6 +55,22 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
     tester: jsonFormsVerticalLayoutTester,
     renderer: jsonFormsVerticalLayoutRenderer,
   },
+  {
+    tester: jsonFormsVerticalLayoutTester,
+    renderer: jsonFormsVerticalLayoutRenderer,
+  },
+  {
+    // NOTE: If we fall through all our previous testers, 
+    // we render null so that the users don't get visual noise
+    tester: rankWith(
+      JSON_FORMS_RANKING.Catchall,
+      // NOTE: This is just for UAT for `sectionIdx` but we might want to make this a general case
+      and(
+        or(schemaTypeIs("integer"), schemaTypeIs("number")),
+      ),
+    ),
+    renderer: () => null
+  }
 ]
 const ajv = new Ajv({ strict: false, logger: false })
 


### PR DESCRIPTION
## Problem
At present, we have an optional `sectionIdx` prop that's already legacy (gg). This causes visual noise because it shows a little red `No applicable renderer found` text, which is distracting + useless.

## Solution
Add a default fallthrough case with super low priority so that stuff that falls through (specifically this, note the `and` condition from json forms) gets caught and rendered as `null`, preventing the visual noise/

## Alternatives considered but discarded
The ideal solution would be to jsut update the schema so section idx doesn't exist. however, i don't know if we can deprecate it yet so i'm still going with this solution for now