### PR TITLE
feat(components): Infocols styling change

### DIFF
--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -1,8 +1,9 @@
+import { BiRightArrowAlt } from "react-icons/bi"
+
 import type { SupportedIconName } from "~/common/icons"
 import type { InfoColsProps } from "~/interfaces"
 import { SUPPORTED_ICONS_MAP } from "~/common/icons"
 import { ComponentContent } from "../../internal/customCssClass"
-import Button from "../Button"
 
 const InfoColsHeader = ({
   title,
@@ -24,40 +25,35 @@ const InfoBoxIcon = ({ icon }: { icon?: SupportedIconName }) => {
   if (!icon) return null
   const Icon = SUPPORTED_ICONS_MAP[icon]
   return (
-    <div className="rounded-lg bg-site-primary-100 p-2">
-      <Icon className="h-auto w-6 text-site-primary" />
+    <div>
+      <Icon className="h-auto w-6 text-base-content-strong group-hover:text-brand-interaction" />
     </div>
   )
 }
 
 const InfoBoxes = ({
   infoBoxes,
-  LinkComponent,
 }: Pick<InfoColsProps, "infoBoxes" | "LinkComponent">) => {
   return (
     <div className="grid grid-cols-1 gap-x-28 gap-y-20 md:grid-cols-2 xl:grid-cols-3">
       {infoBoxes.map((infoBox, idx) => (
-        <div key={idx} className="flex flex-col items-start gap-5 text-left">
+        <a
+          href={infoBox.buttonUrl}
+          key={idx}
+          className="group flex flex-col items-start gap-3 text-left"
+        >
           <InfoBoxIcon icon={infoBox.icon} />
-          <div className="flex flex-col items-start gap-4 text-left">
-            <div className="flex flex-col items-start gap-4 text-content-strong">
-              <h3 className="line-clamp-2 text-lg font-semibold text-content-strong sm:text-2xl">
-                {infoBox.title}
-              </h3>
-              <p className="line-clamp-4 text-sm text-content sm:text-lg">
-                {infoBox.description}
-              </p>
-            </div>
+          <h3 className="prose-headline-lg-semibold text-base-content-strong group-hover:text-brand-interaction">
+            {infoBox.title}
+          </h3>
+          <p className="text-base-content-default prose-body-base">
+            {infoBox.description}
+          </p>
+          <div className="prose-headline-base-medium inline-flex items-center gap-1 text-base-content-strong">
+            {infoBox.buttonLabel}
+            <BiRightArrowAlt className="text-[1.375rem] transition ease-in group-hover:translate-x-1" />
           </div>
-          {infoBox.buttonLabel && infoBox.buttonUrl && (
-            <Button
-              label={infoBox.buttonLabel}
-              href={infoBox.buttonUrl}
-              variant="link"
-              rightIcon="right-arrow"
-            />
-          )}
-        </div>
+        </a>
       ))}
     </div>
   )

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -9,14 +9,10 @@ const InfoColsHeader = ({
   title,
   subtitle,
 }: Pick<InfoColsProps, "title" | "subtitle">) => (
-  <div className="flex w-full max-w-[47.5rem] flex-col items-start gap-7 text-left">
-    <h2 className="text-2xl font-semibold text-content-strong sm:text-4xl">
-      {title}
-    </h2>
+  <div className="flex w-full max-w-[47.5rem] flex-col items-start gap-2.5 text-left">
+    <h2 className="prose-display-md text-base-content-strong">{title}</h2>
     {subtitle && (
-      <p className="text-sm text-content text-paragraph-02 sm:text-lg">
-        {subtitle}
-      </p>
+      <p className="prose-headline-lg-regular text-base-content">{subtitle}</p>
     )}
   </div>
 )
@@ -35,7 +31,7 @@ const InfoBoxes = ({
   infoBoxes,
 }: Pick<InfoColsProps, "infoBoxes" | "LinkComponent">) => {
   return (
-    <div className="grid grid-cols-1 gap-x-28 gap-y-20 md:grid-cols-2 xl:grid-cols-3">
+    <div className="grid grid-cols-1 gap-x-16 gap-y-10 md:grid-cols-2 md:gap-y-12 lg:grid-cols-3">
       {infoBoxes.map((infoBox, idx) => (
         <a
           href={infoBox.buttonUrl}
@@ -46,7 +42,7 @@ const InfoBoxes = ({
           <h3 className="prose-headline-lg-semibold text-base-content-strong group-hover:text-brand-interaction">
             {infoBox.title}
           </h3>
-          <p className="text-base-content-default prose-body-base">
+          <p className="prose-body-base text-base-content">
             {infoBox.description}
           </p>
           <div className="prose-headline-base-medium inline-flex items-center gap-1 text-base-content-strong">
@@ -67,10 +63,10 @@ const InfoCols = ({
 }: InfoColsProps) => {
   return (
     <section className="bg-white">
-      <div className={`${ComponentContent} py-24`}>
-        <div className="flex flex-col gap-24">
+      <div className={`${ComponentContent} py-12 md:py-16`}>
+        <div className="flex flex-col gap-12">
           <InfoColsHeader title={title} subtitle={subtitle} />
-          <InfoBoxes infoBoxes={infoBoxes} LinkComponent={LinkComponent} />
+          <InfoBoxes infoBoxes={infoBoxes} />
         </div>
       </div>
     </section>

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -37,7 +37,7 @@ const InfoBoxes = ({
           key={idx}
           className="group flex flex-col items-start gap-3 text-left"
         >
-          <InfoBoxIcon icon={infoBox.icon} />
+          <InfoBoxIcon icon={infoBox.icon} aria-hidden="true" />
           <h3 className="prose-headline-lg-semibold text-base-content-strong group-hover:text-brand-interaction">
             {infoBox.title}
           </h3>

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -21,19 +21,18 @@ const InfoBoxIcon = ({ icon }: { icon?: SupportedIconName }) => {
   if (!icon) return null
   const Icon = SUPPORTED_ICONS_MAP[icon]
   return (
-    <div>
-      <Icon className="h-auto w-6 text-base-content-strong group-hover:text-brand-interaction" />
-    </div>
+    <Icon className="h-auto w-6 text-base-content-strong group-hover:text-brand-interaction" />
   )
 }
 
 const InfoBoxes = ({
   infoBoxes,
+  LinkComponent,
 }: Pick<InfoColsProps, "infoBoxes" | "LinkComponent">) => {
   return (
     <div className="grid grid-cols-1 gap-x-16 gap-y-10 md:grid-cols-2 md:gap-y-12 lg:grid-cols-3">
       {infoBoxes.map((infoBox, idx) => (
-        <a
+        <LinkComponent
           href={infoBox.buttonUrl}
           key={idx}
           className="group flex flex-col items-start gap-3 text-left"
@@ -49,7 +48,7 @@ const InfoBoxes = ({
             {infoBox.buttonLabel}
             <BiRightArrowAlt className="text-[1.375rem] transition ease-in group-hover:translate-x-1" />
           </div>
-        </a>
+        </LinkComponent>
       ))}
     </div>
   )
@@ -66,7 +65,7 @@ const InfoCols = ({
       <div className={`${ComponentContent} py-12 md:py-16`}>
         <div className="flex flex-col gap-12">
           <InfoColsHeader title={title} subtitle={subtitle} />
-          <InfoBoxes infoBoxes={infoBoxes} />
+          <InfoBoxes infoBoxes={infoBoxes} LinkComponent={LinkComponent} />
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Context

Received some design crit that some of the design choices on Infocols wasn't as intentional (e.g., having rounded corners around the icons), so we had [a design iteration](https://www.figma.com/design/rsKQdmtyoOWawyAv1LkJJK/(New%2C-WIP)-Isomer-Next-Component-Library?node-id=1-14). 

This PR aims to implement said iteration items.

### Changes made

- Overall typography and colour tokens applied
- Overall spacing adjusted for less whitespace
- Adjusted breakpoint (was breaking at `xl` instead of `lg`)
- Hover effects applied to infobox title and icon
- Arrow twitches on hover
- Entire infobox is clickable
