### PR TITLE
fix(overflow): breadcrumbs and titles can overflow leading to bad ux

### DIFF
--- a/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
@@ -33,7 +33,7 @@ export const SiteEditNavbar = (): JSX.Element => {
         borderColor="base.divider.medium"
         transition="padding 0.1s"
       >
-        <Breadcrumb size="xs">
+        <Breadcrumb size="sm">
           <BreadcrumbItem>
             <BreadcrumbLink as={Link} href={`/sites/${siteId}`}>
               <Text textStyle="subhead-2">All pages</Text>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -142,7 +142,7 @@ const FolderPage: NextPageWithLayout = () => {
             </BreadcrumbItem>
           </Breadcrumb>
           <Flex w="full" flexDir="row">
-            <HStack overflow="auto" gap="0.75rem" flex={1}>
+            <HStack mr="1.25rem" overflow="auto" gap="0.75rem" flex={1}>
               <Box
                 aria-hidden
                 bg="brand.secondary.100"

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -109,7 +109,7 @@ const FolderPage: NextPageWithLayout = () => {
     <>
       <VStack w="100%" p="1.75rem" gap="1rem">
         <VStack w="100%" align="start">
-          <Breadcrumb size="sm" overflow="auto">
+          <Breadcrumb size="sm" w="100%">
             {breadcrumbs.map(({ href, label }, index) => {
               return (
                 <BreadcrumbItem key={index}>
@@ -124,8 +124,17 @@ const FolderPage: NextPageWithLayout = () => {
                 </BreadcrumbItem>
               )
             })}
-            <BreadcrumbItem key={folderId}>
-              <Text textStyle="caption-2" color="base.content.default">
+            <BreadcrumbItem
+              key={folderId}
+              overflow="hidden"
+              whiteSpace="nowrap"
+            >
+              <Text
+                textStyle="caption-2"
+                color="base.content.default"
+                overflow="hidden"
+                textOverflow="ellipsis"
+              >
                 {title}
               </Text>
             </BreadcrumbItem>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -117,6 +117,8 @@ const FolderPage: NextPageWithLayout = () => {
                     <Text
                       textStyle="caption-2"
                       color="interaction.links.default"
+                      noOfLines={1}
+                      w="max-content"
                     >
                       {label}
                     </Text>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -156,6 +156,7 @@ const FolderPage: NextPageWithLayout = () => {
                 as="h3"
                 textStyle="h3"
                 textOverflow="ellipsis"
+                wordBreak="break-all"
               >
                 {title}
               </Text>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -109,7 +109,7 @@ const FolderPage: NextPageWithLayout = () => {
     <>
       <VStack w="100%" p="1.75rem" gap="1rem">
         <VStack w="100%" align="start">
-          <Breadcrumb size="sm">
+          <Breadcrumb size="sm" overflow="auto">
             {breadcrumbs.map(({ href, label }, index) => {
               return (
                 <BreadcrumbItem key={index}>
@@ -131,7 +131,7 @@ const FolderPage: NextPageWithLayout = () => {
             </BreadcrumbItem>
           </Breadcrumb>
           <Flex w="full" flexDir="row">
-            <HStack gap="0.75rem" flex={1}>
+            <HStack overflow="auto" gap="0.75rem" flex={1}>
               <Box
                 aria-hidden
                 bg="brand.secondary.100"
@@ -140,12 +140,15 @@ const FolderPage: NextPageWithLayout = () => {
               >
                 <BiFolder />
               </Box>
-              <Text noOfLines={1} as="h3" textStyle="h3">
+              <Text
+                noOfLines={1}
+                as="h3"
+                textStyle="h3"
+                textOverflow="ellipsis"
+              >
                 {title}
               </Text>
             </HStack>
-
-            <Spacer />
 
             <HStack>
               <Button


### PR DESCRIPTION
## Problem
previously, titles and breadcrumbs can overflow, which blocks off content, leading to bad ux

Closes ISOM-1468
Closes ISOM-1480

## Solution
1. define overflow styling and a max width for breadcrumbs so that on overflow, the last breadcrumb will truncate nicely
2. set overflow styling on the container for the title



https://github.com/user-attachments/assets/9acdcdb1-662e-40e2-ac0b-c67e8bdb5636



