### PR TITLE
fix(folder settings): restrict input fields to max length

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -158,13 +158,9 @@ const SuspendableModalContent = ({
                   <Input
                     placeholder="This is a url for your folder"
                     {...field}
+                    maxLength={MAX_FOLDER_PERMALINK_LENGTH}
                     onChange={(e) => {
-                      onChange(
-                        generateResourceUrl(e.target.value).slice(
-                          0,
-                          MAX_FOLDER_PERMALINK_LENGTH,
-                        ),
-                      )
+                      onChange(generateResourceUrl(e.target.value))
                     }}
                   />
                 )}

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from "react"
+import { Suspense } from "react"
 import {
   Box,
   FormControl,
@@ -74,15 +74,7 @@ const SuspendableModalContent = ({
       siteId,
       resourceId: Number(folderId),
     })
-  const {
-    setValue,
-    register,
-    handleSubmit,
-    watch,
-    control,
-    formState,
-    getFieldState,
-  } = useZodForm({
+  const { register, handleSubmit, watch, control, formState } = useZodForm({
     defaultValues: {
       title: originalTitle,
       permalink: originalPermalink,
@@ -122,18 +114,6 @@ const SuspendableModalContent = ({
   })
 
   const [title, permalink] = watch(["title", "permalink"])
-
-  useEffect(() => {
-    const permalinkFieldState = getFieldState("permalink")
-    // This allows the syncing to happen only when the page title is not dirty
-    // Dirty means user has changed the value AND the value is not the same as the default value of "".
-    // Once the value has been cleared, dirty state will reset.
-    if (!permalinkFieldState.isDirty) {
-      setValue("permalink", generateResourceUrl(title || ""), {
-        shouldValidate: !!title,
-      })
-    }
-  }, [getFieldState, setValue, title])
 
   return (
     <ModalContent key={String(!!folderId)}>

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -132,6 +132,7 @@ const SuspendableModalContent = ({
 
               <Input
                 placeholder="This is a title for your new folder"
+                maxLength={MAX_FOLDER_TITLE_LENGTH}
                 {...register("title")}
               />
               {errors.title?.message ? (
@@ -158,7 +159,12 @@ const SuspendableModalContent = ({
                     placeholder="This is a url for your folder"
                     {...field}
                     onChange={(e) => {
-                      onChange(generateResourceUrl(e.target.value))
+                      onChange(
+                        generateResourceUrl(e.target.value).slice(
+                          0,
+                          MAX_FOLDER_PERMALINK_LENGTH,
+                        ),
+                      )
                     }}
                   />
                 )}

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -60,7 +60,6 @@ export const CreateCollectionModal = ({
 }
 
 const CreateCollectionModalContent = ({
-  isOpen,
   onClose,
   siteId,
 }: CreateCollectionModalProps) => {

--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -72,7 +72,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
             >
               <BiData />
             </Box>
-            <Text noOfLines={1} as="h3" textStyle="h3">
+            <Text wordBreak="break-word" noOfLines={1} as="h3" textStyle="h3">
               {metadata.title}
             </Text>
           </HStack>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -16,6 +16,7 @@ import { BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import { folderSettingsModalAtom } from "~/features/dashboard/atoms"
+import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
@@ -212,6 +213,7 @@ const FolderPage: NextPageWithLayout = () => {
         parentFolderId={parseInt(folderId)}
       />
       <FolderSettingsModal />
+      <DeleteResourceModal siteId={parseInt(siteId)} />
     </>
   )
 }


### PR DESCRIPTION
## Problem
previously, the save wasnt disabled when the state of the field was invalid. 

## Solution
1. restrict the 2 fields to their respective max length, so that they cannot exceed the given length
2. for permalink, we already transform every invalid input to `-` so we know that the field's value will always be valid
 
because of this, we dont need to disable save as the permalink and title will always be of a valid length and the permalink will consist only of alphnumeric characters and `-`

## Screenshots

https://github.com/user-attachments/assets/9631c306-571a-423b-8104-5e413fb30328

