### PR TITLE
chore(ci): add graphite ci optimisation

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,16 @@ on:
 
 # List of jobs
 jobs:
+  optimize_ci:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@main
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
   # JOB to run change detection
   changes:
     runs-on: ubuntu-latest
@@ -31,9 +41,9 @@ jobs:
             studio:
               - 'apps/studio/**'
   ui:
-    needs: changes
+    needs: [changes, optimize_ci]
     # Only run if the user is not a bot and has changes
-    if: ${{ !endsWith(github.actor , 'bot') && !endsWith(github.actor, '[bot]') && needs.changes.outputs.ui == 'true' }}
+    if: ${{ !endsWith(github.actor , 'bot') && !endsWith(github.actor, '[bot]') && needs.changes.outputs.ui == 'true' && needs.optimize_ci.outputs.skip == 'false'}}
     # Operating System
     runs-on: ubuntu-latest
     environment: staging
@@ -59,9 +69,9 @@ jobs:
           # Skip running Chromatic on dependabot PRs
           skip: dependabot/**
   studio:
-    needs: changes
+    needs: [changes, optimize_ci]
     # Only run if the user is not a bot and has changes
-    if: ${{ !endsWith(github.actor , 'bot') && !endsWith(github.actor, '[bot]') && needs.changes.outputs.studio == 'true' }}
+    if: ${{ !endsWith(github.actor , 'bot') && !endsWith(github.actor, '[bot]') && needs.changes.outputs.studio == 'true' && needs.optimize_ci.outputs.skip == 'false' }}
     # Operating System
     runs-on: ubuntu-latest
     environment: staging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,16 @@ env:
   LOG_LEVEL: silent
 
 jobs:
+  optimize_ci:
+    runs-on: ubuntu-latest # or whichever runner you use for your CI
+    outputs:
+      skip: ${{ steps.check_skip.outputs.skip }}
+    steps:
+      - name: Optimize CI
+        id: check_skip
+        uses: withgraphite/graphite-ci-action@main
+        with:
+          graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -47,6 +57,8 @@ jobs:
         run: npm run typecheck
 
   test:
+    needs: optimize_ci
+    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### TL;DR

Integrated Graphite CI Optimizer to improve CI workflow efficiency.
Also save some money rerunning chromatic stuff on rebases

### What changed?

- Added a new `optimize_ci` job in both `chromatic.yml` and `ci.yml` workflows.
- Modified the `ui` and `studio` jobs in `chromatic.yml` to depend on the `optimize_ci` job.
- Updated the `test` job in `ci.yml` to depend on the `optimize_ci` job.
- Added conditional checks to skip jobs based on the Graphite CI Optimizer output.

### How to test?

1. Push a commit or create a pull request to trigger the CI workflows.
2. Observe the `optimize_ci` job running first in both workflows.
3. Verify that subsequent jobs are skipped or executed based on the Graphite CI Optimizer's output.
4. Ensure that the existing functionality of the CI pipelines remains intact.

### Why make this change?

This change aims to optimize CI workflows by leveraging the Graphite CI Optimizer. By selectively running jobs based on the optimizer's output, we can reduce unnecessary CI runs, save computational resources, and speed up the overall CI process. This improvement will lead to faster feedback cycles for developers and more efficient use of CI/CD infrastructure.

---