### PR TITLE
fix: directly jump to link parent folder in selector

### DIFF
--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -8,6 +8,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Text,
 } from "@chakra-ui/react"
 import {
   Button,
@@ -23,6 +24,7 @@ import { editPageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useZodForm } from "~/lib/form"
 import { getReferenceLink, getResourceIdFromReferenceLink } from "~/utils/link"
+import { trpc } from "~/utils/trpc"
 import { ResourceSelector } from "../ResourceSelector"
 
 interface PageLinkElementProps {
@@ -35,14 +37,28 @@ const PageLinkElement = ({ value, onChange }: PageLinkElementProps) => {
 
   const selectedResourceId = getResourceIdFromReferenceLink(value)
 
+  const { data: resource } = trpc.resource.getWithFullPermalink.useQuery({
+    resourceId: selectedResourceId,
+  })
+
   return (
-    <ResourceSelector
-      siteId={String(siteId)}
-      onChange={(resourceId) =>
-        onChange(getReferenceLink({ siteId: String(siteId), resourceId }))
-      }
-      selectedResourceId={selectedResourceId}
-    />
+    <>
+      <ResourceSelector
+        siteId={String(siteId)}
+        onChange={(resourceId) =>
+          onChange(getReferenceLink({ siteId: String(siteId), resourceId }))
+        }
+        selectedResourceId={selectedResourceId}
+      />
+
+      {!!resource && (
+        <Box bg="utility.feedback.info-subtle" p="0.75rem" w="full" mt="0.5rem">
+          <Text textStyle="caption-1">
+            You selected /{resource.fullPermalink}
+          </Text>
+        </Box>
+      )}
+    </>
   )
 }
 

--- a/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
@@ -16,7 +16,6 @@ type ResourceItemProps = Pick<
 > & {
   isSelected: boolean
   isDisabled: boolean
-  searchQuery: string
   onResourceItemSelect: () => void
 }
 
@@ -25,7 +24,6 @@ const SuspendableResourceItem = ({
   type,
   isSelected,
   isDisabled,
-  searchQuery,
   onResourceItemSelect,
 }: ResourceItemProps) => {
   const icon: IconType = useMemo(() => {
@@ -39,19 +37,6 @@ const SuspendableResourceItem = ({
         return BiData
     }
   }, [type])
-
-  const SearchTextHighlight = useMemo(() => {
-    const result = fuzzysort.single(searchQuery, permalink)
-    if (!result) {
-      return permalink
-    }
-
-    return fuzzysort.highlight(result, (m, i) => (
-      <Mark key={i} bgColor="interaction.tinted.main.active">
-        {m}
-      </Mark>
-    ))
-  }, [searchQuery, permalink])
 
   return (
     <Button
@@ -90,7 +75,7 @@ const SuspendableResourceItem = ({
     >
       <HStack align="start" w="full" justify="space-between">
         <Text textStyle="caption-1" noOfLines={1}>
-          /{SearchTextHighlight}
+          /{permalink}
         </Text>
         {isDisabled && <Icon as={BiLockAlt} fontSize="0.75rem" />}
       </HStack>

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -25,10 +25,7 @@ const SuspensableResourceSelector = ({
     resourceId: selectedResourceId,
   })
   const [parentIdStack, setParentIdStack] = useState<string[]>(
-    ancestryStack
-      .map((item) => item.id)
-      .reverse()
-      .slice(0, -1),
+    ancestryStack.map((item) => item.id),
   )
   const currResourceId = parentIdStack[parentIdStack.length - 1] ?? null
 

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -1,41 +1,42 @@
-import { useState } from "react"
+import { Suspense, useState } from "react"
 import {
   Box,
   Flex,
   HStack,
   Icon,
-  InputGroup,
-  InputLeftElement,
+  Skeleton,
   Spacer,
   Text,
 } from "@chakra-ui/react"
-import { Button, Input, Link } from "@opengovsg/design-system-react"
-import { BiHomeAlt, BiLeftArrowAlt, BiSearch } from "react-icons/bi"
+import { Button, Link } from "@opengovsg/design-system-react"
+import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
 import { trpc } from "~/utils/trpc"
 import { ResourceItem } from "./ResourceItem"
 
-interface ResourceSelectorProps {
-  siteId: string
-  selectedResourceId?: string
-  onChange: (resourceId: string) => void
-  isDisabledFn?: (resourceId: string) => boolean
-}
-
-export const ResourceSelector = ({
+const SuspensableResourceSelector = ({
   siteId,
   selectedResourceId,
   onChange,
   isDisabledFn,
 }: ResourceSelectorProps) => {
-  const [parentIdStack, setParentIdStack] = useState<string[]>([])
-  const [searchQuery, setSearchQuery] = useState("")
-  const currResourceId = parentIdStack[parentIdStack.length - 1]
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    trpc.resource.getChildrenOf.useInfiniteQuery(
+  const [ancestryStack] = trpc.resource.getAncestryOf.useSuspenseQuery({
+    siteId,
+    resourceId: selectedResourceId,
+  })
+  const [parentIdStack, setParentIdStack] = useState<string[]>(
+    ancestryStack
+      .map((item) => item.id)
+      .reverse()
+      .slice(0, -1),
+  )
+  const currResourceId = parentIdStack[parentIdStack.length - 1] ?? null
+
+  const [data, { fetchNextPage, hasNextPage, isFetchingNextPage }] =
+    trpc.resource.getChildrenOf.useSuspenseInfiniteQuery(
       {
-        resourceId: currResourceId ?? null,
-        siteId: String(siteId),
+        resourceId: currResourceId,
+        siteId,
         limit: 25,
       },
       {
@@ -48,114 +49,112 @@ export const ResourceSelector = ({
   }
 
   return (
-    <>
-      <InputGroup>
-        <InputLeftElement>
-          <Icon as={BiSearch} color="base.content.medium" />
-        </InputLeftElement>
-        <Input
-          type="search"
-          placeholder="Start typing to search, or choose from the list below"
-          mb="0.5rem"
-          value={searchQuery}
-          onChange={(e) => setSearchQuery(e.target.value)}
-        />
-      </InputGroup>
-
-      <Box
-        borderRadius="md"
-        border="1px solid"
-        borderColor="base.divider.strong"
-        w="full"
-        py="0.75rem"
-        px="0.5rem"
-      >
-        {parentIdStack.length > 0 ? (
-          <Link
-            variant="clear"
-            w="full"
-            justifyContent="flex-start"
-            color="base.content.default"
-            onClick={onBack}
-            as="button"
+    <Box
+      borderRadius="md"
+      border="1px solid"
+      borderColor="base.divider.strong"
+      w="full"
+      py="0.75rem"
+      px="0.5rem"
+      maxH="20rem"
+      overflowY="auto"
+    >
+      {parentIdStack.length > 0 ? (
+        <Link
+          variant="clear"
+          w="full"
+          justifyContent="flex-start"
+          color="base.content.default"
+          onClick={onBack}
+          as="button"
+        >
+          <HStack spacing="0.25rem" color="interaction.links.default">
+            <Icon as={BiLeftArrowAlt} />
+            <Text textStyle="caption-1">Back to parent folder</Text>
+          </HStack>
+        </Link>
+      ) : (
+        <Flex
+          w="full"
+          px="0.75rem"
+          py="0.375rem"
+          color="base.content.default"
+          alignItems="center"
+        >
+          <HStack spacing="0.5rem">
+            <Icon as={BiHomeAlt} />
+            <Text textStyle="caption-1">/</Text>
+          </HStack>
+          <Spacer />
+          <Text
+            color="base.content.medium"
+            textTransform="uppercase"
+            textStyle="caption-1"
+            overflow="hidden"
+            textOverflow="ellipsis"
+            whiteSpace="nowrap"
           >
-            <HStack spacing="0.25rem" color="interaction.links.default">
-              <Icon as={BiLeftArrowAlt} />
-              <Text textStyle="caption-1">Back to parent folder</Text>
-            </HStack>
-          </Link>
-        ) : (
-          <Flex
-            w="full"
-            px="0.75rem"
-            py="0.375rem"
-            color="base.content.default"
-            alignItems="center"
-          >
-            <HStack spacing="0.5rem">
-              <Icon as={BiHomeAlt} />
-              <Text textStyle="caption-1">/</Text>
-            </HStack>
-            <Spacer />
-            <Text
-              color="base.content.medium"
-              textTransform="uppercase"
-              textStyle="caption-1"
-              overflow="hidden"
-              textOverflow="ellipsis"
-              whiteSpace="nowrap"
-            >
-              Home
-            </Text>
-          </Flex>
-        )}
+            Home
+          </Text>
+        </Flex>
+      )}
 
-        {data?.pages.flatMap(({ items }) => items).length === 0 ? (
-          <Box py="0.5rem" pl="2.25rem">
-            <Text textStyle="caption-2" fontStyle="italic">
-              No matching results
-            </Text>
-          </Box>
-        ) : (
-          data?.pages.map(({ items }) =>
-            items.map((child) => {
-              const isDisabled = isDisabledFn?.(child.id) ?? false
+      {data.pages.flatMap(({ items }) => items).length === 0 ? (
+        <Box py="0.5rem" pl="2.25rem">
+          <Text textStyle="caption-2" fontStyle="italic">
+            No matching results
+          </Text>
+        </Box>
+      ) : (
+        data.pages.map(({ items }) =>
+          items.map((child) => {
+            const isDisabled = isDisabledFn?.(child.id) ?? false
 
-              return (
-                <ResourceItem
-                  {...child}
-                  key={child.id}
-                  isSelected={selectedResourceId === child.id}
-                  isDisabled={isDisabled}
-                  searchQuery={searchQuery}
-                  onResourceItemSelect={() => {
-                    if (
-                      child.type === "Folder" ||
-                      child.type === "Collection"
-                    ) {
-                      setParentIdStack((prev) => [...prev, child.id])
-                    } else {
-                      onChange(child.id)
-                    }
-                  }}
-                />
-              )
-            }),
-          )
-        )}
+            return (
+              <ResourceItem
+                {...child}
+                key={child.id}
+                isSelected={selectedResourceId === child.id}
+                isDisabled={isDisabled}
+                onResourceItemSelect={() => {
+                  if (child.type === "Folder" || child.type === "Collection") {
+                    setParentIdStack((prev) => [...prev, child.id])
+                  } else {
+                    onChange(child.id)
+                  }
+                }}
+              />
+            )
+          }),
+        )
+      )}
 
-        {hasNextPage && (
-          <Button
-            variant="link"
-            pl="2.25rem"
-            size="xs"
-            isLoading={isFetchingNextPage}
-            onClick={() => fetchNextPage()}
-          >
-            Load more
-          </Button>
-        )}
-      </Box>
-    </>
+      {hasNextPage && (
+        <Button
+          variant="link"
+          pl="2.25rem"
+          size="xs"
+          isLoading={isFetchingNextPage}
+          onClick={() => fetchNextPage()}
+        >
+          Load more
+        </Button>
+      )}
+    </Box>
+  )
+}
+
+interface ResourceSelectorProps {
+  siteId: string
+  selectedResourceId?: string
+  onChange: (resourceId: string) => void
+  isDisabledFn?: (resourceId: string) => boolean
+}
+
+export const ResourceSelector = (props: ResourceSelectorProps) => {
+  return (
+    <Suspense fallback={<Skeleton h="4rem" />}>
+      <SuspensableResourceSelector {...props} />
+    </Suspense>
   )
 }

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -65,7 +65,7 @@ export const getFullPermalinkSchema = z.object({
   resourceId: bigIntSchema,
 })
 
-export const getAncentrySchema = z.object({
+export const getAncestrySchema = z.object({
   siteId: z.string(),
   resourceId: z.string().optional(),
 })

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -64,3 +64,8 @@ export const listResourceSchema = z
 export const getFullPermalinkSchema = z.object({
   resourceId: bigIntSchema,
 })
+
+export const getAncentrySchema = z.object({
+  siteId: z.string(),
+  resourceId: z.string().optional(),
+})

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -5,7 +5,7 @@ import type { ResourceType } from "../database"
 import {
   countResourceSchema,
   deleteResourceSchema,
-  getAncentrySchema,
+  getAncestrySchema,
   getChildrenSchema,
   getFullPermalinkSchema,
   getMetadataSchema,
@@ -281,13 +281,13 @@ export const resourceRouter = router({
     }),
 
   getAncestryOf: protectedProcedure
-    .input(getAncentrySchema)
+    .input(getAncestrySchema)
     .query(async ({ input: { siteId, resourceId } }) => {
       if (!resourceId) {
         return []
       }
 
-      return db
+      const ancestors = await db
         .withRecursive("Resources", (eb) =>
           eb
             .selectFrom("Resource")
@@ -319,5 +319,7 @@ export const resourceRouter = router({
           "Resources.parentId",
         ])
         .execute()
+
+      return ancestors.reverse().slice(0, -1)
     }),
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When selecting the link in the link selector, it will always reset to the root folder.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Retrieve the ancestry information about the selected resource, so that we can construct the parentId stack on load.
- Add feedback to the user about the actual page permalink that is being selected.
- Add a maximum height and an overflow for the resource selector.

## Screenshots

<img width="649" alt="image" src="https://github.com/user-attachments/assets/2f2ecf49-bc35-46c6-aced-3dcda6956806">
