### PR TITLE
fix: allow self links

### DIFF
--- a/packages/components/src/interfaces/native/Text.ts
+++ b/packages/components/src/interfaces/native/Text.ts
@@ -33,7 +33,11 @@ const BaseLinkMarkSchema = Type.Object(
     type: Type.Literal("link", { default: "link" }),
     attrs: Type.Object({
       target: Type.Optional(
-        Type.Union([Type.Literal("_self"), Type.Literal("_blank")]),
+        Type.Union([
+          Type.Literal("_self"),
+          Type.Literal("_blank"),
+          Type.Literal(""),
+        ]),
       ),
       // NOTE: The href given by tiptap here
       // https://github.com/ueberdosis/tiptap/blob/main/packages/extension-link/src/link.ts


### PR DESCRIPTION
## Problem
Previously, we disallowed `target=""` in our schema. This causes a crash when pasting links which contain such a target.

## Solution
1. relax component schema to allow this

## Screenshots

https://github.com/user-attachments/assets/c619ce23-8414-42be-8edc-7950fdc31f6c

