### PR TITLE
feat: update breadcrumb a11y, show current path too

### DIFF
--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
@@ -34,7 +34,7 @@ export const Grandchild: Story = {
       },
       {
         title:
-          "Steven Pinker's Rationality the quick brown fox jumps over the lazy",
+          "Steven Pinker's Rationality the quick brown fox jumps over the lazy dog",
         url: "/irrationality/individuals/pinker-rationality",
       },
     ],

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<BreadcrumbProps> = {
 export default meta
 type Story = StoryObj<typeof Breadcrumb>
 
-export const Default: Story = {
+export const Grandchild: Story = {
   args: {
     links: [
       {
@@ -30,6 +30,32 @@ export const Default: Story = {
       {
         title: "Steven Pinker's Rationality",
         url: "/irrationality/individuals/pinker-rationality",
+      },
+    ],
+  },
+}
+
+export const SingleChild: Story = {
+  args: {
+    links: [
+      {
+        title: "Irrationality",
+        url: "/irrationality",
+      },
+      {
+        title: "For Individuals",
+        url: "/irrationality/individuals",
+      },
+    ],
+  },
+}
+
+export const NoChildren: Story = {
+  args: {
+    links: [
+      {
+        title: "Irrationality",
+        url: "/irrationality",
       },
     ],
   },

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import type { BreadcrumbProps } from "~/interfaces"
 import Breadcrumb from "./Breadcrumb"
 
@@ -17,6 +19,9 @@ export default meta
 type Story = StoryObj<typeof Breadcrumb>
 
 export const Grandchild: Story = {
+  parameters: {
+    chromatic: withChromaticModes(["desktop", "mobile"]),
+  },
   args: {
     links: [
       {

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.stories.tsx
@@ -24,11 +24,12 @@ export const Grandchild: Story = {
         url: "/irrationality",
       },
       {
-        title: "For Individuals",
+        title: "For Individuals this is a long long long long long long child",
         url: "/irrationality/individuals",
       },
       {
-        title: "Steven Pinker's Rationality",
+        title:
+          "Steven Pinker's Rationality the quick brown fox jumps over the lazy",
         url: "/irrationality/individuals/pinker-rationality",
       },
     ],

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import type { ElementType } from "react"
 import type {
   BreadcrumbProps as AriaBreadcrumbProps,

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -47,15 +47,17 @@ const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
               >
                 {link.title}
               </Link>
+              {last && index === rest.length - 1 && (
+                <BiChevronRight
+                  aria-hidden="true"
+                  className={compoundStyles.icon()}
+                />
+              )}
             </li>
           )
         })}
         {last && (
           <li className={compoundStyles.container()}>
-            <BiChevronRight
-              aria-hidden="true"
-              className={compoundStyles.icon()}
-            />
             <span>{last.title}</span>
           </li>
         )}

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,7 @@ import { Link } from "../Link"
 
 const breadcrumbStyles = tv({
   slots: {
-    nav: "flex flex-row flex-wrap items-center gap-2 text-base-content",
+    nav: "flex flex-row flex-wrap items-center gap-1 text-base-content",
     container:
       "prose-label-md-regular flex flex-row items-center gap-1 last:prose-label-md-medium last:text-base-content-medium",
     link: "underline decoration-transparent underline-offset-4 transition active:text-interaction-link-active hover:decoration-inherit",
@@ -31,6 +31,15 @@ const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
             >
               {root.title}
             </Link>
+            {
+              // Edge case, if there is only one child link in the breadcrumb
+              last && rest.length === 0 && (
+                <BiChevronRight
+                  aria-hidden="true"
+                  className={compoundStyles.icon()}
+                />
+              )
+            }
           </li>
         )}
         {rest.map((link, index) => {

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -2,6 +2,7 @@ import { BiChevronRight } from "react-icons/bi"
 
 import type { BreadcrumbProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
+import { Link } from "../Link"
 
 const breadcrumbStyles = tv({
   slots: {
@@ -17,14 +18,19 @@ const compoundStyles = breadcrumbStyles()
 
 const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
   const [root, ...rest] = links
+  const last = rest.pop()
   return (
     <nav aria-label="Breadcrumb">
       <ol role="list" className={compoundStyles.nav()}>
         {root && (
           <li className={compoundStyles.container()}>
-            <LinkComponent href={root.url} className={compoundStyles.link()}>
+            <Link
+              LinkComponent={LinkComponent}
+              href={root.url}
+              className={compoundStyles.link()}
+            >
               {root.title}
-            </LinkComponent>
+            </Link>
           </li>
         )}
         {rest.map((link, index) => {
@@ -34,12 +40,25 @@ const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
                 aria-hidden="true"
                 className={compoundStyles.icon()}
               />
-              <LinkComponent href={link.url} className={compoundStyles.link()}>
+              <Link
+                LinkComponent={LinkComponent}
+                href={link.url}
+                className={compoundStyles.link()}
+              >
                 {link.title}
-              </LinkComponent>
+              </Link>
             </li>
           )
         })}
+        {last && (
+          <li className={compoundStyles.container()}>
+            <BiChevronRight
+              aria-hidden="true"
+              className={compoundStyles.icon()}
+            />
+            <span>{last.title}</span>
+          </li>
+        )}
       </ol>
     </nav>
   )

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -1,77 +1,76 @@
+import type { ElementType } from "react"
+import type {
+  BreadcrumbProps as AriaBreadcrumbProps,
+  BreadcrumbsProps,
+  LinkProps,
+} from "react-aria-components"
+import {
+  Breadcrumb as AriaBreadcrumb,
+  Breadcrumbs as AriaBreadcrumbs,
+  composeRenderProps,
+} from "react-aria-components"
 import { BiChevronRight } from "react-icons/bi"
 
 import type { BreadcrumbProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
+import { twMerge } from "~/lib/twMerge"
+import { focusRing } from "~/utils/focusRing"
 import { Link } from "../Link"
 
-const breadcrumbStyles = tv({
-  slots: {
-    nav: "flex flex-row flex-wrap items-center gap-1 text-base-content",
-    container:
-      "prose-label-md-regular flex flex-row items-center gap-1 last:prose-label-md-medium last:text-base-content-medium",
-    link: "underline decoration-transparent underline-offset-4 transition active:text-interaction-link-active hover:decoration-inherit",
-    icon: "h-5 w-5 flex-shrink-0 text-base-content-subtle",
-  },
+const breadcrumbLinkStyles = tv({
+  extend: focusRing,
+  base: "prose-label-md-regular line-clamp-1 text-base-content underline decoration-transparent underline-offset-4 transition current:prose-label-md-medium active:text-interaction-link-active current:text-base-content-medium hover:decoration-inherit current:hover:decoration-transparent",
 })
 
-const compoundStyles = breadcrumbStyles()
+function BaseBreadcrumbs<T extends object>(props: BreadcrumbsProps<T>) {
+  return (
+    <AriaBreadcrumbs
+      {...props}
+      className={twMerge("flex flex-wrap gap-1", props.className)}
+    />
+  )
+}
+
+function BaseBreadcrumb({
+  LinkComponent,
+  ...props
+}: AriaBreadcrumbProps & LinkProps & { LinkComponent?: ElementType }) {
+  return (
+    <AriaBreadcrumb {...props} className="flex items-center gap-1">
+      <Link
+        {...props}
+        title={typeof props.children === "string" ? props.children : undefined}
+        className={composeRenderProps(
+          props.className,
+          (className, renderProps) =>
+            breadcrumbLinkStyles({
+              className,
+              ...renderProps,
+            }),
+        )}
+        LinkComponent={LinkComponent}
+      />
+      {props.href && (
+        <BiChevronRight className="h-5 w-5 flex-shrink-0 text-base-content-subtle" />
+      )}
+    </AriaBreadcrumb>
+  )
+}
 
 const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
-  const [root, ...rest] = links
-  const last = rest.pop()
   return (
-    <nav aria-label="Breadcrumb">
-      <ol role="list" className={compoundStyles.nav()}>
-        {root && (
-          <li className={compoundStyles.container()}>
-            <Link
-              LinkComponent={LinkComponent}
-              href={root.url}
-              className={compoundStyles.link()}
-            >
-              {root.title}
-            </Link>
-            {
-              // Edge case, if there is only one child link in the breadcrumb
-              last && rest.length === 0 && (
-                <BiChevronRight
-                  aria-hidden="true"
-                  className={compoundStyles.icon()}
-                />
-              )
-            }
-          </li>
-        )}
-        {rest.map((link, index) => {
-          return (
-            <li key={index} className={compoundStyles.container()}>
-              <BiChevronRight
-                aria-hidden="true"
-                className={compoundStyles.icon()}
-              />
-              <Link
-                LinkComponent={LinkComponent}
-                href={link.url}
-                className={compoundStyles.link()}
-              >
-                {link.title}
-              </Link>
-              {last && index === rest.length - 1 && (
-                <BiChevronRight
-                  aria-hidden="true"
-                  className={compoundStyles.icon()}
-                />
-              )}
-            </li>
-          )
-        })}
-        {last && (
-          <li className={compoundStyles.container()}>
-            <span>{last.title}</span>
-          </li>
-        )}
-      </ol>
-    </nav>
+    <BaseBreadcrumbs>
+      {links.map(({ title, url }, index) => (
+        <BaseBreadcrumb
+          LinkComponent={LinkComponent}
+          key={index}
+          aria-current={index === links.length - 1 ? "page" : undefined}
+          href={index === links.length - 1 ? undefined : url}
+        >
+          {title}
+        </BaseBreadcrumb>
+      ))}
+    </BaseBreadcrumbs>
   )
 }
 

--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
@@ -15,9 +15,9 @@ const ContentPageHeader = ({
   return (
     <div className="bg-brand-canvas text-base-content-strong">
       <div className="mx-auto flex max-w-screen-xl flex-col gap-8 px-6 py-8 md:px-10">
-        <div className="flex flex-col">
+        <div className="flex max-w-[54rem] flex-col">
           <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
-          <div className="mt-8 flex max-w-[54rem] flex-col gap-5 md:mt-6">
+          <div className="mt-8 flex flex-col gap-5 md:mt-6">
             <h1 className="prose-display-lg">{title}</h1>
             <p className="prose-title-lg-regular">{summary}</p>
           </div>

--- a/packages/components/src/templates/next/components/internal/Link/Link.tsx
+++ b/packages/components/src/templates/next/components/internal/Link/Link.tsx
@@ -30,6 +30,7 @@ import { useRenderProps } from "./utils"
 export interface LinkProps extends BaseLinkProps {
   LinkComponent?: ElementType
   "aria-current"?: string
+  title?: string
 }
 
 const LinkContext =
@@ -38,46 +39,49 @@ const LinkContext =
 /**
  * Modified version of `react-aria-component`'s Link component to accept a `LinkComponent` prop.
  */
-export const Link = forwardRef<HTMLAnchorElement, LinkProps>((_props, _ref) => {
-  const [props, ref] = useContextProps(_props, _ref, LinkContext)
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ title, ..._props }, _ref) => {
+    const [props, ref] = useContextProps(_props, _ref, LinkContext)
 
-  const ElementType: ElementType = props.href ? "a" : "span"
-  const { linkProps, isPressed } = useLink(
-    { ...props, elementType: ElementType },
-    ref,
-  )
+    const ElementType: ElementType = props.href ? "a" : "span"
+    const { linkProps, isPressed } = useLink(
+      { ...props, elementType: ElementType },
+      ref,
+    )
 
-  const { hoverProps, isHovered } = useHover(props)
-  const { focusProps, isFocused, isFocusVisible } = useFocusRing()
+    const { hoverProps, isHovered } = useHover(props)
+    const { focusProps, isFocused, isFocusVisible } = useFocusRing()
 
-  const renderProps = useRenderProps({
-    ...props,
-    defaultClassName: "react-aria-Link",
-    values: {
-      isCurrent: !!props["aria-current"],
-      isDisabled: props.isDisabled || false,
-      isPressed,
-      isHovered,
-      isFocused,
-      isFocusVisible,
-    },
-  })
+    const renderProps = useRenderProps({
+      ...props,
+      defaultClassName: "react-aria-Link",
+      values: {
+        isCurrent: !!props["aria-current"],
+        isDisabled: props.isDisabled || false,
+        isPressed,
+        isHovered,
+        isFocused,
+        isFocusVisible,
+      },
+    })
 
-  const ElementToRender = props.href ? props.LinkComponent ?? "a" : "span"
+    const ElementToRender = props.href ? props.LinkComponent ?? "a" : "span"
 
-  return (
-    <ElementToRender
-      ref={ref}
-      slot={props.slot ?? undefined}
-      {...mergeProps(renderProps, linkProps, hoverProps, focusProps)}
-      data-focused={isFocused || undefined}
-      data-hovered={isHovered || undefined}
-      data-pressed={isPressed || undefined}
-      data-focus-visible={isFocusVisible || undefined}
-      data-current={!!props["aria-current"] || undefined}
-      data-disabled={props.isDisabled || undefined}
-    >
-      {renderProps.children}
-    </ElementToRender>
-  )
-})
+    return (
+      <ElementToRender
+        title={title}
+        ref={ref}
+        slot={props.slot ?? undefined}
+        {...mergeProps(renderProps, linkProps, hoverProps, focusProps)}
+        data-focused={isFocused || undefined}
+        data-hovered={isHovered || undefined}
+        data-pressed={isPressed || undefined}
+        data-focus-visible={isFocusVisible || undefined}
+        data-current={!!props["aria-current"] || undefined}
+        data-disabled={props.isDisabled || undefined}
+      >
+        {renderProps.children}
+      </ElementToRender>
+    )
+  },
+)

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -40,7 +40,8 @@ export const Default: Story = {
             summary: "",
             children: [
               {
-                title: "Irrationality",
+                title:
+                  "Irrationality this should have a long long long long long long long title that wraps to the max width of the content header, and truncates if necessary",
                 permalink: "/parent/rationality",
                 lastModified: "",
                 layout: "content",

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -41,7 +41,7 @@ export const Default: Story = {
             children: [
               {
                 title:
-                  "Irrationality this should have a long long long long long long long title that wraps to the max width of the content header, and truncates if necessary",
+                  "Irrationality this should have a long long long long long long long title that wraps to the max width of the content header, and its' breadcrumb truncates, but ideally should not be this long",
                 permalink: "/parent/rationality",
                 lastModified: "",
                 layout: "content",
@@ -307,7 +307,8 @@ export const Default: Story = {
     page: {
       permalink: "/parent/rationality",
       lastModified: "2024-05-02T14:12:57.160Z",
-      title: "Content page",
+      title:
+        "Irrationality this should have a long long long long long long long title that wraps to the max width of the content header, and its' breadcrumb truncates, but ideally should not be this long",
       description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary:
@@ -1283,7 +1284,7 @@ export const NoTable: Story = {
     },
     page: {
       permalink: "/parent/rationality",
-      title: "Content page",
+      title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
       description: "A Next.js starter for Isomer",
       contentPageHeader: {
@@ -1665,7 +1666,7 @@ export const SmallTable: Story = {
     },
     page: {
       permalink: "/parent/rationality",
-      title: "Content page",
+      title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
       description: "A Next.js starter for Isomer",
       contentPageHeader: {
@@ -2162,8 +2163,8 @@ export const FirstLevelPage: Story = {
         summary: "",
         children: [
           {
-            title: "Parent page",
-            permalink: "/parent",
+            title: "Content page",
+            permalink: "/content",
             lastModified: "",
             layout: "content",
             summary: "",
@@ -2234,7 +2235,7 @@ export const FirstLevelPage: Story = {
       },
     },
     page: {
-      permalink: "/parent",
+      permalink: "/content",
       title: "Content page",
       lastModified: "2024-05-02T14:12:57.160Z",
       description: "A Next.js starter for Isomer",

--- a/packages/components/src/utils/getBreadcrumbFromSiteMap.ts
+++ b/packages/components/src/utils/getBreadcrumbFromSiteMap.ts
@@ -16,7 +16,7 @@ export const getBreadcrumbFromSiteMap = (
   let node = sitemap
   let currentPath = ""
 
-  for (const pathSegment of permalink.slice(0, -1)) {
+  for (const pathSegment of permalink) {
     currentPath += "/" + pathSegment
     const nextNode = node.children?.find(
       (node) => node.permalink === currentPath,


### PR DESCRIPTION
### TL;DR

Enhanced Breadcrumb component functionality and improved sitemap navigation.

### What changed?

- Updated Breadcrumb component to use the Link component for consistent styling
- Added special handling for the last item in the breadcrumb, displaying it as plain text
- Modified getBreadcrumbFromSiteMap function to include the last segment of the permalink

### How to test?

1. Navigate to a page with a multi-level breadcrumb
2. Verify that all links except the last one are clickable
3. Confirm that the last item in the breadcrumb is displayed as plain text
4. Check that the breadcrumb accurately reflects the full path, including the current page

### Why make this change?

This change improves the user experience by:
1. Providing consistent link styling throughout the breadcrumb
2. Clearly indicating the current page as the last, non-clickable item in the breadcrumb
3. Ensuring that the full path, including the current page, is represented in the breadcrumb navigation

These enhancements make it easier for users to understand their current location within the site structure and navigate between related pages.

---