### PR TITLE
feat: scroll to top of results on page change

### DIFF
--- a/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
+++ b/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
@@ -14,12 +14,17 @@ import { usePaginationRange } from "./usePaginationRange"
 
 const SEPARATOR = "-"
 
+interface PaginationControlsProps extends PaginationProps {
+  onPageChange?: () => void
+}
+
 export function PaginationControls({
   totalItems,
   itemsPerPage,
   currPage,
   setCurrPage,
-}: PaginationProps) {
+  onPageChange,
+}: PaginationControlsProps) {
   const paginationRange = usePaginationRange<typeof SEPARATOR>({
     totalCount: totalItems,
     pageSize: itemsPerPage,
@@ -36,7 +41,10 @@ export function PaginationControls({
         <PaginationItem>
           <PaginationPrevious
             isDisabled={currPage === 1}
-            onPress={() => setCurrPage((p) => Math.max(1, p - 1))}
+            onPress={() => {
+              onPageChange?.()
+              setCurrPage((p) => Math.max(1, p - 1))
+            }}
           />
         </PaginationItem>
         {paginationRange.map((p, i) => {
@@ -46,7 +54,10 @@ export function PaginationControls({
             <PaginationItem key={i}>
               <PaginationButton
                 isActive={currPage === p}
-                onPress={() => setCurrPage(p)}
+                onPress={() => {
+                  onPageChange?.()
+                  setCurrPage(p)
+                }}
               >
                 {p}
               </PaginationButton>
@@ -56,7 +67,10 @@ export function PaginationControls({
         <PaginationItem>
           <PaginationNext
             isDisabled={currPage >= totalPageCount}
-            onPress={() => setCurrPage((p) => Math.min(totalPageCount, p + 1))}
+            onPress={() => {
+              onPageChange?.()
+              setCurrPage((p) => Math.min(totalPageCount, p + 1))
+            }}
           />
         </PaginationItem>
       </PaginationContent>

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -26,7 +26,7 @@ const createCollectionLayoutStyles = tv({
   slots: {
     container:
       "relative mx-auto grid max-w-screen-xl grid-cols-12 px-6 pb-16 pt-8 md:px-10 lg:gap-6 xl:gap-10",
-    filterContainer: "relative col-span-12 pb-10 pt-8 lg:col-span-3",
+    filterContainer: "relative col-span-12 pb-2 pt-8 lg:col-span-3 lg:pb-10",
     content: "col-span-12 flex flex-col gap-8 pt-8 lg:col-span-9 lg:ml-24",
   },
 })

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useRef } from "react"
+
 import type { CollectionPageSchemaType } from "~/engine"
 import type { BreadcrumbProps, CollectionCardProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
@@ -23,9 +25,9 @@ interface CollectionClientProps {
 const createCollectionLayoutStyles = tv({
   slots: {
     container:
-      "relative mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-16 md:px-10 lg:gap-6 xl:gap-10",
-    filterContainer: "relative col-span-12 pb-10 lg:col-span-3",
-    content: "col-span-12 flex flex-col gap-8 lg:col-span-9 lg:ml-24",
+      "relative mx-auto grid max-w-screen-xl grid-cols-12 px-6 pb-16 pt-8 md:px-10 lg:gap-6 xl:gap-10",
+    filterContainer: "relative col-span-12 pb-10 pt-8 lg:col-span-3",
+    content: "col-span-12 flex flex-col gap-8 pt-8 lg:col-span-9 lg:ml-24",
   },
 })
 
@@ -51,6 +53,12 @@ const CollectionClient = ({
     setCurrPage,
   } = useCollection({ items })
 
+  const articleContainerRef = useRef<HTMLDivElement>(null)
+  const onPageChange = () => {
+    articleContainerRef.current?.scrollIntoView({
+      block: "start",
+    })
+  }
   return (
     <>
       <CollectionPageHeader
@@ -76,7 +84,7 @@ const CollectionClient = ({
           />
           <BackToTopLink className="hidden lg:flex" />
         </div>
-        <div className={compoundStyles.content()}>
+        <div className={compoundStyles.content()} ref={articleContainerRef}>
           <div className="flex w-full flex-col gap-3">
             <div className="flex w-full flex-col justify-between gap-x-6 gap-y-2 md:flex-row">
               <div className="flex h-full w-full items-center gap-3">
@@ -130,6 +138,7 @@ const CollectionClient = ({
             <div className="flex w-full justify-center lg:justify-end">
               <PaginationControls
                 totalItems={filteredCount}
+                onPageChange={onPageChange}
                 itemsPerPage={ITEMS_PER_PAGE}
                 currPage={currPage}
                 setCurrPage={setCurrPage}


### PR DESCRIPTION
### TL;DR

Added an `onPageChange` callback to the PaginationControls component and implemented scrolling to top when changing pages in the Collection layout.

### What changed?

- Added an `onPageChange` prop to the PaginationControls component.
- Implemented the `onPageChange` callback in the Collection layout to scroll to the top of the article container when changing pages.
- Updated the PaginationControls component to call the `onPageChange` callback before changing the page.
- Adjusted the layout styles in the Collection component to improve spacing and consistency.

### How to test?

1. Navigate to a Collection page with multiple pages of content.
2. Scroll down the page and click on a pagination control (next, previous, or a specific page number).
3. Verify that the page scrolls to the top of the article container when changing pages.
4. Test this behavior on different screen sizes to ensure it works consistently.

### Why make this change?

This change improves the user experience when navigating through paginated content in the Collection layout. By automatically scrolling to the top of the article container when changing pages, users can easily view the new content without manually scrolling up. This is especially helpful on mobile devices or when dealing with long pages of content.

---