### PR TITLE
fix: remove `schemaMatches`

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
@@ -1,6 +1,6 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
 import { Flex, FormControl } from "@chakra-ui/react"
-import { rankWith, schemaMatches } from "@jsonforms/core"
+import { rankWith } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import { FormLabel } from "@opengovsg/design-system-react"
 
@@ -9,9 +9,9 @@ import { TiptapEditor } from "../TipTapEditor"
 
 export const jsonFormsProseControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.ProseControl,
-  schemaMatches((_, schema) => {
+  (_, schema) => {
     return schema.format === "prose"
-  }),
+  },
 )
 
 export function JsonFormsProseControl({

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsRadioControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsRadioControl.tsx
@@ -4,7 +4,7 @@ import type {
   RankedTester,
 } from "@jsonforms/core"
 import { Box, FormControl, RadioGroup } from "@chakra-ui/react"
-import { and, isEnumControl, rankWith, schemaMatches } from "@jsonforms/core"
+import { and, isEnumControl, rankWith } from "@jsonforms/core"
 import { withJsonFormsEnumProps } from "@jsonforms/react"
 import { FormLabel, Radio } from "@opengovsg/design-system-react"
 
@@ -12,10 +12,7 @@ import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
 export const jsonFormsRadioControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.RadioControl,
-  and(
-    isEnumControl,
-    schemaMatches((schema) => schema.format === "radio"),
-  ),
+  and(isEnumControl, (_, schema) => schema.format === "radio"),
 )
 
 export function JsonFormsRadioControl({


### PR DESCRIPTION
## Problem
using `schemaMatches` prunes away the `format` key, which is what we use to identify a `Prose` block and cause the tester to fail, resulting in the renderer not being shown. 

This a blocker on `callout/accordion` where they are not shown.

## Solution
remove `schemaMatches` - see below ss for extended explanation

## Screenshots
using `schemaMatches` and logging the received `resolvedSchema, rootSchema`, we get the following properties: 
![image](https://github.com/user-attachments/assets/ea34b90a-564c-4029-a915-75ed5a708d70)

note that this does **not** have the `format` key. in contrast, removing the `schemaMatches` function results in this object
![image](https://github.com/user-attachments/assets/5caf3a99-d5fe-40e4-b4c1-626cdaf3cae7)

note the inclusion of the `format` key here but not in the former screenshot.

## How `schemaMatches` work
`schemaMatches` performs a bunch of sanity checks before calling a `resolveSchema` function (see [here](https://github.com/eclipsesource/jsonforms/blob/d3ee13a059ff9e0bc6dc9282b8f0ca65b799f5e6/packages/core/src/util/resolvers.ts#L112)). at this point, the property gets pruned (not very sure why also) which results in the bug.

## Notes
I did a search for `schemaMatches` and found `Radio` also using htis to check `schema.format` and removed it defensively. not sure how to check thoguh?
