### PR TITLE
feat: collapse all siderail sections by default

### DIFF
--- a/packages/components/src/templates/next/components/internal/Siderail/SiderailList.tsx
+++ b/packages/components/src/templates/next/components/internal/Siderail/SiderailList.tsx
@@ -43,7 +43,7 @@ export const SiderailList = ({
   className,
 }: PropsWithChildren<SiderailListProps>): JSX.Element => {
   return (
-    <Disclosure defaultOpen={item.isCurrent}>
+    <Disclosure>
       {({ open: isOpen }) => (
         <li className={compoundStyles.container({ isOpen, className })}>
           <div className={compoundStyles.header({ isOpen })}>


### PR DESCRIPTION
### TL;DR

Removed `defaultOpen` prop from Disclosure component in SiderailList

### What changed?

The `defaultOpen` prop, which was set to `item.isCurrent`, has been removed from the Disclosure component in the SiderailList component.

### How to test?

1. Navigate to a page with a SiderailList component
2. Verify that the Disclosure component's initial state is not affected by the `item.isCurrent` value
3. Check that the Disclosure component opens and closes correctly when interacted with

### Why make this change?

Sidebar too scary when there are many children. Keep it collapsed by default and users can open if needed