### PR TITLE
fix(schema): schema validation

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -3,7 +3,12 @@ import { useState } from "react"
 import { Box, FormControl, Text } from "@chakra-ui/react"
 import { and, isStringControl, rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
-import { Attachment, FormLabel, useToast } from "@opengovsg/design-system-react"
+import {
+  Attachment,
+  FormErrorMessage,
+  FormLabel,
+  useToast,
+} from "@opengovsg/design-system-react"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import {
@@ -24,6 +29,7 @@ export function JsonFormsImageControl({
   path,
   description,
   required,
+  errors,
 }: ControlProps) {
   const toast = useToast()
 
@@ -31,9 +37,10 @@ export function JsonFormsImageControl({
 
   return (
     <Box py={2}>
-      <FormControl isRequired={required} isInvalid={!pendingFile}>
+      <FormControl isRequired={required} isInvalid={!pendingFile || !!errors}>
         <FormLabel description={description}>{label}</FormLabel>
         <Attachment
+          isRequired
           name="image-upload"
           imagePreview="large"
           multiple={false}
@@ -71,6 +78,11 @@ export function JsonFormsImageControl({
         <Text textStyle="body-2" textColor="base.content.medium" pt="0.5rem">
           {`Maximum file size: ${MAX_IMG_FILE_SIZE_BYTES / 1000000} MB`}
         </Text>
+        {!!errors && (
+          <FormErrorMessage>
+            {label} {errors}
+          </FormErrorMessage>
+        )}
       </FormControl>
     </Box>
   )

--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -19,6 +19,7 @@ export const ImageSchema = Type.Object(
         description: "The width of the image",
         exclusiveMinimum: 0,
         maximum: 100,
+        default: 100,
       }),
     ),
     href: Type.Optional(

--- a/packages/components/src/interfaces/internal/ArticlePageHeader.ts
+++ b/packages/components/src/interfaces/internal/ArticlePageHeader.ts
@@ -9,7 +9,7 @@ export const ArticlePageHeaderSchema = Type.Object({
     title: "Article summary",
     description:
       "The summary of the article page's content. Having multiple items will display them as a list.",
-    minItems: 1,
+    minItems: 0,
   }),
 })
 


### PR DESCRIPTION
## Problem
We have some bugs - `articleSchema` -> `minItems: 1` causes block creation to fail validation without error message. 

image block is `required` but there's no error message set. additionally , the default is 100 but this isn't obvious from the UI
 
## Solution
- set `minItems: 0` for `articleSchema`  **or** give some UI feedback (for uat, i just chose the easy fix, open to just removing this) 
- give default in schema + show error message