### PR TITLE
chore: remove edit user profile link in navbar

### DIFF
--- a/apps/studio/src/components/AppNavbar.tsx
+++ b/apps/studio/src/components/AppNavbar.tsx
@@ -68,10 +68,6 @@ export function AppNavbar(): JSX.Element {
             bg="base.canvas.brand-subtle"
             menuListProps={{ maxWidth: "19rem" }}
           >
-            <Menu.Item as={NextLink} href={SETTINGS_PROFILE}>
-              Edit profile
-            </Menu.Item>
-            <AvatarMenuDivider />
             <Menu.Item onClick={() => logout()}>Sign out</Menu.Item>
           </AvatarMenu>
         </HStack>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

There's a link to edit the user profile in the app navbar but that page does not exist currently.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [ ] No - this PR is backwards compatible

**Improvements**:

- Remove the link to edit the user profile.

## Screenshots

![image](https://github.com/user-attachments/assets/a1d6fa8e-dbba-4c8c-a194-f1340b34747b)
