### PR TITLE
fix: remove siderail for first-level and fix TOC

### DIFF
--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -2158,3 +2158,385 @@ export const SmallTable: Story = {
     ],
   },
 }
+
+export const FirstLevelPage: Story = {
+  args: {
+    layout: "content",
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        title: "Isomer Next",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [
+          {
+            title: "Parent page",
+            permalink: "/parent",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+            children: [
+              {
+                title: "Irrationality",
+                permalink: "/parent/rationality",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    title: "For Individuals",
+                    permalink: "/parent/rationality/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                  {
+                    title: "Steven Pinker's Rationality",
+                    permalink: "/parent/rationality/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+              {
+                title: "Sibling",
+                permalink: "/parent/sibling",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    title: "Child that should not appear",
+                    permalink: "/parent/sibling/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            title: "Aunt/Uncle that should not appear",
+            permalink: "/aunt-uncle",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+          },
+        ],
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      navBarItems: [],
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      lastUpdated: "1 Jan 2021",
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+    page: {
+      permalink: "/parent",
+      title: "Content page",
+      lastModified: "2024-05-02T14:12:57.160Z",
+      description: "A Next.js starter for Isomer",
+      contentPageHeader: {
+        summary:
+          "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",
+        buttonLabel: "Submit a proposal",
+        buttonUrl: "/submit-proposal",
+      },
+    },
+    content: [
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: {
+              id: "section1",
+              level: 2,
+            },
+            content: [
+              {
+                type: "text",
+                text: "What does the Irrationality Principle support?",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "callout",
+        content: {
+          type: "prose",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                {
+                  type: "text",
+                  text: `As of December 1, 2024, the scheme is being reviewed for new criteria in 2025. To view the new criteria please refer to <a href="/faq">New Idea Scheme Proposal</a> while it is being updated.`,
+                },
+              ],
+            },
+          ],
+        },
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Our choices become a tangled web of contradictions, driven by instinct rather than careful deliberation. We cling to superstitions and fallacies, seeking comfort in the irrationality that offers solace amidst life's uncertainties. It is a paradoxical dance, where the irrational often masquerades as wisdom, leading us down paths fraught with confusion and folly. Yet, in embracing our irrationality, we find a peculiar sort of freedom, liberated from the constraints of logic and reason. We navigate the world with a blend of intuition and irrationality, embracing the chaos that defines the human experience. And so, in the tapestry of existence, irrationality weaves its intricate threads, adding depth and complexity to the fabric of our lives.",
+              },
+            ],
+          },
+          {
+            type: "unorderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Steven Pinker's Rationality: An Overview Steven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An Overview",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Steven Pinker's Rationality: An Overview Steven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An OverviewSteven Pinker's Rationality: An Overview",
+                      },
+                    ],
+                  },
+                  {
+                    type: "unorderedList",
+                    content: [
+                      {
+                        type: "listItem",
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [
+                              {
+                                type: "text",
+                                text: "Like this, you might have a list of equipments to bring to the luncheon",
+                              },
+                            ],
+                          },
+                          {
+                            type: "unorderedList",
+                            content: [
+                              {
+                                type: "listItem",
+                                content: [
+                                  {
+                                    type: "paragraph",
+                                    content: [
+                                      { type: "text", text: "Luncheon meat" },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "listItem",
+                                content: [
+                                  {
+                                    type: "paragraph",
+                                    content: [{ type: "text", text: "Spam" }],
+                                  },
+                                  {
+                                    type: "unorderedList",
+                                    content: [
+                                      {
+                                        type: "listItem",
+                                        content: [
+                                          {
+                                            type: "paragraph",
+                                            content: [
+                                              {
+                                                type: "text",
+                                                text: "Another level below",
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                      {
+                                        type: "listItem",
+                                        content: [
+                                          {
+                                            type: "paragraph",
+                                            content: [
+                                              {
+                                                type: "text",
+                                                text: "This is very deep",
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                              {
+                                type: "listItem",
+                                content: [
+                                  {
+                                    type: "paragraph",
+                                    content: [{ type: "text", text: "hello" }],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      {
+                        type: "listItem",
+                        content: [
+                          {
+                            type: "paragraph",
+                            content: [{ type: "text", text: "Back out again" }],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Through Pinker's exploration, readers gain a deeper appreciation for the complexities and nuances of human rationality. (Engaging for individuals curious about the intricacies of human behavior and decision-making processes.)",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "heading",
+            attrs: {
+              id: "section2",
+              level: 2,
+            },
+            content: [
+              { type: "text", text: "Checklist for sheer irrationality" },
+            ],
+          },
+          {
+            type: "heading",
+            attrs: {
+              id: "section1",
+              level: 3,
+            },
+            content: [{ type: "text", text: "If you are a small business" }],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "Your business must have:" }],
+          },
+          {
+            type: "unorderedList",
+            content: [
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Through Pinker's exploration, readers gain a deeper appreciation for the complexities and nuances of human rationality. (Engaging for individuals curious about the intricacies of human behavior and decision-making processes.)",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "(Suitable for those interested in the interdisciplinary study of cognitive science and psychology.)",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "listItem",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: "Practical applications of rationality in daily life are elucidated by Pinker, offering actionable insights for better decision-making. (Beneficial for individuals seeking practical strategies to improve their decision-making processes.)",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: "This is yet another paragraph" }],
+          },
+          {
+            type: "heading",
+            attrs: {
+              id: "section3",
+              level: 4,
+            },
+            content: [{ type: "text", text: "But then, if you are listed" }],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "In the realm of human cognition, irrationality often reigns supreme, defying the logic that ostensibly governs our decisions and actions. It manifests in myriad ways, from the subtle biases that influence our perceptions to the outright contradictions that confound our rational minds. We find ourselves ensnared in cognitive dissonance, grappling with conflicting beliefs and emotions that lead us astray from the path of reason. Despite our best intentions, we succumb to the allure of irrationality, surrendering to the whims of impulse and emotion. Our choices become a tangled web of contradictions, driven by instinct rather than careful deliberation. We cling to superstitions and fallacies, seeking comfort in the irrationality that offers solace amidst life's uncertainties. It is a paradoxical dance, where the irrational often masquerades as wisdom, leading us down paths fraught with confusion and folly. Yet, in embracing our irrationality, we find a peculiar sort of freedom, liberated from the constraints of logic and reason. We navigate the world with a blend of intuition and irrationality, embracing the chaos that defines the human experience. And so, in the tapestry of existence, irrationality weaves its intricate threads, adding depth and complexity to the fabric of our lives.",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -115,8 +115,12 @@ const transformContent = (content: ContentPageSchemaType["content"]) => {
             const anchorId = getDigestFromText(
               `${JSON.stringify(component)}_${getRandomNumberBetIntervals(1, 1000)}`,
             )
+            const newAttrs = {
+              ...component.attrs,
+              id: anchorId,
+            }
 
-            return { ...component, id: anchorId }
+            return { ...component, attrs: newAttrs }
           } else {
             return component
           }
@@ -136,7 +140,14 @@ const createContentLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 flex flex-col gap-16 lg:col-span-9 lg:ml-24",
+    content: "col-span-12 flex flex-col gap-16 lg:col-span-9",
+  },
+  variants: {
+    isSideRailPresent: {
+      true: {
+        content: "lg:ml-24",
+      },
+    },
   },
 })
 
@@ -149,10 +160,12 @@ const ContentLayout = ({
   LinkComponent = "a",
   ScriptComponent,
 }: ContentPageSchemaType) => {
-  const sideRail = getSiderailFromSiteMap(
-    site.siteMap,
-    page.permalink.split("/").slice(1),
-  )
+  const isParentPageRoot = page.permalink.split("/").length === 2
+
+  // Note: We do not show side rail for first-level pages
+  const sideRail = !isParentPageRoot
+    ? getSiderailFromSiteMap(site.siteMap, page.permalink.split("/").slice(1))
+    : null
   // auto-inject ids for heading level 2 blocks if does not exist
   const transformedContent = transformContent(content)
   const tableOfContents = getTableOfContentsFromContent(transformedContent)
@@ -188,7 +201,9 @@ const ContentLayout = ({
             </LinkComponent>
           </div>
         )}
-        <div className={compoundStyles.content()}>
+        <div
+          className={compoundStyles.content({ isSideRailPresent: !!sideRail })}
+        >
           {tableOfContents.items.length > 1 && (
             <TableOfContents {...tableOfContents} />
           )}

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -140,12 +140,15 @@ const createContentLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 flex flex-col gap-16 lg:col-span-9",
+    content: "col-span-12 flex flex-col gap-16",
   },
   variants: {
     isSideRailPresent: {
       true: {
-        content: "lg:ml-24",
+        content: "lg:col-span-9 lg:ml-24",
+      },
+      false: {
+        content: "max-w-[54rem]",
       },
     },
   },
@@ -166,6 +169,8 @@ const ContentLayout = ({
   const sideRail = !isParentPageRoot
     ? getSiderailFromSiteMap(site.siteMap, page.permalink.split("/").slice(1))
     : null
+
+  console.log(sideRail)
   // auto-inject ids for heading level 2 blocks if does not exist
   const transformedContent = transformContent(content)
   const tableOfContents = getTableOfContentsFromContent(transformedContent)
@@ -194,13 +199,14 @@ const ContentLayout = ({
             <LinkComponent
               href="#"
               // TODO: Replace LinkComponent with a custom link component with all the styles
-              className="prose-body-base sticky top-8 mt-8 flex items-center text-link underline-offset-4 hover:underline"
+              className="prose-body-base text-link sticky top-8 mt-8 flex items-center underline-offset-4 hover:underline"
             >
               <BiUpArrowAlt aria-hidden className="h-6 w-6" />
               Back to top
             </LinkComponent>
           </div>
         )}
+
         <div
           className={compoundStyles.content({ isSideRailPresent: !!sideRail })}
         >

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -170,7 +170,6 @@ const ContentLayout = ({
     ? getSiderailFromSiteMap(site.siteMap, page.permalink.split("/").slice(1))
     : null
 
-  console.log(sideRail)
   // auto-inject ids for heading level 2 blocks if does not exist
   const transformedContent = transformContent(content)
   const tableOfContents = getTableOfContentsFromContent(transformedContent)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Siderail on first-level pages don't really make sense, and the table of contents broke after a previous schema update to the heading attributes.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Removed siderail for first-level pages.
- Fixed anchor ID generation for level 2 headings.