### PR TITLE
refactor: extract DrawerHeader component

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/DrawerHeader.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/DrawerHeader.tsx
@@ -1,0 +1,38 @@
+import { Flex, IconButton, Text } from "@chakra-ui/react"
+import { BiChevronLeft } from "react-icons/bi"
+
+interface DrawerHeaderProps {
+  label: string
+  onBackClick: () => void
+  isDisabled: boolean
+}
+
+export const DrawerHeader = ({
+  onBackClick,
+  label,
+  isDisabled,
+}: DrawerHeaderProps): JSX.Element => {
+  return (
+    <Flex
+      w="full"
+      py="0.75rem"
+      px="1.5rem"
+      gap="0.25rem"
+      alignItems="center"
+      borderBottom="1px solid"
+      borderColor="base.divider.medium"
+      bg="white"
+    >
+      <IconButton
+        colorScheme="sub"
+        icon={<BiChevronLeft fontSize="1.25rem" />}
+        variant="clear"
+        size="sm"
+        aria-label="Return to previous step"
+        isDisabled={isDisabled}
+        onClick={onBackClick}
+      />
+      <Text textStyle="h6">{label}</Text>
+    </Flex>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -1,24 +1,16 @@
 import type { IsomerComponent } from "@opengovsg/isomer-components"
-import {
-  Box,
-  Flex,
-  Heading,
-  HStack,
-  Icon,
-  IconButton,
-  useDisclosure,
-} from "@chakra-ui/react"
+import { Box, Flex, useDisclosure } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 import isEqual from "lodash/isEqual"
-import { BiDollar, BiX } from "react-icons/bi"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 import { editPageSchema } from "../schema"
 import { DiscardChangesModal } from "./DiscardChangesModal"
+import { DrawerHeader } from "./Drawer/DrawerHeader"
 import FormBuilder from "./form-builder/FormBuilder"
 
 const ajv = new Ajv({ strict: false, logger: false })
@@ -45,10 +37,6 @@ export default function HeroEditorDrawer(): JSX.Element {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
     },
   })
-
-  if (!previewPageState) {
-    return <></>
-  }
 
   const subSchema = getComponentSchema("hero")
   const validateFn = ajv.compile<IsomerComponent>(subSchema)
@@ -78,45 +66,17 @@ export default function HeroEditorDrawer(): JSX.Element {
       />
 
       <Flex flexDir="column" position="relative" h="100%" w="100%">
-        <Box
-          bgColor="base.canvas.default"
-          borderBottomColor="base.divider.medium"
-          borderBottomWidth="1px"
-          px="2rem"
-          py="1.25rem"
-        >
-          <HStack justifyContent="space-between" w="100%">
-            <HStack spacing={3}>
-              <Icon
-                as={BiDollar}
-                fontSize="1.5rem"
-                p="0.25rem"
-                bgColor="slate.100"
-                textColor="blue.600"
-                borderRadius="base"
-              />
-              <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-                Edit Hero banner
-              </Heading>
-            </HStack>
-            <IconButton
-              icon={<Icon as={BiX} />}
-              variant="clear"
-              colorScheme="sub"
-              size="sm"
-              p="0.625rem"
-              isDisabled={isLoading}
-              onClick={() => {
-                if (!isEqual(previewPageState, savedPageState)) {
-                  onDiscardChangesModalOpen()
-                } else {
-                  handleDiscardChanges()
-                }
-              }}
-              aria-label="Close drawer"
-            />
-          </HStack>
-        </Box>
+        <DrawerHeader
+          isDisabled={isLoading}
+          onBackClick={() => {
+            if (!isEqual(previewPageState, savedPageState)) {
+              onDiscardChangesModalOpen()
+            } else {
+              handleDiscardChanges()
+            }
+          }}
+          label="Edit Hero banner"
+        />
 
         <Box px="2rem" py="1rem" flex={1} overflow="auto">
           <FormBuilder<IsomerComponent>

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -1,25 +1,17 @@
 import type { IsomerSchema, schema } from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
-import {
-  Box,
-  Flex,
-  Heading,
-  HStack,
-  Icon,
-  IconButton,
-  useDisclosure,
-} from "@chakra-ui/react"
+import { Box, Flex, useDisclosure } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { getLayoutMetadataSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
-import _ from "lodash"
-import { BiDollar, BiX } from "react-icons/bi"
+import isEqual from "lodash/isEqual"
 
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 import { editPageSchema } from "../schema"
 import { DiscardChangesModal } from "./DiscardChangesModal"
+import { DrawerHeader } from "./Drawer/DrawerHeader"
 import FormBuilder from "./form-builder/FormBuilder"
 
 const ajv = new Ajv({ strict: false, logger: false })
@@ -45,10 +37,6 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
     },
   })
-
-  if (!previewPageState) {
-    return <></>
-  }
 
   const metadataSchema = getLayoutMetadataSchema(previewPageState.layout)
   const validateFn = ajv.compile<Static<typeof metadataSchema>>(metadataSchema)
@@ -78,45 +66,17 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
       />
 
       <Flex flexDir="column" position="relative" h="100%" w="100%">
