### PR TITLE
docs(legal): add CoC and Contributing guide

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+support@open.gov.sg .
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Isomer
+
+Welcome to Isomer! The following are guidelines for contribution. Use your best judgment, and feel free to propose changes to this document in an issue.
+
+## Getting started
+
+To contribute, you can start by taking a look at our open issues marked 'contribute' under GitHub's 'Issues' tab. Feel free to assign yourself to any 'contribute' issue that interests you, and comment with questions or clarifications.
+
+Before starting work on a PR, please **first discuss the change you wish to make via GitHub issue**, or any other method with the repository owners beforehand. This will give us the opportunity to provide feedback, and avoid wasted effort subsequently.
+
+For other changes which are not currently in our open issues, please file an issue first for discussion, before starting work on the PR. We strongly encourage contributors not to open unsolicited PRs, as we may not be able to review or accept them.
+
+## Security reports
+
+Please do not file an open issue for ongoing security bugs. Instead, email us directly with your findings at [contribute@form.gov.sg](mailto:contribute@form.gov.sg).
+
+## Bug reports and feature requests
+
+The following guidelines help maintainers and the community understand your report, reproduce the behavior, and find related reports.
+
+Before submitting bug reports or feature request, please check our [issues](https://github.com/opengovsg/isomer/issues) and [PRs](https://github.com/opengovsg/isomer/pulls).
+You might find out that you don't need to create one.
+
+When **submitting a bug report**, please include as many details as possible, such as the steps to reproduce this bug, expected and actual behaviour.
+
+When **submitting a feature request**, please include the motivation, alternatives that you've considered and any additional contexts that could help us better understand your goal.
+
+Here are some tips to writing good issues:
+
+- **Use a clear and descriptive title** to identify the problem
+- **Describe the exact steps to reproduce the problem** and **explain how you did it**
+- **Provide specific examples to demonstrate the steps**
+- **Include screenshots or animated GIFs if you can**
+- **Explain why this new feature would be useful**
+
+## Making a pull request
+
+Issues available to be picked up by the community are labeled with `contribute`.
+
+If you're submitting a pull request, some points to note:
+
+1. Ensure any install or build dependencies are removed before the end of the layer when doing a build. Refer to [README.md](./README.md) for more details
+2. Update the [README.md](./README.md) with details of changes to the interface, including new environment variables, exposed ports, useful file locations and container parameters.
+3. Write [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/). See past [PRs](https://github.com/opengovsg/isomer/pulls) for examples.
+4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
+
+## Contributor License Agreement
+
+Code contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.
+Head over [here](https://go.gov.sg/ogp-cla) to submit one.
+
+You generally only need to submit a CLA once, so if you've already submitted one (even if it was for a different project owned by [GovTech](https://www.tech.gov.sg)), you probably don't need to do it again.
+
+## Contact us
+
+Have questions? Feel free to reach out to us at [our contact form](https://go.gov.sg/isomer-contact/).


### PR DESCRIPTION
## Problem

As Isomer prepares for use in production, we have to prepare also for code contributions to our public codebase.

## Solution
Add Code of Conduct and Contributing guides to provide clarity on how contributions can be made

