### PR TITLE
fix: sidebar

### DIFF
--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -82,6 +82,7 @@ const SideNavItem = ({
 }: SideNavItemProps) => {
   const [children] = trpc.resource.getChildrenOf.useSuspenseQuery({
     resourceId,
+    siteId,
   })
 
   const icon = ICON_MAPPINGS[resourceType]

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -22,6 +22,8 @@ import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
 import type { PendingMoveResource } from "../../types"
 import { withSuspense } from "~/hocs/withSuspense"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { sitePageSchema } from "~/pages/sites/[siteId]"
 import { isAllowedToHaveChildren } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
 import { moveResourceAtom } from "../../atoms"
@@ -58,6 +60,7 @@ const MoveResourceContent = withSuspense(
     const [resourceStack, setResourceStack] = useState<PendingMoveResource[]>(
       [],
     )
+    const { siteId } = useQueryParse(sitePageSchema)
     const setMovedItem = useSetAtom(moveResourceAtom)
     const [{ title }] = trpc.resource.getMetadataById.useSuspenseQuery({
       resourceId,
@@ -65,6 +68,7 @@ const MoveResourceContent = withSuspense(
     const curResourceId = resourceStack[resourceStack.length - 1]?.resourceId
     const [children] = trpc.resource.getChildrenOf.useSuspenseQuery({
       resourceId: curResourceId ?? null,
+      siteId: String(siteId),
     })
     const utils = trpc.useUtils()
     const toast = useToast({ status: "success" })

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -18,6 +18,7 @@ export const getMetadataSchema = z.object({
 
 export const getChildrenSchema = z.object({
   resourceId: z.union([bigIntSchema, z.null()]),
+  siteId: z.string().min(0),
 })
 
 export const moveSchema = z.object({

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -27,15 +27,14 @@ export const resourceRouter = router({
       return resource
     }),
 
-  // TODO: Hint to the frontend that this can never return
-  // a `RootPage`
   getChildrenOf: protectedProcedure
     .input(getChildrenSchema)
-    .query(async ({ input: { resourceId } }) => {
+    .query(async ({ input: { resourceId, siteId } }) => {
       let query = db
         .selectFrom("Resource")
         .select(["title", "permalink", "type", "id"])
         .where("Resource.type", "!=", "RootPage")
+        .where("Resource.siteId", "=", Number(siteId))
         .$narrowType<{
           type: Extract<
             "Folder" | "Page" | "Collection" | "CollectionPage",


### PR DESCRIPTION
## Problem
Right now we don't have a `where` clause on `siteId`, leading to roto page queries being bugged and showing all pages across all sites.

## Solution
add a `where` clause
