### PR TITLE
fix: sticky bottom overflows in edit resource drawers

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -286,8 +286,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
           </HStack>
         </Box>
 
-        {/* NOTE: reserve at least 4.75rem for the bottom bar */}
-        <Box h="full" px="2rem" py="1rem" mb="4.75rem">
+        <Box flex={1} overflow="auto" px="2rem" py="1rem">
           <FormBuilder<IsomerComponent>
             schema={subSchema}
             validateFn={validateFn}
@@ -295,14 +294,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
             handleChange={handleChange}
           />
         </Box>
-        <Box
-          pos="sticky"
-          bottom={0}
-          bgColor="base.canvas.default"
-          boxShadow="md"
-          py="1.5rem"
-          px="2rem"
-        >
+        <Box bgColor="base.canvas.default" boxShadow="md" py="1.5rem" px="2rem">
           <HStack spacing="0.75rem">
             <IconButton
               icon={<BiTrash fontSize="1.25rem" />}

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -118,7 +118,7 @@ export default function HeroEditorDrawer(): JSX.Element {
           </HStack>
         </Box>
 
-        <Box px="2rem" py="1rem" h="full">
+        <Box px="2rem" py="1rem" flex={1} overflow="auto">
           <FormBuilder<IsomerComponent>
             schema={getComponentSchema("hero")}
             validateFn={validateFn}
@@ -126,14 +126,7 @@ export default function HeroEditorDrawer(): JSX.Element {
             handleChange={handleChange}
           />
         </Box>
-        <Box
-          pos="sticky"
-          bottom={0}
-          bgColor="base.canvas.default"
-          boxShadow="md"
-          py="1.5rem"
-          px="2rem"
-        >
+        <Box bgColor="base.canvas.default" boxShadow="md" py="1.5rem" px="2rem">
           <Button
             w="100%"
             isLoading={isLoading}

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -118,7 +118,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
           </HStack>
         </Box>
 
-        <Box px="2rem" py="1rem" h="full">
+        <Box px="2rem" py="1rem" flex={1} overflow="auto">
           <FormBuilder<Static<typeof schema>>
             schema={metadataSchema}
             validateFn={validateFn}
@@ -126,14 +126,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
             handleChange={(data) => handleChange(data)}
           />
         </Box>
-        <Box
-          pos="sticky"
-          bottom={0}
-          bgColor="base.canvas.default"
-          boxShadow="md"
-          py="1.5rem"
-          px="2rem"
-        >
+        <Box bgColor="base.canvas.default" boxShadow="md" py="1.5rem" px="2rem">
           <Button
             w="100%"
             isLoading={isLoading}

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -1,3 +1,4 @@
+import type { ProseProps } from "@opengovsg/isomer-components"
 import type { JSONContent } from "@tiptap/react"
 import {
   Box,
@@ -9,7 +10,6 @@ import {
   VStack,
 } from "@chakra-ui/react"
 import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
-import { ProseProps } from "@opengovsg/isomer-components"
 import _ from "lodash"
 import { BiText, BiTrash, BiX } from "react-icons/bi"
 
@@ -161,53 +161,51 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
             }}
           />
         </Flex>
-        <Box w="100%" p="2rem" h="100%">
+        <Box w="100%" p="2rem" overflow="auto" flex={1}>
           <TiptapTextEditor editor={editor} />
         </Box>
-      </VStack>
-
-      <Box
-        pos="sticky"
-        bottom={0}
-        bgColor="base.canvas.default"
-        boxShadow="md"
-        py="1.5rem"
-        px="2rem"
-      >
-        <HStack spacing="0.75rem">
-          <IconButton
-            icon={<BiTrash fontSize="1.25rem" />}
-            variant="outline"
-            colorScheme="critical"
-            aria-label="Delete block"
-            onClick={onDeleteBlockModalOpen}
-          />
-          <Box w="100%">
-            <Button
-              w="100%"
-              onClick={() => {
-                setSavedPageState(previewPageState)
-                mutate(
-                  {
-                    pageId,
-                    siteId,
-                    content: JSON.stringify(previewPageState),
-                  },
-                  {
-                    onSuccess: () => {
-                      setAddedBlockIndex(null)
-                      setDrawerState({ state: "root" })
+        <Box
+          bgColor="base.canvas.default"
+          boxShadow="md"
+          py="1.5rem"
+          px="2rem"
+          w="full"
+        >
+          <HStack spacing="0.75rem">
+            <IconButton
+              icon={<BiTrash fontSize="1.25rem" />}
+              variant="outline"
+              colorScheme="critical"
+              aria-label="Delete block"
+              onClick={onDeleteBlockModalOpen}
+            />
+            <Box w="100%">
+              <Button
+                w="100%"
+                onClick={() => {
+                  setSavedPageState(previewPageState)
+                  mutate(
+                    {
+                      pageId,
+                      siteId,
+                      content: JSON.stringify(previewPageState),
                     },
-                  },
-                )
-              }}
-              isLoading={isLoading}
-            >
-              Save changes
-            </Button>
-          </Box>
-        </HStack>
-      </Box>
+                    {
+                      onSuccess: () => {
+                        setAddedBlockIndex(null)
+                        setDrawerState({ state: "root" })
+                      },
+                    },
+                  )
+                }}
+                isLoading={isLoading}
+              >
+                Save changes
+              </Button>
+            </Box>
+          </HStack>
+        </Box>
+      </VStack>
     </>
   )
 }


### PR DESCRIPTION
### TL;DR

Improved layout and scrolling behavior of editor drawers.

### What changed?

- Updated the layout of ComplexEditorStateDrawer, HeroEditorDrawer, MetadataEditorStateDrawer, and TipTapProseComponent
- Replaced fixed height with flex layout and added overflow scrolling to content areas
- Removed sticky positioning from bottom action bars

### How to test?

1. Open various editor drawers (Complex, Hero, Metadata, and TipTap Prose)
2. Verify that the content area scrolls independently when content exceeds the drawer height
3. Ensure the bottom action bar remains visible and doesn't overlap content
4. Check that all functionality (editing, saving, deleting) works as expected
