### PR TITLE
fix: update directory paths

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -124,14 +124,19 @@ async function writeContentToFile(
       return
     }
 
-    const sanitizedPermalink = path
-      // NOTE: normalization here will remove dual backslashes
-      // and also strip .. filepaths except as a prefix
-      .normalize(fullPermalink)
-      // NOTE: this matches on a leading ../
-      // or a leading ..\
-      // or a plain .. without any paths
-      .replace(/^(\.\.(\/|\\|$))+/, "")
+    // NOTE: do a join with ./ here so that
+    // we don't end up with an absolute path to a special unix folder
+    const sanitizedPermalink = path.join(
+      "./",
+      path
+        // NOTE: normalization here will remove dual backslashes
+        // and also strip .. filepaths except as a prefix
+        .normalize(fullPermalink)
+        // NOTE: this matches on a leading ../
+        // or a leading ..\
+        // or a plain .. without any paths
+        .replace(/^(\.\.(\/|\\|$))+/, ""),
+    )
 
     const directoryPath =
       parentId === null

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -124,12 +124,21 @@ async function writeContentToFile(
       return
     }
 
+    const sanitizedPermalink = path
+      // NOTE: normalization here will remove dual backslashes
+      // and also strip .. filepaths except as a prefix
+      .normalize(fullPermalink)
+      // NOTE: this matches on a leading ../
+      // or a leading ..\
+      // or a plain .. without any paths
+      .replace(/^(\.\.(\/|\\|$))+/, "")
+
     const directoryPath =
       parentId === null
         ? path.join(__dirname, "schema")
-        : path.join(__dirname, "schema", path.dirname(fullPermalink))
+        : path.join(__dirname, "schema", path.dirname(sanitizedPermalink))
 
-    const fileName = `${path.basename(fullPermalink)}.json`
+    const fileName = `${path.basename(sanitizedPermalink)}.json`
     const filePath = path.join(directoryPath, fileName)
 
     // Create directories if they don't exist


### PR DESCRIPTION
## Problem
We have a reverse code execution issue as we allow arbitrary file writes. this fixes the problem by sanitizing the path passed to our build.

## Solution
[normalize](https://nodejs.org/api/path.html#path_path_normalize_path) the filepath first so that only leading `..` is allowed. next, we strip the leading `../` because we'll be doing a `file.join` anyways. 

this still allows hidden files/folders: `/.git` is allowed, for example.
