### PR TITLE
chore(arraycontrol): add extra tester so we have a renderer

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsArrayControl.tsx
@@ -15,6 +15,7 @@ import {
   createDefaultValue,
   findUISchema,
   isObjectArrayControl,
+  isPrimitiveArrayControl,
   rankWith,
   Resolve,
 } from "@jsonforms/core"
@@ -37,7 +38,9 @@ import DraggableDrawerButton from "./DraggableDrawerButton"
 
 export const jsonFormsArrayControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.ArrayControl,
-  isObjectArrayControl,
+  (uischema, schema, context) =>
+    isObjectArrayControl(uischema, schema, context) ||
+    isPrimitiveArrayControl(uischema, schema, context),
 )
 
 interface ComplexEditorNestedDrawerProps {


### PR DESCRIPTION
## Problem
Currently, when we have an article, theere is no applicable renderer for the heading as it is an array of primitives.

## Solution
1. add a or statement so that object or primitive arrays are both caught by this tester.

## Screenshots

https://github.com/user-attachments/assets/b28cdb7c-9b27-42d3-b81c-e244ef6ee671


## Note
pending design to confirm if this is what they want... 