### PR TITLE
fix: save changes to db after delete

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -56,6 +56,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     trpc.page.updatePageBlob.useMutation({
       onSuccess: async () => {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+        toast({ title: "Changes saved" })
       },
     })
 
@@ -96,6 +97,11 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     onDeleteBlockModalClose()
     setDrawerState({ state: "root" })
     setAddedBlockIndex(null)
+    savePage({
+      pageId,
+      siteId,
+      content: JSON.stringify(newPageState),
+    })
   }
 
   const handleDiscardChanges = () => {

--- a/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapComponent.tsx
@@ -9,7 +9,7 @@ import {
   useDisclosure,
   VStack,
 } from "@chakra-ui/react"
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
 import _ from "lodash"
 import { BiText, BiTrash, BiX } from "react-icons/bi"
 
@@ -48,10 +48,12 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     setAddedBlockIndex,
   } = useEditorDrawerContext()
 
+  const toast = useToast()
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+      toast({ title: "Changes saved" })
     },
   })
 
@@ -80,6 +82,11 @@ function TipTapComponent({ content }: TipTapComponentProps) {
     onDeleteBlockModalClose()
     setDrawerState({ state: "root" })
     setAddedBlockIndex(null)
+    mutate({
+      pageId,
+      siteId,
+      content: JSON.stringify(newPageState),
+    })
   }
 
   const handleDiscardChanges = () => {


### PR DESCRIPTION
## Problem
Previously, deletes weren't persisted to the db at point of deletion - the users had to drag and drop for it to persist to db.

## Solution
- write to the db on delete
- add a toast saying `Changes saved` for both updates + delete 

## Screenshots

https://github.com/user-attachments/assets/14fefec2-e751-48af-ac69-3e2fe511801a



## Notes
- confirming w @sehyunidaaa  on final wording/settings for toast