### PR TITLE
feat: implement pagination for resource, collection, and getChildrenOf procedures

### DIFF
--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -24,10 +24,6 @@ export interface DatatableProps<D> extends TableProps {
    */
   totalRowCount?: number
   pagination?: boolean
-  /**
-   * If provided, this string will be used to display the total row count.
-   */
-  totalRowCountString?: string
   isFetching?: boolean
   emptyPlaceholder?: React.ReactElement
   overflow?: LayoutProps["overflow"]
@@ -44,7 +40,6 @@ export const Datatable = <T extends object>({
   isFetching,
   pagination,
   totalRowCount,
-  totalRowCountString,
   emptyPlaceholder,
   overflow = "auto",
   ...tableProps

--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -66,10 +66,9 @@ export const Datatable = <T extends object>({
             bottom={0}
             flex={1}
             left={0}
-            pos="fixed"
+            pos="absolute"
             right={0}
             top={0}
-            w="100vw"
             zIndex={2}
           >
             <Box m="auto">

--- a/apps/studio/src/components/Datatable/DatatablePagination.tsx
+++ b/apps/studio/src/components/Datatable/DatatablePagination.tsx
@@ -20,7 +20,7 @@ export const DatatablePagination = <T extends object>({
       onPageChange={(newPage) => {
         instance.setPageIndex(newPage - 1)
       }}
-      pageSize={10}
+      pageSize={paginationState.pageSize}
       totalCount={totalRowCount}
     />
   )

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -19,13 +19,13 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 import { useAtom } from "jotai"
 import upperFirst from "lodash/upperFirst"
 
+import type { DeleteResourceModalState } from "../../types"
 import { isAllowedToHaveChildren } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
 import {
   DEFAULT_RESOURCE_MODAL_STATE,
   deleteResourceModalAtom,
 } from "../../atoms"
-import { DeleteResourceModalState } from "../../types"
 
 const getResourceLabel = (
   resourceType: ResourceType,
@@ -42,7 +42,7 @@ const getResourceLabel = (
 }
 
 const getWarningText = (resourceType: ResourceType): string => {
-  if (!isAllowedToHaveChildren) {
+  if (!isAllowedToHaveChildren(resourceType)) {
     return "This cannot be undone"
   }
 

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -70,7 +70,7 @@ const SuspendableModalContent = ({
   folderId: string
 }) => {
   const [{ title: originalTitle, permalink: originalPermalink, parentId }] =
-    trpc.folder.readFolder.useSuspenseQuery({
+    trpc.folder.getMetadata.useSuspenseQuery({
       siteId,
       resourceId: Number(folderId),
     })
@@ -100,7 +100,7 @@ const SuspendableModalContent = ({
       await utils.resource.getChildrenOf.invalidate({
         resourceId: parentId ? String(parentId) : null,
       })
-      await utils.folder.readFolder.invalidate()
+      await utils.folder.getMetadata.invalidate()
       toast({ title: "Folder updated!", status: "success" })
     },
     onError: (err) => {

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
@@ -2,37 +2,29 @@ import { Suspense, useMemo } from "react"
 import { Text } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { QueryErrorResetBoundary } from "@tanstack/react-query"
-import { useAtomValue } from "jotai"
 import { ErrorBoundary } from "react-error-boundary"
-import { BiData, BiFile, BiFolder } from "react-icons/bi"
+import { BiFile, BiFolder } from "react-icons/bi"
 
 import type { RouterOutput } from "~/utils/trpc"
-import { moveResourceAtom } from "../../atoms"
 
 type MoveItemProps = Pick<
-  RouterOutput["resource"]["getChildrenOf"]["items"][number],
+  RouterOutput["resource"]["getFolderChildrenOf"]["items"][number],
   "permalink" | "type"
 > & {
   onChangeResourceId: () => void
-  resourceId: string
 }
 
 const SuspendableMoveItem = ({
   permalink,
-  resourceId,
   type,
   onChangeResourceId,
 }: MoveItemProps) => {
-  const movedItem = useAtomValue(moveResourceAtom)
   const icon: JSX.Element = useMemo(() => {
     switch (type) {
       case "Folder":
         return <BiFolder />
-      case "CollectionPage":
-      case "Page":
+      case "RootPage":
         return <BiFile />
-      case "Collection":
-        return <BiData />
     }
   }, [type])
 

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
@@ -10,7 +10,7 @@ import type { RouterOutput } from "~/utils/trpc"
 import { moveResourceAtom } from "../../atoms"
 
 type MoveItemProps = Pick<
-  RouterOutput["resource"]["getChildrenOf"][number],
+  RouterOutput["resource"]["getChildrenOf"]["items"][number],
   "permalink" | "type"
 > & {
   onChangeResourceId: () => void
@@ -34,7 +34,7 @@ const SuspendableMoveItem = ({
       case "Collection":
         return <BiData />
     }
-  }, [permalink, type])
+  }, [type])
 
   return (
     <Button

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -22,6 +22,8 @@ import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
 import type { PendingMoveResource } from "../../types"
 import { withSuspense } from "~/hocs/withSuspense"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { sitePageSchema } from "~/pages/sites/[siteId]"
 import { trpc } from "~/utils/trpc"
 import { moveResourceAtom } from "../../atoms"
 import { MoveItem } from "./MoveItem"

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -171,7 +171,6 @@ const MoveResourceContent = withSuspense(
                   return (
                     <MoveItem
                       {...child}
-                      resourceId={child.id}
                       key={child.id}
                       onChangeResourceId={() => {
                         setResourceStack((prev) => [

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -94,7 +94,7 @@ const MoveResourceContent = withSuspense(
         })
         // NOTE: We might want to have smarter logic here
         // and invalidate the new + old folders
-        await utils.folder.readFolder.invalidate()
+        await utils.folder.getMetadata.invalidate()
         toast({ title: "Resource moved!" })
       },
     })

--- a/apps/studio/src/hooks/useTablePagination.ts
+++ b/apps/studio/src/hooks/useTablePagination.ts
@@ -1,0 +1,24 @@
+import { useState } from "react"
+import { type PaginationState } from "@tanstack/react-table"
+
+type UseTablePaginationArgs = PaginationState & {
+  totalCount: number
+}
+
+export const useTablePagination = ({
+  totalCount,
+  ...state
+}: UseTablePaginationArgs) => {
+  const [pagination, setPagination] = useState<PaginationState>(state)
+
+  const { pageSize, pageIndex } = pagination
+  const pageCount = Math.ceil(totalCount / pageSize)
+
+  return {
+    limit: pageSize,
+    pageCount,
+    onPaginationChange: setPagination,
+    pagination,
+    skip: pageSize * pageIndex,
+  }
+}

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -48,7 +48,7 @@ const FolderPage: NextPageWithLayout = () => {
 
   const { folderId, siteId } = useQueryParse(folderPageSchema)
 
-  const [{ title }] = trpc.folder.readFolder.useSuspenseQuery({
+  const [{ title }] = trpc.folder.getMetadata.useSuspenseQuery({
     siteId: parseInt(siteId),
     resourceId: parseInt(folderId),
   })

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 
 import { generateBasePermalinkSchema } from "./common"
+import { offsetPaginationSchema } from "./pagination"
 
 export const MAX_FOLDER_TITLE_LENGTH = 100
 export const MAX_FOLDER_PERMALINK_LENGTH = 200
@@ -25,10 +26,12 @@ export const createFolderSchema = z.object({
   parentFolderId: z.number().optional(),
 })
 
-export const readFolderSchema = z.object({
-  siteId: z.number().min(1),
-  resourceId: z.number().min(1),
-})
+export const readFolderSchema = z
+  .object({
+    siteId: z.number().min(1),
+    resourceId: z.number().min(1),
+  })
+  .merge(offsetPaginationSchema)
 
 export const baseEditFolderSchema = z.object({
   resourceId: z.string(),

--- a/apps/studio/src/schemas/pagination.ts
+++ b/apps/studio/src/schemas/pagination.ts
@@ -1,0 +1,6 @@
+import { z } from "zod"
+
+export const offsetPaginationSchema = z.object({
+  offset: z.number().int().nonnegative().default(0),
+  limit: z.number().int().positive().default(10),
+})

--- a/apps/studio/src/schemas/pagination.ts
+++ b/apps/studio/src/schemas/pagination.ts
@@ -4,3 +4,11 @@ export const offsetPaginationSchema = z.object({
   offset: z.number().int().nonnegative().default(0),
   limit: z.number().int().positive().default(10),
 })
+
+// Use this schema if you want to expose useInfiniteQuery on trpc procedure.
+export const infiniteOffsetPaginationSchema = z.object({
+  // the "cursor" key needs to exist to allow for infinite pagination
+  // but can actually still act as a regular offset pagination
+  cursor: z.number().int().nonnegative().default(0),
+  limit: z.number().int().positive().default(10),
+})

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -1,5 +1,7 @@
 import { z } from "zod"
 
+import { offsetPaginationSchema } from "./pagination"
+
 // NOTE: We want to accept string
 // but validate that the string conforms to bigint.
 // Oddly enough, kysely doesn't allow `bigint` to query
@@ -26,7 +28,7 @@ export const moveSchema = z.object({
   destinationResourceId: bigIntSchema,
 })
 
-export const listResourceSchema = z.object({
+export const countResourceSchema = z.object({
   siteId: z.number(),
   resourceId: z.number().optional(),
 })
@@ -39,3 +41,10 @@ export const deleteResourceSchema = z.object({
     .regex(/[0-9]+/)
     .refine((s) => !s.startsWith("0")),
 })
+
+export const listResourceSchema = z
+  .object({
+    siteId: z.number(),
+    resourceId: z.number().optional(),
+  })
+  .merge(offsetPaginationSchema)

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -1,6 +1,9 @@
 import { z } from "zod"
 
-import { offsetPaginationSchema } from "./pagination"
+import {
+  infiniteOffsetPaginationSchema,
+  offsetPaginationSchema,
+} from "./pagination"
 
 // NOTE: We want to accept string
 // but validate that the string conforms to bigint.
@@ -18,10 +21,12 @@ export const getMetadataSchema = z.object({
   resourceId: bigIntSchema,
 })
 
-export const getChildrenSchema = z.object({
-  resourceId: z.union([bigIntSchema, z.null()]),
-  siteId: z.string().min(0),
-})
+export const getChildrenSchema = z
+  .object({
+    resourceId: z.union([bigIntSchema, z.null()]),
+    siteId: z.string().min(0),
+  })
+  .merge(infiniteOffsetPaginationSchema)
 
 export const moveSchema = z.object({
   movedResourceId: bigIntSchema,

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -87,7 +87,7 @@ export const collectionRouter = router({
     }),
   list: protectedProcedure
     .input(readFolderSchema)
-    .query(async ({ ctx, input }) => {
+    .query(async ({ ctx, input: { resourceId, siteId, limit, offset } }) => {
       // Things that aren't working yet:
       // 0. Perm checking
       // 1. Last Edited user and time
@@ -95,8 +95,11 @@ export const collectionRouter = router({
 
       return await ctx.db
         .selectFrom("Resource")
-        .where("parentId", "=", String(input.resourceId))
+        .where("parentId", "=", String(resourceId))
+        .where("Resource.siteId", "=", siteId)
         .where("Resource.type", "=", ResourceType.CollectionPage)
+        .limit(limit)
+        .offset(offset)
         .select(defaultResourceSelect)
         .execute()
     }),

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -98,6 +98,8 @@ export const collectionRouter = router({
         .where("parentId", "=", String(resourceId))
         .where("Resource.siteId", "=", siteId)
         .where("Resource.type", "=", ResourceType.CollectionPage)
+        .orderBy("Resource.type", "asc")
+        .orderBy("Resource.title", "asc")
         .limit(limit)
         .offset(offset)
         .select(defaultResourceSelect)

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -1,6 +1,8 @@
 import { TRPCError } from "@trpc/server"
 
+import type { ResourceType } from "../database"
 import {
+  countResourceSchema,
   deleteResourceSchema,
   getChildrenSchema,
   getMetadataSchema,
@@ -8,7 +10,7 @@ import {
   moveSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
-import { db, ResourceType } from "../database"
+import { db } from "../database"
 
 export const resourceRouter = router({
   getMetadataById: protectedProcedure
@@ -88,13 +90,35 @@ export const resourceRouter = router({
           .executeTakeFirst()
       })
     }),
-  listWithoutRoot: protectedProcedure
-    .input(listResourceSchema)
+  countWithoutRoot: protectedProcedure
+    .input(countResourceSchema)
     .query(async ({ input: { siteId, resourceId } }) => {
+      // TODO(perf): If too slow, consider caching this count, but 4-5 million rows should be fine
       let query = db
         .selectFrom("Resource")
         .where("Resource.siteId", "=", siteId)
         .where("Resource.type", "!=", "RootPage")
+
+      if (resourceId) {
+        query = query.where("Resource.parentId", "=", String(resourceId))
+      } else {
+        query = query.where("Resource.parentId", "is", null)
+      }
+
+      const result = await query
+        .select((eb) => [eb.fn.countAll().as("totalCount")])
+        .executeTakeFirst()
+      return Number(result?.totalCount ?? 0)
+    }),
+  listWithoutRoot: protectedProcedure
+    .input(listResourceSchema)
+    .query(async ({ input: { siteId, resourceId, offset, limit } }) => {
+      let query = db
+        .selectFrom("Resource")
+        .where("Resource.siteId", "=", siteId)
+        .where("Resource.type", "!=", "RootPage")
+        .offset(offset)
+        .limit(limit)
 
       if (resourceId) {
         query = query.where("Resource.parentId", "=", String(resourceId))

--- a/apps/studio/src/stories/Flows/CreateNewPageFlow.stories.tsx
+++ b/apps/studio/src/stories/Flows/CreateNewPageFlow.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof SitePage> = {
       handlers: [
         meHandlers.me(),
         pageHandlers.getRootPage.default(),
-        pageHandlers.list.default(),
+        pageHandlers.listWithoutRoot.default(),
         sitesHandlers.getConfig.default(),
         sitesHandlers.getTheme.default(),
         sitesHandlers.getFooter.default(),

--- a/apps/studio/src/stories/Page/SitePage.stories.tsx
+++ b/apps/studio/src/stories/Page/SitePage.stories.tsx
@@ -14,8 +14,9 @@ const meta: Meta<typeof SitePage> = {
     msw: {
       handlers: [
         meHandlers.me(),
-        pageHandlers.list.default(),
+        pageHandlers.listWithoutRoot.default(),
         pageHandlers.getRootPage.default(),
+        pageHandlers.count.default(),
         resourceHandlers.getChildrenOf.default(),
       ],
     },

--- a/apps/studio/src/stories/Page/SitePage.stories.tsx
+++ b/apps/studio/src/stories/Page/SitePage.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof SitePage> = {
         meHandlers.me(),
         pageHandlers.listWithoutRoot.default(),
         pageHandlers.getRootPage.default(),
-        pageHandlers.count.default(),
+        pageHandlers.countWithoutRoot.default(),
         resourceHandlers.getChildrenOf.default(),
       ],
     },

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -1,6 +1,7 @@
 import type { DelayMode } from "msw"
 import { delay } from "msw"
 
+import type { RouterOutput } from "~/utils/trpc"
 import { trpcMsw } from "../mockTrpc"
 
 const getRootPageQuery = (wait?: DelayMode | number) => {
@@ -11,58 +12,58 @@ const getRootPageQuery = (wait?: DelayMode | number) => {
     return { title: "A mock page", id: "1", draftBlobId: "1" }
   })
 }
+const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
+  {
+    id: "1",
+    permalink: "newsroom",
+    title: "Press Releases",
+    publishedVersionId: null,
+    draftBlobId: null,
+    type: "Collection",
+  },
+  {
+    id: "4",
+    permalink: "test-page-1",
+    title: "Test page 1",
+    publishedVersionId: null,
+    draftBlobId: "3",
+    type: "Page",
+  },
+  {
+    id: "5",
+    permalink: "test-page-2",
+    title: "Test page 2",
+    publishedVersionId: null,
+    draftBlobId: "4",
+    type: "Page",
+  },
+  {
+    id: "6",
+    permalink: "folder",
+    title: "Test folder 1",
+    publishedVersionId: null,
+    draftBlobId: null,
+    type: "Folder",
+  },
+]
+
 const pageListQuery = (wait?: DelayMode | number) => {
   return trpcMsw.resource.listWithoutRoot.query(async () => {
     if (wait !== undefined) {
       await delay(wait)
     }
-    return [
-      {
-        id: "1",
-        permalink: "",
-        title: "Homepage",
-        publishedVersionId: null,
-        draftBlobId: null,
-        type: "RootPage",
-      },
-      {
-        id: "1",
-        permalink: "newsroom",
-        title: "Press Releases",
-        publishedVersionId: null,
-        draftBlobId: null,
-        type: "Collection",
-      },
-      {
-        id: "4",
-        permalink: "test-page-1",
-        title: "Test page 1",
-        publishedVersionId: null,
-        draftBlobId: "3",
-        type: "Page",
-      },
-      {
-        id: "5",
-        permalink: "test-page-2",
-        title: "Test page 2",
-        publishedVersionId: null,
-        draftBlobId: "4",
-        type: "Page",
-      },
-      {
-        id: "6",
-        permalink: "folder",
-        title: "Test folder 1",
-        publishedVersionId: null,
-        draftBlobId: null,
-        type: "Folder",
-      },
-    ]
+    return DEFAULT_PAGE_ITEMS
   })
 }
 
 export const pageHandlers = {
-  list: {
+  countWithoutRoot: {
+    default: () =>
+      trpcMsw.resource.countWithoutRoot.query(() => {
+        return DEFAULT_PAGE_ITEMS.length
+      }),
+  },
+  listWithoutRoot: {
     default: pageListQuery,
     loading: () => pageListQuery("infinite"),
   },

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -4,7 +4,10 @@ export const resourceHandlers = {
   getChildrenOf: {
     default: () => {
       return trpcMsw.resource.getChildrenOf.query(() => {
-        return []
+        return {
+          items: [],
+          nextOffset: null,
+        }
       })
     },
   },


### PR DESCRIPTION
### TL;DR

Implemented pagination for the Collection and Resource tables, improving performance and user experience for large datasets.

### What changed?

- Added a new `useTablePagination` hook to manage pagination state
- Updated `CollectionTable` and `ResourceTable` components to use pagination
- Modified the backend API to support offset-based pagination
- Added a new `count` endpoint for resources to get the total number of items
- Removed the `totalRowCountString` prop from the `Datatable` component
- Updated the `Datatable` component to use absolute positioning for the loading overlay

### How to test?

1. Navigate to a Collection or Resource table with more than 25 items
2. Verify that only 25 items are displayed initially
3. Use the pagination controls to navigate through the pages
4. Confirm that the total item count is displayed correctly
5. Check that the loading state is shown when fetching new pages

### Why make this change?

This change improves the performance and user experience when dealing with large datasets in Collection and Resource tables. By implementing pagination, we reduce the initial load time and memory usage, while providing a more efficient way to navigate through large sets of data. This also lays the groundwork for future improvements such as sorting and filtering capabilities.
