### PR TITLE
refactor(breadcrumbs): display more states + single query fetch

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -56,11 +56,10 @@ const FolderPage: NextPageWithLayout = () => {
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
 
   const { folderId, siteId } = useQueryParse(folderPageSchema)
-  const [{ parentResourceId, resourceType }] =
-    trpc.resource.getParentOf.useSuspenseQuery({
-      siteId: Number(siteId),
-      resourceId: folderId,
-    })
+  const [{ resource }] = trpc.resource.getParentOf.useSuspenseQuery({
+    siteId: Number(siteId),
+    resourceId: folderId,
+  })
 
   const [{ title }] = trpc.folder.getMetadata.useSuspenseQuery({
     siteId: parseInt(siteId),
@@ -68,9 +67,9 @@ const FolderPage: NextPageWithLayout = () => {
   })
 
   const parentLinkHref = getResourceLink(
-    parentResourceId,
+    resource.parent?.id,
     Number(siteId),
-    resourceType,
+    resource.type,
   )
 
   return (
@@ -85,7 +84,16 @@ const FolderPage: NextPageWithLayout = () => {
                 </Text>
               </BreadcrumbLink>
             </BreadcrumbItem>
-            {parentResourceId && (
+            {resource.parent?.id && (
+              <BreadcrumbItem>
+                <BreadcrumbLink href={parentLinkHref}>
+                  <Text textStyle="caption-2" color="base.content.default">
+                    ...
+                  </Text>
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+            )}
+            {resource.parent?.parentId && (
               <BreadcrumbItem>
                 <BreadcrumbLink href={parentLinkHref}>
                   <Text textStyle="caption-2" color="base.content.default">

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -5,6 +5,12 @@ import {
   offsetPaginationSchema,
 } from "./pagination"
 
+const resourceSchema = z
+  .string()
+  .min(1)
+  .regex(/[0-9]+/)
+  .refine((s) => !s.startsWith("0"))
+
 // NOTE: We want to accept string
 // but validate that the string conforms to bigint.
 // Oddly enough, kysely doesn't allow `bigint` to query
@@ -40,11 +46,12 @@ export const countResourceSchema = z.object({
 
 export const deleteResourceSchema = z.object({
   siteId: z.number(),
-  resourceId: z
-    .string()
-    .min(1)
-    .regex(/[0-9]+/)
-    .refine((s) => !s.startsWith("0")),
+  resourceId: resourceSchema,
+})
+
+export const getParentSchema = z.object({
+  siteId: z.number().min(0),
+  resourceId: resourceSchema,
 })
 
 export const listResourceSchema = z

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -6,6 +6,7 @@ import {
   deleteResourceSchema,
   getChildrenSchema,
   getMetadataSchema,
+  getParentSchema,
   listResourceSchema,
   moveSchema,
 } from "~/schemas/resource"
@@ -197,12 +198,7 @@ export const resourceRouter = router({
       return result.numDeletedRows.toString()
     }),
   getParentOf: protectedProcedure
-    .input(
-      z.object({
-        siteId: z.number().min(0),
-        resourceId: z.string(),
-      }),
-    )
+    .input(getParentSchema)
     .query(async ({ input: { siteId, resourceId } }) => {
       return db.transaction().execute(async (tx) => {
         const resource = await tx

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -1,6 +1,5 @@
 import { TRPCError } from "@trpc/server"
 import { jsonObjectFrom } from "kysely/helpers/postgres"
-import { z } from "zod"
 
 import {
   countResourceSchema,
@@ -205,7 +204,7 @@ export const resourceRouter = router({
         .selectFrom("Resource")
         .where("Resource.siteId", "=", siteId)
         .where("Resource.id", "=", resourceId)
-        .select(["Resource.type"])
+        .select(["Resource.type", "Resource.id", "Resource.title"])
         .select((eb) =>
           jsonObjectFrom(
             eb
@@ -213,7 +212,12 @@ export const resourceRouter = router({
               .innerJoin("Resource as parent", "parent.id", "Resource.parentId")
               .where("Resource.id", "=", resourceId)
               .where("parent.id", "is not", null)
-              .select(["parent.type", "parent.id", "parent.parentId"]),
+              .select([
+                "parent.type",
+                "parent.id",
+                "parent.parentId",
+                "parent.title",
+              ]),
           ).as("parent"),
         )
         .executeTakeFirstOrThrow()


### PR DESCRIPTION
## Problem
We previously did a simplified UI for our breadcrumbs, which was merged in as a baseline. This PR adds more comprehensive states to our breadcrumb + simplifies # of queries from 2 -> 1

## Solution
1. use expression builder from kysely to do a nested `SELECT` statement. this allows us to flatten the query into a single one. 
2. we previously had only 2 states, `Home -> ... -> Current` and `Home -> current`. now, we have expanded the number of states to 3: 
    - `Home -> .. -> parent -> current` 
    - `Home -> parent -> current`
    - `Home  -> current` 

We do this by going from. most specific (top case) to bottom and via checkign of the grandparent. If the grand parent exists, we know it is the first case cos `Home` is indicated via `parentId === null`

## Screenshots and video

https://github.com/user-attachments/assets/4e2518fa-6290-46cd-87c3-239ca66025a7


