### PR TITLE
ci: update upload-artifact action to version 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: npm run teardown
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: test results
           path: |


### PR DESCRIPTION
### TL;DR

Updated the GitHub Actions upload-artifact action to version 4. v2 is [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).

### What changed?

The CI workflow file has been modified to use the latest version of the `actions/upload-artifact` action. Specifically, the version has been updated from v2 to v4.

### How to test?

1. Trigger the CI workflow by pushing a commit or creating a pull request.
2. Verify that the "Upload test results" step completes successfully.
3. Check that the test results artifact is uploaded and accessible.

### Why make this change?
v2 is deprecated
