### PR TITLE
feat: turn on noUncheckedIndexedAccess to remove class of bugs

### DIFF
--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -25,7 +25,7 @@ const ArticlePageHeader = ({
         <p className="text-sm text-gray-800">{date}</p>
 
         <div className="text-xl tracking-tight text-gray-500 md:text-2xl">
-          {summary.length === 1 ? (
+          {summary.length === 1 && summary[0] ? (
             <BaseParagraph content={summary[0]} />
           ) : (
             <ul className="list-disc ps-7">

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -20,11 +20,13 @@ const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
   return (
     <nav aria-label="Breadcrumb">
       <ol role="list" className={compoundStyles.nav()}>
-        <li className={compoundStyles.container()}>
-          <LinkComponent href={root.url} className={compoundStyles.link()}>
-            {root.title}
-          </LinkComponent>
-        </li>
+        {root && (
+          <li className={compoundStyles.container()}>
+            <LinkComponent href={root.url} className={compoundStyles.link()}>
+              {root.title}
+            </LinkComponent>
+          </li>
+        )}
         {rest.map((link, index) => {
           return (
             <li key={index} className={compoundStyles.container()}>

--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -29,18 +29,19 @@ const getStickyRowIndexes = (tableRows: TableProps["content"]) => {
 
   tableRows
     .map((row) => row.content[0])
-    .forEach(({ attrs }, index) => {
-      if (!stickyRowIndexes.includes(index)) {
-        // Index has already been removed by an earlier rowSpan
-        return
-      }
-
-      if (attrs?.rowspan) {
-        // Exclude the next few rows that are covered by the rowSpan
-        stickyRowIndexes = stickyRowIndexes.filter(
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          (value) => value <= index || value >= index + attrs.rowspan!,
-        )
+    .forEach((row, index) => {
+      if (row?.attrs) {
+        if (!stickyRowIndexes.includes(index)) {
+          // Index has already been removed by an earlier rowSpan
+          return
+        }
+        const rowspan = row.attrs.rowspan
+        if (rowspan !== undefined) {
+          // Exclude the next few rows that are covered by the rowSpan
+          stickyRowIndexes = stickyRowIndexes.filter(
+            (value) => value <= index || value >= index + rowspan,
+          )
+        }
       }
     })
 
@@ -78,7 +79,7 @@ const Table = ({ attrs: { caption }, content }: TableProps) => {
         <tbody>
           {content.map((row, index) => {
             const TableCellTag =
-              row.content[0].type === "tableHeader" ? "th" : "td"
+              row.content[0]?.type === "tableHeader" ? "th" : "td"
 
             return (
               <tr

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -12,6 +12,7 @@
     "resolveJsonModule": true /* Include modules imported with .json extension. */,
     "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
     "strict": true /* Enable all strict type-checking options. */,
+    "noUncheckedIndexedAccess": true,
     "skipLibCheck": true,
     /* Strict Type-Checking Options */
     // "noImplicitAny": true,


### PR DESCRIPTION
### TL;DR
Turn on `noUncheckedIndexedAccess` in component's tsconfig to prevent potential runtime errors caused by undefined index access.
Fix typecheck errors caused by the new setting.
