### PR TITLE
fix: add margin to table component if not first child

### DIFF
--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -87,7 +87,7 @@ const Table = ({ attrs: { caption }, content }: TableProps) => {
   }, [])
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 [&:not(:first-child)]:mt-7">
       <BaseParagraph
         id={tableDescriptionId}
         content={caption}


### PR DESCRIPTION
### TL;DR

Added margin-top to non-first Table components.

### What changed?

Updated the Table component's outer div className to include a utility class that adds a top margin of 7 units to all Table components except the first one.

### How to test?

1. Render multiple Table components in a single view.
2. Verify that all Table components after the first one have a top margin of 7 units.
3. Confirm that the first Table component does not have an additional top margin.

### Why make this change?

This change improves the visual spacing between multiple Table components when they appear in sequence, enhancing readability and overall layout structure. The exclusion of the first child from this margin ensures proper alignment at the top of the container.
