### PR TITLE
feat(collection-item): allow dateless collection item in schema, render dateless variant

### DIFF
--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -9,7 +9,7 @@ export interface FileDetails {
   size: string
 }
 interface BaseCardProps {
-  lastUpdated: string
+  lastUpdated?: string
   category: string
   title: string
   url: string

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -37,6 +37,13 @@ export const Default: Story = {
   },
 }
 
+export const HideDate: Story = {
+  args: {
+    ...Default.args,
+    lastUpdated: undefined,
+  },
+}
+
 export const ArticleWithoutImage: Story = {
   args: {
     lastUpdated: "December 2, 2023",

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -21,9 +21,11 @@ export const CollectionCard = ({
   const itemTitle = `${file ? `[${file.type.toUpperCase()}, ${file.size}] ` : ""}${title}`
   return (
     <div className="flex border-collapse flex-col gap-3 border-b border-divider-medium py-5 first:border-t lg:flex-row lg:gap-6">
-      <Text className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
-        {lastUpdated}
-      </Text>
+      {lastUpdated && (
+        <Text className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
+          {lastUpdated}
+        </Text>
+      )}
       <div className="flex flex-col gap-3 text-base-content lg:gap-2">
         <h3 className="inline-block">
           <Link

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -48,11 +48,13 @@ const getAvailableFilters = (items: CollectionCardProps[]): FilterType[] => {
     }
 
     // Step 3: Get all available years
-    const year = new Date(lastUpdated).getFullYear().toString()
-    if (year in years) {
-      years[year] += 1
-    } else {
-      years[year] = 1
+    if (lastUpdated) {
+      const year = new Date(lastUpdated).getFullYear().toString()
+      if (year in years) {
+        years[year] += 1
+      } else {
+        years[year] = 1
+      }
     }
   })
 
@@ -157,6 +159,7 @@ const getFilteredItems = (
       yearFilter &&
       !yearFilter.items.some(
         (filterItem) =>
+          item.lastUpdated &&
           new Date(item.lastUpdated).getFullYear().toString() === filterItem.id,
       )
     ) {
@@ -174,11 +177,11 @@ const getSortedItems = (
 ) => {
   return [...items].sort((a, b) => {
     if (sortBy === "date") {
-      const dateA = new Date(a.lastUpdated)
-      const dateB = new Date(b.lastUpdated)
+      const dateA = a.lastUpdated ? new Date(a.lastUpdated) : undefined
+      const dateB = b.lastUpdated ? new Date(b.lastUpdated) : undefined
       return sortDirection === "asc"
-        ? dateA.getTime() - dateB.getTime()
-        : dateB.getTime() - dateA.getTime()
+        ? (dateA?.getTime() ?? 0) - (dateB?.getTime() ?? 0)
+        : (dateB?.getTime() ?? 0) - (dateA?.getTime() ?? 0)
     }
     return 0
   })


### PR DESCRIPTION
### TL;DR

Make the 'lastUpdated' field optional in the 'CollectionCard' component implementations and stories.

### What changed?

- Updated the 'CollectionCard' interface to make 'lastUpdated' an optional field in `CollectionCard.ts`.
- Adjusted 'CollectionCard' component to conditionally render 'lastUpdated' if it's provided in `CollectionCard.tsx`.
- Updated storybook stories to test scenarios without 'lastUpdated' in `CollectionCard.stories.tsx`.
- Modified `CollectionClient.tsx` to accommodate optional 'lastUpdated' field in collection item processing.

### How to test?

1. Ensure the application builds successfully without any type errors.
2. Run the storybook and ensure the 'CollectionCard' component displays correctly with and without 'lastUpdated'.
3. Verify that the collection filtering and sorting functionalities work as expected when 'lastUpdated' is missing.

### Why make this change?

This change allows for greater flexibility in creating 'CollectionCard' instances. Not all collection items may have a 'lastUpdated' date, and making this field optional accommodates those scenarios.

---
