### PR TITLE
feat: inject site theme CSS variables when previewing in studio

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -99,6 +99,7 @@
     "ajv": "^8.16.0",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.1.3",
+    "flat": "^6.0.1",
     "inter-ui": "^4.0.2",
     "iron-session": "^8.0.1",
     "kysely": "^0.27.3",

--- a/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren } from "react"
+import type { CSSProperties, PropsWithChildren } from "react"
 import { useEffect, useState } from "react"
 import { Flex } from "@chakra-ui/react"
 import Frame, { useFrame } from "react-frame-component"
@@ -6,12 +6,14 @@ import Frame, { useFrame } from "react-frame-component"
 interface PreviewIframeProps extends PropsWithChildren {
   preventPointerEvents?: boolean
   keyForRerender?: string
+  style?: CSSProperties
 }
 
 export const PreviewIframe = ({
   children,
   preventPointerEvents,
   keyForRerender,
+  style,
 }: PreviewIframeProps): JSX.Element => {
   // TODO: Add toolbar for users to adjust the width of the iframe
   const [width, _setWidth] = useState("100%")
@@ -33,7 +35,6 @@ export const PreviewIframe = ({
     >
       <Frame
         style={{
-          // TODO: Inject CSS variables for site theme here.
           width,
           borderRadius: "8px",
         }}
@@ -47,9 +48,11 @@ export const PreviewIframe = ({
           />
         }
       >
-        <IframeInnerComponent key={keyForRerender}>
-          {children}
-        </IframeInnerComponent>
+        <div style={style}>
+          <IframeInnerComponent key={keyForRerender}>
+            {children}
+          </IframeInnerComponent>
+        </div>
       </Frame>
     </Flex>
   )

--- a/apps/studio/src/features/preview/hooks/useSiteThemeCssVars.ts
+++ b/apps/studio/src/features/preview/hooks/useSiteThemeCssVars.ts
@@ -1,0 +1,26 @@
+import type { CSSProperties } from "react"
+import { useMemo } from "react"
+import { flatten } from "flat"
+
+import { trpc } from "~/utils/trpc"
+
+export const useSiteThemeCssVars = ({ siteId }: { siteId: number }) => {
+  const [theme] = trpc.site.getTheme.useSuspenseQuery({ id: siteId })
+  const themeCssVars = useMemo(() => {
+    if (!theme) return
+    // convert theme to css vars
+    const flattenedVars: Record<string, string> = flatten(
+      { color: { brand: { ...theme.colors } } },
+      { delimiter: "-" },
+    )
+    return Object.entries(flattenedVars).reduce(
+      (acc, [key, value]) => {
+        acc[`--${key}`] = value
+        return acc
+      },
+      {} as Record<string, string>,
+    ) as CSSProperties
+  }, [theme])
+
+  return themeCssVars
+}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,5 +1,7 @@
-import { useEffect } from "react"
+import type { CSSProperties } from "react"
+import { useEffect, useMemo } from "react"
 import { Flex, Grid, GridItem } from "@chakra-ui/react"
+import { flatten } from "flat"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
@@ -24,6 +26,24 @@ function EditPage(): JSX.Element {
       pageId,
       siteId,
     })
+
+  // TODO: Export into custom hook
+  const [theme] = trpc.site.getTheme.useSuspenseQuery({ id: siteId })
+  const themeCssVars = useMemo(() => {
+    if (!theme) return
+    // convert theme to css vars
+    const flattenedVars: Record<string, string> = flatten(
+      { color: { brand: { ...theme.colors } } },
+      { delimiter: "-" },
+    )
+    return Object.entries(flattenedVars).reduce(
+      (acc, [key, value]) => {
+        acc[`--${key}`] = value
+        return acc
+      },
+      {} as Record<string, string>,
+    ) as CSSProperties
+  }, [theme])
 
   useEffect(() => {
     setDrawerState({
@@ -54,7 +74,7 @@ function EditPage(): JSX.Element {
           h="100%"
           overflowX="auto"
         >
-          <PreviewIframe>
+          <PreviewIframe style={themeCssVars}>
             <Preview
               {...page}
               {...previewPageState}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,13 +1,12 @@
-import type { CSSProperties } from "react"
-import { useEffect, useMemo } from "react"
+import { useEffect } from "react"
 import { Flex, Grid, GridItem } from "@chakra-ui/react"
-import { flatten } from "flat"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
 import Preview from "~/features/editing-experience/components/Preview"
 import { PreviewIframe } from "~/features/editing-experience/components/PreviewIframe"
 import { editPageSchema } from "~/features/editing-experience/schema"
+import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
@@ -27,23 +26,7 @@ function EditPage(): JSX.Element {
       siteId,
     })
 
-  // TODO: Export into custom hook
-  const [theme] = trpc.site.getTheme.useSuspenseQuery({ id: siteId })
-  const themeCssVars = useMemo(() => {
-    if (!theme) return
-    // convert theme to css vars
-    const flattenedVars: Record<string, string> = flatten(
-      { color: { brand: { ...theme.colors } } },
-      { delimiter: "-" },
-    )
-    return Object.entries(flattenedVars).reduce(
-      (acc, [key, value]) => {
-        acc[`--${key}`] = value
-        return acc
-      },
-      {} as Record<string, string>,
-    ) as CSSProperties
-  }, [theme])
+  const themeCssVars = useSiteThemeCssVars({ siteId })
 
   useEffect(() => {
     setDrawerState({

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -10,6 +10,7 @@ import {
   clearSiteNotification,
   getNotification,
   getSiteConfig,
+  getSiteTheme,
   setSiteNotification,
 } from "./site.service"
 
@@ -28,6 +29,13 @@ export const siteRouter = router({
     .query(async ({ input }) => {
       const { id } = input
       return getSiteConfig(id)
+    }),
+  getTheme: protectedProcedure
+    .input(getConfigSchema)
+    .query(async ({ input }) => {
+      const { id } = input
+      const theme = await getSiteTheme(id)
+      return theme
     }),
   getFooter: protectedProcedure
     .input(getConfigSchema)

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -13,6 +13,16 @@ export const getSiteConfig = async (siteId: number) => {
   return config
 }
 
+export const getSiteTheme = async (siteId: number) => {
+  const { theme } = await db
+    .selectFrom("Site")
+    .where("id", "=", siteId)
+    .select("Site.theme")
+    .executeTakeFirstOrThrow()
+
+  return theme
+}
+
 // Note: This overwrites the full site config
 // TODO: Should triger immediate re-publish of site
 export const setSiteConfig = async (

--- a/apps/studio/src/stories/Flows/CreateNewPageFlow.stories.tsx
+++ b/apps/studio/src/stories/Flows/CreateNewPageFlow.stories.tsx
@@ -16,6 +16,7 @@ const meta: Meta<typeof SitePage> = {
         meHandlers.me(),
         pageHandlers.list.default(),
         sitesHandlers.getConfig.default(),
+        sitesHandlers.getTheme.default(),
         sitesHandlers.getFooter.default(),
         sitesHandlers.getNavbar.default(),
       ],

--- a/apps/studio/tests/msw/handlers/sites.ts
+++ b/apps/studio/tests/msw/handlers/sites.ts
@@ -22,6 +22,27 @@ export const sitesHandlers = {
     default: siteListQuery,
     loading: () => siteListQuery("infinite"),
   },
+  getTheme: {
+    default: () => {
+      return trpcMsw.site.getTheme.query(() => {
+        return {
+          colors: {
+            canvas: {
+              default: "#e6ecef",
+              alt: "#bfcfd7",
+              backdrop: "#80a0af",
+              inverse: "#00405f",
+            },
+            interaction: {
+              default: "#00405f",
+              hover: "#002e44",
+              pressed: "#00283b",
+            },
+          },
+        }
+      })
+    },
+  },
   getConfig: {
     default: () => {
       return trpcMsw.site.getConfig.query(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "ajv": "^8.16.0",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.1.3",
+        "flat": "^6.0.1",
         "inter-ui": "^4.0.2",
         "iron-session": "^8.0.1",
         "kysely": "^0.27.3",
@@ -254,6 +255,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "apps/studio/node_modules/flat": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-6.0.1.tgz",
+      "integrity": "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw==",
+      "bin": {
+        "flat": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "apps/studio/node_modules/glob-parent": {


### PR DESCRIPTION
### TL;DR

This PR introduces the use of site theme CSS variables in the layout preview, ensuring that the site theme is accurately reflected in the preview.

### What changed?

- Added support for site theme CSS variables in `PreviewIframe`.
- Created `useSiteThemeCssVars` hook to fetch and flatten site theme CSS variables.
- Updated `PreviewLayout` component to use `Suspense` for loading previews.
- Updated site router and service to fetch site theme.

### How to test?
Stories

### Why make this change?

To ensure that the layout preview accurately reflects the site's theme, providing a more cohesive editing experience for users.
