### PR TITLE
feat(components): update Accordion styling, use twMerge in Prose

### DIFF
--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -116,6 +116,13 @@ const config: Config = {
   },
   plugins: [
     isomerTypography,
+    plugin(({ addBase }) => {
+      addBase({
+        "::-webkit-details-marker": {
+          display: "none",
+        },
+      })
+    }),
     // !! @deprecated, use isomerTypography plugin instead
     // Delete after no components are using these classes anymore,
     plugin(({ addBase, addUtilities, theme }) => {

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.stories.tsx
@@ -1,24 +1,22 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
-import type { AccordionProps } from "~/interfaces"
 import Accordion from "./Accordion"
-
-// Template for stories
-const Template = (props: AccordionProps) => {
-  return (
-    <>
-      <Accordion {...props} />
-      <Accordion {...props} />
-      <Accordion {...props} />
-    </>
-  )
-}
 
 const meta: Meta<typeof Accordion> = {
   title: "Next/Components/Accordion",
-  component: Template,
+  component: Accordion,
+  render: (args) => {
+    return (
+      <>
+        <Accordion {...args} />
+        <Accordion {...args} />
+        <Accordion {...args} />
+      </>
+    )
+  },
   argTypes: {},
   parameters: {
+    layout: "fullscreen",
     themes: {
       themeOverride: "Isomer Next",
     },

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.stories.tsx
@@ -1,16 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/react"
+import { within } from "@storybook/test"
 
 import Accordion from "./Accordion"
 
 const meta: Meta<typeof Accordion> = {
   title: "Next/Components/Accordion",
   component: Accordion,
-  render: (args) => {
+  render: ({ summary, ...args }) => {
     return (
       <>
-        <Accordion {...args} />
-        <Accordion {...args} />
-        <Accordion {...args} />
+        <Accordion summary={`${summary}1`} {...args} />
+        <Accordion summary={`${summary}2`} {...args} />
+        <Accordion summary={`${summary}3`} {...args} />
       </>
     )
   },
@@ -105,5 +106,13 @@ export const LongContent: Story = {
         },
       ],
     },
+  },
+}
+
+export const Expanded: Story = {
+  args: Basic.args,
+  play: ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    canvas.getByText("Title for accordion item2").click()
   },
 }

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
-import { within } from "@storybook/test"
+import { userEvent, within } from "@storybook/test"
+
+import { withChromaticModes } from "@isomer/storybook-config"
 
 import Accordion from "./Accordion"
 
@@ -18,6 +20,7 @@ const meta: Meta<typeof Accordion> = {
   argTypes: {},
   parameters: {
     layout: "fullscreen",
+    chromatic: withChromaticModes(["desktop", "mobile"]),
     themes: {
       themeOverride: "Isomer Next",
     },
@@ -110,9 +113,9 @@ export const LongContent: Story = {
 }
 
 export const Expanded: Story = {
-  args: Basic.args,
-  play: ({ canvasElement }) => {
+  args: LongContent.args,
+  play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-    canvas.getByText("Title for accordion item2").click()
+    await userEvent.click(canvas.getByText(`${LongContent.args?.summary}2`))
   },
 }

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -1,5 +1,3 @@
-"use client"
-
 import type { VariantProps } from "tailwind-variants"
 import { BiMinus, BiPlus } from "react-icons/bi"
 

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -14,7 +14,7 @@ const createAccordionStyles = tv({
       "group border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0",
     summary:
       "prose-headline-lg-medium flex list-none flex-row items-center justify-between gap-3 text-base-content-strong outline-none outline outline-0 outline-offset-2 outline-brand-interaction hover:cursor-pointer focus-visible:outline-2",
-    icon: "h-6 w-6",
+    icon: "h-6 w-6 flex-shrink-0",
     content: "pt-5 text-base-content-strong",
   },
 })

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -1,17 +1,39 @@
-import { BiChevronDown } from "react-icons/bi"
+import { useState } from "react"
+import { BiMinus, BiPlus } from "react-icons/bi"
 
 import type { AccordionProps } from "~/interfaces"
+import { tv } from "~/lib/tv"
 import { Prose } from "../../native"
 
+const createAccordionStyles = tv({
+  slots: {
+    details:
+      "group border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0",
+    summary:
+      "prose-headline-lg-medium flex list-none flex-row items-center justify-between gap-3 text-base-content-strong outline-none outline outline-0 outline-offset-2 outline-brand-interaction hover:cursor-pointer focus-visible:outline-2",
+    icon: "h-6 w-6",
+    content: "pt-5 text-base-content-strong",
+  },
+})
+
+const accordionStyles = createAccordionStyles()
+
 const Accordion = ({ summary, details }: AccordionProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const Icon = isOpen ? BiMinus : BiPlus
+
   return (
-    <details className="border-y border-divider-medium hover:cursor-pointer has-[+_details]:border-b-0 [&_>_summary_>_svg]:open:rotate-180">
-      <summary className="my-[0.125rem] flex list-none flex-row items-center gap-3 px-4 py-5 font-medium text-content outline-none text-paragraph-01">
+    <details
+      onToggle={(e) => setIsOpen(e.currentTarget.open)}
+      open={isOpen}
+      className={accordionStyles.details()}
+    >
+      <summary className={accordionStyles.summary()}>
         {summary}
-        <BiChevronDown className="ml-auto min-w-6 text-2xl transition-all duration-200 ease-in-out" />
+        <Icon aria-hidden className={accordionStyles.icon()} />
       </summary>
 
-      <div className="mb-4 ml-4 mr-6 mt-2">
+      <div className={accordionStyles.content()}>
         <Prose {...details} />
       </div>
     </details>

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import type { VariantProps } from "tailwind-variants"
-import { useState } from "react"
 import { BiMinus, BiPlus } from "react-icons/bi"
 
 import type { AccordionProps as BaseAccordionProps } from "~/interfaces"
@@ -14,7 +13,7 @@ const createAccordionStyles = tv({
       "group border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0",
     summary:
       "prose-headline-lg-medium flex list-none flex-row items-center justify-between gap-3 text-base-content-strong outline-none outline outline-0 outline-offset-2 outline-brand-interaction hover:cursor-pointer focus-visible:outline-2",
-    icon: "h-6 w-6 flex-shrink-0",
+    icon: "h-6 w-6 flex-shrink-0 [&.minus]:hidden [&.minus]:group-open:block [&.plus]:block [&.plus]:group-open:hidden",
     content: "pt-5 text-base-content-strong",
   },
 })
@@ -23,24 +22,21 @@ const accordionStyles = createAccordionStyles()
 
 interface AccordionProps
   extends BaseAccordionProps,
-    VariantProps<typeof createAccordionStyles> {
-  name?: string
-}
+    VariantProps<typeof createAccordionStyles> {}
 
-const Accordion = ({ summary, details, name }: AccordionProps) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const Icon = isOpen ? BiMinus : BiPlus
-
+const Accordion = ({ summary, details }: AccordionProps) => {
   return (
-    <details
-      name={name}
-      onToggle={(e) => setIsOpen(e.currentTarget.open)}
-      open={isOpen}
-      className={accordionStyles.details()}
-    >
+    <details className={accordionStyles.details()}>
       <summary className={accordionStyles.summary()}>
         {summary}
-        <Icon aria-hidden className={accordionStyles.icon()} />
+        <BiMinus
+          aria-hidden
+          className={accordionStyles.icon({ className: "minus" })}
+        />
+        <BiPlus
+          aria-hidden
+          className={accordionStyles.icon({ className: "plus" })}
+        />
       </summary>
 
       <div className={accordionStyles.content()}>

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -1,9 +1,10 @@
 "use client"
 
+import type { VariantProps } from "tailwind-variants"
 import { useState } from "react"
 import { BiMinus, BiPlus } from "react-icons/bi"
 
-import type { AccordionProps } from "~/interfaces"
+import type { AccordionProps as BaseAccordionProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { Prose } from "../../native"
 
@@ -20,12 +21,19 @@ const createAccordionStyles = tv({
 
 const accordionStyles = createAccordionStyles()
 
-const Accordion = ({ summary, details }: AccordionProps) => {
+interface AccordionProps
+  extends BaseAccordionProps,
+    VariantProps<typeof createAccordionStyles> {
+  name?: string
+}
+
+const Accordion = ({ summary, details, name }: AccordionProps) => {
   const [isOpen, setIsOpen] = useState(false)
   const Icon = isOpen ? BiMinus : BiPlus
 
   return (
     <details
+      name={name}
       onToggle={(e) => setIsOpen(e.currentTarget.open)}
       open={isOpen}
       className={accordionStyles.details()}

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { useState } from "react"
 import { BiMinus, BiPlus } from "react-icons/bi"
 

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -1,16 +1,20 @@
 import type { BaseParagraphProps } from "~/interfaces/native/Paragraph"
+import { twMerge } from "~/lib/twMerge"
 import { getSanitizedInlineContent } from "~/utils"
 
 export const BaseParagraph = ({
   content,
-  className = "",
+  className,
   id,
 }: BaseParagraphProps) => {
   const sanitizedContent = getSanitizedInlineContent(content)
 
   return (
     <p
-      className={`hover:[&_a]text-link-hover [&:not(:first-child)]:mt-6 [&:not(:last-child)]:mb-6 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:text-link [&_a]:underline ${className}`}
+      className={twMerge(
+        `hover:[&_a]text-link-hover [&:not(:first-child)]:mt-6 [&:not(:last-child)]:mb-6 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:text-link [&_a]:underline`,
+        className,
+      )}
       dangerouslySetInnerHTML={{ __html: sanitizedContent }}
       id={id}
     />

--- a/packages/components/src/templates/next/components/native/Prose/Prose.tsx
+++ b/packages/components/src/templates/next/components/native/Prose/Prose.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from "react"
+
 import type { ProseProps } from "~/interfaces"
 import { getTextAsHtml } from "~/utils/getTextAsHtml"
 import BaseParagraph from "../../internal/BaseParagraph"
@@ -7,6 +9,32 @@ import OrderedList from "../OrderedList"
 import Table from "../Table"
 import UnorderedList from "../UnorderedList"
 
+const ProseComponent = ({
+  component,
+}: {
+  component: NonNullable<ProseProps["content"]>[number]
+}): JSX.Element => {
+  switch (component.type) {
+    case "divider":
+      return <Divider {...component} />
+    case "heading":
+      return <Heading {...component} />
+    case "orderedList":
+      return <OrderedList {...component} />
+    case "paragraph":
+      return (
+        <BaseParagraph
+          content={getTextAsHtml(component.content)}
+          className="prose-body-base text-base-content"
+        />
+      )
+    case "table":
+      return <Table {...component} />
+    case "unorderedList":
+      return <UnorderedList {...component} />
+  }
+}
+
 const Prose = ({ content }: ProseProps) => {
   if (!content) {
     return <></>
@@ -14,30 +42,9 @@ const Prose = ({ content }: ProseProps) => {
 
   return (
     <>
-      {content.map((component, index) => {
-        if (component.type === "divider") {
-          return <Divider key={index} {...component} />
-        } else if (component.type === "heading") {
-          return <Heading key={index} {...component} />
-        } else if (component.type === "orderedList") {
-          return <OrderedList key={index} {...component} />
-        } else if (component.type === "paragraph") {
-          return (
-            <BaseParagraph
-              key={index}
-              content={getTextAsHtml(component.content)}
-              className="prose-body-base text-base-content"
-            />
-          )
-        } else if (component.type === "table") {
-          return <Table key={index} {...component} />
-        } else if (component.type === "unorderedList") {
-          return <UnorderedList key={index} {...component} />
-        } else {
-          const _: never = component
-          return <></>
-        }
-      })}
+      {content.map((component, index) => (
+        <ProseComponent component={component} key={index} />
+      ))}
     </>
   )
 }


### PR DESCRIPTION
### TL;DR

Refactor Accordion component and stories for enhanced functionality and code cleanliness.

### What changed?
- Updated Accordion component to use local state to manage the open/close state of each accordion item.
- Replaced the `BiChevronDown` icon with a dynamic `BiMinus` and `BiPlus` icon for better UX feedback based on accordion state.
- Utilized the `tv` function for creating accordion styles for better maintainability.
- Modified `BaseParagraph` component to use `twMerge` for merging TailwindCSS classes more effectively.
- Improved `Prose` component to use a `ProseComponent` helper for cleaner JSX.

### How to test?
Storybook

### Why make this change?
To improve the readability, maintainability, and user experience of the Accordion component and related stories.

