### PR TITLE
chore(modals): standardise input field

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -156,7 +156,7 @@ const SuspendableModalContent = ({
                 name="permalink"
                 render={({ field: { onChange, ...field } }) => (
                   <Input
-                    placeholder="This is a url for your folder"
+                    placeholder="This is a URL for your folder"
                     {...field}
                     maxLength={MAX_FOLDER_PERMALINK_LENGTH}
                     onChange={(e) => {

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -161,7 +161,7 @@ const CreateCollectionModalContent = ({
                 name="permalink"
                 render={({ field: { onChange, ...field } }) => (
                   <Input
-                    placeholder="This is a url for your new collection"
+                    placeholder="This is a URL for your new collection"
                     noOfLines={1}
                     maxLength={MAX_FOLDER_PERMALINK_LENGTH}
                     {...field}

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -22,6 +22,7 @@ import {
   ModalCloseButton,
   useToast,
 } from "@opengovsg/design-system-react"
+import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
 import { useZodForm } from "~/lib/form"
@@ -63,16 +64,23 @@ const CreateCollectionModalContent = ({
   onClose,
   siteId,
 }: CreateCollectionModalProps) => {
-  const { register, handleSubmit, watch, formState, setValue, getFieldState } =
-    useZodForm({
-      defaultValues: {
-        collectionTitle: "",
-        permalink: "",
-      },
-      schema: createCollectionSchema.omit({
-        siteId: true,
-      }),
-    })
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState,
+    setValue,
+    getFieldState,
+  } = useZodForm({
+    defaultValues: {
+      collectionTitle: "",
+      permalink: "",
+    },
+    schema: createCollectionSchema.omit({
+      siteId: true,
+    }),
+  })
   const { errors, isValid } = formState
   const utils = trpc.useUtils()
   const toast = useToast()
@@ -148,9 +156,25 @@ const CreateCollectionModalContent = ({
                   This will be applied to every child under this collection.
                 </FormHelperText>
               </FormLabel>
-              <Input
-                placeholder="This is a url for your new page"
-                {...register("permalink")}
+              <Controller
+                control={control}
+                name="permalink"
+                render={({ field: { onChange, ...field } }) => (
+                  <Input
+                    placeholder="This is a url for your new collection"
+                    noOfLines={1}
+                    maxLength={MAX_FOLDER_PERMALINK_LENGTH}
+                    {...field}
+                    onChange={(e) => {
+                      onChange(
+                        generateResourceUrl(e.target.value).slice(
+                          0,
+                          MAX_FOLDER_PERMALINK_LENGTH,
+                        ),
+                      )
+                    }}
+                  />
+                )}
               />
               {errors.permalink?.message && (
                 <FormErrorMessage>{errors.permalink.message}</FormErrorMessage>

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -129,6 +129,7 @@ export const CreateCollectionPageDetailsScreen = () => {
 
                 <Input
                   placeholder="This is a title for your new page"
+                  maxLength={MAX_TITLE_LENGTH}
                   {...register("title")}
                 />
                 {errors.title?.message ? (
@@ -164,7 +165,12 @@ export const CreateCollectionPageDetailsScreen = () => {
                         placeholder="URL will be autopopulated if left untouched"
                         {...field}
                         onChange={(e) => {
-                          onChange(generatePageUrl(e.target.value))
+                          onChange(
+                            generatePageUrl(e.target.value).slice(
+                              0,
+                              MAX_PAGE_URL_LENGTH,
+                            ),
+                          )
                         }}
                       />
                     )}

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -22,6 +22,7 @@ import {
   ModalCloseButton,
   useToast,
 } from "@opengovsg/design-system-react"
+import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
 import { useZodForm } from "~/lib/form"
@@ -63,14 +64,21 @@ const CreateFolderModalContent = ({
   siteId,
   parentFolderId,
 }: CreateFolderModalProps) => {
-  const { register, handleSubmit, watch, formState, setValue, getFieldState } =
-    useZodForm({
-      defaultValues: {
-        folderTitle: "",
-        permalink: "",
-      },
-      schema: createFolderSchema.omit({ siteId: true, parentFolderId: true }),
-    })
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    formState,
+    setValue,
+    getFieldState,
+  } = useZodForm({
+    defaultValues: {
+      folderTitle: "",
+      permalink: "",
+    },
+    schema: createFolderSchema.omit({ siteId: true, parentFolderId: true }),
+  })
   const { errors, isValid } = formState
   const utils = trpc.useUtils()
   const toast = useToast()
@@ -150,10 +158,25 @@ const CreateFolderModalContent = ({
                   This will be applied to every child under this folder.
                 </FormHelperText>
               </FormLabel>
-              <Input
-                placeholder="This is a url for your new page"
-                maxLength={MAX_FOLDER_PERMALINK_LENGTH}
-                {...register("permalink")}
+              <Controller
+                control={control}
+                name="permalink"
+                render={({ field: { onChange, ...field } }) => (
+                  <Input
+                    placeholder="This is a url for your new page"
+                    noOfLines={1}
+                    maxLength={MAX_FOLDER_PERMALINK_LENGTH}
+                    {...field}
+                    onChange={(e) => {
+                      onChange(
+                        generateResourceUrl(e.target.value).slice(
+                          0,
+                          MAX_FOLDER_PERMALINK_LENGTH,
+                        ),
+                      )
+                    }}
+                  />
+                )}
               />
               {errors.permalink?.message && (
                 <FormErrorMessage>{errors.permalink.message}</FormErrorMessage>

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -163,7 +163,7 @@ const CreateFolderModalContent = ({
                 name="permalink"
                 render={({ field: { onChange, ...field } }) => (
                   <Input
-                    placeholder="This is a url for your new page"
+                    placeholder="This is a url for your new folder"
                     noOfLines={1}
                     maxLength={MAX_FOLDER_PERMALINK_LENGTH}
                     {...field}

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -163,7 +163,7 @@ const CreateFolderModalContent = ({
                 name="permalink"
                 render={({ field: { onChange, ...field } }) => (
                   <Input
-                    placeholder="This is a url for your new folder"
+                    placeholder="This is a URL for your new folder"
                     noOfLines={1}
                     maxLength={MAX_FOLDER_PERMALINK_LENGTH}
                     {...field}

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -122,6 +122,7 @@ export const CreatePageDetailsScreen = () => {
                 <Input
                   placeholder="This is a title for your new page"
                   {...register("title")}
+                  maxLength={MAX_TITLE_LENGTH}
                 />
                 {errors.title?.message ? (
                   <FormErrorMessage>{errors.title.message}</FormErrorMessage>
@@ -157,7 +158,12 @@ export const CreatePageDetailsScreen = () => {
                         placeholder="URL will be autopopulated if left untouched"
                         {...field}
                         onChange={(e) => {
-                          onChange(generateResourceUrl(e.target.value))
+                          onChange(
+                            generateResourceUrl(e.target.value).slice(
+                              0,
+                              MAX_PAGE_URL_LENGTH,
+                            ),
+                          )
                         }}
                       />
                     )}


### PR DESCRIPTION
## Problem
currently, the four modals for creation of pages/folders don't have a standardised way of treating input. this PR fixes that.

## Solution
1. input now has `maxLength` set so users cannot go beyond `maxLength`
2. input now auto transforms illegal characters

## Note
because of #2, if users have illegal characters in the middle, they'll add the characters there, then their cursor will move to the end (eg: aaa -> a<space>aa, cursor at index 1 -> a-aa<cursor>, cursor at ending position)

ok with this trade-off because it standardizes all input field treatment and we don't have error message atm for the input fields hwen illegal characters have been entered. 