### PR TITLE
fix: omit hard breaks when rendering headings

### DIFF
--- a/packages/components/src/templates/next/components/internal/Notification/Notification.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/Notification.tsx
@@ -27,7 +27,7 @@ const NotificationBanner = ({
           <div className="flex flex-1 flex-col gap-1">
             {!!title && <h2 className="prose-headline-lg-medium">{title}</h2>}
             <BaseParagraph
-              content={getTextAsHtml(site.siteMap, content)}
+              content={getTextAsHtml({ sitemap: site.siteMap, content })}
               className="prose-body-base [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0"
               LinkComponent={LinkComponent}
             />

--- a/packages/components/src/templates/next/components/native/Heading/Heading.tsx
+++ b/packages/components/src/templates/next/components/native/Heading/Heading.tsx
@@ -12,7 +12,11 @@ const Heading = ({
         id={id}
         className="prose-display-md text-base-content-strong [&:not(:first-child)]:mt-14"
       >
-        {getTextAsHtml(site.siteMap, content)}
+        {getTextAsHtml({
+          sitemap: site.siteMap,
+          content,
+          shouldHideEmptyHardBreak: true,
+        })}
       </h2>
     )
   }
@@ -22,7 +26,11 @@ const Heading = ({
         id={id}
         className="prose-display-sm text-base-content-strong [&:not(:first-child)]:mt-9"
       >
-        {getTextAsHtml(site.siteMap, content)}
+        {getTextAsHtml({
+          sitemap: site.siteMap,
+          content,
+          shouldHideEmptyHardBreak: true,
+        })}
       </h3>
     )
   }
@@ -32,7 +40,11 @@ const Heading = ({
         id={id}
         className="prose-title-md-semibold text-base-content-strong [&:not(:first-child)]:mt-8"
       >
-        {getTextAsHtml(site.siteMap, content)}
+        {getTextAsHtml({
+          sitemap: site.siteMap,
+          content,
+          shouldHideEmptyHardBreak: true,
+        })}
       </h4>
     )
   }
@@ -42,7 +54,11 @@ const Heading = ({
         id={id}
         className="prose-headline-lg-semibold text-base-content-strong [&:not(:first-child)]:mt-7"
       >
-        {getTextAsHtml(site.siteMap, content)}
+        {getTextAsHtml({
+          sitemap: site.siteMap,
+          content,
+          shouldHideEmptyHardBreak: true,
+        })}
       </h5>
     )
   }
@@ -51,7 +67,11 @@ const Heading = ({
       id={id}
       className="prose-headline-base-semibold text-base-content-strong [&:not(:first-child)]:mt-6"
     >
-      {getTextAsHtml(site.siteMap, content)}
+      {getTextAsHtml({
+        sitemap: site.siteMap,
+        content,
+        shouldHideEmptyHardBreak: true,
+      })}
     </h6>
   )
 }

--- a/packages/components/src/templates/next/components/native/Paragraph/Paragraph.tsx
+++ b/packages/components/src/templates/next/components/native/Paragraph/Paragraph.tsx
@@ -5,7 +5,7 @@ import { BaseParagraph } from "../../internal"
 const Paragraph = ({ content, LinkComponent, site }: ParagraphProps) => {
   return (
     <BaseParagraph
-      content={getTextAsHtml(site.siteMap, content)}
+      content={getTextAsHtml({ sitemap: site.siteMap, content })}
       className="prose-body-base text-base-content"
       LinkComponent={LinkComponent}
     />

--- a/packages/components/src/templates/next/components/native/Prose/Prose.tsx
+++ b/packages/components/src/templates/next/components/native/Prose/Prose.tsx
@@ -28,7 +28,10 @@ const ProseComponent = ({
     case "paragraph":
       return (
         <BaseParagraph
-          content={getTextAsHtml(site.siteMap, component.content)}
+          content={getTextAsHtml({
+            sitemap: site.siteMap,
+            content: component.content,
+          })}
           className="prose-body-base text-base-content"
           LinkComponent={LinkComponent}
         />

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -32,7 +32,7 @@ const getTableOfContentsFromContent = (
       for (const component of block.content) {
         if (component.type === "heading" && component.attrs.level === 2) {
           result.push({
-            content: getTextAsHtml(sitemap, component.content),
+            content: getTextAsHtml({ sitemap, content: component.content }),
             anchorLink: "#" + component.attrs.id,
           })
         }

--- a/packages/components/src/utils/getTextAsHtml.ts
+++ b/packages/components/src/utils/getTextAsHtml.ts
@@ -18,14 +18,21 @@ const MARK_DOM_MAPPING: Record<MarkTypes, string> = {
   underline: "u",
 }
 
+interface GetTextAsHtmlArgs {
+  sitemap: IsomerSitemap
+  content?: (HardBreakProps | TextProps)[]
+  shouldHideEmptyHardBreak?: boolean
+}
+
 // Converts the text node with marks into the appropriate HTML
-export const getTextAsHtml = (
-  sitemap: IsomerSitemap,
-  content?: (HardBreakProps | TextProps)[],
-) => {
+export const getTextAsHtml = ({
+  sitemap,
+  content,
+  shouldHideEmptyHardBreak,
+}: GetTextAsHtmlArgs) => {
   if (!content) {
     // Note: We need to return a <br /> tag to ensure that the paragraph is not collapsed
-    return "<br />"
+    return shouldHideEmptyHardBreak ? "" : "<br />"
   }
 
   const output: string[] = []


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Hard breaks are being rendered in headings.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add a flag to prevent the empty hard break from being rendered in the heading.