### PR TITLE
fix: add max length property on input 

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -102,6 +102,9 @@ const CreateFolderModalContent = ({
     // Dirty means user has changed the value AND the value is not the same as the default value of "".
     // Once the value has been cleared, dirty state will reset.
     if (!permalinkFieldState.isDirty) {
+      // NOTE: We don't slice here because the permalink field already has a max length set.
+      // Because the `permalink`'s max length is longer than what it's derived from
+      // the output of this will always be less than the allowed length for the permalink.
       setValue("permalink", generateResourceUrl(folderTitle), {
         shouldValidate: !!folderTitle,
       })

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -125,6 +125,7 @@ const CreateFolderModalContent = ({
 
               <Input
                 placeholder="This is a title for your new folder"
+                maxLength={MAX_FOLDER_TITLE_LENGTH}
                 {...register("folderTitle")}
               />
               {errors.folderTitle?.message ? (
@@ -146,6 +147,7 @@ const CreateFolderModalContent = ({
               </FormLabel>
               <Input
                 placeholder="This is a url for your new page"
+                maxLength={MAX_FOLDER_PERMALINK_LENGTH}
                 {...register("permalink")}
               />
               {errors.permalink?.message && (


### PR DESCRIPTION
## Problem
see ticket

Closes [insert issue #]

## Solution
1. add max length property on `Input` so it will auto coerce to the appropriate length for us

## Screenshots

https://github.com/user-attachments/assets/68bd65b7-36bb-4bd8-802a-5dd6d02dd5cd

