### PR TITLE
fix: use metadataeditor for hero banner

### DIFF
--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -5,6 +5,8 @@ import { createContext, useContext, useState } from "react"
 import type { ModifiedAsset } from "~/types/assets"
 import { type DrawerState } from "~/types/editorDrawer"
 
+type MetadataEditorType = "hero" | "metadata"
+
 export interface DrawerContextType {
   currActiveIdx: number
   setCurrActiveIdx: (currActiveIdx: number) => void
@@ -18,6 +20,8 @@ export interface DrawerContextType {
   setModifiedAssets: Dispatch<SetStateAction<ModifiedAsset[]>>
   addedBlockIndex: number | null
   setAddedBlockIndex: Dispatch<SetStateAction<number | null>>
+  metadataEditorType: MetadataEditorType
+  setMetadataEditorType: Dispatch<SetStateAction<MetadataEditorType>>
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -38,6 +42,8 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
   // Holding state for images/files that have been modified in the page
   const [modifiedAssets, setModifiedAssets] = useState<ModifiedAsset[]>([])
   const [addedBlockIndex, setAddedBlockIndex] = useState<number | null>(null)
+  const [metadataEditorType, setMetadataEditorType] =
+    useState<MetadataEditorType>("hero")
 
   return (
     <EditorDrawerContext.Provider
@@ -54,6 +60,8 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
         setModifiedAssets,
         addedBlockIndex,
         setAddedBlockIndex,
+        metadataEditorType,
+        setMetadataEditorType,
       }}
     >
       {children}

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -10,7 +10,10 @@ import {
   useDisclosure,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
-import { getLayoutMetadataSchema } from "@opengovsg/isomer-components"
+import {
+  getComponentSchema,
+  getLayoutMetadataSchema,
+} from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 import _ from "lodash"
 import { BiDollar, BiX } from "react-icons/bi"
@@ -36,6 +39,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
     setSavedPageState,
     previewPageState,
     setPreviewPageState,
+    metadataEditorType,
   } = useEditorDrawerContext()
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
@@ -120,7 +124,11 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
 
         <Box px="2rem" py="1rem" h="full">
           <FormBuilder<Static<typeof schema>>
-            schema={metadataSchema}
+            schema={
+              metadataEditorType === "metadata"
+                ? metadataSchema
+                : getComponentSchema("hero")
+            }
             validateFn={validateFn}
             data={previewPageState.page}
             handleChange={(data) => handleChange(data)}

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -30,6 +30,7 @@ export default function RootStateDrawer() {
     savedPageState,
     setSavedPageState,
     setPreviewPageState,
+    setMetadataEditorType,
   } = useEditorDrawerContext()
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
@@ -111,7 +112,8 @@ export default function RootStateDrawer() {
             as="button"
             onClick={() => {
               setCurrActiveIdx(0)
-              setDrawerState({ state: "complexEditor" })
+              setDrawerState({ state: "metadataEditor" })
+              setMetadataEditorType("hero")
             }}
             w="100%"
           >
@@ -127,7 +129,10 @@ export default function RootStateDrawer() {
         ) : (
           <Box
             as="button"
-            onClick={() => setDrawerState({ state: "metadataEditor" })}
+            onClick={() => {
+              setMetadataEditorType("metadata")
+              setDrawerState({ state: "metadataEditor" })
+            }}
             w="100%"
           >
             <HStack w="100%" py="4" bgColor="white">
@@ -204,7 +209,6 @@ export default function RootStateDrawer() {
                                   "prose"
                                     ? "nativeEditor"
                                     : "complexEditor"
-                                // NOTE: SNAPSHOT
                                 setDrawerState({ state: nextState })
                               }}
                             >


### PR DESCRIPTION
## Problem
Currently, we expose a delete button on the hero banner, which allows users to delete it.

## Solution
1. we should be using the `Metadata` editor instead because it disallows deletion of the block
2. now, we need to update the state of the `Metadata` editor to know whether we are editing the metadata of the schema or of the hero

## Screenshots and video