### PR TITLE
refactor(table): use dropdown list for table

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -10,6 +10,7 @@ import {
   BiStrikethrough,
   BiTable,
   BiUnderline,
+  BiWrench,
 } from "react-icons/bi"
 import { MdSubscript, MdSuperscript } from "react-icons/md"
 
@@ -116,78 +117,71 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         },
         isActive: () => editor.isActive("table"),
       },
-
-      // Table-specific commands
       {
-        type: "divider",
+        type: "horizontal-list",
+        label: "Table",
+        defaultIcon: BiWrench,
         isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddColRight} />,
-        title: "Add column after",
-        action: () => editor.chain().focus().addColumnAfter().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddColLeft} />,
-        title: "Add column before",
-        action: () => editor.chain().focus().addColumnBefore().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconDelCol} />,
-        title: "Delete column",
-        action: () => editor.chain().focus().deleteColumn().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddRowAbove} />,
-        title: "Add row before",
-        action: () => editor.chain().focus().addRowBefore().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddRowBelow} />,
-        title: "Add row after",
-        action: () => editor.chain().focus().addRowAfter().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconDelRow} />,
-        title: "Delete row",
-        action: () => editor.chain().focus().deleteRow().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "divider",
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconMergeCells} />,
-        title: "Merge cells",
-        action: () => editor.chain().focus().mergeCells().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconSplitCell} />,
-        title: "Split cell",
-        action: () => editor.chain().focus().splitCell().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: BiCog,
-        title: "Table settings",
-        action: onTableSettingsModalOpen,
-        isHidden: () => !editor.isActive("table"),
+        items: [
+          {
+            type: "item",
+            icon: () => (
+              <Icon color="base.content.medium" as={IconAddColRight} />
+            ),
+            title: "Add column after",
+            action: () => editor.chain().focus().addColumnAfter().run(),
+          },
+          {
+            type: "item",
+            icon: () => (
+              <Icon as={IconAddColLeft} color="base.content.medium" />
+            ),
+            title: "Add column before",
+            action: () => editor.chain().focus().addColumnBefore().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconDelCol} />,
+            title: "Delete column",
+            action: () => editor.chain().focus().deleteColumn().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconAddRowAbove} />,
+            title: "Add row before",
+            action: () => editor.chain().focus().addRowBefore().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconAddRowBelow} />,
+            title: "Add row after",
+            action: () => editor.chain().focus().addRowAfter().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconDelRow} />,
+            title: "Delete row",
+            action: () => editor.chain().focus().deleteRow().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconMergeCells} />,
+            title: "Merge cells",
+            action: () => editor.chain().focus().mergeCells().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconSplitCell} />,
+            title: "Split cell",
+            action: () => editor.chain().focus().splitCell().run(),
+          },
+          {
+            type: "item",
+            icon: BiCog,
+            title: "Table settings",
+            action: onTableSettingsModalOpen,
+          },
+        ],
       },
     ],
     [editor, onTableSettingsModalOpen],

--- a/apps/studio/src/components/PageEditor/MenuBar/MenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenuBar.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react"
+import { isHidden } from "@chakra-ui/utils"
 import { Button, Menu } from "@opengovsg/design-system-react"
 import { BiChevronDown, BiChevronUp } from "react-icons/bi"
 
@@ -158,7 +159,7 @@ export const MenuBar = ({ items }: { items: MenuBarEntry[] }) => {
             </Menu>
           )}
 
