### PR TITLE
feat(studio): add delete resource functionality, update routing logic for RootPage

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,19 +1,19 @@
 export const ResourceState = {
-    Draft: "Draft",
-    Published: "Published"
-} as const;
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
+  Draft: "Draft",
+  Published: "Published",
+} as const
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
 export const ResourceType = {
-    RootPage: "RootPage",
-    Page: "Page",
-    Folder: "Folder",
-    Collection: "Collection",
-    CollectionPage: "CollectionPage"
-} as const;
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
+  RootPage: "RootPage",
+  Page: "Page",
+  Folder: "Folder",
+  Collection: "Collection",
+  CollectionPage: "CollectionPage",
+} as const
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
 export const RoleType = {
-    Admin: "Admin",
-    Editor: "Editor",
-    Publisher: "Publisher"
-} as const;
-export type RoleType = (typeof RoleType)[keyof typeof RoleType];
+  Admin: "Admin",
+  Editor: "Editor",
+  Publisher: "Publisher",
+} as const
+export type RoleType = (typeof RoleType)[keyof typeof RoleType]

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -2,97 +2,104 @@ import type { ColumnType, GeneratedAlways } from "kysely"
 
 import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
 
-export type Blob = {
-    id: GeneratedAlways<string>;
-    /**
-     * @kyselyType(PrismaJson.BlobJsonContent)
-     * [BlobJsonContent]
-     */
-    content: PrismaJson.BlobJsonContent;
-};
-export type Footer = {
-    id: GeneratedAlways<number>;
-    siteId: number;
-    /**
-     * @kyselyType(PrismaJson.FooterJsonContent)
-     * [FooterJsonContent]
-     */
-    content: PrismaJson.FooterJsonContent;
-};
-export type Navbar = {
-    id: GeneratedAlways<number>;
-    siteId: number;
-    /**
-     * @kyselyType(PrismaJson.NavbarJsonContent)
-     * [NavbarJsonContent]
-     */
-    content: PrismaJson.NavbarJsonContent;
-};
-export type Permission = {
-    id: GeneratedAlways<number>;
-    resourceId: string;
-    userId: string;
-    role: RoleType;
-};
-export type Resource = {
-    id: GeneratedAlways<string>;
-    title: string;
-    permalink: string;
-    siteId: number;
-    parentId: string | null;
-    publishedVersionId: string | null;
-    draftBlobId: string | null;
-    state: Generated<ResourceState | null>;
-    type: ResourceType;
-};
-export type Site = {
-    id: GeneratedAlways<number>;
-    name: string;
-    /**
-     * @kyselyType(PrismaJson.SiteJsonConfig)
-     * [SiteJsonConfig]
-     */
-    config: PrismaJson.SiteJsonConfig;
-    /**
-     * @kyselyType(PrismaJson.SiteThemeJson)
-     * [SiteThemeJson]
-     */
-    theme: PrismaJson.SiteThemeJson | null;
-};
-export type SiteMember = {
-    userId: string;
-    siteId: number;
-};
-export type User = {
-    id: string;
-    name: string;
-    email: string;
-    phone: string;
-    preferredName: string | null;
-};
-export type VerificationToken = {
-    identifier: string;
-    token: string;
-    attempts: Generated<number>;
-    expires: Timestamp;
-};
-export type Version = {
-    id: GeneratedAlways<string>;
-    versionNum: number;
-    resourceId: string;
-    blobId: string;
-    publishedAt: Generated<Timestamp>;
-    publishedBy: string;
-};
-export type DB = {
-    Blob: Blob;
-    Footer: Footer;
-    Navbar: Navbar;
-    Permission: Permission;
-    Resource: Resource;
-    Site: Site;
-    SiteMember: SiteMember;
-    User: User;
-    VerificationToken: VerificationToken;
-    Version: Version;
-};
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
+
+export interface Blob {
+  id: GeneratedAlways<string>
+  /**
+   * @kyselyType(PrismaJson.BlobJsonContent)
+   * [BlobJsonContent]
+   */
+  content: PrismaJson.BlobJsonContent
+}
+export interface Footer {
+  id: GeneratedAlways<number>
+  siteId: number
+  /**
+   * @kyselyType(PrismaJson.FooterJsonContent)
+   * [FooterJsonContent]
+   */
+  content: PrismaJson.FooterJsonContent
+}
+export interface Navbar {
+  id: GeneratedAlways<number>
+  siteId: number
+  /**
+   * @kyselyType(PrismaJson.NavbarJsonContent)
+   * [NavbarJsonContent]
+   */
+  content: PrismaJson.NavbarJsonContent
+}
+export interface Permission {
+  id: GeneratedAlways<number>
+  resourceId: string
+  userId: string
+  role: RoleType
+}
+export interface Resource {
+  id: GeneratedAlways<string>
+  title: string
+  permalink: string
+  siteId: number
+  parentId: string | null
+  publishedVersionId: string | null
+  draftBlobId: string | null
+  state: Generated<ResourceState | null>
+  type: ResourceType
+}
+export interface Site {
+  id: GeneratedAlways<number>
+  name: string
+  /**
+   * @kyselyType(PrismaJson.SiteJsonConfig)
+   * [SiteJsonConfig]
+   */
+  config: PrismaJson.SiteJsonConfig
+  /**
+   * @kyselyType(PrismaJson.SiteThemeJson)
+   * [SiteThemeJson]
+   */
+  theme: PrismaJson.SiteThemeJson | null
+  codeBuildId: string | null
+}
+export interface SiteMember {
+  userId: string
+  siteId: number
+}
+export interface User {
+  id: string
+  name: string
+  email: string
+  phone: string
+  preferredName: string | null
+}
+export interface VerificationToken {
+  identifier: string
+  token: string
+  attempts: Generated<number>
+  expires: Timestamp
+}
+export interface Version {
+  id: GeneratedAlways<string>
+  versionNum: number
+  resourceId: string
+  blobId: string
+  publishedAt: Generated<Timestamp>
+  publishedBy: string
+}
+export interface DB {
+  Blob: Blob
+  Footer: Footer
+  Navbar: Navbar
+  Permission: Permission
+  Resource: Resource
+  Site: Site
+  SiteMember: SiteMember
+  User: User
+  VerificationToken: VerificationToken
+  Version: Version
+}

