### PR TITLE
fix: prevent empty image URL string

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -1,18 +1,4 @@
 import type { IsomerComponent } from "@opengovsg/isomer-components"
-import type { IconType } from "react-icons"
-import {
-  BiCard,
-  BiChevronDown,
-  BiColumns,
-  BiCrown,
-  BiHash,
-  BiImageAlt,
-  BiSolidQuoteAltLeft,
-  BiText,
-} from "react-icons/bi"
-
-import { ContentpicIcon } from "~/features/editing-experience/components/icons/Contentpic"
-import { TYPE_TO_ICON } from "~/features/editing-experience/constants"
 
 // TODO: add in default blocks for remaining
 export const DEFAULT_BLOCKS: Record<
@@ -65,7 +51,7 @@ export const DEFAULT_BLOCKS: Record<
   },
   image: {
     type: "image",
-    src: "",
+    src: "/placeholder_no_image.png",
     alt: "Add your alt text here",
     size: "default",
   },

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -114,6 +114,8 @@ export function JsonFormsImageControl({
               setPendingAsset(modifiedAsset)
               handleChange(path, modifiedAsset.blobUrl)
             } else {
+              handleChange(path, undefined)
+
               if (pendingAsset === undefined) {
                 return
               }
@@ -127,7 +129,6 @@ export function JsonFormsImageControl({
                 file: undefined,
                 blobUrl: undefined,
               })
-              handleChange(path, "")
             }
           }}
           onError={(error) => {

--- a/apps/studio/src/server/modules/page/page.service.ts
+++ b/apps/studio/src/server/modules/page/page.service.ts
@@ -14,7 +14,7 @@ export const createDefaultPage = ({
         page: {
           noIndex: false,
           contentPageHeader: {
-            summary: "",
+            summary: "This is the page summary",
           },
         },
         content: [],
@@ -31,7 +31,7 @@ export const createDefaultPage = ({
           date: format(new Date(), "dd-MM-yyyy"),
           category: "Feature Articles",
           articlePageHeader: {
-            summary: [],
+            summary: ["This is the page summary"],
           },
         },
         content: [],

--- a/packages/components/src/utils/isExternalUrl.ts
+++ b/packages/components/src/utils/isExternalUrl.ts
@@ -1,6 +1,7 @@
 // Determine if the provided URL is an external link
-export const isExternalUrl = (url: string) => {
+export const isExternalUrl = (url?: string) => {
   return (
+    !!url &&
     !url.startsWith("/") &&
     !url.startsWith("#") &&
     !url.startsWith("[resource:")


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1569.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Ensure that we set `undefined` rather than empty string, as an empty string is a valid value for the schema whereas undefined isn't.
- This also applies to the content/article page summary, otherwise the schema validation of the page will fail.