### PR TITLE
fix: add names to icons selection

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -90,19 +90,19 @@ export const DEFAULT_BLOCKS: Record<
       {
         title: "This is the first card",
         url: "https://www.google.com",
-        imageUrl: "https://placehold.co/200x200",
+        imageUrl: "/placeholder_no_image.png",
         imageAlt: "This is the alt text",
       },
       {
         title: "This is the second card",
         url: "https://www.google.com",
-        imageUrl: "https://placehold.co/400x200",
+        imageUrl: "/placeholder_no_image.png",
         imageAlt: "This is the alt text",
       },
       {
         title: "This is the third card",
         url: "https://www.google.com",
-        imageUrl: "https://placehold.co/500x200",
+        imageUrl: "/placeholder_no_image.png",
         imageAlt: "This is the alt text",
       },
     ],
@@ -133,7 +133,7 @@ export const DEFAULT_BLOCKS: Record<
     type: "infopic",
     title: "This is an infopic",
     description: "This is the description for the infopic component",
-    imageSrc: "https://placehold.co/600x400",
+    imageSrc: "/placeholder_no_image.png",
   },
   contentpic: {
     type: "contentpic",
@@ -151,7 +151,7 @@ export const DEFAULT_BLOCKS: Record<
         },
       ],
     },
-    imageSrc: "https://placehold.co/600x400",
+    imageSrc: "/placeholder_no_image.png",
     imageAlt: "This is the alt text for the image",
   },
   keystatistics: {

--- a/packages/components/src/interfaces/complex/Button.ts
+++ b/packages/components/src/interfaces/complex/Button.ts
@@ -58,7 +58,12 @@ export const ButtonSchema = Type.Object(
     ),
     leftIcon: Type.Optional(
       Type.Union(
-        SUPPORTED_ICON_NAMES.map((icon) => Type.Literal(icon)),
+        SUPPORTED_ICON_NAMES.map((icon) =>
+          Type.Literal(icon, {
+            title:
+              icon.charAt(0).toUpperCase() + icon.slice(1).replace(/-/g, " "),
+          }),
+        ),
         {
           title: "Button left icon",
           description: "The icon to display on the left of the button's text",
@@ -68,7 +73,12 @@ export const ButtonSchema = Type.Object(
     ),
     rightIcon: Type.Optional(
       Type.Union(
-        SUPPORTED_ICON_NAMES.map((icon) => Type.Literal(icon)),
+        SUPPORTED_ICON_NAMES.map((icon) =>
+          Type.Literal(icon, {
+            title:
+              icon.charAt(0).toUpperCase() + icon.slice(1).replace(/-/g, " "),
+          }),
+        ),
         {
           title: "Button right icon",
           description: "The icon to display on the right of the button's text",

--- a/packages/components/src/interfaces/complex/InfoCols.ts
+++ b/packages/components/src/interfaces/complex/InfoCols.ts
@@ -15,7 +15,12 @@ export const InfoBoxSchema = Type.Object({
   ),
   icon: Type.Optional(
     Type.Union(
-      SUPPORTED_ICON_NAMES.map((icon) => Type.Literal(icon)),
+      SUPPORTED_ICON_NAMES.map((icon) =>
+        Type.Literal(icon, {
+          title:
+            icon.charAt(0).toUpperCase() + icon.slice(1).replace(/-/g, " "),
+        }),
+      ),
       {
         title: "Column icon",
         description: "The icon to display for the column",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The icons selection do not have any names to them.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Added names for the selection of icons.
- Also switch to using the placeholder image when creating new blocks.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/eea3f325-d444-48d3-8444-3d2ed04d5dc1)

**AFTER**:

<!-- [insert screenshot here] -->
![Screenshot 2024-08-26 at 23 47 40](https://github.com/user-attachments/assets/9ee2c3e6-40c5-4a68-b741-bc55fd63233f)