### PR TITLE
fix: crashes when there are other edits

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -20,6 +20,7 @@ export default function RootStateDrawer() {
     setDrawerState,
     setCurrActiveIdx,
     savedPageState,
+    previewPageState,
     setSavedPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
@@ -32,9 +33,15 @@ export default function RootStateDrawer() {
       // and the error type is automatically inferred from the zod validator.
       // However, the type that we use on `pageState` is the full type
       // because `Preview` (amongst other things) requires the other properties on the actual schema type
-      setPreviewPageState(variables.blocks)
+      setPreviewPageState((prevPreview) => ({
+        ...prevPreview,
+        content: variables.blocks,
+      }))
       // @ts-expect-error See above
-      setSavedPageState(variables.blocks)
+      setSavedPageState((prevSavedPageState) => ({
+        ...prevSavedPageState,
+        content: variables.blocks,
+      }))
       toast({
         title: "Failed to update blocks",
         description: error.message,


### PR DESCRIPTION
## Problem
previously, we crashed because we tried to read from undefined. this resulted because we did a bad `setState` when we failed.

we should not set the whole page state because it is the whole blob. since we send only the `content` (ie, the blocks) over to the backend, we should set only that key.

## Solution
1. set only the `content` key when we fail the mutation. this allows the toast to show and for the users to not lose data

## Screenshots

https://github.com/user-attachments/assets/77d3ce32-2c4e-4a9c-9380-7bf2d8876bf0

