### PR TITLE
feat: add disclosure for settings

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -23,7 +23,7 @@ import { BiLink } from "react-icons/bi"
 import { generateResourceUrl } from "~/features/editing-experience/components/utils"
 import { useZodForm } from "~/lib/form"
 import {
-  editFolderSchema,
+  baseEditFolderSchema,
   MAX_FOLDER_PERMALINK_LENGTH,
   MAX_FOLDER_TITLE_LENGTH,
 } from "~/schemas/folder"
@@ -71,7 +71,7 @@ const SuspendableModalContent = ({
         title: originalTitle,
         permalink: originalPermalink,
       },
-      schema: editFolderSchema.omit({ siteId: true, resourceId: true }),
+      schema: baseEditFolderSchema.omit({ siteId: true, resourceId: true }),
     })
   const { errors, isValid } = formState
   const utils = trpc.useUtils()

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/index.ts
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./FolderSettingsModal"

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -79,9 +79,9 @@ const MoveResourceContent = withSuspense(
         // TODO: actually close the modal
         setMovedItem(null)
       },
-      onSuccess: () => {
-        void utils.page.readPageAndBlob.invalidate()
-        void utils.resource.list.invalidate({
+      onSuccess: async () => {
+        await utils.page.readPageAndBlob.invalidate()
+        await utils.resource.list.invalidate({
           // TODO: Update backend `list` to use the proper schema
           resourceId: movedItem?.resourceId
             ? Number(movedItem.resourceId)
@@ -89,7 +89,7 @@ const MoveResourceContent = withSuspense(
         })
         // NOTE: We might want to have smarter logic here
         // and invalidate the new + old folders
-        void utils.folder.readFolder.invalidate()
+        await utils.folder.readFolder.invalidate()
         toast({ title: "Resource moved!" })
       },
     })

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -13,11 +13,11 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Breadcrumb, Button, Menu } from "@opengovsg/design-system-react"
-import { uniqueId } from "lodash"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import { MenuItem } from "~/components/Menu"
+import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
 import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
@@ -27,8 +27,8 @@ import { AdminCmsSidebarLayout } from "~/templates/layouts/AdminCmsSidebarLayout
 import { trpc } from "~/utils/trpc"
 
 const folderPageSchema = z.object({
-  siteId: z.coerce.number(),
-  folderId: z.coerce.number(),
+  siteId: z.string(),
+  folderId: z.string(),
 })
 
 const FolderPage: NextPageWithLayout = () => {
@@ -42,14 +42,18 @@ const FolderPage: NextPageWithLayout = () => {
     onOpen: onFolderCreateModalOpen,
     onClose: onFolderCreateModalClose,
   } = useDisclosure()
+  const {
+    isOpen: isFolderSettingsModalOpen,
+    onOpen: onFolderSettingsModalOpen,
+    onClose: onFolderSettingsModalClose,
+  } = useDisclosure()
 
   const { folderId, siteId } = useQueryParse(folderPageSchema)
 
-  const [{ title, permalink, children, parentId }] =
-    trpc.folder.readFolder.useSuspenseQuery({
-      siteId,
-      resourceId: folderId,
-    })
+  const [{ title, permalink }] = trpc.folder.readFolder.useSuspenseQuery({
+    siteId: parseInt(siteId),
+    resourceId: parseInt(folderId),
+  })
 
   return (
     <>
@@ -78,7 +82,11 @@ const FolderPage: NextPageWithLayout = () => {
             <Spacer />
 
             <HStack>
-              <Button variant="outline" size="md">
+              <Button
+                variant="outline"
+                size="md"
+                onClick={onFolderSettingsModalOpen}
+              >
                 Folder settings
               </Button>
               <Menu isLazy size="sm">
@@ -109,19 +117,27 @@ const FolderPage: NextPageWithLayout = () => {
           </HStack>
         </VStack>
         <Box width="100%">
-          <ResourceTable siteId={siteId} resourceId={folderId} />
+          <ResourceTable
+            siteId={parseInt(siteId)}
+            resourceId={parseInt(folderId)}
+          />
         </Box>
       </VStack>
       <CreatePageModal
         isOpen={isPageCreateModalOpen}
         onClose={onPageCreateModalClose}
-        siteId={siteId}
+        siteId={parseInt(siteId)}
       />
       <CreateFolderModal
         isOpen={isFolderCreateModalOpen}
         onClose={onFolderCreateModalClose}
+        siteId={parseInt(siteId)}
+      />
+      <FolderSettingsModal
+        isOpen={isFolderSettingsModalOpen}
+        onClose={onFolderSettingsModalClose}
         siteId={siteId}
-        key={uniqueId()}
+        resourceId={parseInt(folderId)}
       />
     </>
   )

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -27,14 +27,15 @@ export const readFolderSchema = z.object({
   resourceId: z.number().min(1),
 })
 
-export const editFolderSchema = z
-  .object({
-    resourceId: z.string(),
-    permalink: z.optional(z.string()),
-    title: z.optional(z.string()),
-    siteId: z.string(),
-  })
-  .superRefine(({ permalink, title }, ctx) => {
+export const baseEditFolderSchema = z.object({
+  resourceId: z.string(),
+  permalink: z.optional(z.string()),
+  title: z.optional(z.string()),
+  siteId: z.string(),
+})
+
+export const editFolderSchema = baseEditFolderSchema.superRefine(
+  ({ permalink, title }, ctx) => {
     if (!permalink && !title) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -47,4 +48,5 @@ export const editFolderSchema = z
         message: "Either permalink or title must be provided.",
       })
     }
-  })
+  },
+)

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -26,3 +26,25 @@ export const readFolderSchema = z.object({
   siteId: z.number().min(1),
   resourceId: z.number().min(1),
 })
+
+export const editFolderSchema = z
+  .object({
+    resourceId: z.string(),
+    permalink: z.optional(z.string()),
+    title: z.optional(z.string()),
+    siteId: z.string(),
+  })
+  .superRefine(({ permalink, title }, ctx) => {
+    if (!permalink && !title) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["siteId"],
+        message: "Either permalink or title must be provided.",
+      })
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["title"],
+        message: "Either permalink or title must be provided.",
+      })
+    }
+  })

