### PR TITLE
feat: fetch proper data for edit page breadcrumb

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -122,6 +122,9 @@ const MoveResourceContent = withSuspense(
         // NOTE: We might want to have smarter logic here
         // and invalidate the new + old folders
         await utils.folder.getMetadata.invalidate()
+        await utils.resource.getMetadataById.invalidate({
+          resourceId: movedItem?.resourceId,
+        })
         toast({ title: "Resource moved!" })
       },
     })

--- a/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
@@ -3,6 +3,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   Flex,
+  Skeleton,
   TabList,
   Text,
 } from "@chakra-ui/react"
@@ -10,8 +11,71 @@ import { Breadcrumb, Tab } from "@opengovsg/design-system-react"
 
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { getResourceSubpath } from "~/utils/resource"
+import { trpc } from "~/utils/trpc"
 import { editPageSchema } from "../schema"
 import PublishButton from "./PublishButton"
+
+interface NavigationBreadcrumbsProps {
+  siteId: string
+  pageId: string
+}
+
+const NavigationBreadcrumbs = ({
+  siteId,
+  pageId,
+}: NavigationBreadcrumbsProps): JSX.Element => {
+  const { data: resource, isLoading: isResourceLoading } =
+    trpc.resource.getMetadataById.useQuery({
+      resourceId: pageId,
+    })
+
+  const { data: parentResource, isLoading: isParentResourceLoading } =
+    trpc.resource.getMetadataById.useQuery(
+      {
+        resourceId: resource?.parentId ?? "",
+      },
+      { enabled: !!resource?.parentId },
+    )
+
+  const isBreadcrumbLoaded =
+    (!resource?.parentId || !isParentResourceLoading) && !isResourceLoading
+
+  return (
+    <Breadcrumb size="xs">
+      <BreadcrumbItem>
+        <BreadcrumbLink as={Link} href={`/sites/${siteId}`}>
+          <Text textStyle="subhead-2">All pages</Text>
+        </BreadcrumbLink>
+      </BreadcrumbItem>
+
+      {!isBreadcrumbLoaded && (
+        <BreadcrumbItem>
+          <Skeleton height="1.25rem" width="10rem" />
+        </BreadcrumbItem>
+      )}
+
+      {!!parentResource && (
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            as={Link}
+            href={`/sites/${siteId}/${getResourceSubpath(parentResource.type)}/${parentResource.id}`}
+          >
+            <Text textStyle="subhead-2">{parentResource.title}</Text>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+      )}
+
+      {!!resource && (
+        <BreadcrumbItem isCurrentPage>
+          <BreadcrumbLink href="#">
+            <Text textStyle="subhead-2">{resource.title}</Text>
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+      )}
+    </Breadcrumb>
+  )
+}
 
 export const SiteEditNavbar = (): JSX.Element => {
   const { siteId, pageId } = useQueryParse(editPageSchema)
@@ -33,19 +97,11 @@ export const SiteEditNavbar = (): JSX.Element => {
         borderColor="base.divider.medium"
         transition="padding 0.1s"
       >
-        <Breadcrumb size="xs">
-          <BreadcrumbItem>
-            <BreadcrumbLink as={Link} href={`/sites/${siteId}`}>
-              <Text textStyle="subhead-2">All pages</Text>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
+        <NavigationBreadcrumbs
+          siteId={String(siteId)}
+          pageId={String(pageId)}
+        />
 
-          <BreadcrumbItem isCurrentPage>
-            <BreadcrumbLink href="#">
-              <Text textStyle="subhead-2">Current page</Text>
-            </BreadcrumbLink>
-          </BreadcrumbItem>
-        </Breadcrumb>
         <TabList>
           <Tab>Edit</Tab>
           <Tab>Page Settings</Tab>

--- a/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
@@ -51,7 +51,7 @@ const NavigationBreadcrumbs = ({
 
       {!isBreadcrumbLoaded && (
         <BreadcrumbItem>
-          <Skeleton height="1.25rem" width="10rem" />
+          <Skeleton height="1.25rem" width="16rem" />
         </BreadcrumbItem>
       )}
 
@@ -61,7 +61,9 @@ const NavigationBreadcrumbs = ({
             as={Link}
             href={`/sites/${siteId}/${getResourceSubpath(parentResource.type)}/${parentResource.id}`}
           >
-            <Text textStyle="subhead-2">{parentResource.title}</Text>
+            <Text textStyle="subhead-2" noOfLines={1} maxW="12rem">
+              {parentResource.title}
+            </Text>
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}
@@ -69,7 +71,9 @@ const NavigationBreadcrumbs = ({
       {!!resource && (
         <BreadcrumbItem isCurrentPage>
           <BreadcrumbLink href="#">
-            <Text textStyle="subhead-2">{resource.title}</Text>
+            <Text textStyle="subhead-2" noOfLines={1} maxW="12rem">
+              {resource.title}
+            </Text>
           </BreadcrumbLink>
         </BreadcrumbItem>
       )}

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -22,7 +22,13 @@ export const resourceRouter = router({
       const resource = await db
         .selectFrom("Resource")
         .where("Resource.id", "=", String(resourceId))
-        .select(["permalink", "Resource.id", "Resource.title"])
+        .select([
+          "Resource.id",
+          "Resource.type",
+          "Resource.title",
+          "Resource.permalink",
+          "Resource.parentId",
+        ])
         .executeTakeFirst()
 
       if (!resource) {

--- a/apps/studio/src/utils/resource.ts
+++ b/apps/studio/src/utils/resource.ts
@@ -1,0 +1,18 @@
+import type { ResourceType } from "@prisma/client"
+
+// Gets the Studio URL subpath for a given resource type
+export const getResourceSubpath = (resourceType: ResourceType) => {
+  switch (resourceType) {
+    case "RootPage":
+    case "Page":
+    case "CollectionPage":
+      return "pages"
+    case "Folder":
+      return "folders"
+    case "Collection":
+      return "collections"
+    default:
+      const _: never = resourceType
+      return ""
+  }
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The edit page breadcrumb currently is using dummy data.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Fetch the correct data for the edit page breadcrumb (which is the current page title)
- If the page's parent folder is not the root folder, show the immediate parent of that page as a link (this is mainly for collections).

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/e21d0341-4a2c-4591-af4a-6f8ad3a05218)

**AFTER**:

<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/3da5f3ab-a69a-4679-8b9a-a0b8374aed62)