-          {item.type === "horizontal-list" && (
+          {item.type === "horizontal-list" && !item.isHidden?.() && (
             <Popover placement="bottom" key={index}>
               {({ isOpen }) => (
                 <>
@@ -189,7 +190,7 @@ export const MenuBar = ({ items }: { items: MenuBarEntry[] }) => {
                       </Button>
                     </HStack>
                   </PopoverTrigger>
-                  <PopoverContent w="5.75rem">
+                  <PopoverContent w="fit-content">
                     <PopoverBody>
                       <HStack>
                         {item.items.map((subItem) => (

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -10,6 +10,7 @@ import {
   BiStrikethrough,
   BiTable,
   BiUnderline,
+  BiWrench,
 } from "react-icons/bi"
 import { MdSubscript, MdSuperscript } from "react-icons/md"
 
@@ -167,75 +168,86 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
       },
       // Table-specific commands
       {
-        type: "divider",
+        type: "horizontal-list",
+        label: "Table",
+        defaultIcon: BiWrench,
         isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddColRight} />,
-        title: "Add column after",
-        action: () => editor.chain().focus().addColumnAfter().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddColLeft} />,
-        title: "Add column before",
-        action: () => editor.chain().focus().addColumnBefore().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconDelCol} />,
-        title: "Delete column",
-        action: () => editor.chain().focus().deleteColumn().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddRowAbove} />,
-        title: "Add row before",
-        action: () => editor.chain().focus().addRowBefore().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconAddRowBelow} />,
-        title: "Add row after",
-        action: () => editor.chain().focus().addRowAfter().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconDelRow} />,
-        title: "Delete row",
-        action: () => editor.chain().focus().deleteRow().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "divider",
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconMergeCells} />,
-        title: "Merge cells",
-        action: () => editor.chain().focus().mergeCells().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: () => <Icon as={IconSplitCell} />,
-        title: "Split cell",
-        action: () => editor.chain().focus().splitCell().run(),
-        isHidden: () => !editor.isActive("table"),
-      },
-      {
-        type: "item",
-        icon: BiCog,
-        title: "Table settings",
-        action: onTableSettingsModalOpen,
-        isHidden: () => !editor.isActive("table"),
+        items: [
+          {
+            type: "item",
+            icon: () => (
+              <Icon color="base.content.medium" as={RiLayoutColumnFill} />
+            ),
+            title: "Toggle header column",
+            action: () => editor.chain().focus().toggleHeaderColumn().run(),
+          },
+          {
+            type: "item",
+            icon: () => (
+              <Icon color="base.content.medium" as={RiLayoutRowFill} />
+            ),
+            title: "Toggle header row",
+            action: () => editor.chain().focus().toggleHeaderRow().run(),
+          },
+          {
+            type: "item",
+            icon: () => (
+              <Icon color="base.content.medium" as={IconAddColRight} />
+            ),
+            title: "Add column after",
+            action: () => editor.chain().focus().addColumnAfter().run(),
+          },
+          {
+            type: "item",
+            icon: () => (
+              <Icon as={IconAddColLeft} color="base.content.medium" />
+            ),
+            title: "Add column before",
+            action: () => editor.chain().focus().addColumnBefore().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconDelCol} />,
+            title: "Delete column",
+            action: () => editor.chain().focus().deleteColumn().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconAddRowAbove} />,
+            title: "Add row before",
+            action: () => editor.chain().focus().addRowBefore().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconAddRowBelow} />,
+            title: "Add row after",
+            action: () => editor.chain().focus().addRowAfter().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconDelRow} />,
+            title: "Delete row",
+            action: () => editor.chain().focus().deleteRow().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconMergeCells} />,
+            title: "Merge cells",
+            action: () => editor.chain().focus().mergeCells().run(),
+          },
+          {
+            type: "item",
+            icon: () => <Icon as={IconSplitCell} />,
+            title: "Split cell",
+            action: () => editor.chain().focus().splitCell().run(),
+          },
+          {
+            type: "item",
+            icon: BiCog,
+            title: "Table settings",
+            action: onTableSettingsModalOpen,
+          },
+        ],
       },
     ],
     [editor, onTableSettingsModalOpen],

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -176,22 +176,6 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
           {
             type: "item",
             icon: () => (
-              <Icon color="base.content.medium" as={RiLayoutColumnFill} />
-            ),
-            title: "Toggle header column",
-            action: () => editor.chain().focus().toggleHeaderColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={RiLayoutRowFill} />
-            ),
-            title: "Toggle header row",
-            action: () => editor.chain().focus().toggleHeaderRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
               <Icon color="base.content.medium" as={IconAddColRight} />
             ),
             title: "Add column after",


### PR DESCRIPTION
## Problem
took this up w/ sehyun separately because our table ui looks bad. in order to save space and avoid overflowing into 2 rows, our table is now a vertical list (similar to the ol/ul options)

## Solution
1. change the huge list of table into a vertical list for `Text` and `Accordion`. the other editors **do not** have tables allowed as a legal extension, so this doesn't apply.

## Screenshots

https://github.com/user-attachments/assets/a27dfad4-bc53-4c2d-a732-ce255dd2aa8d

## Notes
it looks better but each click now causes the dropdown to disappear. guess here is that users use this rarely, so we're ok with the dropdown menu but we'd benefit from testing this w/ our users