### PR TITLE
fix(switch): add the property correctly

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -39,7 +39,7 @@ export function JsonFormsBooleanControl({
         <Switch
           id={id}
           isDisabled={!enabled}
-          checked={!!data}
+          isChecked={!!data}
           onChange={(e) => handleChange(path, e.target.checked)}
         />
         <FormErrorMessage>{errors}</FormErrorMessage>


### PR DESCRIPTION
## Problem
we were previously using the wrong property for the `Switch` causing UI errors

## Solution
use correct property

## Screenshots

https://github.com/user-attachments/assets/af232e2e-88bd-4465-8fce-f89ecb56d2b3


