### PR TITLE
chore: update naming

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/TableMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TableMenuBar.tsx
@@ -40,7 +40,7 @@ export const TableMenuBar = ({ editor }: { editor: Editor }) => {
         type: "vertical-list",
         buttonWidth: "9rem",
         menuWidth: "19rem",
-        defaultTitle: "Heading options",
+        defaultTitle: "Text styles",
         items: [
           {
             type: "item",

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -19,7 +19,7 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "vertical-list",
         buttonWidth: "9rem",
         menuWidth: "19rem",
-        defaultTitle: "Heading options",
+        defaultTitle: "Text styles",
         items: [
           {
             type: "item",


### PR DESCRIPTION
## Problem
When we lose focus at present, the dropdown goes to the default title, which is `Heading options` at present. This isn't ideal because it takes up 2 lines

## Solution
Change copy to `Text styles` (cleared with @sehyunidaaa) 

