### PR TITLE
feat: add breadcrumb to collections

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -1,5 +1,13 @@
-import { Box, HStack, Stack, Text, useDisclosure } from "@chakra-ui/react"
-import { Button } from "@opengovsg/design-system-react"
+import {
+  Box,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  HStack,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { Breadcrumb, Button } from "@opengovsg/design-system-react"
 import { BiData } from "react-icons/bi"
 import { z } from "zod"
 
@@ -34,7 +42,27 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
   return (
     <>
       <Stack w="100%" p="1.75rem" gap="1rem">
-        {/* TODO: Add breadcrumb */}
+        <Breadcrumb size="sm">
+          <BreadcrumbItem>
+            <BreadcrumbLink href={`/sites/${siteId}`}>
+              <Text textStyle="caption-2" color="interaction.links.default">
+                Home
+              </Text>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <Text textStyle="caption-2" color="base.content.default">
+              ...
+            </Text>
+          </BreadcrumbItem>
+          <BreadcrumbItem>
+            <BreadcrumbLink isCurrentPage>
+              <Text textStyle="caption-2" color="base.content.default">
+                {metadata.title}
+              </Text>
+            </BreadcrumbLink>
+          </BreadcrumbItem>
+        </Breadcrumb>
         <HStack w="100%" gap="1.5rem">
           <HStack gap="0.75rem" flex={1}>
             <Box

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -59,11 +59,25 @@ const FolderPage: NextPageWithLayout = () => {
         <VStack w="100%" align="start">
           <Breadcrumb size="sm">
             <BreadcrumbItem>
+              <BreadcrumbLink href={`/sites/${siteId}`}>
+                <Text textStyle="caption-2" color="interaction.links.default">
+                  Home
+                </Text>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <Text textStyle="caption-2" color="base.content.default">
+                ...
+              </Text>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
               <BreadcrumbLink
                 isCurrentPage
                 href={`/sites/${siteId}/folders/${folderId}`}
               >
-                <Text color="base.content.default">{title}</Text>
+                <Text textStyle="caption-2" color="base.content.default">
+                  {title}
+                </Text>
               </BreadcrumbLink>
             </BreadcrumbItem>
           </Breadcrumb>


### PR DESCRIPTION
## Problem
Previously, we had unfinished scope on collections where we required breadcrumbs. Now, this PR adds said breadcrumbs in + updates folder breadcrumbs to correct styling too

## Solution
1. add collection breadcrumb
2. update folder breadcrumb to have base `Home > ... > <cur folder>` styling

## Screenshots + video

https://github.com/user-attachments/assets/2cbd13fc-7f00-440d-a8aa-10018d7fc9c4


