### PR TITLE
chore: autonav

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -2,6 +2,7 @@ import type { UseDisclosureReturn } from "@chakra-ui/react"
 import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { PropsWithChildren } from "react"
 import { createContext, useContext, useMemo, useState } from "react"
+import { useRouter } from "next/router"
 import { merge } from "lodash"
 
 import articleLayoutPreview from "~/features/editing-experience/data/articleLayoutPreview.json"
@@ -76,6 +77,7 @@ const useCreatePageWizardContext = ({
   }, [layout, title])
 
   const utils = trpc.useUtils()
+  const router = useRouter()
 
   const { mutate, isLoading } = trpc.page.createPage.useMutation({
     onSuccess: async () => {
@@ -86,11 +88,18 @@ const useCreatePageWizardContext = ({
   })
 
   const handleCreatePage = formMethods.handleSubmit((values) => {
-    mutate({
-      siteId,
-      folderId,
-      ...values,
-    })
+    mutate(
+      {
+        siteId,
+        folderId,
+        ...values,
+      },
+      {
+        onSuccess: ({ pageId }) => {
+          router.push(`/sites/${siteId}/pages/${pageId}`)
+        },
+      },
+    )
   })
 
   const handleNextToDetailScreen = () => {

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -96,7 +96,7 @@ const useCreatePageWizardContext = ({
       },
       {
         onSuccess: ({ pageId }) => {
-          router.push(`/sites/${siteId}/pages/${pageId}`)
+          void router.push(`/sites/${siteId}/pages/${pageId}`)
         },
       },
     )


### PR DESCRIPTION
## Problem
After page creation, users are not able to navigate to the newly created page. 

## Solution
use the `onSuccess` callback to navigate to the newly created page.