### PR TITLE
feat: introduce page metadata editor

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -116,6 +116,8 @@ function ComponentSelector() {
   })
 
   const onProceed = (sectionType: SectionType) => {
+    if (!savedPageState) return
+
     // TODO: add new section to page/editor state
     // NOTE: Only paragraph should go to tiptap editor
     // the rest should use json forms
@@ -125,12 +127,16 @@ function ComponentSelector() {
     const newComponent: IsomerComponent | undefined =
       DEFAULT_BLOCKS[sectionType]
 
-    const nextPageState = !!newComponent
-      ? [...savedPageState, newComponent]
-      : savedPageState
-
+    const updatedBlocks = !!newComponent
+      ? [...savedPageState.content, newComponent]
+      : savedPageState.content
+    const nextPageState = {
+      ...savedPageState,
+      content: updatedBlocks,
+    }
+    setSavedPageState(nextPageState)
     setDrawerState({ state: nextState })
-    setCurrActiveIdx(nextPageState.length - 1)
+    setCurrActiveIdx(nextPageState.content.length - 1)
     setPreviewPageState(nextPageState)
 
     // TODO: Decide if setting addedBlocks

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -1,4 +1,4 @@
-import type { IsomerComponent } from "@opengovsg/isomer-components"
+import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import { createContext, useContext, useState } from "react"
 
@@ -12,10 +12,10 @@ export interface DrawerContextType {
   setDrawerState: (state: DrawerState) => void
   addedBlock: Exclude<SectionType, "prose">
   setAddedBlock: (addedBlock: Exclude<SectionType, "prose">) => void
-  savedPageState: IsomerComponent[]
-  setSavedPageState: Dispatch<SetStateAction<IsomerComponent[]>>
-  previewPageState: IsomerComponent[]
-  setPreviewPageState: Dispatch<SetStateAction<IsomerComponent[]>>
+  savedPageState?: IsomerSchema
+  setSavedPageState: Dispatch<SetStateAction<IsomerSchema | undefined>>
+  previewPageState?: IsomerSchema
+  setPreviewPageState: Dispatch<SetStateAction<IsomerSchema | undefined>>
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -26,11 +26,13 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
   // Index of the current block being edited
   const [currActiveIdx, setCurrActiveIdx] = useState<number>(-1)
   // Current saved state of page
-  const [savedPageState, setSavedPageState] = useState<IsomerComponent[]>([])
+  const [savedPageState, setSavedPageState] = useState<
+    IsomerSchema | undefined
+  >()
   // State of the page to render in the preview
-  const [previewPageState, setPreviewPageState] = useState<IsomerComponent[]>(
-    [],
-  )
+  const [previewPageState, setPreviewPageState] = useState<
+    IsomerSchema | undefined
+  >()
   const [addedBlock, setAddedBlock] =
     useState<Exclude<SectionType, "prose">>("button")
 

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -1,7 +1,4 @@
-import type {
-  IsomerComponent,
-  IsomerSchema,
-} from "@opengovsg/isomer-components"
+import type { IsomerComponent } from "@opengovsg/isomer-components"
 import type { ProseProps } from "@opengovsg/isomer-components/dist/cjs/interfaces"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
@@ -17,11 +14,7 @@ const proseSchema = getComponentSchema("prose")
 const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
 const validate = ajv.compile<ProseProps>(proseSchema)
 
-interface EditPageDrawerProps {
-  layout: IsomerSchema["layout"]
-}
-
-export function EditPageDrawer({ layout }: EditPageDrawerProps): JSX.Element {
+export function EditPageDrawer(): JSX.Element {
   const {
     previewPageState,
     drawerState: currState,
@@ -42,19 +35,23 @@ export function EditPageDrawer({ layout }: EditPageDrawerProps): JSX.Element {
     )
   }
 
+  if (!previewPageState) {
+    return <></>
+  }
+
   switch (currState.state) {
     case "root":
       return <RootStateDrawer />
     case "addBlock":
       return <ComponentSelector />
     case "nativeEditor": {
-      const component = previewPageState?.content[currActiveIdx]
+      const component = previewPageState.content[currActiveIdx]
       return <TipTapComponent content={inferAsProse(component)} />
     }
     case "complexEditor":
       return <ComplexEditorStateDrawer />
     case "metadataEditor":
-      return <MetadataEditorStateDrawer layout={layout} />
+      return <MetadataEditorStateDrawer />
     default:
       const _: never = currState
       return <h1>Edit Page Drawer</h1>

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -1,3 +1,7 @@
+import type {
+  IsomerComponent,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
 import type { ProseProps } from "@opengovsg/isomer-components/dist/cjs/interfaces"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
@@ -5,6 +9,7 @@ import Ajv from "ajv"
 import ComponentSelector from "~/components/PageEditor/ComponentSelector"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import ComplexEditorStateDrawer from "./ComplexEditorStateDrawer"
+import MetadataEditorStateDrawer from "./MetadataEditorStateDrawer"
 import RootStateDrawer from "./RootStateDrawer"
 import TipTapComponent from "./TipTapComponent"
 
@@ -12,16 +17,18 @@ const proseSchema = getComponentSchema("prose")
 const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
 const validate = ajv.compile<ProseProps>(proseSchema)
 
-export function EditPageDrawer() {
+interface EditPageDrawerProps {
+  layout: IsomerSchema["layout"]
+}
+
+export function EditPageDrawer({ layout }: EditPageDrawerProps): JSX.Element {
   const {
     previewPageState,
     drawerState: currState,
     currActiveIdx,
   } = useEditorDrawerContext()
 
-  const inferAsProse = (
-    component?: (typeof previewPageState)[number],
-  ): ProseProps => {
+  const inferAsProse = (component?: IsomerComponent): ProseProps => {
     if (!component) {
       throw new Error(`Expected component of type prose but got undefined`)
     }
@@ -41,11 +48,13 @@ export function EditPageDrawer() {
     case "addBlock":
       return <ComponentSelector />
     case "nativeEditor": {
-      const component = previewPageState[currActiveIdx]
+      const component = previewPageState?.content[currActiveIdx]
       return <TipTapComponent content={inferAsProse(component)} />
     }
     case "complexEditor":
       return <ComplexEditorStateDrawer />
+    case "metadataEditor":
+      return <MetadataEditorStateDrawer layout={layout} />
     default:
       const _: never = currState
       return <h1>Edit Page Drawer</h1>

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -3,7 +3,6 @@ import type { Static } from "@sinclair/typebox"
 import { Box, Heading, HStack, Icon, IconButton } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { getLayoutMetadataSchema } from "@opengovsg/isomer-components"
-import { type TSchema } from "@sinclair/typebox"
 import Ajv from "ajv"
 import { BiDollar, BiX } from "react-icons/bi"
 
@@ -25,10 +24,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
     return <></>
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
-  const metadataSchema: TSchema = getLayoutMetadataSchema(
-    previewPageState.layout,
-  )
+  const metadataSchema = getLayoutMetadataSchema(previewPageState.layout)
   const validateFn = ajv.compile<Static<typeof metadataSchema>>(metadataSchema)
 
   const handleChange = (data: unknown) => {

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -2,14 +2,8 @@ import type { IsomerSchema, schema } from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Heading, HStack, Icon, IconButton } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
-import {
-  ArticlePageMetaSchema,
-  CollectionPageSchema,
-  ContentPageMetaSchema,
-  FileRefSchema,
-  HomePageMetaSchema,
-  LinkRefSchema,
-} from "@opengovsg/isomer-components"
+import { getLayoutMetadataSchema } from "@opengovsg/isomer-components"
+import { type TSchema } from "@sinclair/typebox"
 import Ajv from "ajv"
 import { BiDollar, BiX } from "react-icons/bi"
 
@@ -18,22 +12,7 @@ import FormBuilder from "./form-builder/FormBuilder"
 
 const ajv = new Ajv({ strict: false, logger: false })
 
-interface MetadataEditorStateDrawerProps {
-  layout: IsomerSchema["layout"]
-}
-
-const LAYOUT_METADATA_MAP = {
-  article: ArticlePageMetaSchema,
-  content: ContentPageMetaSchema,
-  homepage: HomePageMetaSchema,
-  link: LinkRefSchema,
-  collection: CollectionPageSchema,
-  file: FileRefSchema,
-}
-
-export default function MetadataEditorStateDrawer({
-  layout,
-}: MetadataEditorStateDrawerProps): JSX.Element {
+export default function MetadataEditorStateDrawer(): JSX.Element {
   const {
     setDrawerState,
     savedPageState,
@@ -41,12 +20,18 @@ export default function MetadataEditorStateDrawer({
     previewPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
-  const metadataSchema = LAYOUT_METADATA_MAP[layout]
+
+  if (!previewPageState) {
+    return <></>
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+  const metadataSchema: TSchema = getLayoutMetadataSchema(
+    previewPageState.layout,
+  )
   const validateFn = ajv.compile<Static<typeof metadataSchema>>(metadataSchema)
 
   const handleChange = (data: unknown) => {
-    if (!previewPageState) return
-
     // TODO: Perform actual validation on the data
     const newPageState = {
       ...previewPageState,
@@ -98,7 +83,7 @@ export default function MetadataEditorStateDrawer({
         <FormBuilder<Static<typeof schema>>
           schema={metadataSchema}
           validateFn={validateFn}
-          data={previewPageState?.page}
+          data={previewPageState.page}
           handleChange={(data) => handleChange(data)}
         />
       </Box>

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -1,0 +1,119 @@
+import type { IsomerSchema, schema } from "@opengovsg/isomer-components"
+import type { Static } from "@sinclair/typebox"
+import { Box, Heading, HStack, Icon, IconButton } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import {
+  ArticlePageMetaSchema,
+  CollectionPageSchema,
+  ContentPageMetaSchema,
+  FileRefSchema,
+  HomePageMetaSchema,
+  LinkRefSchema,
+} from "@opengovsg/isomer-components"
+import Ajv from "ajv"
+import { BiDollar, BiX } from "react-icons/bi"
+
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import FormBuilder from "./form-builder/FormBuilder"
+
+const ajv = new Ajv({ strict: false, logger: false })
+
+interface MetadataEditorStateDrawerProps {
+  layout: IsomerSchema["layout"]
+}
+
+const LAYOUT_METADATA_MAP = {
+  article: ArticlePageMetaSchema,
+  content: ContentPageMetaSchema,
+  homepage: HomePageMetaSchema,
+  link: LinkRefSchema,
+  collection: CollectionPageSchema,
+  file: FileRefSchema,
+}
+
+export default function MetadataEditorStateDrawer({
+  layout,
+}: MetadataEditorStateDrawerProps): JSX.Element {
+  const {
+    setDrawerState,
+    savedPageState,
+    setSavedPageState,
+    previewPageState,
+    setPreviewPageState,
+  } = useEditorDrawerContext()
+  const metadataSchema = LAYOUT_METADATA_MAP[layout]
+  const validateFn = ajv.compile<Static<typeof metadataSchema>>(metadataSchema)
+
+  const handleChange = (data: unknown) => {
+    if (!previewPageState) return
+
+    // TODO: Perform actual validation on the data
+    const newPageState = {
+      ...previewPageState,
+      page: data,
+    } as IsomerSchema
+
+    setPreviewPageState(newPageState)
+  }
+
+  return (
+    <Box w="100%">
+      <Box
+        bgColor="base.canvas.default"
+        borderBottomColor="base.divider.medium"
+        borderBottomWidth="1px"
+        px="2rem"
+        py="1.25rem"
+      >
+        <HStack justifyContent="space-between" w="100%">
+          <HStack spacing={3}>
+            <Icon
+              as={BiDollar}
+              fontSize="1.5rem"
+              p="0.25rem"
+              bgColor="slate.100"
+              textColor="blue.600"
+              borderRadius="base"
+            />
+            <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+              Edit page title and summary
+            </Heading>
+          </HStack>
+          <IconButton
+            icon={<Icon as={BiX} />}
+            variant="clear"
+            colorScheme="sub"
+            size="sm"
+            p="0.625rem"
+            onClick={() => {
+              setPreviewPageState(savedPageState)
+              setDrawerState({ state: "root" })
+            }}
+            aria-label="Close drawer"
+          />
+        </HStack>
+      </Box>
+
+      <Box px="2rem" py="1rem">
+        <FormBuilder<Static<typeof schema>>
+          schema={metadataSchema}
+          validateFn={validateFn}
+          data={previewPageState?.page}
+          handleChange={(data) => handleChange(data)}
+        />
+      </Box>
+
+      <Box px="2rem" pb="1.5rem">
+        <Button
+          w="100%"
+          onClick={() => {
+            setDrawerState({ state: "root" })
+            setSavedPageState(previewPageState)
+          }}
+        >
+          Save
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -21,7 +21,6 @@ export default function RootStateDrawer() {
     setDrawerState,
     setCurrActiveIdx,
     savedPageState,
-    previewPageState,
     setSavedPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
@@ -46,6 +45,11 @@ export default function RootStateDrawer() {
     setSavedPageState(newPageState)
   }
 
+  const isHeroFixedBlock =
+    savedPageState?.layout === "homepage" &&
+    savedPageState.content.length > 0 &&
+    savedPageState.content[0]?.type === "hero"
+
   return (
     <VStack w="100%" h="100%" gap={10} pt={10}>
       {/* TODO: Fixed Blocks Section */}
@@ -53,20 +57,41 @@ export default function RootStateDrawer() {
         <Text fontSize="xl" pl={4} fontWeight={500}>
           Fixed blocks
         </Text>
-        <Box
-          as="button"
-          onClick={() => setDrawerState({ state: "metadataEditor" })}
-          w="100%"
-        >
-          <HStack w="100%" py="4" bgColor="white">
-            <VStack w="100%" align="baseline" pl={1}>
-              <Text px="3" fontWeight={500}>
-                Page title and summary
-              </Text>
-              <Text px="3">Click to edit</Text>
-            </VStack>
-          </HStack>
-        </Box>
+
+        {isHeroFixedBlock ? (
+          <Box
+            as="button"
+            onClick={() => {
+              setCurrActiveIdx(0)
+              setDrawerState({ state: "complexEditor" })
+            }}
+            w="100%"
+          >
+            <HStack w="100%" py="4" bgColor="white">
+              <VStack w="100%" align="baseline" pl={1}>
+                <Text px="3" fontWeight={500}>
+                  Hero banner
+                </Text>
+                <Text px="3">Title, subtitle, and Call-to-Action</Text>
+              </VStack>
+            </HStack>
+          </Box>
+        ) : (
+          <Box
+            as="button"
+            onClick={() => setDrawerState({ state: "metadataEditor" })}
+            w="100%"
+          >
+            <HStack w="100%" py="4" bgColor="white">
+              <VStack w="100%" align="baseline" pl={1}>
+                <Text px="3" fontWeight={500}>
+                  Page title and summary
+                </Text>
+                <Text px="3">Click to edit</Text>
+              </VStack>
+            </HStack>
+          </Box>
+        )}
       </VStack>
 
       <VStack justifyContent="space-between" w="100%" h="100%">
@@ -84,77 +109,80 @@ export default function RootStateDrawer() {
                   Custom blocks
                 </Text>
                 <Box w="100%">
-                  {!savedPageState ||
-                    (savedPageState.content.length === 0 && (
-                      <VStack justifyContent="center" spacing={0} mt="2.75rem">
-                        <BlockEditingPlaceholder />
-                        <Text
-                          mt="0.75rem"
-                          textStyle="subhead-1"
-                          color="base.content.default"
-                        >
-                          Blocks you add will appear here
-                        </Text>
-                        <Text
-                          mt="0.25rem"
-                          textStyle="caption-2"
-                          color="base.content.medium"
-                        >
-                          Click ‘Add a new block’ below to add blocks to this
-                          page
-                        </Text>
-                      </VStack>
-                    ))}
+                  {(!savedPageState ||
+                    (isHeroFixedBlock && savedPageState.content.length === 1) ||
+                    savedPageState.content.length === 0) && (
+                    <VStack justifyContent="center" spacing={0} mt="2.75rem">
+                      <BlockEditingPlaceholder />
+                      <Text
+                        mt="0.75rem"
+                        textStyle="subhead-1"
+                        color="base.content.default"
+                      >
+                        Blocks you add will appear here
+                      </Text>
+                      <Text
+                        mt="0.25rem"
+                        textStyle="caption-2"
+                        color="base.content.medium"
+                      >
+                        Click ‘Add a new block’ below to add blocks to this page
+                      </Text>
+                    </VStack>
+                  )}
 
                   {!!savedPageState &&
-                    savedPageState.content.map((block, index) => (
-                      <Draggable
-                        // TODO: Determine key + draggable id
-                        key={index}
-                        draggableId={`${block.type}-${index}`}
-                        index={index}
-                      >
-                        {(provided) => (
-                          <VStack
-                            w="100%"
-                            gap={0}
-                            onClick={() => {
-                              setCurrActiveIdx(index)
-                              // TODO: we should automatically do this probably?
-                              const nextState =
-                                savedPageState.content[index]?.type === "prose"
-                                  ? "nativeEditor"
-                                  : "complexEditor"
-                              // NOTE: SNAPSHOT
-                              setDrawerState({ state: nextState })
-                            }}
-                          >
-                            <HStack
+                    savedPageState.content
+                      .slice(isHeroFixedBlock ? 1 : 0)
+                      .map((block, index) => (
+                        <Draggable
+                          // TODO: Determine key + draggable id
+                          key={index}
+                          draggableId={`${block.type}-${index}`}
+                          index={index}
+                        >
+                          {(provided) => (
+                            <VStack
                               w="100%"
-                              py="4"
-                              bgColor="white"
-                              ref={provided.innerRef}
-                              {...provided.draggableProps}
-                              {...provided.dragHandleProps}
+                              gap={0}
+                              onClick={() => {
+                                setCurrActiveIdx(index)
+                                // TODO: we should automatically do this probably?
+                                const nextState =
+                                  savedPageState.content[index]?.type ===
+                                  "prose"
+                                    ? "nativeEditor"
+                                    : "complexEditor"
+                                // NOTE: SNAPSHOT
+                                setDrawerState({ state: nextState })
+                              }}
                             >
-                              <Icon
-                                as={BiGridVertical}
-                                fontSize="1.5rem"
-                                ml="0.75rem"
-                              />
-                              <Text px="3" fontWeight={500}>
-                                {/*  NOTE: Because we use `Type.Ref` for prose, */}
-                                {/* this gets a `$Ref` only and not the concrete values */}
-                                {block.type === "prose"
-                                  ? "Prose component"
-                                  : getComponentSchema(block.type).title}
-                              </Text>
-                            </HStack>
-                            <Divider />
-                          </VStack>
-                        )}
-                      </Draggable>
-                    ))}
+                              <HStack
+                                w="100%"
+                                py="4"
+                                bgColor="white"
+                                ref={provided.innerRef}
+                                {...provided.draggableProps}
+                                {...provided.dragHandleProps}
+                              >
+                                <Icon
+                                  as={BiGridVertical}
+                                  fontSize="1.5rem"
+                                  ml="0.75rem"
+                                />
+                                <Text px="3" fontWeight={500}>
+                                  {/*  NOTE: Because we use `Type.Ref` for prose, */}
+                                  {/* this gets a `$Ref` only and not the concrete values */}
+                                  {block.type === "prose"
+                                    ? "Prose component"
+                                    : getComponentSchema(block.type).title}
+                                </Text>
+                              </HStack>
+                              <Divider />
+                            </VStack>
+                          )}
+                        </Draggable>
+                      ))}
                 </Box>
                 {provided.placeholder}
               </VStack>

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -10,7 +10,6 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
-import { cloneDeep } from "lodash"
 import { BiText, BiTrash, BiX } from "react-icons/bi"
 
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
@@ -37,23 +36,28 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     onClose: onDeleteBlockModalClose,
   } = useDisclosure()
 
+  if (!previewPageState || !savedPageState) return
+
   const updatePageState = (editorContent: JSONContent) => {
+    const updatedBlocks = Array.from(previewPageState.content)
     // TODO: actual validation
-    const content = editorContent as ProseProps
-    setPreviewPageState((oldState) => {
-      // TODO: performance - this is a full clone
-      // of the object, which is expensive
-      const newState = cloneDeep(oldState)
-      newState[currActiveIdx] = content
-      return newState
-    })
+    updatedBlocks[currActiveIdx] = editorContent as ProseProps
+    const newPageState = {
+      ...previewPageState,
+      content: updatedBlocks,
+    }
+    setPreviewPageState(newPageState)
   }
 
   const handleDeleteBlock = () => {
-    const updatedBlocks = Array.from(savedPageState)
+    const updatedBlocks = Array.from(savedPageState.content)
     updatedBlocks.splice(currActiveIdx, 1)
-    setSavedPageState(updatedBlocks)
-    setPreviewPageState(updatedBlocks)
+    const newPageState = {
+      ...previewPageState,
+      content: updatedBlocks,
+    }
+    setSavedPageState(newPageState)
+    setPreviewPageState(newPageState)
     onDeleteBlockModalClose()
     setDrawerState({ state: "root" })
   }

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -33,10 +33,9 @@ function EditPage(): JSX.Element {
     setDrawerState({
       state: "root",
     })
-    const blocks = page.content
-    setSavedPageState(blocks)
-    setPreviewPageState(blocks)
-  }, [page.content, setDrawerState, setPreviewPageState, setSavedPageState])
+    setSavedPageState(page)
+    setPreviewPageState(page)
+  }, [page, setDrawerState, setPreviewPageState, setSavedPageState])
 
   return (
     <Grid
@@ -47,18 +46,18 @@ function EditPage(): JSX.Element {
     >
       {/* TODO: Implement sidebar editor */}
       <GridItem colSpan={1} bg="slate.50">
-        <EditPageDrawer />
+        <EditPageDrawer layout={page.layout} />
       </GridItem>
       {/* TODO: Implement preview */}
       <GridItem colSpan={2} overflow="scroll">
         <Box p="2rem" bg="gray.100">
           <Box borderRadius="8px" bg="white" shadow="md" overflow="auto">
             <Preview
-              siteId={siteId}
               {...page}
+              {...previewPageState}
+              siteId={siteId}
               permalink={permalink}
               version="0.1.0"
-              content={previewPageState}
             />
           </Box>
         </Box>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -46,7 +46,7 @@ function EditPage(): JSX.Element {
     >
       {/* TODO: Implement sidebar editor */}
       <GridItem colSpan={1} bg="slate.50">
-        <EditPageDrawer layout={page.layout} />
+        <EditPageDrawer />
       </GridItem>
       {/* TODO: Implement preview */}
       <GridItem colSpan={2} overflow="scroll">

--- a/apps/studio/src/types/editorDrawer.ts
+++ b/apps/studio/src/types/editorDrawer.ts
@@ -14,8 +14,13 @@ export interface ComplexEditorState {
   state: "complexEditor"
 }
 
+export interface MetadataEditorState {
+  state: "metadataEditor"
+}
+
 export type DrawerState =
   | RootDrawerState
   | AddNewBlockState
   | NativeEditorState
   | ComplexEditorState
+  | MetadataEditorState

--- a/packages/components/src/schemas/index.ts
+++ b/packages/components/src/schemas/index.ts
@@ -1,1 +1,1 @@
-export { getComponentSchema, schema } from "./main"
+export { getComponentSchema, getLayoutMetadataSchema, schema } from "./main"

--- a/packages/components/src/schemas/main.ts
+++ b/packages/components/src/schemas/main.ts
@@ -1,8 +1,16 @@
 import type { TSchema } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerComponentTypes } from "~/types"
-import { IsomerPageSchema } from "~/types"
+import type { IsomerComponentTypes, IsomerSchema } from "~/types"
+import {
+  ArticlePageMetaSchema,
+  CollectionPageSchema,
+  ContentPageMetaSchema,
+  FileRefSchema,
+  HomePageMetaSchema,
+  IsomerPageSchema,
+  LinkRefSchema,
+} from "~/types"
 import {
   IsomerComplexComponentsMap,
   IsomerNativeComponentsMap,
@@ -34,4 +42,19 @@ export const getComponentSchema = (
     ...componentSchema,
     ...definitions,
   }
+}
+
+const LAYOUT_METADATA_MAP = {
+  article: ArticlePageMetaSchema,
+  content: ContentPageMetaSchema,
+  homepage: HomePageMetaSchema,
+  link: LinkRefSchema,
+  collection: CollectionPageSchema,
+  file: FileRefSchema,
+}
+
+export const getLayoutMetadataSchema = (
+  layout: IsomerSchema["layout"],
+): TSchema => {
+  return LAYOUT_METADATA_MAP[layout]
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The page metadata editor cannot be changed currently.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Introduce a new page metadata editor state to edit the page's metadata.
    - Changed `previewPageState` and `savedPageState` to handle the entire page and not just the content block.
- Also adjusted the FormBuilder to be generic, so that it can be reused in multiple places.
- Also set the Hero component to be the first fixed block if it is the homepage layout.

## Before & After Screenshots
<img width="507" alt="Screenshot 2024-07-24 at 17 13 32" src="https://github.com/user-attachments/assets/9d28cdb0-2d30-4592-b594-2eccc68c704e">