### PR TITLE
refactor: persist saves for page title and meta to backend

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -72,7 +72,13 @@ function EditPage(): JSX.Element {
         />
       </TabPanel>
       <TabPanel>
-        <PageSettings type={type} permalink={permalink} title={title} />
+        <PageSettings
+          type={type}
+          permalink={permalink}
+          noIndex={page.page.noIndex}
+          description={page.page.description}
+          title={title}
+        />
       </TabPanel>
     </TabPanels>
   )
@@ -129,11 +135,16 @@ interface PageSettingsProps {
   permalink: RouterOutput["page"]["readPageAndBlob"]["permalink"]
   title: RouterOutput["page"]["readPageAndBlob"]["title"]
   type: RouterOutput["page"]["readPageAndBlob"]["type"]
+  // TODO: this is currently defined as `any`
+  noIndex: RouterOutput["page"]["readPageAndBlob"]["content"]["page"]["noIndex"]
+  description: RouterOutput["page"]["readPageAndBlob"]["content"]["page"]["description"]
 }
 const PageSettings = ({
   permalink: originalPermalink,
   type,
   title: originalTitle,
+  description: originalDescription,
+  noIndex: originalNoIndex,
 }: PageSettingsProps) => {
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const { register, watch, control, reset, handleSubmit, formState } =
@@ -142,6 +153,8 @@ const PageSettings = ({
       defaultValues: {
         title: originalTitle || "",
         permalink: originalPermalink || "",
+        noIndex: !!originalNoIndex,
+        meta: originalDescription || "",
       },
     })
 


### PR DESCRIPTION
-  setting as draft first because our typing for the db types is wrong. oddly enough, it's not picking up the `noIndex` key
- also need to update the data from the return value of `mutation` rather than user input but this is relatively minor since saving is a sync point when successful

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
