### PR TITLE
fix: infocols

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
@@ -25,7 +25,7 @@ const LINK_TYPES = {
   },
   external: {
     icon: BiLink,
-    label: "External link",
+    label: "External",
   },
   file: {
     icon: BiFile,


### PR DESCRIPTION
## Problem
rename button text from `external link` to `external` cos it was popping

## screenshots: 
### Old
<img width="441" alt="image" src="https://github.com/user-attachments/assets/014d9cdb-84c9-4488-94c1-a2e2e5da8654">

### New
<img width="478" alt="image" src="https://github.com/user-attachments/assets/8825ca3d-a6cc-44a8-8848-1cdd34491366">
