### PR TITLE
feat: add placeholder for empty editing drawer

### DIFF
--- a/apps/studio/src/components/Svg/BlockEditingPlaceholder.tsx
+++ b/apps/studio/src/components/Svg/BlockEditingPlaceholder.tsx
@@ -1,0 +1,171 @@
+import type { SVGProps } from "react"
+import { chakra } from "@chakra-ui/react"
+
+export const BlockEditingPlaceholder = chakra(
+  (props: SVGProps<SVGSVGElement>) => (
+    <svg
+      width="120"
+      height="57"
+      viewBox="0 0 120 57"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g clipPath="url(#clip0_5588_45516)">
+        <g filter="url(#filter0_d_5588_45516)">
+          <circle cx="23.5" cy="33" r="20" fill="white" />
+        </g>
+        <path
+          d="M31.9444 24H14.0556C12.8889 24 12.5 25.0405 12.5 26.6013V39.0874C12.5 40.6482 12.8889 41.1685 14.0556 41.6887C15.2222 42.209 31.2904 41.9199 32.0682 41.9199C32.846 41.9199 33.5 41.1685 33.5 40.1279V25.5608C33.5 24.5203 32.8784 24.0722 31.9444 24Z"
+          fill="#2164DA"
+        />
+        <rect x="16.5" y="38" width="14" height="1" fill="#B99BF9" />
+        <path
+          d="M26.9 38.5008C26.9 39.1635 26.3627 39.7008 25.7 39.7008C25.0373 39.7008 24.5 39.1635 24.5 38.5008C24.5 37.838 25.0373 37.3008 25.7 37.3008C26.3627 37.3008 26.9 37.838 26.9 38.5008Z"
+          fill="white"
+        />
+        <path
+          d="M20.5079 34.2252C20.5079 33.6773 20.4901 28.2357 20.508 27.6507C20.5259 27.0658 20.5092 26.8535 21.1088 27.1029C21.7085 27.3522 25.719 29.5169 26.517 29.9233C27.3151 30.3296 27.9291 30.9021 27.1179 31.6155C26.3068 32.3289 22.7267 34.2252 21.9871 34.7731C21.2475 35.3209 20.5079 34.7731 20.5079 34.2252Z"
+          fill="white"
+        />
+        <g filter="url(#filter1_d_5588_45516)">
+          <circle cx="58.5" cy="24" r="20" fill="white" />
+        </g>
+        <path
+          d="M66.9444 15H49.0556C47.8889 15 47.5 16.0405 47.5 17.6013V30.0874C47.5 31.6482 47.8889 32.1685 49.0556 32.6887C50.2222 33.209 66.2904 32.9199 67.0682 32.9199C67.846 32.9199 68.5 32.1685 68.5 31.1279V16.5608C68.5 15.5203 67.8784 15.0722 66.9444 15Z"
+          fill="#2164DA"
+        />
+        <path
+          d="M61.5 22C61.5 22.5523 61.0523 23 60.5 23C59.9477 23 59.5 22.5523 59.5 22C59.5 21.4477 59.9477 21 60.5 21C61.0523 21 61.5 21.4477 61.5 22Z"
+          fill="#B99BF9"
+        />
+        <path
+          d="M65.4993 28.0154H50.9993C50.4992 28.0154 50.0679 27.6448 50.4993 27.0154C50.9307 26.3859 53.9993 21.0307 54.4993 20.0154C54.9993 19.0001 55.9993 19.0001 56.4993 20.0154C56.9203 20.8702 59.1601 26.2199 59.3297 26.61C59.4993 27 59.4993 27 59.7712 26.7311C60.0431 26.4622 62.0821 24.3336 62.4993 24.0154C63.0236 23.6156 63.0282 23.6536 63.4993 24.0154C63.9705 24.3771 65.9993 26.5 66.4993 27.0154C66.9993 27.5308 66.4993 28.0153 65.4993 28.0154Z"
+          fill="white"
+        />
+        <g filter="url(#filter2_d_5588_45516)">
+          <circle cx="93.5" cy="33" r="20" fill="white" />
+        </g>
+        <path
+          d="M101.944 24H84.0556C82.8889 24 82.5 25.0405 82.5 26.6013V39.0874C82.5 40.6482 82.8889 41.1685 84.0556 41.6887C85.2222 42.209 101.29 41.9199 102.068 41.9199C102.846 41.9199 103.5 41.1685 103.5 40.1279V25.5608C103.5 24.5203 102.878 24.0722 101.944 24Z"
+          fill="#2164DA"
+        />
+        <rect x="85.5" y="26" width="7" height="14" rx="0.5" fill="white" />
+        <rect x="93.5" y="26" width="7" height="6" rx="0.5" fill="white" />
+        <rect x="93.5" y="33" width="7" height="7" rx="0.5" fill="#B99BF9" />
+      </g>
+      <defs>
+        <filter
+          id="filter0_d_5588_45516"
+          x="-2.5"
+          y="7"
+          width="52"
+          height="52"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="3" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.595833 0 0 0 0 0.595833 0 0 0 0 0.595833 0 0 0 0.5 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow_5588_45516"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_5588_45516"
+            result="shape"
+          />
+        </filter>
+        <filter
+          id="filter1_d_5588_45516"
+          x="32.5"
+          y="-2"
+          width="52"
+          height="52"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="3" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.595833 0 0 0 0 0.595833 0 0 0 0 0.595833 0 0 0 0.5 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow_5588_45516"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_5588_45516"
+            result="shape"
+          />
+        </filter>
+        <filter
+          id="filter2_d_5588_45516"
+          x="67.5"
+          y="7"
+          width="52"
+          height="52"
+          filterUnits="userSpaceOnUse"
+          colorInterpolationFilters="sRGB"
+        >
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feColorMatrix
+            in="SourceAlpha"
+            type="matrix"
+            values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"
+            result="hardAlpha"
+          />
+          <feOffset />
+          <feGaussianBlur stdDeviation="3" />
+          <feColorMatrix
+            type="matrix"
+            values="0 0 0 0 0.595833 0 0 0 0 0.595833 0 0 0 0 0.595833 0 0 0 0.5 0"
+          />
+          <feBlend
+            mode="normal"
+            in2="BackgroundImageFix"
+            result="effect1_dropShadow_5588_45516"
+          />
+          <feBlend
+            mode="normal"
+            in="SourceGraphic"
+            in2="effect1_dropShadow_5588_45516"
+            result="shape"
+          />
+        </filter>
+        <clipPath id="clip0_5588_45516">
+          <rect
+            width="119"
+            height="57"
+            fill="white"
+            transform="translate(0.5)"
+          />
+        </clipPath>
+      </defs>
+    </svg>
+  ),
+)

