### PR TITLE
fix: home styling

### DIFF
--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -96,7 +96,7 @@ const DeleteResourceModalContent = ({
     onSuccess: async () => {
       // TODO: here and elsewhere, we should aim to simplify our query pattern
       // such that the invalidation logic is clear
-      await utils.resource.list.invalidate()
+      await utils.resource.listWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate()
       await utils.collection.list.invalidate()
       toast({ title: `${upperFirst(label)} deleted!`, status: "success" })

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -88,7 +88,7 @@ const SuspendableModalContent = ({
     onSettled: onClose,
     onSuccess: async () => {
       await utils.site.list.invalidate()
-      await utils.resource.list.invalidate()
+      await utils.resource.listWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate({
         resourceId: parentId ? String(parentId) : null,
       })

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -15,7 +15,7 @@ import { trpc } from "~/utils/trpc"
 import { ResourceTableMenu } from "./ResourceTableMenu"
 import { TitleCell } from "./TitleCell"
 
-type ResourceTableData = RouterOutput["resource"]["list"][number]
+type ResourceTableData = RouterOutput["resource"]["listWithoutRoot"][number]
 
 const columnsHelper = createColumnHelper<ResourceTableData>()
 
@@ -62,7 +62,7 @@ export const ResourceTable = ({
     () => getColumns({ siteId, resourceId }),
     [siteId, resourceId],
   )
-  const { data: resources } = trpc.resource.list.useQuery(
+  const { data: resources } = trpc.resource.listWithoutRoot.useQuery(
     {
       siteId,
       resourceId,

--- a/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
@@ -1,3 +1,4 @@
 import type { RouterOutput } from "~/utils/trpc"
 
-export type ResourceTableData = RouterOutput["resource"]["list"][number]
+export type ResourceTableData =
+  RouterOutput["resource"]["listWithoutRoot"][number]

--- a/apps/studio/src/features/dashboard/components/RootpageRow/RootpageRow.tsx
+++ b/apps/studio/src/features/dashboard/components/RootpageRow/RootpageRow.tsx
@@ -1,0 +1,69 @@
+import Link from "next/link"
+import { HStack, IconButton, Text, VStack } from "@chakra-ui/react"
+import { Badge, BadgeLeftIcon } from "@opengovsg/design-system-react"
+import { BiChevronRight, BiHomeAlt, BiSolidCircle } from "react-icons/bi"
+
+import { trpc } from "~/utils/trpc"
+
+interface RootpageRowProps {
+  siteId: number
+}
+
+export const RootpageRow = ({ siteId }: RootpageRowProps) => {
+  const [{ id, title, draftBlobId }] = trpc.page.getRootPage.useSuspenseQuery({
+    siteId,
+  })
+  return (
+    <HStack
+      as={Link}
+      href={`/sites/${siteId}/pages/${id}`}
+      gap="0.75rem"
+      px="1.25rem"
+      py="0.5rem"
+      w="full"
+      bg="base.canvas.default"
+      border="1px solid"
+      borderColor="base.divider.medium"
+      borderRadius="8px"
+      layerStyle="focusRing"
+      _active={{}}
+      _hover={{ background: "interaction.muted.main.hover" }}
+      data-group
+    >
+      <BiHomeAlt fontSize={"1.25rem"} />
+      <VStack flex={1} gap="0.25rem" alignItems="flex-start">
+        <HStack gap="0.25rem">
+          <Text textStyle="subhead-2">{title}</Text>
+          <Badge
+            size="xs"
+            variant="clear"
+            colorScheme={draftBlobId ? "warning" : "success"}
+          >
+            <BadgeLeftIcon fontSize="0.5rem" as={BiSolidCircle} />
+            <Text textStyle="legal">{draftBlobId ? "Draft" : "Published"}</Text>
+          </Badge>
+        </HStack>
+        {/*   TODO: werequire the last updated at and to display it */}
+        {/* as a relative time. */}
+        {/* we also need to give the user who did the update */}
+      </VStack>
+      <Text
+        textStyle="caption-2"
+        _groupHover={{ display: "flex" }}
+        _groupFocus={{ display: "flex" }}
+        display="none"
+      >
+        Edit page
+      </Text>
+      <IconButton
+        as="div"
+        aria-hidden
+        variant="clear"
+        pointerEvents="none"
+        colorScheme="neutral"
+        icon={<BiChevronRight />}
+        aria-label="edit homepage"
+      />
+    </HStack>
+  )
+}

--- a/apps/studio/src/features/dashboard/components/RootpageRow/index.ts
+++ b/apps/studio/src/features/dashboard/components/RootpageRow/index.ts
@@ -1,0 +1,1 @@
+export * from "./RootpageRow"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -80,7 +80,7 @@ const CreateCollectionModalContent = ({
   const { mutate, isLoading } = trpc.collection.create.useMutation({
     onSettled: onClose,
     onSuccess: async () => {
-      await utils.resource.list.invalidate()
+      await utils.resource.listWithoutRoot.invalidate()
       toast({ title: "Collection created!", status: "success" })
     },
     onError: (err) => {

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -78,7 +78,7 @@ const CreateFolderModalContent = ({
     onSettled: onClose,
     onSuccess: async () => {
       await utils.site.list.invalidate()
-      await utils.resource.list.invalidate()
+      await utils.resource.listWithoutRoot.invalidate()
       toast({ title: "Folder created!", status: "success" })
     },
     onError: (err) => {

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -81,7 +81,7 @@ const useCreatePageWizardContext = ({
 
   const { mutate, isLoading } = trpc.page.createPage.useMutation({
     onSuccess: async () => {
-      await utils.resource.list.invalidate()
+      await utils.resource.listWithoutRoot.invalidate()
       onClose()
     },
     // TOOD: Error handling

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -81,7 +81,7 @@ const MoveResourceContent = withSuspense(
       },
       onSuccess: async () => {
         await utils.page.readPageAndBlob.invalidate()
-        await utils.resource.list.invalidate({
+        await utils.resource.listWithoutRoot.invalidate({
           // TODO: Update backend `list` to use the proper schema
           resourceId: movedItem?.resourceId
             ? Number(movedItem.resourceId)

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -22,6 +22,7 @@ import {
 import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
+import { RootpageRow } from "~/features/dashboard/components/RootpageRow"
 import { CreateCollectionModal } from "~/features/editing-experience/components/CreateCollectionModal"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
 import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
@@ -60,9 +61,6 @@ const SitePage: NextPageWithLayout = () => {
     <>
       <VStack w="100%" p="1.75rem" gap="1rem">
         <VStack w="100%" align="start">
-          <Text textColor="base.content.default" textStyle="h5">
-            My Pages
-          </Text>
           <HStack w="100%" justify="space-between" align="center" gap={0}>
             <Box />
             <Menu isLazy size="sm">
@@ -94,6 +92,7 @@ const SitePage: NextPageWithLayout = () => {
             </Menu>
           </HStack>
         </VStack>
+        <RootpageRow siteId={siteId} />
         <Box width="100%">
           <ResourceTable siteId={siteId} />
         </Box>

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -107,3 +107,7 @@ export const createCollectionPageSchema = createCollectionPageFormSchema.and(
     siteId: z.number().min(1),
   }),
 )
+
+export const getRootPageSchema = z.object({
+  siteId: z.number().min(1),
+})

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -255,8 +255,8 @@ export const pageRouter = router({
           // TODO: Only return sites that the user has access to
           .where("Resource.siteId", "=", siteId)
           .where("Resource.type", "=", "RootPage")
-          .select(["id", "type", "title", "publishedVersionId", "draftBlobId"])
-          .execute()
+          .select(["id", "title", "draftBlobId"])
+          .executeTakeFirstOrThrow()
       )
     }),
   publishPage: protectedProcedure

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -9,6 +9,7 @@ import {
   createPageSchema,
   getEditPageSchema,
   getPageSchema,
+  getRootPageSchema,
   publishPageSchema,
   reorderBlobSchema,
   updatePageBlobSchema,
@@ -245,7 +246,19 @@ export const pageRouter = router({
         return { pageId: resource.id }
       },
     ),
-
+  getRootPage: protectedProcedure
+    .input(getRootPageSchema)
+    .query(async ({ input: { siteId } }) => {
+      return (
+        db
+          .selectFrom("Resource")
+          // TODO: Only return sites that the user has access to
+          .where("Resource.siteId", "=", siteId)
+          .where("Resource.type", "=", "RootPage")
+          .select(["id", "type", "title", "publishedVersionId", "draftBlobId"])
+          .execute()
+      )
+    }),
   publishPage: protectedProcedure
     .input(publishPageSchema)
     .mutation(async ({ ctx, input: { siteId, pageId } }) => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -89,12 +89,13 @@ export const resourceRouter = router({
           .executeTakeFirst()
       })
     }),
-  list: protectedProcedure
+  listWithoutRoot: protectedProcedure
     .input(listResourceSchema)
     .query(async ({ input: { siteId, resourceId } }) => {
       let query = db
         .selectFrom("Resource")
         .where("Resource.siteId", "=", siteId)
+        .where("Resource.type", "!=", "RootPage")
 
       if (resourceId) {
         query = query.where("Resource.parentId", "=", String(resourceId))

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -4,7 +4,7 @@ import { delay } from "msw"
 import { trpcMsw } from "../mockTrpc"
 
 const pageListQuery = (wait?: DelayMode | number) => {
-  return trpcMsw.resource.list.query(async () => {
+  return trpcMsw.resource.listWithoutRoot.query(async () => {
     if (wait !== undefined) {
       await delay(wait)
     }


### PR DESCRIPTION
### TL;DR

- Added a new `RootpageRow` component to display root page information on the site dashboard.
- Updated the usage of the resource list query to the new `listWithoutRoot` endpoint to exclude root pages from the general resource list.

### What changed?

1. Introduced the `RootpageRow` component to show basic details of the root page, such as title and status (draft or published), on the site dashboard.
2. Modified the `FolderSettingsModal` to wrap `SuspendableModalContent` with a `Suspense` component using a `Skeleton` as a fallback.
3. Changed several instances of `resource.list` to `resource.listWithoutRoot` to exclude root pages from resource listings.
4. Added `getRootPage` query to the `page.router` to support fetching root page details.

### How to test?

1. Navigate to the site dashboard and verify that the root page information is displayed correctly using the new `RootpageRow` component.
2. Check that opening the folder settings modal shows the loading skeleton while content is being fetched.
3. Ensure that resource listings do not include the root page.

### Why make this change?

This change aims to improve the user interface by clearly displaying the root page information on the dashboard and ensuring resource listings are more accurate by excluding root pages.
