### PR TITLE
feat: redesign ComponentSelector and add page-specific block options

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -1,4 +1,5 @@
 import type { IsomerComponent } from "@opengovsg/isomer-components"
+import { useMemo } from "react"
 import {
   chakra,
   Flex,
@@ -12,25 +13,16 @@ import {
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { type IconType } from "react-icons"
-import {
-  BiCard,
-  BiColumns,
-  BiDollar,
-  BiExpandVertical,
-  BiHash,
-  BiImage,
-  BiImages,
-  BiMap,
-  BiMovie,
-  BiQuestionMark,
-  BiSolidHandUp,
-  BiSolidQuoteAltLeft,
-  BiText,
-} from "react-icons/bi"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { type DrawerState } from "~/types/editorDrawer"
-import { DEFAULT_BLOCKS } from "./constants"
+import {
+  ARTICLE_ALLOWED_BLOCKS,
+  BLOCK_TO_META,
+  CONTENT_ALLOWED_BLOCKS,
+  DEFAULT_BLOCKS,
+  HOMEPAGE_ALLOWED_BLOCKS,
+} from "./constants"
 import { type SectionType } from "./types"
 
 function Section({ children }: React.PropsWithChildren) {
@@ -127,6 +119,7 @@ function ComponentSelector() {
     setSavedPageState,
     setPreviewPageState,
     setAddedBlockIndex,
+    type,
   } = useEditorDrawerContext()
 
   const onProceed = (sectionType: SectionType) => {
@@ -154,6 +147,28 @@ function ComponentSelector() {
     setAddedBlockIndex(nextPageState.content.length - 1)
     setPreviewPageState(nextPageState)
   }
+
+  const availableBlocks = useMemo(() => {
+    switch (type) {
+      case "RootPage":
+        return HOMEPAGE_ALLOWED_BLOCKS
+      case "Page":
+        if (savedPageState?.layout === "content") {
+          return CONTENT_ALLOWED_BLOCKS
+        } else if (savedPageState?.layout === "article") {
+          return ARTICLE_ALLOWED_BLOCKS
+        }
+        throw new Error(`Unsupported page layout: ${savedPageState?.layout}`)
+      case "CollectionPage":
+        return ARTICLE_ALLOWED_BLOCKS
+      case "Collection":
+      case "Folder":
+        throw new Error(`Unsupported resource type: ${type}`)
+      default:
+        const exhaustiveCheck: never = type
+        return exhaustiveCheck
+    }
+  }, [savedPageState?.layout, type])
 
   return (
     <VStack w="full" h="full" gap="0">
@@ -192,140 +207,27 @@ function ComponentSelector() {
         flex={1}
         overflow="auto"
       >
-        <Section>
-          <SectionTitle title="Organise complex content" />
-          <BlockList>
-            <BlockItem
-              label="Statistics"
-              icon={BiHash}
-              onProceed={onProceed}
-              sectionType="keystatistics"
-              description="Display KPIs or key statistics for your agency"
-              usageText="Do you have metrics to show the public? Designed to be bold, this block supports up to four numbers with labels."
-            />
-            <BlockItem
-              label="Cards"
-              icon={BiCard}
-              onProceed={onProceed}
-              sectionType="infocards"
-              description={`Link information in "cards" with or without images`}
-              usageText="This block supports up to six cards."
-            />
-            <BlockItem
-              label="Contentpic"
-              icon={BiImages}
-              onProceed={onProceed}
-              sectionType="contentpic"
-              description="Put an image and text side-by-side"
-              usageText="Use this block to juxtapose text next to a smaller image than usual, such as introducing a committee member along with their headshot."
-            />
-          </BlockList>
-        </Section>
-        <Section>
-          <SectionTitle title="Basic Building Blocks" />
-          <BlockList>
-            <BlockItem
-              label="Text"
-              icon={BiText}
-              onProceed={onProceed}
-              sectionType="prose"
-              description="Add text to your page - lists, headings, paragraph, and links."
-            />
-            <BlockItem
-              label="Image"
-              icon={BiImage}
-              onProceed={onProceed}
-              sectionType="image"
-              description="TODO"
-            />
-          </BlockList>
-        </Section>
-        <Section>
-          <SectionTitle title="Highlight Important Information" />
-          <BlockList>
-            <BlockItem
-              label="Statistics"
-              icon={BiDollar}
-              onProceed={onProceed}
-              sectionType="keystatistics"
-              description="TODO"
-            />
-            <BlockItem
-              label="Callout"
-              icon={BiSolidQuoteAltLeft}
-              onProceed={onProceed}
-              sectionType="callout"
-              description="TODO"
-            />
-            <BlockItem
-              label="Text with button"
-              icon={BiSolidHandUp}
-              onProceed={onProceed}
-              sectionType="infobar"
-              description="TODO"
-            />
-            <BlockItem
-              label="Text with image"
-              icon={BiImages}
-              onProceed={onProceed}
-              sectionType="infopic"
-              description="TODO"
-            />
-          </BlockList>
-        </Section>
-        <Section>
-          <SectionTitle title="Organise Content" />
-          {/* TODO: this should map over the schema and take values + components from there */}
-          <BlockList>
-            <BlockItem
-              label="Cards"
-              icon={BiCard}
-              onProceed={onProceed}
-              sectionType="infocards"
-              description="TODO"
-            />
-            <BlockItem
-              label="Columns"
-              icon={BiColumns}
-              onProceed={onProceed}
-              sectionType="infocols"
-              description="TODO"
-            />
-            <BlockItem
-              label="Accordion"
-              icon={BiExpandVertical}
-              onProceed={onProceed}
-              sectionType="accordion"
-              description="TODO"
-            />
-          </BlockList>
-        </Section>
-        <Section>
-          <SectionTitle title="External Content" />
-          <BlockList>
-            <BlockItem
-              label="YouTube"
-              icon={BiMovie}
-              onProceed={onProceed}
-              sectionType="iframe"
-              description="TODO"
-            />
-            <BlockItem
-              label="Google Maps"
-              icon={BiMap}
-              onProceed={onProceed}
-              sectionType="iframe"
-              description="TODO"
-            />
-            <BlockItem
-              label="FormSG"
-              icon={BiQuestionMark}
-              onProceed={onProceed}
-              sectionType="iframe"
-              description="TODO"
-            />
-          </BlockList>
-        </Section>
+        {availableBlocks.map((section) => (
+          <Section>
+            <SectionTitle title={section.label} />
+            <BlockList>
+              {section.types.map((type) => {
+                const blockMeta = BLOCK_TO_META[type]
+                return (
+                  <BlockItem
+                    key={type}
+                    icon={blockMeta.icon}
+                    label={blockMeta.label}
+                    onProceed={onProceed}
+                    sectionType={type}
+                    description={blockMeta.description}
+                    usageText={blockMeta.usageText}
+                  />
+                )
+              })}
+            </BlockList>
+          </Section>
+        ))}
       </VStack>
     </VStack>
   )

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -1,21 +1,23 @@
 import type { IsomerComponent } from "@opengovsg/isomer-components"
 import {
+  chakra,
   Flex,
+  Icon,
   Popover,
-  PopoverArrow,
   PopoverContent,
   PopoverTrigger,
+  Stack,
   Text,
   VStack,
-  Wrap,
 } from "@chakra-ui/react"
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
 import { type IconType } from "react-icons"
 import {
   BiCard,
   BiColumns,
   BiDollar,
   BiExpandVertical,
+  BiHash,
   BiImage,
   BiImages,
   BiMap,
@@ -24,7 +26,6 @@ import {
   BiSolidHandUp,
   BiSolidQuoteAltLeft,
   BiText,
-  BiX,
 } from "react-icons/bi"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -34,7 +35,7 @@ import { type SectionType } from "./types"
 
 function Section({ children }: React.PropsWithChildren) {
   return (
-    <VStack gap="0.5rem" alignItems="start">
+    <VStack gap="1rem" alignItems="start" w="full">
       {children}
     </VStack>
   )
@@ -42,54 +43,76 @@ function Section({ children }: React.PropsWithChildren) {
 
 function SectionTitle({ title }: { title: string }) {
   return (
-    <Text textStyle="subhead-3" textColor="base.content.medium">
+    <Text textStyle="subhead-2" textColor="base.content.medium">
       {title}
     </Text>
   )
 }
 
 function BlockList({ children }: React.PropsWithChildren) {
-  return <Wrap spacing="0">{children}</Wrap>
+  return <Stack w="full">{children}</Stack>
 }
 
-function BlockItem({
-  icon: Icon,
-  label,
-  onProceed,
-  sectionType,
-  description,
-}: {
+interface BlockItemProps {
   icon: IconType
   label: string
   onProceed: (sectionType: SectionType) => void
   sectionType: SectionType
   description: string
-}) {
+  usageText?: string
+}
+
+function BlockItem({
+  icon,
+  label,
+  onProceed,
+  sectionType,
+  description,
+  usageText,
+}: BlockItemProps) {
   return (
-    <Popover trigger="hover" placement="right">
+    <Popover trigger="hover" placement="right" isLazy offset={[0, 20]}>
       <PopoverTrigger>
-        <Button
-          m="0.75rem"
-          w="6rem"
-          h="6rem"
-          variant="clear"
-          colorScheme="neutral"
+        <chakra.button
+          layerStyle="focusRing"
+          w="100%"
+          borderRadius="6px"
+          border="1px solid"
+          borderColor="base.divider.medium"
+          transitionProperty="common"
+          transitionDuration="normal"
+          _hover={{
+            bg: "interaction.muted.main.hover",
+            borderColor: "interaction.main-subtle.hover",
+          }}
+          bg="white"
+          p="0.75rem"
+          flexDirection="row"
+          display="flex"
+          alignItems="start"
+          gap="0.75rem"
           onClick={() => onProceed(sectionType)}
         >
-          <VStack gap="0.5rem" color="base.content.default">
-            <Icon size="1.25rem" />
+          <Flex
+            p="0.5rem"
+            bg="interaction.main-subtle.default"
+            borderRadius="full"
+          >
+            <Icon as={icon} fontSize="1rem" color="base.content.default" />
+          </Flex>
+          <Stack align="start" gap="0.25rem">
             <Text textStyle="caption-1">{label}</Text>
-          </VStack>
-        </Button>
+            <Text textStyle="caption-2">{description}</Text>
+          </Stack>
+        </chakra.button>
       </PopoverTrigger>
       <PopoverContent>
-        <PopoverArrow />
         <VStack p="1.5rem" alignItems="start" gap="0.75rem">
-          <Flex alignItems="center" gap="0.5rem">
-            <Icon size="1.25rem" />
+          <Flex alignItems="center" gap="0.25rem">
+            <Icon as={icon} size="1.25rem" />
             <Text textStyle="subhead-2">{label}</Text>
           </Flex>
-          <Text textStyle="body-2">{description}</Text>
+          <Text textStyle="body-2">{usageText ?? description}</Text>
         </VStack>
       </PopoverContent>
     </Popover>
@@ -169,6 +192,35 @@ function ComponentSelector() {
         flex={1}
         overflow="auto"
       >
+        <Section>
+          <SectionTitle title="Organise complex content" />
+          <BlockList>
+            <BlockItem
+              label="Statistics"
+              icon={BiHash}
+              onProceed={onProceed}
+              sectionType="keystatistics"
+              description="Display KPIs or key statistics for your agency"
+              usageText="Do you have metrics to show the public? Designed to be bold, this block supports up to four numbers with labels."
+            />
+            <BlockItem
+              label="Cards"
+              icon={BiCard}
+              onProceed={onProceed}
+              sectionType="infocards"
+              description={`Link information in "cards" with or without images`}
+              usageText="This block supports up to six cards."
+            />
+            <BlockItem
+              label="Contentpic"
+              icon={BiImages}
+              onProceed={onProceed}
+              sectionType="contentpic"
+              description="Put an image and text side-by-side"
+              usageText="Use this block to juxtapose text next to a smaller image than usual, such as introducing a committee member along with their headshot."
+            />
+          </BlockList>
+        </Section>
         <Section>
           <SectionTitle title="Basic Building Blocks" />
           <BlockList>

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -153,12 +153,12 @@ function ComponentSelector() {
       case "RootPage":
         return HOMEPAGE_ALLOWED_BLOCKS
       case "Page":
-        if (savedPageState?.layout === "content") {
+        if (savedPageState.layout === "content") {
           return CONTENT_ALLOWED_BLOCKS
-        } else if (savedPageState?.layout === "article") {
+        } else if (savedPageState.layout === "article") {
           return ARTICLE_ALLOWED_BLOCKS
         }
-        throw new Error(`Unsupported page layout: ${savedPageState?.layout}`)
+        throw new Error(`Unsupported page layout: ${savedPageState.layout}`)
       case "CollectionPage":
         return ARTICLE_ALLOWED_BLOCKS
       case "Collection":
@@ -168,7 +168,7 @@ function ComponentSelector() {
         const exhaustiveCheck: never = type
         return exhaustiveCheck
     }
-  }, [savedPageState?.layout, type])
+  }, [savedPageState.layout, type])
 
   return (
     <VStack w="full" h="full" gap="0">

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -92,7 +92,7 @@ function BlockItem({
           >
             <Icon as={icon} fontSize="1rem" color="base.content.default" />
           </Flex>
-          <Stack align="start" gap="0.25rem">
+          <Stack align="start" gap="0.25rem" textAlign="start">
             <Text textStyle="caption-1">{label}</Text>
             <Text textStyle="caption-2">{description}</Text>
           </Stack>

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -133,36 +133,42 @@ function ComponentSelector() {
   }
 
   return (
-    <VStack w="full" gap="0">
+    <VStack w="full" h="full" gap="0">
       <Flex
         w="full"
-        py="1.25rem"
-        px="2rem"
+        py="0.75rem"
+        px="1.5rem"
+        gap="0.75rem"
         alignItems="center"
         justifyContent="space-between"
-        borderBottom="solid"
-        borderWidth="1px"
+        borderBottom="1px solid"
         borderColor="base.divider.medium"
+        bg="white"
       >
-        <VStack alignItems="start">
-          <Text as="h5" textStyle="h5">
-            Add a new block
+        <VStack alignItems="start" gap="0.25rem">
+          <Text textStyle="subhead-1">Add a new block</Text>
+          <Text textStyle="caption-2" color="base.content.medium">
+            Click a block to add to the page
           </Text>
-          <Text textStyle="body-2">Click a block to add to the page</Text>
         </VStack>
-        <IconButton
-          size="lg"
+        <Button
+          size="xs"
           variant="clear"
-          colorScheme="neutral"
-          color="interaction.sub.default"
-          aria-label="Close add component"
-          icon={<BiX />}
           onClick={() => {
             setDrawerState({ state: "root" })
           }}
-        />
+        >
+          Cancel
+        </Button>
       </Flex>
-      <VStack p="2rem" w="full" gap="1.25rem" alignItems="start">
+      <VStack
+        p="2rem"
+        w="full"
+        gap="1.25rem"
+        alignItems="start"
+        flex={1}
+        overflow="auto"
+      >
         <Section>
           <SectionTitle title="Basic Building Blocks" />
           <BlockList>

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -207,8 +207,8 @@ function ComponentSelector() {
         flex={1}
         overflow="auto"
       >
-        {availableBlocks.map((section) => (
-          <Section>
+        {availableBlocks.map((section, index) => (
+          <Section key={index}>
             <SectionTitle title={section.label} />
             <BlockList>
               {section.types.map((type) => {

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -1,4 +1,17 @@
 import type { IsomerComponent } from "@opengovsg/isomer-components"
+import type { IconType } from "react-icons"
+import {
+  BiCard,
+  BiChevronDown,
+  BiColumns,
+  BiCrown,
+  BiHash,
+  BiImageAlt,
+  BiSolidQuoteAltLeft,
+  BiText,
+} from "react-icons/bi"
+
+import { ContentpicIcon } from "~/features/editing-experience/components/icons/Contentpic"
 
 // TODO: add in default blocks for remaining
 export const DEFAULT_BLOCKS: Record<
@@ -160,3 +173,114 @@ export const DEFAULT_BLOCKS: Record<
     ],
   },
 }
+
+export const BLOCK_TO_META: Record<
+  IsomerComponent["type"],
+  { label: string; icon: IconType; description: string; usageText?: string }
+> = {
+  hero: {
+    label: "Hero banner",
+    icon: BiCrown,
+    description: "Title, summary, hero image, and Call-to-Action",
+  },
+  image: {
+    label: "Image",
+    icon: BiImageAlt,
+    description: "Add an image with caption",
+    usageText:
+      "Get your readers' attention and create emotions by using an image. You can adjust the size of the image.",
+  },
+  prose: {
+    label: "Text",
+    icon: BiText,
+    description: "Add a block of text to your page",
+    usageText:
+      "You can add structure to your content by using features such as headings, lists, links, and body text.",
+  },
+  callout: {
+    label: "Callout",
+    icon: BiSolidQuoteAltLeft,
+    description: "Bring attention to important information",
+    usageText:
+      "Callouts are great for highlighting information such as updates. We recommend not overusing the callouts.",
+  },
+  keystatistics: {
+    label: "Statistics",
+    icon: BiHash,
+    description: "Display KPIs or key statistics for your agency",
+    usageText:
+      "Do you have metrics to show the public? Designed to be bold, this block supports up to four numbers with labels.",
+  },
+  infobar: {
+    label: "Text with CTA",
+    icon: ContentpicIcon,
+    description: "Add a strong call-to-action",
+    usageText:
+      "Use this block to highlight key initatives on your homepage. It supports up to two buttons.",
+  },
+  contentpic: {
+    label: "Contentpic",
+    icon: ContentpicIcon,
+    description: "Put an image and text side-by-side",
+    usageText:
+      "Use this block to juxtapose text next to a smaller image than usual, such as introducing a committee member along with their headshot.",
+  },
+  infopic: {
+    label: "Text with image",
+    icon: ContentpicIcon,
+    description: "Place an image with a text and call-to-action",
+    usageText: "This block comes with a button.",
+  },
+  accordion: {
+    label: "Accordion",
+    icon: BiChevronDown,
+    description: "Display content in expandable accordions",
+    usageText:
+      "Accordions hide details by default, so they are great for content that isn't relevant to every reader.",
+  },
+  infocards: {
+    label: "Cards",
+    icon: BiCard,
+    description: `Link information in "cards" with or without images`,
+    usageText: "This block supports up to six cards.",
+  },
+  infocols: {
+    label: "Columns of text",
+    icon: BiColumns,
+    description: "Show important links in multiple columns",
+    usageText: "This block supports up to six links.",
+  },
+  iframe: {
+    label: "Embed",
+    icon: BiColumns,
+    description: "Embed a video or other content",
+    usageText: "This block supports embedding content from other websites.",
+  },
+}
+
+type AllowedBlockSections = {
+  label: string
+  types: IsomerComponent["type"][]
+}[]
+
+export const ARTICLE_ALLOWED_BLOCKS: AllowedBlockSections = [
+  { label: "Basic building blocks", types: ["prose", "image", "callout"] },
+]
+
+export const CONTENT_ALLOWED_BLOCKS: AllowedBlockSections = [
+  { label: "Basic building blocks", types: ["prose", "image", "callout"] },
+  {
+    label: "Organise complex content",
+    types: ["contentpic", "infocards", "accordion", "infocols", "iframe"],
+  },
+]
+export const HOMEPAGE_ALLOWED_BLOCKS: AllowedBlockSections = [
+  {
+    label: "Highlight important information",
+    types: ["keystatistics", "infobar"],
+  },
+  {
+    label: "Organise complex content",
+    types: ["contentpic", "infocards", "infocols", "iframe"],
+  },
+]

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -281,6 +281,6 @@ export const HOMEPAGE_ALLOWED_BLOCKS: AllowedBlockSections = [
   },
   {
     label: "Organise complex content",
-    types: ["contentpic", "infocards", "infocols", "iframe"],
+    types: ["infopic", "infocards", "infocols", "iframe"],
   },
 ]

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -3,17 +3,19 @@ import type { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import { createContext, useContext, useState } from "react"
 
 import type { ModifiedAsset } from "~/types/assets"
+import type { ResourceType } from "~prisma/generated/generatedEnums"
 import { type DrawerState } from "~/types/editorDrawer"
 
-export interface DrawerContextType {
+export interface DrawerContextType
+  extends Pick<EditorDrawerProviderProps, "type" | "permalink" | "siteId"> {
   currActiveIdx: number
   setCurrActiveIdx: (currActiveIdx: number) => void
   drawerState: DrawerState
   setDrawerState: (state: DrawerState) => void
   savedPageState?: IsomerSchema
-  setSavedPageState: Dispatch<SetStateAction<IsomerSchema | undefined>>
+  setSavedPageState: Dispatch<SetStateAction<IsomerSchema>>
   previewPageState?: IsomerSchema
-  setPreviewPageState: Dispatch<SetStateAction<IsomerSchema | undefined>>
+  setPreviewPageState: Dispatch<SetStateAction<IsomerSchema>>
   modifiedAssets: ModifiedAsset[]
   setModifiedAssets: Dispatch<SetStateAction<ModifiedAsset[]>>
   addedBlockIndex: number | null
@@ -21,20 +23,31 @@ export interface DrawerContextType {
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
-export function EditorDrawerProvider({ children }: PropsWithChildren) {
+interface EditorDrawerProviderProps extends PropsWithChildren {
+  initialPageState: IsomerSchema
+  type: ResourceType
+  permalink: string
+  siteId: number
+}
+
+export function EditorDrawerProvider({
+  children,
+  initialPageState,
+  type,
+  permalink,
+  siteId,
+}: EditorDrawerProviderProps) {
   const [drawerState, setDrawerState] = useState<DrawerState>({
     state: "root",
   })
   // Index of the current block being edited
   const [currActiveIdx, setCurrActiveIdx] = useState<number>(-1)
   // Current saved state of page
-  const [savedPageState, setSavedPageState] = useState<
-    IsomerSchema | undefined
-  >()
+  const [savedPageState, setSavedPageState] =
+    useState<IsomerSchema>(initialPageState)
   // State of the page to render in the preview
-  const [previewPageState, setPreviewPageState] = useState<
-    IsomerSchema | undefined
-  >()
+  const [previewPageState, setPreviewPageState] =
+    useState<IsomerSchema>(initialPageState)
   // Holding state for images/files that have been modified in the page
   const [modifiedAssets, setModifiedAssets] = useState<ModifiedAsset[]>([])
   const [addedBlockIndex, setAddedBlockIndex] = useState<number | null>(null)
@@ -54,6 +67,9 @@ export function EditorDrawerProvider({ children }: PropsWithChildren) {
         setModifiedAssets,
         addedBlockIndex,
         setAddedBlockIndex,
+        type,
+        permalink,
+        siteId,
       }}
     >
       {children}

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -12,9 +12,9 @@ export interface DrawerContextType
   setCurrActiveIdx: (currActiveIdx: number) => void
   drawerState: DrawerState
   setDrawerState: (state: DrawerState) => void
-  savedPageState?: IsomerSchema
+  savedPageState: IsomerSchema
   setSavedPageState: Dispatch<SetStateAction<IsomerSchema>>
-  previewPageState?: IsomerSchema
+  previewPageState: IsomerSchema
   setPreviewPageState: Dispatch<SetStateAction<IsomerSchema>>
   modifiedAssets: ModifiedAsset[]
   setModifiedAssets: Dispatch<SetStateAction<ModifiedAsset[]>>

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -9,7 +9,6 @@ export const EditPagePreview = (): JSX.Element => {
 
   return (
     <PreviewIframe style={themeCssVars}>
-      {/* @ts-expect-error JsonForm types are messing up */}
       <Preview
         {...previewPageState}
         siteId={siteId}

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -1,0 +1,21 @@
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
+import Preview from "./Preview"
+import { PreviewIframe } from "./PreviewIframe"
+
+export const EditPagePreview = (): JSX.Element => {
+  const { previewPageState, siteId, permalink } = useEditorDrawerContext()
+  const themeCssVars = useSiteThemeCssVars({ siteId })
+
+  return (
+    <PreviewIframe style={themeCssVars}>
+      {/* @ts-expect-error JsonForm types are messing up */}
+      <Preview
+        {...previewPageState}
+        siteId={siteId}
+        permalink={permalink}
+        version="0.1.0"
+      />
+    </PreviewIframe>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -110,22 +110,13 @@ export default function RootStateDrawer() {
             icon={BiCrown}
           />
         ) : (
-          <Box
-            as="button"
+          <BaseBlock
             onClick={() => {
               setDrawerState({ state: "metadataEditor" })
             }}
-            w="100%"
-          >
-            <HStack w="100%" py="4" bgColor="white">
-              <VStack w="100%" pl={1} align="start">
-                <Text px="3" fontWeight={500}>
-                  Page title and summary
-                </Text>
-                <Text px="3">Click to edit</Text>
-              </VStack>
-            </HStack>
-          </Box>
+            label="Page title and summary"
+            description="Click to edit"
+          />
         )}
       </VStack>
 

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -1,6 +1,6 @@
 import type { DropResult } from "@hello-pangea/dnd"
 import { useCallback } from "react"
-import { Box, Button, Flex, HStack, Text, VStack } from "@chakra-ui/react"
+import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react"
 import { DragDropContext, Droppable } from "@hello-pangea/dnd"
 import { useToast } from "@opengovsg/design-system-react"
 import { BiCrown, BiPlusCircle } from "react-icons/bi"
@@ -84,7 +84,7 @@ export default function RootStateDrawer() {
   )
 
   const isHeroFixedBlock =
-    savedPageState?.layout === "homepage" &&
+    savedPageState.layout === "homepage" &&
     savedPageState.content.length > 0 &&
     savedPageState.content[0]?.type === "hero"
 

--- a/apps/studio/src/features/editing-experience/components/icons/Contentpic.tsx
+++ b/apps/studio/src/features/editing-experience/components/icons/Contentpic.tsx
@@ -3,8 +3,7 @@ import type { IconBaseProps } from "react-icons"
 export const ContentpicIcon = (props: IconBaseProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
-    width={22}
-    height={22}
+    viewBox="0 0 22 22"
     fill="none"
     {...props}
   >

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,5 +1,4 @@
 import type { z } from "zod"
-import { useEffect } from "react"
 import {
   Box,
   Flex,
@@ -16,7 +15,10 @@ import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
 import type { RouterOutput } from "~/utils/trpc"
-import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import {
+  EditorDrawerProvider,
+  useEditorDrawerContext,
+} from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
 import Preview from "~/features/editing-experience/components/Preview"
 import { PreviewIframe } from "~/features/editing-experience/components/PreviewIframe"
@@ -34,8 +36,6 @@ import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
 
 function EditPage(): JSX.Element {
-  const { setDrawerState, setSavedPageState, setPreviewPageState } =
-    useEditorDrawerContext()
   const { pageId, siteId } = useQueryParse(editPageSchema)
 
   const [{ content: page, permalink, type, title, updatedAt }] =
@@ -47,24 +47,23 @@ function EditPage(): JSX.Element {
       { refetchOnWindowFocus: false },
     )
 
-  useEffect(() => {
-    setDrawerState({
-      state: "root",
-    })
-    setSavedPageState(page)
-    setPreviewPageState(page)
-  }, [page, setDrawerState, setPreviewPageState, setSavedPageState])
-
   return (
     <TabPanels _dark={{ color: "white" }}>
       <TabPanel height="full">
-        <PageEditingView
-          pageId={pageId}
+        <EditorDrawerProvider
+          initialPageState={page}
+          type={type}
           permalink={permalink}
-          page={page}
           siteId={siteId}
-          updatedAt={updatedAt}
-        />
+        >
+          <PageEditingView
+            pageId={pageId}
+            permalink={permalink}
+            page={page}
+            siteId={siteId}
+            updatedAt={updatedAt}
+          />
+        </EditorDrawerProvider>
       </TabPanel>
       <TabPanel>
         <PageSettings type={type} permalink={permalink} title={title} />

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { userEvent, waitFor, within } from "@storybook/test"
+import { meHandlers } from "tests/msw/handlers/me"
+import { pageHandlers } from "tests/msw/handlers/page"
+import { resourceHandlers } from "tests/msw/handlers/resource"
+import { sitesHandlers } from "tests/msw/handlers/sites"
+
+import { withChromaticModes } from "@isomer/storybook-config"
+
+import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
+
+const COMMON_HANDLERS = [
+  meHandlers.me(),
+  pageHandlers.listWithoutRoot.default(),
+  pageHandlers.getRootPage.default(),
+  pageHandlers.countWithoutRoot.default(),
+  sitesHandlers.getTheme.default(),
+  sitesHandlers.getConfig.default(),
+  sitesHandlers.getFooter.default(),
+  sitesHandlers.getNavbar.default(),
+  resourceHandlers.getChildrenOf.default(),
+  pageHandlers.readPageAndBlob.article(),
+  pageHandlers.readPage.content(),
+]
+
+const meta: Meta<typeof EditPage> = {
+  title: "Pages/Edit Page/Article Page",
+  component: EditPage,
+  parameters: {
+    getLayout: EditPage.getLayout,
+    msw: {
+      handlers: COMMON_HANDLERS,
+    },
+    nextjs: {
+      router: {
+        query: {
+          siteId: "1",
+          pageId: "1",
+        },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof EditPage>
+
+export const Default: Story = {
+  parameters: {
+    chromatic: withChromaticModes(["gsib", "mobile"]),
+  },
+}
+
+export const AddBlock: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByRole("button", { name: /add block/i }))
+    })
+  },
+}
+
+export const PublishedState: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.readPage.article({
+          state: "Published",
+          draftBlobId: null,
+        }),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+}

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -5,8 +5,6 @@ import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
-import { withChromaticModes } from "@isomer/storybook-config"
-
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 
 const COMMON_HANDLERS = [
@@ -45,11 +43,7 @@ const meta: Meta<typeof EditPage> = {
 export default meta
 type Story = StoryObj<typeof EditPage>
 
-export const Default: Story = {
-  parameters: {
-    chromatic: withChromaticModes(["gsib", "mobile"]),
-  },
-}
+export const Default: Story = {}
 
 export const AddBlock: Story = {
   play: async ({ canvasElement }) => {

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -5,8 +5,6 @@ import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
-import { withChromaticModes } from "@isomer/storybook-config"
-
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 
 const COMMON_HANDLERS = [
@@ -45,11 +43,7 @@ const meta: Meta<typeof EditPage> = {
 export default meta
 type Story = StoryObj<typeof EditPage>
 
-export const Default: Story = {
-  parameters: {
-    chromatic: withChromaticModes(["gsib", "mobile"]),
-  },
-}
+export const Default: Story = {}
 
 export const AddBlock: Story = {
   play: async ({ canvasElement }) => {

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { userEvent, waitFor, within } from "@storybook/test"
+import { meHandlers } from "tests/msw/handlers/me"
+import { pageHandlers } from "tests/msw/handlers/page"
+import { resourceHandlers } from "tests/msw/handlers/resource"
+import { sitesHandlers } from "tests/msw/handlers/sites"
+
+import { withChromaticModes } from "@isomer/storybook-config"
+
+import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
+
+const COMMON_HANDLERS = [
+  meHandlers.me(),
+  pageHandlers.listWithoutRoot.default(),
+  pageHandlers.getRootPage.default(),
+  pageHandlers.countWithoutRoot.default(),
+  sitesHandlers.getTheme.default(),
+  sitesHandlers.getConfig.default(),
+  sitesHandlers.getFooter.default(),
+  sitesHandlers.getNavbar.default(),
+  resourceHandlers.getChildrenOf.default(),
+  pageHandlers.readPageAndBlob.content(),
+  pageHandlers.readPage.content(),
+]
+
+const meta: Meta<typeof EditPage> = {
+  title: "Pages/Edit Page/Content Page",
+  component: EditPage,
+  parameters: {
+    getLayout: EditPage.getLayout,
+    msw: {
+      handlers: COMMON_HANDLERS,
+    },
+    nextjs: {
+      router: {
+        query: {
+          siteId: "1",
+          pageId: "1",
+        },
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof EditPage>
+
+export const Default: Story = {
+  parameters: {
+    chromatic: withChromaticModes(["gsib", "mobile"]),
+  },
+}
+
+export const AddBlock: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await waitFor(async () => {
+      await userEvent.click(canvas.getByRole("button", { name: /add block/i }))
+    })
+  },
+}
+
+export const PublishedState: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.readPage.content({
+          state: "Published",
+          draftBlobId: null,
+        }),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+}

--- a/apps/studio/src/templates/layouts/PageEditingLayout.tsx
+++ b/apps/studio/src/templates/layouts/PageEditingLayout.tsx
@@ -4,7 +4,6 @@ import { Tabs } from "@opengovsg/design-system-react"
 import { EnforceLoginStatePageWrapper } from "~/components/AuthWrappers"
 import { LayoutHead } from "~/components/LayoutHead"
 import { APP_GRID_TEMPLATE_AREA } from "~/constants/layouts"
-import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
 import { SiteEditNavbar } from "~/features/editing-experience/components/SiteEditNavbar"
 import { type GetLayout } from "~/lib/types"
 
@@ -12,28 +11,21 @@ export const PageEditingLayout: GetLayout = (page) => {
   return (
     <EnforceLoginStatePageWrapper>
       <LayoutHead />
-      <EditorDrawerProvider>
-        <Tabs>
-          <Flex
-            minH="100vh"
-            flexDir="column"
-            bg="base.canvas.alt"
-            pos="relative"
+      <Tabs>
+        <Flex minH="100vh" flexDir="column" bg="base.canvas.alt" pos="relative">
+          <Grid
+            flex={1}
+            width="100vw"
+            gridColumnGap={{ base: 0, md: "1rem" }}
+            gridTemplate={APP_GRID_TEMPLATE_AREA}
           >
-            <Grid
-              flex={1}
-              width="100vw"
-              gridColumnGap={{ base: 0, md: "1rem" }}
-              gridTemplate={APP_GRID_TEMPLATE_AREA}
-            >
-              <SiteEditNavbar />
-              <Flex flex={1} bg="base.canvas.alt" w="100vw">
-                {page}
-              </Flex>
-            </Grid>
-          </Flex>
-        </Tabs>
-      </EditorDrawerProvider>
+            <SiteEditNavbar />
+            <Flex flex={1} bg="base.canvas.alt" w="100vw">
+              {page}
+            </Flex>
+          </Grid>
+        </Flex>
+      </Tabs>
     </EnforceLoginStatePageWrapper>
   )
 }

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -212,6 +212,199 @@ export const pageHandlers = {
         }
       })
     },
+    content: () => {
+      // @ts-expect-error incomplete types
+      return trpcMsw.page.readPageAndBlob.query(() => {
+        return {
+          permalink: "page-title-here",
+          navbar: {
+            id: 1,
+            siteId: 1,
+            content: [
+              {
+                url: "/item-one",
+                name: "Expandable nav item",
+                items: [
+                  {
+                    url: "/item-one/pa-network-one",
+                    name: "PA's network one",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                  {
+                    url: "/item-one/pa-network-two",
+                    name: "PA's network two",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                  {
+                    url: "/item-one/pa-network-three",
+                    name: "PA's network three",
+                  },
+                  {
+                    url: "/item-one/pa-network-four",
+                    name: "PA's network four",
+                    description:
+                      "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+                  },
+                  {
+                    url: "/item-one/pa-network-five",
+                    name: "PA's network five",
+                    description:
+                      "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+                  },
+                  {
+                    url: "/item-one/pa-network-six",
+                    name: "PA's network six",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                ],
+              },
+            ],
+          },
+          footer: {
+            id: 1,
+            siteId: 1,
+            content: {
+              siteNavItems: [
+                { url: "/about", title: "About us" },
+                { url: "/partners", title: "Our partners" },
+                {
+                  url: "/grants-and-programmes",
+                  title: "Grants and programmes",
+                },
+                { url: "/contact-us", title: "Contact us" },
+                { url: "/something-else", title: "Something else" },
+                { url: "/resources", title: "Resources" },
+              ],
+              contactUsLink: "/contact-us",
+              termsOfUseLink: "/terms-of-use",
+              feedbackFormLink: "https://www.form.gov.sg",
+              privacyStatementLink: "/privacy",
+            },
+          },
+          content: {
+            page: {
+              title: "Page title here",
+              permalink: "page-title-here",
+              lastModified:
+                "Wed Sep 11 2024 16:32:44 GMT+0800 (Singapore Standard Time)",
+              contentPageHeader: { summary: "" },
+            },
+            layout: "content",
+            content: [
+              {
+                type: "prose",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [{ text: "This is a prose block", type: "text" }],
+                  },
+                ],
+              },
+            ],
+            version: "0.1.0",
+          },
+          type: "Page",
+          theme: "isomer-next",
+          logoUrl: "",
+          siteName: "MTI",
+          isGovernment: true,
+        }
+      })
+    },
+    article: () => {
+      // @ts-expect-error incomplete types
+      return trpcMsw.page.readPageAndBlob.query(() => {
+        return {
+          permalink: "article-layout",
+          navbar: {
+            id: 1,
+            siteId: 1,
+            content: [
+              {
+                url: "/item-one",
+                name: "Expandable nav item",
+                items: [
+                  {
+                    url: "/item-one/pa-network-one",
+                    name: "PA's network one",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                  {
+                    url: "/item-one/pa-network-two",
+                    name: "PA's network two",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                  {
+                    url: "/item-one/pa-network-three",
+                    name: "PA's network three",
+                  },
+                  {
+                    url: "/item-one/pa-network-four",
+                    name: "PA's network four",
+                    description:
+                      "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+                  },
+                  {
+                    url: "/item-one/pa-network-five",
+                    name: "PA's network five",
+                    description:
+                      "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+                  },
+                  {
+                    url: "/item-one/pa-network-six",
+                    name: "PA's network six",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                ],
+              },
+            ],
+          },
+          footer: {
+            id: 1,
+            siteId: 1,
+            content: {
+              siteNavItems: [
+                { url: "/about", title: "About us" },
+                { url: "/partners", title: "Our partners" },
+                {
+                  url: "/grants-and-programmes",
+                  title: "Grants and programmes",
+                },
+                { url: "/contact-us", title: "Contact us" },
+                { url: "/something-else", title: "Something else" },
+                { url: "/resources", title: "Resources" },
+              ],
+              contactUsLink: "/contact-us",
+              termsOfUseLink: "/terms-of-use",
+              feedbackFormLink: "https://www.form.gov.sg",
+              privacyStatementLink: "/privacy",
+            },
+          },
+          content: {
+            page: {
+              date: "11-09-2024",
+              title: "article layout",
+              category: "Feature Articles",
+              articlePageHeader: { summary: [] },
+            },
+            layout: "article",
+            content: [],
+            version: "0.1.0",
+          },
+          type: "Page",
+          theme: "isomer-next",
+          logoUrl: "",
+          siteName: "MTI",
+          isGovernment: true,
+        }
+      })
+    },
   },
   readPage: {
     homepage: (
@@ -230,6 +423,42 @@ export const pageHandlers = {
           state: "Draft",
           createdAt: new Date("2024-09-12T07:00:00.000Z"),
           updatedAt: new Date("2024-09-12T07:00:00.000Z"),
+          ...overrides,
+        }
+      })
+    },
+    content: (
+      overrides: Partial<Awaited<ReturnType<typeof getPageById>>> = {},
+    ) => {
+      return trpcMsw.page.readPage.query(() => {
+        return {
+          id: "3",
+          title: "Page title here",
+          permalink: "page-title-here",
+          siteId: 1,
+          parentId: null,
+          publishedVersionId: null,
+          draftBlobId: "2",
+          type: "Page",
+          state: "Draft",
+          ...overrides,
+        }
+      })
+    },
+    article: (
+      overrides: Partial<Awaited<ReturnType<typeof getPageById>>> = {},
+    ) => {
+      return trpcMsw.page.readPage.query(() => {
+        return {
+          id: "4",
+          title: "article layout",
+          permalink: "article-layout",
+          siteId: 1,
+          parentId: null,
+          publishedVersionId: null,
+          draftBlobId: "3",
+          type: "Page",
+          state: "Draft",
           ...overrides,
         }
       })

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -81,7 +81,10 @@ export const pageHandlers = {
       // @ts-expect-error incomplete types
       return trpcMsw.page.readPageAndBlob.query(() => {
         return {
+          type: "RootPage",
           permalink: "home",
+          title: "Home",
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
           navbar: {
             id: 1,
             siteId: 1,
@@ -225,6 +228,8 @@ export const pageHandlers = {
           draftBlobId: "1",
           type: "RootPage",
           state: "Draft",
+          createdAt: new Date("2024-09-12T07:00:00.000Z"),
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
           ...overrides,
         }
       })

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -217,6 +217,8 @@ export const pageHandlers = {
       return trpcMsw.page.readPageAndBlob.query(() => {
         return {
           permalink: "page-title-here",
+          title: "Content page",
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
           navbar: {
             id: 1,
             siteId: 1,
@@ -318,6 +320,8 @@ export const pageHandlers = {
       // @ts-expect-error incomplete types
       return trpcMsw.page.readPageAndBlob.query(() => {
         return {
+          title: "Article page",
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
           permalink: "article-layout",
           navbar: {
             id: 1,
@@ -441,6 +445,9 @@ export const pageHandlers = {
           draftBlobId: "2",
           type: "Page",
           state: "Draft",
+
+          createdAt: new Date("2024-09-12T07:00:00.000Z"),
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
           ...overrides,
         }
       })
@@ -459,6 +466,9 @@ export const pageHandlers = {
           draftBlobId: "3",
           type: "Page",
           state: "Draft",
+
+          createdAt: new Date("2024-09-12T07:00:00.000Z"),
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
           ...overrides,
         }
       })


### PR DESCRIPTION
### TL;DR

Redesigned the component selector for adding new blocks to pages, improving the user interface and experience.

### What changed?

- Restructured the ComponentSelector component to use a more organized layout
- Introduced new constants for allowed blocks based on page type (homepage, content, article)
- Updated the UI to display blocks in a vertical list with improved visual hierarchy
- Added more detailed descriptions and usage information for each block type
- Implemented context-aware block selection based on page type
- Created new icons and components for better visual representation of blocks
- Updated the EditPagePreview component to use the new EditorDrawerProvider
- Added new stories for testing different page types (article, content) in edit mode

### How to test?

1. Navigate to the edit page for different page types (homepage, content, article)
2. Click on "Add Block" to open the component selector
3. Verify that the available blocks are appropriate for the page type
4. Check that block descriptions and usage information are displayed correctly
5. Test adding different block types to the page
6. Ensure the preview updates correctly when adding new blocks

### Why make this change?

This change aims to improve the user experience when adding new blocks to pages by:

1. Providing clearer visual cues and descriptions for each block type
2. Offering context-aware block selection to prevent users from adding inappropriate blocks to certain page types
3. Enhancing the overall look and feel of the component selector to make it more intuitive and user-friendly
4. Improving maintainability by centralizing block metadata and allowed block types

---