### PR TITLE
fix: select only children of current site

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -38,6 +38,7 @@ export const resourceRouter = router({
         .selectFrom("Resource")
         .select(["title", "permalink", "type", "id"])
         .where("Resource.type", "in", ["Folder"])
+        .where("Resource.siteId", "=", Number(siteId))
         .$narrowType<{
           type: "Folder"
         }>()


### PR DESCRIPTION
## Problem
Previously, when moving children, we got all resources but omitted a `where` clause for `site`. This allows us to move resources from 1 site to another

## Solution
add a `where` clause
