### PR TITLE
fix(ui): adding a new block and exiting without saving causes a block to be wrongly created

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -29,7 +29,6 @@ import {
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { type DrawerState } from "~/types/editorDrawer"
-import { trpc } from "~/utils/trpc"
 import { DEFAULT_BLOCKS } from "./constants"
 import { type SectionType } from "./types"
 
@@ -104,7 +103,7 @@ function ComponentSelector() {
     setDrawerState,
     setSavedPageState,
     setPreviewPageState,
-    setAddedBlock,
+    setAddedBlockIndex,
   } = useEditorDrawerContext()
 
   const onProceed = (sectionType: SectionType) => {
@@ -129,15 +128,8 @@ function ComponentSelector() {
     setSavedPageState(nextPageState)
     setDrawerState({ state: nextState })
     setCurrActiveIdx(nextPageState.content.length - 1)
+    setAddedBlockIndex(nextPageState.content.length - 1)
     setPreviewPageState(nextPageState)
-
-    // TODO: Decide if setting addedBlocks
-    // to only be for complex blocks is a good idea
-    // or if we should combine prose to addedBlocks as well
-    // and handle prose -> complex components in the renderer itself
-    if (sectionType !== "prose") {
-      setAddedBlock(sectionType)
-    }
   }
 
   return (

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -10,12 +10,6 @@ export const DEFAULT_BLOCKS: Record<
     content: [
       {
         type: "paragraph",
-        content: [
-          {
-            type: "text",
-            text: "",
-          },
-        ],
       },
     ],
   },
@@ -27,12 +21,6 @@ export const DEFAULT_BLOCKS: Record<
       content: [
         {
           type: "paragraph",
-          content: [
-            {
-              type: "text",
-              text: "Enter content for the accordion here.",
-            },
-          ],
         },
       ],
     },

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -2,7 +2,6 @@ import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import { createContext, useContext, useState } from "react"
 
-import type { SectionType } from "~/components/PageEditor/types"
 import type { ModifiedAsset } from "~/types/assets"
 import { type DrawerState } from "~/types/editorDrawer"
 
@@ -11,14 +10,14 @@ export interface DrawerContextType {
   setCurrActiveIdx: (currActiveIdx: number) => void
   drawerState: DrawerState
   setDrawerState: (state: DrawerState) => void
-  addedBlock: Exclude<SectionType, "prose">
-  setAddedBlock: (addedBlock: Exclude<SectionType, "prose">) => void
   savedPageState?: IsomerSchema
   setSavedPageState: Dispatch<SetStateAction<IsomerSchema | undefined>>
   previewPageState?: IsomerSchema
   setPreviewPageState: Dispatch<SetStateAction<IsomerSchema | undefined>>
   modifiedAssets: ModifiedAsset[]
   setModifiedAssets: Dispatch<SetStateAction<ModifiedAsset[]>>
+  addedBlockIndex: number | null
+  setAddedBlockIndex: Dispatch<SetStateAction<number | null>>
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -36,10 +35,9 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
   const [previewPageState, setPreviewPageState] = useState<
     IsomerSchema | undefined
   >()
-  const [addedBlock, setAddedBlock] =
-    useState<Exclude<SectionType, "prose">>("button")
   // Holding state for images/files that have been modified in the page
   const [modifiedAssets, setModifiedAssets] = useState<ModifiedAsset[]>([])
+  const [addedBlockIndex, setAddedBlockIndex] = useState<number | null>(null)
 
   return (
     <EditorDrawerContext.Provider
@@ -52,10 +50,10 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
         setSavedPageState,
         previewPageState,
         setPreviewPageState,
-        addedBlock,
-        setAddedBlock,
         modifiedAssets,
         setModifiedAssets,
+        addedBlockIndex,
+        setAddedBlockIndex,
       }}
     >
       {children}

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -36,6 +36,8 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     onClose: onDiscardChangesModalClose,
   } = useDisclosure()
   const {
+    addedBlockIndex,
+    setAddedBlockIndex,
     setDrawerState,
     currActiveIdx,
     savedPageState,
@@ -93,10 +95,23 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     setPreviewPageState(newPageState)
     onDeleteBlockModalClose()
     setDrawerState({ state: "root" })
+    setAddedBlockIndex(null)
   }
 
   const handleDiscardChanges = () => {
-    setPreviewPageState(savedPageState)
+    if (addedBlockIndex !== null) {
+      const updatedBlocks = Array.from(savedPageState.content)
+      updatedBlocks.splice(addedBlockIndex, 1)
+      const newPageState = {
+        ...previewPageState,
+        content: updatedBlocks,
+      }
+      setSavedPageState(newPageState)
+      setPreviewPageState(newPageState)
+    } else {
+      setPreviewPageState(savedPageState)
+    }
+    setAddedBlockIndex(null)
     onDiscardChangesModalClose()
     setDrawerState({ state: "root" })
   }
