### PR TITLE
fix: update AWS GitHub OIDC role

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       aws-region: "ap-southeast-1"
       aws-account-id: "058264420411"
-      cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-github-oidc-role-aaefdfd"
+      cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-github-oidc-role-b58f3de"
       ecr-repository: "isomer-next-infra-stg-ecr"
       ecs-cluster-name: "isomer-next-infra-ecs"
       ecs-service-name: "isomer-next-infra-ecs-service"

--- a/.github/workflows/deploy_vapt.yml
+++ b/.github/workflows/deploy_vapt.yml
@@ -18,7 +18,7 @@ jobs:
     with:
       aws-region: "ap-southeast-1"
       aws-account-id: "058264420411"
-      cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-github-oidc-role-aaefdfd"
+      cicd-role: "arn:aws:iam::058264420411:role/isomer-next-infra-github-oidc-role-b58f3de"
       ecr-repository: "isomer-next-infra-vapt-ecr"
       ecs-cluster-name: "studio-vapt-ecs"
       ecs-service-name: "studio-vapt-ecs-service"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There is a desync on the OIDC role ID that GitHub uses to authenticate with AWS.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fix the OIDC role ID that we are currently using in Pulumi.