### PR TITLE
feat: add tabindex to overflowing table

### DIFF
--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -93,7 +93,7 @@ const Table = ({ attrs: { caption }, content }: TableProps) => {
         content={caption}
         className="prose-label-md-regular text-base-content-subtle [&:not(:last-child)]:mb-0"
       />
-      <div className="overflow-x-auto">
+      <div className="overflow-x-auto" tabIndex={0}>
         <table
           className="w-full border-separate border-spacing-0"
           aria-describedby={tableDescriptionId}


### PR DESCRIPTION
### TL;DR

Added tabIndex attribute to the table wrapper div for improved accessibility.
fixes https://dequeuniversity.com/rules/axe/4.8/scrollable-region-focusable a11y warning.

### What changed?

The `<div>` element wrapping the table now includes a `tabIndex={0}` attribute. This change allows the scrollable table container to receive keyboard focus.

### How to test?

1. Navigate to a page containing a table component.
2. Use the keyboard to tab through the page elements.
3. Verify that the table container can receive focus.
4. When focused, ensure that arrow keys can be used to scroll the table horizontally if it overflows.

### Why make this change?

This change enhances the accessibility of the table component. By making the scrollable container focusable, it allows keyboard users to interact with and navigate oversized tables more easily. This is particularly beneficial for users who rely on keyboard navigation or assistive technologies.

---