### PR TITLE
fix: remove fetch

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -44,9 +44,6 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
-  const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery(
-    { siteId, pageId },
-  )
   const utils = trpc.useUtils()
 
   const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -40,9 +40,6 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const utils = trpc.useUtils()
-  const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery(
-    { siteId, pageId },
-  )
   const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })


### PR DESCRIPTION
# tl;dr 
- we were refetching on every refocus and this led to the drawer state being reset.
- in order to avoid this, we have to avoid the refetch

# what changed
- removed the fetch in drawers since it was never being used ._.