### PR TITLE
feat: introduce discard changes modal

### DIFF
--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
@@ -1,0 +1,50 @@
+import {
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+interface DiscardChangesModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onDiscard: () => void
+}
+
+export const DiscardChangesModal = ({
+  isOpen,
+  onClose,
+  onDiscard,
+}: DiscardChangesModalProps): JSX.Element => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          Are you sure you want to discard your changes?
+        </ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>
+          <Text textStyle="body-2">All edits will be lost.</Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <HStack spacing="1rem">
+            <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+              Go back to editing
+            </Button>
+            <Button variant="solid" colorScheme="critical" onClick={onDiscard}>
+              Yes, discard changes
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/index.ts
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./DiscardChangesModal"

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -57,7 +57,7 @@ export default function RootStateDrawer() {
 
       const from = result.source.index
       const to = result.destination.index
-      const contentLength = savedPageState?.content.length ?? 0
+      const contentLength = savedPageState.content.length ?? 0
 
       if (from >= contentLength || to >= contentLength || from < 0 || to < 0)
         return


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We do not have a discard changes warning modal when users close the drawer with pending changes.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add a new discard changes warning modal when the user attempts to close the complex/native/metadata editing drawer when there are differences between the preview and saved states.

## Before & After Screenshots
<img width="703" alt="Screenshot 2024-07-31 at 15 41 57" src="https://github.com/user-attachments/assets/e7114193-41eb-4648-b128-294340d8a66e">
