### PR TITLE
fix(cascades): update schema so that deletes are cascaded

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,19 +1,19 @@
 export const ResourceState = {
-  Draft: "Draft",
-  Published: "Published",
-} as const
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
+    Draft: "Draft",
+    Published: "Published"
+} as const;
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
 export const ResourceType = {
-  RootPage: "RootPage",
-  Page: "Page",
-  Folder: "Folder",
-  Collection: "Collection",
-  CollectionPage: "CollectionPage",
-} as const
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
+    RootPage: "RootPage",
+    Page: "Page",
+    Folder: "Folder",
+    Collection: "Collection",
+    CollectionPage: "CollectionPage"
+} as const;
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
 export const RoleType = {
-  Admin: "Admin",
-  Editor: "Editor",
-  Publisher: "Publisher",
-} as const
-export type RoleType = (typeof RoleType)[keyof typeof RoleType]
+    Admin: "Admin",
+    Editor: "Editor",
+    Publisher: "Publisher"
+} as const;
+export type RoleType = (typeof RoleType)[keyof typeof RoleType];

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,105 +1,103 @@
-import type { ColumnType, GeneratedAlways } from "kysely"
+import type { ColumnType, GeneratedAlways } from "kysely";
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
 
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
-
-export interface Blob {
-  id: GeneratedAlways<string>
-  /**
-   * @kyselyType(PrismaJson.BlobJsonContent)
-   * [BlobJsonContent]
-   */
-  content: PrismaJson.BlobJsonContent
-}
-export interface Footer {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.FooterJsonContent)
-   * [FooterJsonContent]
-   */
-  content: PrismaJson.FooterJsonContent
-}
-export interface Navbar {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.NavbarJsonContent)
-   * [NavbarJsonContent]
-   */
-  content: PrismaJson.NavbarJsonContent
-}
-export interface Permission {
-  id: GeneratedAlways<number>
-  resourceId: string
-  userId: string
-  role: RoleType
-}
-export interface Resource {
-  id: GeneratedAlways<string>
-  title: string
-  permalink: string
-  siteId: number
-  parentId: string | null
-  publishedVersionId: string | null
-  draftBlobId: string | null
-  state: Generated<ResourceState | null>
-  type: ResourceType
-}
-export interface Site {
-  id: GeneratedAlways<number>
-  name: string
-  /**
-   * @kyselyType(PrismaJson.SiteJsonConfig)
-   * [SiteJsonConfig]
-   */
-  config: PrismaJson.SiteJsonConfig
-  /**
-   * @kyselyType(PrismaJson.SiteThemeJson)
-   * [SiteThemeJson]
-   */
-  theme: PrismaJson.SiteThemeJson | null
-  codeBuildId: string | null
-}
-export interface SiteMember {
-  userId: string
-  siteId: number
-}
-export interface User {
-  id: string
-  name: string
-  email: string
-  phone: string
-  preferredName: string | null
-}
-export interface VerificationToken {
-  identifier: string
-  token: string
-  attempts: Generated<number>
-  expires: Timestamp
-}
-export interface Version {
-  id: GeneratedAlways<string>
-  versionNum: number
-  resourceId: string
-  blobId: string
-  publishedAt: Generated<Timestamp>
-  publishedBy: string
-}
-export interface DB {
-  Blob: Blob
-  Footer: Footer
-  Navbar: Navbar
-  Permission: Permission
-  Resource: Resource
-  Site: Site
-  SiteMember: SiteMember
-  User: User
-  VerificationToken: VerificationToken
-  Version: Version
-}
+export type Blob = {
+    id: GeneratedAlways<string>;
+    /**
+     * @kyselyType(PrismaJson.BlobJsonContent)
+     * [BlobJsonContent]
+     */
+    content: PrismaJson.BlobJsonContent;
+};
+export type Footer = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.FooterJsonContent)
+     * [FooterJsonContent]
+     */
+    content: PrismaJson.FooterJsonContent;
+};
+export type Navbar = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.NavbarJsonContent)
+     * [NavbarJsonContent]
+     */
+    content: PrismaJson.NavbarJsonContent;
+};
+export type Permission = {
+    id: GeneratedAlways<number>;
+    resourceId: string;
+    userId: string;
+    role: RoleType;
+};
+export type Resource = {
+    id: GeneratedAlways<string>;
+    title: string;
+    permalink: string;
+    siteId: number;
+    parentId: string | null;
+    publishedVersionId: string | null;
+    draftBlobId: string | null;
+    state: Generated<ResourceState | null>;
+    type: ResourceType;
+};
+export type Site = {
+    id: GeneratedAlways<number>;
+    name: string;
+    /**
+     * @kyselyType(PrismaJson.SiteJsonConfig)
+     * [SiteJsonConfig]
+     */
+    config: PrismaJson.SiteJsonConfig;
+    /**
+     * @kyselyType(PrismaJson.SiteThemeJson)
+     * [SiteThemeJson]
+     */
+    theme: PrismaJson.SiteThemeJson | null;
+    codeBuildId: string | null;
+};
+export type SiteMember = {
+    userId: string;
+    siteId: number;
+};
+export type User = {
+    id: string;
+    name: string;
+    email: string;
+    phone: string;
+    preferredName: string | null;
+};
+export type VerificationToken = {
+    identifier: string;
+    token: string;
+    attempts: Generated<number>;
+    expires: Timestamp;
+};
+export type Version = {
+    id: GeneratedAlways<string>;
+    versionNum: number;
+    resourceId: string;
+    blobId: string;
+    publishedAt: Generated<Timestamp>;
+    publishedBy: string;
+};
+export type DB = {
+    Blob: Blob;
+    Footer: Footer;
+    Navbar: Navbar;
+    Permission: Permission;
+    Resource: Resource;
+    Site: Site;
+    SiteMember: SiteMember;
+    User: User;
+    VerificationToken: VerificationToken;
+    Version: Version;
+};

--- a/apps/studio/prisma/migrations/20240909103759_cascade_deletions_for_resource/migration.sql
+++ b/apps/studio/prisma/migrations/20240909103759_cascade_deletions_for_resource/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "Resource" DROP CONSTRAINT "Resource_parentId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "Resource" ADD CONSTRAINT "Resource_parentId_fkey" FOREIGN KEY ("parentId") REFERENCES "Resource"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -52,7 +52,7 @@ model Resource {
   siteId    Int
   site      Site      @relation(fields: [siteId], references: [id])
   parentId  BigInt?
-  parent    Resource? @relation("ParentRelation", fields: [parentId], references: [id])
+  parent    Resource? @relation("ParentRelation", fields: [parentId], references: [id], onDelete: Cascade)
 
   children Resource[] @relation("ParentRelation")
 


### PR DESCRIPTION
**THIS IS A ONE LINE PR!!! autogen code cause the extra lines**
## Problem
Previously, our deletes are not cascaded - this means that when we delete a folder, for example, the child pages and folders are not deleted. 

## Solution
1. add a constraint to the table's relation so that it does a `CASCADE` on delete

## Screenshots
(note, after running migration)

https://github.com/user-attachments/assets/2e30b61e-4719-44e9-bb12-d20b8f3fc916



## Notes
i **did not** delete the blob as we want to archive it presumably and also for auditing purposes