--- a/apps/studio/src/server/modules/folder/folder.select.ts
+++ b/apps/studio/src/server/modules/folder/folder.select.ts
@@ -1,0 +1,13 @@
+import { DB } from "~prisma/generated/generatedTypes"
+
+type ResourceProperties = keyof DB["Resource"]
+export const defaultFolderSelect: readonly ResourceProperties[] = [
+  "id",
+  "parentId",
+  "permalink",
+  "title",
+  "siteId",
+  "state",
+  "type",
+  "draftBlobId",
+] as const

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -3,7 +3,6 @@ import { schema } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import Ajv from "ajv"
 import isEqual from "lodash/isEqual"
-import z from "zod"
 
 import {
   createPageSchema,


### PR DESCRIPTION
### TL;DR

This PR introduces a folder settings modal in the folder page.

### What changed?

- Imported necessary components like `Modal`, `Input`, `FormControl`, etc.
- Added folder settings modal state management using `useDisclosure` hook.
- Created a new `FolderSettingsModal` component for folder settings.
- Utilized the `useZodForm` for form handling and validation.
- Implemented the mutation to save folder settings changes to the database.
- Updated schema and router to support editing folder's title and permalink.

### How to test?

1. Navigate to the folder page.
2. Click on the `Folder settings` button.
3. Update the title and permalink in the modal.
4. Click `Save changes` and verify if the changes are reflected.

### Why make this change?

This change adds the ability to edit the folder title and permalink directly from the folder page, enhancing the user experience by providing a straightforward way to manage folder settings.

---


https://github.com/user-attachments/assets/206c6663-663b-4c8d-a002-25dfc2c25a72

