### PR TITLE
feat: add admin mode to editor

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ActivateAdminMode.tsx
+++ b/apps/studio/src/features/editing-experience/components/ActivateAdminMode.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react"
+import { Box, Text } from "@chakra-ui/react"
+
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+
+const COMBO: KeyboardEvent["key"][] = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+]
+
+// Activate admin mode when a key combo is pressed
+export const ActivateAdminMode = () => {
+  const { setDrawerState } = useEditorDrawerContext()
+
+  const [comboIndex, setComboIndex] = useState(0)
+  const [showCounter, setShowCounter] = useState(false)
+
+  const counterRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const currentCombo = COMBO[comboIndex] || ""
+      if (event.key.toLowerCase() === currentCombo.toLowerCase()) {
+        setComboIndex(comboIndex + 1)
+        setShowCounter(true)
+        if (counterRef.current) {
+          clearTimeout(counterRef.current)
+        }
+        if (comboIndex < COMBO.length) {
+          counterRef.current = setTimeout(() => {
+            setShowCounter(false)
+          }, 400)
+        }
+      } else {
+        setComboIndex(0)
+      }
+    }
+
+    if (comboIndex === COMBO.length) {
+      setDrawerState({ state: "adminMode" })
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [comboIndex, setDrawerState])
+
+  return (
+    <Box
+      position="fixed"
+      bottom="-3rem"
+      right="1.25rem"
+      bgGradient="linear(to-r, yellow.500, orange.500, red.600)"
+      fontSize="5xl"
+      fontWeight="black"
+      color="transparent"
+      bgClip="text"
+      transition="all 0.2s ease-out"
+      transform={
+        showCounter && comboIndex ? "translateY(-5rem)" : "translateY(0)"
+      }
+      opacity={comboIndex / 10}
+    >
+      <Text>{comboIndex === COMBO.length ? "FULL" : comboIndex} COMBO</Text>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
@@ -1,5 +1,12 @@
-import { useState } from "react"
-import { Box, Heading, HStack, Icon, Spacer, Text } from "@chakra-ui/react"
+import {
+  Box,
+  Heading,
+  HStack,
+  Icon,
+  Spacer,
+  Text,
+  useClipboard,
+} from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { BiDollar, BiX } from "react-icons/bi"
 
@@ -7,15 +14,9 @@ import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 
 export default function AdminModeStateDrawer(): JSX.Element {
   const { savedPageState, setDrawerState } = useEditorDrawerContext()
-  const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false)
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(JSON.stringify(savedPageState, null, 2))
-    setIsCopiedToClipboard(true)
-    setTimeout(() => {
-      setIsCopiedToClipboard(false)
-    }, 2000)
-  }
+  const { onCopy, hasCopied } = useClipboard(
+    JSON.stringify(savedPageState, null, 2),
+  )
 
   return (
     <Box h="100%" w="100%" overflow="auto">
@@ -41,8 +42,8 @@ export default function AdminModeStateDrawer(): JSX.Element {
             </Heading>
           </HStack>
           <Spacer />
-          <Button onClick={handleCopy} variant="clear">
-            {!isCopiedToClipboard ? "Copy to clipboard" : "Copied!"}
+          <Button onClick={onCopy} variant="clear">
+            {!hasCopied ? "Copy to clipboard" : "Copied!"}
           </Button>
           <IconButton
             icon={<Icon as={BiX} />}

--- a/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
@@ -58,7 +58,7 @@ export default function AdminModeStateDrawer(): JSX.Element {
         </HStack>
       </Box>
 
-      <Box px="2rem" py="1rem">
+      <Box px="2rem" py="1rem" maxW="33vw" overflow="auto">
         <Text as="pre">{JSON.stringify(savedPageState, null, 2)}</Text>
       </Box>
     </Box>

--- a/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react"
+import { Box, Heading, HStack, Icon, Spacer, Text } from "@chakra-ui/react"
+import { Button, IconButton } from "@opengovsg/design-system-react"
+import { BiDollar, BiX } from "react-icons/bi"
+
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+
+export default function AdminModeStateDrawer(): JSX.Element {
+  const { savedPageState, setDrawerState } = useEditorDrawerContext()
+  const [isCopiedToClipboard, setIsCopiedToClipboard] = useState(false)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(JSON.stringify(savedPageState, null, 2))
+    setIsCopiedToClipboard(true)
+    setTimeout(() => {
+      setIsCopiedToClipboard(false)
+    }, 2000)
+  }
+
+  return (
+    <Box h="100%" w="100%" overflow="auto">
+      <Box
+        bgColor="base.canvas.default"
+        borderBottomColor="base.divider.medium"
+        borderBottomWidth="1px"
+        px="2rem"
+        py="1.25rem"
+      >
+        <HStack justifyContent="start" w="100%">
+          <HStack spacing={3}>
+            <Icon
+              as={BiDollar}
+              fontSize="1.5rem"
+              p="0.25rem"
+              bgColor="slate.100"
+              textColor="blue.600"
+              borderRadius="base"
+            />
+            <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+              Admin Mode
+            </Heading>
+          </HStack>
+          <Spacer />
+          <Button onClick={handleCopy} variant="clear">
+            {!isCopiedToClipboard ? "Copy to clipboard" : "Copied!"}
+          </Button>
+          <IconButton
+            icon={<Icon as={BiX} />}
+            variant="clear"
+            colorScheme="sub"
+            size="sm"
+            p="0.625rem"
+            onClick={() => {
+              setDrawerState({ state: "root" })
+            }}
+            aria-label="Close drawer"
+          />
+        </HStack>
+      </Box>
+
+      <Box px="2rem" py="1rem">
+        <Text as="pre">{JSON.stringify(savedPageState, null, 2)}</Text>
+      </Box>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -84,6 +84,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         onClose={onDeleteBlockModalClose}
         onDelete={handleDeleteBlock}
       />
+
       <Flex
         flexDir="column"
         position="relative"

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -135,37 +135,37 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
             handleChange={handleChange}
           />
         </Box>
-
-        <Box
-          pos="sticky"
-          bottom={0}
-          bgColor="base.canvas.default"
-          boxShadow="md"
-          py="1.5rem"
-          px="2rem"
-        >
-          <HStack spacing="0.75rem">
-            <IconButton
-              icon={<BiTrash fontSize="1.25rem" />}
-              variant="outline"
-              colorScheme="critical"
-              aria-label="Delete block"
-              onClick={onDeleteBlockModalOpen}
-            />
-            <Box w="100%">
-              <Button
-                w="100%"
-                onClick={() => {
-                  setDrawerState({ state: "root" })
-                  setSavedPageState(previewPageState)
-                }}
-              >
-                Save changes
-              </Button>
-            </Box>
-          </HStack>
-        </Box>
       </Flex>
+
+      <Box
+        pos="sticky"
+        bottom={0}
+        bgColor="base.canvas.default"
+        boxShadow="md"
+        py="1.5rem"
+        px="2rem"
+      >
+        <HStack spacing="0.75rem">
+          <IconButton
+            icon={<BiTrash fontSize="1.25rem" />}
+            variant="outline"
+            colorScheme="critical"
+            aria-label="Delete block"
+            onClick={onDeleteBlockModalOpen}
+          />
+          <Box w="100%">
+            <Button
+              w="100%"
+              onClick={() => {
+                setDrawerState({ state: "root" })
+                setSavedPageState(previewPageState)
+              }}
+            >
+              Save changes
+            </Button>
+          </Box>
+        </HStack>
+      </Box>
     </>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -126,46 +126,46 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
             />
           </HStack>
         </Box>
-      </Flex>
 
-      <Box px="2rem" py="1rem">
-        <FormBuilder<IsomerComponent>
-          schema={subSchema}
-          validateFn={validateFn}
-          data={component}
-          handleChange={handleChange}
-        />
-      </Box>
-
-      <Box
-        pos="sticky"
-        bottom={0}
-        bgColor="base.canvas.default"
-        boxShadow="md"
-        py="1.5rem"
-        px="2rem"
-      >
-        <HStack spacing="0.75rem">
-          <IconButton
-            icon={<BiTrash fontSize="1.25rem" />}
-            variant="outline"
-            colorScheme="critical"
-            aria-label="Delete block"
-            onClick={onDeleteBlockModalOpen}
+        <Box px="2rem" py="1rem">
+          <FormBuilder<IsomerComponent>
+            schema={subSchema}
+            validateFn={validateFn}
+            data={component}
+            handleChange={handleChange}
           />
-          <Box w="100%">
-            <Button
-              w="100%"
-              onClick={() => {
-                setDrawerState({ state: "root" })
-                setSavedPageState(previewPageState)
-              }}
-            >
-              Save changes
-            </Button>
-          </Box>
-        </HStack>
-      </Box>
+        </Box>
+
+        <Box
+          pos="sticky"
+          bottom={0}
+          bgColor="base.canvas.default"
+          boxShadow="md"
+          py="1.5rem"
+          px="2rem"
+        >
+          <HStack spacing="0.75rem">
+            <IconButton
+              icon={<BiTrash fontSize="1.25rem" />}
+              variant="outline"
+              colorScheme="critical"
+              aria-label="Delete block"
+              onClick={onDeleteBlockModalOpen}
+            />
+            <Box w="100%">
+              <Button
+                w="100%"
+                onClick={() => {
+                  setDrawerState({ state: "root" })
+                  setSavedPageState(previewPageState)
+                }}
+              >
+                Save changes
+              </Button>
+            </Box>
+          </HStack>
+        </Box>
+      </Flex>
     </>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -5,6 +5,7 @@ import Ajv from "ajv"
 
 import ComponentSelector from "~/components/PageEditor/ComponentSelector"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import AdminModeStateDrawer from "./AdminModeStateDrawer"
 import ComplexEditorStateDrawer from "./ComplexEditorStateDrawer"
 import MetadataEditorStateDrawer from "./MetadataEditorStateDrawer"
 import RootStateDrawer from "./RootStateDrawer"
@@ -42,6 +43,8 @@ export function EditPageDrawer(): JSX.Element {
   switch (currState.state) {
     case "root":
       return <RootStateDrawer />
+    case "adminMode":
+      return <AdminModeStateDrawer />
     case "addBlock":
       return <ComponentSelector />
     case "nativeEditor": {

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -1,6 +1,6 @@
 import type { IsomerSchema, schema } from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
-import { Box, Heading, HStack, Icon, IconButton } from "@chakra-ui/react"
+import { Box, Flex, Heading, HStack, Icon, IconButton } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { getLayoutMetadataSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
@@ -38,53 +38,68 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
   }
 
   return (
-    <Box w="100%">
-      <Box
-        bgColor="base.canvas.default"
-        borderBottomColor="base.divider.medium"
-        borderBottomWidth="1px"
-        px="2rem"
-        py="1.25rem"
+    <>
+      <Flex
+        flexDir="column"
+        position="relative"
+        h="100%"
+        w="100%"
+        overflow="auto"
       >
-        <HStack justifyContent="space-between" w="100%">
-          <HStack spacing={3}>
-            <Icon
-              as={BiDollar}
-              fontSize="1.5rem"
-              p="0.25rem"
-              bgColor="slate.100"
-              textColor="blue.600"
-              borderRadius="base"
+        <Box
+          bgColor="base.canvas.default"
+          borderBottomColor="base.divider.medium"
+          borderBottomWidth="1px"
+          px="2rem"
+          py="1.25rem"
+        >
+          <HStack justifyContent="space-between" w="100%">
+            <HStack spacing={3}>
+              <Icon
+                as={BiDollar}
+                fontSize="1.5rem"
+                p="0.25rem"
+                bgColor="slate.100"
+                textColor="blue.600"
+                borderRadius="base"
+              />
+              <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+                Edit page title and summary
+              </Heading>
+            </HStack>
+            <IconButton
+              icon={<Icon as={BiX} />}
+              variant="clear"
+              colorScheme="sub"
+              size="sm"
+              p="0.625rem"
+              onClick={() => {
+                setPreviewPageState(savedPageState)
+                setDrawerState({ state: "root" })
+              }}
+              aria-label="Close drawer"
             />
-            <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-              Edit page title and summary
-            </Heading>
           </HStack>
-          <IconButton
-            icon={<Icon as={BiX} />}
-            variant="clear"
-            colorScheme="sub"
-            size="sm"
-            p="0.625rem"
-            onClick={() => {
-              setPreviewPageState(savedPageState)
-              setDrawerState({ state: "root" })
-            }}
-            aria-label="Close drawer"
+        </Box>
+
+        <Box px="2rem" py="1rem">
+          <FormBuilder<Static<typeof schema>>
+            schema={metadataSchema}
+            validateFn={validateFn}
+            data={previewPageState.page}
+            handleChange={(data) => handleChange(data)}
           />
-        </HStack>
-      </Box>
+        </Box>
+      </Flex>
 
-      <Box px="2rem" py="1rem">
-        <FormBuilder<Static<typeof schema>>
-          schema={metadataSchema}
-          validateFn={validateFn}
-          data={previewPageState.page}
-          handleChange={(data) => handleChange(data)}
-        />
-      </Box>
-
-      <Box px="2rem" pb="1.5rem">
+      <Box
+        pos="sticky"
+        bottom={0}
+        bgColor="base.canvas.default"
+        boxShadow="md"
+        py="1.5rem"
+        px="2rem"
+      >
         <Button
           w="100%"
           onClick={() => {
@@ -92,9 +107,9 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
             setSavedPageState(previewPageState)
           }}
         >
-          Save
+          Save changes
         </Button>
       </Box>
-    </Box>
+    </>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -146,7 +146,9 @@ export default function RootStateDrawer() {
                               w="100%"
                               gap={0}
                               onClick={() => {
-                                setCurrActiveIdx(index)
+                                setCurrActiveIdx(
+                                  isHeroFixedBlock ? index + 1 : index,
+                                )
                                 // TODO: we should automatically do this probably?
                                 const nextState =
                                   savedPageState.content[index]?.type ===

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -15,6 +15,7 @@ import { BsPlus } from "react-icons/bs"
 
 import { BlockEditingPlaceholder } from "~/components/Svg"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { ActivateAdminMode } from "./ActivateAdminMode"
 
 export default function RootStateDrawer() {
   const {
@@ -52,6 +53,7 @@ export default function RootStateDrawer() {
 
   return (
     <VStack w="100%" h="100%" gap={10} pt={10}>
+      <ActivateAdminMode />
       {/* TODO: Fixed Blocks Section */}
       <VStack w="100%" align="baseline">
         <Text fontSize="xl" pl={4} fontWeight={500}>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -46,7 +46,7 @@ function EditPage(): JSX.Element {
     >
       {/* TODO: Implement sidebar editor */}
       <GridItem colSpan={1} bg="slate.50">
-        <EditPageDrawer layout={page.layout} />
+        <EditPageDrawer />
       </GridItem>
       {/* TODO: Implement preview */}
       <GridItem colSpan={2} overflow="scroll">

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -46,7 +46,7 @@ function EditPage(): JSX.Element {
     >
       {/* TODO: Implement sidebar editor */}
       <GridItem colSpan={1} bg="slate.50">
-        <EditPageDrawer />
+        <EditPageDrawer layout={page.layout} />
       </GridItem>
       {/* TODO: Implement preview */}
       <GridItem colSpan={2} overflow="scroll">

--- a/apps/studio/src/types/editorDrawer.ts
+++ b/apps/studio/src/types/editorDrawer.ts
@@ -2,6 +2,10 @@ export interface RootDrawerState {
   state: "root"
 }
 
+export interface AdminModeDrawerState {
+  state: "adminMode"
+}
+
 export interface AddNewBlockState {
   state: "addBlock"
 }
@@ -20,6 +24,7 @@ export interface MetadataEditorState {
 
 export type DrawerState =
   | RootDrawerState
+  | AdminModeDrawerState
   | AddNewBlockState
   | NativeEditorState
   | ComplexEditorState


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

POEs want to use the Studio in its current state, and we don't have an admin mode to see the underlying source code.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add an admin mode to the editor to view the underlying JSON page state. Full credit goes to @pregnantboy [in report cards](https://github.com/opengovsg/report-card/blob/993c99783505956a2451463b029f86d806a17b67/src/app/%5B...card%5D/ActivateDraft.tsx).
    - The admin mode can only be entered via the root state, so that we ensure the blocks are all valid first before allowing it to be copied.

## Before & After Screenshots

https://github.com/user-attachments/assets/44dbdabb-058f-4edc-a4d7-d6e127d47b14