### PR TITLE
feat: perf improvements to tiptap menu, allow column headers in table

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar.tsx
@@ -1,6 +1,7 @@
 import type { MenuButtonProps, MenuListProps } from "@chakra-ui/react"
 import type { Editor } from "@tiptap/react"
 import type { IconType } from "react-icons/lib"
+import { useMemo } from "react"
 import {
   Box,
   Divider,
@@ -28,6 +29,7 @@ import {
   BiUnderline,
 } from "react-icons/bi"
 import { MdSubscript, MdSuperscript } from "react-icons/md"
+import { RiLayoutColumnFill, RiLayoutRowFill } from "react-icons/ri"
 
 import {
   IconAddColLeft,
@@ -106,205 +108,224 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
     onClose: onTableSettingsModalClose,
   } = useDisclosure()
 
-  const items: MenuBarEntry[] = [
-    {
-      type: "vertical-list",
-      buttonWidth: "9rem",
-      menuWidth: "19rem",
-      defaultTitle: "Heading options",
-      items: [
-        {
-          type: "item",
-          title: "Heading 1",
-          textStyle: "h2",
-          useSecondaryColor: true,
-          action: () =>
-            editor.chain().focus().toggleHeading({ level: 2 }).run(),
-          isActive: () => editor.isActive("heading", { level: 2 }),
-        },
-        {
-          type: "item",
-          title: "Heading 2",
-          textStyle: "h3",
-          useSecondaryColor: true,
-          action: () =>
-            editor.chain().focus().toggleHeading({ level: 3 }).run(),
-          isActive: () => editor.isActive("heading", { level: 3 }),
-        },
-        {
-          type: "item",
-          title: "Heading 3",
-          textStyle: "h4",
-          useSecondaryColor: true,
-          action: () =>
-            editor.chain().focus().toggleHeading({ level: 4 }).run(),
-          isActive: () => editor.isActive("heading", { level: 4 }),
-        },
-        {
-          type: "item",
-          title: "Paragraph",
-          textStyle: "body-1",
-          action: () =>
-            editor.chain().focus().clearNodes().unsetAllMarks().run(),
-          isActive: () => editor.isActive("paragraph"),
-        },
-      ],
-    },
-    {
-      type: "divider",
-    },
-    {
-      type: "item",
-      icon: BiBold,
-      title: "Bold",
-      action: () => editor.chain().focus().toggleBold().run(),
-      isActive: () => editor.isActive("bold"),
-    },
-    {
-      type: "item",
-      icon: BiItalic,
-      title: "Italicise",
-      action: () => editor.chain().focus().toggleItalic().run(),
-      isActive: () => editor.isActive("italic"),
-    },
-    {
-      type: "item",
-      icon: BiUnderline,
-      title: "Underline",
-      action: () => editor.chain().focus().toggleUnderline().run(),
-      isActive: () => editor.isActive("underline"),
-    },
-    {
-      type: "item",
-      icon: BiStrikethrough,
-      title: "Strikethrough",
-      action: () => editor.chain().focus().toggleStrike().run(),
-      isActive: () => editor.isActive("strike"),
-    },
-    {
-      type: "item",
-      icon: MdSuperscript,
-      title: "Superscript",
-      action: () => editor.chain().focus().toggleSuperscript().run(),
-      isActive: () => editor.isActive("superscript"),
-    },
-    {
-      type: "item",
-      icon: MdSubscript,
-      title: "Subscript",
-      action: () => editor.chain().focus().toggleSubscript().run(),
-      isActive: () => editor.isActive("subscript"),
-    },
-    {
-      type: "divider",
-    },
-    {
-      type: "horizontal-list",
-      label: "Lists",
-      defaultIcon: BiListOl,
-      items: [
-        {
-          type: "item",
-          icon: BiListOl,
-          title: "Ordered list",
-          action: () => editor.chain().focus().toggleOrderedList().run(),
-          isActive: () => editor.isActive("orderedList"),
-        },
-
-        {
-          type: "item",
-          icon: BiListUl,
-          title: "Bullet list",
-          action: () => editor.chain().focus().toggleBulletList().run(),
-          isActive: () => editor.isActive("bulletList"),
-        },
-      ],
-    },
-    {
-      type: "item",
-      icon: BiTable,
-      title: "Table",
-      action: () => {
-        if (editor.isActive("table")) {
-          return editor.chain().focus().deleteTable().run()
-        }
-        return editor.chain().focus().insertTable().run()
+  const items: MenuBarEntry[] = useMemo(
+    () => [
+      {
+        type: "vertical-list",
+        buttonWidth: "9rem",
+        menuWidth: "19rem",
+        defaultTitle: "Heading options",
+        items: [
+          {
+            type: "item",
+            title: "Heading 1",
+            textStyle: "h2",
+            useSecondaryColor: true,
+            action: () =>
+              editor.chain().focus().toggleHeading({ level: 2 }).run(),
+            isActive: () => editor.isActive("heading", { level: 2 }),
+          },
+          {
+            type: "item",
+            title: "Heading 2",
+            textStyle: "h3",
+            useSecondaryColor: true,
+            action: () =>
+              editor.chain().focus().toggleHeading({ level: 3 }).run(),
+            isActive: () => editor.isActive("heading", { level: 3 }),
+          },
+          {
+            type: "item",
+            title: "Heading 3",
+            textStyle: "h4",
+            useSecondaryColor: true,
+            action: () =>
+              editor.chain().focus().toggleHeading({ level: 4 }).run(),
+            isActive: () => editor.isActive("heading", { level: 4 }),
+          },
+          {
+            type: "item",
+            title: "Paragraph",
+            textStyle: "body-1",
+            action: () =>
+              editor.chain().focus().clearNodes().unsetAllMarks().run(),
+            isActive: () => editor.isActive("paragraph"),
+          },
+        ],
       },
-      isActive: () => editor.isActive("table"),
-    },
-    // Table-specific commands
-    {
-      type: "divider",
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconAddColRight} />,
-      title: "Add column after",
-      action: () => editor.chain().focus().addColumnAfter().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconAddColLeft} />,
-      title: "Add column before",
-      action: () => editor.chain().focus().addColumnBefore().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconDelCol} />,
-      title: "Delete column",
-      action: () => editor.chain().focus().deleteColumn().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconAddRowAbove} />,
-      title: "Add row before",
-      action: () => editor.chain().focus().addRowBefore().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconAddRowBelow} />,
-      title: "Add row after",
-      action: () => editor.chain().focus().addRowAfter().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconDelRow} />,
-      title: "Delete row",
-      action: () => editor.chain().focus().deleteRow().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "divider",
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconMergeCells} />,
-      title: "Merge cells",
-      action: () => editor.chain().focus().mergeCells().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: () => <Icon as={IconSplitCell} />,
-      title: "Split cell",
-      action: () => editor.chain().focus().splitCell().run(),
-      isHidden: !editor.isActive("table"),
-    },
-    {
-      type: "item",
-      icon: BiCog,
-      title: "Table settings",
-      action: onTableSettingsModalOpen,
-      isHidden: !editor.isActive("table"),
-    },
-  ]
+      {
+        type: "divider",
+      },
+      {
+        type: "item",
+        icon: BiBold,
+        title: "Bold",
+        action: () => editor.chain().focus().toggleBold().run(),
+        isActive: () => editor.isActive("bold"),
+      },
+      {
+        type: "item",
+        icon: BiItalic,
+        title: "Italicise",
+        action: () => editor.chain().focus().toggleItalic().run(),
+        isActive: () => editor.isActive("italic"),
+      },
+      {
+        type: "item",
+        icon: BiUnderline,
+        title: "Underline",
+        action: () => editor.chain().focus().toggleUnderline().run(),
+        isActive: () => editor.isActive("underline"),
+      },
+      {
+        type: "item",
+        icon: BiStrikethrough,
+        title: "Strikethrough",
+        action: () => editor.chain().focus().toggleStrike().run(),
+        isActive: () => editor.isActive("strike"),
+      },
+      {
+        type: "item",
+        icon: MdSuperscript,
+        title: "Superscript",
+        action: () => editor.chain().focus().toggleSuperscript().run(),
+        isActive: () => editor.isActive("superscript"),
+      },
+      {
+        type: "item",
+        icon: MdSubscript,
+        title: "Subscript",
+        action: () => editor.chain().focus().toggleSubscript().run(),
+        isActive: () => editor.isActive("subscript"),
+      },
+      {
+        type: "divider",
+      },
+      {
+        type: "horizontal-list",
+        label: "Lists",
+        defaultIcon: BiListOl,
+        items: [
+          {
+            type: "item",
+            icon: BiListOl,
+            title: "Ordered list",
+            action: () => editor.chain().focus().toggleOrderedList().run(),
+            isActive: () => editor.isActive("orderedList"),
+          },
+
+          {
+            type: "item",
+            icon: BiListUl,
+            title: "Bullet list",
+            action: () => editor.chain().focus().toggleBulletList().run(),
+            isActive: () => editor.isActive("bulletList"),
+          },
+        ],
+      },
+      {
+        type: "item",
+        icon: BiTable,
+        title: "Table",
+        action: () => {
+          if (editor.isActive("table")) {
+            return editor.chain().focus().deleteTable().run()
+          }
+          return editor.chain().focus().insertTable().run()
+        },
+        isActive: () => editor.isActive("table"),
+      },
+      // Table-specific commands
+      {
+        type: "divider",
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => (
+          <Icon color="base.content.medium" as={RiLayoutColumnFill} />
+        ),
+        title: "Toggle header column",
+        action: () => editor.chain().focus().toggleHeaderColumn().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon color="base.content.medium" as={RiLayoutRowFill} />,
+        title: "Toggle header row",
+        action: () => editor.chain().focus().toggleHeaderRow().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconAddColRight} />,
+        title: "Add column after",
+        action: () => editor.chain().focus().addColumnAfter().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconAddColLeft} />,
+        title: "Add column before",
+        action: () => editor.chain().focus().addColumnBefore().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconDelCol} />,
+        title: "Delete column",
+        action: () => editor.chain().focus().deleteColumn().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconAddRowAbove} />,
+        title: "Add row before",
+        action: () => editor.chain().focus().addRowBefore().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconAddRowBelow} />,
+        title: "Add row after",
+        action: () => editor.chain().focus().addRowAfter().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconDelRow} />,
+        title: "Delete row",
+        action: () => editor.chain().focus().deleteRow().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "divider",
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconMergeCells} />,
+        title: "Merge cells",
+        action: () => editor.chain().focus().mergeCells().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon as={IconSplitCell} />,
+        title: "Split cell",
+        action: () => editor.chain().focus().splitCell().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
+        action: onTableSettingsModalOpen,
+        isHidden: !editor.isActive("table"),
+      },
+    ],
+    [editor, onTableSettingsModalOpen],
+  )
 
   return (
     <>
@@ -327,10 +348,11 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
         borderTopRadius="0.25rem"
         spacing="0.25rem"
       >
-        {items.map((item) => (
+        {items.map((item, index) => (
           <>
             {item.type === "divider" && !item.isHidden && (
               <Divider
+                key={index}
                 orientation="vertical"
                 borderColor="base.divider.strong"
                 h="1.25rem"
@@ -339,7 +361,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
             )}
 
             {item.type === "vertical-list" && (
-              <Menu>
+              <Menu key={index}>
                 {({ isOpen }) => {
                   const activeItem = item.items.find((subItem) =>
                     subItem.isActive?.(),
@@ -395,7 +417,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
             )}
 
             {item.type === "horizontal-list" && (
-              <Popover placement="bottom">
+              <Popover placement="bottom" key={index}>
                 {({ isOpen }) => (
                   <>
                     <PopoverTrigger>
@@ -445,7 +467,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
             )}
 
             {item.type === "detailed-list" && !item.isHidden && (
-              <Popover placement="bottom" offset={[0, 16]}>
+              <Popover placement="bottom" offset={[0, 16]} key={index}>
                 <PopoverTrigger>
                   <Button
                     _hover={{ bg: "gray.100" }}
@@ -517,7 +539,9 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
               </Popover>
             )}
 
-            {item.type === "item" && !item.isHidden && <MenuItem {...item} />}
+            {item.type === "item" && !item.isHidden && (
+              <MenuItem key={index} {...item} />
+            )}
           </>
         ))}
       </HStack>

--- a/apps/studio/src/components/PageEditor/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar.tsx
@@ -240,6 +240,23 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
         type: "divider",
         isHidden: !editor.isActive("table"),
       },
+
+      {
+        type: "item",
+        icon: () => (
+          <Icon color="base.content.medium" as={RiLayoutColumnFill} />
+        ),
+        title: "Toggle header column",
+        action: () => editor.chain().focus().toggleHeaderColumn().run(),
+        isHidden: !editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: () => <Icon color="base.content.medium" as={RiLayoutRowFill} />,
+        title: "Toggle header row",
+        action: () => editor.chain().focus().toggleHeaderRow().run(),
+        isHidden: !editor.isActive("table"),
+      },
       {
         type: "item",
         icon: () => (

--- a/apps/studio/src/components/PageEditor/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar.tsx
@@ -240,23 +240,6 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
         type: "divider",
         isHidden: !editor.isActive("table"),
       },
-
-      {
-        type: "item",
-        icon: () => (
-          <Icon color="base.content.medium" as={RiLayoutColumnFill} />
-        ),
-        title: "Toggle header column",
-        action: () => editor.chain().focus().toggleHeaderColumn().run(),
-        isHidden: !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon color="base.content.medium" as={RiLayoutRowFill} />,
-        title: "Toggle header row",
-        action: () => editor.chain().focus().toggleHeaderRow().run(),
-        isHidden: !editor.isActive("table"),
-      },
       {
         type: "item",
         icon: () => (

--- a/apps/studio/src/components/PageEditor/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar.tsx
@@ -152,9 +152,12 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
             isActive: () => editor.isActive("paragraph"),
           },
         ],
+
+        isHidden: () => editor.isActive("table"),
       },
       {
         type: "divider",
+        isHidden: () => editor.isActive("table"),
       },
       {
         type: "item",
@@ -360,7 +363,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
               />
             )}
 
-            {item.type === "vertical-list" && (
+            {item.type === "vertical-list" && !item.isHidden?.() && (
               <Menu key={index}>
                 {({ isOpen }) => {
                   const activeItem = item.items.find((subItem) =>

--- a/apps/studio/src/components/PageEditor/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar.tsx
@@ -53,12 +53,12 @@ interface MenuBarItem {
   leftItem?: JSX.Element
   action: () => void
   isActive?: () => boolean
-  isHidden?: boolean
+  isHidden?: () => boolean
 }
 
 interface MenuBarDivider {
   type: "divider"
-  isHidden?: boolean
+  isHidden?: () => boolean
 }
 
 interface MenuBarVerticalList {
@@ -67,7 +67,7 @@ interface MenuBarVerticalList {
   menuWidth: MenuListProps["width"]
   defaultTitle: string
   items: MenuBarItem[]
-  isHidden?: boolean
+  isHidden?: () => boolean
 }
 
 interface MenuBarHorizontalList {
@@ -75,7 +75,7 @@ interface MenuBarHorizontalList {
   label: string
   defaultIcon: IconType
   items: MenuBarItem[]
-  isHidden?: boolean
+  isHidden?: () => boolean
 }
 
 interface MenuBarDetailedItem {
@@ -83,7 +83,7 @@ interface MenuBarDetailedItem {
   description: string
   icon: IconType
   action: () => void
-  isHidden?: boolean
+  isHidden?: () => boolean
 }
 
 interface MenuBarDetailedList {
@@ -91,7 +91,7 @@ interface MenuBarDetailedList {
   label: string
   icon: IconType
   items: MenuBarDetailedItem[]
-  isHidden?: boolean
+  isHidden?: () => boolean
 }
 
 type MenuBarEntry =
@@ -238,7 +238,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       // Table-specific commands
       {
         type: "divider",
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
@@ -247,81 +247,81 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
         ),
         title: "Toggle header column",
         action: () => editor.chain().focus().toggleHeaderColumn().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon color="base.content.medium" as={RiLayoutRowFill} />,
         title: "Toggle header row",
         action: () => editor.chain().focus().toggleHeaderRow().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconAddColRight} />,
         title: "Add column after",
         action: () => editor.chain().focus().addColumnAfter().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconAddColLeft} />,
         title: "Add column before",
         action: () => editor.chain().focus().addColumnBefore().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconDelCol} />,
         title: "Delete column",
         action: () => editor.chain().focus().deleteColumn().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconAddRowAbove} />,
         title: "Add row before",
         action: () => editor.chain().focus().addRowBefore().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconAddRowBelow} />,
         title: "Add row after",
         action: () => editor.chain().focus().addRowAfter().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconDelRow} />,
         title: "Delete row",
         action: () => editor.chain().focus().deleteRow().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "divider",
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconMergeCells} />,
         title: "Merge cells",
         action: () => editor.chain().focus().mergeCells().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: () => <Icon as={IconSplitCell} />,
         title: "Split cell",
         action: () => editor.chain().focus().splitCell().run(),
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
       {
         type: "item",
         icon: BiCog,
         title: "Table settings",
         action: onTableSettingsModalOpen,
-        isHidden: !editor.isActive("table"),
+        isHidden: () => !editor.isActive("table"),
       },
     ],
     [editor, onTableSettingsModalOpen],
@@ -350,7 +350,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
       >
         {items.map((item, index) => (
           <>
-            {item.type === "divider" && !item.isHidden && (
+            {item.type === "divider" && !item.isHidden?.() && (
               <Divider
                 key={index}
                 orientation="vertical"
@@ -466,7 +466,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
               </Popover>
             )}
 
-            {item.type === "detailed-list" && !item.isHidden && (
+            {item.type === "detailed-list" && !item.isHidden?.() && (
               <Popover placement="bottom" offset={[0, 16]} key={index}>
                 <PopoverTrigger>
                   <Button
@@ -493,7 +493,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
                     <VStack spacing="0.75rem">
                       {item.items.map(
                         (subItem) =>
-                          !subItem.isHidden && (
+                          !subItem.isHidden?.() && (
                             <Button
                               onClick={subItem.action}
                               variant="clear"
@@ -539,7 +539,7 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
               </Popover>
             )}
 
-            {item.type === "item" && !item.isHidden && (
+            {item.type === "item" && !item.isHidden?.() && (
               <MenuItem key={index} {...item} />
             )}
           </>

--- a/packages/components/src/interfaces/native/Table.ts
+++ b/packages/components/src/interfaces/native/Table.ts
@@ -76,7 +76,7 @@ const TableHeaderCellSchema = Type.Object({
 const TableContentRowSchema = Type.Object(
   {
     type: Type.Literal("tableRow", { default: "tableRow" }),
-    content: Type.Array(TableCellSchema, {
+    content: Type.Array(Type.Union([TableCellSchema, TableHeaderCellSchema]), {
       title: "Table cells",
       minItems: 1,
     }),


### PR DESCRIPTION
### TL;DR
Enhanced tiptap editor perf using useMemo.
Allow table column headers.

### What changed?

- Added toggle options for header column and header row in the table menu
- Implemented useMemo for performance optimization of menu items
- Updated TableContentRowSchema to allow header cells within table rows
- Added new icons for table header toggles (RiLayoutColumnFill, RiLayoutRowFill)

### How to test?

1. Open the page editor and insert a table
2. Verify that new options for toggling header column and header row are available in the table menu
3. Test the functionality of these new toggle options
4. Create a table with mixed regular and header cells in a single row
5. Ensure that the editor correctly handles and displays the mixed cell types

### Why make this change?

This change improves the flexibility and usability of tables in the page editor. By allowing users to easily toggle header columns and rows, it enhances the ability to create more complex and informative tables. The schema update supports this new functionality by allowing header cells to exist alongside regular cells in table rows. The performance optimization ensures that the menu items are only recalculated when necessary, potentially improving the editor's responsiveness.

Now we can also have column headers. Might be useful for certain table types.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/0yF1kSri7ug0Z2JQvKtX/97b688a0-b3ed-46ce-844d-cd87948fea7f.png)

