### PR TITLE
feat: add folder views

### DIFF
--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -122,11 +122,19 @@ const SideNavItem = ({
           return (
             <>
               {/* NOTE: required for focus ring */}
-              <Box p="4px">
+              <Box m="4px">
                 <AccordionButton
                   boxSizing="border-box"
                   disabled={isDisabled}
                   borderRadius="0.25rem"
+                  _focusVisible={{
+                    boxShadow: "none !important",
+                    outline: `2px solid var(--chakra-colors-utility-focus-default)`,
+                    outlineOffset: "0.125rem",
+                    _dark: {
+                      outline: `2px solid var(--chakra-colors-utility-focus-inverse)`,
+                    },
+                  }}
                   _hover={{
                     backgroundColor: "interaction.muted.main.hover",
                   }}

--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -136,18 +136,11 @@ export const Datatable = <T extends object>({
         </Table>
       </Box>
       <Flex py="1rem" gap="1rem">
-        {totalRowCountString && (
-          <Text textStyle="caption-2" color="base.content.medium">
-            {totalRowCountString}
-          </Text>
-        )}
         {pagination && (
-          <Flex ml="auto">
-            <DatatablePagination
-              instance={instance}
-              totalRowCount={totalRowCount}
-            />
-          </Flex>
+          <DatatablePagination
+            instance={instance}
+            totalRowCount={totalRowCount}
+          />
         )}
       </Flex>
     </Flex>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -1,0 +1,131 @@
+import {
+  Box,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  Flex,
+  HStack,
+  MenuButton,
+  MenuList,
+  Portal,
+  Spacer,
+  Text,
+  useDisclosure,
+  VStack,
+} from "@chakra-ui/react"
+import { Breadcrumb, Button, Menu } from "@opengovsg/design-system-react"
+import { uniqueId } from "lodash"
+import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
+import { z } from "zod"
+
+import { MenuItem } from "~/components/Menu"
+import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
+import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
+import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { type NextPageWithLayout } from "~/lib/types"
+import { AdminCmsSidebarLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
+import { trpc } from "~/utils/trpc"
+
+const folderPageSchema = z.object({
+  siteId: z.coerce.number(),
+  folderId: z.coerce.number(),
+})
+
+const FolderPage: NextPageWithLayout = () => {
+  const {
+    isOpen: isPageCreateModalOpen,
+    onOpen: onPageCreateModalOpen,
+    onClose: onPageCreateModalClose,
+  } = useDisclosure()
+  const {
+    isOpen: isFolderCreateModalOpen,
+    onOpen: onFolderCreateModalOpen,
+    onClose: onFolderCreateModalClose,
+  } = useDisclosure()
+
+  const { folderId, siteId } = useQueryParse(folderPageSchema)
+
+  const [{ title, permalink, children, parentId }] =
+    trpc.folder.readFolder.useSuspenseQuery({
+      siteId,
+      resourceId: folderId,
+    })
+
+  return (
+    <>
+      <VStack w="100%" p="1.75rem" gap="1rem">
+        <VStack w="100%" align="start">
+          <Breadcrumb size="sm">
+            <BreadcrumbItem>
+              <BreadcrumbLink isCurrentPage href={permalink}>
+                <Text color="base.content.default">{title}</Text>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+          </Breadcrumb>
+          <Flex w="full" flexDir="row">
+            <HStack gap="0.75rem" flex={1}>
+              <Box
+                aria-hidden
+                bg="brand.secondary.100"
+                p="0.5rem"
+                borderRadius="6px"
+              >
+                <BiData />
+              </Box>
+              <Text textStyle="h3">{title}</Text>
+            </HStack>
+
+            <Spacer />
+
+            <HStack>
+              <Button variant="outline" size="md">
+                Folder settings
+              </Button>
+              <Menu isLazy size="sm">
+                <MenuButton as={Button} size="md" justifySelf="flex-end">
+                  Create new...
+                </MenuButton>
+                <Portal>
+                  <MenuList>
+                    <MenuItem
+                      onClick={onFolderCreateModalOpen}
+                      icon={<BiFolder fontSize="1rem" />}
+                    >
+                      Folder
+                    </MenuItem>
+                    <MenuItem
+                      onClick={onPageCreateModalOpen}
+                      icon={<BiFileBlank fontSize="1rem" />}
+                    >
+                      Page
+                    </MenuItem>
+                  </MenuList>
+                </Portal>
+              </Menu>
+            </HStack>
+          </Flex>
+          <HStack w="100%" justify="space-between" align="center" gap={0}>
+            <Box />
+          </HStack>
+        </VStack>
+        <Box width="100%">
+          <ResourceTable siteId={siteId} resourceId={folderId} />
+        </Box>
+      </VStack>
+      <CreatePageModal
+        isOpen={isPageCreateModalOpen}
+        onClose={onPageCreateModalClose}
+        siteId={siteId}
+      />
+      <CreateFolderModal
+        isOpen={isFolderCreateModalOpen}
+        onClose={onFolderCreateModalClose}
+        siteId={siteId}
+        key={uniqueId()}
+      />
+    </>
+  )
+}
+
+FolderPage.getLayout = AdminCmsSidebarLayout
+export default FolderPage

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -49,7 +49,7 @@ const SitePage: NextPageWithLayout = () => {
           <HStack w="100%" justify="space-between" align="center" gap={0}>
             <Box />
             <Menu isLazy size="sm">
-              <MenuButton as={Button} size="xs" justifySelf="flex-end">
+              <MenuButton as={Button} size="md" justifySelf="flex-end">
                 Create new...
               </MenuButton>
               <Portal>

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -55,11 +55,11 @@ export const folderRouter = router({
         }
       })
 
-      const { parentId } = folderResult
-      const folderName = folderResult.permalink
+      const { title, permalink, parentId } = folderResult
 
       return {
-        folderName,
+        title,
+        permalink,
         children,
         parentId,
       }


### PR DESCRIPTION
### TL;DR

- Updated focus rings in `CmsSideNav` component for better accessibility.
- Fixed pagination display issues in `Datatable` component.
- Added new route for folder details page under `/sites/[siteId]/folders/[folderId]/`.
- Adjusted button size in site page to maintain consistency.
- Updated `folder.router.ts` to include title and permalink in the response.

### What changed?

- Changed `p` to `m` in `CmsSideNav` component to ensure proper margin for focus ring.
- Removed unnecessary check on `totalRowCountString` in `Datatable` component.
- Added components and hooks for the new folder details page.
- Modified button size in `/sites/[siteId]/` from `xs` to `md`.
- Updated folder router to return title and permalink.

### How to test?

1. **Focus Ring**: Navigate to the CMS sidebar and check focus ring behavior on navigation items.
2. **Pagination**: Verify pagination works correctly in the `Datatable` component without hidden elements.
3. **Folder Page**: Access a folder using the new route and ensure all elements load correctly.
4. **Button Size**: Check the button size consistency on the site page.
5. **Router**: Confirm the API returns title and permalink along with other details for a folder.

### Why make this change?

- Improve the accessibility and user experience of the navigation components.
- Ensure pagination elements are displayed correctly.
- Introduce the folder details page for enhanced content management.
- Maintain UI consistency across the application.
- Provide more data context in API responses for better frontend handling.