### PR TITLE
feat: show less pagination siblings in mobile

### DIFF
--- a/packages/components/src/hooks/useBreakpoint.ts
+++ b/packages/components/src/hooks/useBreakpoint.ts
@@ -1,0 +1,21 @@
+import { useMediaQuery } from "usehooks-ts"
+
+// Unable to use breakpoints directly from tailwind config as it may not be available
+// depending on how this component is used.
+const breakpoints = {
+  xs: "576px",
+  sm: "640px",
+  md: "768px",
+  lg: "1024px",
+  xl: "1240px",
+  "2xl": "1536px",
+}
+
+/**
+ * Returns `true` if screen size matches the
+ * `breakpoint`.
+ */
+export const useBreakpoint = (breakpoint: keyof typeof breakpoints) => {
+  const breakpointQuery = breakpoints[breakpoint]
+  return useMediaQuery(`(min-width: ${breakpointQuery})`)
+}

--- a/packages/components/src/templates/next/components/internal/PaginationControls/Pagination.tsx
+++ b/packages/components/src/templates/next/components/internal/PaginationControls/Pagination.tsx
@@ -14,7 +14,7 @@ import { Button } from "../Button"
 const createPaginationStyles = tv({
   slots: {
     nav: "flex",
-    content: "flex flex-row flex-wrap items-center gap-3",
+    content: "flex flex-row flex-wrap items-center gap-1 md:gap-3",
     button:
       "prose-caption-1 min-h-0 rounded-none px-2.5 py-1 tabular-nums current:bg-base-content-subtle current:text-white hover:bg-base-canvas-backdrop hover:current:bg-base-content-subtle",
     item: "flex cursor-pointer select-none",

--- a/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react"
 import { useState } from "react"
 
+import { withChromaticModes } from "@isomer/storybook-config"
+
 import type { PaginationProps } from "../../../types/Pagination"
 import { PaginationControls } from "./PaginationControls"
 
@@ -45,6 +47,9 @@ export const SomePages: Story = {
 }
 
 export const ManyPages: Story = {
+  parameters: {
+    chromatic: withChromaticModes(["mobile", "tablet"]),
+  },
   args: {
     totalItems: 1240,
     itemsPerPage: 6,

--- a/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
+++ b/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
@@ -1,8 +1,7 @@
 "use client"
 
-import { useMediaQuery } from "usehooks-ts"
-
 import type { PaginationProps } from "../../../types/Pagination"
+import { useBreakpoint } from "~/hooks/useBreakpoint"
 import {
   Pagination,
   PaginationButton,
@@ -27,7 +26,7 @@ export function PaginationControls({
   setCurrPage,
   onPageChange,
 }: PaginationControlsProps) {
-  const isTablet = useMediaQuery("(min-width: 768px)")
+  const isTablet = useBreakpoint("md")
 
   const paginationRange = usePaginationRange<typeof SEPARATOR>({
     totalCount: totalItems,

--- a/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
+++ b/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { useMediaQuery } from "usehooks-ts"
+
 import type { PaginationProps } from "../../../types/Pagination"
 import {
   Pagination,
@@ -25,12 +27,14 @@ export function PaginationControls({
   setCurrPage,
   onPageChange,
 }: PaginationControlsProps) {
+  const isTablet = useMediaQuery("(min-width: 768px)")
+
   const paginationRange = usePaginationRange<typeof SEPARATOR>({
     totalCount: totalItems,
     pageSize: itemsPerPage,
     currentPage: currPage,
     separator: SEPARATOR,
-    siblingCount: 1,
+    siblingCount: isTablet ? 1 : 0,
   })
 
   const totalPageCount = Math.ceil(totalItems / itemsPerPage)


### PR DESCRIPTION
### TL;DR

Improved pagination controls responsiveness and added mobile/tablet view testing.

### What changed?

- Adjusted gap spacing in pagination content for better mobile display
- Added mobile and tablet view testing for the "ManyPages" story
- Implemented responsive sibling count for pagination range based on screen size

### How to test?

1. Run the Storybook for PaginationControls
2. Check the "ManyPages" story in mobile and tablet views
3. Verify that the pagination controls adjust appropriately for different screen sizes
4. Ensure that fewer sibling pages are shown on mobile compared to tablet/desktop views

### Why make this change?

To enhance the user experience on mobile devices by optimizing the pagination controls for smaller screens. This change ensures that the pagination component remains functional and visually appealing across various device sizes, improving overall usability and accessibility.
