### PR TITLE
chore: add filter so that we cannot do self-moves

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
@@ -12,11 +12,13 @@ type MoveItemProps = Pick<
   "permalink"
 > & {
   onChangeResourceId: () => void
+  isDisabled?: boolean
 }
 
 const SuspendableMoveItem = ({
   permalink,
   onChangeResourceId,
+  ...rest
 }: MoveItemProps) => {
   return (
     <Button
@@ -24,15 +26,10 @@ const SuspendableMoveItem = ({
       w="full"
       justifyContent="flex-start"
       color="base.content.default"
-      // NOTE: Set special styling because pages should show normally
-      // but have no onClick
-      // TODO: add permissions for folders that users have no access to
-      // These should have disabled styling
-      _disabled={{ color: "base.content.default" }}
-      disabled
       pl="2.25rem"
       onClick={onChangeResourceId}
       leftIcon={<BiFolder />}
+      {...rest}
     >
       <Text noOfLines={1} textStyle="caption-1">
         /{permalink}

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -191,24 +191,26 @@ const MoveResourceContent = withSuspense(
                 </Flex>
               )}
               {data?.pages.map(({ items }) =>
-                items.map((child) => {
-                  return (
-                    <MoveItem
-                      {...child}
-                      key={child.id}
-                      onChangeResourceId={() => {
-                        setResourceStack((prev) => [
-                          ...prev,
-                          {
-                            ...child,
-                            parentId: curResourceId ?? null,
-                            resourceId: child.id,
-                          },
-                        ])
-                      }}
-                    />
-                  )
-                }),
+                items
+                  .filter((child) => child.id !== movedItem?.resourceId)
+                  .map((child) => {
+                    return (
+                      <MoveItem
+                        {...child}
+                        key={child.id}
+                        onChangeResourceId={() => {
+                          setResourceStack((prev) => [
+                            ...prev,
+                            {
+                              ...child,
+                              parentId: curResourceId ?? null,
+                              resourceId: child.id,
+                            },
+                          ])
+                        }}
+                      />
+                    )
+                  }),
               )}
               {hasNextPage && (
                 <Button

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -191,26 +191,25 @@ const MoveResourceContent = withSuspense(
                 </Flex>
               )}
               {data?.pages.map(({ items }) =>
-                items
-                  .filter((child) => child.id !== movedItem?.resourceId)
-                  .map((child) => {
-                    return (
-                      <MoveItem
-                        {...child}
-                        key={child.id}
-                        onChangeResourceId={() => {
-                          setResourceStack((prev) => [
-                            ...prev,
-                            {
-                              ...child,
-                              parentId: curResourceId ?? null,
-                              resourceId: child.id,
-                            },
-                          ])
-                        }}
-                      />
-                    )
-                  }),
+                items.map((child) => {
+                  return (
+                    <MoveItem
+                      {...child}
+                      isDisabled={child.id === movedItem?.resourceId}
+                      key={child.id}
+                      onChangeResourceId={() => {
+                        setResourceStack((prev) => [
+                          ...prev,
+                          {
+                            ...child,
+                            parentId: curResourceId ?? null,
+                            resourceId: child.id,
+                          },
+                        ])
+                      }}
+                    />
+                  )
+                }),
               )}
               {hasNextPage && (
                 <Button


### PR DESCRIPTION
## Problem
previously, we didnt do a filter on the data retrieved from backend, which led to self-moves being possible (ie, i move a folder to itself)

## Solution
1. filter by `resourceId` on the frontend
    - this is safe to do because the method invoked on the backend returns strictly `folder`
    - so for pages, the condition will be `false` by default (this is paginated so run time isn't an issue)
    - for folders, we disallow move to self (and children) and because we start move from `root`, we'll never to able to get to the folder and its associated children
2. backend already has an error message here for self moves so it's still disallowed but this error message wouldn't be seen by law abiding citizens who use our frontend

## Screenshots
https://github.com/user-attachments/assets/8bcd295f-6ce8-4cc3-b3a0-416b02dbce81

