### PR TITLE
feat: use a fake link when rendering page preview

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Preview.tsx
+++ b/apps/studio/src/features/editing-experience/components/Preview.tsx
@@ -2,6 +2,7 @@ import type {
   IsomerPageSchemaType,
   IsomerSchema,
 } from "@opengovsg/isomer-components"
+import type { PropsWithChildren } from "react"
 import type { PartialDeep } from "type-fest"
 import { Skeleton } from "@chakra-ui/react"
 import { RenderEngine } from "@opengovsg/isomer-components"
@@ -16,6 +17,13 @@ type PreviewProps = IsomerSchema & {
   siteId: number
   overrides?: PartialDeep<IsomerPageSchemaType>
 }
+
+// Add a fake link component to prevent the preview from navigating away
+const FakeLink = ({ children, ...rest }: PropsWithChildren<unknown>) => (
+  <a {...rest} href="#" onClick={(e) => e.preventDefault()}>
+    {children}
+  </a>
+)
 
 function SuspendablePreview({
   permalink,
@@ -54,6 +62,7 @@ function SuspendablePreview({
         footerItems: footer,
         assetsBaseUrl: `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`,
       }}
+      LinkComponent={FakeLink}
     />
   )
 }

--- a/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
+++ b/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
@@ -15,10 +15,12 @@ const linkStyle = tv({
 
 interface BackToTopLinkProps extends VariantProps<typeof linkStyle> {
   className?: string
+  LinkComponent?: any // Next.js link
 }
 
 export const BackToTopLink = ({
   className,
+  LinkComponent,
 }: BackToTopLinkProps): JSX.Element => {
   return (
     <Link
@@ -26,6 +28,7 @@ export const BackToTopLink = ({
       className={composeRenderProps(className, (className, renderProps) =>
         linkStyle({ className, ...renderProps }),
       )}
+      LinkComponent={LinkComponent}
     >
       <BiUpArrowAlt aria-hidden className="h-6 w-6" />
       Back to top


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Right now, the links in our preview are legit links, which means the user can potentially open a "mini studio" or go to a 404 page when clicking on them.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Introduce a fake link component that prevents the default from occurring (which is the actual navigating away).

**Note**:

- The links created in Tiptap have not yet been ported over to use the LinkComponent, cos we are directly generating the HTML. This will be tackled in a future PR.