### PR TITLE
fix: prevent redir till save done

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -153,6 +153,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
               colorScheme="sub"
               size="sm"
               p="0.625rem"
+              isDisabled={isLoading}
               onClick={() => {
                 if (!_.isEqual(previewPageState, savedPageState)) {
                   onDiscardChangesModalOpen()
@@ -195,13 +196,15 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
             <Button
               w="100%"
               onClick={() => {
-                setDrawerState({ state: "root" })
                 setSavedPageState(previewPageState)
-                mutate({
-                  pageId,
-                  siteId,
-                  content: JSON.stringify(previewPageState),
-                })
+                mutate(
+                  {
+                    pageId,
+                    siteId,
+                    content: JSON.stringify(previewPageState),
+                  },
+                  { onSuccess: () => setDrawerState({ state: "root" }) },
+                )
               }}
               isLoading={isLoading}
             >

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -43,7 +43,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
   const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery(
     { siteId, pageId },
   )
-  const { mutate } = trpc.page.updatePageBlob.useMutation({
+  const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
     },
@@ -114,6 +114,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
               colorScheme="sub"
               size="sm"
               p="0.625rem"
+              isDisabled={isLoading}
               onClick={() => {
                 if (!_.isEqual(previewPageState, savedPageState)) {
                   onDiscardChangesModalOpen()
@@ -146,14 +147,19 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
       >
         <Button
           w="100%"
+          isLoading={isLoading}
           onClick={() => {
-            setDrawerState({ state: "root" })
             setSavedPageState(previewPageState)
-            mutate({
-              pageId,
-              siteId,
-              content: JSON.stringify(previewPageState),
-            })
+            mutate(
+              {
+                pageId,
+                siteId,
+                content: JSON.stringify(previewPageState),
+              },
+              {
+                onSuccess: () => setDrawerState({ state: "root" }),
+              },
+            )
           }}
         >
           Save changes


### PR DESCRIPTION
## Problem
This PR fixes an issue where the user could be redirected to the dashboard before the save was completed. This could cause the user to lose their changes if they navigated away from the page before the save was completed.

## Solution
Update the create page wizard so that the user is not redirected until the save is complete.

