### PR TITLE
fix: filter for page and folder

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -69,13 +69,15 @@ export const ResourceTableMenu = ({
               Edit folder settings
             </MenuItem>
           )}
-          <MenuItem
-            as="button"
-            onClick={handleMoveResourceClick}
-            icon={<BiFolderOpen fontSize="1rem" />}
-          >
-            Move to...
-          </MenuItem>
+          {(type === "Page" || type === "Folder") && (
+            <MenuItem
+              as="button"
+              onClick={handleMoveResourceClick}
+              icon={<BiFolderOpen fontSize="1rem" />}
+            >
+              Move to...
+            </MenuItem>
+          )}
           {resourceType !== ResourceType.RootPage && (
             <MenuItem
               onClick={() => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -126,6 +126,7 @@ export const resourceRouter = router({
         await tx
           .updateTable("Resource")
           .where("id", "=", String(movedResourceId))
+          .where("Resource.type", "in", ["Page", "Folder"])
           .set({ parentId: String(destinationResourceId) })
           .execute()
         return tx


### PR DESCRIPTION
## Problem
Right now, we can move collections from the dashboard. this should not be allowed as only pages and folders can be moved.

## Solution
1. Filter the `resource.type` on the frontend
2. add a `where` clause on the backend so we only allow move on `Page/Folder`

## Screenshots

https://github.com/user-attachments/assets/22515214-e3e3-4adf-a7d0-c676b0d0b8e0

