### PR TITLE
feat(components): create custom TV and twMerge config so dedupe works for prose

### DIFF
--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -24,6 +24,25 @@ export default [
         { ignorePrimitives: true },
       ],
       "@typescript-eslint/no-unnecessary-condition": "warn",
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "tailwind-variants",
+              importNames: ["tv"],
+              message:
+                "Please use export from ~/lib/tv instead of the node module",
+            },
+            {
+              name: "tailwind-merge",
+              importNames: ["twMerge"],
+              message:
+                "Please use export from ~/lib/twMerge instead of the node module",
+            },
+          ],
+        },
+      ],
     },
   },
 ]

--- a/packages/components/src/lib/tv.ts
+++ b/packages/components/src/lib/tv.ts
@@ -1,39 +1,11 @@
-/**
- * Keep in sync with packages/components/src/presets/next/typography.ts,
- * or deduplicate between prose classes will not work as expected.
- */
+import { validators } from "tailwind-merge"
 import { createTV } from "tailwind-variants"
 
 export const tv = createTV({
   twMergeConfig: {
     classGroups: {
-      prose: [
-        "prose-display-xl",
-        "prose-display-lg",
-        "prose-display-md",
-        "prose-display-sm",
-        "prose-title-lg",
-        "prose-title-lg-medium",
-        "prose-title-lg-regular",
-        "prose-title-md",
-        "prose-title-md-semibold",
-        "prose-title-md-medium",
-        "prose-headline-lg",
-        "prose-headline-lg-semibold",
-        "prose-headline-lg-medium",
-        "prose-headline-lg-regular",
-        "prose-headline-base",
-        "prose-headline-base-semibold",
-        "prose-headline-base-medium",
-        "prose-body-base",
-        "prose-body-sm",
-        "prose-label-md",
-        "prose-label-md-medium",
-        "prose-label-md-regular",
-        "prose-label-sm",
-        "prose-label-sm-medium",
-        "prose-label-sm-regular",
-      ],
+      // Match everything in the prose namespace
+      prose: [{ prose: [validators.isAny] }],
     },
   },
 })

--- a/packages/components/src/lib/tv.ts
+++ b/packages/components/src/lib/tv.ts
@@ -1,11 +1,7 @@
-import { validators } from "tailwind-merge"
 import { createTV } from "tailwind-variants"
 
+import { customTwMergeConfig } from "./twMerge"
+
 export const tv = createTV({
-  twMergeConfig: {
-    classGroups: {
-      // Match everything in the prose namespace
-      prose: [{ prose: [validators.isAny] }],
-    },
-  },
+  twMergeConfig: customTwMergeConfig,
 })

--- a/packages/components/src/lib/tv.ts
+++ b/packages/components/src/lib/tv.ts
@@ -1,0 +1,39 @@
+/**
+ * Keep in sync with packages/components/src/presets/next/typography.ts,
+ * or deduplicate between prose classes will not work as expected.
+ */
+import { createTV } from "tailwind-variants"
+
+export const tv = createTV({
+  twMergeConfig: {
+    classGroups: {
+      prose: [
+        "prose-display-xl",
+        "prose-display-lg",
+        "prose-display-md",
+        "prose-display-sm",
+        "prose-title-lg",
+        "prose-title-lg-medium",
+        "prose-title-lg-regular",
+        "prose-title-md",
+        "prose-title-md-semibold",
+        "prose-title-md-medium",
+        "prose-headline-lg",
+        "prose-headline-lg-semibold",
+        "prose-headline-lg-medium",
+        "prose-headline-lg-regular",
+        "prose-headline-base",
+        "prose-headline-base-semibold",
+        "prose-headline-base-medium",
+        "prose-body-base",
+        "prose-body-sm",
+        "prose-label-md",
+        "prose-label-md-medium",
+        "prose-label-md-regular",
+        "prose-label-sm",
+        "prose-label-sm-medium",
+        "prose-label-sm-regular",
+      ],
+    },
+  },
+})

--- a/packages/components/src/lib/twMerge.ts
+++ b/packages/components/src/lib/twMerge.ts
@@ -1,0 +1,17 @@
+import { extendTailwindMerge, validators } from "tailwind-merge"
+
+type MergeConfig = Parameters<typeof extendTailwindMerge>[0]
+type AdditionalClassGroupIds = "prose"
+
+// Exported for used in tailwind-variants too.
+export const customTwMergeConfig = {
+  extend: {
+    classGroups: {
+      // Match everything in the prose namespace
+      prose: [{ prose: [validators.isAny] }],
+    },
+  },
+} satisfies MergeConfig
+
+export const twMerge =
+  extendTailwindMerge<AdditionalClassGroupIds>(customTwMergeConfig)

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 import { BiChevronRight } from "react-icons/bi"
-import { tv } from "tailwind-variants"
 
 import type { BreadcrumbProps } from "~/interfaces"
+import { tv } from "~/lib/tv"
 
 const breadcrumbStyles = tv({
   slots: {

--- a/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavItemAccordion.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavItemAccordion.tsx
@@ -1,7 +1,7 @@
 import { BiChevronDown } from "react-icons/bi"
-import { tv } from "tailwind-variants"
 
 import type { NavbarItem, NavbarProps } from "~/interfaces/internal/Navbar"
+import { tv } from "~/lib/tv"
 
 interface NavItemAccordionProps
   extends NavbarItem,

--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -1,12 +1,12 @@
 import { forwardRef } from "react"
 import { FocusScope } from "react-aria"
 import { BiChevronDown, BiRightArrowAlt, BiX } from "react-icons/bi"
-import { tv } from "tailwind-variants"
 
 import type {
   NavbarItem as BaseNavbarItemProps,
   NavbarProps,
 } from "~/interfaces/internal/Navbar"
+import { tv } from "~/lib/tv"
 
 interface NavbarItemProps
   extends BaseNavbarItemProps,

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -3,10 +3,10 @@
 import { useCallback, useLayoutEffect, useRef, useState } from "react"
 import { usePreventScroll } from "react-aria"
 import { BiSearch, BiX } from "react-icons/bi"
-import { tv } from "tailwind-variants"
 import { useOnClickOutside, useResizeObserver } from "usehooks-ts"
 
 import type { NavbarProps } from "~/interfaces"
+import { tv } from "~/lib/tv"
 import { LocalSearchInputBox, SearchSGInputBox } from "../../internal"
 import { HamburgerIcon } from "./HamburgerIcon"
 import { MobileNavMenu } from "./MobileNavMenu"


### PR DESCRIPTION
### TL;DR
Currently `.prose` classes are not being deduped by `tailwind-variants` because it does not know about it. Add a custom config for proper dedupe
