### PR TITLE
fix: add delete resource modal in folders

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -16,6 +16,7 @@ import { BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import { folderSettingsModalAtom } from "~/features/dashboard/atoms"
+import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
@@ -212,6 +213,7 @@ const FolderPage: NextPageWithLayout = () => {
         parentFolderId={parseInt(folderId)}
       />
       <FolderSettingsModal />
+      <DeleteResourceModal siteId={parseInt(siteId)} />
     </>
   )
 }


### PR DESCRIPTION
## Problem
previously, clicking on the menu items to delete resources did not do anything inside folders. 

Closes ISOM-1486

## Solution
1. add the delete resource modal in

## Screenshots and videos

https://github.com/user-attachments/assets/87097d71-a3d3-4c66-b431-c1def4ea2a88

