### PR TITLE
feat: add new site side nav

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,10 +1,6 @@
-import type { ColumnType, GeneratedAlways } from "kysely";
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
-export type Timestamp = ColumnType<Date, Date | string, Date | string>;
+import type { ColumnType, GeneratedAlways } from "kysely"
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
 
 export type Generated<T> =
   T extends ColumnType<infer S, infer I, infer U>

--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -1,0 +1,186 @@
+import { Suspense } from "react"
+import { useRouter } from "next/router"
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Flex,
+  Skeleton,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import { Menu } from "@opengovsg/design-system-react"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { BiData, BiFile, BiFolder, BiHomeAlt } from "react-icons/bi"
+
+import { trpc } from "~/utils/trpc"
+
+interface CmsSideNavProps {
+  siteId: string
+}
+export const CmsSideNav = ({ siteId }: CmsSideNavProps) => {
+  return (
+    <Flex flexDir="column">
+      <VStack
+        align="flex-start"
+        spacing="1.5rem"
+        pt="2rem"
+        px="1.25rem"
+        pb="0.75rem"
+        boxShadow="sm"
+      >
+        <Menu>
+          <Menu.Button w="full" variant="outline">
+            Create new
+          </Menu.Button>
+          <Menu.List>
+            <Menu.Item>Create new page</Menu.Item>
+            <Menu.Item>Create new folder</Menu.Item>
+            <Menu.Item>Create new collection</Menu.Item>
+          </Menu.List>
+        </Menu>
+        <Text textStyle="caption-1">Site content</Text>
+      </VStack>
+      <Box mt="4px" px="1.25rem">
+        {/* TODO: update the resource id here */}
+        <Suspense fallback={<Skeleton />}>
+          <SideNavItem
+            resourceId={null}
+            permalink={"/"}
+            siteId={siteId}
+            resourceType="Folder"
+          />
+        </Suspense>
+      </Box>
+    </Flex>
+  )
+}
+
+// TODO: Add this in after #426 is merged
+const ICON_MAPPINGS = {
+  [ResourceType.Page]: <BiFile />,
+  [ResourceType.Folder]: <BiFolder />,
+  [ResourceType.Collection]: <BiData />,
+  [ResourceType.CollectionPage]: <BiFile />,
+  [ResourceType.RootPage]: <BiHomeAlt />,
+}
+
+interface SideNavItemProps {
+  permalink: string
+  resourceId: string | null
+  resourceType: ResourceType
+  isDisabled?: boolean
+  siteId: string
+}
+
+const getResourceType = (
+  resourceType: ResourceType,
+): "pages" | "folders" | "collections" => {
+  if (
+    resourceType === ResourceType.Page ||
+    resourceType === ResourceType.CollectionPage
+  ) {
+    return "pages"
+  }
+
+  if (resourceType === ResourceType.Collection) {
+    return "collections"
+  }
+
+  return "folders"
+}
+
+const SideNavItem = ({
+  resourceType,
+  resourceId,
+  permalink,
+  isDisabled,
+  siteId,
+}: SideNavItemProps) => {
+  const [children] = trpc.resource.getChildrenOf.useSuspenseQuery({
+    resourceId,
+  })
+
+  const icon = ICON_MAPPINGS[resourceType]
+  const router = useRouter()
+
+  return (
+    <Accordion allowToggle>
+      <AccordionItem
+        _disabled={{
+          textColor: "interaction.support.disabled-content",
+        }}
+        isDisabled={isDisabled}
+        border="none"
+      >
+        {/* NOTE: This is to lazy load on expand  */}
+        {/* so that we don't issue multiple db reads on load */}
+        {({ isExpanded }) => {
+          return (
+            <>
+              {/* NOTE: required for focus ring */}
+              <Box p="4px">
+                <AccordionButton
+                  boxSizing="border-box"
+                  disabled={isDisabled}
+                  borderRadius="0.25rem"
+                  _hover={{
+                    backgroundColor: "interaction.muted.main.hover",
+                  }}
+                  _active={{
+                    backgroundColor: "interaction.muted.main.active",
+                    textColor: "interaction.main.default",
+                  }}
+                  onDoubleClick={async () => {
+                    const urlType = getResourceType(resourceType)
+                    await router.push({
+                      pathname: "/sites/[siteId]/[resourceType]/[id]",
+                      query: {
+                        siteId,
+                        resourceType: urlType,
+                        id: resourceId,
+                      },
+                    })
+                  }}
+                >
+                  {resourceType === ResourceType.Folder ? (
+                    <AccordionIcon
+                      mr="0.25rem"
+                      color="interaction.support.unselected"
+                    />
+                  ) : (
+                    <Box w="1.5rem"></Box>
+                  )}
+                  {icon}
+                  {/* TODO: add the home text on rhs if is home */}
+                  <Text textStyle="caption-1" ml="0.5rem">
+                    {permalink}
+                  </Text>
+                </AccordionButton>
+              </Box>
+              <Suspense fallback={<Skeleton />}>
+                {isExpanded && (
+                  <AccordionPanel p="0" pl="1.25rem">
+                    {children.map((props) => {
+                      return (
+                        <SideNavItem
+                          resourceType={props.type}
+                          siteId={siteId}
+                          resourceId={props.id}
+                          permalink={props.permalink}
+                        />
+                      )
+                    })}
+                  </AccordionPanel>
+                )}
+              </Suspense>
+            </>
+          )
+        }}
+      </AccordionItem>
+    </Accordion>
+  )
+}

