### PR TITLE
fix: HTML generation from prose JSON content

### DIFF
--- a/packages/components/src/templates/next/components/native/Paragraph/Paragraph.stories.tsx
+++ b/packages/components/src/templates/next/components/native/Paragraph/Paragraph.stories.tsx
@@ -109,3 +109,84 @@ export const Simple: Story = {
     ],
   },
 }
+
+export const Combined: Story = {
+  args: {
+    content: [
+      {
+        type: "text",
+        marks: [
+          {
+            type: "link",
+            attrs: {
+              href: "https://www.google.com",
+              target: "_blank",
+            },
+          },
+        ],
+        text: "Create customised ",
+      },
+      {
+        type: "text",
+        marks: [
+          {
+            type: "link",
+            attrs: {
+              href: "https://www.google.com",
+              target: "_blank",
+            },
+          },
+          {
+            type: "superscript",
+          },
+          {
+            type: "italic",
+          },
+        ],
+        text: "business",
+      },
+      {
+        type: "text",
+        marks: [
+          {
+            type: "link",
+            attrs: {
+              href: "https://www.google.com",
+              target: "_blank",
+            },
+          },
+          {
+            type: "italic",
+          },
+        ],
+        text: "custom",
+      },
+      {
+        type: "text",
+        marks: [
+          {
+            type: "link",
+            attrs: {
+              href: "https://www.google.com",
+              target: "_blank",
+            },
+          },
+        ],
+        text: " solutions for growth",
+      },
+      {
+        type: "text",
+        marks: [
+          {
+            type: "link",
+            attrs: {
+              href: "https://www.google2.com",
+              target: "_blank",
+            },
+          },
+        ],
+        text: " Another link",
+      },
+    ],
+  },
+}

--- a/packages/components/src/utils/getTextAsHtml.ts
+++ b/packages/components/src/utils/getTextAsHtml.ts
@@ -1,3 +1,5 @@
+import isEqual from "lodash/isEqual"
+
 import type { HardBreakProps } from "~/interfaces"
 import type { Marks, TextProps } from "~/interfaces/native/Text"
 
@@ -20,31 +22,79 @@ export const getTextAsHtml = (content?: (HardBreakProps | TextProps)[]) => {
     return ""
   }
 
-  return content
-    .map((node) => {
-      if (node.type === "hardBreak") {
-        return "<br />"
-      }
+  const output: string[] = []
+  let existingLinkMark: Marks | undefined = undefined
 
-      if (!node.marks) {
-        return node.text
-      }
+  // At every step, we will close off all marks except for links
+  // First encounter with a link, always open it first before other marks
+  // Close all other marks first before closing the link mark
+  content.forEach((node) => {
+    if (node.type === "hardBreak") {
+      output.push("<br />")
+      return
+    }
 
-      let output = node.text
-      node.marks.forEach((mark) => {
-        if (mark.type === "link") {
-          output = `<${MARK_DOM_MAPPING[mark.type]} href="${
-            mark.attrs.href
-          }">${output}</${MARK_DOM_MAPPING[mark.type]}>`
-          return
+    const newLinkMark = node.marks?.find((mark) => mark.type === "link")
+    const isLinkMarkNew =
+      !!newLinkMark && !isEqual(existingLinkMark, newLinkMark)
+
+    // Close off the existing link mark if it is different
+    if (isLinkMarkNew && !!existingLinkMark) {
+      output.push(`</${MARK_DOM_MAPPING.link}>`)
+      existingLinkMark = undefined
+    }
+
+    // If there are no marks, just push the text
+    if (!node.marks) {
+      output.push(node.text)
+      return
+    }
+
+    if (isLinkMarkNew) {
+      existingLinkMark = newLinkMark
+
+      // Sort such that the link mark is the first item
+      node.marks.sort((a, b) => {
+        if (a.type === "link") {
+          return -1
         }
 
-        output = `<${MARK_DOM_MAPPING[mark.type]}>${output}</${
-          MARK_DOM_MAPPING[mark.type]
-        }>`
+        return 1
       })
 
-      return output
-    })
-    .join("")
+      node.marks.forEach((mark) => {
+        if (mark.type === "link") {
+          output.push(
+            `<${MARK_DOM_MAPPING[mark.type]} target="${mark.attrs.target ?? "_self"}" href="${mark.attrs.href}">`,
+          )
+        } else {
+          output.push(`<${MARK_DOM_MAPPING[mark.type]}>`)
+        }
+      })
+    } else {
+      // Continue with the rest of the marks
+      node.marks
+        .filter((mark) => mark.type !== "link")
+        .forEach((mark) => {
+          output.push(`<${MARK_DOM_MAPPING[mark.type]}>`)
+        })
+    }
+
+    // Push the text
+    output.push(node.text)
+
+    // Close off all marks except for links
+    node.marks
+      .filter((mark) => mark.type !== "link")
+      .forEach((mark) => {
+        output.push(`</${MARK_DOM_MAPPING[mark.type]}>`)
+      })
+  })
+
+  // Close off the last link mark if it exists
+  if (existingLinkMark) {
+    output.push(`</${MARK_DOM_MAPPING.link}>`)
+  }
+
+  return output.join("")
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There is an issue with how the HTML is generated by components when it comes to nested marks.

Closes ISOM-1532

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Change the way we generate the HTML from the JSON prose content so that we are able to combine multiple text nodes with the same link mark.