### PR TITLE
fix: update dashboard route

### DIFF
--- a/apps/studio/src/lib/routes.ts
+++ b/apps/studio/src/lib/routes.ts
@@ -1,6 +1,6 @@
 export const SIGN_IN = "/sign-in"
 export const SIGN_IN_SELECT_PROFILE_SUBROUTE = "/select-profile"
 
-export const DASHBOARD = "/dashboard"
+export const DASHBOARD = "/"
 export const PROFILE = "/profile"
 export const SETTINGS_PROFILE = "/settings/profile"


### PR DESCRIPTION
## Problem
we removed the `/dashboard` page previously but was still directing users there. 

Closes ISOM-1455

## Solution
update the constant to `/`

## Screenshots and videos

https://github.com/user-attachments/assets/0ab634f0-fcc5-4fb2-9aa8-59f24455e061

