### PR TITLE
chore: style fixes for save button

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -79,7 +79,8 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         bottom={0}
         bgColor="base.canvas.default"
         boxShadow="md"
-        p="1.5rem 2rem 1.5rem 2rem"
+        py="1.5rem"
+        px="2rem"
       >
         <Button
           w="100%"

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, HStack, Icon, Spacer } from "@chakra-ui/react"
+import { Box, Flex, Heading, HStack, Icon } from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiDollar, BiX } from "react-icons/bi"
@@ -74,8 +74,9 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
       <Box px="2rem" py="1rem">
         <FormBuilder />
       </Box>
-      <Spacer />
       <Box
+        pos="sticky"
+        bottom={0}
         bgColor="base.canvas.default"
         boxShadow="md"
         p="1.5rem 2rem 1.5rem 2rem"

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, HStack, Icon } from "@chakra-ui/react"
+import { Box, Flex, Heading, HStack, Icon, Spacer } from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiDollar, BiX } from "react-icons/bi"
@@ -29,7 +29,13 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
   const { title } = getComponentSchema(component.type)
 
   return (
-    <Box position="relative" h="100%" w="100%" overflow="auto">
+    <Flex
+      flexDir="column"
+      position="relative"
+      h="100%"
+      w="100%"
+      overflow="auto"
+    >
       <Box
         bgColor="base.canvas.default"
         borderBottomColor="base.divider.medium"
@@ -68,7 +74,12 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
       <Box px="2rem" py="1rem">
         <FormBuilder />
       </Box>
-      <Box px="2rem" pb="1.5rem">
+      <Spacer />
+      <Box
+        bgColor="base.canvas.default"
+        boxShadow="md"
+        p="1.5rem 2rem 1.5rem 2rem"
+      >
         <Button
           w="100%"
           onClick={() => {
@@ -79,6 +90,6 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
           Save
         </Button>
       </Box>
-    </Box>
+    </Flex>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -151,8 +151,9 @@ export default function RootStateDrawer() {
         w="100%"
         bgColor="base.canvas.default"
         boxShadow="md"
-        p="1.5rem 2rem 1.5rem 2rem"
         pos="sticky"
+        py="1.5rem"
+        px="2rem"
         bottom={0}
       >
         <Button

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -149,7 +149,6 @@ export default function RootStateDrawer() {
         </DragDropContext>
       </VStack>
       <Spacer />
-      {/* TODO: Add New Block Section */}
       <Box
         w="100%"
         bgColor="base.canvas.default"

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -5,7 +5,6 @@ import {
   Divider,
   HStack,
   Icon,
-  Spacer,
   Text,
   VStack,
 } from "@chakra-ui/react"
@@ -148,12 +147,13 @@ export default function RootStateDrawer() {
           </Droppable>
         </DragDropContext>
       </VStack>
-      <Spacer />
       <Box
         w="100%"
         bgColor="base.canvas.default"
         boxShadow="md"
         p="1.5rem 2rem 1.5rem 2rem"
+        pos="sticky"
+        bottom={0}
       >
         <Button
           w="100%"

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -152,9 +152,9 @@ export default function RootStateDrawer() {
       {/* TODO: Add New Block Section */}
       <Box
         w="100%"
-        bgColor="white"
+        bgColor="base.canvas.default"
+        boxShadow="md"
         p="1.5rem 2rem 1.5rem 2rem"
-        boxShadow="0px 0px 10px 0px #BFBFBF80"
       >
         <Button
           w="100%"


### PR DESCRIPTION
## Problem
Previously, our save button was very high up and not pinned ot the bottom. this means the UI is very cramped. design has specified that hte save button should be pinned to the bottom and be sticky so that even when there are many items, it'll display correctly.

## Solution
- use `Flex` + `Spacer` so that the `Box` containing the button is at the bottom
- add shadows so that the box containing the save button is visually distinct. this is done via tokens rather than palette + raw css values as we've done before
- ~take note that adding many items will still cause the save button **to be pinned to the bottom of the sidebar**; i think what design wants is for the save button to be pinned **to the bottom of the screen**. this is slightly trickier and might involve `pos: absolute` which might complicate overflows, for example (save button now blocks blocks) <- say that real fast a few times.~
    - this `sticky` behaviour which we have now is actually correct, try it on [this site](https://developer.mozilla.org/en-US/docs/Web/CSS/Layout_cookbook/Sticky_footers)

## Before & After Screenshots
**AFTER**:
<img width="499" alt="image" src="https://github.com/user-attachments/assets/e704c04f-e58e-45bc-9bc9-add55aca2a8d">