--- a/apps/studio/src/components/Svg/index.ts
+++ b/apps/studio/src/components/Svg/index.ts
@@ -1,2 +1,4 @@
-export * from "./OgpLogo"
 export * from "./BusStop"
+export * from "./BlockEditingPlaceholder"
+export * from "./OgpLogo"
+export * from "./SingpassFullLogo"

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -14,6 +14,7 @@ import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiGridVertical } from "react-icons/bi"
 import { BsPlus } from "react-icons/bs"
 
+import { BlockEditingPlaceholder } from "~/components/Svg"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 
 export default function RootStateDrawer() {
@@ -72,6 +73,26 @@ export default function RootStateDrawer() {
                   Custom blocks
                 </Text>
                 <Box w="100%">
+                  {savedPageState.length === 0 && (
+                    <VStack justifyContent="center" spacing={0} mt="2.75rem">
+                      <BlockEditingPlaceholder />
+                      <Text
+                        mt="0.75rem"
+                        textStyle="subhead-1"
+                        color="base.content.default"
+                      >
+                        Blocks you add will appear here
+                      </Text>
+                      <Text
+                        mt="0.25rem"
+                        textStyle="caption-2"
+                        color="base.content.medium"
+                      >
+                        Click ‘Add a new block’ below to add blocks to this page
+                      </Text>
+                    </VStack>
+                  )}
+
                   {savedPageState.map((block, index) => (
                     <Draggable
                       // TODO: Determine key + draggable id


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There is a missing placeholder when the editing drawer is empty.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add a placeholder when the editing drawer is empty.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="517" alt="Screenshot 2024-07-24 at 13 06 31" src="https://github.com/user-attachments/assets/c747f198-2658-4042-acb4-bb5b4f5aa571">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="501" alt="Screenshot 2024-07-24 at 13 06 14" src="https://github.com/user-attachments/assets/d7a60ebd-340d-4acf-9765-676ba0ae8958">