### PR TITLE
chore(noIndex and meta): update copy and set noIndex to required

### DIFF
--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -25,7 +25,7 @@ const ISOMER_ADMINS = [
 const PAGE_BLOB: IsomerSchema = {
   version: "0.1.0",
   layout: "homepage",
-  page: {},
+  page: { noIndex: false },
   content: [
     {
       type: "hero",

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -79,7 +79,12 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
     renderer: () => null,
   },
 ]
-const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
+const ajv = new Ajv({
+  useDefaults: true,
+  allErrors: true,
+  strict: false,
+  logger: false,
+})
 
 interface FormBuilderProps<T> {
   schema: TSchema

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAnyOfControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAnyOfControl.tsx
@@ -84,7 +84,6 @@ export function JsonFormsAnyOfControl({
       <Box mt="1.25rem" _first={{ mt: 0 }}>
         <FormControl isRequired gap="0.5rem">
           <FormLabel description={description}>{label || "Variant"}</FormLabel>
-
           {schema.format === "radio" ? (
             <RadioGroup
               onChange={onChange}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -25,6 +25,7 @@ export function JsonFormsBooleanControl({
   path,
   description,
   schema,
+  required,
 }: ControlProps): JSX.Element {
   if (schema.const !== undefined) {
     return <></>
@@ -32,7 +33,8 @@ export function JsonFormsBooleanControl({
 
   return (
     <Box mt="1.25rem" _first={{ mt: 0 }}>
-      <FormControl>
+      {schema.required}
+      <FormControl isRequired={required}>
         <FormLabel description={description} htmlFor={id}>
           {label}
         </FormLabel>

--- a/apps/studio/src/features/editing-experience/data/articleLayoutPreview.json
+++ b/apps/studio/src/features/editing-experience/data/articleLayoutPreview.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "layout": "article",
   "page": {
+    "noIndex": false,
     "permalink": "/resources/newsroom/relevant-news/todays-news",
     "title": "Performance and Outlook of the Electronics Cluster in Singapore",
     "date": "15 Feb 2024",

--- a/apps/studio/src/features/editing-experience/data/collectionPdfPreview.json
+++ b/apps/studio/src/features/editing-experience/data/collectionPdfPreview.json
@@ -2,6 +2,7 @@
   "version": "0.1.0",
   "layout": "article",
   "page": {
+    "noIndex": false,
     "permalink": "/resources/newsroom/relevant-news/todays-news",
     "title": "Speech by Minister for Trade and Industry at the Committee of Supply Debate 2024",
     "date": "15 Feb 2024",

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -6,6 +6,7 @@ export const createCollectionPageJson = ({}: {
   return {
     layout: "article",
     page: {
+      noIndex: false,
       date: format(new Date(), "dd-MM-yyyy"),
       // TODO: this is actually supposed to be passed from the frontend
       // which is not done at present
@@ -28,6 +29,7 @@ export const createCollectionPdfJson = ({
   return {
     layout: "content",
     page: {
+      noIndex: false,
       contentPageHeader: {
         summary: "",
       },

--- a/apps/studio/src/server/modules/page/page.service.ts
+++ b/apps/studio/src/server/modules/page/page.service.ts
@@ -12,6 +12,7 @@ export const createDefaultPage = ({
       const contentDefaultPage = {
         layout: "content",
         page: {
+          noIndex: false,
           contentPageHeader: {
             summary: "",
           },
@@ -26,6 +27,7 @@ export const createDefaultPage = ({
       const articleDefaultPage = {
         layout: "article",
         page: {
+          noIndex: false,
           date: format(new Date(), "dd-MM-yyyy"),
           category: "Feature Articles",
           articlePageHeader: {

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -95,6 +95,7 @@ export const Default: Story = {
       },
     },
     page: {
+      noIndex: false,
       title:
         "Singapore's Spectacular Citizens' Festival: a Celebration of Unity and Diversity",
       permalink:

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -228,6 +228,7 @@ const meta: Meta<CollectionPageSchemaType> = {
       },
     },
     page: {
+      noIndex: false,
       title: "Publications and other press releases",
       description: "A Next.js starter for Isomer",
       permalink: "/publications",

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -337,6 +337,7 @@ export const Default: Story = {
       },
     },
     page: {
+      noIndex: false,
       permalink: "/parent/rationality",
       lastModified: "2024-05-02T14:12:57.160Z",
       title:
@@ -1505,6 +1506,7 @@ export const NoTable: Story = {
       assetsBaseUrl: "https://cms.isomer.gov.sg",
     },
     page: {
+      noIndex: false,
       permalink: "/parent/rationality",
       title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
@@ -1915,6 +1917,7 @@ export const SmallTable: Story = {
       },
     },
     page: {
+      noIndex: false,
       permalink: "/parent/rationality",
       title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
@@ -2493,6 +2496,7 @@ export const FirstLevelPage: Story = {
       },
     },
     page: {
+      noIndex: false,
       permalink: "/content",
       title: "Content page",
       lastModified: "2024-05-02T14:12:57.160Z",

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -188,6 +188,7 @@ export const Default: Story = {
       },
     },
     page: {
+      noIndex: false,
       permalink: "/",
       lastModified: "2024-05-02T14:12:57.160Z",
       title: "Home page",

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
@@ -113,6 +113,7 @@ export const WithSiderail: Story = {
       },
     },
     page: {
+      noIndex: false,
       permalink: "/parent/rationality",
       title: "Index page",
       lastModified: "2024-05-02T14:12:57.160Z",
@@ -251,6 +252,7 @@ export const NoSiderail: Story = {
     },
     page: {
       permalink: "/parent",
+      noIndex: false,
       title: "Index page",
       lastModified: "2024-05-02T14:12:57.160Z",
       description: "A Next.js starter for Isomer",

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
@@ -53,6 +53,7 @@ export const Default: Story = {
     },
     page: {
       title: "Search",
+      noIndex: false,
       description: "Search results",
       permalink: "/404.html",
       lastModified: "2024-05-02T14:12:57.160Z",

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -74,6 +74,7 @@ export const SearchSG: Story = {
       },
     },
     page: {
+      noIndex: false,
       title: "Search",
       description: "Search results",
       permalink: "/search",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -16,13 +16,12 @@ const BaseItemSchema = Type.Object({
 const BasePageSchema = Type.Composite([
   BaseItemSchema,
   Type.Object({
-    noIndex: Type.Optional(
-      Type.Boolean({
-        description:
-          "If this is turned on, the page won't appear on Google search results.",
-        title: "Prevent search engines from indexing this page?",
-      }),
-    ),
+    noIndex: Type.Boolean({
+      description:
+        "If this is turned on, the page won't appear on Google search results.",
+      title: "Prevent search engines from indexing this page?",
+      default: false,
+    }),
   }),
 ])
 

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -6,8 +6,9 @@ import { ArticlePageHeaderSchema, ContentPageHeaderSchema } from "~/interfaces"
 const BaseItemSchema = Type.Object({
   description: Type.Optional(
     Type.String({
-      title: "Page description",
-      description: "The summary of the page for SEO purposes",
+      title: "Meta description",
+      description:
+        "This is a description that appears on search engine results.",
     }),
   ),
 })
@@ -15,11 +16,11 @@ const BaseItemSchema = Type.Object({
 const BasePageSchema = Type.Composite([
   BaseItemSchema,
   Type.Object({
-    noIndex: Type.Optional(
-      Type.Boolean({
-        description: "Whether to exclude the page from search engine indexing",
-      }),
-    ),
+    noIndex: Type.Boolean({
+      description:
+        "If this is turned on, the page won't appear on Google search results.",
+      title: "Prevent search engines from indexing this page?",
+    }),
   }),
 ])
 

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -16,11 +16,13 @@ const BaseItemSchema = Type.Object({
 const BasePageSchema = Type.Composite([
   BaseItemSchema,
   Type.Object({
-    noIndex: Type.Boolean({
-      description:
-        "If this is turned on, the page won't appear on Google search results.",
-      title: "Prevent search engines from indexing this page?",
-    }),
+    noIndex: Type.Optional(
+      Type.Boolean({
+        description:
+          "If this is turned on, the page won't appear on Google search results.",
+        title: "Prevent search engines from indexing this page?",
+      }),
+    ),
   }),
 ])
 

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -62,6 +62,7 @@ const NotFound = () => {
         }}
         layout="notfound"
         page={{
+          noIndex: false,
           title: PAGE_TITLE,
           description: PAGE_DESCRIPTION,
           permalink: "/404.html",


### PR DESCRIPTION
## Problem
we want to update the copy for both components and also, set `noIndex` to becoming required

## Solution
1. update schema for pages so that `noIndex` is now a required property
2. various changes in our app so that we default to `noIndex: false` (previously was undefined)
3. update `ajv` instance to use `default` 

## Screenshots
<img width="488" alt="image" src="https://github.com/user-attachments/assets/0fe64fcb-9d8e-45ba-9314-1b4deef1245c">
