### PR TITLE
update to use bigint for resourceId and blobId

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -9,7 +9,7 @@ export type Generated<T> =
 export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
 export interface Blob {
-  id: GeneratedAlways<number>
+  id: GeneratedAlways<string>
   /**
    * @kyselyType(PrismaJson.BlobJsonContent)
    * [BlobJsonContent]
@@ -36,18 +36,18 @@ export interface Navbar {
 }
 export interface Permission {
   id: GeneratedAlways<number>
-  resourceId: number
+  resourceId: string
   userId: string
   role: RoleType
 }
 export interface Resource {
-  id: GeneratedAlways<number>
+  id: GeneratedAlways<string>
   title: string
   permalink: string
   siteId: number
-  parentId: number | null
-  mainBlobId: number | null
-  draftBlobId: number | null
+  parentId: string | null
+  mainBlobId: string | null
+  draftBlobId: string | null
   state: Generated<ResourceState | null>
   type: ResourceType
 }

--- a/apps/studio/prisma/migrations/20240724082002_update_to_bigint/migration.sql
+++ b/apps/studio/prisma/migrations/20240724082002_update_to_bigint/migration.sql
@@ -1,0 +1,46 @@
+/*
+  Warnings:
+
+  - The primary key for the `Blob` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - The primary key for the `Resource` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Permission" DROP CONSTRAINT "Permission_resourceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Resource" DROP CONSTRAINT "Resource_draftBlobId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Resource" DROP CONSTRAINT "Resource_mainBlobId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Resource" DROP CONSTRAINT "Resource_parentId_fkey";
+
+-- AlterTable
+ALTER TABLE "Blob" DROP CONSTRAINT "Blob_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "Blob_pkey" PRIMARY KEY ("id");
+
+-- AlterTable
+ALTER TABLE "Permission" ALTER COLUMN "resourceId" SET DATA TYPE BIGINT;
+
+-- AlterTable
+ALTER TABLE "Resource" DROP CONSTRAINT "Resource_pkey",
+ALTER COLUMN "id" SET DATA TYPE BIGINT,
+ALTER COLUMN "parentId" SET DATA TYPE BIGINT,
+ALTER COLUMN "draftBlobId" SET DATA TYPE BIGINT,
+ALTER COLUMN "mainBlobId" SET DATA TYPE BIGINT,
+ADD CONSTRAINT "Resource_pkey" PRIMARY KEY ("id");
+
+-- AddForeignKey
+ALTER TABLE "Resource" ADD CONSTRAINT "Resource_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Resource"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Resource" ADD CONSTRAINT "Resource_mainBlobId_fkey" FOREIGN KEY ("mainBlobId") REFERENCES "Blob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Resource" ADD CONSTRAINT "Resource_draftBlobId_fkey" FOREIGN KEY ("draftBlobId") REFERENCES "Blob"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Permission" ADD CONSTRAINT "Permission_resourceId_fkey" FOREIGN KEY ("resourceId") REFERENCES "Resource"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -34,23 +34,23 @@ model VerificationToken {
 }
 
 model Resource {
-  id        Int       @id @default(autoincrement())
+  id        BigInt    @id @default(autoincrement())
   title     String
   permalink String
   siteId    Int
   site      Site      @relation(fields: [siteId], references: [id])
-  parentId  Int?
+  parentId  BigInt?
   parent    Resource? @relation("ParentRelation", fields: [parentId], references: [id])
 
   children Resource[] @relation("ParentRelation")
 
   permission Permission[]
 
-  mainBlob   Blob? @relation("MainBlob", fields: [mainBlobId], references: [id])
-  mainBlobId Int?  @unique
+  mainBlob   Blob?   @relation("MainBlob", fields: [mainBlobId], references: [id])
+  mainBlobId BigInt? @unique
 
-  draftBlob   Blob? @relation("DraftBlob", fields: [draftBlobId], references: [id])
-  draftBlobId Int?  @unique
+  draftBlob   Blob?   @relation("DraftBlob", fields: [draftBlobId], references: [id])
+  draftBlobId BigInt? @unique
 
   state ResourceState? @default(Draft)
   type  ResourceType
@@ -79,7 +79,7 @@ model User {
 
 model Permission {
   id         Int      @id @default(autoincrement())
-  resourceId Int
+  resourceId BigInt
   resource   Resource @relation(fields: [resourceId], references: [id])
   userId     String
   user       User     @relation(fields: [userId], references: [id])
@@ -125,7 +125,7 @@ model Footer {
 }
 
 model Blob {
-  id      Int  @id @default(autoincrement())
+  id      BigInt @id @default(autoincrement())
   /// @kyselyType(PrismaJson.BlobJsonContent)
   /// [BlobJsonContent]
   content Json

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -205,10 +205,10 @@ async function main() {
     )
     .execute()
 
-  let blobId = 1
+  let blobId = BigInt(1)
   const dedupeBlobId = await db
     .selectFrom("Blob")
-    .where("Blob.id", "=", blobId)
+    .where("Blob.id", "=", String(blobId))
     .select("Blob.id")
     .executeTakeFirst()
   if (!dedupeBlobId) {
@@ -217,13 +217,13 @@ async function main() {
       .values({ content: jsonb(PAGE_BLOB) })
       .returning("id")
       .executeTakeFirstOrThrow()
-    blobId = id
+    blobId = BigInt(id)
   }
 
   await db
     .insertInto("Resource")
     .values({
-      mainBlobId: blobId,
+      mainBlobId: String(blobId),
       permalink: "home",
       siteId,
       type: "Page",

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -18,12 +18,12 @@ export const folderRouter = router({
       const folderResult = await ctx.db
         .selectFrom("Resource")
         .selectAll("Resource")
-        .where("id", "=", input.resourceId)
+        .where("id", "=", String(input.resourceId))
         .executeTakeFirstOrThrow()
       const childrenResult = await ctx.db
         .selectFrom("Resource")
         .selectAll("Resource")
-        .where("parentId", "=", input.resourceId)
+        .where("parentId", "=", String(input.resourceId))
         .execute()
       const children = childrenResult.map((c) => {
         if (c.draftBlobId || c.mainBlobId) {

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -62,7 +62,7 @@ export const pageRouter = router({
         .where("Resource.siteId", "=", siteId)
 
       if (resourceId) {
-        query = query.where("Resource.parentId", "=", resourceId)
+        query = query.where("Resource.parentId", "=", String(resourceId))
       }
       return query
         .select([
@@ -126,7 +126,7 @@ export const pageRouter = router({
               title,
               permalink,
               siteId,
-              parentId: folderId,
+              parentId: String(folderId),
               draftBlobId: blob.id,
               type: ResourceType.Page,
             })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -60,7 +60,7 @@ const getById = ({
 }) =>
   db
     .selectFrom("Resource")
-    .where("Resource.id", "=", resourceId)
+    .where("Resource.id", "=", String(resourceId))
     .where("siteId", "=", siteId)
 
 // NOTE: Throw here to fail early if our invariant that a page has a `blobId` is violated
@@ -102,7 +102,7 @@ export const updatePageById = (
     return tx
       .updateTable("Resource")
       .set(rest)
-      .where("id", "=", id)
+      .where("id", "=", String(id))
       .executeTakeFirstOrThrow()
   })
 }
@@ -120,7 +120,7 @@ export const updateBlobById = (props: {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore excessive deep type instantiaton
       .set({ content })
-      .where("Resource.id", "=", id)
+      .where("Resource.id", "=", String(id))
       .executeTakeFirstOrThrow()
   )
 }
@@ -155,8 +155,8 @@ export const moveResource = async (
 ) => {
   return db
     .updateTable("Resource")
-    .set({ parentId: newParentId })
+    .set({ parentId: String(newParentId) })
     .where("siteId", "=", siteId)
-    .where("id", "=", resourceId)
+    .where("id", "=", String(resourceId))
     .executeTakeFirstOrThrow()
 }

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -10,23 +10,23 @@ const pageListQuery = (wait?: DelayMode | number) => {
     }
     return [
       {
-        id: 4,
+        id: "4",
         permalink: "test-page-1",
         title: "Test page 1",
-        mainBlobId: 3,
+        mainBlobId: "3",
         draftBlobId: null,
         type: "Page",
       },
       {
-        id: 5,
+        id: "5",
         permalink: "test-page-2",
         title: "Test page 2",
-        mainBlobId: 4,
+        mainBlobId: "4",
         draftBlobId: null,
         type: "Page",
       },
       {
-        id: 6,
+        id: "6",
         permalink: "folder",
         title: "Test folder 1",
         mainBlobId: null,


### PR DESCRIPTION
### TL;DR

This pull request updates the ID fields for the `Resource`, and `Blob` models to use `BigInt` instead of `Int`. Corresponding changes have been made to Prisma schema, migration files, TypeScript types, and various parts of the application code to handle this change.

This is in relation to introducing versions later!

### What changed?

- Updated Prisma schema to change ID types.
- Created migration script for the database schema changes.
- Modified TypeScript types to reflect new ID types.
- Updated application code to handle `BigInt` IDs.

Note: 
1. We still use `Number` in JS throughout, so we are technically limited by the max int support in JS which is 2^53 - 1. 
2. If you look at the generatedTypes, you will see that bigints are output as String. This requires a cast to and fro number and string. For example, Zod might validate the incoming payload field as a number. But when we query or mutate DB we will need to convert this into a String.



### How to test?

1. Run the migration script to update the database schema.
2. Ensure that the application builds without errors.
3. Execute the application and ensure that all parts work as expected, particularly those dealing with `Resource`, and `Blob` models.
4. Run existing tests to ensure they pass, and add new tests if necessary.

### Why make this change?

To accommodate larger datasets and future-proof the application, enabling the use of `BigInt` for IDs in critical models like `Resource`, and `Blob`. This change reduces the risk of ID collisions and supports the scaling of the application.

As shared, a quick back-of-envelope calculation shows:

We now have a 1-many relationship for resources and versions. Estimating worst case scenario:
Max running order of integer = 5000 sites, 14k pages each site, each page has 1000 versions = 5k * 14k * 1k = 70,000,000,000
Current max supported int = 4 bytes = 32 bits = 2,147,483,647
But JS supports up to 53 bits (2^53 - 1)
Might be good to consider using BigInt for all our IDs - 8 bytes = 64 bits

But in our app, we will only use a max of 53 bits (JS's max INT value)

