### PR TITLE
fix(ui): update three dots to go to parent

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -92,6 +92,7 @@ const MoveResourceContent = withSuspense(
       },
       onSuccess: async () => {
         await utils.page.readPageAndBlob.invalidate()
+        await utils.resource.getParentOf.invalidate()
         await utils.resource.listWithoutRoot.invalidate({
           // TODO: Update backend `list` to use the proper schema
           resourceId: movedItem?.resourceId

--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -55,11 +55,6 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbItem>
-            <Text textStyle="caption-2" color="base.content.default">
-              ...
-            </Text>
-          </BreadcrumbItem>
-          <BreadcrumbItem>
             <BreadcrumbLink isCurrentPage>
               <Text textStyle="caption-2" color="base.content.default">
                 {metadata.title}


### PR DESCRIPTION
## Problem
The three dots didn't do anything previously. This PR adds a new functionality to update teh 3 dots to go back to parent. This only works for folders >1 level deep (as if they're 1 level deep, the immediate parent is the root folder, so don't need 3 dots)

Closes ISOM-1433

## Solution
1. add new endpoint (`Resource.getParentOf`) 
2. invalidate `move` endpoint. we only need to invalidate this because this is the only end point that can chnage the parent. 

## Screenshots + video

https://github.com/user-attachments/assets/7cca9ce9-deab-487e-807b-ef6e7e37a34d

