### PR TITLE
feat: update ContentPageHeader and ContentLayout with new design

### DIFF
--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
@@ -1,7 +1,6 @@
 import type { ContentPageHeaderProps } from "~/interfaces"
 import { getFormattedDate } from "~/utils"
 import Button from "../../complex/Button"
-import BaseParagraph from "../BaseParagraph"
 import Breadcrumb from "../Breadcrumb"
 
 const ContentPageHeader = ({
@@ -14,34 +13,26 @@ const ContentPageHeader = ({
   LinkComponent,
 }: ContentPageHeaderProps) => {
   return (
-    <div className="bg-site-secondary-100">
-      <div className="mx-auto max-w-container">
-        <div className="flex max-w-[880px] flex-col gap-8 px-6 py-8 md:px-10 lg:gap-12 lg:py-16">
-          <div className="hidden lg:block">
-            <Breadcrumb
-              links={breadcrumb.links}
-              LinkComponent={LinkComponent}
-            />
-          </div>
-          <div className="flex flex-col">
-            <h1 className="text-[2.75rem] font-semibold leading-tight text-site-secondary lg:text-[3.75rem]">
-              {title}
-            </h1>
-            <div className="pt-6 lg:pb-2">{`Last updated ${getFormattedDate(lastUpdated)}`}</div>
-            <BaseParagraph
-              content={summary}
-              className="text-content text-paragraph-01"
-            />
+    <div className="bg-site-secondary-100 text-base-content-strong">
+      <div className="mx-auto flex max-w-screen-xl flex-col gap-8 px-6 py-8 md:px-10">
+        <div className="flex flex-col">
+          <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
+          <div className="mt-8 flex flex-col gap-5 md:mt-6">
+            <h1 className="prose-display-lg">{title}</h1>
+            <p className="prose-title-lg-regular">{summary}</p>
           </div>
           {buttonLabel && buttonUrl && (
-            <Button
-              label={buttonLabel}
-              href={buttonUrl}
-              rightIcon="right-arrow"
-              LinkComponent={LinkComponent}
-            />
+            <div className="mt-9">
+              <Button
+                label={buttonLabel}
+                href={buttonUrl}
+                rightIcon="right-arrow"
+                LinkComponent={LinkComponent}
+              />
+            </div>
           )}
         </div>
+        <div className="prose-body-sm text-base-content-subtle">{`Last updated ${getFormattedDate(lastUpdated)}`}</div>
       </div>
     </div>
   )

--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
@@ -17,7 +17,7 @@ const ContentPageHeader = ({
       <div className="mx-auto flex max-w-screen-xl flex-col gap-8 px-6 py-8 md:px-10">
         <div className="flex flex-col">
           <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
-          <div className="mt-8 flex flex-col gap-5 md:mt-6">
+          <div className="mt-8 flex max-w-[54rem] flex-col gap-5 md:mt-6">
             <h1 className="prose-display-lg">{title}</h1>
             <p className="prose-title-lg-regular">{summary}</p>
           </div>

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -1,7 +1,6 @@
-import { tv } from "tailwind-variants"
-
 import type { ContentPageSchemaType, IsomerSitemap } from "~/engine"
 import type { SiderailProps } from "~/interfaces"
+import { tv } from "~/lib/tv"
 import {
   getBreadcrumbFromSiteMap,
   getDigestFromText,

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -133,9 +133,9 @@ const transformContent = (content: ContentPageSchemaType["content"]) => {
 const createContentLayoutStyles = tv({
   slots: {
     container:
-      "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:gap-6 md:px-10 md:py-16 lg:gap-10",
-    siderailContainer: "col-span-3 hidden md:block",
-    content: "col-span-12 flex flex-col gap-16 md:col-span-9 md:ml-24",
+      "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
+    siderailContainer: "col-span-3 hidden lg:block",
+    content: "col-span-12 flex flex-col gap-16 lg:col-span-9 lg:ml-24",
   },
 })
 

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -1,3 +1,5 @@
+import { tv } from "tailwind-variants"
+
 import type { ContentPageSchemaType, IsomerSitemap } from "~/engine"
 import type { SiderailProps } from "~/interfaces"
 import {
@@ -128,6 +130,17 @@ const transformContent = (content: ContentPageSchemaType["content"]) => {
   return transformedContent
 }
 
+const createContentLayoutStyles = tv({
+  slots: {
+    container:
+      "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:gap-6 md:px-10 md:py-16 lg:gap-10",
+    siderailContainer: "col-span-3 hidden md:block",
+    content: "col-span-12 flex flex-col gap-16 md:col-span-9 md:ml-24",
+  },
+})
+
+const compoundStyles = createContentLayoutStyles()
+
 const ContentLayout = ({
   site,
   page,
@@ -160,13 +173,13 @@ const ContentLayout = ({
         LinkComponent={LinkComponent}
         lastUpdated={page.lastModified}
       />
-      <div className="mx-auto flex max-w-container justify-center gap-[120px] px-6 py-16 md:px-10">
+      <div className={compoundStyles.container()}>
         {sideRail && (
-          <div className="hidden w-full max-w-[240px] lg:block">
+          <div className={compoundStyles.siderailContainer()}>
             <Siderail {...sideRail} LinkComponent={LinkComponent} />
           </div>
         )}
-        <div className="flex w-full max-w-[800px] flex-col gap-[90px] overflow-x-auto">
+        <div className={compoundStyles.content()}>
           {tableOfContents.items.length > 1 && (
             <TableOfContents {...tableOfContents} />
           )}


### PR DESCRIPTION
### TL;DR
Enhanced the ContentPageHeader and Content layout components to match new figma styles and refactored code for better readability and maintainability.

### What changed?
- Updated styles in `ContentPageHeader.tsx` for better layout and typography.
- Refactored Content layout in `Content.tsx` to use `tailwind-variants` for consistent styling.
- Removed unnecessary imports and cleaned up the code.

### How to test?
storybook

### Why make this change?
To improve the visual appearance and maintainability of the content page components.
