### PR TITLE
ISOM-1111: add publishing scripts

### DIFF
--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -1,5 +1,9 @@
 import { Skeleton } from "@chakra-ui/react"
-import { Button, useToast } from "@opengovsg/design-system-react"
+import {
+  Button,
+  TouchableTooltip,
+  useToast,
+} from "@opengovsg/design-system-react"
 
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
@@ -47,15 +51,20 @@ const SuspendablePublishButton = ({
       mutate({ pageId: coercedPageId, siteId: coercedSiteId })
   }
   return (
-    <Button
-      variant="solid"
-      size="sm"
-      onClick={handlePublish}
-      isLoading={isLoading}
-      isDisabled={!currPage.draftBlobId}
+    <TouchableTooltip
+      hidden={!!currPage.draftBlobId}
+      label="All changes have been published"
     >
-      Publish
-    </Button>
+      <Button
+        variant="solid"
+        size="sm"
+        onClick={handlePublish}
+        isLoading={isLoading}
+        isDisabled={!currPage.draftBlobId}
+      >
+        Publish
+      </Button>
+    </TouchableTooltip>
   )
 }
 

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Helper function to calculate duration
+calculate_duration() {
+  start_time=$1
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "Time taken: $duration seconds"
+}
+
+# Cloning the repository
+echo "Cloning repository..."
+start_time=$(date +%s)
+
+git clone --depth 1 --branch main https://github.com/opengovsg/isomer.git
+cd isomer/
+calculate_duration $start_time
+
+echo $(pwd)
+
+# Checkout specific branch
+echo "Checking out branch..."
+start_time=$(date +%s)
+git checkout main
+calculate_duration $start_time
+
+echo $(git branch)
+
+# Perform a clean of npm cache
+npm cache clean --force
+
+# Install dependencies
+echo "Installing dependencies..."
+start_time=$(date +%s)
+npm ci
+calculate_duration $start_time
+
+# Build components
+echo "Building components..."
+start_time=$(date +%s)
+cd packages/components
+npm run build
+cd ../.. # back to root
+echo $(pwd)
+calculate_duration $start_time
+
+# Move build scripts from scripts into the template folder
+echo "Moving build scripts..."
+start_time=$(date +%s)
+cp tooling/build/scripts/preBuild.sh tooling/template/
+chmod +x tooling/template/preBuild.sh
+cp tooling/build/scripts/build.sh tooling/template/
+chmod +x tooling/template/build.sh
+calculate_duration $start_time
+
+# Fetch from database
+echo "Fetching from database..."
+start_time=$(date +%s)
+cd tooling/build/scripts/publishing
+echo $(pwd)
+npm ci
+npm install ts-node -g
+npm run start
+calculate_duration $start_time
+
+# Build site
+echo "Building site..."
+start_time=$(date +%s)
+rm -rf ../../../template/schema
+rm -rf ../../../template/data
+mv schema/ ../../../template/
+mv data/ ../../../template/
+cd ../../../template
+echo $(pwd)
+npm ci
+
+# Prebuild
+echo "Prebuilding..."
+rm -rf node_modules && rm -rf .next
+./preBuild.sh
+
+# Build
+echo "Building..."
+rm -rf scripts/
+./build.sh
+
+# Check if the 'out' folder exists
+if [ ! -d "./out" ]; then
+  echo "Error: 'out' folder not found. Build failed."
+  exit 1
+fi
+
+ls -al
+find ./out -type f | wc -l
+calculate_duration $start_time
+
+cd out/
+echo $(pwd)
+ls -al
+
+# Zip the build
+echo "Zipping build..."
+start_time=$(date +%s)
+# we use compression level = 3 to zip faster
+zip -rqX -3 ../build.zip .
+cd ../
+echo $(pwd)
+calculate_duration $start_time
+
+# Upload to AWS Amplify
+echo "Uploading to AWS Amplify..."
+start_time=$(date +%s)
+DEPLOY_DATA=$(aws amplify create-deployment --app-id "$AMPLIFY_APP_ID" --branch-name "production")
+JOB_ID=$(echo $DEPLOY_DATA | jq -r '.jobId')
+echo "JOB_ID: $JOB_ID"
+UPLOAD_URL=$(echo $DEPLOY_DATA | jq -r '.zipUploadUrl')
+echo "UPLOAD_URL: $UPLOAD_URL"
+echo "Uploading build artifacts..."
+curl -T build.zip "$UPLOAD_URL"
+calculate_duration $start_time
+
+# Start AWS Amplify deployment
+echo "Starting deployment..."
+start_time=$(date +%s)
+aws amplify start-deployment --app-id "$AMPLIFY_APP_ID" --branch-name "production" --job-id $JOB_ID
+echo "Deployment created in Amplify successfully"
+calculate_duration $start_time

