### PR TITLE
feat: update breakpoints for isomer components, prebuild tw when building studio

### DIFF
--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -112,9 +112,6 @@ const config: Config = {
       letterSpacing: {
         tight: "-0.022em",
       },
-      spacing: {
-        container: "1240px",
-      },
     },
   },
   plugins: [

--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -9,7 +9,17 @@ import { isomerTypography } from "./typography"
 const config: Config = {
   content: [],
   theme: {
+    screens: {
+      // breakpoints need to be sorted from smallest to largest in order to work as expected with a min-width breakpoint system
+      // See https://tailwindcss.com/docs/screens#adding-smaller-breakpoints
+      xs: "576px",
+      //
+      ...defaultTheme.screens,
+    },
     extend: {
+      screens: {
+        xl: "1240px",
+      },
       boxShadow: {
         sm: "0 0px 10px 0px rgba(191, 191, 191, 0.5)",
       },
@@ -101,9 +111,6 @@ const config: Config = {
       },
       letterSpacing: {
         tight: "-0.022em",
-      },
-      screens: {
-        xs: "576px",
       },
       spacing: {
         container: "1240px",

--- a/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
+++ b/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
@@ -17,7 +17,7 @@ export const Masthead = ({
       className="bg-[#f0f0f0] text-[0.6875rem] text-[#474747] lg:text-sm"
       aria-label="A Singapore Government Agency Website"
     >
-      <div className="mx-auto max-w-container px-6 lg:px-10">
+      <div className="mx-auto max-w-screen-xl px-6 lg:px-10">
         <div className="flex gap-1">
           <svg
             version="1.1"
@@ -79,7 +79,7 @@ export const Masthead = ({
 
       <div
         id="sgds-masthead-content"
-        className={`mx-auto max-w-container px-6 pb-8 pt-4 text-[#474747] lg:px-10 lg:pb-12 lg:pt-10 ${
+        className={`mx-auto max-w-screen-xl px-6 pb-8 pt-4 text-[#474747] lg:px-10 lg:pb-12 lg:pt-10 ${
           isMastheadContentVisible ? "block" : "hidden"
         }`}
       >

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -189,7 +189,7 @@ export const Navbar = ({
         <div
           className={`${
             isSearchOpen ? "block" : "hidden"
-          } mx-auto mb-4 w-full max-w-container px-6 lg:px-10`}
+          } mx-auto mb-4 w-full max-w-screen-xl px-6 lg:px-10`}
         >
           {search.type === "localSearch" && (
             <LocalSearchInputBox searchUrl={search.searchUrl} />

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -264,7 +264,7 @@ const CollectionClient = ({
   )
 
   return (
-    <div className="mx-auto my-16 flex max-w-container flex-col items-start gap-16 px-6 md:px-10">
+    <div className="mx-auto my-16 flex max-w-screen-xl flex-col items-start gap-16 px-6 md:px-10">
       <div className="flex max-w-[47.8rem] flex-col gap-12">
         <h1 className="flex flex-col gap-16 text-content-strong text-heading-01">
           {title}

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -19,7 +19,7 @@ const HomepageLayout = ({
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,
         // but cannot be used here as tailwind does not support dynamic class names
-        className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-container [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
+        className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
       >
         {renderPageContent({ content, LinkComponent })}
       </div>

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
@@ -18,7 +18,7 @@ const NotFoundLayout = ({
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,
         // but cannot be used here as tailwind does not support dynamic class names
-        className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-container [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
+        className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
       >
         {renderComponent({
           component: {


### PR DESCRIPTION
Unsure if we should call it "desktop" instead of xl. but maybe xl better. who knows.

### TL;DR

This update modifies various screen size and max-width configurations across multiple files.

Also updates turbo config to prebuild tw when running dev/build

### What changed?

- Added new screen size breakpoints to the theme configuration, ensuring they are sorted correctly.
- Removed redundant screen size and spacing definitions.
- Updated the max-width utility classes in several components (ContentPageHeader, Masthead, Navbar, CollectionClient, ContentLayout, HomepageLayout, NotFoundLayout) to use `max-w-screen-xl` instead of `max-w-container`.

### How to test?

Stories
### Why make this change?
To be consistent with desktop breakpoint in design.