### PR TITLE
fix: add missing format image for articles

### DIFF
--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -46,6 +46,7 @@ const BaseRefSchema = Type.Composite([
         src: Type.String({
           title: "Image source URL",
           description: "The source URL of the image",
+          format: "image",
         }),
         alt: Type.String({
           title: "Image alt text",
@@ -74,6 +75,7 @@ export const ArticlePageMetaSchema = Type.Composite([
         src: Type.String({
           title: "Image source URL",
           description: "The source URL of the image",
+          format: "image",
         }),
         alt: Type.String({
           title: "Image alt text",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We use `format: image` to determine if the image control should be rendered for Studio, but that is missing for article page header and the ref items.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add the `format: image` key in the schema for the article page header and the ref items schema.