### PR TITLE
fix: add z-index so navbar shows even on searchsg page

### DIFF
--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -67,7 +67,7 @@ export const NavItem = forwardRef<HTMLButtonElement, NavbarItemProps>(
           <BiChevronDown className={chevron({ isOpen })} />
         </button>
         {isOpen && (
-          <div className="absolute left-0 right-0 top-full">
+          <div className="absolute left-0 right-0 top-full z-50">
             <div className="absolute bottom-0 left-0 right-0 top-full z-[1] h-screen bg-canvas-overlay/40" />
             <FocusOn
               onClickOutside={onCloseMegamenu}


### PR DESCRIPTION
### TL;DR

Added z-index to the navbar dropdown menu for proper layering.

### What changed?

Added a `z-50` class to the dropdown menu container in the NavItem component. This ensures the dropdown appears above other page elements when opened.

### How to test?

1. Navigate to a page with the navbar.
2. Click on a dropdown menu item.
3. Verify that the dropdown menu appears above all other page content.
4. Check for any visual inconsistencies or layering issues with the dropdown.

### Why make this change?

This change improves the user experience by ensuring the dropdown menu is always visible and not obscured by other page elements. The z-index addition prevents potential layout issues where the dropdown might be hidden behind other components with higher z-index values.
