### PR TITLE
feat: add base modal ui

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,6 +1,10 @@
-import type { ColumnType, GeneratedAlways } from "kysely"
+import type { ColumnType, GeneratedAlways } from "kysely";
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
 
 export type Generated<T> =
   T extends ColumnType<infer S, infer I, infer U>

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -1,0 +1,173 @@
+import type { UseDisclosureReturn } from "@chakra-ui/react"
+import { useEffect } from "react"
+import {
+  Box,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Icon,
+  Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  VStack,
+} from "@chakra-ui/react"
+import {
+  Button,
+  FormErrorMessage,
+  ModalCloseButton,
+  useToast,
+} from "@opengovsg/design-system-react"
+import { uniqueId } from "lodash"
+import { BiLink } from "react-icons/bi"
+import { z } from "zod"
+
+import { useZodForm } from "~/lib/form"
+import {
+  createFolderSchema,
+  MAX_FOLDER_PERMALINK_LENGTH,
+  MAX_FOLDER_TITLE_LENGTH,
+} from "~/schemas/folder"
+import { trpc } from "~/utils/trpc"
+import { generateResourceUrl } from "../utils"
+
+type CreateFolderProps = z.infer<typeof createFolderSchema>
+
+type CreateFolderModalProps = Pick<UseDisclosureReturn, "isOpen" | "onClose"> &
+  Pick<CreateFolderProps, "siteId" | "parentFolderId">
+
+export const CreateFolderModal = ({
+  isOpen,
+  onClose,
+  siteId,
+  parentFolderId,
+}: CreateFolderModalProps): JSX.Element => {
+  const { setValue, register, handleSubmit, watch, formState, getFieldState } =
+    useZodForm({
+      defaultValues: {
+        folderTitle: "",
+        permalink: "",
+      },
+      schema: createFolderSchema.omit({ siteId: true, parentFolderId: true }),
+    })
+  const { errors, isValid } = formState
+  const utils = trpc.useUtils()
+  const toast = useToast()
+  const { mutate, isLoading } = trpc.folder.create.useMutation({
+    onSettled: onClose,
+    onSuccess: () => {
+      void utils.site.list.invalidate()
+      void utils.page.list.invalidate()
+      toast({ title: "Folder created!", status: "success" })
+    },
+    onError: (err) => {
+      toast({
+        title: "Failed to create folder",
+        status: "error",
+        // TODO: check if this property is correct
+        description: err.message,
+      })
+    },
+  })
+
+  const onSubmit = handleSubmit((data) => {
+    mutate({ ...data, parentFolderId, siteId })
+  })
+
+  const [folderTitle, permalink] = watch(["folderTitle", "permalink"])
+
+  useEffect(() => {
+    const permalinkFieldState = getFieldState("permalink")
+    // This allows the syncing to happen only when the page title is not dirty
+    // Dirty means user has changed the value AND the value is not the same as the default value of "".
+    // Once the value has been cleared, dirty state will reset.
+    if (!permalinkFieldState.isDirty) {
+      setValue("permalink", generateResourceUrl(folderTitle), {
+        shouldValidate: !!folderTitle,
+      })
+    }
+  }, [getFieldState, setValue, folderTitle])
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent key={uniqueId()}>
+        <form onSubmit={onSubmit}>
+          <ModalHeader>Create a new folder </ModalHeader>
+          <ModalCloseButton size="sm" />
+          <ModalBody>
+            <VStack alignItems="flex-start" spacing="1.5rem">
+              <FormControl isInvalid={!!errors.folderTitle}>
+                <FormLabel color="base.content.strong">
+                  Folder name
+                  <FormHelperText color="base.content.default">
+                    This will be the title of the index page of your folder.
+                  </FormHelperText>
+                </FormLabel>
+
+                <Input
+                  placeholder="This is a title for your new folder"
+                  {...register("folderTitle")}
+                />
+                {errors.folderTitle?.message ? (
+                  <FormErrorMessage>
+                    {errors.folderTitle.message}
+                  </FormErrorMessage>
+                ) : (
+                  <FormHelperText mt="0.5rem" color="base.content.medium">
+                    {MAX_FOLDER_TITLE_LENGTH - folderTitle.length} characters
+                    left
+                  </FormHelperText>
+                )}
+              </FormControl>
+              <FormControl isInvalid={!!errors.permalink}>
+                <FormLabel color="base.content.strong">
+                  Folder URL
+                  <FormHelperText color="base.content.default">
+                    This will be applied to every child under this folder.
+                  </FormHelperText>
+                </FormLabel>
+                <Input
+                  placeholder="This is a url for your new page"
+                  {...register("permalink")}
+                />
+                {errors.permalink?.message && (
+                  <FormErrorMessage>
+                    {errors.permalink.message}
+                  </FormErrorMessage>
+                )}
+
+                <Box
+                  mt="0.5rem"
+                  py="0.5rem"
+                  px="0.75rem"
+                  bg="interaction.support.disabled"
+                >
+                  <Icon mr="0.5rem" as={BiLink} />
+                  {permalink}
+                </Box>
+
+                <FormHelperText mt="0.5rem" color="base.content.medium">
+                  {MAX_FOLDER_PERMALINK_LENGTH - permalink.length} characters
+                  left
+                </FormHelperText>
+              </FormControl>
+            </VStack>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button mr={3} onClick={onClose} variant="clear">
+              Close
+            </Button>
+            <Button isLoading={isLoading} isDisabled={!isValid} type="submit">
+              Create Folder
+            </Button>
+          </ModalFooter>
+        </form>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/index.ts
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./CreateFolderModal"

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -17,17 +17,9 @@ import { Button, FormErrorMessage } from "@opengovsg/design-system-react"
 import { Controller } from "react-hook-form"
 
 import { MAX_PAGE_URL_LENGTH, MAX_TITLE_LENGTH } from "~/schemas/page"
+import { generateResourceUrl } from "../utils"
 import { useCreatePageWizard } from "./CreatePageWizardContext"
 import { PreviewLayout } from "./PreviewLayout"
-
-const generatePageUrl = (value: string) => {
-  return (
-    value
-      .toLowerCase()
-      // Replace non-alphanum characters with hyphen for UX
-      .replace(/[^a-z0-9]/g, "-")
-  )
-}
 
 export const CreatePageDetailsScreen = () => {
   const {
@@ -65,7 +57,7 @@ export const CreatePageDetailsScreen = () => {
     // Dirty means user has changed the value AND the value is not the same as the default value of "".
     // Once the value has been cleared, dirty state will reset.
     if (!permalinkFieldState.isDirty) {
-      setValue("permalink", generatePageUrl(title), {
+      setValue("permalink", generateResourceUrl(title), {
         shouldValidate: !!title,
       })
     }
@@ -164,7 +156,7 @@ export const CreatePageDetailsScreen = () => {
                         placeholder="URL will be autopopulated if left untouched"
                         {...field}
                         onChange={(e) => {
-                          onChange(generatePageUrl(e.target.value))
+                          onChange(generateResourceUrl(e.target.value))
                         }}
                       />
                     )}

--- a/apps/studio/src/features/editing-experience/components/utils.ts
+++ b/apps/studio/src/features/editing-experience/components/utils.ts
@@ -1,0 +1,8 @@
+export const generateResourceUrl = (value: string) => {
+  return (
+    value
+      .toLowerCase()
+      // Replace non-alphanum characters with hyphen for UX
+      .replace(/[^a-z0-9]/g, "-")
+  )
+}

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -9,11 +9,13 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
+import { uniqueId } from "lodash"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import { MenuItem } from "~/components/Menu"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
+import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
 import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
 import { MoveResourceModal } from "~/features/editing-experience/components/MoveResourceModal"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -29,6 +31,11 @@ const SitePage: NextPageWithLayout = () => {
     isOpen: isPageCreateModalOpen,
     onOpen: onPageCreateModalOpen,
     onClose: onPageCreateModalClose,
+  } = useDisclosure()
+  const {
+    isOpen: isFolderCreateModalOpen,
+    onOpen: onFolderCreateModalOpen,
+    onClose: onFolderCreateModalClose,
   } = useDisclosure()
 
   const { siteId } = useQueryParse(sitePageSchema)
@@ -48,7 +55,10 @@ const SitePage: NextPageWithLayout = () => {
               </MenuButton>
               <Portal>
                 <MenuList>
-                  <MenuItem icon={<BiFolder fontSize="1rem" />}>
+                  <MenuItem
+                    onClick={onFolderCreateModalOpen}
+                    icon={<BiFolder fontSize="1rem" />}
+                  >
                     Folder
                   </MenuItem>
                   <MenuItem
@@ -72,6 +82,11 @@ const SitePage: NextPageWithLayout = () => {
       <CreatePageModal
         isOpen={isPageCreateModalOpen}
         onClose={onPageCreateModalClose}
+        siteId={siteId}
+      />
+      <CreateFolderModal
+        isOpen={isFolderCreateModalOpen}
+        onClose={onFolderCreateModalClose}
         siteId={siteId}
       />
       <MoveResourceModal />

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -1,13 +1,22 @@
 import { z } from "zod"
 
-const MAX_FOLDER_TITLE_LENGTH = 100
-const MAX_FOLDER_PERMALINK_LENGTH = 200
-const MAX_FOLDER_DESCRIPTION_LENGTH = 300
+export const MAX_FOLDER_TITLE_LENGTH = 100
+export const MAX_FOLDER_PERMALINK_LENGTH = 200
+export const MAX_FOLDER_DESCRIPTION_LENGTH = 300
 
 export const createFolderSchema = z.object({
-  folderTitle: z.string().max(MAX_FOLDER_TITLE_LENGTH),
-  folderDescription: z.string().max(MAX_FOLDER_DESCRIPTION_LENGTH),
-  permalink: z.string().max(MAX_FOLDER_PERMALINK_LENGTH),
+  folderTitle: z
+    .string()
+    .min(1, { message: "Enter a title for this folder" })
+    .max(MAX_FOLDER_TITLE_LENGTH, {
+      message: `Folder title should be shorter than ${MAX_FOLDER_TITLE_LENGTH} characters.`,
+    }),
+  permalink: z
+    .string()
+    .min(1, { message: "Enter a URL for this folder" })
+    .max(MAX_FOLDER_PERMALINK_LENGTH, {
+      message: `Folder URL should be shorter than ${MAX_FOLDER_PERMALINK_LENGTH} characters.`,
+    }),
   siteId: z.number().min(1),
   // Nullable for top level folder
   parentFolderId: z.number().optional(),


### PR DESCRIPTION
## Problem
We need to create a base modal UI for creating folders. This PR adds this modal + updates the backend endpoint to actually do something

## Solution
- use `useZodForm` to create schema for validation 
- simple modal UI following figma 

## SS/Vid

https://github.com/user-attachments/assets/a1e7295f-d13c-4fef-92f3-e29cd8f641b5

