### PR TITLE
feat: capture responsive viewports for typography story

### DIFF
--- a/packages/components/src/stories/foundation/Typography.stories.tsx
+++ b/packages/components/src/stories/foundation/Typography.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 const meta: Meta = {
   title: "Foundation/Typography",
   tags: ["!autodocs"],
+  parameters: {
+    chromatic: withChromaticModes(["desktop", "tablet", "mobile"]),
+  },
 }
 export default meta
 type Story = StoryObj<typeof meta>


### PR DESCRIPTION
### TL;DR

Added Chromatic modes for Typography stories 

### What changed?

- Added Chromatic modes (desktop, tablet, mobile) to the Typography stories using `withChromaticModes`.

### How to test?

1. Run Storybook and navigate to the Typography stories.
2. Verify that the stories are now captured in desktop, tablet, and mobile modes in Chromatic.


### Why make this change?

- Adding Chromatic modes to Typography stories ensures consistent rendering across different device types, improving the overall design system consistency.
