### PR TITLE
fix: prevent modal title from overflowing to close button

### DIFF
--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -27,7 +27,10 @@ export const DeleteBlockModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>Are you sure you want to delete {itemName}?</ModalHeader>
+        <ModalHeader maxW="90%">
+          Are you sure you want to delete {itemName}?
+        </ModalHeader>
+
         <ModalCloseButton />
 
         <ModalBody>

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -27,7 +27,7 @@ export const DeleteBlockModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader maxW="90%">
+        <ModalHeader pr="4.5rem">
           Are you sure you want to delete {itemName}?
         </ModalHeader>
 

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
@@ -25,9 +25,10 @@ export const DiscardChangesModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>
+        <ModalHeader maxW="90%">
           Are you sure you want to discard your changes?
         </ModalHeader>
+
         <ModalCloseButton />
 
         <ModalBody>

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
@@ -25,7 +25,7 @@ export const DiscardChangesModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader maxW="90%">
+        <ModalHeader pr="4.5rem">
           Are you sure you want to discard your changes?
         </ModalHeader>
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The modal title sometimes overflows to the close button.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Set a max width to the modal title to prevent it from overflowing to the close button.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="627" alt="Screenshot 2024-08-12 at 14 07 38" src="https://github.com/user-attachments/assets/b7560f1f-2a5c-4904-978e-f66b17376245">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="624" alt="Screenshot 2024-08-12 at 14 07 57" src="https://github.com/user-attachments/assets/c3ed1921-9268-4b5c-9b7b-493598720317">