### PR TITLE
feat(tiptap): save updates to db + invalidate queries

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -111,7 +111,12 @@ function ComponentSelector({ pageId, siteId }: ComponentSelectorProps) {
     setPreviewPageState,
     setAddedBlock,
   } = useEditorDrawerContext()
-  const { mutate } = trpc.page.updatePageBlob.useMutation()
+  const utils = trpc.useUtils()
+  const { mutate } = trpc.page.updatePageBlob.useMutation({
+    onSuccess: async () => {
+      await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+    },
+  })
   const [page] = trpc.page.readPageAndBlob.useSuspenseQuery({
     pageId,
     siteId,

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -3,17 +3,12 @@ import { Box, Heading, HStack, Icon } from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiDollar, BiX } from "react-icons/bi"
-import z from "zod"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { editPageSchema } from "~/pages/sites/[siteId]/pages/[pageId]"
 import { trpc } from "~/utils/trpc"
 import FormBuilder from "./form-builder/FormBuilder"
-
-const complexEditorSchema = z.object({
-  pageId: z.coerce.number(),
-  siteId: z.coerce.number(),
-})
 
 interface ComplexEditorStateDrawerProps {
   component: IsomerComponent
@@ -22,7 +17,7 @@ interface ComplexEditorStateDrawerProps {
 const ComplexEditorStateDrawer = ({
   component,
 }: ComplexEditorStateDrawerProps) => {
-  const { pageId, siteId } = useQueryParse(complexEditorSchema)
+  const { pageId, siteId } = useQueryParse(editPageSchema)
   const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery(
     { siteId, pageId },
   )

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -34,8 +34,13 @@ const ComplexEditorStateDrawer = ({
     setPreviewPageState,
   } = useEditorDrawerContext()
   const { title } = getComponentSchema(component.type)
+  const utils = trpc.useUtils()
 
-  const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation()
+  const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
+    onSuccess: async () => {
+      await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+    },
+  })
 
   return (
     <Box position="relative" h="100%" w="100%" overflow="auto">

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,41 +1,38 @@
+import type { IsomerComponent } from "@opengovsg/isomer-components"
 import { Box, Heading, HStack, Icon } from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { BiDollar, BiX } from "react-icons/bi"
-
 import z from "zod"
+
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import FormBuilder from "./form-builder/FormBuilder"
-import { trpc } from "~/utils/trpc"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { trpc } from "~/utils/trpc"
+import FormBuilder from "./form-builder/FormBuilder"
 
 const complexEditorSchema = z.object({
   pageId: z.coerce.number(),
   siteId: z.coerce.number(),
 })
 
-export default function ComplexEditorStateDrawer(): JSX.Element {
+interface ComplexEditorStateDrawerProps {
+  component: IsomerComponent
+}
+
+const ComplexEditorStateDrawer = ({
+  component,
+}: ComplexEditorStateDrawerProps) => {
+  const { pageId, siteId } = useQueryParse(complexEditorSchema)
+  const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery(
+    { siteId, pageId },
+  )
   const {
-    currActiveIdx,
     setDrawerState,
     savedPageState,
     setSavedPageState,
     previewPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
-
-  if (currActiveIdx === -1 || currActiveIdx > savedPageState.length) {
-    return <></>
-  }
-
-  const component = previewPageState[currActiveIdx]
-
-  if (!component) {
-    return <></>
-  }
-
-  const { pageId, siteId } = useQueryParse(complexEditorSchema)
-  const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery({ siteId, pageId })
   const { title } = getComponentSchema(component.type)
 
   const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation()
@@ -86,7 +83,14 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
           onClick={() => {
             setDrawerState({ state: "root" })
             setSavedPageState(previewPageState)
-            mutate({ pageId, siteId, content: JSON.stringify({ ...pageContent, content: previewPageState }) })
+            mutate({
+              pageId,
+              siteId,
+              content: JSON.stringify({
+                ...pageContent,
+                content: previewPageState,
+              }),
+            })
           }}
           isLoading={isLoading}
         >
@@ -95,4 +99,20 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
       </Box>
     </Box>
   )
+}
+
+export default function ComplexEditorStateDrawerContainer(): JSX.Element {
+  const { currActiveIdx, savedPageState, previewPageState } =
+    useEditorDrawerContext()
+  if (currActiveIdx === -1 || currActiveIdx > savedPageState.length) {
+    return <></>
+  }
+
+  const component = previewPageState[currActiveIdx]
+
+  if (!component) {
+    return <></>
+  }
+
+  return <ComplexEditorStateDrawer component={component} />
 }

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -193,7 +193,7 @@ export const pageRouter = router({
     .mutation(async ({ input }) => {
       // @ts-expect-error we need this because we sanitise as a string
       // but this accepts a nested JSON object
-      await updateBlobById({ ...input, pageId: input.pageId })
+      await updateBlobById(db, { ...input, pageId: input.pageId })
 
       return input
     }),


### PR DESCRIPTION
## Problem
Previously, `Prose` wasn't saving to db. When `uat` added the save to db, there wasnt the query invalidation portion. This PR adds both functionality in

## Solution
- use the `updatePageBlob` hook in `TiptapComponent`. 
- invalidate queries on save so that we see the new state

## Screenshots and video 

https://github.com/user-attachments/assets/cd4baed3-f3a8-4791-848b-0effee6dee25



