### PR TITLE
feat: add page settings route and separate edit/settings views, link to page in dashboard

### DIFF
--- a/apps/studio/src/components/TabLink.tsx
+++ b/apps/studio/src/components/TabLink.tsx
@@ -1,0 +1,16 @@
+import type { LinkProps } from "@chakra-ui/react"
+import NextLink from "next/link"
+import { chakra, useMultiStyleConfig } from "@chakra-ui/react"
+
+const Link = chakra(NextLink)
+
+interface TabLinkProps extends LinkProps {
+  isActive?: boolean
+}
+
+/** A Link component that looks like the Tab component */
+export const TabLink = ({ isActive, ...props }: TabLinkProps) => {
+  const styles = useMultiStyleConfig("Tabs", {})
+
+  return <Link aria-selected={isActive} {...props} sx={styles.tab} />
+}

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -9,7 +9,7 @@ import { type DrawerState } from "~/types/editorDrawer"
 export interface DrawerContextType
   extends Pick<
     EditorDrawerProviderProps,
-    "type" | "permalink" | "siteId" | "pageId" | "updatedAt"
+    "type" | "permalink" | "siteId" | "pageId" | "updatedAt" | "title"
   > {
   currActiveIdx: number
   setCurrActiveIdx: (currActiveIdx: number) => void
@@ -33,6 +33,7 @@ interface EditorDrawerProviderProps extends PropsWithChildren {
   siteId: number
   pageId: number
   updatedAt: Date
+  title: string
 }
 
 export function EditorDrawerProvider({
@@ -43,6 +44,7 @@ export function EditorDrawerProvider({
   siteId,
   pageId,
   updatedAt,
+  title,
 }: EditorDrawerProviderProps) {
   const [drawerState, setDrawerState] = useState<DrawerState>({
     state: "root",
@@ -79,6 +81,7 @@ export function EditorDrawerProvider({
         siteId,
         pageId,
         updatedAt,
+        title,
       }}
     >
       {children}

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -36,6 +36,7 @@ const getColumns = ({ siteId }: CollectionTableProps) => [
     header: () => <TableHeader>Actions</TableHeader>,
     cell: ({ row }) => (
       <CollectionTableMenu
+        siteId={siteId}
         resourceType={row.original.type}
         title={row.original.title}
         resourceId={row.original.id}

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react"
+import NextLink from "next/link"
 import { MenuButton, MenuList, Portal } from "@chakra-ui/react"
 import { IconButton, Menu } from "@opengovsg/design-system-react"
 import { useSetAtom } from "jotai"
@@ -5,20 +7,29 @@ import { BiCog, BiDotsHorizontalRounded, BiTrash } from "react-icons/bi"
 
 import type { CollectionTableData } from "./types"
 import { MenuItem } from "~/components/Menu"
+import { getLinkToResource } from "~/utils/resource"
 import { deleteResourceModalAtom } from "../../atoms"
 
 interface CollectionTableMenuProps {
   title: CollectionTableData["title"]
   resourceId: CollectionTableData["id"]
-  resourceType: CollectionTableData["resourceType"]
+  resourceType: CollectionTableData["type"]
+  siteId: number
 }
 
 export const CollectionTableMenu = ({
+  siteId,
   title,
   resourceId,
   resourceType,
 }: CollectionTableMenuProps) => {
   const setValue = useSetAtom(deleteResourceModalAtom)
+
+  const linkToResourceSettings = useMemo(
+    () =>
+      `${getLinkToResource({ siteId, resourceId, type: resourceType })}/settings`,
+    [siteId, resourceId, resourceType],
+  )
 
   return (
     <Menu isLazy size="sm">
@@ -31,7 +42,12 @@ export const CollectionTableMenu = ({
       />
       <Portal>
         <MenuList>
-          <MenuItem icon={<BiCog fontSize="1rem" />}>
+          <MenuItem
+            icon={<BiCog fontSize="1rem" />}
+            as={NextLink}
+            // @ts-expect-error type inconsistency with `as`
+            href={linkToResourceSettings}
+          >
             Edit page settings
           </MenuItem>
           <MenuItem

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -38,6 +38,7 @@ const getColumns = ({ siteId }: ResourceTableProps) => [
     header: () => <TableHeader>Actions</TableHeader>,
     cell: ({ row }) => (
       <ResourceTableMenu
+        siteId={siteId}
         parentId={row.original.parentId}
         title={row.original.title}
         resourceId={row.original.id}

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react"
+import NextLink from "next/link"
 import { MenuButton, MenuList, Portal } from "@chakra-ui/react"
 import { IconButton, Menu } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
@@ -13,6 +15,7 @@ import {
 import type { ResourceTableData } from "./types"
 import { MenuItem } from "~/components/Menu"
 import { moveResourceAtom } from "~/features/editing-experience/atoms"
+import { getLinkToResource } from "~/utils/resource"
 import { deleteResourceModalAtom, folderSettingsModalAtom } from "../../atoms"
 
 interface ResourceTableMenuProps {
@@ -22,6 +25,7 @@ interface ResourceTableMenuProps {
   permalink: ResourceTableData["permalink"]
   resourceType: ResourceTableData["type"]
   parentId: ResourceTableData["parentId"]
+  siteId: number
 }
 
 export const ResourceTableMenu = ({
@@ -31,12 +35,18 @@ export const ResourceTableMenu = ({
   permalink,
   resourceType,
   parentId,
+  siteId,
 }: ResourceTableMenuProps) => {
   const setMoveResource = useSetAtom(moveResourceAtom)
   const handleMoveResourceClick = () =>
     setMoveResource({ resourceId, title, permalink, parentId })
   const setResourceModalState = useSetAtom(deleteResourceModalAtom)
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
+
+  const linkToResourceSettings = useMemo(
+    () => `${getLinkToResource({ siteId, resourceId, type })}/settings`,
+    [siteId, resourceId, type],
+  )
 
   return (
     <Menu isLazy size="sm">
@@ -52,7 +62,12 @@ export const ResourceTableMenu = ({
           {/* TODO: Open edit modal depending on resource  */}
           {type === "Page" ? (
             <>
-              <MenuItem icon={<BiCog fontSize="1rem" />}>
+              <MenuItem
+                as={NextLink}
+                // @ts-expect-error type inconsistency with `as`
+                href={linkToResourceSettings}
+                icon={<BiCog fontSize="1rem" />}
+              >
                 Edit page settings
               </MenuItem>
               <MenuItem icon={<BiDuplicate fontSize="1rem" />}>

--- a/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
@@ -6,6 +6,7 @@ import { Link } from "@opengovsg/design-system-react"
 import { BiData, BiFile, BiFileBlank, BiFolder, BiHome } from "react-icons/bi"
 
 import type { ResourceTableData } from "./types"
+import { getLinkToResource } from "~/utils/resource"
 
 export interface TitleCellProps
   extends Pick<ResourceTableData, "title" | "permalink" | "type" | "id"> {
@@ -20,16 +21,7 @@ export const TitleCell = ({
   id,
 }: TitleCellProps): JSX.Element => {
   const linkToResource: string = useMemo(() => {
-    switch (type) {
-      case "RootPage":
-      case "CollectionPage":
-      case "Page":
-        return `/sites/${siteId}/pages/${id}`
-      case "Folder":
-        return `/sites/${siteId}/folders/${id}`
-      case "Collection":
-        return `/sites/${siteId}/collections/${id}`
-    }
+    return getLinkToResource({ resourceId: id, siteId, type })
   }, [id, siteId, type])
 
   const ResourceTypeIcon: IconType = useMemo(() => {

--- a/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
@@ -1,14 +1,15 @@
 import Link from "next/link"
+import { useRouter } from "next/router"
 import {
   BreadcrumbItem,
   BreadcrumbLink,
   Flex,
   Skeleton,
-  TabList,
   Text,
 } from "@chakra-ui/react"
-import { Breadcrumb, Tab } from "@opengovsg/design-system-react"
+import { Breadcrumb } from "@opengovsg/design-system-react"
 
+import { TabLink } from "~/components/TabLink"
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { getResourceSubpath } from "~/utils/resource"
@@ -94,6 +95,8 @@ const NavigationBreadcrumbs = ({
 export const SiteEditNavbar = (): JSX.Element => {
   const { siteId, pageId } = useQueryParse(editPageSchema)
 
+  const { pathname } = useRouter()
+
   return (
     <Flex flex="0 0 auto" gridColumn="1/-1">
       <Flex
@@ -117,10 +120,20 @@ export const SiteEditNavbar = (): JSX.Element => {
           pageId={String(pageId)}
         />
 
-        <TabList>
-          <Tab>Edit</Tab>
-          <Tab>Page Settings</Tab>
-        </TabList>
+        <Flex gap="2rem">
+          <TabLink
+            isActive={pathname === "/sites/[siteId]/pages/[pageId]"}
+            href={`/sites/${siteId}/pages/${pageId}`}
+          >
+            Edit
+          </TabLink>
+          <TabLink
+            isActive={pathname === "/sites/[siteId]/pages/[pageId]/settings"}
+            href={`/sites/${siteId}/pages/${pageId}/settings`}
+          >
+            Page Settings
+          </TabLink>
+        </Flex>
         {pageId && siteId && (
           <Flex justifyContent={"end"} alignItems={"center"} flex={1}>
             <PublishButton pageId={pageId} siteId={siteId} />

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,20 +1,6 @@
-import {
-  Box,
-  Flex,
-  Grid,
-  GridItem,
-  TabPanel,
-  TabPanels,
-  Text,
-  VStack,
-} from "@chakra-ui/react"
-import { Infobox, Input, useToast } from "@opengovsg/design-system-react"
-import { ResourceType } from "~prisma/generated/generatedEnums"
-import { isEmpty, merge } from "lodash"
-import { Controller } from "react-hook-form"
-import { BiLink } from "react-icons/bi"
+import { Flex, Grid, GridItem } from "@chakra-ui/react"
+import merge from "lodash/merge"
 
-import type { RouterOutput } from "~/utils/trpc"
 import {
   EditorDrawerProvider,
   useEditorDrawerContext,
@@ -22,23 +8,16 @@ import {
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
 import Preview from "~/features/editing-experience/components/Preview"
 import { PreviewIframe } from "~/features/editing-experience/components/PreviewIframe"
-import { generateResourceUrl } from "~/features/editing-experience/components/utils"
 import { editPageSchema } from "~/features/editing-experience/schema"
 import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { useZodForm } from "~/lib/form"
-import {
-  MAX_PAGE_URL_LENGTH,
-  MAX_TITLE_LENGTH,
-  pageSettingsSchema,
-} from "~/schemas/page"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
 
 function EditPage(): JSX.Element {
   const { pageId, siteId } = useQueryParse(editPageSchema)
 
-  const [{ content: page, type, title, updatedAt }] =
+  const [{ content: page, type, updatedAt, title }] =
     trpc.page.readPageAndBlob.useSuspenseQuery(
       {
         pageId,
@@ -56,36 +35,22 @@ function EditPage(): JSX.Element {
   )
 
   return (
-    <TabPanels _dark={{ color: "white" }}>
-      <TabPanel height="full">
-        <EditorDrawerProvider
-          initialPageState={page}
-          type={type}
-          permalink={permalink}
-          siteId={siteId}
-          pageId={pageId}
-          updatedAt={updatedAt}
-        >
-          <PageEditingView title={title} />
-        </EditorDrawerProvider>
-      </TabPanel>
-      <TabPanel>
-        <PageSettings
-          type={type}
-          permalink={permalink.split("/").at(-1) || "/"}
-          prefix={permalink.split("/").slice(0, -1).join("/")}
-          title={title}
-        />
-      </TabPanel>
-    </TabPanels>
+    <EditorDrawerProvider
+      initialPageState={page}
+      type={type}
+      permalink={permalink}
+      siteId={siteId}
+      pageId={pageId}
+      updatedAt={updatedAt}
+      title={title}
+    >
+      <PageEditingView />
+    </EditorDrawerProvider>
   )
 }
 
-interface PageEditingViewProps {
-  title: string
-}
-const PageEditingView = ({ title }: PageEditingViewProps) => {
-  const { previewPageState, permalink, siteId, pageId, updatedAt } =
+const PageEditingView = () => {
+  const { previewPageState, permalink, siteId, pageId, updatedAt, title } =
     useEditorDrawerContext()
   const themeCssVars = useSiteThemeCssVars({ siteId })
 
@@ -123,153 +88,6 @@ const PageEditingView = ({ title }: PageEditingViewProps) => {
         </Flex>
       </GridItem>
     </Grid>
-  )
-}
-
-const THREE_SECONDS_IN_MS = 3000
-const SUCCESS_TOAST_ID = "save-page-settings-success"
-
-interface PageSettingsProps {
-  permalink: RouterOutput["page"]["readPageAndBlob"]["permalink"]
-  title: RouterOutput["page"]["readPageAndBlob"]["title"]
-  type: RouterOutput["page"]["readPageAndBlob"]["type"]
-  prefix?: string
-}
-const PageSettings = ({
-  permalink: originalPermalink,
-  type,
-  title: originalTitle,
-  prefix,
-}: PageSettingsProps) => {
-  const { pageId, siteId } = useQueryParse(editPageSchema)
-  const { register, watch, control, reset, handleSubmit, formState } =
-    useZodForm({
-      schema: pageSettingsSchema.omit({ pageId: true, siteId: true }),
-      defaultValues: {
-        title: originalTitle || "",
-        permalink: originalPermalink || "",
-      },
-    })
-
-  const [title, permalink] = watch(["title", "permalink"])
-
-  const toast = useToast({ duration: THREE_SECONDS_IN_MS, isClosable: true })
-  const utils = trpc.useUtils()
-
-  const updatePageSettingsMutation = trpc.page.updateSettings.useMutation({
-    onSuccess: async () => {
-      // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
-      await utils.page.readPageAndBlob.invalidate()
-      await utils.page.readPage.invalidate()
-      await utils.page.getFullPermalink.invalidate()
-      if (!toast.isActive(SUCCESS_TOAST_ID)) {
-        toast({
-          id: SUCCESS_TOAST_ID,
-          title: "Saved page settings",
-          description: "Publish this page for your changes to go live.",
-          status: "success",
-        })
-      }
-    },
-    onError: (error) => {
-      toast({
-        title: "Failed to save page settings",
-        description: error.message,
-        status: "error",
-      })
-    },
-  })
-
-  const onSubmit = handleSubmit((values) => {
-    if (!isEmpty(formState.dirtyFields)) {
-      updatePageSettingsMutation.mutate(
-        { pageId, siteId, ...values },
-        {
-          onSuccess: () => reset(values),
-        },
-      )
-    }
-  })
-
-  const fullPermalink =
-    type === ResourceType.RootPage ? "/" : `${prefix}/${permalink}`
-
-  return (
-    <form onBlur={onSubmit}>
-      <Grid w="100vw" my="3rem" templateColumns="repeat(4, 1fr)">
-        <GridItem colSpan={1}></GridItem>
-        <GridItem colSpan={2}>
-          <VStack w="100%" gap="2rem" alignItems="flex-start">
-            <Box>
-              <Text as="h3" textStyle="h3-semibold">
-                Page settings
-              </Text>
-              <Text textStyle="body-2" mt="0.5rem">
-                These settings will only affect this page. Publish the page to
-                make these changes live.
-              </Text>
-            </Box>
-            <Box w="full">
-              <Text textStyle="subhead-1">Page URL</Text>
-              <Controller
-                control={control}
-                name="permalink"
-                render={({ field: { onChange, ...field } }) => (
-                  <Input
-                    mt="0.5rem"
-                    isDisabled={type === ResourceType.RootPage}
-                    placeholder="URL will be autopopulated if left untouched"
-                    noOfLines={1}
-                    w="100%"
-                    {...field}
-                    onChange={(e) => {
-                      onChange(
-                        generateResourceUrl(e.target.value).slice(
-                          0,
-                          MAX_PAGE_URL_LENGTH,
-                        ),
-                      )
-                    }}
-                  />
-                )}
-              />
-              <Infobox
-                mt="0.5rem"
-                icon={<BiLink />}
-                variant="info-secondary"
-                size="sm"
-              >
-                <Text noOfLines={1} textStyle="subhead-2">
-                  {fullPermalink}
-                </Text>
-              </Infobox>
-              <Text mt="0.5rem" textColor="base.content.medium">
-                {MAX_PAGE_URL_LENGTH - permalink.length} characters left
-              </Text>
-            </Box>
-            <Box w="full">
-              <Text textStyle="subhead-1">Page title</Text>
-              <Text textStyle="body-2" mt="0.25rem">
-                By default, this is the title of your your page. Edit this if
-                you want to show a different title on search engines.
-              </Text>
-              <Input
-                w="100%"
-                noOfLines={1}
-                maxLength={MAX_TITLE_LENGTH}
-                isDisabled={type === ResourceType.RootPage}
-                {...register("title")}
-                mt="0.5rem"
-              />
-              <Text mt="0.5rem" textColor="base.content.medium">
-                {MAX_TITLE_LENGTH - title.length} characters left
-              </Text>
-            </Box>
-          </VStack>
-        </GridItem>
-        <GridItem colSpan={1}></GridItem>
-      </Grid>
-    </form>
   )
 }
 

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -93,6 +93,7 @@ const PageSettings = () => {
       // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
       await utils.page.readPageAndBlob.invalidate()
       await utils.page.readPage.invalidate()
+      await utils.resource.getMetadataById.invalidate()
       if (toast.isActive(SUCCESS_TOAST_ID)) {
         toast.close(SUCCESS_TOAST_ID)
       }

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -1,0 +1,214 @@
+import { useMemo } from "react"
+import {
+  Box,
+  chakra,
+  FormControl,
+  Grid,
+  GridItem,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import {
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Infobox,
+  Input,
+  useToast,
+} from "@opengovsg/design-system-react"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { Controller } from "react-hook-form"
+import { BiLink } from "react-icons/bi"
+
+import { generateResourceUrl } from "~/features/editing-experience/components/utils"
+import { editPageSchema } from "~/features/editing-experience/schema"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { useZodForm } from "~/lib/form"
+import {
+  MAX_PAGE_URL_LENGTH,
+  MAX_TITLE_LENGTH,
+  pageSettingsSchema,
+} from "~/schemas/page"
+import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
+import { trpc } from "~/utils/trpc"
+
+const THREE_SECONDS_IN_MS = 3000
+const SUCCESS_TOAST_ID = "save-page-settings-success"
+
+const PageSettings = () => {
+  const { pageId, siteId } = useQueryParse(editPageSchema)
+  const [{ type, title: originalTitle }] =
+    trpc.page.readPageAndBlob.useSuspenseQuery(
+      {
+        pageId,
+        siteId,
+      },
+      { refetchOnWindowFocus: false },
+    )
+
+  const [permalinkTree] = trpc.page.getPermalinkTree.useSuspenseQuery(
+    {
+      pageId,
+      siteId,
+    },
+    { refetchOnWindowFocus: false },
+  )
+
+  const {
+    register,
+    watch,
+    control,
+    reset,
+    handleSubmit,
+    formState: { isDirty, errors },
+  } = useZodForm({
+    schema: pageSettingsSchema.omit({ pageId: true, siteId: true }),
+    defaultValues: {
+      title: originalTitle,
+      permalink: permalinkTree[permalinkTree.length - 1] || "/",
+    },
+  })
+
+  const [title, permalink] = watch(["title", "permalink"])
+
+  const permalinksToRender = useMemo(() => {
+    if (permalinkTree.length === 0) {
+      return {
+        lastPermalink: "/",
+        parentPermalinks: "",
+      }
+    }
+
+    return {
+      permalink,
+      parentPermalinks: `/${permalinkTree.slice(0, -1).join("/")}/`,
+    }
+  }, [permalink, permalinkTree])
+
+  const toast = useToast({ duration: THREE_SECONDS_IN_MS, isClosable: true })
+  const utils = trpc.useUtils()
+
+  const updatePageSettingsMutation = trpc.page.updateSettings.useMutation({
+    onSuccess: async () => {
+      // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
+      await utils.page.readPageAndBlob.invalidate()
+      await utils.page.readPage.invalidate()
+      if (toast.isActive(SUCCESS_TOAST_ID)) {
+        toast.close(SUCCESS_TOAST_ID)
+      }
+      toast({
+        id: SUCCESS_TOAST_ID,
+        title: "Saved page settings",
+        description: "Publish this page for your changes to go live.",
+        status: "success",
+      })
+    },
+    onError: (error) => {
+      toast({
+        title: "Failed to save page settings",
+        description: error.message,
+        status: "error",
+      })
+    },
+  })
+
+  const onSubmit = handleSubmit((values) => {
+    if (isDirty) {
+      updatePageSettingsMutation.mutate(
+        { pageId, siteId, ...values },
+        {
+          onSuccess: () => reset(values),
+        },
+      )
+    }
+  })
+
+  return (
+    <form onBlur={onSubmit}>
+      <Grid w="100vw" my="3rem" templateColumns="repeat(4, 1fr)">
+        <GridItem colSpan={1}></GridItem>
+        <GridItem colSpan={2}>
+          <VStack w="100%" gap="2rem" alignItems="flex-start">
+            <Box>
+              <Text as="h3" textStyle="h3-semibold">
+                Page settings
+              </Text>
+              <Text textStyle="body-2" mt="0.5rem">
+                These settings will only affect this page. Publish the page to
+                make these changes live.
+              </Text>
+            </Box>
+            <FormControl isRequired isInvalid={!!errors.permalink}>
+              <FormLabel>Page URL</FormLabel>
+              <Controller
+                control={control}
+                name="permalink"
+                render={({ field: { onChange, ...field } }) => (
+                  <Input
+                    isDisabled={type === ResourceType.RootPage}
+                    placeholder="URL will be autopopulated if left untouched"
+                    noOfLines={1}
+                    mt="0.5rem"
+                    w="100%"
+                    {...field}
+                    onChange={(e) => {
+                      onChange(
+                        generateResourceUrl(e.target.value).slice(
+                          0,
+                          MAX_PAGE_URL_LENGTH,
+                        ),
+                      )
+                    }}
+                  />
+                )}
+              />
+              <Infobox
+                my="0.5rem"
+                icon={<BiLink />}
+                variant="info-secondary"
+                size="sm"
+              >
+                <Text noOfLines={1} textStyle="subhead-2">
+                  <chakra.span color="base.content.medium">
+                    {permalinksToRender.parentPermalinks}
+                  </chakra.span>
+                  {permalinksToRender.permalink}
+                </Text>
+              </Infobox>
+              <FormHelperText>
+                {MAX_PAGE_URL_LENGTH - permalink.length} characters left
+              </FormHelperText>
+              <FormErrorMessage>{errors.permalink?.message}</FormErrorMessage>
+            </FormControl>
+
+            <FormControl isRequired isInvalid={!!errors.title}>
+              <FormLabel
+                description="By default, this is the title of your your page. Edit this if
+                you want to show a different title on search engines."
+              >
+                Page title
+              </FormLabel>
+              <Input
+                w="100%"
+                noOfLines={1}
+                maxLength={MAX_TITLE_LENGTH}
+                isDisabled={type === ResourceType.RootPage}
+                {...register("title")}
+                mt="0.5rem"
+              />
+              <FormHelperText pt="0.5rem">
+                {MAX_TITLE_LENGTH - title.length} characters left
+              </FormHelperText>
+              <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+            </FormControl>
+          </VStack>
+        </GridItem>
+        <GridItem colSpan={1}></GridItem>
+      </Grid>
+    </form>
+  )
+}
+
+PageSettings.getLayout = PageEditingLayout
+
+export default PageSettings

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -102,9 +102,9 @@ const PageSettings = () => {
   const updatePageSettingsMutation = trpc.page.updateSettings.useMutation({
     onSuccess: async () => {
       // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
-      await utils.page.readPageAndBlob.invalidate()
-      await utils.page.readPage.invalidate()
-      await utils.resource.getMetadataById.invalidate()
+      await utils.page.invalidate()
+      await utils.resource.invalidate()
+      await utils.folder.invalidate()
       if (toast.isActive(SUCCESS_TOAST_ID)) {
         toast.close(SUCCESS_TOAST_ID)
       }

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -72,16 +72,27 @@ const PageSettings = () => {
   const [title, permalink] = watch(["title", "permalink"])
 
   const permalinksToRender = useMemo(() => {
-    if (permalinkTree.length === 0) {
+    // Case 1: Root page
+    if (permalinkTree.length === 0 || permalinkTree[0] === "") {
       return {
-        lastPermalink: "/",
+        permalink: "/",
         parentPermalinks: "",
       }
     }
 
+    const parentPermalinks = permalinkTree.slice(0, -1).join("/").trim()
+    // Case 2: Parent is root page
+    if (!parentPermalinks) {
+      return {
+        permalink,
+        parentPermalinks: "/",
+      }
+    }
+
+    // Default case: Nested page
     return {
       permalink,
-      parentPermalinks: `/${permalinkTree.slice(0, -1).join("/")}/`,
+      parentPermalinks: `/${parentPermalinks}/`,
     }
   }, [permalink, permalinkTree])
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -2,6 +2,7 @@ import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { schema } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import Ajv from "ajv"
+import { isEmpty } from "lodash"
 import isEqual from "lodash/isEqual"
 import { z } from "zod"
 
@@ -25,6 +26,7 @@ import {
   getNavBar,
   getPageById,
   getResourceFullPermalink,
+  getResourcePermalinkTree,
   updateBlobById,
   updatePageById,
 } from "../resource/resource.service"
@@ -325,5 +327,19 @@ export const pageRouter = router({
       }
 
       return permalink
+    }),
+  getPermalinkTree: protectedProcedure
+    .input(basePageSchema)
+    .query(async ({ input }) => {
+      const { pageId, siteId } = input
+      const permalinkTree = await getResourcePermalinkTree(siteId, pageId)
+      if (isEmpty(permalinkTree)) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "No permalink could be found for the given page",
+        })
+      }
+
+      return permalinkTree
     }),
 })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -373,12 +373,6 @@ export const getResourcePermalinkTree = async (
             // Recursive case: Get all the ancestors of the resource
             .selectFrom("Resource")
             .where("Resource.siteId", "=", siteId)
-            .where("Resource.type", "in", [
-              "Folder",
-              "Page",
-              "CollectionPage",
-              "RootPage",
-            ])
             .innerJoin("Ancestors", "Ancestors.parentId", "Resource.id")
             .select(defaultResourceSelect),
         ),

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1,4 +1,3 @@
-import type { IsomerSitemap } from "@opengovsg/isomer-components"
 import type { SelectExpression } from "kysely"
 import { type DB } from "~prisma/generated/generatedTypes"
 
@@ -357,12 +356,12 @@ export const getLocalisedSitemap = async (
   return getSitemapTree(rootResource, allResources)
 }
 
-export const getResourceFullPermalink = async (
+export const getResourcePermalinkTree = async (
   siteId: number,
   resourceId: number,
 ) => {
   const resourcePermalinks = await db
-    .withRecursive("ancestors", (eb) =>
+    .withRecursive("Ancestors", (eb) =>
       eb
         // Base case: Get the actual resource
         .selectFrom("Resource")
@@ -380,16 +379,23 @@ export const getResourceFullPermalink = async (
               "CollectionPage",
               "RootPage",
             ])
-            .innerJoin("ancestors", "ancestors.parentId", "Resource.id")
+            .innerJoin("Ancestors", "Ancestors.parentId", "Resource.id")
             .select(defaultResourceSelect),
         ),
     )
-    .selectFrom("ancestors")
-    .select("ancestors.permalink")
+    .selectFrom("Ancestors")
+    .select("Ancestors.permalink")
     .execute()
 
-  return `/${resourcePermalinks
-    .map((r) => r.permalink)
-    .reverse()
-    .join("/")}`
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return resourcePermalinks.map((r) => r.permalink).reverse() as string[]
+}
+
+export const getResourceFullPermalink = async (
+  siteId: number,
+  resourceId: number,
+) => {
+  const permalinkTree = await getResourcePermalinkTree(siteId, resourceId)
+
+  return `/${permalinkTree.join("/")}`
 }

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -39,6 +39,7 @@ const meta: Meta<typeof EditPage> = {
           siteId: "1",
           pageId: "1",
         },
+        pathname: "/sites/[siteId]/pages/[pageId]",
       },
     },
   },

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -39,6 +39,7 @@ const meta: Meta<typeof EditPage> = {
           siteId: "1",
           pageId: "1",
         },
+        pathname: "/sites/[siteId]/pages/[pageId]",
       },
     },
   },

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -39,6 +39,7 @@ const meta: Meta<typeof EditPage> = {
           siteId: "1",
           pageId: "1",
         },
+        pathname: "/sites/[siteId]/pages/[pageId]",
       },
     },
   },

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -36,7 +36,11 @@ type Story = StoryObj<typeof PageSettings>
 export const Root: Story = {
   parameters: {
     msw: {
-      handlers: [pageHandlers.getPermalinkTree.root(), ...COMMON_HANDLERS],
+      handlers: [
+        pageHandlers.getPermalinkTree.root(),
+        pageHandlers.readPageAndBlob.homepage(),
+        pageHandlers.readPage.homepage(),
+      ],
     },
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { pageHandlers } from "tests/msw/handlers/page"
+import { resourceHandlers } from "tests/msw/handlers/resource"
+
+import PageSettings from "~/pages/sites/[siteId]/pages/[pageId]/settings"
+
+const COMMON_HANDLERS = [
+  resourceHandlers.getMetadataById.content(),
+  pageHandlers.readPageAndBlob.content(),
+  pageHandlers.readPage.content(),
+]
+
+const meta: Meta<typeof PageSettings> = {
+  title: "Pages/Edit Page/Settings",
+  component: PageSettings,
+  parameters: {
+    getLayout: PageSettings.getLayout,
+    msw: {
+      handlers: COMMON_HANDLERS,
+    },
+    nextjs: {
+      router: {
+        query: {
+          siteId: "1",
+          pageId: "1",
+        },
+        pathname: "/sites/[siteId]/pages/[pageId]/settings",
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof PageSettings>
+
+export const Root: Story = {
+  parameters: {
+    msw: {
+      handlers: [pageHandlers.getPermalinkTree.root(), ...COMMON_HANDLERS],
+    },
+  },
+}
+
+export const WithParent: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.getPermalinkTree.withParent(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+}
+
+export const WithGrandparent: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.getPermalinkTree.withGrandParent(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+}

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -40,6 +40,7 @@ export const Root: Story = {
         pageHandlers.getPermalinkTree.root(),
         pageHandlers.readPageAndBlob.homepage(),
         pageHandlers.readPage.homepage(),
+        resourceHandlers.getMetadataById.homepage(),
       ],
     },
   },

--- a/apps/studio/src/utils/resource.ts
+++ b/apps/studio/src/utils/resource.ts
@@ -16,3 +16,15 @@ export const getResourceSubpath = (resourceType: ResourceType) => {
       return ""
   }
 }
+
+export const getLinkToResource = ({
+  siteId,
+  type,
+  resourceId,
+}: {
+  siteId: string | number
+  resourceId: string
+  type: ResourceType
+}) => {
+  return `/sites/${siteId}/${getResourceSubpath(type)}/${resourceId}`
+}

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -3,7 +3,6 @@ import { delay } from "msw"
 
 import type { getPageById } from "~/server/modules/resource/resource.service"
 import type { RouterOutput } from "~/utils/trpc"
-import { trpc } from "~/utils/trpc"
 import { trpcMsw } from "../mockTrpc"
 
 const getRootPageQuery = (wait?: DelayMode | number) => {
@@ -487,6 +486,20 @@ export const pageHandlers = {
     article: () =>
       trpcMsw.page.getFullPermalink.query(() => {
         return "/article-layout"
+      }),
+  },
+  getPermalinkTree: {
+    root: () =>
+      trpcMsw.page.getPermalinkTree.query(() => {
+        return [""]
+      }),
+    withParent: () =>
+      trpcMsw.page.getPermalinkTree.query(() => {
+        return ["newsroom", "collection-page"]
+      }),
+    withGrandParent: () =>
+      trpcMsw.page.getPermalinkTree.query(() => {
+        return ["newsroom", "collection-page", "sub-collection-page"]
       }),
   },
 }


### PR DESCRIPTION
### TL;DR

Added a new page settings view and improved navigation between edit and settings pages.

### What changed?

- Created a new `TabLink` component for consistent tab-like navigation
- Added a new `/settings` page for editing page settings
- Moved page settings form from the edit page to the new settings page
- Updated the `SiteEditNavbar` to use `TabLink` for navigation between edit and settings views
- Implemented `getResourcePermalinkTree` and `getPermalinkTree` API endpoints
- Updated resource utility functions for better link generation

### How to test?

1. Navigate to a page editing view
2. Verify that the "Edit" and "Page Settings" tabs are present and functional
3. Click on "Page Settings" to access the new settings page
4. Test editing page title and URL on the settings page
5. Verify that changes are saved and reflected in the UI
6. Test navigation between edit and settings views

### Why make this change?

This change improves the user experience by separating the page editing and settings functionalities into distinct views. It provides a cleaner interface for managing page settings and allows for easier navigation between editing content and modifying page metadata. The new structure also lays the groundwork for potential future expansions of page settings options.