### PR TITLE
feat: sort collection items by desc date (with title tiebreaker)

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -37,7 +37,7 @@ const getCollectionItems = (
     getSitemapAsArray(child),
   )
 
-  return items
+  const transformedItems = items
     .filter(
       (item) =>
         item.layout === "file" ||
@@ -55,6 +55,7 @@ const getCollectionItems = (
 
       const baseItem = {
         type: "collectionCard" as const,
+        rawDate: date,
         lastUpdated,
         category: item.category || "Others",
         title: item.title,
@@ -82,7 +83,15 @@ const getCollectionItems = (
         variant: "article",
         url: item.permalink,
       }
-    })
+    }) satisfies CollectionCardProps[]
+
+  return transformedItems.sort((a, b) => {
+    // Sort by last updated date, tiebreaker by title
+    if (a.rawDate === b.rawDate) {
+      return a.title > b.title ? 1 : -1
+    }
+    return a.rawDate < b.rawDate ? 1 : -1
+  }) as CollectionCardProps[]
 }
 
 const CollectionLayout = ({


### PR DESCRIPTION
### TL;DR

Updated the `getCollectionItems` function to include sorting functionality and added a new `rawDate` property to collection items so sorting can be done.

### What changed?

- Added a `rawDate` property to the `baseItem` object in the `getCollectionItems` function.
- Implemented a sorting mechanism for the transformed items based on the `rawDate` and `title` properties.
- Added type assertion for the `transformedItems` array to ensure it conforms to `CollectionCardProps[]`.

### How to test?

1. Navigate to a collection page in the application.
2. Verify that the collection items are sorted by their last updated date in descending order.
3. For items with the same last updated date, confirm they are sorted alphabetically by title.
4. Check that all collection items display correctly with their associated properties.

### Why make this change?

This change improves the organization and presentation of collection items by implementing a consistent sorting order. It prioritizes the most recently updated items while providing a clear secondary sorting criterion for items with the same update date. This enhancement will make it easier for users to find and access the most relevant and up-to-date content within collections.

---