--- a/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
@@ -4,15 +4,17 @@ import { Box, Grid, GridItem } from "@chakra-ui/react"
 export interface CmsSidebarContainerProps {
   children: ReactNode
   sidebar: ReactElement
+  sidenav: ReactElement
 }
 
 export function CmsSidebarContainer({
   children,
   sidebar,
+  sidenav,
 }: CmsSidebarContainerProps) {
   return (
     <Grid
-      templateAreas={`'sidebar main'`}
+      templateAreas={`'sidebar sidenav main'`}
       templateColumns="auto 1fr"
       width="100%"
     >
@@ -37,6 +39,27 @@ export function CmsSidebarContainer({
           }}
         >
           {sidebar}
+        </Box>
+      </GridItem>
+      <GridItem as="aside" area="sidenav" overflow="hidden">
+        <Box
+          pos="sticky"
+          top={0}
+          borderRight="1px solid"
+          borderColor="base.divider.medium"
+          height="100vh"
+          overflow="auto"
+          css={{
+            "&::-webkit-scrollbar": {
+              height: "var(--chakra-sizes-1)",
+              width: "var(--chakra-sizes-1)",
+            },
+            "&::-webkit-scrollbar-thumb": {
+              backgroundColor: "var(--chakra-colors-gray-400)",
+            },
+          }}
+        >
+          {sidenav}
         </Box>
       </GridItem>
       <GridItem as="main" area="main" overflow="hidden">

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -1,4 +1,5 @@
 import type { UseDisclosureReturn } from "@chakra-ui/react"
+import type { z } from "zod"
 import { useEffect } from "react"
 import {
   Box,
@@ -23,7 +24,6 @@ import {
 } from "@opengovsg/design-system-react"
 import { uniqueId } from "lodash"
 import { BiLink } from "react-icons/bi"
-import { z } from "zod"
 
 import { useZodForm } from "~/lib/form"
 import {

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -9,7 +9,6 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
-import { uniqueId } from "lodash"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
@@ -22,7 +21,7 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminCmsSidebarLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
 
-const sitePageSchema = z.object({
+export const sitePageSchema = z.object({
   siteId: z.coerce.number(),
 })
 

--- a/apps/studio/src/stories/Flows/CreateNewPageFlow.stories.tsx
+++ b/apps/studio/src/stories/Flows/CreateNewPageFlow.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { userEvent, waitFor, within } from "@storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
+import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import SitePage from "~/pages/sites/[siteId]"
@@ -19,6 +20,7 @@ const meta: Meta<typeof SitePage> = {
         sitesHandlers.getTheme.default(),
         sitesHandlers.getFooter.default(),
         sitesHandlers.getNavbar.default(),
+        resourceHandlers.getChildrenOf.default(),
       ],
     },
     nextjs: {

--- a/apps/studio/src/stories/Page/SitePage.stories.tsx
+++ b/apps/studio/src/stories/Page/SitePage.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { userEvent, waitFor, within } from "@storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
+import { resourceHandlers } from "tests/msw/handlers/resource"
 
 import SitePage from "~/pages/sites/[siteId]"
 
@@ -11,7 +12,11 @@ const meta: Meta<typeof SitePage> = {
   parameters: {
     getLayout: SitePage.getLayout,
     msw: {
-      handlers: [meHandlers.me(), pageHandlers.list.default()],
+      handlers: [
+        meHandlers.me(),
+        pageHandlers.list.default(),
+        resourceHandlers.getChildrenOf.default(),
+      ],
     },
     nextjs: {
       router: {

--- a/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
@@ -13,6 +13,7 @@ import {
 import type { CmsSidebarItem } from "~/components/CmsSidebar/CmsSidebarItems"
 import { EnforceLoginStatePageWrapper } from "~/components/AuthWrappers"
 import { CmsSidebar, CmsSidebarContainer } from "~/components/CmsSidebar"
+import { CmsSideNav } from "~/components/CmsSidebar/CmsSideNav"
 import { useMe } from "~/features/me/api"
 import { type GetLayout } from "~/lib/types"
 
@@ -70,6 +71,7 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
       sidebar={
         <CmsSidebar topNavItems={pageNavItems} bottomNavItems={userNavItems} />
       }
+      sidenav={<CmsSideNav siteId={siteId} />}
     >
       {children}
     </CmsSidebarContainer>

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -1,0 +1,11 @@
+import { trpcMsw } from "../mockTrpc"
+
+export const resourceHandlers = {
+  getChildrenOf: {
+    default: () => {
+      return trpcMsw.resource.getChildrenOf.query(() => {
+        return []
+      })
+    },
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36783,7 +36783,7 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-jsx-a11y": "^6.9.0",
         "eslint-plugin-react": "^7.34.3",
-        "eslint-plugin-react-hooks": "*",
+        "eslint-plugin-react-hooks": "beta",
         "typescript-eslint": "^7.15.0"
       },
       "devDependencies": {


### PR DESCRIPTION
This PR implements a new side navigation component (`CmsSideNav`) and integrates it into the CMS layout. The change updates the layout structure within the `CmsSidebarContainer`, adding support for a new sidebar section specifically for navigation purposes. Additionally, the PR includes the necessary modifications to the `AdminCmsSidebarLayout` to include the new side navigation.

