### PR TITLE
chore: shift page.list to resource

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -15,7 +15,7 @@ import { trpc } from "~/utils/trpc"
 import { ResourceTableMenu } from "./ResourceTableMenu"
 import { TitleCell } from "./TitleCell"
 
-type ResourceTableData = RouterOutput["page"]["list"][number]
+type ResourceTableData = RouterOutput["resource"]["list"][number]
 
 const columnsHelper = createColumnHelper<ResourceTableData>()
 
@@ -61,7 +61,7 @@ export const ResourceTable = ({
     () => getColumns({ siteId, resourceId }),
     [siteId, resourceId],
   )
-  const { data: resources } = trpc.page.list.useQuery(
+  const { data: resources } = trpc.resource.list.useQuery(
     {
       siteId,
       resourceId,

--- a/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
@@ -1,3 +1,3 @@
 import type { RouterOutput } from "~/utils/trpc"
 
-export type ResourceTableData = RouterOutput["page"]["list"][number]
+export type ResourceTableData = RouterOutput["resource"]["list"][number]

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -60,7 +60,7 @@ export const CreateFolderModal = ({
     onSettled: onClose,
     onSuccess: () => {
       void utils.site.list.invalidate()
-      void utils.page.list.invalidate()
+      void utils.resource.list.invalidate()
       toast({ title: "Folder created!", status: "success" })
     },
     onError: (err) => {

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -81,7 +81,7 @@ const useCreatePageWizardContext = ({
 
   const { mutate, isLoading } = trpc.page.createPage.useMutation({
     onSuccess: async () => {
-      await utils.page.list.invalidate()
+      await utils.resource.list.invalidate()
       onClose()
     },
     // TOOD: Error handling

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -81,7 +81,7 @@ const MoveResourceContent = withSuspense(
       },
       onSuccess: () => {
         void utils.page.readPageAndBlob.invalidate()
-        void utils.page.list.invalidate({
+        void utils.resource.list.invalidate({
           // TODO: Update backend `list` to use the proper schema
           resourceId: movedItem?.resourceId
             ? Number(movedItem.resourceId)

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -24,3 +24,8 @@ export const moveSchema = z.object({
   movedResourceId: bigIntSchema,
   destinationResourceId: bigIntSchema,
 })
+
+export const listResourceSchema = z.object({
+  siteId: z.number(),
+  resourceId: z.number().optional(),
+})

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -58,35 +58,6 @@ const validatedPageProcedure = protectedProcedure.use(
 )
 
 export const pageRouter = router({
-  list: protectedProcedure
-    .input(
-      z.object({
-        siteId: z.number(),
-        resourceId: z.number().optional(),
-      }),
-    )
-    .query(async ({ input: { siteId, resourceId } }) => {
-      let query = db
-        .selectFrom("Resource")
-        .where("Resource.siteId", "=", siteId)
-
-      if (resourceId) {
-        query = query.where("Resource.parentId", "=", String(resourceId))
-      } else {
-        query = query.where("Resource.parentId", "is", null)
-      }
-
-      return query
-        .select([
-          "Resource.id",
-          "Resource.permalink",
-          "Resource.title",
-          "Resource.publishedVersionId",
-          "Resource.draftBlobId",
-          "Resource.type",
-        ])
-        .execute()
-    }),
   readPageAndBlob: protectedProcedure
     .input(getEditPageSchema)
     .query(async ({ input: { pageId, siteId } }) => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server"
 import {
   getChildrenSchema,
   getMetadataSchema,
+  listResourceSchema,
   moveSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
@@ -77,5 +78,29 @@ export const resourceRouter = router({
           ])
           .executeTakeFirst()
       })
+    }),
+  list: protectedProcedure
+    .input(listResourceSchema)
+    .query(async ({ input: { siteId, resourceId } }) => {
+      let query = db
+        .selectFrom("Resource")
+        .where("Resource.siteId", "=", siteId)
+
+      if (resourceId) {
+        query = query.where("Resource.parentId", "=", String(resourceId))
+      } else {
+        query = query.where("Resource.parentId", "is", null)
+      }
+
+      return query
+        .select([
+          "Resource.id",
+          "Resource.permalink",
+          "Resource.title",
+          "Resource.publishedVersionId",
+          "Resource.draftBlobId",
+          "Resource.type",
+        ])
+        .execute()
     }),
 })

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -4,7 +4,7 @@ import { delay } from "msw"
 import { trpcMsw } from "../mockTrpc"
 
 const pageListQuery = (wait?: DelayMode | number) => {
-  return trpcMsw.page.list.query(async () => {
+  return trpcMsw.resource.list.query(async () => {
     if (wait !== undefined) {
       await delay(wait)
     }


### PR DESCRIPTION
### TL;DR

Consolidates the page listing functionality into the resource module and updates related components.

### What changed?

- Replaced `page.list` calls with `resource.list` calls in various components and modals.
- Updated `resource.router.ts` to include the `list` procedure previously in `page.router.ts`.
- Removed the `list` procedure from `page.router.ts`.
- Adjusted invalidation calls to use `utils.resource.list` instead of `utils.page.list`.

### How to test?

- Go to the base site page
- ensure that you can see pages/folders
- create a new page/folder
- the ui should be updated

### Why make this change?

This change aims to streamline the codebase by consolidating listing functionalities, reducing redundancy, and improving maintainability.