@@ -200,6 +215,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
           setModifiedAssets([])
           setSavedPageState(newPageState)
           setDrawerState({ state: "root" })
+          setAddedBlockIndex(null)
         },
       },
     )

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -44,6 +44,8 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     previewPageState,
     setPreviewPageState,
     currActiveIdx,
+    addedBlockIndex,
+    setAddedBlockIndex,
   } = useEditorDrawerContext()
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
@@ -64,6 +66,7 @@ function TipTapComponent({ content }: TipTapComponentProps) {
       content: updatedBlocks,
     }
     setPreviewPageState(newPageState)
+    setAddedBlockIndex(null)
   }
 
   const handleDeleteBlock = () => {
@@ -77,10 +80,23 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     setPreviewPageState(newPageState)
     onDeleteBlockModalClose()
     setDrawerState({ state: "root" })
+    setAddedBlockIndex(null)
   }
 
   const handleDiscardChanges = () => {
-    setPreviewPageState(savedPageState)
+    if (addedBlockIndex !== null) {
+      const updatedBlocks = Array.from(savedPageState.content)
+      updatedBlocks.splice(addedBlockIndex, 1)
+      const newPageState = {
+        ...previewPageState,
+        content: updatedBlocks,
+      }
+      setSavedPageState(newPageState)
+      setPreviewPageState(newPageState)
+    } else {
+      setPreviewPageState(savedPageState)
+    }
+    setAddedBlockIndex(null)
     onDiscardChangesModalClose()
     setDrawerState({ state: "root" })
   }

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -66,7 +66,6 @@ function TipTapComponent({ content }: TipTapComponentProps) {
       content: updatedBlocks,
     }
     setPreviewPageState(newPageState)
-    setAddedBlockIndex(null)
   }
 
   const handleDeleteBlock = () => {
@@ -181,7 +180,12 @@ function TipTapComponent({ content }: TipTapComponentProps) {
                     siteId,
                     content: JSON.stringify(previewPageState),
                   },
-                  { onSuccess: () => setDrawerState({ state: "root" }) },
+                  {
+                    onSuccess: () => {
+                      setAddedBlockIndex(null)
+                      setDrawerState({ state: "root" })
+                    },
+                  },
                 )
               }}
               isLoading={isLoading}


### PR DESCRIPTION
## Problem
adding a block to our state and then exiting the editor without doing anything cause a wrong block to be created. this leads to issues later when dragging and dropping as the editor will attempt to update the blob/resourceid of a block that doesnt exist

## Solution
this is a pretty complicated fix so i'll try to explain as much detail as possible. 
1. the root cause of the bug is because we preemptively update the page state in our base `ComponentSelector`. This is to allow our components to use the page state to update the block. because of this, however, when we exit editing, we reset to the state **with the block**. ie, the sequence of events is as follows:
    - page state initially: []
    - page state after clicking on add component: [[]], where the inner array denotes teh initial empty state of the component
    - now we enter into the actual editor 
    - if we exit, we will reset to the state in step 2. ie, we still retain the empty state of the inital added component, which is wrong. 
2. there was an additional bug where we set an inner `text` on the Prose node. this causes the comparison between adding component then immediately exiting and adding component, making some edits then deleting to empty state and exiting to be different. this is because tiptap internally removes the `content` of the paragraph node when it's empty. 
    - i tested that this works via saving when it's empty (backend `schema` accepts this)
3. to make this fix comprehensive, we need to keep this `addedBlockIndex` state in sync across all possible Editor -> Root drawer scenarios. this is done via: 
    - adding the reset to `null` when deleting the block (addedBlock no longer exists)
    - adding the reset to `null` when discarding changes
    - adding the reset to `null` when saving (it's no longer the last added block)

## Before & After Screenshots

**BEFORE**:
see ticket

**AFTER**:

https://github.com/user-attachments/assets/25e5e717-4fdd-4a92-9b51-c84e41cd8b7a




## Notes 
i think the saving/deleting/discarding functionality is shared across all the different types of the editor (complex/metadata/prose) and it's getting unwieldy to keep remembering to sync etc esp when we now have implicit guarantees in place.