### PR TITLE
feat: set fullscreen layout and remove autodocs for layout stories

### DIFF
--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -7,7 +7,9 @@ const meta: Meta<ArticlePageSchemaType> = {
   title: "Next/Layouts/Article",
   component: ArticleLayout,
   argTypes: {},
+  tags: ["!autodocs"],
   parameters: {
+    layout: "fullscreen",
     themes: {
       themeOverride: "Isomer Next",
     },
@@ -17,6 +19,7 @@ export default meta
 type Story = StoryObj<typeof ArticleLayout>
 
 export const Default: Story = {
+  name: "Article",
   args: {
     layout: "article",
     site: {

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -7,7 +7,9 @@ const meta: Meta<CollectionPageSchemaType> = {
   title: "Next/Layouts/Collection",
   component: CollectionLayout,
   argTypes: {},
+  tags: ["!autodocs"],
   parameters: {
+    layout: "fullscreen",
     themes: {
       themeOverride: "Isomer Next",
     },
@@ -17,6 +19,7 @@ export default meta
 type Story = StoryObj<typeof CollectionLayout>
 
 export const Default: Story = {
+  name: "Collection",
   args: {
     layout: "collection",
     site: {

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -6,7 +6,9 @@ const meta: Meta<typeof Content> = {
   title: "Next/Layouts/Content",
   component: Content,
   argTypes: {},
+  tags: ["!autodocs"],
   parameters: {
+    layout: "fullscreen",
     themes: {
       themeOverride: "Isomer Next",
     },

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -21,7 +21,9 @@ const meta: Meta<typeof Homepage> = {
   component: Homepage,
   render: Template,
   argTypes: {},
+  tags: ["!autodocs"],
   parameters: {
+    layout: "fullscreen",
     themes: {
       themeOverride: "Isomer Next",
     },
@@ -33,6 +35,7 @@ type Story = StoryObj<typeof Homepage>
 const TEST_CLIENT_ID = "5485bb61-2d5d-440a-bc37-91c48fc0c9d4"
 
 export const Default: Story = {
+  name: "Homepage",
   args: {
     layout: "homepage",
     site: {

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
@@ -7,7 +7,9 @@ const meta: Meta<NotFoundPageSchemaType> = {
   title: "Next/Layouts/NotFound",
   component: NotFoundLayout,
   argTypes: {},
+  tags: ["!autodocs"],
   parameters: {
+    layout: "fullscreen",
     themes: {
       themeOverride: "Isomer Next",
     },
@@ -17,6 +19,7 @@ export default meta
 type Story = StoryObj<NotFoundPageSchemaType>
 
 export const Default: Story = {
+  name: "NotFound",
   args: {
     layout: "notfound",
     site: {

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -27,6 +27,7 @@ const meta: Meta<typeof Template> = {
   title: "Next/Layouts/Search",
   component: Template,
   argTypes: {},
+  tags: ["!autodocs"],
   parameters: {
     themes: {
       themeOverride: "Isomer Next",


### PR DESCRIPTION
### TL;DR
Updated the Storybook layouts to include fullscreen parameter and autodocs tags for template layouts that should be in fullscreen.

### What changed?
- Added `layout: fullscreen` parameter to the meta object for Article, Collection, Content, Homepage, NotFound, and Search story files.
- Added `tags: ['!autodocs']` to the meta object for the same story files.
- Updated the names of the default stories to match their corresponding layout names.

### How to test?
1. Run Storybook.
2. Verify that the specified stories are displayed in fullscreen.
3. Check that the tags for autodocs are present.

### Why make this change?
To ensure consistency across the Storybook layouts and make use of the fullscreen parameter and autodocs tags for better documentation and presentation.
