### PR TITLE
fix(footer): update title casing for 'Reach' to 'REACH' when isGovernment is true

### DIFF
--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -215,7 +215,7 @@ const LegalSection = ({
           )}
           {isGovernment && (
             <FooterItem
-              title="Reach"
+              title="REACH"
               url={"https://www.reach.gov.sg"}
               LinkComponent={LinkComponent}
             />


### PR DESCRIPTION
"REACH" should be in all caps

Closes [ISOM-1303](https://linear.app/ogp/issue/ISOM-1303/footer-reach-should-be-in-all-caps)