### PR TITLE
fix(page-settings): change field generation

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -158,6 +158,7 @@ const PageSettings = ({
       // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
       await utils.page.readPageAndBlob.invalidate()
       await utils.page.readPage.invalidate()
+      await utils.page.getFullPermalink.invalidate()
       if (!toast.isActive(SUCCESS_TOAST_ID)) {
         toast({
           id: SUCCESS_TOAST_ID,

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -10,7 +10,6 @@ import {
 import { publicProcedure, router } from "~/server/trpc"
 import { getBaseUrl } from "~/utils/getBaseUrl"
 import { defaultMeSelect } from "../../me/me.select"
-import { generateUsername } from "../../me/me.service"
 import { VerificationError } from "../auth.error"
 import { verifyToken } from "../auth.service"
 import { createTokenHash, createVfnPrefix, createVfnToken } from "../auth.util"


### PR DESCRIPTION
## Problem
previously, we swapped the method for determining the permalink. unfortunately, this method fetches the full permalink which contains invalid characters (`/`). this led to the save being disabled until the field is typed.

additionally, `isDirty` wasn't quite fitting our use case and we have to check against the `dirtyFields` of the `formState` instead. this showed up as edits not working until the second blur.
<img width="957" alt="image" src="https://github.com/user-attachments/assets/0f67301f-0b36-4acc-80f0-37e60ec5e545">

## Solution
1. change the api of the component to accept a `prefix`. this is the front portion of hte `permalink`
2. update the full permalink retrieved to be 2 portions, the prefix and the current url
3. updat the component so that input edits only the last portion 

## Screenshots

https://github.com/user-attachments/assets/b826990e-9be4-4089-a3c0-70a0d43b85ec

