### PR TITLE
feat(components): add keys where required when mapping over

### DIFF
--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -26,8 +26,9 @@ const KeyStatistics = ({ title, statistics }: KeyStatisticsProps) => {
         {title}
       </h2>
       <div className="flex flex-col flex-wrap gap-x-8 gap-y-12 md:flex-row">
-        {statistics.slice(0, MAX_ITEMS).map(({ label, value }) => (
+        {statistics.slice(0, MAX_ITEMS).map(({ label, value }, index) => (
           <div
+            key={index}
             className={`flex grow flex-col gap-3 ${
               ITEM_WIDTHS[Math.min(MAX_ITEMS, statistics.length)]
             }`}

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -29,8 +29,8 @@ const ArticlePageHeader = ({
             <BaseParagraph content={summary[0]} />
           ) : (
             <ul className="list-disc ps-7">
-              {summary.map((item) => (
-                <li key={Math.random()} className="pl-0.5 [&_p]:inline">
+              {summary.map((item, index) => (
+                <li key={index} className="pl-0.5 [&_p]:inline">
                   <BaseParagraph content={item} />
                 </li>
               ))}

--- a/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
+++ b/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
@@ -36,7 +36,7 @@ const generateSiderailItems = (items: Item[]): JSX.Element[] => {
     }
     // No children
     return (
-      <li className={compoundStyles.container()}>
+      <li key={index} className={compoundStyles.container()}>
         <SiderailLabel
           key={index}
           {...item}

--- a/packages/components/src/templates/next/components/internal/Siderail/SiderailList.tsx
+++ b/packages/components/src/templates/next/components/internal/Siderail/SiderailList.tsx
@@ -65,10 +65,12 @@ export const SiderailList = ({
           <DisclosurePanel>
             <ul>
               {item.childPages.map((child, index) => (
-                <li className={compoundStyles.childHeader({ isOpen })}>
+                <li
+                  key={index}
+                  className={compoundStyles.childHeader({ isOpen })}
+                >
                   <SiderailLabel
                     showIconOnHover
-                    key={index}
                     {...child}
                     className={compoundStyles.childLabel({ isOpen })}
                   />

--- a/packages/components/src/templates/next/render/render.tsx
+++ b/packages/components/src/templates/next/render/render.tsx
@@ -28,6 +28,7 @@ import {
 } from "../layouts"
 
 interface RenderComponentProps {
+  elementKey?: number
   component: IsomerComponent
   assetsBaseUrl?: IsomerSiteConfigProps["assetsBaseUrl"]
   LinkComponent?: any // Next.js link
@@ -38,38 +39,54 @@ export const renderComponent = ({
   component,
   assetsBaseUrl,
   LinkComponent,
+  elementKey,
 }: RenderComponentProps) => {
   switch (component.type) {
     case "accordion":
-      return <Accordion {...component} />
+      return <Accordion key={elementKey} {...component} />
     case "button":
-      return <Button {...component} LinkComponent={LinkComponent} />
+      return (
+        <Button key={elementKey} {...component} LinkComponent={LinkComponent} />
+      )
     case "callout":
-      return <Callout {...component} />
+      return <Callout key={elementKey} {...component} />
     case "hero":
-      return <Hero {...component} />
+      return <Hero key={elementKey} {...component} />
     case "iframe":
-      return <Iframe {...component} />
+      return <Iframe key={elementKey} {...component} />
     case "image":
       return (
         <Image
+          key={elementKey}
           {...component}
           assetsBaseUrl={assetsBaseUrl}
           LinkComponent={LinkComponent}
         />
       )
     case "infobar":
-      return <Infobar {...component} LinkComponent={LinkComponent} />
+      return (
+        <Infobar
+          key={elementKey}
+          {...component}
+          LinkComponent={LinkComponent}
+        />
+      )
     case "infocards":
-      return <InfoCards {...component} />
+      return <InfoCards key={elementKey} {...component} />
     case "infocols":
-      return <InfoCols {...component} LinkComponent={LinkComponent} />
+      return (
+        <InfoCols
+          key={elementKey}
+          {...component}
+          LinkComponent={LinkComponent}
+        />
+      )
     case "infopic":
-      return <Infopic {...component} />
+      return <Infopic key={elementKey} {...component} />
     case "keystatistics":
-      return <KeyStatistics {...component} />
+      return <KeyStatistics key={elementKey} {...component} />
     case "prose":
-      return <Prose {...component} />
+      return <Prose key={elementKey} {...component} />
     default:
       const _: never = component
       return <></>

--- a/packages/components/src/templates/next/render/renderPageContent.ts
+++ b/packages/components/src/templates/next/render/renderPageContent.ts
@@ -11,7 +11,7 @@ export const renderPageContent = ({
   LinkComponent: any
 }) => {
   let isInfopicTextOnRight = false
-  return content.map((component) => {
+  return content.map((component, index) => {
     if (component.type === "infopic") {
       isInfopicTextOnRight = !isInfopicTextOnRight
       const formattedComponent = {
@@ -20,10 +20,16 @@ export const renderPageContent = ({
       }
       return renderComponent({
         component: formattedComponent,
+        elementKey: index,
         assetsBaseUrl,
         LinkComponent,
       })
     }
-    return renderComponent({ component, assetsBaseUrl, LinkComponent })
+    return renderComponent({
+      component,
+      elementKey: index,
+      assetsBaseUrl,
+      LinkComponent,
+    })
   })
 }


### PR DESCRIPTION
### TL;DR

Added missing `key` props to improve React rendering performance and resolve console warnings.

### What changed?

- Added `key` props to various components in multiple files:
  - `KeyStatistics.tsx`: Added `key={index}` to the mapped div elements
  - `ArticlePageHeader.tsx`: Changed `key={Math.random()}` to `key={index}` for list items
  - `Siderail.tsx`: Added `key={index}` to the `li` element
  - `SiderailList.tsx`: Moved `key={index}` from `SiderailLabel` to the parent `li` element
- Updated `renderComponent` function in `render.tsx` to accept and use an `elementKey` prop
- Modified `renderPageContent` in `renderPageContent.ts` to pass `elementKey={index}` to `renderComponent`

### How to test?

1. Run the application and navigate through pages with components like KeyStatistics, ArticlePageHeader, Siderail, and SiderailList
2. Open the browser console and verify that there are no warnings related to missing `key` props
3. Interact with the components to ensure they still function as expected

### Why make this change?

Adding proper `key` props to elements in loops is a React best practice. It helps React identify which items have changed, been added, or been removed, leading to more efficient updates and better performance. This change also eliminates console warnings about missing keys, improving the overall code quality and developer experience.

---