### PR TITLE
feat: add first cut indices for resource table, unique constraint on permalinks

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -27,6 +27,7 @@
     "lint:fix": "eslint --fix",
     "typecheck": "tsc --noEmit",
     "migrate:dev": "prisma migrate dev",
+    "migrate:custom": "tsx prisma/custom/install.ts",
     "migrate": "prisma migrate deploy",
     "test": "run-s test:*",
     "test:unit": "dotenv -e .env.test vitest run",

--- a/apps/studio/prisma/custom/install.ts
+++ b/apps/studio/prisma/custom/install.ts
@@ -1,0 +1,74 @@
+import fs from "fs/promises"
+import path from "path"
+
+const __dirname = import.meta.dirname
+
+const NOW = new Date()
+
+const NOW_STRING =
+  String(NOW.getUTCFullYear()) +
+  String(NOW.getUTCMonth() + 1).padStart(2, "0") +
+  String(NOW.getUTCDate()).padStart(2, "0") +
+  String(NOW.getUTCHours()).padStart(2, "0") +
+  String(NOW.getUTCMinutes()).padStart(2, "0") +
+  String(NOW.getUTCSeconds()).padStart(2, "0")
+
+const PRISMA_MIGRATIONS_PATH = path.join(__dirname, "../migrations")
+const MIGRATION_FILE_NAME = "migration.sql"
+
+const MIGRATION_NAME = "custom_migration"
+
+const CUSTOM_MIGRATION_NAME = `${NOW_STRING}_${MIGRATION_NAME}`
+
+const CUSTOM_MIGRATIONS_RECORD = path.join(__dirname, MIGRATION_FILE_NAME)
+
+const custom = async () => {
+  const files = await fs.readdir(PRISMA_MIGRATIONS_PATH, {
+    withFileTypes: true,
+  })
+  const folders = files
+    .filter((file) => /^\d{14}_.+/.test(file.name) && file.isDirectory())
+    .filter((folder) => folder.name.includes(MIGRATION_NAME))
+
+  let statements = (await fs.readFile(CUSTOM_MIGRATIONS_RECORD))
+    .toString()
+    .split(";")
+    .map((statement) => statement.trim() + ";")
+    .filter((statement) => !!statement.length)
+
+  for (const folder of folders) {
+    const filePath = path.join(folder.path, folder.name, MIGRATION_FILE_NAME)
+
+    const file = await fs.readFile(filePath)
+
+    const fileStatements = file
+      .toString()
+      .split(";")
+      .map((statement) => statement.trim() + ";")
+      .filter((statement) => !!statement.length)
+
+    statements = statements.filter(
+      (statement) => !fileStatements.includes(statement),
+    )
+  }
+
+  if (!statements.length) {
+    console.log("All custom migrations are up to date.")
+    return
+  }
+
+  statements = statements.map((statement) => statement.trim() + "\n\n")
+
+  await fs.mkdir(path.join(PRISMA_MIGRATIONS_PATH, CUSTOM_MIGRATION_NAME))
+  await fs.writeFile(
+    path.join(
+      PRISMA_MIGRATIONS_PATH,
+      CUSTOM_MIGRATION_NAME,
+      MIGRATION_FILE_NAME,
+    ),
+    statements,
+  )
+  console.log("New custom migrations added.")
+}
+
+custom().catch((error) => console.error(error))

--- a/apps/studio/prisma/custom/migration.sql
+++ b/apps/studio/prisma/custom/migration.sql
@@ -1,0 +1,4 @@
+-- Override Prisma's unique index with unique NOT DISTINCT index
+DROP INDEX IF EXISTS "Resource_siteId_parentId_permalink_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Resource_siteId_parentId_permalink_key" ON "Resource"("siteId", "parentId", "permalink") NULLS NOT DISTINCT;

