### PR TITLE
fix: force SearchSG to reload on page route change

### DIFF
--- a/packages/components/src/interfaces/internal/Navbar.ts
+++ b/packages/components/src/interfaces/internal/Navbar.ts
@@ -1,5 +1,6 @@
 import type { LocalSearchProps } from "./LocalSearchInputBox"
-import type { SearchSGProps } from "./SearchSGInputBox"
+import type { SearchSGInputBoxProps } from "./SearchSGInputBox"
+import type { IsomerPageSchemaType } from "~/engine"
 
 export interface NavbarItem {
   name: string
@@ -11,7 +12,8 @@ export interface NavbarItem {
 export interface NavbarProps {
   logoUrl: string
   logoAlt: string
-  search?: LocalSearchProps | SearchSGProps
+  layout: IsomerPageSchemaType["layout"]
+  search?: LocalSearchProps | SearchSGInputBoxProps
   items: NavbarItem[]
   LinkComponent?: any
   ScriptComponent?: any

--- a/packages/components/src/interfaces/internal/SearchSGInputBox.ts
+++ b/packages/components/src/interfaces/internal/SearchSGInputBox.ts
@@ -1,4 +1,5 @@
 export interface SearchSGInputBoxProps {
   type: "searchSG"
   clientId: string
+  isOpen?: boolean
 }

--- a/packages/components/src/interfaces/internal/SearchSGInputBox.ts
+++ b/packages/components/src/interfaces/internal/SearchSGInputBox.ts
@@ -1,8 +1,4 @@
-export interface SearchSGProps {
+export interface SearchSGInputBoxProps {
   type: "searchSG"
   clientId: string
-}
-
-export interface SearchSGInputBoxProps extends SearchSGProps {
-  ScriptComponent?: any // Next.js script
 }

--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -4,6 +4,7 @@ import type { ImageProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { isExternalUrl } from "~/utils"
 import { Link } from "../../internal/Link"
+import ImageClient from "./ImageClient"
 
 const createImageStyles = tv({
   slots: {
@@ -73,16 +74,12 @@ const Image = ({
 
   return (
     <ImageContainer href={href} LinkComponent={LinkComponent}>
-      <img
+      <ImageClient
         src={imgSrc}
         alt={alt}
         width={getSizeWidth(size)}
-        height="auto"
         className={compoundStyles.image({ size: size ?? "default" })}
-        onError={({ currentTarget }) => {
-          currentTarget.onerror = null
-          currentTarget.src = `${assetsBaseUrl}/placeholder_no_image.png`
-        }}
+        assetsBaseUrl={assetsBaseUrl}
       />
 
       {caption && <p className={compoundStyles.caption()}>{caption}</p>}

--- a/packages/components/src/templates/next/components/complex/Image/ImageClient.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/ImageClient.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+interface ImageClientProps {
+  src: string
+  alt: string
+  width: string
+  className: string
+  assetsBaseUrl?: string
+}
+
+const ImageClient = ({
+  src,
+  alt,
+  width,
+  className,
+  assetsBaseUrl,
+}: ImageClientProps) => {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      width={width}
+      height="auto"
+      className={className}
+      onError={({ currentTarget }) => {
+        currentTarget.onerror = null
+        currentTarget.src = `${assetsBaseUrl ?? ""}/placeholder_no_image.png`
+      }}
+    />
+  )
+}
+
+export default ImageClient

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -169,7 +169,10 @@ export const Navbar = ({
           )}
 
           {search.type === "searchSG" && (
-            <SearchSGInputBox clientId={search.clientId} />
+            <SearchSGInputBox
+              clientId={search.clientId}
+              isOpen={isSearchOpen}
+            />
           )}
         </div>
       )}

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -27,10 +27,10 @@ const { navItemContainer, navbarContainer, navbar, logo } = navbarStyles()
 export const Navbar = ({
   logoUrl,
   logoAlt,
+  layout,
   search,
   items,
   LinkComponent = "a",
-  ScriptComponent = "script",
 }: Omit<NavbarProps, "type">) => {
   const [openNavItemIdx, setOpenNavItemIdx] = useState(-1)
   const [isHamburgerOpen, setIsHamburgerOpen] = useState(false)
@@ -107,7 +107,7 @@ export const Navbar = ({
 
           <div className="flex flex-row gap-1">
             {/* Search icon */}
-            {search && !isHamburgerOpen && (
+            {search && !isHamburgerOpen && layout !== "search" && (
               <div className="flex h-[68px] items-center">
                 {isSearchOpen ? (
                   <IconButton
@@ -158,7 +158,7 @@ export const Navbar = ({
       </div>
 
       {/* Search bar */}
-      {search && (
+      {search && layout !== "search" && (
         <div
           className={`${
             isSearchOpen ? "block" : "hidden"
@@ -169,11 +169,7 @@ export const Navbar = ({
           )}
 
           {search.type === "searchSG" && (
-            <SearchSGInputBox
-              clientId={search.clientId}
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-              ScriptComponent={ScriptComponent}
-            />
+            <SearchSGInputBox clientId={search.clientId} />
           )}
         </div>
       )}

--- a/packages/components/src/templates/next/components/internal/SearchSGInputBox/SearchSGInputBox.tsx
+++ b/packages/components/src/templates/next/components/internal/SearchSGInputBox/SearchSGInputBox.tsx
@@ -1,24 +1,31 @@
 "use client"
 
 import { useEffect } from "react"
-import { usePathname } from "next/navigation"
 
 import type { SearchSGInputBoxProps } from "~/interfaces"
 
 const SearchSGInputBox = ({
   clientId,
+  isOpen,
 }: Omit<SearchSGInputBoxProps, "type">) => {
-  const pathname = usePathname()
-
   useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    const existingScriptTag = document.getElementById("searchsg-config")
+    if (existingScriptTag) {
+      existingScriptTag.remove()
+    }
+
     const scriptTag = document.createElement("script")
     scriptTag.id = "searchsg-config"
     scriptTag.src = `https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}`
     scriptTag.setAttribute("defer", "")
     document.body.appendChild(scriptTag)
-  }, [clientId, pathname])
+  }, [clientId, isOpen])
 
-  return <div id="searchsg-searchbar" />
+  return <div id="searchsg-searchbar" className="h-[3.25rem] lg:h-16" />
 }
 
 export default SearchSGInputBox

--- a/packages/components/src/templates/next/components/internal/SearchSGInputBox/SearchSGInputBox.tsx
+++ b/packages/components/src/templates/next/components/internal/SearchSGInputBox/SearchSGInputBox.tsx
@@ -12,6 +12,7 @@ const SearchSGInputBox = ({
 
   useEffect(() => {
     const scriptTag = document.createElement("script")
+    scriptTag.id = "searchsg-config"
     scriptTag.src = `https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}`
     scriptTag.setAttribute("defer", "")
     document.body.appendChild(scriptTag)

--- a/packages/components/src/templates/next/components/internal/SearchSGInputBox/SearchSGInputBox.tsx
+++ b/packages/components/src/templates/next/components/internal/SearchSGInputBox/SearchSGInputBox.tsx
@@ -1,19 +1,23 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname } from "next/navigation"
+
 import type { SearchSGInputBoxProps } from "~/interfaces"
 
 const SearchSGInputBox = ({
   clientId,
-  ScriptComponent = "script",
 }: Omit<SearchSGInputBoxProps, "type">) => {
-  return (
-    <>
-      <ScriptComponent
-        id="searchsg-config"
-        src={`https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}`}
-        defer
-      ></ScriptComponent>
-      <div id="searchsg-searchbar" />
-    </>
-  )
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const scriptTag = document.createElement("script")
+    scriptTag.src = `https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}`
+    scriptTag.setAttribute("defer", "")
+    document.body.appendChild(scriptTag)
+  }, [clientId, pathname])
+
+  return <div id="searchsg-searchbar" />
 }
 
 export default SearchSGInputBox

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from "../Skeleton"
 const ArticleLayout = ({
   site,
   page,
+  layout,
   content,
   LinkComponent,
   ScriptComponent,
@@ -20,6 +21,7 @@ const ArticleLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -3,7 +3,6 @@ import type { CollectionCardProps } from "~/interfaces"
 import { getBreadcrumbFromSiteMap, getSitemapAsArray } from "~/utils"
 import { Skeleton } from "../Skeleton"
 import CollectionClient from "./CollectionClient"
-import CollectionPageHeader from "./CollectionPageHeader"
 
 const getCollectionItems = (
   siteMap: IsomerSitemap,
@@ -89,6 +88,7 @@ const getCollectionItems = (
 const CollectionLayout = ({
   site,
   page,
+  layout,
   LinkComponent,
   ScriptComponent,
 }: CollectionPageSchemaType) => {
@@ -105,6 +105,7 @@ const CollectionLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -1,7 +1,6 @@
 import { BiUpArrowAlt } from "react-icons/bi"
 
-import type { ContentPageSchemaType, IsomerSitemap } from "~/engine"
-import type { SiderailProps } from "~/interfaces"
+import type { ContentPageSchemaType } from "~/engine"
 import { tv } from "~/lib/tv"
 import {
   getBreadcrumbFromSiteMap,
@@ -105,6 +104,7 @@ const compoundStyles = createContentLayoutStyles()
 const ContentLayout = ({
   site,
   page,
+  layout,
   content,
   LinkComponent = "a",
   ScriptComponent,
@@ -127,6 +127,7 @@ const ContentLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "../Skeleton"
 const HomepageLayout = ({
   site,
   page,
+  layout,
   content,
   LinkComponent,
   ScriptComponent,
@@ -13,6 +14,7 @@ const HomepageLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -28,6 +28,7 @@ const compoundStyles = createIndexPageLayoutStyles()
 const IndexPageLayout = ({
   site,
   page,
+  layout,
   content,
   LinkComponent = "a",
   ScriptComponent,
@@ -47,6 +48,7 @@ const IndexPageLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "../Skeleton"
 const NotFoundLayout = ({
   site,
   page,
+  layout,
   LinkComponent = "a",
   ScriptComponent = "script",
 }: NotFoundPageSchemaType) => {
@@ -12,6 +13,7 @@ const NotFoundLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >

--- a/packages/components/src/templates/next/layouts/Search/Search.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.tsx
@@ -1,5 +1,6 @@
 import { type SearchPageSchemaType } from "~/engine"
 import { Skeleton } from "../Skeleton"
+import SearchSG from "./SearchSG"
 
 const SearchLayout = ({
   site,
@@ -25,14 +26,7 @@ const SearchLayout = ({
 
       {/* SearchSG-powered search */}
       {site.search && site.search.type === "searchSG" && clientId && (
-        <>
-          <ScriptComponent
-            id="searchsg-config"
-            src={`https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}&page=result`}
-            defer
-          />
-          <div id="searchsg-result-container" className="h-[29.25rem]" />
-        </>
+        <SearchSG clientId={clientId} />
       )}
     </Skeleton>
   )

--- a/packages/components/src/templates/next/layouts/Search/Search.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from "../Skeleton"
 const SearchLayout = ({
   site,
   page,
+  layout,
   LinkComponent = "a",
   ScriptComponent = "script",
 }: SearchPageSchemaType) => {
@@ -15,6 +16,7 @@ const SearchLayout = ({
     <Skeleton
       site={site}
       page={page}
+      layout={layout}
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >
@@ -29,7 +31,7 @@ const SearchLayout = ({
             src={`https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}&page=result`}
             defer
           />
-          <div id="searchsg-result-container" />
+          <div id="searchsg-result-container" className="h-[29.25rem]" />
         </>
       )}
     </Skeleton>

--- a/packages/components/src/templates/next/layouts/Search/SearchSG.tsx
+++ b/packages/components/src/templates/next/layouts/Search/SearchSG.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { useEffect } from "react"
+
+const SearchSG = ({ clientId }: { clientId: string }) => {
+  useEffect(() => {
+    const scriptTag = document.createElement("script")
+    scriptTag.id = "searchsg-config"
+    scriptTag.src = `https://api.search.gov.sg/v1/searchconfig.js?clientId=${clientId}&page=result`
+    scriptTag.setAttribute("defer", "")
+    document.body.appendChild(scriptTag)
+  }, [clientId])
+
+  return <div id="searchsg-result-container" className="h-[29.25rem]" />
+}
+
+export default SearchSG

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -3,13 +3,13 @@ import { Footer, Masthead, Navbar } from "../../components/internal"
 
 export const Skeleton = ({
   site,
+  layout,
   LinkComponent,
-  ScriptComponent,
   children,
 }: React.PropsWithChildren<
   Pick<
     IsomerPageSchemaType,
-    "site" | "page" | "LinkComponent" | "ScriptComponent"
+    "site" | "page" | "layout" | "LinkComponent" | "ScriptComponent"
   >
 >) => {
   const isStaging = site.environment === "staging"
@@ -21,10 +21,10 @@ export const Skeleton = ({
       <Navbar
         logoUrl={site.logoUrl}
         logoAlt={site.siteName}
+        layout={layout}
         search={site.search}
         items={site.navBarItems}
         LinkComponent={LinkComponent}
-        ScriptComponent={ScriptComponent}
       />
 
       {children}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `next/script` is optimised such that it will [only load once](https://stackoverflow.com/a/78479249) when the site is first loaded, then it will no longer load despite any route changes.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Force the SearchSG script to load again whenever there is a page route change.
- Add an initial height for the search results page (note that SearchSG will override this height when the script fully loads).
- Remove the search icon on the navbar if on the search results page (because the search bar is already on the page).