### PR TITLE
fix: prevent 404 redirects for prefetches of assets

### DIFF
--- a/tooling/build/amplify/create-app.js
+++ b/tooling/build/amplify/create-app.js
@@ -40,7 +40,13 @@ const createApp = async (appName) => {
     environmentVariables: {
       NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT: "staging",
     },
-    customRules: [{ source: "/<*>", target: "/404.html", status: "404" }],
+    customRules: [
+      {
+        source: "</^[^.]+$|.(?!(txt)$)([^.]+$)/>",
+        target: "/404.html",
+        status: "404",
+      },
+    ],
   })
 
   await amplifyClient


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Due to the switchover of all links to use LinkComponent (which is essentially Next.js Link), it has resulted in PDF links being unable to be opened due to the way we set up the redirect rules on Amplify.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Update Amplify's 404 redirect rule to exclude `.txt` files.
    - This is a special file that Next.js uses to perform pre-fetches and if it encounters a 404, the link is treated as per normal.
    - However, Amplify's 404 redirect means a 302 response is returned instead, which Next.js misinterprets to be a valid internal page (and not resource) and brings the user to the actual path (which would be /404.html in this case, because that is the path that was returned during the pre-fetching).
    - The /404.html comes about due to the way we original set up the redirect rules.

**Note**:

- As actual production sites will be pointing directly to our assets domain and not be using an internal link, so this issue will no longer be present then.