### PR TITLE
fix: add missing folder id

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -203,6 +203,7 @@ const FolderPage: NextPageWithLayout = () => {
         isOpen={isPageCreateModalOpen}
         onClose={onPageCreateModalClose}
         siteId={parseInt(siteId)}
+        folderId={parseInt(folderId)}
       />
       <CreateFolderModal
         isOpen={isFolderCreateModalOpen}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There was a missing folder id in the page creation modal, so pages being created were being created at root. 

## Solution
<!-- How did you solve the problem? -->
add the folderId back in

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->
