### PR TITLE
Restrict whitelist check to production environment

### DIFF
--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -38,6 +38,15 @@ describe("auth.email", () => {
       await expect(result).rejects.toThrowError()
     })
 
+    // skipping as we need to allow vendor emails as well
+    it.skip("should throw if email is not a government email address", async () => {
+      // Act
+      const result = caller.login({ email: "validbutnotgovt@example.com" })
+
+      // Assert
+      await expect(result).rejects.toThrowError()
+    })
+
     it("should return email and a prefix if OTP is sent successfully", async () => {
       // Arrange
       const spy = vi.spyOn(mailLib, "sendMail")

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -38,14 +38,6 @@ describe("auth.email", () => {
       await expect(result).rejects.toThrowError()
     })
 
-    it("should throw if email is not a government email address", async () => {
-      // Act
-      const result = caller.login({ email: "validbutnotgovt@example.com" })
-
-      // Assert
-      await expect(result).rejects.toThrowError()
-    })
-
     it("should return email and a prefix if OTP is sent successfully", async () => {
       // Arrange
       const spy = vi.spyOn(mailLib, "sendMail")

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -19,17 +19,19 @@ export const emailSessionRouter = router({
   login: publicProcedure
     .input(emailSignInSchema)
     .mutation(async ({ ctx, input: { email } }) => {
-      // check if whitelisted email on Growthbook
-      const defaultWhitelist: string[] = []
-      const whitelistedUsers = ctx.gb.getFeatureValue("whitelisted_users", {
-        whitelist: defaultWhitelist,
-      })
-
-      if (!whitelistedUsers.whitelist.includes(email)) {
-        throw new TRPCError({
-          code: "UNAUTHORIZED",
-          message: "Unauthorized. Contact Isomer support.",
+      if (env.NODE_ENV === "production") {
+        // check if whitelisted email on Growthbook
+        const defaultWhitelist: string[] = []
+        const whitelistedUsers = ctx.gb.getFeatureValue("whitelisted_users", {
+          whitelist: defaultWhitelist,
         })
+
+        if (!whitelistedUsers.whitelist.includes(email)) {
+          throw new TRPCError({
+            code: "UNAUTHORIZED",
+            message: "Unauthorized. Contact Isomer support.",
+          })
+        }
       }
 
       // TODO: instead of storing expires, store issuedAt to calculate when the next otp can be re-issued

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -134,8 +134,11 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
     throw new TRPCError({ code: "UNAUTHORIZED" })
   }
 
-  if (!whitelistedUsers.whitelist.includes(user.email)) {
-    throw new TRPCError({ code: "UNAUTHORIZED" })
+  // check against Growthbook if user is whitelisted for prod/stg
+  if (env.NODE_ENV === "production") {
+    if (!whitelistedUsers.whitelist.includes(user.email)) {
+      throw new TRPCError({ code: "UNAUTHORIZED" })
+    }
   }
 
   return next({


### PR DESCRIPTION
Note: This whitelist via GB is a temp measure till we get permissions model rolled out

## Problem

Prevent local dev from being coupled with growthbook

## Solution

This PR modifies the email authentication process to only check for whitelisted users in production environments.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Email authentication now only checks for whitelisted users in production environments
- Improved security by restricting access in production while allowing easier testing in non-production environments

## Tests

- Test email login functionality in both production and non-production environments
- Verify that whitelisted user checks are only performed in production
- Ensure unauthorized users are still blocked in production
- Removed test case for non-government email addresses