### PR TITLE
fix(components): remove @tailwindcss/typography and add racPlugin inside Next preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13914,21 +13914,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@tailwindcss/typography": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.13.tgz",
-      "integrity": "sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==",
-      "dev": true,
-      "dependencies": {
-        "lodash.castarray": "^4.4.0",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.merge": "^4.6.2",
-        "postcss-selector-parser": "6.0.10"
-      },
-      "peerDependencies": {
-        "tailwindcss": ">=3.0.0 || insiders"
-      }
-    },
     "node_modules/@tanstack/match-sorter-utils": {
       "version": "8.15.1",
       "resolved": "https://registry.npmjs.org/@tanstack/match-sorter-utils/-/match-sorter-utils-8.15.1.tgz",
@@ -26061,12 +26046,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.castarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
-      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
-      "dev": true
-    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -36718,7 +36697,6 @@
         "@storybook/react": "^8.1.10",
         "@storybook/react-vite": "^8.0.9",
         "@storybook/test": "^8.1.10",
-        "@tailwindcss/typography": "^0.5.13",
         "@types/dompurify": "^3.0.5",
         "@types/lunr": "^2.3.7",
         "@types/react": "^18.3.3",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -43,7 +43,6 @@
     "@storybook/react": "^8.1.10",
     "@storybook/react-vite": "^8.0.9",
     "@storybook/test": "^8.1.10",
-    "@tailwindcss/typography": "^0.5.13",
     "@types/dompurify": "^3.0.5",
     "@types/lunr": "^2.3.7",
     "@types/react": "^18.3.3",

--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss"
+import racPlugin from "tailwindcss-react-aria-components"
 import defaultTheme from "tailwindcss/defaultTheme"
 import plugin from "tailwindcss/plugin"
 
@@ -114,6 +115,7 @@ const config: Config = {
     },
   },
   plugins: [
+    racPlugin,
     isomerTypography,
     plugin(({ addBase }) => {
       addBase({

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -1,6 +1,9 @@
+/**
+ * This file is only used for storybook. The actual tailwind configuration that
+ * built sites used is in the `tailwind.config.js` file in tooling/templates package.
+ */
+
 /** @type {import('tailwindcss').Config} */
-import typographyPlugin from "@tailwindcss/typography"
-import racPlugin from "tailwindcss-react-aria-components"
 
 import classicPreset from "./src/presets/classic"
 import nextPreset from "./src/presets/next"
@@ -31,5 +34,4 @@ export default {
       },
     },
   },
-  plugins: [typographyPlugin, racPlugin],
 }


### PR DESCRIPTION
### TL;DR

Removed @tailwindcss/typography plugin and added tailwindcss-react-aria-components plugin to the Next.js preset instead.

### What changed?

- Removed @tailwindcss/typography dependency from package.json and package-lock.json
- Added tailwindcss-react-aria-components plugin to the Next.js preset configuration
- Updated the Tailwind configuration for Storybook, removing unnecessary plugins

### How to test?

1. Ensure that the project builds successfully without the @tailwindcss/typography plugin
2. Verify that the tailwindcss-react-aria-components plugin is working correctly in the Next.js preset
3. Check that Storybook still functions properly with the updated Tailwind configuration

### Why make this change?

The @tailwindcss/typography plugin was no longer needed, while the tailwindcss-react-aria-components was put in the wrong tailwind config. 
