### PR TITLE
feat(components): use desktop breakpoint as default chromatic snapshot

### DIFF
--- a/packages/components/.storybook/preview.ts
+++ b/packages/components/.storybook/preview.ts
@@ -93,7 +93,7 @@ const preview: Preview = {
      * ```
      * export const SomeStory: Story = {
      *   parameters: {
-     *     chromatic: withChromaticModes(["mobile", "desktop", "tablet"]),
+     *     chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
      *   }
      * }
      * ```

--- a/packages/components/.storybook/preview.ts
+++ b/packages/components/.storybook/preview.ts
@@ -6,7 +6,7 @@ import { MINIMAL_VIEWPORTS } from "@storybook/addon-viewport"
 import "bootstrap-icons/font/bootstrap-icons.css"
 import "../src/index.css"
 
-import { viewport } from "@isomer/storybook-config"
+import { viewport, withChromaticModes } from "@isomer/storybook-config"
 
 const CUSTOM_GENERAL_VIEWPORTS = {
   smallDesktop: {
@@ -86,6 +86,21 @@ const preview: Preview = {
         ...CUSTOM_GENERAL_VIEWPORTS,
         ...CUSTOM_GSIB_VIEWPORTS,
       },
+    },
+    /**
+     * If tablet view is needed, add it on a per-story basis.
+     * @example
+     * ```
+     * export const SomeStory: Story = {
+     *   parameters: {
+     *     chromatic: withChromaticModes(["mobile", "desktop", "tablet"]),
+     *   }
+     * }
+     * ```
+     */
+    chromatic: {
+      ...withChromaticModes(["desktop"]),
+      prefersReducedMotion: "reduce",
     },
   },
 }

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import { type CollectionPageSchemaType } from "~/engine"
 import CollectionLayout from "./Collection"
 
@@ -10,6 +12,7 @@ const meta: Meta<CollectionPageSchemaType> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",
+    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
     themes: {
       themeOverride: "Isomer Next",
     },

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import Content from "./Content"
 
 const meta: Meta<typeof Content> = {
@@ -9,6 +11,7 @@ const meta: Meta<typeof Content> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",
+    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
     themes: {
       themeOverride: "Isomer Next",
     },

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { useEffect } from "react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import type { HomePageSchemaType } from "~/engine"
 import Homepage from "./Homepage"
 
@@ -24,6 +26,7 @@ const meta: Meta<typeof Homepage> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",
+    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
     themes: {
       themeOverride: "Isomer Next",
     },

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import type { NotFoundPageSchemaType } from "~/engine"
 import NotFoundLayout from "./NotFound"
 
@@ -10,6 +12,7 @@ const meta: Meta<NotFoundPageSchemaType> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",
+    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
     themes: {
       themeOverride: "Isomer Next",
     },

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { useEffect } from "react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import type { SearchPageSchemaType } from "~/engine"
 import SearchLayout from "./Search"
 
@@ -29,6 +31,7 @@ const meta: Meta<typeof Template> = {
   argTypes: {},
   tags: ["!autodocs"],
   parameters: {
+    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
     themes: {
       themeOverride: "Isomer Next",
     },


### PR DESCRIPTION
### TL;DR
Add chromatic modes support to Storybook preview configuration for better visual test coverage.

### What changed?
- Imported `withChromaticModes` from `@isomer/storybook-config`
- Modified the Storybook preview configuration to include chromatic mode settings.
- Updated documentation to guide adding chromatic mode in a per-story basis.
- Set default chromatic mode to 'desktop' with prefer-reduced-motion to 'reduce'.

### How to test?
1. Run Storybook
2. Verify the chromatic mode is applied correctly for stories.

### Why make this change?
To improve visual test coverage and ensure components behave correctly across different viewing modes.

---