### PR TITLE
feat: add validation error messages to form

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -55,7 +55,7 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
     renderer: jsonFormsVerticalLayoutRenderer,
   },
 ]
-const ajv = new Ajv({ strict: false, logger: false })
+const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
 
 export default function FormBuilder(): JSX.Element {
   const {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
@@ -58,15 +58,23 @@ export function JsonFormsIntegerControl({
   const min = Number(exclusiveMinimum) + 1 || minimum || 0
   const max = Number(exclusiveMaximum) - 1 || maximum || 0
 
+  const onChange = (valueAsString: string, valueAsNumber: number) => {
+    if (valueAsString === "") {
+      handleChange(path, undefined)
+    } else {
+      handleChange(path, valueAsNumber)
+    }
+  }
+
   return (
     <Box py={2}>
-      <FormControl isRequired={required}>
+      <FormControl isRequired={required} isInvalid={!!errors}>
         <FormLabel description={description}>{label}</FormLabel>
         <NumberInput
           defaultValue={defaultValue || min}
           min={min}
           max={max}
-          onChange={(e) => handleChange(path, e)}
+          onChange={onChange}
         >
           <NumberInputField />
           <NumberInputStepper>
@@ -74,7 +82,9 @@ export function JsonFormsIntegerControl({
             <NumberDecrementStepper />
           </NumberInputStepper>
         </NumberInput>
-        <FormErrorMessage>{errors}</FormErrorMessage>
+        <FormErrorMessage>
+          {label} {errors}
+        </FormErrorMessage>
       </FormControl>
     </Box>
   )

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
@@ -1,8 +1,12 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import { Box, FormControl } from "@chakra-ui/react"
+import { Box, FormControl, FormHelperText } from "@chakra-ui/react"
 import { isStringControl, rankWith } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
-import { FormLabel, Input } from "@opengovsg/design-system-react"
+import {
+  FormErrorMessage,
+  FormLabel,
+  Input,
+} from "@opengovsg/design-system-react"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
@@ -11,6 +15,14 @@ export const jsonFormsTextControlTester: RankedTester = rankWith(
   isStringControl,
 )
 
+const getRemainingCharacterCount = (maxLength: number, data?: string) => {
+  if (!data) {
+    return maxLength
+  }
+
+  return Math.max(0, maxLength - data.length)
+}
+
 export function JsonFormsTextControl({
   data,
   label,
@@ -18,17 +30,42 @@ export function JsonFormsTextControl({
   path,
   description,
   required,
+  errors,
+  schema,
 }: ControlProps) {
+  const { maxLength } = schema
+  const remainingCharacterCount = maxLength
+    ? getRemainingCharacterCount(maxLength, data)
+    : -1
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { value } = e.target
+
+    if (value === "") {
+      handleChange(path, undefined)
+    } else {
+      handleChange(path, value)
+    }
+  }
+
   return (
     <Box py={2}>
-      <FormControl isRequired={required}>
+      <FormControl isRequired={required} isInvalid={!!errors}>
         <FormLabel description={description}>{label}</FormLabel>
         <Input
           type="text"
           value={data || ""}
-          onChange={(e) => handleChange(path, e.target.value)}
+          onChange={onChange}
           placeholder={label}
         />
+        {maxLength && !errors && (
+          <FormHelperText mt="0.5rem">
+            {remainingCharacterCount}{" "}
+            {remainingCharacterCount === 1 ? "character" : "characters"} left
+          </FormHelperText>
+        )}
+        <FormErrorMessage>
+          {label} {errors}
+        </FormErrorMessage>
       </FormControl>
     </Box>
   )

--- a/packages/components/src/interfaces/complex/InfoCols.ts
+++ b/packages/components/src/interfaces/complex/InfoCols.ts
@@ -10,6 +10,7 @@ export const InfoBoxSchema = Type.Object({
   description: Type.Optional(
     Type.String({
       title: "Description",
+      maxLength: 300,
     }),
   ),
   icon: Type.Optional(

--- a/packages/components/src/interfaces/complex/KeyStatistics.ts
+++ b/packages/components/src/interfaces/complex/KeyStatistics.ts
@@ -11,6 +11,7 @@ export const KeyStatisticsSchema = Type.Object(
       Type.Object({
         label: Type.String({
           title: "Description",
+          maxLength: 100,
         }),
         value: Type.String({
           title: "Number",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There is no feedback to the user if there is a validation error.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Display the validation error message to the user if the input does not satisfy the schema.
- For text input fields, if the input becomes empty, set the value to be undefined so that it is taken out of the JSON object (to trigger validation errors if the property is required).
- Also added a simple character counter if the schema has a `maxLength` property set.

## Before & After Screenshots
<img width="822" alt="Screenshot 2024-07-25 at 15 06 45" src="https://github.com/user-attachments/assets/4805ae1f-d207-4947-898d-09e4c72aef0b">