### PR TITLE
fix: datatable

### DIFF
--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -129,7 +129,7 @@ export const Datatable = <T extends object>({
         </Table>
       </Box>
       <Flex py="1rem" gap="1rem">
-        {pagination && (
+        {pagination && !!totalRowCount && (
           <DatatablePagination
             instance={instance}
             totalRowCount={totalRowCount}


### PR DESCRIPTION
## Problem
Previously, we showed an empty pagination when there are no items in the collection. To avoid this, we will do a conditional render only if `totalRowCount` is defined and greater than 0.

## Solution
remove pagination if total row count is 0

## Screenshots
### Before
<img width="1112" alt="image" src="https://github.com/user-attachments/assets/92b5d554-65ed-4803-af01-949fc1d9fbb4">


### After
<img width="1111" alt="image" src="https://github.com/user-attachments/assets/e24c78cb-092b-4bb1-bb98-a901fbf7b503">