-        <Box
-          bgColor="base.canvas.default"
-          borderBottomColor="base.divider.medium"
-          borderBottomWidth="1px"
-          px="2rem"
-          py="1.25rem"
-        >
-          <HStack justifyContent="space-between" w="100%">
-            <HStack spacing={3}>
-              <Icon
-                as={BiDollar}
-                fontSize="1.5rem"
-                p="0.25rem"
-                bgColor="slate.100"
-                textColor="blue.600"
-                borderRadius="base"
-              />
-              <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-                Edit page title and summary
-              </Heading>
-            </HStack>
-            <IconButton
-              icon={<Icon as={BiX} />}
-              variant="clear"
-              colorScheme="sub"
-              size="sm"
-              p="0.625rem"
-              isDisabled={isLoading}
-              onClick={() => {
-                if (!_.isEqual(previewPageState, savedPageState)) {
-                  onDiscardChangesModalOpen()
-                } else {
-                  handleDiscardChanges()
-                }
-              }}
-              aria-label="Close drawer"
-            />
-          </HStack>
-        </Box>
+        <DrawerHeader
+          isDisabled={isLoading}
+          onBackClick={() => {
+            if (!isEqual(previewPageState, savedPageState)) {
+              onDiscardChangesModalOpen()
+            } else {
+              handleDiscardChanges()
+            }
+          }}
+          label="Edit page title and summary"
+        />
 
         <Box px="2rem" py="1rem" flex={1} overflow="auto">
           <FormBuilder<Static<typeof schema>>

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -1,17 +1,9 @@
 import type { ProseProps } from "@opengovsg/isomer-components"
 import type { JSONContent } from "@tiptap/react"
-import {
-  Box,
-  Text as ChakraText,
-  Flex,
-  HStack,
-  Icon,
-  useDisclosure,
-  VStack,
-} from "@chakra-ui/react"
+import { Box, HStack, useDisclosure, VStack } from "@chakra-ui/react"
 import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
-import _ from "lodash"
-import { BiText, BiTrash, BiX } from "react-icons/bi"
+import isEqual from "lodash/isEqual"
+import { BiTrash } from "react-icons/bi"
 
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -22,6 +14,7 @@ import { editPageSchema } from "../schema"
 import { BRIEF_TOAST_SETTINGS } from "./constants"
 import { DeleteBlockModal } from "./DeleteBlockModal"
 import { DiscardChangesModal } from "./DiscardChangesModal"
+import { DrawerHeader } from "./Drawer/DrawerHeader"
 import { TiptapTextEditor } from "./form-builder/renderers/TipTapEditor"
 
 interface TipTapComponentProps {
@@ -60,8 +53,6 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
   })
 
   const updatePageState = (editorContent: JSONContent) => {
-    if (!previewPageState) return
-
     const updatedBlocks = Array.from(previewPageState.content)
     // TODO: actual validation
     updatedBlocks[currActiveIdx] = editorContent as ProseProps
@@ -73,8 +64,6 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
   }
 
   const editor = useTextEditor({ data: content, handleChange: updatePageState })
-
-  if (!previewPageState || !savedPageState) return
 
   const handleDeleteBlock = () => {
     const updatedBlocks = Array.from(savedPageState.content)
@@ -132,35 +121,17 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
       />
 
       <VStack bg="white" h="100%" gap="0">
-        <Flex
-          px="2rem"
-          py="1.25rem"
-          borderBottom="1px solid"
-          borderColor="base.divider.strong"
-          w="100%"
-          alignItems="center"
-        >
-          <Icon as={BiText} color="blue.600" />
-          <ChakraText pl="0.75rem" textStyle="h5" w="100%">
-            Edit {PROSE_COMPONENT_NAME}
-          </ChakraText>
-          <IconButton
-            size="lg"
-            variant="clear"
-            colorScheme="neutral"
-            color="interaction.sub.default"
-            aria-label="Close drawer"
-            isDisabled={isLoading}
-            icon={<BiX />}
-            onClick={() => {
-              if (!_.isEqual(previewPageState, savedPageState)) {
-                onDiscardChangesModalOpen()
-              } else {
-                handleDiscardChanges()
-              }
-            }}
-          />
-        </Flex>
+        <DrawerHeader
+          isDisabled={isLoading}
+          onBackClick={() => {
+            if (!isEqual(previewPageState, savedPageState)) {
+              onDiscardChangesModalOpen()
+            } else {
+              handleDiscardChanges()
+            }
+          }}
+          label={`Edit ${PROSE_COMPONENT_NAME}`}
+        />
         <Box w="100%" p="2rem" overflow="auto" flex={1}>
           <TiptapTextEditor editor={editor} />
         </Box>


### PR DESCRIPTION
### TL;DR

Introduced a new DrawerHeader component and refactored existing drawer components to use it.

### What changed?

- Created a new `DrawerHeader` component in `Drawer/DrawerHeader.tsx`
- Refactored `ComplexEditorStateDrawer`, `HeroEditorDrawer`, `MetadataEditorStateDrawer`, and `TipTapProseComponent` to use the new `DrawerHeader`
- Removed redundant imports and simplified code in the refactored components
- Replaced lodash imports with specific function imports to optimize bundle size

### How to test?

1. Open the editing experience for various components (Complex, Hero, Metadata, and Prose)
2. Verify that the drawer header appears consistent across all components
3. Test the back button functionality in each drawer
4. Ensure that the discard changes modal appears when appropriate

### Why make this change?

This change improves code consistency and maintainability by centralizing the drawer header logic into a single component. It also reduces code duplication and improves performance by optimizing imports. The new `DrawerHeader` component provides a unified look and feel across different editing experiences, enhancing the overall user interface consistency.
