### PR TITLE
fix: don't refetch on focus

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -97,12 +97,7 @@ function BlockItem({
   )
 }
 
-interface ComponentSelectorProps {
-  siteId: number
-  pageId: number
-}
-
-function ComponentSelector({ pageId, siteId }: ComponentSelectorProps) {
+function ComponentSelector() {
   const {
     setCurrActiveIdx,
     savedPageState,
@@ -111,16 +106,6 @@ function ComponentSelector({ pageId, siteId }: ComponentSelectorProps) {
     setPreviewPageState,
     setAddedBlock,
   } = useEditorDrawerContext()
-  const utils = trpc.useUtils()
-  const { mutate } = trpc.page.updatePageBlob.useMutation({
-    onSuccess: async () => {
-      await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
-    },
-  })
-  const [page] = trpc.page.readPageAndBlob.useSuspenseQuery({
-    pageId,
-    siteId,
-  })
 
   const onProceed = (sectionType: SectionType) => {
     if (!savedPageState) return

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -5,8 +5,6 @@ import Ajv from "ajv"
 
 import ComponentSelector from "~/components/PageEditor/ComponentSelector"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import { useQueryParse } from "~/hooks/useQueryParse"
-import { editPageSchema } from "../schema"
 import AdminModeStateDrawer from "./AdminModeStateDrawer"
 import ComplexEditorStateDrawer from "./ComplexEditorStateDrawer"
 import MetadataEditorStateDrawer from "./MetadataEditorStateDrawer"
@@ -23,8 +21,6 @@ export function EditPageDrawer(): JSX.Element {
     drawerState: currState,
     currActiveIdx,
   } = useEditorDrawerContext()
-
-  const { pageId, siteId } = useQueryParse(editPageSchema)
 
   const inferAsProse = (component?: IsomerComponent): ProseProps => {
     if (!component) {
@@ -50,7 +46,7 @@ export function EditPageDrawer(): JSX.Element {
     case "adminMode":
       return <AdminModeStateDrawer />
     case "addBlock":
-      return <ComponentSelector siteId={siteId} pageId={pageId} />
+      return <ComponentSelector />
     case "nativeEditor": {
       const component = previewPageState.content[currActiveIdx]
       return <TipTapComponent content={inferAsProse(component)} />

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -21,10 +21,13 @@ function EditPage(): JSX.Element {
   const { pageId, siteId } = useQueryParse(editPageSchema)
 
   const [{ content: page, permalink }] =
-    trpc.page.readPageAndBlob.useSuspenseQuery({
-      pageId,
-      siteId,
-    })
+    trpc.page.readPageAndBlob.useSuspenseQuery(
+      {
+        pageId,
+        siteId,
+      },
+      { refetchOnWindowFocus: false },
+    )
 
   const themeCssVars = useSiteThemeCssVars({ siteId })
 


### PR DESCRIPTION
## Problem
previously, we refetched on focus for the root drawer. this led to components rerendering when the window loses focus and then the user tabs back. 

in order to remediate this problem, we just remove the fetch on refocus totally. however, we do need to be sure that we do a revalidate and refetch when we know that our data is stale. (this part isn't quite done yet)

## Solution
- set `refetchOnFocus: false` on the root drawer. compare hte behaviour in the 2 videos below

## Screenshots and Videos 
### With refetch on focus
note the jump back

https://github.com/user-attachments/assets/6027552b-fece-42eb-b75a-429f2924f359


### WithOUT refetch on focus

https://github.com/user-attachments/assets/e5366b20-59ab-4870-b11b-90d1ab6499a6

