### PR TITLE
fix: remove image preview and adjust URL

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -33,6 +33,7 @@ const ContentSecurityPolicy = `
     https://vitals.vercel-insights.com/v1/vitals
     https://*.amazonaws.com
     https://placehold.co
+    ${env.NODE_ENV === "production" ? "https://isomer-user-content-vapt.by.gov.sg" : "https://*.by.gov.sg"}
     ;
   worker-src 'self' blob:;
   ${env.NODE_ENV === "production" ? "upgrade-insecure-requests" : ""}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The image preview right now is a little wonky.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed the fetch URL to include the missing `https://`, so the fetching is now from the correct source.
- Disabled the image preview from the Attachment component as it is possible that the uploading/malware scan is still in progress, so there is nothing to show.
    - Opted to use a fallback blob that is empty, so the file size would be inaccurate. Future fix is to directly retrieve this metadata from the S3 bucket.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

![image](https://github.com/user-attachments/assets/bbb64d51-3f8b-4f3d-87f3-635e41a49163)

**AFTER**:

<!-- [insert screenshot here] -->

![image](https://github.com/user-attachments/assets/a468be23-72d4-4d9f-a15f-6145e3c72fd1)