### PR TITLE
fix: hero fixed block off by one error

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -134,9 +134,12 @@ export default function RootStateDrawer() {
                   )}
 
                   {!!savedPageState &&
-                    savedPageState.content
-                      .slice(isHeroFixedBlock ? 1 : 0)
-                      .map((block, index) => (
+                    savedPageState.content.map((block, index) => {
+                      if (isHeroFixedBlock && index === 0) {
+                        return <></>
+                      }
+
+                      return (
                         <Draggable
                           // TODO: Determine key + draggable id
                           key={index}
@@ -148,9 +151,7 @@ export default function RootStateDrawer() {
                               w="100%"
                               gap={0}
                               onClick={() => {
-                                setCurrActiveIdx(
-                                  isHeroFixedBlock ? index + 1 : index,
-                                )
+                                setCurrActiveIdx(index)
                                 // TODO: we should automatically do this probably?
                                 const nextState =
                                   savedPageState.content[index]?.type ===
@@ -186,7 +187,8 @@ export default function RootStateDrawer() {
                             </VStack>
                           )}
                         </Draggable>
-                      ))}
+                      )
+                    })}
                 </Box>
                 {provided.placeholder}
               </VStack>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Slicing the blocks array makes everything more complicated and causes an off-by-one error.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Avoid doing a slice on the blocks array and handle the fixed first hero block explicitly.