### PR TITLE
fix: numbering for nested ordered lists

### DIFF
--- a/packages/components/src/templates/next/components/native/ListItem/ListItem.tsx
+++ b/packages/components/src/templates/next/components/native/ListItem/ListItem.tsx
@@ -5,7 +5,7 @@ import UnorderedList from "../UnorderedList"
 
 const ListItem = ({ content }: ListItemProps) => {
   return (
-    <li className="my-5 pl-2 [&:has(>_ol)]:list-none [&:has(>_ul)]:list-none [&_>_p]:inline">
+    <li className="my-5 pl-2 [&_>_p]:inline">
       {content.map((item, index) => {
         if (item.type === "paragraph") {
           return <Paragraph key={index} {...item} />

--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.stories.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.stories.tsx
@@ -97,11 +97,6 @@ export const Nested: Story = {
         type: "listItem",
         content: [
           { type: "paragraph", content: [{ type: "text", text: "Item 2" }] },
-        ],
-      },
-      {
-        type: "listItem",
-        content: [
           {
             type: "orderedList",
             attrs: {
@@ -124,11 +119,6 @@ export const Nested: Story = {
                     type: "paragraph",
                     content: [{ type: "text", text: "Item 4" }],
                   },
-                ],
-              },
-              {
-                type: "listItem",
-                content: [
                   {
                     type: "unorderedList",
                     content: [

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.stories.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.stories.tsx
@@ -97,11 +97,6 @@ export const Nested: Story = {
         type: "listItem",
         content: [
           { type: "paragraph", content: [{ type: "text", text: "Item 2" }] },
-        ],
-      },
-      {
-        type: "listItem",
-        content: [
           {
             type: "unorderedList",
             content: [
@@ -121,11 +116,6 @@ export const Nested: Story = {
                     type: "paragraph",
                     content: [{ type: "text", text: "Item 4" }],
                   },
-                ],
-              },
-              {
-                type: "listItem",
-                content: [
                   {
                     type: "orderedList",
                     attrs: {

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -190,11 +190,6 @@ export const Default: Story = {
                       },
                     ],
                   },
-                ],
-              },
-              {
-                type: "listItem",
-                content: [
                   {
                     type: "unorderedList",
                     content: [
@@ -210,11 +205,6 @@ export const Default: Story = {
                               },
                             ],
                           },
-                        ],
-                      },
-                      {
-                        type: "listItem",
-                        content: [
                           {
                             type: "unorderedList",
                             content: [
@@ -236,11 +226,6 @@ export const Default: Story = {
                                     type: "paragraph",
                                     content: [{ type: "text", text: "Spam" }],
                                   },
-                                ],
-                              },
-                              {
-                                type: "listItem",
-                                content: [
                                   {
                                     type: "unorderedList",
                                     content: [
@@ -1199,11 +1184,6 @@ export const NoTable: Story = {
                       },
                     ],
                   },
-                ],
-              },
-              {
-                type: "listItem",
-                content: [
                   {
                     type: "unorderedList",
                     content: [
@@ -1219,11 +1199,6 @@ export const NoTable: Story = {
                               },
                             ],
                           },
-                        ],
-                      },
-                      {
-                        type: "listItem",
-                        content: [
                           {
                             type: "unorderedList",
                             content: [
@@ -1245,11 +1220,6 @@ export const NoTable: Story = {
                                     type: "paragraph",
                                     content: [{ type: "text", text: "Spam" }],
                                   },
-                                ],
-                              },
-                              {
-                                type: "listItem",
-                                content: [
                                   {
                                     type: "unorderedList",
                                     content: [
@@ -1597,11 +1567,6 @@ export const SmallTable: Story = {
                       },
                     ],
                   },
-                ],
-              },
-              {
-                type: "listItem",
-                content: [
                   {
                     type: "unorderedList",
                     content: [
@@ -1617,11 +1582,6 @@ export const SmallTable: Story = {
                               },
                             ],
                           },
-                        ],
-                      },
-                      {
-                        type: "listItem",
-                        content: [
                           {
                             type: "unorderedList",
                             content: [
@@ -1643,11 +1603,6 @@ export const SmallTable: Story = {
                                     type: "paragraph",
                                     content: [{ type: "text", text: "Spam" }],
                                   },
-                                ],
-                              },
-                              {
-                                type: "listItem",
-                                content: [
                                   {
                                     type: "unorderedList",
                                     content: [


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The numbering for ordered lists keeps skipping by 1 whenever there is a nested list.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make the nested list be rendered properly (with `ol`, `ul` and `p` being siblings in a nested list).
    - No schema changes is necessary because that was the original intent of the schema (which also matches what Tiptap provides), just that the way it was used is incorrect.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="335" alt="Screenshot 2024-07-23 at 16 48 35" src="https://github.com/user-attachments/assets/8cf377ba-4b67-48cf-85da-81bb98471d4c">


**AFTER**:

<!-- [insert screenshot here] -->
<img width="353" alt="Screenshot 2024-07-23 at 16 48 12" src="https://github.com/user-attachments/assets/c2240869-6458-4502-ac1f-1cb4d355bd24">