--- a/apps/studio/prisma/migrations/20240917043702_add_resource_indexes_and_unique/migration.sql
+++ b/apps/studio/prisma/migrations/20240917043702_add_resource_indexes_and_unique/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[siteId,parentId,permalink]` on the table `Resource` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE INDEX "Resource_siteId_idx" ON "Resource"("siteId");
+
+-- CreateIndex
+CREATE INDEX "Resource_siteId_id_idx" ON "Resource"("siteId", "id");
+
+-- CreateIndex
+CREATE INDEX "Resource_siteId_id_parentId_idx" ON "Resource"("siteId", "id", "parentId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Resource_siteId_parentId_permalink_key" ON "Resource"("siteId", "parentId", "permalink");

--- a/apps/studio/prisma/migrations/20240917045344_custom_migration/migration.sql
+++ b/apps/studio/prisma/migrations/20240917045344_custom_migration/migration.sql
@@ -1,0 +1,4 @@
+-- Override Prisma's unique index with unique NOT DISTINCT index
+DROP INDEX IF EXISTS "Resource_siteId_parentId_permalink_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Resource_siteId_parentId_permalink_key" ON "Resource"("siteId", "parentId", "permalink") NULLS NOT DISTINCT;

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -72,7 +72,10 @@ model Resource {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  @@unique([siteId, parentId, permalink], name: "unique_site_permalink")
+  // This unique index is subsequently replaced with a custom index that
+  // treats nulls as not distinct.
+  // This is required so prisma does not attempt to drop the custom index.
+  @@unique([siteId, parentId, permalink])
   @@index([siteId])
   @@index([siteId, id])
   @@index([siteId, id, parentId])

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -44,7 +44,7 @@ model Version {
   publishedBy String
   publisher   User       @relation(fields: [publishedBy], references: [id])
 
-  updatedAt   DateTime   @default(now()) @updatedAt
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Resource {
@@ -71,16 +71,21 @@ model Resource {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
+
+  @@unique([siteId, parentId, permalink], name: "unique_site_permalink")
+  @@index([siteId])
+  @@index([siteId, id])
+  @@index([siteId, id, parentId])
 }
 
 model Blob {
-  id            BigInt    @id @default(autoincrement())
+  id      BigInt @id @default(autoincrement())
   /// @kyselyType(PrismaJson.BlobJsonContent)
   /// [BlobJsonContent]
-  content       Json
+  content Json
 
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @default(now()) @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   draftResource Resource?
   version       Version?
@@ -106,8 +111,8 @@ model User {
   phone         String
   preferredName String?
 
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   permissions Permission[]
   siteMembers SiteMember[]
@@ -122,8 +127,8 @@ model Permission {
   user       User     @relation(fields: [userId], references: [id])
   role       RoleType
 
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @default(now()) @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   // Delete the row if either resource or user is deleted, default behavior cascade
 }
@@ -147,8 +152,8 @@ model Site {
   footer      Footer?
   codeBuildId String?
 
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @default(now()) @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 }
 
 model Navbar {

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
@@ -95,6 +95,17 @@ const useCreateCollectionPageWizardContext = ({
         onSuccess: ({ pageId }) => {
           void router.push(`/sites/${siteId}/pages/${pageId}`)
         },
+        onError: (error) => {
+          if (error.data?.code === "CONFLICT") {
+            formMethods.setError(
+              "permalink",
+              { message: error.message },
+              { shouldFocus: true },
+            )
+          } else {
+            console.error(error)
+          }
+        },
       },
     )
   })

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -96,6 +96,17 @@ const useCreatePageWizardContext = ({
         onSuccess: ({ pageId }) => {
           void router.push(`/sites/${siteId}/pages/${pageId}`)
         },
+        onError: (error) => {
+          if (error.data?.code === "CONFLICT") {
+            formMethods.setError(
+              "permalink",
+              { message: error.message },
+              { shouldFocus: true },
+            )
+          } else {
+            console.error(error)
+          }
+        },
       },
     )
   })

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -121,6 +121,7 @@ const PageSettings = () => {
         description: error.message,
         status: "error",
       })
+      reset()
     },
   })
 

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server"
+import { get } from "lodash"
 
 import { createCollectionSchema } from "~/schemas/collection"
 import { readFolderSchema } from "~/schemas/folder"
@@ -45,6 +46,15 @@ export const collectionRouter = router({
         })
         .returning(defaultCollectionSelect)
         .executeTakeFirstOrThrow()
+        .catch((err) => {
+          if (get(err, "code") === "23505") {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A resource with the same permalink already exists",
+            })
+          }
+          throw err
+        })
     }),
   createCollectionPage: protectedProcedure
     .input(createCollectionPageSchema)
@@ -81,6 +91,15 @@ export const collectionRouter = router({
           })
           .returning("Resource.id")
           .executeTakeFirstOrThrow()
+          .catch((err) => {
+            if (get(err, "code") === "23505") {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message: "A resource with the same permalink already exists",
+              })
+            }
+            throw err
+          })
         return addedResource
       })
       return { pageId: resource.id }

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,3 +1,6 @@
+import { TRPCError } from "@trpc/server"
+import { get } from "lodash"
+
 import {
   createFolderSchema,
   editFolderSchema,
@@ -20,6 +23,15 @@ export const folderRouter = router({
           parentId: parentFolderId ? String(parentFolderId) : null,
         })
         .executeTakeFirstOrThrow()
+        .catch((err) => {
+          if (get(err, "code") === "23505") {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A resource with the same permalink already exists",
+            })
+          }
+          throw err
+        })
       return { folderId: folder.insertId }
     }),
   getMetadata: protectedProcedure
@@ -50,5 +62,14 @@ export const folderRouter = router({
         })
         .returning(defaultFolderSelect)
         .execute()
+        .catch((err) => {
+          if (get(err, "code") === "23505") {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A resource with the same permalink already exists",
+            })
+          }
+          throw err
+        })
     }),
 })

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -2,8 +2,7 @@ import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { schema } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import Ajv from "ajv"
-import { isEmpty } from "lodash"
-import isEqual from "lodash/isEqual"
+import { get, isEmpty, isEqual } from "lodash"
 import { z } from "zod"
 
 import {
@@ -225,29 +224,40 @@ export const pageRouter = router({
         // TODO: Validate whether folderId actually is a folder instead of a page
         // TODO: Validate whether siteId is a valid site
         // TODO: Validate user has write-access to the site
-        const resource = await db.transaction().execute(async (tx) => {
-          const blob = await tx
-            .insertInto("Blob")
-            .values({
-              content: newPage,
-            })
-            .returning("Blob.id")
-            .executeTakeFirstOrThrow()
+        const resource = await db
+          .transaction()
+          .execute(async (tx) => {
+            const blob = await tx
+              .insertInto("Blob")
+              .values({
+                content: newPage,
+              })
+              .returning("Blob.id")
+              .executeTakeFirstOrThrow()
 
-          const addedResource = await tx
-            .insertInto("Resource")
-            .values({
-              title,
-              permalink,
-              siteId,
-              parentId: folderId ? String(folderId) : undefined,
-              draftBlobId: blob.id,
-              type: ResourceType.Page,
-            })
-            .returning("Resource.id")
-            .executeTakeFirstOrThrow()
-          return addedResource
-        })
+            const addedResource = await tx
+              .insertInto("Resource")
+              .values({
+                title,
+                permalink,
+                siteId,
+                parentId: folderId ? String(folderId) : undefined,
+                draftBlobId: blob.id,
+                type: ResourceType.Page,
+              })
+              .returning("Resource.id")
+              .executeTakeFirstOrThrow()
+            return addedResource
+          })
+          .catch((err) => {
+            if (get(err, "code") === "23505") {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message: "A page with the same permalink already exists",
+              })
+            }
+            throw err
+          })
         return { pageId: resource.id }
       },
     ),

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -253,7 +253,7 @@ export const pageRouter = router({
             if (get(err, "code") === "23505") {
               throw new TRPCError({
                 code: "CONFLICT",
-                message: "A page with the same permalink already exists",
+                message: "A resource with the same permalink already exists",
               })
             }
             throw err
@@ -322,6 +322,15 @@ export const pageRouter = router({
           "Resource.draftBlobId",
         ])
         .executeTakeFirstOrThrow()
+        .catch((err) => {
+          if (get(err, "code") === "23505") {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A resource with the same permalink already exists",
+            })
+          }
+          throw err
+        })
     },
   ),
   getFullPermalink: protectedProcedure


### PR DESCRIPTION
Has breaking changes!!!!

Also closes ISOM-1559

## Solution

**Breaking Changes**

- [x] Yes - this PR contains breaking changes

May fail to apply on any databases that has duplicate permalinks. 

**Improvements**:

- Added indices to the Resource table in the database schema to optimize query performance
- Created a unique constraint on the `siteId` and `permalink` columns of the Resource table
