### PR TITLE
fix(vapt): update sanitization

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@chakra-ui/react"
 import { Button, useToast } from "@opengovsg/design-system-react"
 import { useAtomValue, useSetAtom } from "jotai"
+import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
 import { generateResourceUrl } from "~/features/editing-experience/components/utils"
@@ -73,14 +74,21 @@ const SuspendableModalContent = ({
       siteId,
       resourceId: Number(folderId),
     })
-  const { setValue, register, handleSubmit, watch, formState, getFieldState } =
-    useZodForm({
-      defaultValues: {
-        title: originalTitle,
-        permalink: originalPermalink,
-      },
-      schema: baseEditFolderSchema.omit({ siteId: true, resourceId: true }),
-    })
+  const {
+    setValue,
+    register,
+    handleSubmit,
+    watch,
+    control,
+    formState,
+    getFieldState,
+  } = useZodForm({
+    defaultValues: {
+      title: originalTitle,
+      permalink: originalPermalink,
+    },
+    schema: baseEditFolderSchema.omit({ siteId: true, resourceId: true }),
+  })
   const { errors, isValid } = formState
   const utils = trpc.useUtils()
   const toast = useToast()
@@ -158,9 +166,18 @@ const SuspendableModalContent = ({
                   This will be applied to every child under this folder.
                 </FormHelperText>
               </FormLabel>
-              <Input
-                placeholder="This is a url for your new page"
-                {...register("permalink")}
+              <Controller
+                control={control}
+                name="permalink"
+                render={({ field: { onChange, ...field } }) => (
+                  <Input
+                    placeholder="This is a url for your folder"
+                    {...field}
+                    onChange={(e) => {
+                      onChange(generateResourceUrl(e.target.value))
+                    }}
+                  />
+                )}
               />
               {errors.permalink?.message && (
                 <FormErrorMessage>{errors.permalink.message}</FormErrorMessage>

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -1,6 +1,13 @@
 import { z } from "zod"
 
+import { generateBasePermalinkSchema } from "./common"
 import { MAX_FOLDER_PERMALINK_LENGTH, MAX_FOLDER_TITLE_LENGTH } from "./folder"
+
+const permalinkSchema = generateBasePermalinkSchema("folder")
+  .min(1, { message: "Enter a URL for this folder" })
+  .max(MAX_FOLDER_PERMALINK_LENGTH, {
+    message: `Folder URL should be shorter than ${MAX_FOLDER_PERMALINK_LENGTH} characters.`,
+  })
 
 export const createCollectionSchema = z.object({
   collectionTitle: z
@@ -9,11 +16,6 @@ export const createCollectionSchema = z.object({
     .max(MAX_FOLDER_TITLE_LENGTH, {
       message: `Folder title should be shorter than ${MAX_FOLDER_TITLE_LENGTH} characters.`,
     }),
-  permalink: z
-    .string()
-    .min(1, { message: "Enter a URL for this folder" })
-    .max(MAX_FOLDER_PERMALINK_LENGTH, {
-      message: `Folder URL should be shorter than ${MAX_FOLDER_PERMALINK_LENGTH} characters.`,
-    }),
+  permalink: permalinkSchema,
   siteId: z.number().min(1),
 })

--- a/apps/studio/src/schemas/common.ts
+++ b/apps/studio/src/schemas/common.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+export const generateBasePermalinkSchema = (label: string) =>
+  z
+    .string({
+      required_error: `Enter a URL for this ${label}.`,
+    })
+    // Using `*` instead of `+` to allow empty strings, so the correct required error message is shown instead of the regex error message.
+    .regex(/^[a-z0-9\-]*$/, {
+      message: "Only lowercase alphanumeric characters and hyphens are allowed",
+    })

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -1,8 +1,16 @@
 import { z } from "zod"
 
+import { generateBasePermalinkSchema } from "./common"
+
 export const MAX_FOLDER_TITLE_LENGTH = 100
 export const MAX_FOLDER_PERMALINK_LENGTH = 200
 export const MAX_FOLDER_DESCRIPTION_LENGTH = 300
+
+const permalinkSchema = generateBasePermalinkSchema("folder")
+  .min(1, { message: "Enter a URL for this folder" })
+  .max(MAX_FOLDER_PERMALINK_LENGTH, {
+    message: `Folder URL should be shorter than ${MAX_FOLDER_PERMALINK_LENGTH} characters.`,
+  })
 
 export const createFolderSchema = z.object({
   folderTitle: z
@@ -11,12 +19,7 @@ export const createFolderSchema = z.object({
     .max(MAX_FOLDER_TITLE_LENGTH, {
       message: `Folder title should be shorter than ${MAX_FOLDER_TITLE_LENGTH} characters.`,
     }),
-  permalink: z
-    .string()
-    .min(1, { message: "Enter a URL for this folder" })
-    .max(MAX_FOLDER_PERMALINK_LENGTH, {
-      message: `Folder URL should be shorter than ${MAX_FOLDER_PERMALINK_LENGTH} characters.`,
-    }),
+  permalink: permalinkSchema,
   siteId: z.number().min(1),
   // Nullable for top level folder
   parentFolderId: z.number().optional(),
@@ -29,7 +32,7 @@ export const readFolderSchema = z.object({
 
 export const baseEditFolderSchema = z.object({
   resourceId: z.string(),
-  permalink: z.optional(z.string()),
+  permalink: z.optional(permalinkSchema),
   title: z.optional(z.string()),
   siteId: z.string(),
 })

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -1,5 +1,7 @@
 import { z } from "zod"
 
+import { generateBasePermalinkSchema } from "./common"
+
 const NEW_PAGE_LAYOUT_VALUES = [
   "article",
   "content",
@@ -7,6 +9,12 @@ const NEW_PAGE_LAYOUT_VALUES = [
 
 export const MAX_TITLE_LENGTH = 150
 export const MAX_PAGE_URL_LENGTH = 250
+
+const permalinkSchema = generateBasePermalinkSchema("page")
+  .min(1, { message: "Enter a URL for this page" })
+  .max(MAX_PAGE_URL_LENGTH, {
+    message: `Page URL should be shorter than ${MAX_PAGE_URL_LENGTH} characters.`,
+  })
 
 export const getEditPageSchema = z.object({
   pageId: z.number().min(1),
@@ -55,18 +63,7 @@ export const createPageSchema = z.object({
     .max(MAX_TITLE_LENGTH, {
       message: `Page title should be shorter than ${MAX_TITLE_LENGTH} characters.`,
     }),
-  permalink: z
-    .string({
-      required_error: "Enter a URL for this page.",
-    })
-    // Using `*` instead of `+` to allow empty strings, so the correct required error message is shown instead of the regex error message.
-    .regex(/^[a-z0-9\-]*$/, {
-      message: "Only lowercase alphanumeric characters and hyphens are allowed",
-    })
-    .min(1, { message: "Enter a URL for this page" })
-    .max(MAX_PAGE_URL_LENGTH, {
-      message: `Page URL should be shorter than ${MAX_PAGE_URL_LENGTH} characters.`,
-    }),
+  permalink: permalinkSchema,
   layout: z.enum(NEW_PAGE_LAYOUT_VALUES).default("content"),
   siteId: z.number().min(1),
   // NOTE: implies that top level pages are allowed

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -76,13 +76,7 @@ export const folderRouter = router({
         .updateTable("Resource")
         .where("Resource.id", "=", resourceId)
         .where("Resource.siteId", "=", Number(siteId))
-        .where((eb) =>
-          eb("Resource.type", "=", "Folder").or(
-            "Resource.type",
-            "=",
-            "Collection",
-          ),
-        )
+        .where("Resource.type", "in", ["Folder", "Collection"])
         .set({
           permalink,
           title,

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -56,7 +56,7 @@ export const folderRouter = router({
           id: c.id,
           permalink: c.permalink,
           title: c.title,
-          type: ResourceType.Folder,
+          type: c.type,
         }
       })
 
@@ -76,7 +76,13 @@ export const folderRouter = router({
         .updateTable("Resource")
         .where("Resource.id", "=", resourceId)
         .where("Resource.siteId", "=", Number(siteId))
-        .where("Resource.type", "=", "Folder")
+        .where((eb) =>
+          eb("Resource.type", "=", "Folder").or(
+            "Resource.type",
+            "=",
+            "Collection",
+          ),
+        )
         .set({
           permalink,
           title,


### PR DESCRIPTION
## Problem
Previously, we had a path traversal attack against us where the directory name was not generated correctly in the presence of `../..`.

to counteract this, we adopt a strict validation of only allowing alphanumeric + `-`, similar to pages.

## Solution
1. use same validator throughout fe/be and for pages/collections/folder
2. for frontend, update so that disallowed characters (non alphanum) are automatically replaced with `-`