### PR TITLE
fix: sidebar

### DIFF
--- a/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
@@ -49,7 +49,7 @@ export function CmsSidebarContainer({
           top={0}
           borderRight="1px solid"
           borderColor="base.divider.medium"
-          height="100vh"
+          height="100%"
           overflow="auto"
           css={{
             "&::-webkit-scrollbar": {

--- a/apps/studio/src/components/CmsSidebar/CmsSidebarItems.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSidebarItems.tsx
@@ -39,7 +39,11 @@ const generateSidebarItem = (
             variant="clear"
             isActive={isActive}
             aria-label={item.label}
-            icon={<Icon fontSize="1.5rem" />}
+            icon={<Icon fontSize="1.5rem" fill="base.content.default" />}
+            _active={{
+              fill: "base.content.brand",
+              bg: "interaction.muted.main.active",
+            }}
             href={item.href}
           />
         ) : (

--- a/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
@@ -37,7 +37,7 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
   const pageNavItems: CmsSidebarItem[] = [
     {
       icon: BiFolder,
-      label: "Team spaces",
+      label: "Site content",
       href: `/sites/${siteId}`,
       isActive:
         router.asPath === `/sites/${siteId}` ||


### PR DESCRIPTION
## Problem
we got some styling that isn't consistent with the figma, this PR fixes some of those. 

Closes ISOM-1367

## Solution
- update the tooltip to display the correct text on hover
- update the colours for the button so that it only shows the blue colour on active state.

figma [here](https://www.figma.com/design/g7LnLn4IUcUC9dYxgsHEJM/IsomerCMS-V2-(working-title%3A-%22Isomer-Studio%22)?node-id=7213-188325&t=7Yfy9M4VoRRLtJMN-0)



https://github.com/user-attachments/assets/668805b2-a46c-4447-b5a4-8e9e16b5b623


