### PR TITLE
fix: properly create nested folder

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -137,6 +137,7 @@ const FolderPage: NextPageWithLayout = () => {
         isOpen={isFolderCreateModalOpen}
         onClose={onFolderCreateModalClose}
         siteId={parseInt(siteId)}
+        parentFolderId={parseInt(folderId)}
       />
       <FolderSettingsModal />
     </>

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -4,7 +4,7 @@ import {
   readFolderSchema,
 } from "~/schemas/folder"
 import { protectedProcedure, router } from "~/server/trpc"
-import { db, ResourceType } from "../database"
+import { db } from "../database"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({


### PR DESCRIPTION
### TL;DR

Added support for creating subfolders within existing folders.

### What changed?

- Updated the `FolderCreateModal` component to accept a `parentFolderId` prop.
- Modified the `FolderPage` component to pass the current folder's ID as the `parentFolderId` when opening the folder creation modal.
- Removed an unused import (`ResourceType`) from the folder router file.

### How to test?

1. Navigate to a folder page in the studio.
2. Click on the "Create Folder" button.
3. Verify that the new folder is created as a subfolder of the current folder.
4. Check that the folder hierarchy is correctly maintained in the database and UI.

### Why make this change?

This change enhances the folder management functionality by allowing users to create nested folder structures. This improvement provides better organization capabilities for users managing complex site structures or large amounts of content.

---