### PR TITLE
fix(folders): invalidate queries on creation 

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -79,6 +79,7 @@ const CreateFolderModalContent = ({
     onSuccess: async () => {
       await utils.site.list.invalidate()
       await utils.resource.listWithoutRoot.invalidate()
+      await utils.resource.getChildrenOf.invalidate()
       toast({ title: "Folder created!", status: "success" })
     },
     onError: (err) => {

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -79,6 +79,7 @@ const CreateFolderModalContent = ({
     onSuccess: async () => {
       await utils.site.list.invalidate()
       await utils.resource.listWithoutRoot.invalidate()
+      await utils.resource.countWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate()
       toast({ title: "Folder created!", status: "success" })
     },


### PR DESCRIPTION
## Problem
previously, we did not invalidate the query that our sidebar used to fetch children of a folder when we created a folder. this led to the sidebar not updating whenever we created another folder.  

## Solution
1. invalidate the query used to fetch the children of a folder whenever we create another folder
2. invalidate the `count` query used for pagination whenver we create a folder. this is so that the count gets updated correctly and the pagination will update to show the newest index if required

## Screenshots and videos

https://github.com/user-attachments/assets/0772bfbe-66dd-48fe-8037-9486ceff3b76
