### PR TITLE
feat(InfoCards): add maxColumns styling prop

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -100,4 +100,5 @@ export type SingleCardWithImageProps = Static<
 export type InfoCardsProps = Static<typeof InfoCardsSchema> & {
   LinkComponent?: any // Next.js link
   sectionIdx?: number // TODO: Remove this property, only used in classic theme
+  maxColumns?: 1 | 2 | 3
 }

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -50,7 +50,11 @@ const InfoCardsBaseSchema = Type.Object({
     }),
   ),
   maxColumns: Type.Optional(
-    Type.Union([Type.Literal(1), Type.Literal(2), Type.Literal(3)]),
+    Type.Union([Type.Literal(1), Type.Literal(2), Type.Literal(3)], {
+      title: "Maximum columns variant",
+      description:
+        "Controls the responsive behaviour regarding the number of columns that this component will expand to in different viewports",
+    }),
   ),
 })
 

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -49,6 +49,9 @@ const InfoCardsBaseSchema = Type.Object({
       default: "This is an optional description for the Cards component",
     }),
   ),
+  maxColumns: Type.Optional(
+    Type.Union([Type.Literal(1), Type.Literal(2), Type.Literal(3)]),
+  ),
 })
 
 const InfoCardsWithImageSchema = Type.Object(
@@ -100,5 +103,4 @@ export type SingleCardWithImageProps = Static<
 export type InfoCardsProps = Static<typeof InfoCardsSchema> & {
   LinkComponent?: any // Next.js link
   sectionIdx?: number // TODO: Remove this property, only used in classic theme
-  maxColumns?: 1 | 2 | 3
 }

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -16,7 +16,7 @@ const createInfoCardsStyles = tv({
     headingContainer: "flex flex-col gap-2.5 pb-8 sm:pb-12 lg:max-w-3xl",
     headingTitle: "prose-display-md text-base-content-strong",
     headingSubtitle: "prose-headline-lg-regular text-base-content",
-    grid: "grid grid-cols-1 gap-10 md:grid-cols-2 md:gap-7 lg:grid-cols-3 lg:gap-x-16 lg:gap-y-12",
+    grid: "grid grid-cols-1 gap-10 md:gap-7 lg:gap-x-16 lg:gap-y-12",
     cardContainer: "group flex flex-col gap-5 outline-offset-4",
     cardImageContainer:
       "h-[11.875rem] w-full overflow-hidden rounded-lg border border-base-divider-subtle drop-shadow-none transition ease-in md:h-52",
@@ -34,6 +34,20 @@ const createInfoCardsStyles = tv({
         cardImageContainer: "group-hover:drop-shadow-md",
       },
     },
+    maxColumns: {
+      1: {
+        grid: "",
+      },
+      2: {
+        grid: "md:grid-cols-2",
+      },
+      3: {
+        grid: "lg:grid-cols-3",
+      },
+    },
+  },
+  defaultVariants: {
+    maxColumns: 3,
   },
 })
 
@@ -143,6 +157,7 @@ const InfoCards = ({
   variant,
   cards,
   LinkComponent,
+  maxColumns,
 }: InfoCardsProps): JSX.Element => {
   const InfoCardtoRender = () => {
     switch (variant) {
@@ -182,7 +197,7 @@ const InfoCards = ({
         <InfoCardsHeadingSection title={title} subtitle={subtitle} />
       )}
 
-      <div className={compoundStyles.grid()}>
+      <div className={compoundStyles.grid({ maxColumns })}>
         <InfoCardtoRender />
       </div>
     </section>

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -42,7 +42,7 @@ const createInfoCardsStyles = tv({
         grid: "md:grid-cols-2",
       },
       3: {
-        grid: "lg:grid-cols-3",
+        grid: "md:grid-cols-2 lg:grid-cols-3",
       },
     },
   },

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -12,7 +12,7 @@ import { Link } from "../../internal/Link"
 
 const createInfoCardsStyles = tv({
   slots: {
-    container: `${ComponentContent} mx-auto flex flex-col py-12 first:pt-0 lg:py-24`,
+    container: `${ComponentContent} flex flex-col py-12 first:pt-0 lg:py-24`,
     headingContainer: "flex flex-col gap-2.5 pb-8 sm:pb-12 lg:max-w-3xl",
     headingTitle: "prose-display-md text-base-content-strong",
     headingSubtitle: "prose-headline-lg-regular text-base-content",

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
@@ -117,6 +117,7 @@ export const WithSiderail: Story = {
       {
         type: "infocards",
         variant: "cardsWithoutImages",
+        maxColumns: 1,
         cards: [
           {
             title:
@@ -244,6 +245,7 @@ export const NoSiderail: Story = {
       {
         type: "infocards",
         variant: "cardsWithoutImages",
+        maxColumns: 1,
         cards: [
           {
             title:

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -19,6 +19,9 @@ const createIndexPageLayoutStyles = tv({
       true: {
         content: "lg:col-span-9 lg:ml-24",
       },
+      false: {
+        content: "max-w-[54rem]",
+      },
     },
   },
 })

--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -125,6 +125,7 @@ const processDanglingDirectory = async (fullPath, relativePath, name) => {
       url: child.permalink,
       description: child.summary,
     })),
+    maxColumns: 1,
   }
 
   const pageName = name.replace(/-/g, " ")


### PR DESCRIPTION
oops forgot submit

### TL;DR

Added a new `maxColumns` property to the InfoCards component, allowing for customizable grid layouts.

### What changed?

- Introduced a `maxColumns` property to the InfoCardsBaseSchema
- Updated the InfoCards component to support 1, 2, or 3 column layouts
- Modified the grid styling in the InfoCards component to accommodate the new `maxColumns` property
- Updated the IndexPage stories to use single-column layouts for InfoCards
- Adjusted the generate-sitemap script to set `maxColumns` to 1 for dangling directories

### How to test?

1. Review the InfoCards component in various layouts (1, 2, and 3 columns)
2. Check the IndexPage stories to ensure the InfoCards are displayed in a single column
3. Generate a sitemap and verify that dangling directories use a single-column layout for InfoCards

### Why make this change?

This change provides greater flexibility in displaying InfoCards, allowing for better adaptation to different content types and screen sizes. It enhances the component's versatility and improves the overall user experience by enabling more tailored layouts.

---