### PR TITLE
chore: rename prose component to text component

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -175,7 +175,7 @@ function ComponentSelector() {
           <SectionTitle title="Basic Building Blocks" />
           <BlockList>
             <BlockItem
-              label="Prose"
+              label="Text"
               icon={BiText}
               onProceed={onProceed}
               sectionType="prose"

--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -17,4 +17,4 @@ export const JSON_FORMS_RANKING = {
   Catchall: -99999999999,
 }
 
-export const PROSE_COMPONENT_NAME = "Prose component"
+export const PROSE_COMPONENT_NAME = "Text component"

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -16,6 +16,7 @@ import { BiGridVertical } from "react-icons/bi"
 import { BsPlus } from "react-icons/bs"
 
 import { BlockEditingPlaceholder } from "~/components/Svg"
+import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
@@ -224,7 +225,7 @@ export default function RootStateDrawer() {
                                   {/*  NOTE: Because we use `Type.Ref` for prose, */}
                                   {/* this gets a `$Ref` only and not the concrete values */}
                                   {block.type === "prose"
-                                    ? "Prose component"
+                                    ? PROSE_COMPONENT_NAME
                                     : getComponentSchema(block.type).title}
                                 </Text>
                               </HStack>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Component is called Prose component now.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Rename "Prose component" to "Text component"