--- a/tooling/build/scripts/publishing/.env.template
+++ b/tooling/build/scripts/publishing/.env.template
@@ -1,0 +1,13 @@
+# DB-related
+DB_USERNAME=local_user
+DB_PASSWORD=
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=isomer_studio
+
+SITE_ID=1
+AMPLIFY_APP_ID=123
+
+# optional to set, default is false
+# set to true to print more debug logs
+DEBUG=false

--- a/tooling/build/scripts/publishing/README.md
+++ b/tooling/build/scripts/publishing/README.md
@@ -1,0 +1,5 @@
+# Publishing Tooling Scripts
+
+Note: This is a NPM project which is executed at build time of end sites.
+
+To start, clone `.env.template` to `.env` and populate with the respective values.

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -1,0 +1,198 @@
+import * as fs from "fs"
+import * as path from "path"
+import { performance } from "perf_hooks"
+import * as dotenv from "dotenv"
+import { Client } from "pg"
+
+import {
+  GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+  GET_CONFIG,
+  GET_FOOTER,
+  GET_NAVBAR,
+} from "./queries"
+
+dotenv.config()
+
+// Env vars
+const DB_USERNAME = process.env.DB_USERNAME
+const DB_PASSWORD = process.env.DB_PASSWORD
+const DB_HOST = process.env.DB_HOST
+const DB_PORT = process.env.DB_PORT
+const DB_NAME = process.env.DB_NAME
+const SITE_ID = Number(process.env.SITE_ID)
+
+interface Resource {
+  id: number
+  title: string
+  permalink: string
+  parentId: number | null
+  type: string
+  content?: any
+  fullPermalink?: string
+}
+
+// Wrapper function for debug logging
+function logDebug(message: string, ...optionalParams: any[]) {
+  if (process.env.DEBUG === "true") {
+    console.log(message, ...optionalParams)
+  }
+}
+
+async function main() {
+  const client = new Client({
+    user: DB_USERNAME,
+    host: DB_HOST,
+    database: DB_NAME,
+    password: DB_PASSWORD,
+    port: Number(DB_PORT),
+  })
+
+  const start = performance.now() // Start profiling
+
+  try {
+    await client.connect()
+
+    // Fetch and write navbar, footer, and config JSONs
+    await fetchAndWriteSiteData(client)
+
+    // Fetch all resources and their full permalinks
+    const resources = await getAllResourcesWithFullPermalinks(client)
+
+    // Process each resource
+    for (const resource of resources) {
+      logDebug(
+        `Processing resource with id ${resource.id}, fullPermalink: ${resource.fullPermalink}`,
+      )
+
+      // Ensure the resource is a page (we don't need to write folders)
+      if (
+        (resource.type === "Page" ||
+          resource.type === "CollectionPage" ||
+          resource.type === "RootPage") &&
+        resource.content
+      ) {
+        // Inject page type and title into content before writing to file
+        resource.content.page = {
+          ...resource.content.page,
+          title: resource.title,
+        }
+
+        await writeContentToFile(
+          resource.fullPermalink,
+          resource.content,
+          resource.parentId,
+        )
+      } else {
+        logDebug(
+          `Skipping resource with id ${resource.id} as it is not a Page or has no content.`,
+        )
+      }
+    }
+  } finally {
+    await client.end()
+    const end = performance.now() // End profiling
+    console.log(`Program completed in ${(end - start) / 1000} seconds`)
+  }
+}
+
+async function getAllResourcesWithFullPermalinks(
+  client: Client,
+): Promise<Resource[]> {
+  const values = [SITE_ID]
+
+  try {
+    const res = await client.query(
+      GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+      values,
+    )
+    logDebug("Fetched resources with full permalinks:", res.rows)
+    return res.rows
+  } catch (err) {
+    console.error("Error fetching resources:", err)
+    return []
+  }
+}
+
+async function writeContentToFile(
+  fullPermalink: string | undefined,
+  content: any,
+  parentId: number | null,
+) {
+  try {
+    if (!fullPermalink) {
+      console.error("Error: fullPermalink is undefined or empty for resource")
+      return
+    }
+
+    const directoryPath =
+      parentId === null
+        ? path.join(__dirname, "schema")
+        : path.join(__dirname, "schema", path.dirname(fullPermalink))
+
+    const fileName = `${path.basename(fullPermalink)}.json`
+    const filePath = path.join(directoryPath, fileName)
+
+    // Create directories if they don't exist
+    fs.mkdirSync(directoryPath, { recursive: true })
+
+    // Write JSON content to file
+    fs.writeFileSync(filePath, JSON.stringify(content), "utf-8")
+
+    logDebug(`Successfully wrote file: ${filePath}`)
+  } catch (error) {
+    console.error("Error writing content to file:", error)
+  }
+}
+
+async function fetchAndWriteSiteData(client: Client) {
+  try {
+    // Fetch navbar.json
+    const navbarResult = await client.query(GET_NAVBAR, [SITE_ID])
+    if (navbarResult.rows.length > 0) {
+      await writeJsonToFile(navbarResult.rows[0].content, "navbar.json")
+    }
+
+    // Fetch footer.json
+    const footerResult = await client.query(GET_FOOTER, [SITE_ID])
+    if (footerResult.rows.length > 0) {
+      await writeJsonToFile(footerResult.rows[0].content, "footer.json")
+    }
+
+    // Fetch config.json
+    const configResult = await client.query(GET_CONFIG, [SITE_ID])
+    if (configResult.rows.length > 0) {
+      const config = {
+        site: {
+          ...configResult.rows[0].config,
+          siteName: configResult.rows[0].name,
+        },
+        colors:
+          configResult.rows[0].theme === undefined
+            ? {}
+            : configResult.rows[0].theme,
+      }
+
+      await writeJsonToFile(config, "config.json")
+    }
+  } catch (err) {
+    console.error("Error fetching site data:", err)
+  }
+}
+
+async function writeJsonToFile(content: any, filename: string) {
+  const directoryPath = path.join(__dirname, "data")
+
+  try {
+    // Create directories if they don't exist
+    fs.mkdirSync(directoryPath, { recursive: true })
+
+    const filePath = path.join(directoryPath, filename)
+    fs.writeFileSync(filePath, JSON.stringify(content), "utf-8")
+
+    logDebug(`Successfully wrote file: ${filePath}`)
+  } catch (error) {
+    console.error(`Error writing ${filename} to file:`, error)
+  }
+}
+
+main().catch((err) => console.error(err))

