### PR TITLE
fix seed permalink for root page

### DIFF
--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -215,7 +215,7 @@ async function main() {
     .insertInto("Resource")
     .values({
       draftBlobId: String(blobId),
-      permalink: "home",
+      permalink: "",
       siteId,
       type: "RootPage",
       title: "Home",


### PR DESCRIPTION
### TL;DR

Updated the permalink for the home resource in the seed data.

### What changed?

Changed the permalink value for the home resource from "home" to an empty string ("") in the seed.ts file.

### How to test?

1. Run the database seeding process
2. Check the Resource table in the database
3. Verify that the home resource has an empty string as its permalink

### Why make this change?

This change ensures that the home page has an empty permalink, which is typically the expected behavior for the root page of a website. It allows the home page to be accessed at the root URL (/) rather than at /home, improving URL structure and SEO.
