### PR TITLE
feat: add top margin to accordion "groups"

### DIFF
--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -8,7 +8,7 @@ import { Prose } from "../../native"
 const createAccordionStyles = tv({
   slots: {
     details:
-      "group border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0",
+      "group border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0 [&:not(:first-child)]:first-of-type:mt-7",
     summary:
       "prose-headline-lg-medium flex list-none flex-row items-center justify-between gap-3 text-base-content-strong outline-none outline outline-0 outline-offset-2 outline-brand-interaction hover:cursor-pointer focus-visible:outline-2",
     icon: "h-6 w-6 flex-shrink-0 [&.minus]:hidden [&.minus]:group-open:block [&.plus]:block [&.plus]:group-open:hidden",

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1087,6 +1087,32 @@ export const Default: Story = {
         ],
       },
       {
+        type: "accordion",
+        details: {
+          type: "prose",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ text: "this is the first item", type: "text" }],
+            },
+          ],
+        },
+        summary: "First title for an accordion item",
+      },
+      {
+        type: "accordion",
+        details: {
+          type: "prose",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ text: "this is the second item", type: "text" }],
+            },
+          ],
+        },
+        summary: "Second title for the accordion item",
+      },
+      {
         type: "contentpic",
         imageAlt:
           "Two rhinos. A rhino is peacefully grazing on grass in a field in front of the other rhino.",


### PR DESCRIPTION
### TL;DR

Added spacing to non-first Accordion items and included Accordion examples in the Content story.

### What changed?

- Updated the Accordion component's CSS to add top margin to non-first items.
- Added two Accordion examples to the Content story for demonstration purposes.

### How to test?

1. Run the storybook and navigate to the Content story.
2. Verify that the newly added Accordion items are visible and properly styled.
3. Check that non-first Accordion items have additional top margin.
4. Interact with the Accordion items to ensure they expand and collapse correctly.

### Why make this change?

This change improves the visual separation between Accordion items when they're not the first element in a group. It also provides concrete examples of Accordion usage within the Content component, making it easier for developers to understand and implement Accordions in various contexts.
