### PR TITLE
fix: change infobox to warning

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings.tsx
@@ -120,7 +120,7 @@ const SiteSettingsPage: NextPageWithLayout = () => {
         nextUrl={nextUrl}
       />
       <form onSubmit={onClickUpdate}>
-        <Center pt="5.5rem">
+        <Center pt="5.5rem" px="2rem">
           <VStack w="48rem" alignItems="flex-start" spacing="1.5rem">
             <FormControl isInvalid={!!errors.notification}>
               <Text w="full" textStyle="h3-semibold">

--- a/apps/studio/src/pages/sites/[siteId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings.tsx
@@ -127,8 +127,8 @@ const SiteSettingsPage: NextPageWithLayout = () => {
                 Manage site settings
               </Text>
               <Infobox
+                variant="warning"
                 textStyle="body-2"
-                textColor="base.content.strong"
                 size="sm"
                 mt="1.75rem"
               >


### PR DESCRIPTION
## Problem
1. bad contrast of infobox bg against base bg
2. smaller widths causes the settings text to be squished against the side

Closes ISOM-1530
Closes ISOM-1528

## Solution
1. change to `warning` 

## Screenshots
### Infobox after change
<img width="844" alt="image" src="https://github.com/user-attachments/assets/bd38ea5b-4bac-46c8-855c-0c693941edf7">
### Settings page on smaller width
<img width="687" alt="image" src="https://github.com/user-attachments/assets/9b8ebfb7-a3ff-4ebd-83e3-c0c49102f3dd">