--- a/tooling/build/scripts/publishing/package-lock.json
+++ b/tooling/build/scripts/publishing/package-lock.json
@@ -1,0 +1,267 @@
+{
+  "name": "publishing",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "publishing",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.4.5",
+        "pg": "^8.12.0"
+      },
+      "devDependencies": {
+        "@types/pg": "^8.11.6"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
+      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.13.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.6",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.6.tgz",
+      "integrity": "sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true
+    },
+    "node_modules/pg": {
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
+      "dependencies": {
+        "pg-connection-string": "^2.6.4",
+        "pg-pool": "^3.6.2",
+        "pg-protocol": "^1.6.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
+      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
+      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+    },
+    "node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
+      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  }
+}

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "publishing",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.ts",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "ts-node index.ts "
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "pg": "^8.12.0"
+  },
+  "devDependencies": {
+    "@types/pg": "^8.11.6"
+  }
+}

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -1,0 +1,64 @@
+export const GET_ALL_RESOURCES_WITH_FULL_PERMALINKS = `
+    WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "fullPermalink", "publishedVersionId") AS (
+    -- Base case for all resources
+    SELECT
+        r.id,
+        r.title,
+        r.permalink,
+        r."parentId",
+        r.type,
+        CASE
+            WHEN r.type IN ('Page', 'CollectionPage', 'RootPage') THEN b."content"
+            ELSE NULL
+        END AS content,
+        r.permalink AS "fullPermalink",
+        r."publishedVersionId"
+    FROM
+        public."Resource" r
+    LEFT JOIN public."Version" v ON v."id" = r."publishedVersionId"
+    LEFT JOIN public."Blob" b ON v."blobId" = b.id
+    WHERE
+        r."siteId" = $1 AND r."parentId" IS NULL
+
+    UNION ALL
+
+    -- Recursive case
+    SELECT
+        r.id,
+        r.title,
+        r.permalink,
+        r."parentId",
+        r.type,
+        CASE
+            WHEN r.type IN ('Page', 'CollectionPage', 'RootPage') THEN b."content"
+            ELSE NULL
+        END AS content,
+        CONCAT(path."fullPermalink", '/', r.permalink) AS "fullPermalink",
+        r."publishedVersionId"
+    FROM
+        public."Resource" r
+    LEFT JOIN public."Version" v ON v."id" = r."publishedVersionId"
+    LEFT JOIN public."Blob" b ON v."blobId" = b.id
+
+        -- This join determines if the recursion continues if there are more rows
+    INNER JOIN "resourcePath" path ON r."parentId" = path.id
+    WHERE
+        r."siteId" = $1
+        AND r.type IN ('Folder', 'Page', 'CollectionPage', 'RootPage')
+    )
+
+    -- We are only concerned with resources where the publishedVersionId exists
+    SELECT * FROM "resourcePath" WHERE "publishedVersionId" IS NOT NULL;
+`
+
+export const GET_NAVBAR = `
+  SELECT content FROM public."Navbar" WHERE "siteId" = $1;
+`
+
+export const GET_FOOTER = `
+  SELECT content FROM public."Footer" WHERE "siteId" = $1;
+`
+
+export const GET_CONFIG = `
+  SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
+`

--- a/tooling/build/scripts/publishing/tsconfig.json
+++ b/tooling/build/scripts/publishing/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Language and Environment */
+    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}


### PR DESCRIPTION
### TL;DR
Add a new script (`publisher.sh`) and supporting TypeScript code to clone the `isomer` repo, fetch site data, and build schemas.

### What changed?
- Added `publisher.sh` to handle the publishing workflow, including cloning the repository, building the components, fetching from the database, and generating the site.
- Script includes a step to run preBuild and build scripts from remote.
- Created supporting TypeScript files to fetch and write site data (navbar, footer, config) and process resources from the database.
- Added `.env.template` for environment variables.
- Added `package.json` and `package-lock.json` for dependencies.
- Configured `tsconfig.json` for TypeScript settings.

### How to test?
1. Set up the required environment variables in `.env` based on `.env.template`.
2. Run `publisher.sh` and verify that it correctly clones the repository, fetches data, and generates the site.
3. Check the output directories for schema and data files to confirm they have been created correctly.
4. Validate the logging output to ensure all steps succeeded without errors.

### Why make this change?
This script and supporting code streamline the process of building and publishing the site by automating the steps involved, thereby reducing the potential for human error and making the process more efficient.

Closes ISOM-1111 and ISOM-1245