### PR TITLE
feat: collection settings

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -95,12 +95,16 @@ const SuspendableModalContent = ({
   const { mutate, isLoading } = trpc.folder.editFolder.useMutation({
     onSettled: onClose,
     onSuccess: async () => {
-      await utils.site.list.invalidate()
       await utils.resource.listWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate({
         resourceId: parentId ? String(parentId) : null,
       })
-      await utils.folder.getMetadata.invalidate()
+      await utils.folder.getMetadata.invalidate({
+        resourceId: Number(folderId),
+      })
+      await utils.collection.getMetadata.invalidate({
+        resourceId: Number(folderId),
+      })
       toast({ title: "Folder updated!", status: "success" })
     },
     onError: (err) => {

--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -1,11 +1,14 @@
 import { Box, HStack, Stack, Text, useDisclosure } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
+import { useSetAtom } from "jotai"
 import { BiData } from "react-icons/bi"
 import { z } from "zod"
 
+import { folderSettingsModalAtom } from "~/features/dashboard/atoms"
 import { CollectionBanner } from "~/features/dashboard/components/CollectionBanner"
 import { CollectionTable } from "~/features/dashboard/components/CollectionTable"
 import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
+import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { CreateCollectionPageModal } from "~/features/editing-experience/components/CreateCollectionPageModal"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
@@ -24,6 +27,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
     onClose: onPageCreateModalClose,
   } = useDisclosure()
   const { siteId, resourceId } = useQueryParse(sitePageSchema)
+  const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
 
   // TODO: Handle not found error in error boundary
   const [metadata] = trpc.collection.getMetadata.useSuspenseQuery({
@@ -50,6 +54,17 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
             </Text>
           </HStack>
           <HStack align="center" gap="0.75rem">
+            <Button
+              variant="outline"
+              size="md"
+              onClick={() =>
+                setFolderSettingsModalState({
+                  folderId: String(resourceId),
+                })
+              }
+            >
+              Collection settings
+            </Button>
             <Button onClick={onPageCreateModalOpen} size="sm">
               Add new item
             </Button>
@@ -67,6 +82,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
         collectionId={resourceId}
       />
       <DeleteResourceModal siteId={siteId} />
+      <FolderSettingsModal />
     </>
   )
 }


### PR DESCRIPTION
## Problem
We need to have collection settings, which is missing at present from our collections list page.

## Solution
Reuse `FolderModal` and change some invalidation logic. The main chnage to invalidation logic is that we invalidate **specifically the resource id**. we also add invalidation of `collection.getMetadata` as this is what `CollectionsListPage` relies on to fetch.

## Notes
- not a fan of this pattern, where we lump `collection + page` together ;--; 
- the copy needs some change too 
(if got time i'll chnage both)

## Screenshots + video

https://github.com/user-attachments/assets/4d379076-d75a-46ad-8274-1dde38cc083d

