### PR TITLE
fix: remove stray bullet point in ArticlePageHeader

### DIFF
--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -2,6 +2,28 @@ import type { ArticlePageHeaderProps } from "~/interfaces"
 import BaseParagraph from "../BaseParagraph"
 import Breadcrumb from "../Breadcrumb"
 
+const ArticleSummaryContent = ({
+  summary,
+}: Pick<ArticlePageHeaderProps, "summary">) => {
+  if (summary.length === 1 && summary[0] !== undefined) {
+    return <BaseParagraph content={summary[0]} />
+  }
+
+  if (summary.length > 1) {
+    return (
+      <ul className="list-disc ps-7">
+        {summary.map((item, index) => (
+          <li key={index} className="pl-0.5 [&_p]:inline">
+            <BaseParagraph content={item} />
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  return <></>
+}
+
 const ArticlePageHeader = ({
   breadcrumb,
   category,
@@ -25,17 +47,7 @@ const ArticlePageHeader = ({
         <p className="text-sm text-gray-800">{date}</p>
 
         <div className="text-xl tracking-tight text-gray-500 md:text-2xl">
-          {summary.length === 1 && summary[0] ? (
-            <BaseParagraph content={summary[0]} />
-          ) : (
-            <ul className="list-disc ps-7">
-              {summary.map((item, index) => (
-                <li key={index} className="pl-0.5 [&_p]:inline">
-                  <BaseParagraph content={item} />
-                </li>
-              ))}
-            </ul>
-          )}
+          <ArticleSummaryContent summary={summary} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some of the auto-migrated pages do not have a summary so an empty string is used, but that causes a stray bullet to appear.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Only check if the summary is undefined instead of also checking if it is an empty string.