### PR TITLE
feat: dynamically generate the sitemap for preview

### DIFF
--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -9,7 +9,7 @@ import { type DrawerState } from "~/types/editorDrawer"
 export interface DrawerContextType
   extends Pick<
     EditorDrawerProviderProps,
-    "type" | "permalink" | "siteId" | "updatedAt"
+    "type" | "permalink" | "siteId" | "pageId" | "updatedAt"
   > {
   currActiveIdx: number
   setCurrActiveIdx: (currActiveIdx: number) => void
@@ -31,6 +31,7 @@ interface EditorDrawerProviderProps extends PropsWithChildren {
   type: ResourceType
   permalink: string
   siteId: number
+  pageId: number
   updatedAt: Date
 }
 
@@ -40,6 +41,7 @@ export function EditorDrawerProvider({
   type,
   permalink,
   siteId,
+  pageId,
   updatedAt,
 }: EditorDrawerProviderProps) {
   const [drawerState, setDrawerState] = useState<DrawerState>({
@@ -75,6 +77,7 @@ export function EditorDrawerProvider({
         type,
         permalink,
         siteId,
+        pageId,
         updatedAt,
       }}
     >

--- a/apps/studio/src/features/editing-experience/components/Preview.tsx
+++ b/apps/studio/src/features/editing-experience/components/Preview.tsx
@@ -17,6 +17,7 @@ type PreviewProps = IsomerSchema & {
   permalink: string
   lastModified?: Date
   siteId: number
+  resourceId?: number
   overrides?: PartialDeep<IsomerPageSchemaType>
 }
 
@@ -33,6 +34,7 @@ function SuspendablePreview({
   permalink,
   lastModified = new Date(),
   siteId,
+  resourceId,
   overrides = {},
   ...props
 }: PreviewProps) {
@@ -43,6 +45,10 @@ function SuspendablePreview({
   })
   const [{ content: navbar }] = trpc.site.getNavbar.useSuspenseQuery({
     id: siteId,
+  })
+  const [siteMap] = trpc.site.getLocalisedSitemap.useSuspenseQuery({
+    siteId,
+    resourceId,
   })
 
   const renderProps = merge(props, overrides, {
@@ -58,8 +64,7 @@ function SuspendablePreview({
       site={{
         // TODO: fixup all the typing errors
         // @ts-expect-error to fix when types are proper
-        // TODO: dynamically generate sitemap
-        siteMap: { title: "Home", permalink: "/", children: [] },
+        siteMap,
         environment: "production",
         ...siteConfig,
         navBarItems: navbar,

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -37,7 +37,7 @@ import { trpc } from "~/utils/trpc"
 function EditPage(): JSX.Element {
   const { pageId, siteId } = useQueryParse(editPageSchema)
 
-  const [{ content: page, permalink, type, title, updatedAt }] =
+  const [{ content: page, type, title, updatedAt }] =
     trpc.page.readPageAndBlob.useSuspenseQuery(
       {
         pageId,
@@ -45,6 +45,14 @@ function EditPage(): JSX.Element {
       },
       { refetchOnWindowFocus: false },
     )
+
+  const [permalink] = trpc.page.getFullPermalink.useSuspenseQuery(
+    {
+      pageId,
+      siteId,
+    },
+    { refetchOnWindowFocus: false },
+  )
 
   return (
     <TabPanels _dark={{ color: "white" }}>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -54,6 +54,7 @@ function EditPage(): JSX.Element {
           type={type}
           permalink={permalink}
           siteId={siteId}
+          pageId={pageId}
           updatedAt={updatedAt}
         >
           <PageEditingView />
@@ -67,7 +68,7 @@ function EditPage(): JSX.Element {
 }
 
 const PageEditingView = () => {
-  const { previewPageState, permalink, siteId, updatedAt } =
+  const { previewPageState, permalink, siteId, pageId, updatedAt } =
     useEditorDrawerContext()
   const themeCssVars = useSiteThemeCssVars({ siteId })
 
@@ -96,6 +97,7 @@ const PageEditingView = () => {
             <Preview
               {...previewPageState}
               siteId={siteId}
+              resourceId={pageId}
               permalink={permalink}
               lastModified={updatedAt}
               version="0.1.0"

--- a/apps/studio/src/schemas/site.ts
+++ b/apps/studio/src/schemas/site.ts
@@ -4,6 +4,11 @@ export const getConfigSchema = z.object({
   id: z.number().min(1),
 })
 
+export const getLocalisedSitemapSchema = z.object({
+  siteId: z.number().min(1),
+  resourceId: z.number().min(1).optional(),
+})
+
 export const getNotificationSchema = z.object({
   siteId: z.number().min(1),
 })

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -24,6 +24,7 @@ import {
   getFullPageById,
   getNavBar,
   getPageById,
+  getResourceFullPermalink,
   updateBlobById,
   updatePageById,
 } from "../resource/resource.service"
@@ -248,6 +249,7 @@ export const pageRouter = router({
         return { pageId: resource.id }
       },
     ),
+
   getRootPage: protectedProcedure
     .input(getRootPageSchema)
     .query(async ({ input: { siteId } }) => {
@@ -261,6 +263,7 @@ export const pageRouter = router({
           .executeTakeFirstOrThrow()
       )
     }),
+
   publishPage: protectedProcedure
     .input(publishPageSchema)
     .mutation(async ({ ctx, input: { siteId, pageId } }) => {
@@ -309,4 +312,18 @@ export const pageRouter = router({
         .executeTakeFirstOrThrow()
     },
   ),
+  getFullPermalink: protectedProcedure
+    .input(basePageSchema)
+    .query(async ({ input }) => {
+      const { pageId, siteId } = input
+      const permalink = await getResourceFullPermalink(siteId, pageId)
+      if (!permalink) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No permalink could be found for the given page",
+        })
+      }
+
+      return permalink
+    }),
 })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -306,7 +306,7 @@ export const getLocalisedSitemap = async (
           if (resource.parentId === null) {
             return fb("Resource.parentId", "is", null)
           }
-          return fb("Resource.parentId", "=", String(resourceId))
+          return fb("Resource.parentId", "=", String(resource.parentId))
         })
         .select(defaultResourceSelect),
     )

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -346,3 +346,34 @@ export const getLocalisedSitemap = async (
 
   return getSitemapTree(rootResource, allResources)
 }
+
+export const getResourceFullPermalink = async (
+  siteId: number,
+  resourceId: number,
+) => {
+  // Step 1: Get the actual resource
+  const resource = await getById(db, { resourceId, siteId })
+    .select(defaultResourceSelect)
+    .executeTakeFirstOrThrow()
+
+  // Step 2: Get all the ancestors of the resource
+  const ancestors = [resource]
+  let currentResource = resource
+
+  while (currentResource.parentId !== null) {
+    const parent = await getById(db, {
+      resourceId: Number(currentResource.parentId),
+      siteId,
+    })
+      .select(defaultResourceSelect)
+      .executeTakeFirstOrThrow()
+
+    ancestors.push(parent)
+    currentResource = parent
+  }
+
+  return `/${ancestors
+    .reverse()
+    .map((r) => r.permalink)
+    .join("/")}`
+}

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -1,11 +1,16 @@
 import {
   getConfigSchema,
+  getLocalisedSitemapSchema,
   getNotificationSchema,
   setNotificationSchema,
 } from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
 import { db } from "../database"
-import { getFooter, getNavBar } from "../resource/resource.service"
+import {
+  getFooter,
+  getLocalisedSitemap,
+  getNavBar,
+} from "../resource/resource.service"
 import {
   clearSiteNotification,
   getNotification,
@@ -48,6 +53,12 @@ export const siteRouter = router({
     .query(async ({ input }) => {
       const { id } = input
       return getNavBar(id)
+    }),
+  getLocalisedSitemap: protectedProcedure
+    .input(getLocalisedSitemapSchema)
+    .query(async ({ input }) => {
+      const { siteId, resourceId } = input
+      return getLocalisedSitemap(siteId, resourceId)
     }),
   getNotification: protectedProcedure
     .input(getNotificationSchema)

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -26,8 +26,8 @@ const getSitemapTreeFromArray = (
   })
 
   // Filter out duplicate resources with the same permalink, keeping only the
-  // Folder or Collection resource, then re-assigning the parentId of the
-  // children to the Folder or Collection resource
+  // Folder or Collection resource, then re-assigning the resource ID to the ID
+  // of the resource with the Page type
   return children
     .filter(
       (child) =>

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -18,6 +18,7 @@ const getSitemapTreeFromArray = (
     return undefined
   }
 
+  // Get the immediate children of the resource with the given parent ID
   const children = resources.filter((resource) => {
     if (parentId === null) {
       return resource.parentId === null && resource.type !== "RootPage"
@@ -80,10 +81,6 @@ const getSitemapTreeFromArray = (
             (resource.type === "Folder" ? "Page" : "CollectionPage"),
       )?.id
 
-      const folderChildren = resources.filter(
-        (item) => item.parentId === resource.id,
-      )
-
       return {
         id: String(idOfPage ?? resource.id),
         layout: "content", // Note: We are not using the layout field in our previews
@@ -93,7 +90,7 @@ const getSitemapTreeFromArray = (
           .toISOString(),
         permalink,
         children: getSitemapTreeFromArray(
-          folderChildren,
+          resources,
           resource.id,
           `${permalink}/`,
         ),

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -20,14 +20,14 @@ const getSitemapTreeFromArray = (
 
   const children = resources.filter((resource) => {
     if (parentId === null) {
-      return resource.parentId === null && resource.permalink !== ""
+      return resource.parentId === null && resource.type !== "RootPage"
     }
     return resource.parentId === parentId
   })
 
-  // Filter out children that have both the Page and the Folder types and keep
-  // only the one with the Folder type, then reassign the ID to the ID of the
-  // resource with the Page type
+  // Filter out duplicate resources with the same permalink, keeping only the
+  // Folder or Collection resource, then re-assigning the parentId of the
+  // children to the Folder or Collection resource
   return children
     .filter(
       (child) =>
@@ -41,44 +41,62 @@ const getSitemapTreeFromArray = (
           )
         ),
     )
+    .filter(
+      (child) =>
+        !(
+          child.type === "CollectionPage" &&
+          children.some(
+            (otherChild) =>
+              otherChild.id !== child.id &&
+              otherChild.permalink === child.permalink &&
+              otherChild.type === "Collection",
+          )
+        ),
+    )
     .map((resource) => {
       const permalink = `${path}${resource.permalink}`
-      if (resource.type === "Folder") {
-        const idOfPage = children.find(
-          (child) =>
-            child.id !== resource.id &&
-            child.permalink === resource.permalink &&
-            child.type === "Page",
-        )?.id
 
-        const folderChildren = resources.filter(
-          (item) => item.parentId === resource.id,
-        )
-
+      if (
+        resource.type === "RootPage" ||
+        resource.type === "Page" ||
+        resource.type === "CollectionPage"
+      ) {
         return {
-          id: String(idOfPage ?? resource.id),
+          id: String(resource.id),
           layout: "content", // Note: We are not using the layout field in our previews
           title: resource.title,
           summary: "", // Note: We are not using the summary field in our previews
           lastModified: new Date() // TODO: Update this to the updated_at field in DB
             .toISOString(),
           permalink,
-          children: getSitemapTreeFromArray(
-            folderChildren,
-            resource.id,
-            `${permalink}/`,
-          ),
         }
       }
 
+      const idOfPage = children.find(
+        (child) =>
+          child.id !== resource.id &&
+          child.permalink === resource.permalink &&
+          child.type ===
+            (resource.type === "Folder" ? "Page" : "CollectionPage"),
+      )?.id
+
+      const folderChildren = resources.filter(
+        (item) => item.parentId === resource.id,
+      )
+
       return {
-        id: String(resource.id),
+        id: String(idOfPage ?? resource.id),
         layout: "content", // Note: We are not using the layout field in our previews
         title: resource.title,
         summary: "", // Note: We are not using the summary field in our previews
         lastModified: new Date() // TODO: Update this to the updated_at field in DB
           .toISOString(),
         permalink,
+        children: getSitemapTreeFromArray(
+          folderChildren,
+          resource.id,
+          `${permalink}/`,
+        ),
       }
     })
 }

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -1,0 +1,101 @@
+import type { IsomerSitemap } from "@opengovsg/isomer-components"
+import type { Resource } from "@prisma/client"
+
+type ResourceDto = Omit<
+  Resource,
+  "id" | "parentId" | "publishedVersionId" | "draftBlobId"
+> & {
+  id: string
+  parentId: string | null
+}
+
+const getSitemapTreeFromArray = (
+  resources: ResourceDto[],
+  parentId: string | null,
+  path: string,
+): IsomerSitemap[] | undefined => {
+  if (resources.length === 0) {
+    return undefined
+  }
+
+  const children = resources.filter((resource) => {
+    if (parentId === null) {
+      return resource.parentId === null && resource.permalink !== ""
+    }
+    return resource.parentId === parentId
+  })
+
+  // Filter out children that have both the Page and the Folder types and keep
+  // only the one with the Folder type, then reassign the ID to the ID of the
+  // resource with the Page type
+  return children
+    .filter(
+      (child) =>
+        !(
+          child.type === "Page" &&
+          children.some(
+            (otherChild) =>
+              otherChild.id !== child.id &&
+              otherChild.permalink === child.permalink &&
+              otherChild.type === "Folder",
+          )
+        ),
+    )
+    .map((resource) => {
+      const permalink = `${path}${resource.permalink}`
+      if (resource.type === "Folder") {
+        const idOfPage = children.find(
+          (child) =>
+            child.id !== resource.id &&
+            child.permalink === resource.permalink &&
+            child.type === "Page",
+        )?.id
+
+        const folderChildren = resources.filter(
+          (item) => item.parentId === resource.id,
+        )
+
+        return {
+          id: String(idOfPage ?? resource.id),
+          layout: "content", // Note: We are not using the layout field in our previews
+          title: resource.title,
+          summary: "", // Note: We are not using the summary field in our previews
+          lastModified: new Date() // TODO: Update this to the updated_at field in DB
+            .toISOString(),
+          permalink,
+          children: getSitemapTreeFromArray(
+            folderChildren,
+            resource.id,
+            `${permalink}/`,
+          ),
+        }
+      }
+
+      return {
+        id: String(resource.id),
+        layout: "content", // Note: We are not using the layout field in our previews
+        title: resource.title,
+        summary: "", // Note: We are not using the summary field in our previews
+        lastModified: new Date() // TODO: Update this to the updated_at field in DB
+          .toISOString(),
+        permalink,
+      }
+    })
+}
+
+// Construct the sitemap tree given an array of individual sitemap items
+export const getSitemapTree = (
+  rootResource: ResourceDto,
+  resources: ResourceDto[],
+): IsomerSitemap => {
+  return {
+    id: String(rootResource.id),
+    layout: "content", // Note: We are not using the layout field in our previews
+    title: rootResource.title,
+    summary: "", // Note: We are not using the summary field in our previews
+    lastModified: new Date() // TODO: Update this to the updated_at field in DB
+      .toISOString(),
+    permalink: "/",
+    children: getSitemapTreeFromArray(resources, null, "/"),
+  }
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The sitemap is not being dynamically generated right now, so our preview's siderails are incorrect.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add the ability to generate a sparse sitemap that only includes resources that revolve around the current page that the user is editing.
- For other types of previews (e.g. when creating pages), we show a basic version for now but we can potentially expand to provide a sparse sitemap but with the resource itself being dynamically updated upon user inputs.
- The permalink passed to the preview is also updated to provide the full path from root, instead of only providing the slug of the page.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="403" alt="Screenshot 2024-09-06 at 20 22 14" src="https://github.com/user-attachments/assets/f4987fd2-ba91-4ed6-93e7-94e586297bcf">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="675" alt="Screenshot 2024-09-06 at 20 21 40" src="https://github.com/user-attachments/assets/3abb3fc3-7eb2-48ec-a183-21e8771da1a1">