### PR TITLE
feat: introduce functionality to delete editor block

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -14,3 +14,5 @@ export const JSON_FORMS_RANKING = {
   GroupLayoutRenderer: 1,
   VerticalLayoutRenderer: 1,
 }
+
+export const PROSE_COMPONENT_NAME = "Prose component"

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -1,9 +1,17 @@
-import { Box, Flex, Heading, HStack, Icon } from "@chakra-ui/react"
+import {
+  Box,
+  Flex,
+  Heading,
+  HStack,
+  Icon,
+  useDisclosure,
+} from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
-import { BiDollar, BiX } from "react-icons/bi"
+import { BiDollar, BiTrash, BiX } from "react-icons/bi"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { DeleteBlockModal } from "./DeleteBlockModal"
 import FormBuilder from "./form-builder/FormBuilder"
 
 export default function ComplexEditorStateDrawer(): JSX.Element {
@@ -15,6 +23,11 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     previewPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
+  const {
+    isOpen: isDeleteBlockModalOpen,
+    onOpen: onDeleteBlockModalOpen,
+    onClose: onDeleteBlockModalClose,
+  } = useDisclosure()
 
   if (currActiveIdx === -1 || currActiveIdx > savedPageState.length) {
     return <></>
@@ -27,53 +40,72 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
   }
 
   const { title } = getComponentSchema(component.type)
+  const componentName = title || "component"
+
+  const handleDeleteBlock = () => {
+    const updatedBlocks = Array.from(savedPageState)
+    updatedBlocks.splice(currActiveIdx, 1)
+    setSavedPageState(updatedBlocks)
+    setPreviewPageState(updatedBlocks)
+    onDeleteBlockModalClose()
+    setDrawerState({ state: "root" })
+  }
 
   return (
-    <Flex
-      flexDir="column"
-      position="relative"
-      h="100%"
-      w="100%"
-      overflow="auto"
-    >
-      <Box
-        bgColor="base.canvas.default"
-        borderBottomColor="base.divider.medium"
-        borderBottomWidth="1px"
-        px="2rem"
-        py="1.25rem"
+    <>
+      <DeleteBlockModal
+        itemName={componentName}
+        isOpen={isDeleteBlockModalOpen}
+        onClose={onDeleteBlockModalClose}
+        onDelete={handleDeleteBlock}
+      />
+      <Flex
+        flexDir="column"
+        position="relative"
+        h="100%"
+        w="100%"
+        overflow="auto"
       >
-        <HStack justifyContent="space-between" w="100%">
-          <HStack spacing={3}>
-            <Icon
-              as={BiDollar}
-              fontSize="1.5rem"
-              p="0.25rem"
-              bgColor="slate.100"
-              textColor="blue.600"
-              borderRadius="base"
+        <Box
+          bgColor="base.canvas.default"
+          borderBottomColor="base.divider.medium"
+          borderBottomWidth="1px"
+          px="2rem"
+          py="1.25rem"
+        >
+          <HStack justifyContent="space-between" w="100%">
+            <HStack spacing="0.75rem">
+              <Icon
+                as={BiDollar}
+                fontSize="1.5rem"
+                p="0.25rem"
+                bgColor="slate.100"
+                textColor="blue.600"
+                borderRadius="base"
+              />
+              <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+                Edit {componentName}
+              </Heading>
+            </HStack>
+            <IconButton
+              icon={<Icon as={BiX} />}
+              variant="clear"
+              colorScheme="sub"
+              size="sm"
+              p="0.625rem"
+              onClick={() => {
+                setPreviewPageState(savedPageState)
+                setDrawerState({ state: "root" })
+              }}
+              aria-label="Close drawer"
             />
-            <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-              Edit {title}
-            </Heading>
           </HStack>
-          <IconButton
-            icon={<Icon as={BiX} />}
-            variant="clear"
-            colorScheme="sub"
-            size="sm"
-            p="0.625rem"
-            onClick={() => {
-              setPreviewPageState(savedPageState)
-              setDrawerState({ state: "root" })
-            }}
-            aria-label="Close drawer"
-          />
-        </HStack>
-      </Box>
-      <Box px="2rem" py="1rem">
-        <FormBuilder />
-      </Box>
+        </Box>
+        <Box px="2rem" py="1rem">
+          <FormBuilder />
+        </Box>
+      </Flex>
+
       <Box
         pos="sticky"
         bottom={0}
@@ -82,16 +114,27 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         py="1.5rem"
         px="2rem"
       >
-        <Button
-          w="100%"
-          onClick={() => {
-            setDrawerState({ state: "root" })
-            setSavedPageState(previewPageState)
-          }}
-        >
-          Save
-        </Button>
+        <HStack spacing="0.75rem">
+          <IconButton
+            icon={<BiTrash fontSize="1.25rem" />}
+            variant="outline"
+            colorScheme="critical"
+            aria-label="Delete block"
+            onClick={onDeleteBlockModalOpen}
+          />
+          <Box w="100%">
+            <Button
+              w="100%"
+              onClick={() => {
+                setDrawerState({ state: "root" })
+                setSavedPageState(previewPageState)
+              }}
+            >
+              Save changes
+            </Button>
+          </Box>
+        </HStack>
       </Box>
-    </Flex>
+    </>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -1,0 +1,50 @@
+import {
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+interface DeleteBlockModalProps {
+  itemName: string
+  isOpen: boolean
+  onClose: () => void
+  onDelete: () => void
+}
+
+export const DeleteBlockModal = ({
+  itemName,
+  isOpen,
+  onClose,
+  onDelete,
+}: DeleteBlockModalProps): JSX.Element => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Are you sure you want to delete {itemName}?</ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>
+          <Text textStyle="body-2">This cannot be undone.</Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <HStack spacing="1rem">
+            <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+              Go back to editing
+            </Button>
+            <Button variant="solid" colorScheme="critical" onClick={onDelete}>
+              Yes, delete
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/index.ts
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./DeleteBlockModal"

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -1,11 +1,21 @@
 import type { ProseProps } from "@opengovsg/isomer-components/dist/cjs/interfaces"
 import type { JSONContent } from "@tiptap/react"
-import { Box, Text as ChakraText, Flex, Icon, VStack } from "@chakra-ui/react"
+import {
+  Box,
+  Text as ChakraText,
+  Flex,
+  HStack,
+  Icon,
+  useDisclosure,
+  VStack,
+} from "@chakra-ui/react"
 import { Button, IconButton } from "@opengovsg/design-system-react"
 import { cloneDeep } from "lodash"
-import { BiText, BiX } from "react-icons/bi"
+import { BiText, BiTrash, BiX } from "react-icons/bi"
 
+import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { DeleteBlockModal } from "./DeleteBlockModal"
 import { TiptapEditor } from "./form-builder/renderers/TipTapEditor"
 
 interface TipTapComponentProps {
@@ -21,6 +31,11 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     setPreviewPageState,
     currActiveIdx,
   } = useEditorDrawerContext()
+  const {
+    isOpen: isDeleteBlockModalOpen,
+    onOpen: onDeleteBlockModalOpen,
+    onClose: onDeleteBlockModalClose,
+  } = useDisclosure()
 
   const updatePageState = (editorContent: JSONContent) => {
     // TODO: actual validation
@@ -34,55 +49,86 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     })
   }
 
+  const handleDeleteBlock = () => {
+    const updatedBlocks = Array.from(savedPageState)
+    updatedBlocks.splice(currActiveIdx, 1)
+    setSavedPageState(updatedBlocks)
+    setPreviewPageState(updatedBlocks)
+    onDeleteBlockModalClose()
+    setDrawerState({ state: "root" })
+  }
+
   // TODO: Add a loading state or use suspsense
   return (
-    <VStack bg="white" h="100%" gap="0">
-      <Flex
-        px="2rem"
-        py="1.25rem"
-        borderBottom="1px solid"
-        borderColor="base.divider.strong"
-        w="100%"
-        alignItems="center"
-      >
-        <Icon as={BiText} color="blue.600" />
-        <ChakraText pl="0.75rem" textStyle="h5" w="100%">
-          Prose
-        </ChakraText>
-        <IconButton
-          size="lg"
-          variant="clear"
-          colorScheme="neutral"
-          color="interaction.sub.default"
-          aria-label="Close add component"
-          icon={<BiX />}
-          onClick={() => {
-            setDrawerState({ state: "root" })
-            setPreviewPageState(savedPageState)
-          }}
-        />
-      </Flex>
-      <Box w="100%" p="2rem" h="100%">
-        <TiptapEditor data={content} handleChange={updatePageState} />
-      </Box>
-      <Flex
-        px="2rem"
-        py="1.25rem"
-        borderTop="1px solid"
-        borderColor="base.divider.strong"
-        w="100%"
-        justifyContent="end"
-      >
-        <Button
-          onClick={() => {
-            setDrawerState({ state: "root" })
-            setSavedPageState(previewPageState)
-          }}
+    <>
+      <DeleteBlockModal
+        itemName={PROSE_COMPONENT_NAME}
+        isOpen={isDeleteBlockModalOpen}
+        onClose={onDeleteBlockModalClose}
+        onDelete={handleDeleteBlock}
+      />
+
+      <VStack bg="white" h="100%" gap="0">
+        <Flex
+          px="2rem"
+          py="1.25rem"
+          borderBottom="1px solid"
+          borderColor="base.divider.strong"
+          w="100%"
+          alignItems="center"
         >
-          Save
-        </Button>
-      </Flex>
-    </VStack>
+          <Icon as={BiText} color="blue.600" />
+          <ChakraText pl="0.75rem" textStyle="h5" w="100%">
+            Edit {PROSE_COMPONENT_NAME}
+          </ChakraText>
+          <IconButton
+            size="lg"
+            variant="clear"
+            colorScheme="neutral"
+            color="interaction.sub.default"
+            aria-label="Close add component"
+            icon={<BiX />}
+            onClick={() => {
+              setDrawerState({ state: "root" })
+              setPreviewPageState(savedPageState)
+            }}
+          />
+        </Flex>
+        <Box w="100%" p="2rem" h="100%">
+          <TiptapEditor data={content} handleChange={updatePageState} />
+        </Box>
+      </VStack>
+
+      <Box
+        pos="sticky"
+        bottom={0}
+        bgColor="base.canvas.default"
+        boxShadow="md"
+        py="1.5rem"
+        px="2rem"
+      >
+        <HStack spacing="0.75rem">
+          <IconButton
+            icon={<BiTrash fontSize="1.25rem" />}
+            variant="outline"
+            colorScheme="critical"
+            aria-label="Delete block"
+            onClick={onDeleteBlockModalOpen}
+          />
+          <Box w="100%">
+            <Button
+              w="100%"
+              onClick={() => {
+                setDrawerState({ state: "root" })
+                setSavedPageState(previewPageState)
+              }}
+            >
+              Save changes
+            </Button>
+          </Box>
+        </HStack>
+      </Box>
+    </>
   )
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We don't have the ability to delete blocks in the editor currently.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Introduce new functionality to delete both a complex and native block.
    - Note: The Hero component should be disabled, this will be done depending on whether this or #358 goes in first.
- Added a new modal to confirm with the user that we want to delete the block.
- Also fixed up the stick save button.

## Screenshots

<img width="507" alt="Screenshot 2024-07-26 at 15 22 39" src="https://github.com/user-attachments/assets/9ccb38ec-d6db-44ba-8855-7bf957b7bf1d">

<img width="734" alt="Screenshot 2024-07-26 at 15 23 14" src="https://github.com/user-attachments/assets/237e7514-c120-4655-adb8-8ec16f7d5591">