### PR TITLE
fix(move): perform UI invalidations correctly

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -38,6 +38,7 @@ const getColumns = ({ siteId }: ResourceTableProps) => [
     header: () => <TableHeader>Actions</TableHeader>,
     cell: ({ row }) => (
       <ResourceTableMenu
+        parentId={row.original.parentId}
         title={row.original.title}
         resourceId={row.original.id}
         type={row.original.type}

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -21,6 +21,7 @@ interface ResourceTableMenuProps {
   type: ResourceTableData["type"]
   permalink: ResourceTableData["permalink"]
   resourceType: ResourceTableData["type"]
+  parentId: ResourceTableData["parentId"]
 }
 
 export const ResourceTableMenu = ({
@@ -29,10 +30,11 @@ export const ResourceTableMenu = ({
   type,
   permalink,
   resourceType,
+  parentId,
 }: ResourceTableMenuProps) => {
   const setMoveResource = useSetAtom(moveResourceAtom)
   const handleMoveResourceClick = () =>
-    setMoveResource({ resourceId, title, permalink })
+    setMoveResource({ resourceId, title, permalink, parentId })
   const setResourceModalState = useSetAtom(deleteResourceModalAtom)
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
 

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -95,6 +95,18 @@ const MoveResourceContent = withSuspense(
         await utils.page.readPageAndBlob.invalidate()
         await utils.resource.getParentOf.invalidate()
         await utils.resource.getChildrenOf.invalidate()
+        await utils.resource.countWithoutRoot.invalidate({
+          // TODO: Update backend `list` to use the proper schema
+          resourceId: moveDest?.resourceId
+            ? Number(moveDest.resourceId)
+            : undefined,
+        })
+        await utils.resource.countWithoutRoot.invalidate({
+          // TODO: Update backend `list` to use the proper schema
+          resourceId: movedItem?.parentId
+            ? Number(movedItem.parentId)
+            : undefined,
+        })
         await utils.resource.listWithoutRoot.invalidate({
           // TODO: Update backend `list` to use the proper schema
           resourceId: moveDest?.resourceId

--- a/apps/studio/src/features/editing-experience/types.ts
+++ b/apps/studio/src/features/editing-experience/types.ts
@@ -2,4 +2,5 @@ export interface PendingMoveResource {
   permalink: string
   title: string
   resourceId: string
+  parentId: string | null
 }

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -20,6 +20,7 @@ import { FolderSettingsModal } from "~/features/dashboard/components/FolderSetti
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
 import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
+import { MoveResourceModal } from "~/features/editing-experience/components/MoveResourceModal"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminCmsSidebarLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
@@ -212,6 +213,7 @@ const FolderPage: NextPageWithLayout = () => {
         parentFolderId={parseInt(folderId)}
       />
       <FolderSettingsModal />
+      <MoveResourceModal />
     </>
   )
 }

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -187,6 +187,7 @@ export const resourceRouter = router({
           "Resource.publishedVersionId",
           "Resource.draftBlobId",
           "Resource.type",
+          "Resource.parentId",
         ])
         .execute()
     }),

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -20,6 +20,7 @@ const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     publishedVersionId: null,
     draftBlobId: null,
     type: "Collection",
+    parentId: null,
   },
   {
     id: "4",
@@ -28,6 +29,7 @@ const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     publishedVersionId: null,
     draftBlobId: "3",
     type: "Page",
+    parentId: null,
   },
   {
     id: "5",
@@ -36,6 +38,7 @@ const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     publishedVersionId: null,
     draftBlobId: "4",
     type: "Page",
+    parentId: null,
   },
   {
     id: "6",
@@ -44,6 +47,7 @@ const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     publishedVersionId: null,
     draftBlobId: null,
     type: "Folder",
+    parentId: null,
   },
 ]
 


### PR DESCRIPTION
## Problem
currently, the invalidation logic is wrong for moving items. this results in the ui not updating after we move an item from 1 folder to another. 

Closes ISOM-1483
Closes ISOM-1461

## Solution
1. retrieve parent id from backend and pass it into the table so that each initial click will have access to the parent id
2. update the type of the atom and set parent id on each click of destination so that the move item knows the (original) parent id of the move item 
3. invalidate both destination and origin folder queries so that the ui will appear correct. the origin folder is `moveItem.parentId` and the destination is given by `moveDest.resourceId`

## Screenshots and videos
### Invalidation for pages
https://github.com/user-attachments/assets/73d6d807-8844-4b11-b7dd-a3c96a39b1ce

### Invalidation for folders

https://github.com/user-attachments/assets/5073218a-f844-4bf7-b4b6-3f74d9f12533



