### PR TITLE
feat: build tailwind after as studio's build pipeline

### DIFF
--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -7,8 +7,9 @@
       "cache": false
     },
     "build:theme": {},
+    "build:preview-tw": {},
     "build": {
-      "dependsOn": ["generate", "build:theme", "^build"],
+      "dependsOn": ["generate", "build:theme", "^build", "build:preview-tw"],
       "outputs": [".next/**", "!.next/cache/**"]
     }
   }


### PR DESCRIPTION
### TL;DR

Added a new build step for preview tailwind and updated build dependencies.

### What changed?

- Added a new `build:preview-tw` task to the `turbo.json` configuration.
- Updated the `build` task dependencies to include the new `build:preview-tw` task.

### How to test?

Vercel should build properly, and preview should render properly

### Why make this change?

By adding this as a dependency to the main build task, we ensure that the preview styles are always up-to-date when building the project. This can improve the development experience and ensure consistency between preview and production styles.
