### PR TITLE
fix(InfoCards): use string union and add title for maxColumns

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -65,6 +65,7 @@ export const DEFAULT_BLOCKS: Record<
     title: "This is an optional title of the Infocards component",
     subtitle: "This is an optional subtitle for the Infocards component",
     variant: "cardsWithImages",
+    maxColumns: "3",
     cards: [
       {
         title: "This is the first card",

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -24,6 +24,7 @@ const SingleCardNoImageSchema = Type.Object({
 })
 
 const SingleCardWithImageSchema = Type.Composite([
+  SingleCardNoImageSchema,
   Type.Object({
     imageUrl: Type.String({
       title: "Upload image",
@@ -52,7 +53,6 @@ const SingleCardWithImageSchema = Type.Composite([
         "Add a descriptive alternative text for this image. This helps visually impaired users to understand your image.",
     }),
   }),
-  SingleCardNoImageSchema,
 ])
 
 const InfoCardsBaseSchema = Type.Object({
@@ -70,11 +70,19 @@ const InfoCardsBaseSchema = Type.Object({
     }),
   ),
   maxColumns: Type.Optional(
-    Type.Union([Type.Literal(1), Type.Literal(2), Type.Literal(3)], {
-      title: "Maximum columns variant",
-      description:
-        "Controls the responsive behaviour regarding the number of columns that this component will expand to in different viewports",
-    }),
+    Type.Union(
+      [
+        Type.Literal("1", { title: "1 column" }),
+        Type.Literal("2", { title: "2 columns" }),
+        Type.Literal("3", { title: "3 columns" }),
+      ],
+      {
+        title: "Maximum columns variant",
+        description:
+          "Controls the responsive behaviour regarding the number of columns that this component will expand to in different viewports",
+        default: "3",
+      },
+    ),
   ),
 })
 

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -55,19 +55,19 @@ const createInfoCardsStyles = tv({
       },
     },
     maxColumns: {
-      1: {
+      "1": {
         grid: "",
       },
-      2: {
+      "2": {
         grid: "md:grid-cols-2",
       },
-      3: {
+      "3": {
         grid: "md:grid-cols-2 lg:grid-cols-3",
       },
     },
   },
   defaultVariants: {
-    maxColumns: 3,
+    maxColumns: "3",
     imageFit: "cover",
   },
 })

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
@@ -125,7 +125,7 @@ export const WithSiderail: Story = {
       {
         type: "infocards",
         variant: "cardsWithoutImages",
-        maxColumns: 1,
+        maxColumns: "1",
         cards: [
           {
             title:
@@ -261,7 +261,7 @@ export const NoSiderail: Story = {
       {
         type: "infocards",
         variant: "cardsWithoutImages",
-        maxColumns: 1,
+        maxColumns: "1",
         cards: [
           {
             title:


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The max columns property for the InfoCards component does not specify a title and uses numbers instead of strings, which causes issues in rendering for the form builder.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Added a title for every option in the `maxColumns` property, which is displayed for the user in the form builder.
- Switch number to string, as we don't actually support using numbers as part of an `anyOf` selector (no real benefit of using numbers here anyway, since this is really a variant).
- Added the default value to the `DEFAULT_BLOCKS` constant so the value is defined on the form builder.
- Moved the `SingleCardNoImageSchema` to before the image fields, as the first field (title) is used as the title of the card. Otherwise, the URL to the image is used instead, which can be confusing to the user.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="817" alt="image" src="https://github.com/user-attachments/assets/438774ea-a4f3-40f0-85d5-e2a40ab2dd4a">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="794" alt="image" src="https://github.com/user-attachments/assets/b9327c97-f752-4d2d-8f5a-2cfcfdb25e2f">