### PR TITLE
fix: invalidate collections

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -60,7 +60,6 @@ export const CreateCollectionModal = ({
 }
 
 const CreateCollectionModalContent = ({
-  isOpen,
   onClose,
   siteId,
 }: CreateCollectionModalProps) => {
@@ -81,6 +80,8 @@ const CreateCollectionModalContent = ({
     onSettled: onClose,
     onSuccess: async () => {
       await utils.resource.listWithoutRoot.invalidate()
+      await utils.resource.countWithoutRoot.invalidate()
+      await utils.resource.getChildrenOf.invalidate()
       toast({ title: "Collection created!", status: "success" })
     },
     onError: (err) => {


### PR DESCRIPTION
## Problem
see ticket for a description of the problem

Closes [insert issue #]

## Solution
1. invalidate the query that the sidebar uses to fetch children
2. invalidate the count so that pagination updates

## Screenshots

https://github.com/user-attachments/assets/e26ff969-33db-4f1c-b2d5-ec26b6316418

