### PR TITLE
fix: add env vars for AWS access and secret keys

### DIFF
--- a/apps/studio/src/env.mjs
+++ b/apps/studio/src/env.mjs
@@ -54,6 +54,13 @@ const sgidServerSchema = z.discriminatedUnion("NEXT_PUBLIC_ENABLE_SGID", [
   }),
 ])
 
+// NOTE: This is only needed by Vercel. Use the task role permissions instead
+// if deploying on AWS
+const awsAccessSchema = z.object({
+  AWS_ACCESS_KEY_ID: z.string().optional(),
+  AWS_SECRET_ACCESS_KEY: z.string().optional(),
+})
+
 /**
  * Specify your server-side environment variables schema here. This way you can ensure the app isn't
  * built with invalid env vars.
@@ -71,6 +78,7 @@ const server = z
     ]),
     SESSION_SECRET: z.string().min(32),
   })
+  .merge(awsAccessSchema)
   .merge(s3Schema)
   // Add on schemas as needed that requires conditional validation.
   .merge(baseSgidSchema)
@@ -120,6 +128,8 @@ const processEnv = {
   SGID_CLIENT_SECRET: process.env.SGID_CLIENT_SECRET,
   SGID_PRIVATE_KEY: process.env.SGID_PRIVATE_KEY,
   SGID_REDIRECT_URI: process.env.SGID_REDIRECT_URI,
+  AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+  AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
   // Client-side env vars
   NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
   NEXT_PUBLIC_APP_VERSION:

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -12,10 +12,14 @@ import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
 
 import { env } from "~/env.mjs"
 
-const { NEXT_PUBLIC_S3_REGION } = env
+const { NEXT_PUBLIC_S3_REGION, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = env
 
 export const storage = new S3Client({
   region: NEXT_PUBLIC_S3_REGION,
+  credentials: {
+    accessKeyId: AWS_ACCESS_KEY_ID ?? "",
+    secretAccessKey: AWS_SECRET_ACCESS_KEY ?? "",
+  },
 })
 
 export const generateSignedPutUrl = async ({


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Vercel requires using AWS access and secret keys to access our S3 bucket.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add the env vars for AWS access and secret keys.