### PR TITLE
fix: break words on overflow for titles and use h2

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -2056,10 +2056,6 @@ video {
   white-space: nowrap;
 }
 
-.text-wrap {
-  text-wrap: wrap;
-}
-
 .text-pretty {
   text-wrap: pretty;
 }
@@ -4593,6 +4589,10 @@ video {
 
   .md\:items-center {
     align-items: center;
+  }
+
+  .md\:gap-3 {
+    gap: 0.75rem;
   }
 
   .md\:gap-7 {

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -93,6 +93,7 @@ const InfoCardsWithImageSchema = Type.Object(
     variant: Type.Literal("cardsWithImages", { default: "cardsWithImages" }),
     cards: Type.Array(SingleCardWithImageSchema, {
       title: "Cards",
+      maxItems: 6,
       default: [],
     }),
   },
@@ -108,6 +109,7 @@ const InfoCardsNoImageSchema = Type.Object(
     }),
     cards: Type.Array(SingleCardNoImageSchema, {
       title: "Cards",
+      maxItems: 6,
       default: [],
     }),
   },

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
@@ -27,7 +27,7 @@ const Hero = ({
         >
           <div className="xl:max-w-50% flex w-full flex-col gap-9 sm:w-3/5">
             <div className="flex flex-col gap-6">
-              <h1 className="prose-display-xl">{title}</h1>
+              <h1 className="prose-display-xl break-words">{title}</h1>
               {subtitle && <p className="prose-body-base">{subtitle}</p>}
             </div>
             {buttonLabel && buttonUrl && (

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -28,7 +28,7 @@ const createInfoCardsStyles = tv({
   slots: {
     container: `${ComponentContent} flex flex-col py-12 first:pt-0 lg:py-24`,
     headingContainer: "flex flex-col gap-2.5 pb-8 sm:pb-12 lg:max-w-3xl",
-    headingTitle: "prose-display-md text-base-content-strong",
+    headingTitle: "prose-display-md break-words text-base-content-strong",
     headingSubtitle: "prose-headline-lg-regular text-base-content",
     grid: "grid grid-cols-1 gap-10 md:gap-7 lg:gap-x-16 lg:gap-y-12",
     cardContainer: "group flex flex-col gap-5 outline-0",

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -16,7 +16,9 @@ const InfoColsHeader = ({
   subtitle,
 }: Pick<InfoColsProps, "title" | "subtitle">) => (
   <div className="flex w-full max-w-[47.5rem] flex-col items-start gap-2.5 text-left">
-    <h2 className="prose-display-md text-base-content-strong">{title}</h2>
+    <h2 className="prose-display-md break-words text-base-content-strong">
+      {title}
+    </h2>
     {subtitle && (
       <p className="prose-headline-lg-regular text-base-content">{subtitle}</p>
     )}

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -18,9 +18,9 @@ const Infobar = ({
       <div className={`${ComponentContent} mx-6 py-16 sm:mx-10 lg:py-24`}>
         <div className="mx-auto flex flex-col items-center gap-9 text-center lg:max-w-3xl">
           <div className="flex flex-col gap-6">
-            <h1 className="prose-display-lg text-base-content-strong">
+            <h2 className="prose-display-lg break-words text-base-content-strong">
               {title}
-            </h1>
+            </h2>
             {description && (
               <p className="prose-headline-lg-regular text-base-content">
                 {description}

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -16,7 +16,7 @@ const infopicStyles = tv({
     // since content is half of screen width in desktop.
     content:
       "px-6 pb-16 pt-10 text-base-content [grid-area:content] md:max-w-[760px] md:px-10 md:pb-20 md:pt-16 lg:max-w-[620px] lg:py-24 lg:pl-10",
-    title: "prose-display-md text-base-content-strong",
+    title: "prose-display-md break-words text-base-content-strong",
     description: "prose-body-base mt-4 md:mt-6",
     button: "mt-9",
   },
@@ -57,7 +57,7 @@ export const Infopic = ({
   return (
     <div className={compoundStyles.container()}>
       <div className={compoundStyles.content()}>
-        <h3 className={compoundStyles.title()}>{title}</h3>
+        <h2 className={compoundStyles.title()}>{title}</h2>
         <p className={compoundStyles.description()}>{description}</p>
         {hasLinkButton && (
           <div className={compoundStyles.button()}>

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -22,7 +22,7 @@ const KeyStatistics = ({ title, statistics }: KeyStatisticsProps) => {
     <div
       className={`${ComponentContent} flex flex-col gap-10 py-12 xs:py-24 lg:gap-24`}
     >
-      <h2 className="prose-display-md w-full max-w-[47.5rem] text-base-content-strong">
+      <h2 className="prose-display-md w-full max-w-[47.5rem] break-words text-base-content-strong">
         {title}
       </h2>
       <div className="flex flex-col flex-wrap gap-x-8 gap-y-12 md:flex-row">

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -42,7 +42,7 @@ const ArticlePageHeader = ({
       <div className="mb-3 text-base font-medium text-gray-600">{category}</div>
 
       <div className="flex flex-col gap-5">
-        <h1 className="text-3xl font-semibold tracking-tight text-content-strong lg:text-4xl">
+        <h1 className="text-3xl font-semibold tracking-tight text-content-strong lg:text-4xl break-words">
           {title}
         </h1>
         <p className="text-sm text-gray-800">{date}</p>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -25,7 +25,7 @@ export const CollectionCard = ({
   ...props
 }: CollectionCardProps): JSX.Element => {
   const file = props.variant === "file" ? props.fileDetails : null
-  const itemTitle = `${file ? `[${file.type.toUpperCase()}, ${file.size}] ` : ""}${title}`
+  const itemTitle = `${title}${file ? ` [${file.type.toUpperCase()}, ${file.size.toUpperCase()}]` : ""}`
   return (
     <div className="flex border-collapse flex-col gap-3 border-b border-divider-medium py-5 first:border-t lg:flex-row lg:gap-6">
       {lastUpdated && (

--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
@@ -18,7 +18,7 @@ const ContentPageHeader = ({
         <div className="flex max-w-[54rem] flex-col">
           <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
           <div className="mt-8 flex flex-col gap-5 md:mt-6">
-            <h1 className="prose-display-lg">{title}</h1>
+            <h1 className="prose-display-lg break-words">{title}</h1>
             <p className="prose-title-lg-regular">{summary}</p>
           </div>
           {buttonLabel && buttonUrl && (

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -125,11 +125,15 @@ const SocialMediaSection = ({
   socialMediaLinks,
   LinkComponent,
 }: Pick<FooterProps, "socialMediaLinks" | "LinkComponent">) => {
+  if (!socialMediaLinks || socialMediaLinks.length === 0) {
+    return <></>
+  }
+
   return (
     <div className="flex flex-col gap-5">
       <h3 className="prose-headline-base-medium">Reach us</h3>
       <div className="flex flex-row flex-wrap gap-7">
-        {socialMediaLinks?.map((link) => {
+        {socialMediaLinks.map((link) => {
           const Icon = SocialMediaTypeToIconMap[link.type]
           return (
             <BaseLink

--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -115,7 +115,7 @@ const Megamenu = ({
           <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-8 px-10 pb-16 pt-12">
             <div className="flex w-full flex-row items-start">
               <div className="flex flex-col gap-1">
-                <h1 className="prose-display-sm text-base-content">{name}</h1>
+                <h2 className="prose-display-sm text-base-content">{name}</h2>
                 {description && (
                   <p className="prose-label-sm-regular text-base-content-subtle">
                     {description}

--- a/packages/components/src/templates/next/layouts/Collection/CollectionPageHeader.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionPageHeader.tsx
@@ -24,7 +24,7 @@ const CollectionPageHeader = ({
         <div className="flex flex-col">
           <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
           <div className="mt-8 flex max-w-[54rem] flex-col gap-5 md:mt-6">
-            <h1 className="prose-display-lg">{title}</h1>
+            <h1 className="prose-display-lg break-words">{title}</h1>
             <p className="prose-title-lg-regular">{subtitle}</p>
           </div>
         </div>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Titles in our components and headers are overflowing without breaking the words.

Fixes ISOM-1519.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Added validation to set maximum number of cards in the InfoCards component to be 6.

**Bug Fixes**:

- Add `break-words` for headers.
- Standardise all component-level headers to be `<h2>`.