### PR TITLE
feat: use page state from context instead of from query

### DIFF
--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -7,7 +7,10 @@ import type { ResourceType } from "~prisma/generated/generatedEnums"
 import { type DrawerState } from "~/types/editorDrawer"
 
 export interface DrawerContextType
-  extends Pick<EditorDrawerProviderProps, "type" | "permalink" | "siteId"> {
+  extends Pick<
+    EditorDrawerProviderProps,
+    "type" | "permalink" | "siteId" | "updatedAt"
+  > {
   currActiveIdx: number
   setCurrActiveIdx: (currActiveIdx: number) => void
   drawerState: DrawerState
@@ -28,6 +31,7 @@ interface EditorDrawerProviderProps extends PropsWithChildren {
   type: ResourceType
   permalink: string
   siteId: number
+  updatedAt: Date
 }
 
 export function EditorDrawerProvider({
@@ -36,6 +40,7 @@ export function EditorDrawerProvider({
   type,
   permalink,
   siteId,
+  updatedAt,
 }: EditorDrawerProviderProps) {
   const [drawerState, setDrawerState] = useState<DrawerState>({
     state: "root",
@@ -70,6 +75,7 @@ export function EditorDrawerProvider({
         type,
         permalink,
         siteId,
+        updatedAt,
       }}
     >
       {children}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,4 +1,3 @@
-import type { z } from "zod"
 import {
   Box,
   Flex,
@@ -55,14 +54,9 @@ function EditPage(): JSX.Element {
           type={type}
           permalink={permalink}
           siteId={siteId}
+          updatedAt={updatedAt}
         >
-          <PageEditingView
-            pageId={pageId}
-            permalink={permalink}
-            page={page}
-            siteId={siteId}
-            updatedAt={updatedAt}
-          />
+          <PageEditingView />
         </EditorDrawerProvider>
       </TabPanel>
       <TabPanel>
@@ -72,19 +66,9 @@ function EditPage(): JSX.Element {
   )
 }
 
-interface PageEditingViewProps extends z.infer<typeof editPageSchema> {
-  page: RouterOutput["page"]["readPageAndBlob"]["content"]
-  permalink: RouterOutput["page"]["readPageAndBlob"]["permalink"]
-  updatedAt: RouterOutput["page"]["readPageAndBlob"]["updatedAt"]
-}
-
-const PageEditingView = ({
-  page,
-  permalink,
-  updatedAt,
-  siteId,
-}: PageEditingViewProps) => {
-  const { previewPageState } = useEditorDrawerContext()
+const PageEditingView = () => {
+  const { previewPageState, permalink, siteId, updatedAt } =
+    useEditorDrawerContext()
   const themeCssVars = useSiteThemeCssVars({ siteId })
 
   return (
@@ -110,7 +94,6 @@ const PageEditingView = ({
         >
           <PreviewIframe style={themeCssVars}>
             <Preview
-              {...page}
               {...previewPageState}
               siteId={siteId}
               permalink={permalink}


### PR DESCRIPTION
### TL;DR

Added `updatedAt` to the EditorDrawerContext and simplified the PageEditingView component.

### What changed?

- Extended the DrawerContextType to include `updatedAt`
- Added `updatedAt` as a prop to EditorDrawerProvider
- Removed unnecessary props from PageEditingView component
- Updated PageEditingView to use context for `permalink`, `siteId`, and `updatedAt`
- Removed `page` prop from Preview component in PageEditingView

### How to test?

1. Navigate to the page editing view for a site
2. Verify that the page loads correctly and all functionality remains intact
3. Check that the preview updates properly when changes are made
4. Ensure that the `updatedAt` information is correctly displayed and updated

### Why make this change?

This change simplifies the component structure by moving more data into the EditorDrawerContext. It reduces prop drilling and makes the code more maintainable. The addition of `updatedAt` to the context allows for easier access to this information across components that need it, improving consistency and reducing redundancy.
