### PR TITLE
fix: make all images aware of assetsBaseUrl

### DIFF
--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -1,5 +1,5 @@
 import type { ImageProps } from "~/interfaces"
-import type { LinkComponentType } from "~/types"
+import type { IsomerSiteProps, LinkComponentType } from "~/types"
 
 export interface Tag {
   title: string
@@ -17,6 +17,7 @@ interface BaseCardProps {
   description: string
   image?: Pick<ImageProps, "src" | "alt">
   LinkComponent?: LinkComponentType
+  site: IsomerSiteProps
 }
 
 export interface ArticleCardProps extends BaseCardProps {

--- a/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
+++ b/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
@@ -2,7 +2,9 @@ import type { VariantProps } from "tailwind-variants"
 
 import type { ContentpicProps as BaseContentpicProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
+import { isExternalUrl } from "~/utils"
 import { Prose } from "../../native"
+import { ImageClient } from "../Image"
 
 const contentpicStyles = tv({
   slots: {
@@ -27,9 +29,21 @@ export const Contentpic = ({
   LinkComponent,
   site,
 }: ContentpicProps): JSX.Element => {
+  const imgSrc =
+    isExternalUrl(imageSrc) || site.assetsBaseUrl === undefined
+      ? imageSrc
+      : `${site.assetsBaseUrl}${imageSrc}`
+
   return (
     <div className={compoundStyles.container()}>
-      <img className={compoundStyles.image()} alt={imageAlt} src={imageSrc} />
+      <ImageClient
+        src={imgSrc}
+        alt={imageAlt || ""}
+        width="100%"
+        className={compoundStyles.image()}
+        assetsBaseUrl={site.assetsBaseUrl}
+      />
+
       <div className={compoundStyles.content()}>
         <Prose {...content} LinkComponent={LinkComponent} site={site} />
       </div>

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
@@ -1,5 +1,5 @@
 import type { HeroProps } from "~/interfaces/complex/Hero"
-import { getReferenceLinkHref } from "~/utils"
+import { getReferenceLinkHref, isExternalUrl } from "~/utils"
 import { ComponentContent } from "../../internal/customCssClass"
 import { LinkButton } from "../../internal/LinkButton/LinkButton"
 
@@ -14,11 +14,16 @@ const Hero = ({
   site,
   LinkComponent,
 }: HeroProps) => {
+  const backgroundSrc =
+    isExternalUrl(backgroundUrl) || site.assetsBaseUrl === undefined
+      ? backgroundUrl
+      : `${site.assetsBaseUrl}${backgroundUrl}`
+
   return (
     <section
       className="flex min-h-[15rem] bg-cover bg-center bg-no-repeat sm:min-h-[22.5rem] lg:min-h-[31.25rem]"
       style={{
-        backgroundImage: `url('${backgroundUrl}')`,
+        backgroundImage: `url('${backgroundSrc}')`,
       }}
     >
       <div className="w-full content-center bg-gradient-to-r from-[rgba(0,0,0,85%)] to-[rgba(0,0,0,10%)] xl:from-[rgba(0,0,0,100%)]">

--- a/packages/components/src/templates/next/components/complex/Image/Image.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
 import type { ImageProps } from "~/interfaces"
-import Image from "./Image"
+import { Image } from "./Image"
 
 const meta: Meta<ImageProps> = {
   title: "Next/Components/Image",

--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -4,7 +4,7 @@ import type { ImageProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { getReferenceLinkHref, isExternalUrl } from "~/utils"
 import { Link } from "../../internal/Link"
-import ImageClient from "./ImageClient"
+import { ImageClient } from "./ImageClient"
 
 const createImageStyles = tv({
   slots: {
@@ -58,7 +58,7 @@ const ImageContainer = ({
   </div>
 )
 
-const Image = ({
+export const Image = ({
   src,
   alt,
   caption,
@@ -89,5 +89,3 @@ const Image = ({
     </ImageContainer>
   )
 }
-
-export default Image

--- a/packages/components/src/templates/next/components/complex/Image/ImageClient.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/ImageClient.tsx
@@ -8,7 +8,7 @@ interface ImageClientProps {
   assetsBaseUrl?: string
 }
 
-const ImageClient = ({
+export const ImageClient = ({
   src,
   alt,
   width,
@@ -29,5 +29,3 @@ const ImageClient = ({
     />
   )
 }
-
-export default ImageClient

--- a/packages/components/src/templates/next/components/complex/Image/index.ts
+++ b/packages/components/src/templates/next/components/complex/Image/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./Image"
+export * from "./Image"
+export * from "./ImageClient"

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -9,10 +9,11 @@ import type {
   SingleCardWithImageProps,
 } from "~/interfaces/complex/InfoCards"
 import { tv } from "~/lib/tv"
-import { getReferenceLinkHref } from "~/utils"
+import { getReferenceLinkHref, isExternalUrl } from "~/utils"
 import { groupFocusVisibleHighlightNonRac } from "~/utils/rac"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
+import { ImageClient } from "../Image"
 
 const infoCardTitleStyle = tv({
   extend: groupFocusVisibleHighlightNonRac,
@@ -111,22 +112,32 @@ const InfoCardImage = ({
   imageAlt,
   imageFit,
   url,
+  site,
 }: Pick<
   SingleCardWithImageProps,
-  "imageUrl" | "imageAlt" | "url" | "imageFit"
->): JSX.Element => (
-  <div
-    className={compoundStyles.cardImageContainer({ isClickableCard: !!url })}
-  >
-    <img
-      src={imageUrl}
-      alt={imageAlt}
-      className={compoundStyles.cardImage({
-        imageFit,
-      })}
-    />
-  </div>
-)
+  "imageUrl" | "imageAlt" | "url" | "imageFit" | "site"
+>): JSX.Element => {
+  const imgSrc =
+    isExternalUrl(imageUrl) || site.assetsBaseUrl === undefined
+      ? imageUrl
+      : `${site.assetsBaseUrl}${imageUrl}`
+
+  return (
+    <div
+      className={compoundStyles.cardImageContainer({ isClickableCard: !!url })}
+    >
+      <ImageClient
+        src={imgSrc}
+        alt={imageAlt}
+        width="100%"
+        className={compoundStyles.cardImage({
+          imageFit,
+        })}
+        assetsBaseUrl={site.assetsBaseUrl}
+      />
+    </div>
+  )
+}
 
 const InfoCardText = ({
   title,
@@ -182,6 +193,7 @@ const InfoCardWithImage = ({
         imageUrl={imageUrl}
         imageAlt={imageAlt}
         url={url}
+        site={site}
       />
       <InfoCardText title={title} description={description} url={url} />
     </InfoCardContainer>

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -2,8 +2,9 @@ import type { VariantProps } from "tailwind-variants"
 
 import type { InfopicProps as BaseInfopicProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
-import { getReferenceLinkHref } from "~/utils"
+import { getReferenceLinkHref, isExternalUrl } from "~/utils"
 import { LinkButton } from "../../internal/LinkButton"
+import { ImageClient } from "../Image"
 
 const infopicStyles = tv({
   slots: {
@@ -54,6 +55,11 @@ export const Infopic = ({
   const compoundStyles = infopicStyles({ isTextOnRight })
   const hasLinkButton = buttonLabel && buttonUrl
 
+  const imgSrc =
+    isExternalUrl(imageSrc) || site.assetsBaseUrl === undefined
+      ? imageSrc
+      : `${site.assetsBaseUrl}${imageSrc}`
+
   return (
     <div className={compoundStyles.container()}>
       <div className={compoundStyles.content()}>
@@ -71,7 +77,13 @@ export const Infopic = ({
         )}
       </div>
       <div className={compoundStyles.imageContainer()}>
-        <img className={compoundStyles.image()} alt={imageAlt} src={imageSrc} />
+        <ImageClient
+          src={imgSrc}
+          alt={imageAlt || ""}
+          width="100%"
+          className={compoundStyles.image()}
+          assetsBaseUrl={site.assetsBaseUrl}
+        />
       </div>
     </div>
   )

--- a/packages/components/src/templates/next/components/complex/index.ts
+++ b/packages/components/src/templates/next/components/complex/index.ts
@@ -1,7 +1,7 @@
 export { default as Accordion } from "./Accordion"
 export { default as Callout } from "./Callout"
 export { default as Hero } from "./Hero"
-export { default as Image } from "./Image"
+export * from "./Image"
 export { default as Iframe } from "./Iframe"
 export { default as Infobar } from "./Infobar"
 export { default as InfoCards } from "./InfoCards"

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -16,6 +16,35 @@ const meta: Meta<CollectionCardProps> = {
     },
     chromatic: withChromaticModes(["desktop", "mobile"]),
   },
+  args: {
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        id: "1",
+        title: "Home",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [],
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      lastUpdated: "2021-10-01",
+      assetsBaseUrl: "https://cms.isomer.gov.sg",
+      navBarItems: [],
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+  },
 }
 export default meta
 type Story = StoryObj<typeof CollectionCard>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -4,7 +4,9 @@ import { composeRenderProps, Text } from "react-aria-components"
 
 import type { CollectionCardProps as BaseCollectionCardProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
+import { isExternalUrl } from "~/utils"
 import { focusVisibleHighlight } from "~/utils/rac"
+import { ImageClient } from "../../complex/Image"
 import { Link } from "../Link"
 
 type CollectionCardProps = BaseCollectionCardProps
@@ -22,10 +24,16 @@ export const CollectionCard = ({
   description,
   category,
   image,
+  site,
   ...props
 }: CollectionCardProps): JSX.Element => {
   const file = props.variant === "file" ? props.fileDetails : null
   const itemTitle = `${title}${file ? ` [${file.type.toUpperCase()}, ${file.size.toUpperCase()}]` : ""}`
+  const imgSrc =
+    isExternalUrl(image?.src) || site.assetsBaseUrl === undefined
+      ? image?.src
+      : `${site.assetsBaseUrl}${image?.src}`
+
   return (
     <div className="flex border-collapse flex-col gap-3 border-b border-divider-medium py-5 first:border-t lg:flex-row lg:gap-6">
       {lastUpdated && (
@@ -58,10 +66,12 @@ export const CollectionCard = ({
       </div>
       {image && (
         <div className="relative mt-3 h-[140px] w-full shrink-0 lg:ml-4 lg:mt-0 lg:h-auto lg:w-[320px]">
-          <img
-            className="absolute left-0 h-full w-full rounded object-cover"
-            src={image.src}
+          <ImageClient
+            src={imgSrc || ""}
             alt={image.alt}
+            width="100%"
+            className="absolute left-0 h-full w-full rounded object-cover"
+            assetsBaseUrl={site.assetsBaseUrl}
           />
         </div>
       )}

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -1,14 +1,18 @@
-import type { CollectionPageSchemaType, IsomerSitemap } from "~/engine"
+import type {
+  CollectionPageSchemaType,
+  IsomerSitemap,
+  IsomerSiteProps,
+} from "~/engine"
 import type { CollectionCardProps } from "~/interfaces"
 import { getBreadcrumbFromSiteMap, getSitemapAsArray } from "~/utils"
 import { Skeleton } from "../Skeleton"
 import CollectionClient from "./CollectionClient"
 
 const getCollectionItems = (
-  siteMap: IsomerSitemap,
+  site: IsomerSiteProps,
   permalink: string,
 ): CollectionCardProps[] => {
-  let currSitemap = siteMap
+  let currSitemap = site.siteMap
   const permalinkParts = permalink.split("/")
 
   for (let i = 2; i <= permalinkParts.length; i++) {
@@ -61,6 +65,7 @@ const getCollectionItems = (
         title: item.title,
         description: item.summary,
         image: item.image,
+        site,
       }
 
       if (item.layout === "file") {
@@ -102,9 +107,8 @@ const CollectionLayout = ({
   ScriptComponent,
 }: CollectionPageSchemaType) => {
   const { permalink } = page
-  const { siteMap } = site
 
-  const items = getCollectionItems(siteMap, permalink)
+  const items = getCollectionItems(site, permalink)
   const breadcrumb = getBreadcrumbFromSiteMap(
     site.siteMap,
     page.permalink.split("/").slice(1),
@@ -121,8 +125,9 @@ const CollectionLayout = ({
       <CollectionClient
         page={page}
         breadcrumb={breadcrumb}
-        LinkComponent={LinkComponent}
         items={items}
+        LinkComponent={LinkComponent}
+        site={site}
       />
     </Skeleton>
   )

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -17,9 +17,10 @@ import { ITEMS_PER_PAGE, useCollection } from "./useCollection"
 
 interface CollectionClientProps {
   page: CollectionPageSchemaType["page"]
-  LinkComponent: CollectionPageSchemaType["LinkComponent"]
   items: CollectionCardProps[]
   breadcrumb: BreadcrumbProps
+  LinkComponent: CollectionPageSchemaType["LinkComponent"]
+  site: CollectionPageSchemaType["site"]
 }
 
 const createCollectionLayoutStyles = tv({
@@ -43,9 +44,10 @@ const compoundStyles = createCollectionLayoutStyles()
 
 const CollectionClient = ({
   page,
-  LinkComponent,
   items,
   breadcrumb,
+  LinkComponent,
+  site,
 }: CollectionClientProps) => {
   const {
     filters,
@@ -118,6 +120,7 @@ const CollectionClient = ({
               searchValue={searchValue}
               totalCount={totalCount}
               LinkComponent={LinkComponent}
+              site={site}
             />
           </div>
           {paginatedItems.length > 0 && (

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -13,6 +13,7 @@ interface CollectionResultProps
     | "totalCount"
   > {
   LinkComponent: CollectionPageSchemaType["LinkComponent"]
+  site: CollectionPageSchemaType["site"]
 }
 
 export const CollectionResults = ({
@@ -23,6 +24,7 @@ export const CollectionResults = ({
   handleClearFilter,
   totalCount,
   LinkComponent,
+  site,
 }: CollectionResultProps) => {
   if (totalCount === 0) {
     return (
@@ -58,6 +60,7 @@ export const CollectionResults = ({
               key={Math.random()}
               {...item}
               LinkComponent={LinkComponent}
+              site={site}
             />
           ))}
         {paginatedItems.length === 0 && (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Not all the components that use image is aware of the `assetsBaseUrl`.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make all image usages aware of the `assetsBaseUrl`.