### PR TITLE
fix: crashes when we paste hardbreak into heading

### DIFF
--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
@@ -50,27 +50,6 @@ export const useTableEditor = ({ data, handleChange }: BaseEditorProps) =>
       Dropcursor,
       Gapcursor,
       HardBreak,
-      Heading.extend({
-        marks: "",
-        // NOTE: Have to override the default input rules
-        // because we should map the number of `#` into
-        // a h<num # + 1>.
-        // eg: # -> h2
-        //     ## -> h3
-        addInputRules() {
-          return HEADING_LEVELS.map((level) => {
-            return textblockTypeInputRule({
-              find: new RegExp(`^(#{1,${level - 1}})\\s$`),
-              type: this.type,
-              getAttributes: {
-                level,
-              },
-            })
-          })
-        },
-      }).configure({
-        levels: HEADING_LEVELS,
-      }),
       History,
       HorizontalRule.extend({
         name: "divider",
@@ -131,6 +110,7 @@ export const useTextEditor = ({ data, handleChange }: BaseEditorProps) =>
       Gapcursor,
       HardBreak,
       Heading.extend({
+        content: "text*",
         marks: "",
         // NOTE: Have to override the default input rules
         // because we should map the number of `#` into


### PR DESCRIPTION
## Problem
(elaborating on ticket)
Previously, when we paste something containing a `hardbreak` into `Heading`, this causes our schema to crash because our schema doesn't accept hardbreaks in heading but tiptap does
```html
Heading
    |_ br
````

now that we've split up the editor into different hooks, the only one that accepts `Heading` is `useTextEditor` so we configure this to accept `Hardbreak` 

To ensure that this problem doesn't occur again, we need to check that other components in the schema that don't accept `hardbreak` will also disallow the `hardbreak` from being a child of these other components in the tiptap editor itself

## Solution
1. ensure that the content for `Heading` is only `text*`
2. i did the check for other components as well (see attached video) 

```            
Type.Ref(DividerSchema),
Type.Ref(HeadingSchema),
Type.Ref(OrderedListSchema),
Type.Ref(ParagraphSchema),
Type.Ref(TableSchema),
Type.Ref(UnorderedListSchema),
```

note: `tableEditor` in our frontend won't have `heading`

## Screenshots and video

https://github.com/user-attachments/assets/6740c181-ddd5-4818-8dbb-d4b2dd3edf18

