### PR TITLE
ref: separate out link type selection functionality

### DIFF
--- a/apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react"
+import { useState } from "react"
+import {
+  Box,
+  FormControl,
+  HStack,
+  Icon,
+  Text,
+  useRadioGroup,
+} from "@chakra-ui/react"
+import { FormLabel } from "@opengovsg/design-system-react"
+
+import { LINK_TYPES } from "./constants"
+import { LinkTypeRadioCard } from "./LinkTypeRadioCard"
+import { LinkTypeRadioContent } from "./LinkTypeRadioContent"
+import { getLinkHrefType } from "./utils"
+
+interface LinkHrefEditorProps {
+  value: string
+  onChange: (href: string) => void
+  label: string
+  description?: string
+  isRequired?: boolean
+  pageLinkElement: ReactNode
+  fileLinkElement: ReactNode
+}
+
+export const LinkHrefEditor = ({
+  value,
+  onChange,
+  label,
+  description,
+  isRequired,
+  pageLinkElement,
+  fileLinkElement,
+}: LinkHrefEditorProps) => {
+  const linkType = getLinkHrefType(value)
+  const [selectedLinkType, setSelectedLinkType] = useState(linkType)
+
+  const handleLinkTypeChange = (value: string) => {
+    setSelectedLinkType(value)
+    onChange("")
+  }
+
+  const { getRootProps, getRadioProps } = useRadioGroup({
+    name: "link-type",
+    defaultValue: linkType,
+    onChange: handleLinkTypeChange,
+  })
+
+  return (
+    <FormControl isRequired={isRequired}>
+      <FormLabel description={description}>{label}</FormLabel>
+
+      <HStack {...getRootProps()} spacing={0}>
+        {Object.entries(LINK_TYPES).map(([key, { icon, label }]) => {
+          const radio = getRadioProps({ value: key })
+
+          return (
+            <LinkTypeRadioCard key={key} {...radio}>
+              <HStack spacing={2}>
+                <Icon as={icon} fontSize="1.25rem" />
+                <Text textStyle="subhead-2">{label}</Text>
+              </HStack>
+            </LinkTypeRadioCard>
+          )
+        })}
+      </HStack>
+
+      <Box my="0.5rem">
+        <LinkTypeRadioContent
+          selectedLinkType={selectedLinkType}
+          data={value}
+          handleChange={onChange}
+          pageLinkElement={pageLinkElement}
+          fileLinkElement={fileLinkElement}
+        />
+      </Box>
+    </FormControl>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/LinkTypeRadioCard.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/LinkTypeRadioCard.tsx
@@ -1,0 +1,49 @@
+import type { UseRadioProps } from "@chakra-ui/react"
+import type { PropsWithChildren } from "react"
+import { Box, useRadio } from "@chakra-ui/react"
+
+export const LinkTypeRadioCard = ({
+  children,
+  ...rest
+}: PropsWithChildren<UseRadioProps>) => {
+  const { getInputProps, getRadioProps } = useRadio(rest)
+
+  return (
+    <Box
+      as="label"
+      _first={{
+        "> div": {
+          borderLeftRadius: "base",
+        },
+      }}
+      _last={{
+        "> div": {
+          borderRightRadius: "base",
+        },
+      }}
+    >
+      <input {...getInputProps()} />
+
+      <Box
+        {...getRadioProps()}
+        cursor="pointer"
+        border="1px solid"
+        borderColor="base.divider.strong"
+        bgColor="utility.ui"
+        px="1rem"
+        py="0.5rem"
+        mx={0}
+        _checked={{
+          bgColor: "interaction.muted.main.active",
+          color: "interaction.main.default",
+          borderColor: "interaction.main.default",
+        }}
+        textTransform="none"
+        fontWeight={500}
+        lineHeight="1.25rem"
+      >
+        {children}
+      </Box>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/LinkTypeRadioContent.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/LinkTypeRadioContent.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react"
+import { Input } from "@opengovsg/design-system-react"
+
+interface LinkTypeRadioContentProps {
+  selectedLinkType: string
+  data: string
+  handleChange: (value: string) => void
+  pageLinkElement: ReactNode
+  fileLinkElement: ReactNode
+}
+
+export const LinkTypeRadioContent = ({
+  selectedLinkType,
+  data,
+  handleChange,
+  pageLinkElement,
+  fileLinkElement,
+}: LinkTypeRadioContentProps): JSX.Element => {
+  switch (selectedLinkType) {
+    case "page":
+      return <>{pageLinkElement}</>
+    case "external":
+      return (
+        <Input
+          type="text"
+          value={data}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="https://www.isomer.gov.sg"
+        />
+      )
+    case "file":
+      return <>{fileLinkElement}</>
+    case "email":
+      return (
+        <Input
+          type="text"
+          value={data.startsWith("mailto:") ? data.slice("mailto:".length) : ""}
+          onChange={(e) => handleChange(`mailto:${e.target.value}`)}
+          placeholder="test@example.com"
+        />
+      )
+    default:
+      return <></>
+  }
+}

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/constants.ts
@@ -1,0 +1,21 @@
+import type { IconType } from "react-icons"
+import { BiEnvelopeOpen, BiFile, BiFileBlank, BiLink } from "react-icons/bi"
+
+export const LINK_TYPES: Record<string, { icon: IconType; label: string }> = {
+  page: {
+    icon: BiFileBlank,
+    label: "Page",
+  },
+  external: {
+    icon: BiLink,
+    label: "External",
+  },
+  file: {
+    icon: BiFile,
+    label: "File",
+  },
+  email: {
+    icon: BiEnvelopeOpen,
+    label: "Email",
+  },
+} as const

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/index.ts
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/index.ts
@@ -1,0 +1,3 @@
+export * from "./LinkHrefEditor"
+export * from "./LinkTypeRadioCard"
+export * from "./LinkTypeRadioContent"

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/utils.ts
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/utils.ts
@@ -1,0 +1,23 @@
+export const getLinkHrefType = (href: string | undefined) => {
+  if (!href) {
+    // We default to page if no href is provided, as that is the first option
+    return "page"
+  }
+
+  if (href.startsWith("mailto:")) {
+    return "email"
+  }
+
+  // Internal links are in the format [resource:$siteId:$pageId]
+  const referenceLinkMatch = href.match(/\[resource:(\d+):(\d+)\]/)
+  if (referenceLinkMatch && referenceLinkMatch.length === 3) {
+    return "page"
+  }
+
+  // File links would be pointing to the assets bucket, so they start with a /
+  if (href.startsWith("/")) {
+    return "file"
+  }
+
+  return "external"
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
@@ -1,7 +1,4 @@
-import type { UseRadioProps } from "@chakra-ui/react"
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import type { PropsWithChildren } from "react"
-import { useState } from "react"
 import { useRouter } from "next/router"
 import {
   Box,
@@ -16,8 +13,6 @@ import {
   ModalOverlay,
   Text,
   useDisclosure,
-  useRadio,
-  useRadioGroup,
   VStack,
 } from "@chakra-ui/react"
 import { and, isStringControl, rankWith, schemaMatches } from "@jsonforms/core"
@@ -28,7 +23,7 @@ import {
   Input,
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
-import { BiEnvelopeOpen, BiFile, BiFileBlank, BiLink } from "react-icons/bi"
+import { BiFile } from "react-icons/bi"
 import { z } from "zod"
 
 import { ResourceSelector } from "~/components/ResourceSelector"
@@ -36,25 +31,7 @@ import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { useZodForm } from "~/lib/form"
 import { getReferenceLink, getResourceIdFromReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
-
-const LINK_TYPES = {
-  page: {
-    icon: BiFileBlank,
-    label: "Page",
-  },
-  external: {
-    icon: BiLink,
-    label: "External",
-  },
-  file: {
-    icon: BiFile,
-    label: "File",
-  },
-  email: {
-    icon: BiEnvelopeOpen,
-    label: "Email",
-  },
-} as const
+import { LinkHrefEditor } from "../../../LinkEditor"
 
 export const jsonFormsLinkControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.LinkControl,
@@ -186,61 +163,17 @@ const PageLinkModal = ({
   )
 }
 
-const RadioCard = ({ children, ...rest }: PropsWithChildren<UseRadioProps>) => {
-  const { getInputProps, getRadioProps } = useRadio(rest)
-
-  return (
-    <Box
-      as="label"
-      _first={{
-        "> div": {
-          borderLeftRadius: "base",
-        },
-      }}
-      _last={{
-        "> div": {
-          borderRightRadius: "base",
-        },
-      }}
-    >
-      <input {...getInputProps()} />
-      <Box
-        {...getRadioProps()}
-        cursor="pointer"
-        border="1px solid"
-        borderColor="base.divider.strong"
-        bgColor="utility.ui"
-        px="1rem"
-        py="0.5rem"
-        mx={0}
-        _checked={{
-          bgColor: "interaction.muted.main.active",
-          color: "interaction.main.default",
-          borderColor: "interaction.main.default",
-        }}
-        textTransform="none"
-        fontWeight={500}
-        lineHeight="1.25rem"
-      >
-        {children}
-      </Box>
-    </Box>
-  )
-}
-
-interface RadioContentProps {
-  selectedLinkType: string
-  description?: string
+interface PageLinkElementProps {
   data: string
-  handleChange: (value: string) => void
+  description?: string
+  onChange: (value: string) => void
 }
 
-const RadioContent = ({
-  selectedLinkType,
-  description,
+const PageLinkElement = ({
   data,
-  handleChange,
-}: RadioContentProps): JSX.Element => {
+  description,
+  onChange,
+}: PageLinkElementProps) => {
   const router = useRouter()
   const siteId = String(router.query.siteId)
   const {
@@ -259,89 +192,57 @@ const RadioContent = ({
       },
     )
 
-  switch (selectedLinkType) {
-    case "page":
-      return (
-        <>
-          <PageLinkModal
-            data={data}
-            siteId={siteId}
-            description={description}
-            isOpen={isPageLinkModalOpen}
-            onClose={onPageLinkModalClose}
-            onSave={(value) => {
-              const referenceId = getReferenceLink({
-                siteId,
-                resourceId: value,
-              })
-              handleChange(referenceId)
-              onPageLinkModalClose()
-            }}
-          />
+  return (
+    <>
+      <PageLinkModal
+        data={data}
+        siteId={siteId}
+        description={description}
+        isOpen={isPageLinkModalOpen}
+        onClose={onPageLinkModalClose}
+        onSave={(value) => {
+          const referenceId = getReferenceLink({
+            siteId,
+            resourceId: value,
+          })
+          onChange(referenceId)
+          onPageLinkModalClose()
+        }}
+      />
 
-          {!!potentialInternalLinkResourceId ? (
-            <HStack mt="1rem">
-              <VStack w="full" align="start">
-                <HStack>
-                  <Icon as={BiFile} />
-                  <Text
-                    textStyle="subhead-2"
-                    noOfLines={1}
-                    color="base.content.default"
-                  >
-                    {potentialInternalLinkResource?.title || "Page title"}
-                  </Text>
-                </HStack>
-                <Text
-                  textStyle="caption-2"
-                  noOfLines={1}
-                  color="base.content.default"
-                >
-                  {`/${potentialInternalLinkResource?.fullPermalink || ""}`}
-                </Text>
-              </VStack>
-
-              <Button variant="clear" onClick={onPageLinkModalOpen}>
-                Change
-              </Button>
+      {!!potentialInternalLinkResourceId ? (
+        <HStack mt="1rem">
+          <VStack w="full" align="start">
+            <HStack>
+              <Icon as={BiFile} />
+              <Text
+                textStyle="subhead-2"
+                noOfLines={1}
+                color="base.content.default"
+              >
+                {potentialInternalLinkResource?.title || "Page title"}
+              </Text>
             </HStack>
-          ) : (
-            <Button variant="solid" w="full" onClick={onPageLinkModalOpen}>
-              Select a page to link...
-            </Button>
-          )}
-        </>
-      )
-    case "external":
-      return (
-        <Input
-          type="text"
-          value={data}
-          onChange={(e) => handleChange(e.target.value)}
-          placeholder="https://www.isomer.gov.sg"
-        />
-      )
-    case "file":
-      return (
-        <Input
-          type="text"
-          value={data}
-          onChange={(e) => handleChange(e.target.value)}
-          placeholder="File link"
-        />
-      )
-    case "email":
-      return (
-        <Input
-          type="text"
-          value={data.startsWith("mailto:") ? data.slice("mailto:".length) : ""}
-          onChange={(e) => handleChange(`mailto:${e.target.value}`)}
-          placeholder="test@example.com"
-        />
-      )
-    default:
-      return <></>
-  }
+            <Text
+              textStyle="caption-2"
+              noOfLines={1}
+              color="base.content.default"
+            >
+              {`/${potentialInternalLinkResource?.fullPermalink || ""}`}
+            </Text>
+          </VStack>
+
+          <Button variant="clear" onClick={onPageLinkModalOpen}>
+            Change
+          </Button>
+        </HStack>
+      ) : (
+        <Button variant="solid" w="full" onClick={onPageLinkModalOpen}>
+          Select a page to link...
+        </Button>
+      )}
+    </>
+  )
 }
 
 export function JsonFormsLinkControl({
@@ -352,50 +253,31 @@ export function JsonFormsLinkControl({
   description,
   required,
 }: ControlProps) {
-  const [selectedLinkType, setSelectedLinkType] = useState("page")
-
-  const handleLinkTypeChange = (value: string) => {
-    setSelectedLinkType(value)
-    handleChange(path, "")
-  }
-
-  const { getRootProps, getRadioProps } = useRadioGroup({
-    name: "link-type",
-    defaultValue: "page",
-    onChange: handleLinkTypeChange,
-  })
-
   const dataString = data && typeof data === "string" ? data : ""
 
   return (
     <Box mt="1.25rem" _first={{ mt: 0 }}>
-      <FormControl isRequired={required}>
-        <FormLabel description={description}>{label}</FormLabel>
-
-        <HStack {...getRootProps()} spacing={0}>
-          {Object.entries(LINK_TYPES).map(([key, { icon, label }]) => {
-            const radio = getRadioProps({ value: key })
-
-            return (
-              <RadioCard key={key} {...radio}>
-                <HStack spacing={2}>
-                  <Icon as={icon} fontSize="1.25rem" />
-                  <Text textStyle="subhead-2">{label}</Text>
-                </HStack>
-              </RadioCard>
-            )
-          })}
-        </HStack>
-
-        <Box my="0.5rem">
-          <RadioContent
-            selectedLinkType={selectedLinkType}
+      <LinkHrefEditor
+        value={dataString}
+        onChange={(value) => handleChange(path, value)}
+        label={label}
+        isRequired={required}
+        pageLinkElement={
+          <PageLinkElement
             data={dataString}
             description={description}
-            handleChange={(value) => handleChange(path, value)}
+            onChange={(value) => handleChange(path, value)}
           />
-        </Box>
-      </FormControl>
+        }
+        fileLinkElement={
+          <Input
+            type="text"
+            value={dataString}
+            onChange={(e) => handleChange(path, e.target.value)}
+            placeholder="File link"
+          />
+        }
+      />
     </Box>
   )
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Preparing to abstract out this functionality so that we can support adding links inside the Tiptap editor.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Abstract out the link adding functionality to a separate component. No change in actual functionality.