### PR TITLE
fix: update tablet px of masthead and navbar

### DIFF
--- a/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
+++ b/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
@@ -153,7 +153,7 @@ const RestrictedContent = () => {
   return (
     <div
       id={MASTHEAD_CONTROL_ID}
-      className={`mx-auto max-w-screen-xl px-6 py-2 pb-8 pt-4 text-[#474747] lg:px-10 lg:pb-12 lg:pt-10 ${
+      className={`mx-auto max-w-screen-xl px-6 py-2 pb-8 pt-4 text-[#474747] md:px-10 lg:pb-12 lg:pt-10 ${
         isMastheadContentVisible ? "block" : "hidden"
       }`}
     >

--- a/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
+++ b/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
@@ -91,7 +91,7 @@ const RestrictedHeaderBarContent = ({ children }: PropsWithChildren) => {
 const RestrictedHeaderBar = ({ children }: PropsWithChildren) => {
   const { isMastheadContentVisible, toggleMastheadContent } = useMasthead()
   return (
-    <div className="mx-auto max-w-screen-xl px-6 lg:px-10">
+    <div className="mx-auto max-w-screen-xl px-6 md:px-10">
       <Button
         className={composeRenderProps(
           "flex w-full gap-1 text-start leading-5 lg:hidden",

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -16,7 +16,7 @@ const navbarStyles = tv({
     logo: "max-h-[68px] object-contain object-center",
     navbarContainer: "flex min-h-16 w-full bg-white lg:min-h-[4.25rem]",
     navbar:
-      "mx-auto flex w-full max-w-screen-xl justify-between gap-x-2 pl-6 pr-3 lg:px-10",
+      "mx-auto flex w-full max-w-screen-xl justify-between gap-x-2 pl-6 pr-3 md:px-10",
     navItemContainer:
       "hidden flex-1 flex-wrap items-center gap-x-3 pl-2 lg:flex",
   },


### PR DESCRIPTION
### TL;DR

Adjusted padding breakpoints for improved responsive design in Masthead and Navbar components.

### What changed?

- In the Masthead component, changed the `lg:px-10` class to `md:px-10` for the RestrictedHeaderBar.
- In the Navbar component, updated the `lg:px-10` class to `md:px-10` for the navbar container.

### How to test?

1. Open the application and navigate to pages containing the Masthead and Navbar components.
2. Resize the browser window to various widths, particularly focusing on the transition between mobile and tablet views.
3. Verify that the padding adjusts correctly at the medium (md) breakpoint instead of the large (lg) breakpoint.
4. Ensure the layout looks consistent and properly aligned across different screen sizes.

### Why make this change?

This change aims to improve the responsive behavior of the Masthead and Navbar components. By adjusting the padding breakpoint from large (lg) to medium (md), the layout will adapt more appropriately for tablet-sized devices, providing a better user experience across a wider range of screen sizes.
