### PR TITLE
fix: upgrade @headlessui/react to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36685,7 +36685,7 @@
       "dependencies": {
         "@govtechsg/sgds": "^2.3.3",
         "@govtechsg/sgds-react": "^2.5.1",
-        "@headlessui/react": "^2.0.4",
+        "@headlessui/react": "^2.1.2",
         "@sinclair/typebox": "^0.32.34",
         "isomorphic-dompurify": "^2.12.0",
         "js-base64": "^3.7.7",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -98,7 +98,7 @@
   "dependencies": {
     "@govtechsg/sgds": "^2.3.3",
     "@govtechsg/sgds-react": "^2.5.1",
-    "@headlessui/react": "^2.0.4",
+    "@headlessui/react": "^2.1.2",
     "@sinclair/typebox": "^0.32.34",
     "isomorphic-dompurify": "^2.12.0",
     "js-base64": "^3.7.7",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Got some issue with the DialogDrawer.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Upgrade dependency for `@headlessui/react` for the components package.