### PR TITLE
Remove .gov.sg email restriction and update email validation

### DIFF
--- a/apps/studio/src/schemas/auth/email/sign-in.ts
+++ b/apps/studio/src/schemas/auth/email/sign-in.ts
@@ -1,12 +1,12 @@
 import { z } from "zod"
 
 import { OTP_LENGTH } from "~/lib/auth"
-import { isGovEmail } from "~/utils/email"
+import { isValidEmail } from "~/utils/email"
 import { normaliseEmail } from "~/utils/zod"
 
 export const emailSignInSchema = z.object({
-  email: normaliseEmail.refine(isGovEmail, {
-    message: "Please sign in with an .gov.sg email address.",
+  email: normaliseEmail.refine(isValidEmail, {
+    message: "Please sign in with a valid email address.",
   }),
 })
 

--- a/apps/studio/src/server/context.ts
+++ b/apps/studio/src/server/context.ts
@@ -47,6 +47,7 @@ export const createContext = async (opts: CreateNextContextOptions) => {
     apiHost: "https://cdn.growthbook.io",
     clientKey: env.GROWTHBOOK_CLIENT_KEY,
     debug: false, // NOTE: do not put true unless local dev
+    disableCache: true,
   })
   await growthbookContext.init({ timeout: 2000 })
 

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -10,7 +10,6 @@ import {
 import { publicProcedure, router } from "~/server/trpc"
 import { getBaseUrl } from "~/utils/getBaseUrl"
 import { defaultMeSelect } from "../../me/me.select"
-import { generateUsername } from "../../me/me.service"
 import { VerificationError } from "../auth.error"
 import { verifyToken } from "../auth.service"
 import { createTokenHash, createVfnPrefix, createVfnToken } from "../auth.util"

--- a/apps/studio/src/utils/email.ts
+++ b/apps/studio/src/utils/email.ts
@@ -18,3 +18,10 @@ export const isGovEmail = (value: unknown) => {
     typeof value === "string" && isEmail(value) && value.endsWith(".gov.sg")
   )
 }
+
+/**
+ * Returns whether the passed value is a valid email.
+ */
+export const isValidEmail = (value: unknown) => {
+  return typeof value === "string" && isEmail(value)
+}


### PR DESCRIPTION
### TL;DR

Updated email validation to accept all valid email addresses instead of only .gov.sg emails.

### What changed?

- Modified `emailSignInSchema` to use `isValidEmail` instead of `isGovEmail`
- Updated error message for invalid email addresses
- Added `isValidEmail` function to validate any valid email address
- Removed unused import of `generateUsername` in email router
- Added `disableCache: true` to GrowthBook context initialization

### How to test?

1. Attempt to sign in with various email addresses:
   - A valid .gov.sg email
   - A valid non-.gov.sg email
   - An invalid email address
2. Verify that all valid email addresses are accepted, regardless of domain
3. Confirm that invalid email addresses are rejected with the new error message

### Why make this change?

This change allows for a broader user base by accepting all valid email addresses, not just those with .gov.sg domains. This modification enhances the accessibility of the application while maintaining email validation security.
