### PR TITLE
fix: accordion

### DIFF
--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -1,3 +1,5 @@
+import { PropsWithChildren } from "react"
+import NextLink from "next/link"
 import { useRouter } from "next/router"
 import {
   Accordion,
@@ -6,11 +8,15 @@ import {
   AccordionItem,
   AccordionPanel,
   Box,
+  ButtonProps,
   Flex,
+  Grid,
+  GridItem,
   Icon,
   Spacer,
   Text,
 } from "@chakra-ui/react"
+import { GridProps } from "@chakra-ui/styled-system"
 import { Button, Spinner } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { BiData, BiFile, BiFolder, BiHomeAlt } from "react-icons/bi"
@@ -70,6 +76,25 @@ const getResourceType = (
   return "folders"
 }
 
+const SideNavRow = ({ children, ...rest }: ButtonProps & { href: string }) => {
+  return (
+    <Button
+      as={NextLink}
+      data-group
+      gap="0.25rem"
+      w="full"
+      variant="clear"
+      pl="0.75rem"
+      pr="0.5rem"
+      py="0.38rem"
+      justifyContent="flex-start"
+      {...rest}
+    >
+      {children}
+    </Button>
+  )
+}
+
 const SideNavItem = ({
   resourceType,
   resourceId,
@@ -100,6 +125,7 @@ const SideNavItem = ({
     )
   }
 
+  const urlType = getResourceType(resourceType)
   const { pages } = data
 
   return (
@@ -118,86 +144,114 @@ const SideNavItem = ({
         {/* so that we don't issue multiple db reads on load */}
         {({ isExpanded }) => {
           return (
-            <>
+            <Box pos="relative">
               {/* NOTE: required for focus ring */}
-              <Box m="4px">
-                <AccordionButton
-                  boxSizing="border-box"
-                  disabled={isDisabled}
-                  borderRadius="0.25rem"
-                  _focusVisible={{
-                    boxShadow: "none !important",
-                    outline: `2px solid var(--chakra-colors-utility-focus-default)`,
-                    outlineOffset: "0.125rem",
-                    _dark: {
-                      outline: `2px solid var(--chakra-colors-utility-focus-inverse)`,
-                    },
-                  }}
-                  _hover={{
-                    backgroundColor: "interaction.muted.main.hover",
-                  }}
-                  _active={{
-                    backgroundColor: "interaction.muted.main.active",
-                    textColor: "interaction.main.default",
-                  }}
-                  onDoubleClick={async () => {
-                    const urlType = getResourceType(resourceType)
-                    if (resourceType === "RootPage") {
-                      return router.push({
-                        pathname: "/sites/[siteId]",
-                        query: {
-                          siteId,
-                        },
-                      })
-                    }
-                    return router.push({
-                      pathname: "/sites/[siteId]/[resourceType]/[id]",
-                      query: {
-                        siteId,
-                        resourceType: urlType,
-                        id: resourceId,
-                      },
-                    })
-                  }}
+              <SideNavRow
+                leftIcon={<Box w="1rem" />}
+                href={
+                  resourceType === ResourceType.RootPage
+                    ? `/sites/${siteId}`
+                    : `/sites/${siteId}/${urlType}/${resourceId}`
+                }
+              >
+                {/* <AccordionButton */}
+                {/*   boxSizing="border-box" */}
+                {/*   disabled={isDisabled} */}
+                {/*   borderRadius="0.25rem" */}
+                {/*   _focusVisible={{ */}
+                {/*     boxShadow: "none !important", */}
+                {/*     outline: `2px solid var(--chakra-colors-utility-focus-default)`, */}
+                {/*     outlineOffset: "0.125rem", */}
+                {/*     _dark: { */}
+                {/*       outline: `2px solid var(--chakra-colors-utility-focus-inverse)`, */}
+                {/*     }, */}
+                {/*   }} */}
+                {/*   _hover={{ */}
+                {/*     backgroundColor: "interaction.muted.main.hover", */}
+                {/*   }} */}
+                {/*   _active={{ */}
+                {/*     backgroundColor: "interaction.muted.main.active", */}
+                {/*     textColor: "interaction.main.default", */}
+                {/*   }} */}
+                {/*   onDoubleClick={async () => { */}
+                {/*     const urlType = getResourceType(resourceType) */}
+                {/*     if (resourceType === "RootPage") { */}
+                {/*       return router.push({ */}
+                {/*         pathname: "/sites/[siteId]", */}
+                {/*         query: { */}
+                {/*           siteId, */}
+                {/*         }, */}
+                {/*       }) */}
+                {/*     } */}
+                {/*     return router.push({ */}
+                {/*       pathname: "/sites/[siteId]/[resourceType]/[id]", */}
+                {/*       query: { */}
+                {/*         siteId, */}
+                {/*         resourceType: urlType, */}
+                {/*         id: resourceId, */}
+                {/*       }, */}
+                {/*     }) */}
+                {/*   }} */}
+                {/* > */}
+                {/*   <Flex */}
+                {/*     w="full" */}
+                {/*     color="base.content.default" */}
+                {/*     alignItems="center" */}
+                {/*   > */}
+                {/*     {isAllowedToHaveChildren(resourceType) ? ( */}
+                {/*       <AccordionIcon */}
+                {/*         mr="0.25rem" */}
+                {/*         color="interaction.support.unselected" */}
+                {/*       /> */}
+                {/*     ) : ( */}
+                {/*       <Box w="1.5rem"></Box> */}
+                {/*     )} */}
+                {/*     <Icon as={icon} flexShrink={0} /> */}
+                {/*     <Text */}
+                {/*       noOfLines={1} */}
+                {/*       textAlign="left" */}
+                {/*       textStyle="subhead-2" */}
+                {/*       ml="0.5rem" */}
+                {/*     > */}
+                {/*       {permalink} */}
+                {/*     </Text> */}
+                {/*     <Spacer /> */}
+                {/*     {resourceType === ResourceType.RootPage && ( */}
+                {/*       <Text */}
+                {/*         color="base.content.medium" */}
+                {/*         textTransform="uppercase" */}
+                {/*         textStyle="caption-1" */}
+                {/*         overflow="hidden" */}
+                {/*         textOverflow="ellipsis" */}
+                {/*         whiteSpace="nowrap" */}
+                {/*       > */}
+                {/*         Home */}
+                {/*       </Text> */}
+                {/*     )} */}
+                {/*   </Flex> */}
+                {/* </AccordionButton> */}
+                <Icon fill="base.content.default" as={icon} flexShrink={0} />
+                <Text
+                  ml="0.25rem"
+                  noOfLines={1}
+                  textColor="base.content.default"
+                  textAlign="left"
+                  textStyle="subhead-2"
                 >
-                  <Flex
-                    w="full"
-                    color="base.content.default"
-                    alignItems="center"
-                  >
-                    {isAllowedToHaveChildren(resourceType) ? (
-                      <AccordionIcon
-                        mr="0.25rem"
-                        color="interaction.support.unselected"
-                      />
-                    ) : (
-                      <Box w="1.5rem"></Box>
-                    )}
-                    <Icon as={icon} flexShrink={0} />
-                    <Text
-                      noOfLines={1}
-                      textAlign="left"
-                      textStyle="subhead-2"
-                      ml="0.5rem"
-                    >
-                      {permalink}
-                    </Text>
-                    <Spacer />
-                    {resourceType === ResourceType.RootPage && (
-                      <Text
-                        color="base.content.medium"
-                        textTransform="uppercase"
-                        textStyle="caption-1"
-                        overflow="hidden"
-                        textOverflow="ellipsis"
-                        whiteSpace="nowrap"
-                      >
-                        Home
-                      </Text>
-                    )}
-                  </Flex>
+                  {permalink}
+                </Text>
+              </SideNavRow>
+              {isAllowedToHaveChildren(resourceType) && (
+                <AccordionButton
+                  pos="absolute"
+                  w="fit-content"
+                  p={0}
+                  left="0.75rem"
+                  top="0.75rem"
+                >
+                  <AccordionIcon color="interaction.support.unselected" />
                 </AccordionButton>
-              </Box>
+              )}
               {isExpanded && (
                 <AccordionPanel p="0" pl="1.25rem">
                   {pages.map(({ items }) => {
@@ -224,7 +278,7 @@ const SideNavItem = ({
                   )}
                 </AccordionPanel>
               )}
-            </>
+            </Box>
           )
         }}
       </AccordionItem>

--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -1,6 +1,4 @@
-import { PropsWithChildren } from "react"
 import NextLink from "next/link"
-import { useRouter } from "next/router"
 import {
   Accordion,
   AccordionButton,
@@ -10,13 +8,9 @@ import {
   Box,
   ButtonProps,
   Flex,
-  Grid,
-  GridItem,
   Icon,
-  Spacer,
   Text,
 } from "@chakra-ui/react"
-import { GridProps } from "@chakra-ui/styled-system"
 import { Button, Spinner } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { BiData, BiFile, BiFolder, BiHomeAlt } from "react-icons/bi"
@@ -115,7 +109,6 @@ const SideNavItem = ({
     )
 
   const icon = ICON_MAPPINGS[resourceType]
-  const router = useRouter()
 
   if (isLoading || !data) {
     return (
@@ -127,6 +120,8 @@ const SideNavItem = ({
 
   const urlType = getResourceType(resourceType)
   const { pages } = data
+
+  const hasChildren = pages.some(({ items }) => items.length > 0)
 
   return (
     <Accordion
@@ -154,82 +149,6 @@ const SideNavItem = ({
                     : `/sites/${siteId}/${urlType}/${resourceId}`
                 }
               >
-                {/* <AccordionButton */}
-                {/*   boxSizing="border-box" */}
-                {/*   disabled={isDisabled} */}
-                {/*   borderRadius="0.25rem" */}
-                {/*   _focusVisible={{ */}
-                {/*     boxShadow: "none !important", */}
-                {/*     outline: `2px solid var(--chakra-colors-utility-focus-default)`, */}
-                {/*     outlineOffset: "0.125rem", */}
-                {/*     _dark: { */}
-                {/*       outline: `2px solid var(--chakra-colors-utility-focus-inverse)`, */}
-                {/*     }, */}
-                {/*   }} */}
-                {/*   _hover={{ */}
-                {/*     backgroundColor: "interaction.muted.main.hover", */}
-                {/*   }} */}
-                {/*   _active={{ */}
-                {/*     backgroundColor: "interaction.muted.main.active", */}
-                {/*     textColor: "interaction.main.default", */}
-                {/*   }} */}
-                {/*   onDoubleClick={async () => { */}
-                {/*     const urlType = getResourceType(resourceType) */}
-                {/*     if (resourceType === "RootPage") { */}
-                {/*       return router.push({ */}
-                {/*         pathname: "/sites/[siteId]", */}
-                {/*         query: { */}
-                {/*           siteId, */}
-                {/*         }, */}
-                {/*       }) */}
-                {/*     } */}
-                {/*     return router.push({ */}
-                {/*       pathname: "/sites/[siteId]/[resourceType]/[id]", */}
-                {/*       query: { */}
-                {/*         siteId, */}
-                {/*         resourceType: urlType, */}
-                {/*         id: resourceId, */}
-                {/*       }, */}
-                {/*     }) */}
-                {/*   }} */}
-                {/* > */}
-                {/*   <Flex */}
-                {/*     w="full" */}
-                {/*     color="base.content.default" */}
-                {/*     alignItems="center" */}
-                {/*   > */}
-                {/*     {isAllowedToHaveChildren(resourceType) ? ( */}
-                {/*       <AccordionIcon */}
-                {/*         mr="0.25rem" */}
-                {/*         color="interaction.support.unselected" */}
-                {/*       /> */}
-                {/*     ) : ( */}
-                {/*       <Box w="1.5rem"></Box> */}
-                {/*     )} */}
-                {/*     <Icon as={icon} flexShrink={0} /> */}
-                {/*     <Text */}
-                {/*       noOfLines={1} */}
-                {/*       textAlign="left" */}
-                {/*       textStyle="subhead-2" */}
-                {/*       ml="0.5rem" */}
-                {/*     > */}
-                {/*       {permalink} */}
-                {/*     </Text> */}
-                {/*     <Spacer /> */}
-                {/*     {resourceType === ResourceType.RootPage && ( */}
-                {/*       <Text */}
-                {/*         color="base.content.medium" */}
-                {/*         textTransform="uppercase" */}
-                {/*         textStyle="caption-1" */}
-                {/*         overflow="hidden" */}
-                {/*         textOverflow="ellipsis" */}
-                {/*         whiteSpace="nowrap" */}
-                {/*       > */}
-                {/*         Home */}
-                {/*       </Text> */}
-                {/*     )} */}
-                {/*   </Flex> */}
-                {/* </AccordionButton> */}
                 <Icon fill="base.content.default" as={icon} flexShrink={0} />
                 <Text
                   ml="0.25rem"
@@ -241,17 +160,19 @@ const SideNavItem = ({
                   {permalink}
                 </Text>
               </SideNavRow>
-              {isAllowedToHaveChildren(resourceType) && (
-                <AccordionButton
-                  pos="absolute"
-                  w="fit-content"
-                  p={0}
-                  left="0.75rem"
-                  top="0.75rem"
-                >
-                  <AccordionIcon color="interaction.support.unselected" />
-                </AccordionButton>
-              )}
+              {isAllowedToHaveChildren(resourceType) &&
+                (isLoading || hasChildren) && (
+                  <AccordionButton
+                    disabled={isLoading}
+                    pos="absolute"
+                    w="fit-content"
+                    p={0}
+                    left="0.75rem"
+                    top="0.75rem"
+                  >
+                    <AccordionIcon color="interaction.support.unselected" />
+                  </AccordionButton>
+                )}
               {isExpanded && (
                 <AccordionPanel p="0" pl="1.25rem">
                   {pages.map(({ items }) => {


### PR DESCRIPTION
## Problem
Change the double click flow to accordion dropdown flow as it's better for user. This change also prevents the accordion from appearing if collections/folders **do not have children**.

Closes ISOM-1340
Closes ISOM-1342

## Solution
- Use a box as a wrapper element with `pos="relative"`. 
- Position the chevron (`AccordionButton`) absolutely inside the box
- reserve spacing for the chevron so that it doesn't look too weird
- add a **full width** link so on single click, we redirect that
- additionally, only show the chevon if 
   - `isAllowedToHaveChildren(resourceType) === true` **and**
   -  `isLoading` (we dk how many pages are in this folder, so potentially ambiguous - also disabled said chevron during load) **or**
   - `pages.items.length > 0`

## Screenshots and video

https://github.com/user-attachments/assets/3ec93b73-e87a-431c-b925-75648de1cfc4