--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -17,14 +17,8 @@ import { Menu } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { BiData, BiFile, BiFolder, BiHomeAlt } from "react-icons/bi"
 
+import { isAllowedToHaveChildren } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
-
-const isAllowedToHaveChildren = (resourceType: ResourceType): boolean => {
-  return (
-    resourceType !== ResourceType.Page &&
-    resourceType !== ResourceType.CollectionPage
-  )
-}
 
 interface CmsSideNavProps {
   siteId: string
@@ -151,7 +145,15 @@ const SideNavItem = ({
                   }}
                   onDoubleClick={async () => {
                     const urlType = getResourceType(resourceType)
-                    await router.push({
+                    if (resourceType === "RootPage") {
+                      return router.push({
+                        pathname: "/sites/[siteId]",
+                        query: {
+                          siteId,
+                        },
+                      })
+                    }
+                    return router.push({
                       pathname: "/sites/[siteId]/[resourceType]/[id]",
                       query: {
                         siteId,

--- a/apps/studio/src/features/dashboard/atoms.ts
+++ b/apps/studio/src/features/dashboard/atoms.ts
@@ -1,0 +1,21 @@
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { atom } from "jotai"
+
+import { DeleteResourceModalState, FolderSettingsModalState } from "./types"
+
+export const DEFAULT_RESOURCE_MODAL_STATE = {
+  isOpen: false,
+  title: "",
+  resourceId: "",
+  resourceType: ResourceType.Collection,
+}
+export const deleteResourceModalAtom = atom<DeleteResourceModalState>(
+  DEFAULT_RESOURCE_MODAL_STATE,
+)
+
+export const DEFAULT_FOLDER_SETTINGS_MODAL_STATE = {
+  folderId: "",
+}
+export const folderSettingsModalAtom = atom<FolderSettingsModalState>(
+  DEFAULT_FOLDER_SETTINGS_MODAL_STATE,
+)

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -36,6 +36,7 @@ const getColumns = ({ siteId }: CollectionTableProps) => [
     header: () => <TableHeader>Actions</TableHeader>,
     cell: ({ row }) => (
       <CollectionTableMenu
+        resourceType={row.original.type}
         title={row.original.title}
         resourceId={row.original.id}
       />

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -1,16 +1,25 @@
 import { MenuButton, MenuList, Portal } from "@chakra-ui/react"
 import { IconButton, Menu } from "@opengovsg/design-system-react"
+import { useSetAtom } from "jotai"
 import { BiCog, BiDotsHorizontalRounded, BiTrash } from "react-icons/bi"
 
 import type { CollectionTableData } from "./types"
 import { MenuItem } from "~/components/Menu"
+import { deleteResourceModalAtom } from "../../atoms"
 
 interface CollectionTableMenuProps {
   title: CollectionTableData["title"]
   resourceId: CollectionTableData["id"]
+  resourceType: CollectionTableData["resourceType"]
 }
 
-export const CollectionTableMenu = ({ title }: CollectionTableMenuProps) => {
+export const CollectionTableMenu = ({
+  title,
+  resourceId,
+  resourceType,
+}: CollectionTableMenuProps) => {
+  const setValue = useSetAtom(deleteResourceModalAtom)
+
   return (
     <Menu isLazy size="sm">
       <MenuButton
@@ -25,7 +34,17 @@ export const CollectionTableMenu = ({ title }: CollectionTableMenuProps) => {
           <MenuItem icon={<BiCog fontSize="1rem" />}>
             Edit page settings
           </MenuItem>
-          <MenuItem colorScheme="critical" icon={<BiTrash fontSize="1rem" />}>
+          <MenuItem
+            onClick={() => {
+              setValue({
+                title,
+                resourceId,
+                resourceType,
+              })
+            }}
+            colorScheme="critical"
+            icon={<BiTrash fontSize="1rem" />}
+          >
             Delete
           </MenuItem>
         </MenuList>

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react"
+import {
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react"
+import {
+  Button,
+  Checkbox,
+  ModalCloseButton,
+  useToast,
+} from "@opengovsg/design-system-react"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { useAtom } from "jotai"
+import upperFirst from "lodash/upperFirst"
+
+import { isAllowedToHaveChildren } from "~/utils/resources"
+import { trpc } from "~/utils/trpc"
+import {
+  DEFAULT_RESOURCE_MODAL_STATE,
+  deleteResourceModalAtom,
+} from "../../atoms"
+import { DeleteResourceModalState } from "../../types"
+
+const getResourceLabel = (
+  resourceType: ResourceType,
+): Lowercase<Extract<ResourceType, "Page" | "Collection" | "Folder">> => {
+  if (!isAllowedToHaveChildren(resourceType)) {
+    return "page"
+  }
+
+  if (resourceType === ResourceType.Collection) {
+    return "collection"
+  }
+
+  return "folder"
+}
+
+const getWarningText = (resourceType: ResourceType): string => {
+  if (!isAllowedToHaveChildren) {
+    return "This cannot be undone"
+  }
+
+  if (resourceType === ResourceType.Collection) {
+    return "All pages under this collection will be deleted. This cannot be undone."
+  }
+
+  return "All folders and pages under this folder will be deleted. This cannot be undone."
+}
+
+interface DeleteResourceModalProps {
+  siteId: number
+}
+
+export const DeleteResourceModal = ({
+  siteId,
+}: DeleteResourceModalProps): JSX.Element => {
+  const [{ resourceId, ...rest }, setDeleteCollectionModalState] = useAtom(
+    deleteResourceModalAtom,
+  )
+  const onClose = () =>
+    setDeleteCollectionModalState(DEFAULT_RESOURCE_MODAL_STATE)
+  return (
+    <Modal isOpen={!!resourceId} onClose={onClose}>
+      <ModalOverlay />
+      {!!resourceId && (
+        <DeleteResourceModalContent
+          {...rest}
+          siteId={siteId}
+          resourceId={resourceId}
+          onClose={onClose}
+        />
+      )}
+    </Modal>
+  )
+}
+
+const DeleteResourceModalContent = ({
+  onClose,
+  title,
+  resourceType,
+  siteId,
+  resourceId,
+}: DeleteResourceModalState & { siteId: number; onClose: () => void }) => {
+  const label = getResourceLabel(resourceType)
+  const utils = trpc.useUtils()
+  const toast = useToast()
+  const [isChecked, setIsChecked] = useState(false)
+  const { mutate, isLoading } = trpc.resource.delete.useMutation({
+    onSettled: onClose,
+    onSuccess: async () => {
+      // TODO: here and elsewhere, we should aim to simplify our query pattern
+      // such that the invalidation logic is clear
+      await utils.resource.list.invalidate()
+      await utils.resource.getChildrenOf.invalidate()
+      await utils.collection.list.invalidate()
+      toast({ title: `${upperFirst(label)} deleted!`, status: "success" })
+    },
+    onError: (err) => {
+      toast({
+        title: `Failed to delete ${label}`,
+        status: "error",
+        // TODO: check if this property is correct
+        description: err.message,
+      })
+    },
+  })
+
+  const onDelete = () => {
+    mutate({ siteId, resourceId })
+  }
+
+  return (
+    <ModalContent>
+      <ModalHeader pr="4.5rem">Delete {title}?</ModalHeader>
+      <ModalCloseButton />
+
+      <ModalBody>
+        <Text textStyle="body-2">{getWarningText(resourceType)}</Text>
+        <HStack mt="1.5rem">
+          <Checkbox onChange={() => setIsChecked((prev) => !prev)}>
+            Yes, delete this {label} permanently
+          </Checkbox>
+        </HStack>
+      </ModalBody>
+
+      <ModalFooter>
+        <HStack spacing="1rem">
+          <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+            No, keep {label}
+          </Button>
+          <Button
+            isDisabled={!isChecked}
+            variant="solid"
+            colorScheme="critical"
+            onClick={onDelete}
+            isLoading={isLoading}
+          >
+            Delete {label}
+          </Button>
+        </HStack>
+      </ModalFooter>
+    </ModalContent>
+  )
+}

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -42,6 +42,7 @@ const getColumns = ({ siteId }: ResourceTableProps) => [
         resourceId={row.original.id}
         type={row.original.type}
         permalink={row.original.permalink}
+        resourceType={row.original.type}
       />
     ),
     size: 24,

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -1,5 +1,6 @@
 import { MenuButton, MenuList, Portal } from "@chakra-ui/react"
 import { IconButton, Menu } from "@opengovsg/design-system-react"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 import { useSetAtom } from "jotai"
 import {
   BiCog,
@@ -12,12 +13,14 @@ import {
 import type { ResourceTableData } from "./types"
 import { MenuItem } from "~/components/Menu"
 import { moveResourceAtom } from "~/features/editing-experience/atoms"
+import { deleteResourceModalAtom, folderSettingsModalAtom } from "../../atoms"
 
 interface ResourceTableMenuProps {
   title: ResourceTableData["title"]
   resourceId: ResourceTableData["id"]
   type: ResourceTableData["type"]
   permalink: ResourceTableData["permalink"]
+  resourceType: ResourceTableData["type"]
 }
 
 export const ResourceTableMenu = ({
@@ -25,10 +28,14 @@ export const ResourceTableMenu = ({
   title,
   type,
   permalink,
+  resourceType,
 }: ResourceTableMenuProps) => {
   const setMoveResource = useSetAtom(moveResourceAtom)
   const handleMoveResourceClick = () =>
     setMoveResource({ resourceId, title, permalink })
+  const setResourceModalState = useSetAtom(deleteResourceModalAtom)
+  const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
+
   return (
     <Menu isLazy size="sm">
       <MenuButton
@@ -51,7 +58,14 @@ export const ResourceTableMenu = ({
               </MenuItem>
             </>
           ) : (
-            <MenuItem icon={<BiCog fontSize="1rem" />}>
+            <MenuItem
+              onClick={() =>
+                setFolderSettingsModalState({
+                  folderId: resourceId,
+                })
+              }
+              icon={<BiCog fontSize="1rem" />}
+            >
               Edit folder settings
             </MenuItem>
           )}
@@ -62,9 +76,21 @@ export const ResourceTableMenu = ({
           >
             Move to...
           </MenuItem>
-          <MenuItem colorScheme="critical" icon={<BiTrash fontSize="1rem" />}>
-            Delete
-          </MenuItem>
+          {resourceType !== ResourceType.RootPage && (
+            <MenuItem
+              onClick={() => {
+                setResourceModalState({
+                  title,
+                  resourceId,
+                  resourceType,
+                })
+              }}
+              colorScheme="critical"
+              icon={<BiTrash fontSize="1rem" />}
+            >
+              Delete
+            </MenuItem>
+          )}
         </MenuList>
       </Portal>
     </Menu>

--- a/apps/studio/src/features/dashboard/types.ts
+++ b/apps/studio/src/features/dashboard/types.ts
@@ -1,0 +1,11 @@
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+export interface DeleteResourceModalState {
+  title: string
+  resourceId: string
+  resourceType: ResourceType
+}
+
+export interface FolderSettingsModalState {
+  folderId: string
+}

--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -5,6 +5,7 @@ import { z } from "zod"
 
 import { CollectionBanner } from "~/features/dashboard/components/CollectionBanner"
 import { CollectionTable } from "~/features/dashboard/components/CollectionTable"
+import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
 import { CreateCollectionPageModal } from "~/features/editing-experience/components/CreateCollectionPageModal"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
@@ -63,6 +64,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
         siteId={siteId}
         collectionId={resourceId}
       />
+      <DeleteResourceModal siteId={siteId} />
     </>
   )
 }

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -13,10 +13,12 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Breadcrumb, Button, Menu } from "@opengovsg/design-system-react"
+import { useSetAtom } from "jotai"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import { MenuItem } from "~/components/Menu"
+import { folderSettingsModalAtom } from "~/features/dashboard/atoms"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
@@ -42,11 +44,7 @@ const FolderPage: NextPageWithLayout = () => {
     onOpen: onFolderCreateModalOpen,
     onClose: onFolderCreateModalClose,
   } = useDisclosure()
-  const {
-    isOpen: isFolderSettingsModalOpen,
-    onOpen: onFolderSettingsModalOpen,
-    onClose: onFolderSettingsModalClose,
-  } = useDisclosure()
+  const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
 
   const { folderId, siteId } = useQueryParse(folderPageSchema)
 
@@ -85,7 +83,11 @@ const FolderPage: NextPageWithLayout = () => {
               <Button
                 variant="outline"
                 size="md"
-                onClick={onFolderSettingsModalOpen}
+                onClick={() =>
+                  setFolderSettingsModalState({
+                    folderId,
+                  })
+                }
               >
                 Folder settings
               </Button>
@@ -133,12 +135,7 @@ const FolderPage: NextPageWithLayout = () => {
         onClose={onFolderCreateModalClose}
         siteId={parseInt(siteId)}
       />
-      <FolderSettingsModal
-        isOpen={isFolderSettingsModalOpen}
-        onClose={onFolderSettingsModalClose}
-        siteId={siteId}
-        resourceId={parseInt(folderId)}
-      />
+      <FolderSettingsModal />
     </>
   )
 }

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -9,10 +9,18 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
+import { useAtom, useSetAtom } from "jotai"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import { MenuItem } from "~/components/Menu"
+import {
+  DEFAULT_RESOURCE_MODAL_STATE,
+  deleteResourceModalAtom,
+  folderSettingsModalAtom,
+} from "~/features/dashboard/atoms"
+import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
+import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateCollectionModal } from "~/features/editing-experience/components/CreateCollectionModal"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
@@ -44,6 +52,9 @@ const SitePage: NextPageWithLayout = () => {
   } = useDisclosure()
 
   const { siteId } = useQueryParse(sitePageSchema)
+  const [deleteResourceModalState, setDeleteResourceModalState] = useAtom(
+    deleteResourceModalAtom,
+  )
 
   return (
     <>
@@ -102,7 +113,9 @@ const SitePage: NextPageWithLayout = () => {
         onClose={onCollectionCreateModalClose}
         siteId={siteId}
       />
+      <DeleteResourceModal siteId={siteId} />
       <MoveResourceModal />
+      <FolderSettingsModal />
     </>
   )
 }

--- a/apps/studio/src/pages/sites/[siteId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings.tsx
@@ -36,9 +36,9 @@ const SiteSettingsPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteSettingsSchema)
 
   const notificationMutation = trpc.site.setNotification.useMutation({
-    onSuccess: () => {
+    onSuccess: async () => {
       reset({ notificationEnabled, notification })
-      void trpcUtils.site.getNotification.invalidate({ siteId })
+      await trpcUtils.site.getNotification.invalidate({ siteId })
       toast({
         title: "Saved site settings!",
         description: "Check your site in 5-10 minutes to view it live.",

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -29,3 +29,12 @@ export const listResourceSchema = z.object({
   siteId: z.number(),
   resourceId: z.number().optional(),
 })
+
+export const deleteResourceSchema = z.object({
+  siteId: z.number(),
+  resourceId: z
+    .string()
+    .min(1)
+    .regex(/[0-9]+/)
+    .refine((s) => !s.startsWith("0")),
+})

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server"
 
 import {
+  deleteResourceSchema,
   getChildrenSchema,
   getMetadataSchema,
   listResourceSchema,
@@ -111,5 +112,17 @@ export const resourceRouter = router({
           "Resource.type",
         ])
         .execute()
+    }),
+  delete: protectedProcedure
+    .input(deleteResourceSchema)
+    .mutation(async ({ input: { siteId, resourceId } }) => {
+      const result = await db
+        .deleteFrom("Resource")
+        .where("Resource.id", "=", String(resourceId))
+        .where("Resource.siteId", "=", siteId)
+        .executeTakeFirst()
+      // NOTE: We need to do this `toString` as the property is a `bigint`
+      // and trpc cannot serialise it, which leads to errors
+      return result.numDeletedRows.toString()
     }),
 })

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -1,0 +1,11 @@
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+export const isAllowedToHaveChildren = (
+  resourceType: ResourceType,
+): boolean => {
+  return (
+    resourceType === ResourceType.Folder ||
+    resourceType === ResourceType.Collection ||
+    resourceType === ResourceType.RootPage
+  )
+}


### PR DESCRIPTION
### TL;DR

This PR adds a feature to delete resources using a modal, refactors some related code for better structure, and ensures correct navigation behavior.

### What changed?

- Moved the `isAllowedToHaveChildren` function to `utils/resources`.
- Added a `deleteResourceModalAtom` to store the state of the delete resource modal.
- Created a new `DeleteResourceModal` component to handle the deletion of resources with confirmation.
- Updated `CollectionTableMenu` and `ResourceTableMenu` to use the new modal for deleting resources.
- Refactored routing logic to handle `RootPage` separately.
- Ensured that deletion of resources includes confirmation and proper state management.
- Added accompanying types and schemas.

### How to test?

1. Navigate to the resource table or collection table.
2. Attempt to delete a resource and observe the new modal behavior.
3. Confirm the deletion and ensure the resource is removed appropriately.
4. Verify that navigation and state management work as expected.

### Why make this change?

This change introduces a user-friendly way to delete resources and centralizes the delete modal state, improving the code structure and user experience.
