### PR TITLE
feat: add collection and collection page to resourcetype enum

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -6,6 +6,8 @@ export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
 export const ResourceType = {
   Page: "Page",
   Folder: "Folder",
+  Collection: "Collection",
+  CollectionPage: "CollectionPage",
 } as const
 export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
 export const RoleType = {

--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -4,6 +4,7 @@ export const ResourceState = {
 } as const
 export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
 export const ResourceType = {
+  RootPage: "RootPage",
   Page: "Page",
   Folder: "Folder",
   Collection: "Collection",

--- a/apps/studio/prisma/migrations/20240805083439_add_collection_and_collection_page_resource_types/migration.sql
+++ b/apps/studio/prisma/migrations/20240805083439_add_collection_and_collection_page_resource_types/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ResourceType" ADD VALUE 'Collection';
+ALTER TYPE "ResourceType" ADD VALUE 'CollectionPage';

--- a/apps/studio/prisma/migrations/20240805090947_add_root_page_resource_type/migration.sql
+++ b/apps/studio/prisma/migrations/20240805090947_add_root_page_resource_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ResourceType" ADD VALUE 'RootPage';

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -83,6 +83,7 @@ enum ResourceState {
 }
 
 enum ResourceType {
+  RootPage
   Page
   Folder
   Collection

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -85,6 +85,8 @@ enum ResourceState {
 enum ResourceType {
   Page
   Folder
+  Collection
+  CollectionPage // Can only live inside `Collection` resources
 }
 
 model User {

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -226,7 +226,7 @@ async function main() {
       draftBlobId: String(blobId),
       permalink: "home",
       siteId,
-      type: "Page",
+      type: "RootPage",
       title: "Home",
     })
 

--- a/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
@@ -18,15 +18,16 @@ export const TitleCell = ({
   siteId,
   id,
 }: TitleCellProps): JSX.Element => {
-  const linkToResource = useMemo(() => {
-    const resourceType = `${type.toLowerCase()}s`
-    return {
-      pathname: "/sites/[siteId]/[resourceType]/[id]",
-      query: {
-        siteId,
-        resourceType,
-        id,
-      },
+  const linkToResource: string = useMemo(() => {
+    switch (type) {
+      case "RootPage":
+      case "CollectionPage":
+      case "Page":
+        return `/sites/${siteId}/pages/${id}`
+      case "Folder":
+        return `/sites/${siteId}/folders/${id}`
+      case "Collection":
+        return `/sites/${siteId}/collections/${id}`
     }
   }, [id, siteId, type])
 

--- a/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
@@ -2,7 +2,7 @@ import type { IconType } from "react-icons"
 import { useMemo } from "react"
 import NextLink from "next/link"
 import { HStack, Icon, Text, VStack } from "@chakra-ui/react"
-import { BiData, BiFile, BiFileBlank, BiFolder } from "react-icons/bi"
+import { BiData, BiFile, BiFileBlank, BiFolder, BiHome } from "react-icons/bi"
 
 import type { ResourceTableData } from "./types"
 
@@ -32,6 +32,8 @@ export const TitleCell = ({
 
   const ResourceTypeIcon: IconType = useMemo(() => {
     switch (type) {
+      case "RootPage":
+        return BiHome
       case "Page":
         return BiFileBlank
       case "Folder":

--- a/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
@@ -1,7 +1,8 @@
+import type { IconType } from "react-icons"
 import { useMemo } from "react"
 import NextLink from "next/link"
 import { HStack, Icon, Text, VStack } from "@chakra-ui/react"
-import { BiFileBlank, BiFolder } from "react-icons/bi"
+import { BiData, BiFile, BiFileBlank, BiFolder } from "react-icons/bi"
 
 import type { ResourceTableData } from "./types"
 
@@ -29,11 +30,24 @@ export const TitleCell = ({
     }
   }, [id, siteId, type])
 
+  const ResourceTypeIcon: IconType = useMemo(() => {
+    switch (type) {
+      case "Page":
+        return BiFileBlank
+      case "Folder":
+        return BiFolder
+      case "Collection":
+        return BiData
+      case "CollectionPage":
+        return BiFile
+    }
+  }, [type])
+
   return (
     <HStack align="center" spacing="0.625rem">
       <Icon
         fontSize="1.25rem"
-        as={type === "Page" ? BiFileBlank : BiFolder}
+        as={ResourceTypeIcon}
         color="base.content.strong"
       />
       <VStack spacing="0.25rem" align="start">

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -10,6 +10,22 @@ const pageListQuery = (wait?: DelayMode | number) => {
     }
     return [
       {
+        id: "1",
+        permalink: "",
+        title: "Homepage",
+        publishedVersionId: null,
+        draftBlobId: null,
+        type: "RootPage",
+      },
+      {
+        id: "1",
+        permalink: "newsroom",
+        title: "Press Releases",
+        publishedVersionId: null,
+        draftBlobId: null,
+        type: "Collection",
+      },
+      {
         id: "4",
         permalink: "test-page-1",
         title: "Test page 1",


### PR DESCRIPTION
### TL;DR

This PR introduces support for two new resource types: `Collection` and `CollectionPage`.

### What changed?

1. Added `Collection` and `CollectionPage` to the `ResourceType` enum in Prisma schema and generated files.
2. Created a new migration file to update the `ResourceType` enum in the database.
3. Updated the `TitleCell` component to display appropriate icons for the new resource types.

### How to test?

1. Run the Prisma migrations to update the database schema.
2. Verify that the new resource types can be created and managed through the UI.
3. Check that the correct icons are displayed for the new resource types in the `ResourceTable`.

### Why make this change?

To enhance the feature set by introducing new resource types that allow better organization and categorization of content.

---