### PR TITLE
feat: replace hard-coded color values with (hardcoded) CSS variables from site theme

### DIFF
--- a/apps/studio/tailwind.config.js
+++ b/apps/studio/tailwind.config.js
@@ -1,6 +1,6 @@
-/** @type {import('tailwindcss').Config} */
 import { NextPreset } from "@opengovsg/isomer-components"
 
+/** @type {import('tailwindcss').Config} */
 export default {
   content: [
     "./src/**/*.{js,ts,jsx,tsx,mdx}",

--- a/packages/components/src/index.css
+++ b/packages/components/src/index.css
@@ -4,6 +4,17 @@
 @tailwind components;
 @tailwind utilities;
 
+/* TODO: Inject with storybook's theme manager instead of hardcoding here */
+:root {
+  --color-brand-canvas-default: #e6ecef;
+  --color-brand-canvas-alt: #bfcfd7;
+  --color-brand-canvas-backdrop: #80a0af;
+  --color-brand-canvas-inverse: #00405f;
+  --color-brand-interaction-default: #00405f;
+  --color-brand-interaction-hover: #002e44;
+  --color-brand-interaction-pressed: #00283b;
+}
+
 @layer base {
   html[data-theme="isomer-next"] {
     font-family: "Inter", system-ui, sans-serif;

--- a/packages/components/src/presets/index.ts
+++ b/packages/components/src/presets/index.ts
@@ -1,2 +1,3 @@
 export { default as ClassicPreset } from "./classic"
 export { default as NextPreset } from "./next"
+export { isomerSiteTheme } from "./next/site-theme"

--- a/packages/components/src/presets/next/colors.ts
+++ b/packages/components/src/presets/next/colors.ts
@@ -1,18 +1,17 @@
 import twColors from "tailwindcss/colors"
 
 export const colors = {
-  // TODO: Use CSS variables for brand
   brand: {
     canvas: {
-      DEFAULT: "#E6ECEF",
-      alt: "#BFCFD7",
-      backdrop: "#80A0AF",
-      inverse: "#00405F",
+      DEFAULT: "var(--color-brand-canvas-default)",
+      alt: "var(--color-brand-canvas-alt)",
+      backdrop: "var(--color-brand-canvas-backdrop)",
+      inverse: "var(--color-brand-canvas-inverse)",
     },
     interaction: {
-      DEFAULT: "#00405F",
-      hover: "#002E44",
-      pressed: "#00283B",
+      DEFAULT: "var(--color-brand-interaction-default)",
+      hover: "var(--color-brand-interaction-hover)",
+      pressed: "var(--color-brand-interaction-pressed)",
     },
   },
   base: {

--- a/packages/components/src/presets/next/colors.ts
+++ b/packages/components/src/presets/next/colors.ts
@@ -32,7 +32,7 @@ export const colors = {
       subtle: twColors.gray["600"],
       inverse: {
         DEFAULT: twColors.white,
-        subtle: twColors.slate["200"],
+        subtle: twColors.zinc["400"],
       },
     },
     divider: {
@@ -46,8 +46,7 @@ export const colors = {
   },
   link: {
     DEFAULT: twColors.blue["600"],
-    hover: "#0D4FCA",
-    active: "#0B44AC",
+    hover: twColors.blue["700"],
   },
   utility: {
     feedback: {

--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -112,7 +112,6 @@ const config: Config = {
   },
   plugins: [
     isomerTypography,
-    isomerSiteTheme,
     // !! @deprecated, use isomerTypography plugin instead
     // Delete after no components are using these classes anymore,
     plugin(({ addBase, addUtilities, theme }) => {

--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -3,6 +3,7 @@ import defaultTheme from "tailwindcss/defaultTheme"
 import plugin from "tailwindcss/plugin"
 
 import { colors } from "./colors"
+import { isomerSiteTheme } from "./site-theme"
 import { isomerTypography } from "./typography"
 
 const config: Config = {
@@ -14,23 +15,6 @@ const config: Config = {
       },
       colors: {
         ...colors,
-        // TODO: Should be injected by the site theme
-        // Currently using MOH theme as an example
-        brand: {
-          canvas: {
-            primary: "#00405F",
-            alt: "#80A0AF",
-            backdrop: "#E6ECEF",
-          },
-          interaction: {
-            DEFAULT: "#00405F",
-            hover: {
-              DEFAULT: "#002E44",
-              inverse: "#002E44",
-            },
-            pressed: "#00283B",
-          },
-        },
         // Everything below is deprecated and should be removed when
         // all components are using the new color tokens above
         canvas: {
@@ -128,6 +112,7 @@ const config: Config = {
   },
   plugins: [
     isomerTypography,
+    isomerSiteTheme,
     // !! @deprecated, use isomerTypography plugin instead
     // Delete after no components are using these classes anymore,
     plugin(({ addBase, addUtilities, theme }) => {

--- a/packages/components/src/presets/next/site-theme.ts
+++ b/packages/components/src/presets/next/site-theme.ts
@@ -1,0 +1,16 @@
+import plugin from "tailwindcss/plugin"
+
+export const isomerSiteTheme = plugin(({ addBase }) => {
+  addBase({
+    // TODO: Inject dynamically based on whatever is passed in.
+    ":root": {
+      "--color-brand-canvas-default": "#e6ecef",
+      "--color-brand-canvas-alt": "#bfcfd7",
+      "--color-brand-canvas-backdrop": "#80a0af",
+      "--color-brand-canvas-inverse": "#00405f",
+      "--color-brand-interaction-default": "#00405f",
+      "--color-brand-interaction-hover": "#002e44",
+      "--color-brand-interaction-pressed": "#00283b",
+    },
+  })
+})

--- a/packages/components/src/presets/next/site-theme.ts
+++ b/packages/components/src/presets/next/site-theme.ts
@@ -1,16 +1,35 @@
 import plugin from "tailwindcss/plugin"
 
-export const isomerSiteTheme = plugin(({ addBase }) => {
-  addBase({
-    // TODO: Inject dynamically based on whatever is passed in.
-    ":root": {
-      "--color-brand-canvas-default": "#e6ecef",
-      "--color-brand-canvas-alt": "#bfcfd7",
-      "--color-brand-canvas-backdrop": "#80a0af",
-      "--color-brand-canvas-inverse": "#00405f",
-      "--color-brand-interaction-default": "#00405f",
-      "--color-brand-interaction-hover": "#002e44",
-      "--color-brand-interaction-pressed": "#00283b",
+interface SiteThemeOptions {
+  colors: {
+    canvas: {
+      default: string
+      alt: string
+      backdrop: string
+      inverse: string
+    }
+    interaction: {
+      default: string
+      hover: string
+      pressed: string
+    }
+  }
+}
+
+export const isomerSiteTheme = plugin.withOptions(
+  ({ colors }: SiteThemeOptions) =>
+    ({ addBase }) => {
+      addBase({
+        // TODO: Inject dynamically based on whatever is passed in.
+        ":root": {
+          "--color-brand-canvas-default": colors.canvas.default,
+          "--color-brand-canvas-alt": colors.canvas.alt,
+          "--color-brand-canvas-backdrop": colors.canvas.backdrop,
+          "--color-brand-canvas-inverse": colors.canvas.inverse,
+          "--color-brand-interaction-default": colors.interaction.default,
+          "--color-brand-interaction-hover": colors.interaction.hover,
+          "--color-brand-interaction-pressed": colors.interaction.pressed,
+        },
+      })
     },
-  })
-})
+)

--- a/tooling/template/data/config.json
+++ b/tooling/template/data/config.json
@@ -15,6 +15,19 @@
     "site-primary-default": "#f78f1e",
     "site-primary-100": "#fef4e8",
     "site-primary-200": "#ffeec2",
-    "site-secondary-default": "#877664"
+    "site-secondary-default": "#877664",
+    "brand": {
+      "canvas": {
+        "default": "#e6ecef",
+        "alt": "#bfcfd7",
+        "backdrop": "#80a0af",
+        "inverse": "#00405f"
+      },
+      "interaction": {
+        "default": "#00405f",
+        "hover": "#002e44",
+        "pressed": "#00283b"
+      }
+    }
   }
 }

--- a/tooling/template/tailwind.config.js
+++ b/tooling/template/tailwind.config.js
@@ -1,14 +1,20 @@
 /** @type {import('tailwindcss').Config} */
-import { NextPreset } from "@opengovsg/isomer-components"
+import { isomerSiteTheme, NextPreset } from "@opengovsg/isomer-components"
 
 import siteConfig from "./data/config.json"
 
+/** @type {import('tailwindcss').Config} */
 const config = {
   content: [
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./node_modules/@opengovsg/isomer-components/**/*.{js,ts,jsx,tsx}",
   ],
   presets: [NextPreset],
+  plugins: [
+    isomerSiteTheme({
+      colors: siteConfig.colors.brand,
+    }),
+  ],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
### TL;DR
Migrated brand colors to CSS variables and introduced a new `isomerSiteTheme` plugin for (future) dynamic theme injection.

### What changed?
- Updated `colors.ts` to use CSS variables for brand colors.
- Introduced `isomerSiteTheme` in `site-theme.ts` to dynamically inject CSS variables.
- Removed the old MOH theme from `index.ts` and integrated the new `isomerSiteTheme` plugin.

### How to test?
Should have no changes for components that were already using the previously (more) hardcoded tokens. 

### Why make this change?
This change is motivated by the need for better theme management and dynamic theming capabilities using CSS variables.
