### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
         patterns:
           - "@prisma/client"
           - "prisma"
+      react:
+        applies-to: version-updates
+        patterns:
+          - "react"
+          - "react-dom"
       storybook:
         applies-to: version-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,26 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    ignore:
-      # Storybook packages should be updated together to avoid breaking changes, but dependabot updates them separately.
-      - dependency-name: "storybook*"
-      - dependency-name: "@storybook*"
-      - dependency-name: "prisma*"
-      - dependency-name: "@prisma*"
-      - dependency-name: "@trpc*"
+    groups:
+      babel:
+        applies-to: version-updates
+        patterns:
+          - "@babel/*"
+      prisma:
+        applies-to: version-updates
+        patterns:
+          - "@prisma/client"
+          - "prisma"
+      storybook:
+        applies-to: version-updates
+        patterns:
+          - "@storybook/*"
+          - "storybook"
+      tiptap:
+        applies-to: version-updates
+        patterns:
+          - "@tiptap/*"
+      trpc:
+        applies-to: version-updates
+        patterns:
+          - "@trpc/*"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Dependabot is providing updates to grouped packages individually.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Group dependencies together so that they can be updated in a single PR
    - Reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups