### PR TITLE
fix(studio): add missing msw handlers for edit page stories

### DIFF
--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -12,13 +12,15 @@ const COMMON_HANDLERS = [
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
   pageHandlers.countWithoutRoot.default(),
+  sitesHandlers.getLocalisedSitemap.default(),
   sitesHandlers.getTheme.default(),
   sitesHandlers.getConfig.default(),
   sitesHandlers.getFooter.default(),
   sitesHandlers.getNavbar.default(),
   resourceHandlers.getChildrenOf.default(),
   pageHandlers.readPageAndBlob.article(),
-  pageHandlers.readPage.content(),
+  pageHandlers.readPage.article(),
+  pageHandlers.getFullPermalink.article(),
 ]
 
 const meta: Meta<typeof EditPage> = {

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -18,6 +18,7 @@ const COMMON_HANDLERS = [
   sitesHandlers.getFooter.default(),
   sitesHandlers.getNavbar.default(),
   resourceHandlers.getChildrenOf.default(),
+  resourceHandlers.getMetadataById.article(),
   pageHandlers.readPageAndBlob.article(),
   pageHandlers.readPage.article(),
   pageHandlers.getFullPermalink.article(),

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -18,6 +18,7 @@ const COMMON_HANDLERS = [
   sitesHandlers.getFooter.default(),
   sitesHandlers.getNavbar.default(),
   resourceHandlers.getChildrenOf.default(),
+  resourceHandlers.getMetadataById.content(),
   pageHandlers.readPageAndBlob.content(),
   pageHandlers.readPage.content(),
   pageHandlers.getFullPermalink.content(),

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -12,6 +12,7 @@ const COMMON_HANDLERS = [
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
   pageHandlers.countWithoutRoot.default(),
+  sitesHandlers.getLocalisedSitemap.default(),
   sitesHandlers.getTheme.default(),
   sitesHandlers.getConfig.default(),
   sitesHandlers.getFooter.default(),
@@ -19,6 +20,7 @@ const COMMON_HANDLERS = [
   resourceHandlers.getChildrenOf.default(),
   pageHandlers.readPageAndBlob.content(),
   pageHandlers.readPage.content(),
+  pageHandlers.getFullPermalink.content(),
 ]
 
 const meta: Meta<typeof EditPage> = {

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -18,6 +18,7 @@ const COMMON_HANDLERS = [
   sitesHandlers.getFooter.default(),
   sitesHandlers.getNavbar.default(),
   resourceHandlers.getChildrenOf.default(),
+  resourceHandlers.getMetadataById.homepage(),
   pageHandlers.readPageAndBlob.homepage(),
   pageHandlers.readPage.homepage(),
   pageHandlers.getFullPermalink.homepage(),

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -12,6 +12,7 @@ const COMMON_HANDLERS = [
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
   pageHandlers.countWithoutRoot.default(),
+  sitesHandlers.getLocalisedSitemap.default(),
   sitesHandlers.getTheme.default(),
   sitesHandlers.getConfig.default(),
   sitesHandlers.getFooter.default(),
@@ -19,6 +20,7 @@ const COMMON_HANDLERS = [
   resourceHandlers.getChildrenOf.default(),
   pageHandlers.readPageAndBlob.homepage(),
   pageHandlers.readPage.homepage(),
+  pageHandlers.getFullPermalink.homepage(),
 ]
 
 const meta: Meta<typeof EditPage> = {

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -3,6 +3,7 @@ import { delay } from "msw"
 
 import type { getPageById } from "~/server/modules/resource/resource.service"
 import type { RouterOutput } from "~/utils/trpc"
+import { trpc } from "~/utils/trpc"
 import { trpcMsw } from "../mockTrpc"
 
 const getRootPageQuery = (wait?: DelayMode | number) => {
@@ -473,5 +474,19 @@ export const pageHandlers = {
         }
       })
     },
+  },
+  getFullPermalink: {
+    homepage: () =>
+      trpcMsw.page.getFullPermalink.query(() => {
+        return "/"
+      }),
+    content: () =>
+      trpcMsw.page.getFullPermalink.query(() => {
+        return "/page-title-here"
+      }),
+    article: () =>
+      trpcMsw.page.getFullPermalink.query(() => {
+        return "/article-layout"
+      }),
   },
 }

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -11,4 +11,36 @@ export const resourceHandlers = {
       })
     },
   },
+  getMetadataById: {
+    homepage: () =>
+      trpcMsw.resource.getMetadataById.query(() => {
+        return {
+          id: "1",
+          type: "RootPage",
+          title: "Home",
+          permalink: "home",
+          parentId: null,
+        }
+      }),
+    content: () =>
+      trpcMsw.resource.getMetadataById.query(() => {
+        return {
+          id: "3",
+          type: "Page",
+          title: "Page title here",
+          permalink: "page-title-here",
+          parentId: null,
+        }
+      }),
+    article: () =>
+      trpcMsw.resource.getMetadataById.query(() => {
+        return {
+          id: "4",
+          type: "Page",
+          title: "article layout",
+          permalink: "article-layout",
+          parentId: null,
+        }
+      }),
+  },
 }

--- a/apps/studio/tests/msw/handlers/sites.ts
+++ b/apps/studio/tests/msw/handlers/sites.ts
@@ -158,4 +158,36 @@ export const sitesHandlers = {
       })
     },
   },
+  getLocalisedSitemap: {
+    default: () => {
+      return trpcMsw.site.getLocalisedSitemap.query(() => {
+        return {
+          id: "1",
+          layout: "content",
+          title: "Home",
+          summary: "",
+          lastModified: "2024-09-16T04:34:54.838Z",
+          permalink: "/",
+          children: [
+            {
+              id: "4",
+              layout: "content",
+              title: "article layout",
+              summary: "",
+              lastModified: "2024-09-16T04:34:54.838Z",
+              permalink: "/article-layout",
+            },
+            {
+              id: "3",
+              layout: "content",
+              title: "Page title here",
+              summary: "",
+              lastModified: "2024-09-16T04:34:54.838Z",
+              permalink: "/page-title-here",
+            },
+          ],
+        }
+      })
+    },
+  },
 }


### PR DESCRIPTION
Storybook tests failing due to missing msw handlers for newly added procedures. This PR adds those missing mocked procedures in.