### PR TITLE
feat: remove blockquote functionality from editor

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar.tsx
@@ -142,23 +142,6 @@ export const MenuBar = ({ editor }: { editor: Editor }) => {
         },
         {
           type: "item",
-          title: "Quote block",
-          textStyle: "body-1",
-          useSecondaryColor: true,
-          leftItem: (
-            <Divider
-              orientation="vertical"
-              border="1px solid"
-              borderColor="chakra-body-text"
-              h="1.625rem"
-              mr="0.75rem"
-            />
-          ),
-          action: () => editor.chain().focus().toggleBlockquote().run(),
-          isActive: () => editor.isActive("blockquote"),
-        },
-        {
-          type: "item",
           title: "Paragraph",
           textStyle: "body-1",
           action: () =>

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -87,10 +87,6 @@ function TipTapComponent({ content }: TipTapComponentProps) {
 
   const utils = trpc.useUtils()
 
-  const [{ content: pageContent }] = trpc.page.readPageAndBlob.useSuspenseQuery(
-    { siteId, pageId },
-  )
-
   // TODO: Add a loading state or use suspsense
   return (
     <>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor.tsx
@@ -3,7 +3,6 @@ import type { ControlProps } from "@jsonforms/core"
 import type { Level } from "@tiptap/extension-heading"
 import type { JSONContent } from "@tiptap/react"
 import { Box, VStack } from "@chakra-ui/react"
-import { Blockquote } from "@tiptap/extension-blockquote"
 import { Bold } from "@tiptap/extension-bold"
 import { BulletList } from "@tiptap/extension-bullet-list"
 import { Document } from "@tiptap/extension-document"
@@ -42,7 +41,6 @@ export function TiptapEditor({ data, handleChange }: TiptapEditorProps) {
   const editor = useEditor({
     extensions: [
       Link,
-      Blockquote,
       Bold,
       BulletList.extend({
         name: "unorderedList",


### PR DESCRIPTION
### TL;DR

Removed blockquote functionality from the TipTap editor.

### What changed?

- Removed the "Quote block" option from the MenuBar component in the PageEditor.
- Removed the Blockquote extension from the TipTapEditor component.
- Removed an unused query for page content in the TipTapComponent.

### How to test?

1. Open the PageEditor in the studio app.
2. Verify that the "Quote block" option is no longer present in the text formatting menu.
3. Attempt to create a blockquote in the editor and confirm that it's not possible.
4. Ensure that existing content and other text formatting options still work as expected.

### Why make this change?

This change simplifies the text editor by removing the blockquote functionality. It may have been determined that this feature was not necessary for the current use case or was causing issues in the editor. Removing unused code also helps to maintain a cleaner and more efficient codebase.
