### PR TITLE
fix(contentpic): add a renderer

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -12,7 +12,6 @@ import {
   BiUnderline,
 } from "react-icons/bi"
 import { MdSubscript, MdSuperscript } from "react-icons/md"
-import { RiLayoutColumnFill, RiLayoutRowFill } from "react-icons/ri"
 
 import type { MenuBarEntry } from "./MenuBar"
 import {

--- a/apps/studio/src/components/PageEditor/MenuBar/ProseMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/ProseMenuBar.tsx
@@ -1,0 +1,141 @@
+import type { Editor } from "@tiptap/react"
+import { useMemo } from "react"
+import {
+  BiBold,
+  BiItalic,
+  BiListOl,
+  BiListUl,
+  BiStrikethrough,
+  BiUnderline,
+} from "react-icons/bi"
+import { MdSubscript, MdSuperscript } from "react-icons/md"
+
+import type { MenuBarEntry } from "./MenuBar"
+import { MenuBar } from "./MenuBar"
+
+export const ProseMenuBar = ({ editor }: { editor: Editor }) => {
+  const items: MenuBarEntry[] = useMemo(
+    () => [
+      {
+        type: "vertical-list",
+        buttonWidth: "9rem",
+        menuWidth: "19rem",
+        defaultTitle: "Text styles",
+        items: [
+          {
+            type: "item",
+            title: "Heading 1",
+            textStyle: "h2",
+            useSecondaryColor: true,
+            action: () =>
+              editor.chain().focus().toggleHeading({ level: 2 }).run(),
+            isActive: () => editor.isActive("heading", { level: 2 }),
+          },
+          {
+            type: "item",
+            title: "Heading 2",
+            textStyle: "h3",
+            useSecondaryColor: true,
+            action: () =>
+              editor.chain().focus().toggleHeading({ level: 3 }).run(),
+            isActive: () => editor.isActive("heading", { level: 3 }),
+          },
+          {
+            type: "item",
+            title: "Heading 3",
+            textStyle: "h4",
+            useSecondaryColor: true,
+            action: () =>
+              editor.chain().focus().toggleHeading({ level: 4 }).run(),
+            isActive: () => editor.isActive("heading", { level: 4 }),
+          },
+          {
+            type: "item",
+            title: "Paragraph",
+            textStyle: "body-1",
+            action: () =>
+              editor.chain().focus().clearNodes().unsetAllMarks().run(),
+            isActive: () => editor.isActive("paragraph"),
+          },
+        ],
+
+        isHidden: () => editor.isActive("table"),
+      },
+      {
+        type: "divider",
+        isHidden: () => editor.isActive("table"),
+      },
+      {
+        type: "item",
+        icon: BiBold,
+        title: "Bold",
+        action: () => editor.chain().focus().toggleBold().run(),
+        isActive: () => editor.isActive("bold"),
+      },
+      {
+        type: "item",
+        icon: BiItalic,
+        title: "Italicise",
+        action: () => editor.chain().focus().toggleItalic().run(),
+        isActive: () => editor.isActive("italic"),
+      },
+      {
+        type: "item",
+        icon: BiUnderline,
+        title: "Underline",
+        action: () => editor.chain().focus().toggleUnderline().run(),
+        isActive: () => editor.isActive("underline"),
+      },
+      {
+        type: "item",
+        icon: BiStrikethrough,
+        title: "Strikethrough",
+        action: () => editor.chain().focus().toggleStrike().run(),
+        isActive: () => editor.isActive("strike"),
+      },
+      {
+        type: "item",
+        icon: MdSuperscript,
+        title: "Superscript",
+        action: () =>
+          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+        isActive: () => editor.isActive("superscript"),
+      },
+      {
+        type: "item",
+        icon: MdSubscript,
+        title: "Subscript",
+        action: () =>
+          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+        isActive: () => editor.isActive("subscript"),
+      },
+      {
+        type: "divider",
+      },
+      {
+        type: "horizontal-list",
+        label: "Lists",
+        defaultIcon: BiListOl,
+        items: [
+          {
+            type: "item",
+            icon: BiListOl,
+            title: "Ordered list",
+            action: () => editor.chain().focus().toggleOrderedList().run(),
+            isActive: () => editor.isActive("orderedList"),
+          },
+
+          {
+            type: "item",
+            icon: BiListUl,
+            title: "Bullet list",
+            action: () => editor.chain().focus().toggleBulletList().run(),
+            isActive: () => editor.isActive("unorderedList"),
+          },
+        ],
+      },
+    ],
+    [editor],
+  )
+  return <MenuBar items={items} />
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -1,5 +1,5 @@
 import type { JsonFormsRendererRegistryEntry } from "@jsonforms/core"
-import type { ErrorObject, ValidateFunction } from "ajv"
+import type { ValidateFunction } from "ajv"
 import { rankWith } from "@jsonforms/core"
 import { JsonForms } from "@jsonforms/react"
 import { type TSchema } from "@sinclair/typebox"
@@ -33,6 +33,8 @@ import {
   jsonFormsLinkControlTester,
   JsonFormsObjectControl,
   jsonFormsObjectControlTester,
+  JsonFormsProseControl,
+  jsonFormsProseControlTester,
   JsonFormsTextControl,
   jsonFormsTextControlTester,
   jsonFormsVerticalLayoutRenderer,
@@ -40,6 +42,10 @@ import {
 } from "./renderers"
 
 const renderers: JsonFormsRendererRegistryEntry[] = [
+  {
+    tester: jsonFormsProseControlTester,
+    renderer: JsonFormsProseControl,
+  },
   { tester: jsonFormsObjectControlTester, renderer: JsonFormsObjectControl },
   { tester: jsonFormsArrayControlTester, renderer: JsonFormsArrayControl },
   { tester: jsonFormsBooleanControlTester, renderer: JsonFormsBooleanControl },

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/TiptapProseEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/TiptapProseEditor.tsx
@@ -1,0 +1,11 @@
+import type { Editor as TiptapEditor } from "@tiptap/react"
+
+import { ProseMenuBar } from "~/components/PageEditor/MenuBar/ProseMenuBar"
+import { Editor } from "./components"
+
+export function TiptapProseEditor({ editor }: { editor: TiptapEditor | null }) {
+  // TODO: Add a loading state or use suspense
+  if (!editor) return null
+
+  return <Editor menubar={ProseMenuBar} editor={editor} />
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAccordionTextControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAccordionTextControl.tsx
@@ -1,5 +1,5 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import { Box, Flex, FormControl } from "@chakra-ui/react"
+import { Box, FormControl } from "@chakra-ui/react"
 import { rankWith } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import { FormLabel } from "@opengovsg/design-system-react"
@@ -15,7 +15,7 @@ export const jsonFormsAccordionTextControlTester: RankedTester = rankWith(
   },
 )
 
-export function JsonFormsCalloutTextControl({
+export function JsonFormsAccordionTextControl({
   data,
   label,
   handleChange,
@@ -38,4 +38,4 @@ export function JsonFormsCalloutTextControl({
   )
 }
 
-export default withJsonFormsControlProps(JsonFormsCalloutTextControl)
+export default withJsonFormsControlProps(JsonFormsAccordionTextControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
@@ -1,0 +1,41 @@
+import type { ControlProps, RankedTester } from "@jsonforms/core"
+import { Box, FormControl } from "@chakra-ui/react"
+import { rankWith } from "@jsonforms/core"
+import { withJsonFormsControlProps } from "@jsonforms/react"
+import { FormLabel } from "@opengovsg/design-system-react"
+
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { useProseEditor } from "~/features/editing-experience/hooks/useTextEditor"
+import { TiptapProseEditor } from "../TipTapEditor/TiptapProseEditor"
+
+export const jsonFormsProseControlTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.ProseControl,
+  (_, schema) => {
+    return schema.format === "prose"
+  },
+)
+
+export function JsonFormsProseControl({
+  data,
+  label,
+  handleChange,
+  path,
+  description,
+  required,
+}: ControlProps) {
+  const editor = useProseEditor({
+    data,
+    handleChange: (content) => handleChange(path, content),
+  })
+
+  return (
+    <Box mt="1.25rem" _first={{ mt: 0 }}>
+      <FormControl isRequired={required}>
+        <FormLabel description={description}>{label}</FormLabel>
+        <TiptapProseEditor editor={editor} />
+      </FormControl>
+    </Box>
+  )
+}
+
+export default withJsonFormsControlProps(JsonFormsProseControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -46,3 +46,7 @@ export {
   default as JsonFormsImageControl,
   jsonFormsImageControlTester,
 } from "./JsonFormsImageControl"
+export {
+  default as JsonFormsProseControl,
+  jsonFormsProseControlTester,
+} from "./JsonFormsProseControl"

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
@@ -155,3 +155,10 @@ export const useAccordionEditor = ({ data, handleChange }: BaseEditorProps) => {
     handleChange,
   })
 }
+
+export const useProseEditor = ({ data, handleChange }: BaseEditorProps) =>
+  useBaseEditor({
+    data,
+    handleChange,
+    extensions: [IsomerHeading],
+  })


### PR DESCRIPTION
## Problem
Currently, our contentpic has no applicable renderer as it's using the default `Prose` schema and now, the various editors have been split up into their own specialised editor

## Solution
1. define a **default** editor (this will be used when we use something with `prose` as the format)
2. add the testers into `FormBuilder`

## Alternatives considered but discarded
1. add another specialised editor - i think we'd rather have classes of editor than specialised editor for each component. all our previous components have had no overlap so far so it's been pretty annoying...

## Screenshots

https://github.com/user-attachments/assets/6074a46d-e2b5-472b-8a34-46b04c94f0e9

