### PR TITLE
feat(studio): allow admins to change preview viewport size

### DIFF
--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -30,7 +30,7 @@ export const EditPagePreview = (): JSX.Element => {
         pt="1rem"
         overflowX="auto"
         height="100%"
-        justify="center"
+        justify="flex-start"
       >
         <PreviewIframe style={themeCssVars} viewport={viewport}>
           <Preview

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -69,7 +69,7 @@ export const EditPagePreview = (): JSX.Element => {
           pt="1rem"
           overflowX="auto"
           height="100%"
-          justify="flex-start"
+          width="100%"
           {...innerContainerProps}
         >
           <PreviewIframe style={themeCssVars} viewport={viewport}>

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react"
 import { Flex } from "@chakra-ui/react"
 import merge from "lodash/merge"
 
+import type { ViewportOptions } from "./IframeToolbar"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
+import { IframeToolbar } from "./IframeToolbar"
 import Preview from "./Preview"
 import { PreviewIframe } from "./PreviewIframe"
 
@@ -11,27 +14,39 @@ export const EditPagePreview = (): JSX.Element => {
     useEditorDrawerContext()
   const themeCssVars = useSiteThemeCssVars({ siteId })
 
+  const [selectedViewport, setSelectedViewport] =
+    useState<ViewportOptions>("responsive")
+
   return (
     <Flex
       shrink={0}
-      justify="flex-start"
-      px="2rem"
-      pb="2rem"
-      pt="1rem"
       bg="base.canvas.backdrop"
-      h="100%"
-      overflowX="auto"
+      height="100%"
+      flexDirection="column"
     >
-      <PreviewIframe style={themeCssVars}>
-        <Preview
-          {...merge(previewPageState, { page: { title } })}
-          siteId={siteId}
-          resourceId={pageId}
-          permalink={permalink}
-          lastModified={updatedAt}
-          version="0.1.0"
-        />
-      </PreviewIframe>
+      <IframeToolbar
+        selectedViewport={selectedViewport}
+        setSelectedViewport={setSelectedViewport}
+      />
+      <Flex
+        px="2rem"
+        pb="2rem"
+        pt="1rem"
+        overflowX="auto"
+        height="100%"
+        justify="center"
+      >
+        <PreviewIframe style={themeCssVars} viewport={selectedViewport}>
+          <Preview
+            {...merge(previewPageState, { page: { title } })}
+            siteId={siteId}
+            resourceId={pageId}
+            permalink={permalink}
+            lastModified={updatedAt}
+            version="0.1.0"
+          />
+        </PreviewIframe>
+      </Flex>
     </Flex>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -1,20 +1,37 @@
+import { Flex } from "@chakra-ui/react"
+import merge from "lodash/merge"
+
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
 import Preview from "./Preview"
 import { PreviewIframe } from "./PreviewIframe"
 
 export const EditPagePreview = (): JSX.Element => {
-  const { previewPageState, siteId, permalink } = useEditorDrawerContext()
+  const { previewPageState, pageId, updatedAt, siteId, permalink, title } =
+    useEditorDrawerContext()
   const themeCssVars = useSiteThemeCssVars({ siteId })
 
   return (
-    <PreviewIframe style={themeCssVars}>
-      <Preview
-        {...previewPageState}
-        siteId={siteId}
-        permalink={permalink}
-        version="0.1.0"
-      />
-    </PreviewIframe>
+    <Flex
+      shrink={0}
+      justify="flex-start"
+      px="2rem"
+      pb="2rem"
+      pt="1rem"
+      bg="base.canvas.backdrop"
+      h="100%"
+      overflowX="auto"
+    >
+      <PreviewIframe style={themeCssVars}>
+        <Preview
+          {...merge(previewPageState, { page: { title } })}
+          siteId={siteId}
+          resourceId={pageId}
+          permalink={permalink}
+          lastModified={updatedAt}
+          version="0.1.0"
+        />
+      </PreviewIframe>
+    </Flex>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -14,8 +14,7 @@ export const EditPagePreview = (): JSX.Element => {
     useEditorDrawerContext()
   const themeCssVars = useSiteThemeCssVars({ siteId })
 
-  const [selectedViewport, setSelectedViewport] =
-    useState<ViewportOptions>("responsive")
+  const [viewport, setViewport] = useState<ViewportOptions>("responsive")
 
   return (
     <Flex
@@ -24,10 +23,7 @@ export const EditPagePreview = (): JSX.Element => {
       height="100%"
       flexDirection="column"
     >
-      <IframeToolbar
-        selectedViewport={selectedViewport}
-        setSelectedViewport={setSelectedViewport}
-      />
+      <IframeToolbar viewport={viewport} setViewport={setViewport} />
       <Flex
         px="2rem"
         pb="2rem"
@@ -36,7 +32,7 @@ export const EditPagePreview = (): JSX.Element => {
         height="100%"
         justify="center"
       >
-        <PreviewIframe style={themeCssVars} viewport={selectedViewport}>
+        <PreviewIframe style={themeCssVars} viewport={viewport}>
           <Preview
             {...merge(previewPageState, { page: { title } })}
             siteId={siteId}

--- a/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPagePreview.tsx
@@ -46,7 +46,7 @@ export const EditPagePreview = (): JSX.Element => {
   const innerContainerProps: Partial<FlexProps> = useMemo(() => {
     if (viewport === "fullscreen") {
       return {
-        p: "1rem",
+        p: 0,
       }
     }
 

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -8,8 +8,8 @@ import {
   Portal,
   Text,
 } from "@chakra-ui/react"
-import { Button, Menu, TouchableTooltip } from "@opengovsg/design-system-react"
-import { BiPencil, BiShow } from "react-icons/bi"
+import { Button, Menu } from "@opengovsg/design-system-react"
+import { BiPencil, BiShow, BiX } from "react-icons/bi"
 
 export type ViewportOptions = "mobile" | "tablet" | "responsive" | "fullscreen"
 
@@ -26,28 +26,28 @@ export const IframeToolbar = ({
     switch (viewport) {
       case "mobile":
         return {
-          mode: "You’re in editing mode",
+          mode: "You’re in editing mode.",
           caption:
             "Use the dropdown to see what the page might look like for various devices.",
           viewport: "Mobile",
         }
       case "tablet":
         return {
-          mode: "You’re in editing mode",
+          mode: "You’re in editing mode.",
           caption:
             "Use the dropdown to see what the page might look like for various devices.",
           viewport: "Tablet",
         }
       case "responsive":
         return {
-          mode: "You’re in editing mode",
+          mode: "You’re in editing mode.",
           caption:
             "Use the dropdown to see what the page might look like for various devices.",
           viewport: "Default mode",
         }
       case "fullscreen":
         return {
-          mode: "You’re in full screen mode",
+          mode: "You’re in full screen preview mode.",
           caption:
             "If you adjust the size of this browser, you can see what the page looks like in different sizes.",
           viewport: "Full screen",
@@ -72,8 +72,18 @@ export const IframeToolbar = ({
           </Text>
           <Text textStyle="caption-2">{toolbarTextLabels.caption}</Text>
         </Flex>
-        <Menu size="sm" placement="bottom-end">
-          <TouchableTooltip label="Change preview viewport">
+        {viewport === "fullscreen" ? (
+          <Button
+            onClick={() => setViewport("responsive")}
+            variant="outline"
+            colorScheme="neutral"
+            size="sm"
+            leftIcon={<BiX fontSize="1.5rem" />}
+          >
+            Back to editing
+          </Button>
+        ) : (
+          <Menu size="sm" placement="bottom-end">
             <MenuButton
               as={Button}
               leftIcon={<BiPencil size="1rem" />}
@@ -82,45 +92,53 @@ export const IframeToolbar = ({
             >
               {toolbarTextLabels.viewport}
             </MenuButton>
-          </TouchableTooltip>
-          <Portal>
-            <Menu.List>
-              <MenuOptionGroup
-                value={viewport}
-                title="Viewport"
-                type="radio"
-                onChange={(nextValue) =>
-                  setViewport(nextValue as ViewportOptions)
-                }
-              >
-                <MenuItemOption value="responsive">
-                  <Text color="base.content.strong" textStyle="body-1">
-                    Fit to screen (default)
-                  </Text>
-                  <Text color="base.content.medium" textStyle="body-2">
-                    Editing mode
-                  </Text>
-                </MenuItemOption>
-                <MenuItemOption value="tablet">
-                  <Text color="base.content.strong" textStyle="body-1">
-                    Tablet
-                  </Text>
-                  <Text color="base.content.medium" textStyle="body-2">
-                    View how page would look like on a tablet screen
-                  </Text>
-                </MenuItemOption>
-                <MenuItemOption value="mobile">
-                  <Text color="base.content.strong" textStyle="body-1">
-                    Mobile
-                  </Text>
-                  <Text color="base.content.medium" textStyle="body-2">
-                    View how page would look like on a mobile screen
-                  </Text>
-                </MenuItemOption>
-              </MenuOptionGroup>
-            </Menu.List>
-          </Portal>
-        </Menu>
+            <Portal>
+              <Menu.List>
+                <MenuOptionGroup
+                  value={viewport}
+                  title="Viewport"
+                  type="radio"
+                  onChange={(nextValue) =>
+                    setViewport(nextValue as ViewportOptions)
+                  }
+                >
+                  <MenuItemOption value="responsive">
+                    <Text color="base.content.strong" textStyle="body-1">
+                      Fit to screen (default)
+                    </Text>
+                    <Text color="base.content.medium" textStyle="body-2">
+                      Editing mode
+                    </Text>
+                  </MenuItemOption>
+                  <MenuItemOption value="fullscreen">
+                    <Text color="base.content.strong" textStyle="body-1">
+                      Full screen
+                    </Text>
+                    <Text color="base.content.medium" textStyle="body-2">
+                      View this page in full-screen mode
+                    </Text>
+                  </MenuItemOption>
+                  <MenuItemOption value="tablet">
+                    <Text color="base.content.strong" textStyle="body-1">
+                      Tablet
+                    </Text>
+                    <Text color="base.content.medium" textStyle="body-2">
+                      View how page would look like on a tablet screen
+                    </Text>
+                  </MenuItemOption>
+                  <MenuItemOption value="mobile">
+                    <Text color="base.content.strong" textStyle="body-1">
+                      Mobile
+                    </Text>
+                    <Text color="base.content.medium" textStyle="body-2">
+                      View how page would look like on a mobile screen
+                    </Text>
+                  </MenuItemOption>
+                </MenuOptionGroup>
+              </Menu.List>
+            </Portal>
+          </Menu>
+        )}
       </Flex>
     </>
   )

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import {
+  Box,
   Flex,
   Icon,
   MenuButton,
@@ -64,14 +65,17 @@ export const IframeToolbar = ({
         align="center"
         justify="space-between"
         gap="1rem"
+        flexWrap="wrap"
       >
-        <Flex flexDirection="row" align="center" color="base.content.brand">
+        <Box color="base.content.brand">
           <Icon mr="0.25rem" aria-hidden as={BiShow} />
-          <Text mr="0.5rem" textStyle="caption-1">
+          <Text as="span" mr="0.5rem" textStyle="caption-1">
             {toolbarTextLabels.mode}
           </Text>
-          <Text textStyle="caption-2">{toolbarTextLabels.caption}</Text>
-        </Flex>
+          <Text as="span" textStyle="caption-2">
+            {toolbarTextLabels.caption}
+          </Text>
+        </Box>
         {viewport === "fullscreen" ? (
           <Button
             onClick={() => setViewport("responsive")}

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -18,16 +18,16 @@ import { RxDimensions } from "react-icons/rx"
 export type ViewportOptions = "desktop" | "mobile" | "tablet" | "responsive"
 
 interface IframeToolbarProps {
-  selectedViewport: ViewportOptions
-  setSelectedViewport: (viewport: ViewportOptions) => void
+  viewport: ViewportOptions
+  setViewport: (viewport: ViewportOptions) => void
 }
 
 export const IframeToolbar = ({
-  selectedViewport,
-  setSelectedViewport,
+  viewport,
+  setViewport,
 }: IframeToolbarProps): JSX.Element => {
   const viewportLabel = useMemo(() => {
-    switch (selectedViewport) {
+    switch (viewport) {
       case "desktop":
         return "(Desktop)"
       case "mobile":
@@ -37,7 +37,7 @@ export const IframeToolbar = ({
       default:
         return null
     }
-  }, [selectedViewport])
+  }, [viewport])
 
   return (
     <Toolbar size="xs" px="2rem">
@@ -52,7 +52,7 @@ export const IframeToolbar = ({
               size="xs"
               colorScheme="inverse"
               bg={
-                selectedViewport !== "responsive"
+                viewport !== "responsive"
                   ? "interaction.tinted.inverse.active"
                   : undefined
               }
@@ -65,11 +65,11 @@ export const IframeToolbar = ({
           <Portal>
             <Menu.List>
               <MenuOptionGroup
-                value={selectedViewport}
+                value={viewport}
                 title="Viewport"
                 type="radio"
                 onChange={(nextValue) =>
-                  setSelectedViewport(nextValue as ViewportOptions)
+                  setViewport(nextValue as ViewportOptions)
                 }
               >
                 <MenuItemOption value="responsive">Responsive</MenuItemOption>

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react"
 import {
-  Box,
   Flex,
   Icon,
   MenuButton,
@@ -67,15 +66,17 @@ export const IframeToolbar = ({
         gap="1rem"
         flexWrap="wrap"
       >
-        <Box color="base.content.brand">
-          <Icon mr="0.25rem" aria-hidden as={BiShow} />
-          <Text as="span" mr="0.5rem" textStyle="caption-1">
-            {toolbarTextLabels.mode}
-          </Text>
+        <Flex flexWrap="wrap" color="base.content.brand">
+          <Flex>
+            <Icon mr="0.25rem" aria-hidden as={BiShow} />
+            <Text as="span" mr="0.5rem" textStyle="caption-1">
+              {toolbarTextLabels.mode}
+            </Text>
+          </Flex>
           <Text as="span" textStyle="caption-2">
             {toolbarTextLabels.caption}
           </Text>
-        </Box>
+        </Flex>
         {viewport === "fullscreen" ? (
           <Button
             onClick={() => setViewport("responsive")}

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -1,21 +1,17 @@
 import { useMemo } from "react"
 import {
+  Flex,
+  Icon,
   MenuButton,
   MenuItemOption,
   MenuOptionGroup,
   Portal,
-  Spacer,
+  Text,
 } from "@chakra-ui/react"
-import {
-  Button,
-  Menu,
-  Toolbar,
-  ToolbarGroup,
-  TouchableTooltip,
-} from "@opengovsg/design-system-react"
-import { RxDimensions } from "react-icons/rx"
+import { Button, Menu, TouchableTooltip } from "@opengovsg/design-system-react"
+import { BiPencil, BiShow } from "react-icons/bi"
 
-export type ViewportOptions = "desktop" | "mobile" | "tablet" | "responsive"
+export type ViewportOptions = "mobile" | "tablet" | "responsive" | "fullscreen"
 
 interface IframeToolbarProps {
   viewport: ViewportOptions
@@ -26,40 +22,65 @@ export const IframeToolbar = ({
   viewport,
   setViewport,
 }: IframeToolbarProps): JSX.Element => {
-  const viewportLabel = useMemo(() => {
+  const toolbarTextLabels = useMemo(() => {
     switch (viewport) {
-      case "desktop":
-        return "(Desktop)"
       case "mobile":
-        return "(Mobile)"
+        return {
+          mode: "You’re in editing mode",
+          caption:
+            "Use the dropdown to see what the page might look like for various devices.",
+          viewport: "Mobile",
+        }
       case "tablet":
-        return "(Tablet)"
-      default:
-        return null
+        return {
+          mode: "You’re in editing mode",
+          caption:
+            "Use the dropdown to see what the page might look like for various devices.",
+          viewport: "Tablet",
+        }
+      case "responsive":
+        return {
+          mode: "You’re in editing mode",
+          caption:
+            "Use the dropdown to see what the page might look like for various devices.",
+          viewport: "Default mode",
+        }
+      case "fullscreen":
+        return {
+          mode: "You’re in full screen mode",
+          caption:
+            "If you adjust the size of this browser, you can see what the page looks like in different sizes.",
+          viewport: "Full screen",
+        }
     }
   }, [viewport])
 
   return (
-    <Toolbar size="xs" px="2rem">
-      <Spacer />
-      <ToolbarGroup>
+    <>
+      <Flex
+        bg="utility.feedback.info-subtle"
+        py="0.5rem"
+        px="1rem"
+        align="center"
+        justify="space-between"
+        gap="1rem"
+      >
+        <Flex flexDirection="row" align="center" color="base.content.brand">
+          <Icon mr="0.25rem" aria-hidden as={BiShow} />
+          <Text mr="0.5rem" textStyle="caption-1">
+            {toolbarTextLabels.mode}
+          </Text>
+          <Text textStyle="caption-2">{toolbarTextLabels.caption}</Text>
+        </Flex>
         <Menu size="sm" placement="bottom-end">
           <TouchableTooltip label="Change preview viewport">
             <MenuButton
               as={Button}
-              leftIcon={<RxDimensions size="1rem" />}
-              variant="clear"
+              leftIcon={<BiPencil size="1rem" />}
+              variant="outline"
               size="xs"
-              colorScheme="inverse"
-              bg={
-                viewport !== "responsive"
-                  ? "interaction.tinted.inverse.active"
-                  : undefined
-              }
-              layerStyle="focusRing.inverse"
-              iconSpacing={viewportLabel ? undefined : 0}
             >
-              {viewportLabel}
+              {toolbarTextLabels.viewport}
             </MenuButton>
           </TouchableTooltip>
           <Portal>
@@ -72,15 +93,35 @@ export const IframeToolbar = ({
                   setViewport(nextValue as ViewportOptions)
                 }
               >
-                <MenuItemOption value="responsive">Responsive</MenuItemOption>
-                <MenuItemOption value="desktop">Desktop</MenuItemOption>
-                <MenuItemOption value="tablet">Tablet</MenuItemOption>
-                <MenuItemOption value="mobile">Mobile</MenuItemOption>
+                <MenuItemOption value="responsive">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Fit to screen (default)
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    Editing mode
+                  </Text>
+                </MenuItemOption>
+                <MenuItemOption value="tablet">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Tablet
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    View how page would look like on a tablet screen
+                  </Text>
+                </MenuItemOption>
+                <MenuItemOption value="mobile">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Mobile
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    View how page would look like on a mobile screen
+                  </Text>
+                </MenuItemOption>
               </MenuOptionGroup>
             </Menu.List>
           </Portal>
         </Menu>
-      </ToolbarGroup>
-    </Toolbar>
+      </Flex>
+    </>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -1,0 +1,80 @@
+import { useMemo, useState } from "react"
+import {
+  MenuButton,
+  MenuItemOption,
+  MenuOptionGroup,
+  Portal,
+  Spacer,
+} from "@chakra-ui/react"
+import {
+  Button,
+  Menu,
+  Toolbar,
+  ToolbarGroup,
+  TouchableTooltip,
+} from "@opengovsg/design-system-react"
+import { RxDimensions } from "react-icons/rx"
+
+type ViewportOptions = "desktop" | "mobile" | "tablet" | "unset"
+
+export const IframeToolbar = (): JSX.Element => {
+  const [selectedViewport, setSelectedViewport] =
+    useState<ViewportOptions>("unset")
+
+  const viewportLabel = useMemo(() => {
+    switch (selectedViewport) {
+      case "desktop":
+        return "(Desktop)"
+      case "mobile":
+        return "(Mobile)"
+      case "tablet":
+        return "(Tablet)"
+      default:
+        return null
+    }
+  }, [selectedViewport])
+
+  return (
+    <Toolbar size="xs" px="2rem">
+      <Spacer />
+      <ToolbarGroup>
+        <Menu size="sm" placement="bottom-end">
+          <TouchableTooltip label="Change preview viewport">
+            <MenuButton
+              as={Button}
+              leftIcon={<RxDimensions size="1rem" />}
+              variant="clear"
+              size="xs"
+              colorScheme="inverse"
+              bg={
+                selectedViewport !== "unset"
+                  ? "interaction.tinted.inverse.active"
+                  : undefined
+              }
+              layerStyle="focusRing.inverse"
+              iconSpacing={viewportLabel ? undefined : 0}
+            >
+              {viewportLabel}
+            </MenuButton>
+          </TouchableTooltip>
+          <Portal>
+            <Menu.List>
+              <MenuOptionGroup
+                value={selectedViewport}
+                title="Viewport"
+                type="radio"
+                onChange={(nextValue) =>
+                  setSelectedViewport(nextValue as ViewportOptions)
+                }
+              >
+                <MenuItemOption value="unset">Unset</MenuItemOption>
+                <MenuItemOption value="desktop">Desktop</MenuItemOption>
+                <MenuItemOption value="mobile">Mobile</MenuItemOption>
+              </MenuOptionGroup>
+            </Menu.List>
+          </Portal>
+        </Menu>
+      </ToolbarGroup>
+    </Toolbar>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -2,14 +2,13 @@ import { useMemo } from "react"
 import {
   Flex,
   Icon,
-  MenuButton,
   MenuItemOption,
   MenuOptionGroup,
   Portal,
   Text,
 } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
-import { BiPencil, BiShow, BiX } from "react-icons/bi"
+import { BiShow, BiX } from "react-icons/bi"
 
 export type ViewportOptions = "mobile" | "tablet" | "responsive" | "fullscreen"
 
@@ -55,96 +54,105 @@ export const IframeToolbar = ({
     }
   }, [viewport])
 
+  const containerStyles = useMemo(() => {
+    if (viewport === "fullscreen") {
+      return {
+        borderBottom: "1px solid",
+        borderColor: "base.divider.medium",
+      }
+    }
+    return {
+      mx: "2rem",
+      mt: "1rem",
+      borderRadius: "8px",
+      border: "1px solid",
+      borderColor: "interaction.main-subtle.default",
+    }
+  }, [viewport])
+
   return (
-    <>
-      <Flex
-        bg="utility.feedback.info-subtle"
-        py="0.5rem"
-        px="1rem"
-        align="center"
-        justify="space-between"
-        gap="1rem"
-        flexWrap="wrap"
-      >
-        <Flex flexWrap="wrap" color="base.content.brand">
-          <Flex>
-            <Icon mr="0.25rem" aria-hidden as={BiShow} />
-            <Text as="span" mr="0.5rem" textStyle="caption-1">
-              {toolbarTextLabels.mode}
-            </Text>
-          </Flex>
-          <Text as="span" textStyle="caption-2">
-            {toolbarTextLabels.caption}
+    <Flex
+      bg="utility.feedback.info-subtle"
+      py="0.5rem"
+      px="1rem"
+      align="center"
+      justify="space-between"
+      columnGap="1rem"
+      flexWrap="wrap"
+      {...containerStyles}
+    >
+      <Flex flexWrap="wrap">
+        <Flex>
+          <Icon mr="0.25rem" aria-hidden as={BiShow} />
+          <Text as="span" mr="0.5rem" textStyle="caption-1">
+            {toolbarTextLabels.mode}
           </Text>
         </Flex>
-        {viewport === "fullscreen" ? (
-          <Button
-            onClick={() => setViewport("responsive")}
-            variant="outline"
-            colorScheme="neutral"
-            size="sm"
-            leftIcon={<BiX fontSize="1.5rem" />}
-          >
-            Back to editing
-          </Button>
-        ) : (
-          <Menu size="sm" placement="bottom-end">
-            <MenuButton
-              as={Button}
-              leftIcon={<BiPencil size="1rem" />}
-              variant="outline"
-              size="xs"
-            >
-              {toolbarTextLabels.viewport}
-            </MenuButton>
-            <Portal>
-              <Menu.List>
-                <MenuOptionGroup
-                  value={viewport}
-                  title="Viewport"
-                  type="radio"
-                  onChange={(nextValue) =>
-                    setViewport(nextValue as ViewportOptions)
-                  }
-                >
-                  <MenuItemOption value="responsive">
-                    <Text color="base.content.strong" textStyle="body-1">
-                      Fit to screen (default)
-                    </Text>
-                    <Text color="base.content.medium" textStyle="body-2">
-                      Editing mode
-                    </Text>
-                  </MenuItemOption>
-                  <MenuItemOption value="fullscreen">
-                    <Text color="base.content.strong" textStyle="body-1">
-                      Full screen
-                    </Text>
-                    <Text color="base.content.medium" textStyle="body-2">
-                      View this page in full-screen mode
-                    </Text>
-                  </MenuItemOption>
-                  <MenuItemOption value="tablet">
-                    <Text color="base.content.strong" textStyle="body-1">
-                      Tablet
-                    </Text>
-                    <Text color="base.content.medium" textStyle="body-2">
-                      View how page would look like on a tablet screen
-                    </Text>
-                  </MenuItemOption>
-                  <MenuItemOption value="mobile">
-                    <Text color="base.content.strong" textStyle="body-1">
-                      Mobile
-                    </Text>
-                    <Text color="base.content.medium" textStyle="body-2">
-                      View how page would look like on a mobile screen
-                    </Text>
-                  </MenuItemOption>
-                </MenuOptionGroup>
-              </Menu.List>
-            </Portal>
-          </Menu>
-        )}
+        <Text as="span" textStyle="caption-2" color="base.content.medium">
+          {toolbarTextLabels.caption}
+        </Text>
       </Flex>
-    </>
+      {viewport === "fullscreen" ? (
+        <Button
+          onClick={() => setViewport("responsive")}
+          variant="outline"
+          colorScheme="neutral"
+          size="xs"
+          leftIcon={<BiX fontSize="1.25rem" />}
+        >
+          Back to editing
+        </Button>
+      ) : (
+        <Menu size="sm" placement="bottom-end">
+          <Menu.Button variant="clear" size="xs" p="0" minH="auto">
+            {toolbarTextLabels.viewport}
+          </Menu.Button>
+          <Portal>
+            <Menu.List>
+              <MenuOptionGroup
+                value={viewport}
+                type="radio"
+                onChange={(nextValue) =>
+                  setViewport(nextValue as ViewportOptions)
+                }
+              >
+                <MenuItemOption value="responsive">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Fit to screen (default)
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    Editing mode
+                  </Text>
+                </MenuItemOption>
+                <MenuItemOption value="fullscreen">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Full screen
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    View this page in full-screen mode
+                  </Text>
+                </MenuItemOption>
+                <MenuItemOption value="tablet">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Tablet
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    View how page would look like on a tablet screen
+                  </Text>
+                </MenuItemOption>
+                <MenuItemOption value="mobile">
+                  <Text color="base.content.strong" textStyle="body-1">
+                    Mobile
+                  </Text>
+                  <Text color="base.content.medium" textStyle="body-2">
+                    View how page would look like on a mobile screen
+                  </Text>
+                </MenuItemOption>
+              </MenuOptionGroup>
+            </Menu.List>
+          </Portal>
+        </Menu>
+      )}
+    </Flex>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/IframeToolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
 import {
   MenuButton,
   MenuItemOption,
@@ -15,12 +15,17 @@ import {
 } from "@opengovsg/design-system-react"
 import { RxDimensions } from "react-icons/rx"
 
-type ViewportOptions = "desktop" | "mobile" | "tablet" | "unset"
+export type ViewportOptions = "desktop" | "mobile" | "tablet" | "responsive"
 
-export const IframeToolbar = (): JSX.Element => {
-  const [selectedViewport, setSelectedViewport] =
-    useState<ViewportOptions>("unset")
+interface IframeToolbarProps {
+  selectedViewport: ViewportOptions
+  setSelectedViewport: (viewport: ViewportOptions) => void
+}
 
+export const IframeToolbar = ({
+  selectedViewport,
+  setSelectedViewport,
+}: IframeToolbarProps): JSX.Element => {
   const viewportLabel = useMemo(() => {
     switch (selectedViewport) {
       case "desktop":
@@ -47,7 +52,7 @@ export const IframeToolbar = (): JSX.Element => {
               size="xs"
               colorScheme="inverse"
               bg={
-                selectedViewport !== "unset"
+                selectedViewport !== "responsive"
                   ? "interaction.tinted.inverse.active"
                   : undefined
               }
@@ -67,8 +72,9 @@ export const IframeToolbar = (): JSX.Element => {
                   setSelectedViewport(nextValue as ViewportOptions)
                 }
               >
-                <MenuItemOption value="unset">Unset</MenuItemOption>
+                <MenuItemOption value="responsive">Responsive</MenuItemOption>
                 <MenuItemOption value="desktop">Desktop</MenuItemOption>
+                <MenuItemOption value="tablet">Tablet</MenuItemOption>
                 <MenuItemOption value="mobile">Mobile</MenuItemOption>
               </MenuOptionGroup>
             </Menu.List>

--- a/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
@@ -45,6 +45,7 @@ export const PreviewIframe = ({
       justify="center"
       w={viewportWidth}
       h="100%"
+      mx="auto"
       borderRadius="8px"
       userSelect="none"
     >

--- a/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
@@ -29,8 +29,6 @@ export const PreviewIframe = ({
   const viewportWidth = useMemo(() => {
     if (!viewport) return "100%"
     switch (viewport) {
-      case "desktop":
-        return "1440px"
       case "tablet":
         return "768px"
       case "mobile":

--- a/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
@@ -26,15 +26,33 @@ export const PreviewIframe = ({
       }
     : {}
 
-  const viewportWidth = useMemo(() => {
-    if (!viewport) return "100%"
+  const containerStyles = useMemo(() => {
+    if (!viewport)
+      return {
+        width: "100%",
+      }
     switch (viewport) {
       case "tablet":
-        return "768px"
+        return {
+          width: "768px",
+          borderRadius: "8px",
+        }
       case "mobile":
-        return "480px"
-      default:
-        return "100%"
+        return {
+          width: "480px",
+          borderRadius: "8px",
+        }
+      case "responsive":
+        return {
+          width: "100%",
+          borderRadius: "8px",
+        }
+      case "fullscreen": {
+        return {
+          width: "100%",
+          borderRadius: 0,
+        }
+      }
     }
   }, [viewport])
 
@@ -43,17 +61,13 @@ export const PreviewIframe = ({
       bg="white"
       shadow="md"
       justify="center"
-      w={viewportWidth}
       h="100%"
       mx="auto"
-      borderRadius="8px"
       userSelect="none"
+      {...containerStyles}
     >
       <Frame
-        style={{
-          width: viewportWidth,
-          borderRadius: "8px",
-        }}
+        style={containerStyles}
         {...extraProps}
         head={
           // eslint-disable-next-line @next/next/no-css-tags

--- a/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewIframe.tsx
@@ -1,12 +1,15 @@
 import type { CSSProperties, PropsWithChildren } from "react"
-import { useEffect, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { Flex } from "@chakra-ui/react"
 import Frame, { useFrame } from "react-frame-component"
+
+import type { ViewportOptions } from "./IframeToolbar"
 
 interface PreviewIframeProps extends PropsWithChildren {
   preventPointerEvents?: boolean
   keyForRerender?: string
   style?: CSSProperties
+  viewport?: ViewportOptions
 }
 
 export const PreviewIframe = ({
@@ -14,9 +17,8 @@ export const PreviewIframe = ({
   preventPointerEvents,
   keyForRerender,
   style,
+  viewport,
 }: PreviewIframeProps): JSX.Element => {
-  // TODO: Add toolbar for users to adjust the width of the iframe
-  const [width, _setWidth] = useState("100%")
   const extraProps = preventPointerEvents
     ? {
         initialContent: `<!DOCTYPE html><html><head></head><body><div id="frame-root" style="pointer-events: none;"></div></body></html>`,
@@ -24,19 +26,33 @@ export const PreviewIframe = ({
       }
     : {}
 
+  const viewportWidth = useMemo(() => {
+    if (!viewport) return "100%"
+    switch (viewport) {
+      case "desktop":
+        return "1440px"
+      case "tablet":
+        return "768px"
+      case "mobile":
+        return "480px"
+      default:
+        return "100%"
+    }
+  }, [viewport])
+
   return (
     <Flex
       bg="white"
       shadow="md"
       justify="center"
-      w={width}
+      w={viewportWidth}
       h="100%"
       borderRadius="8px"
       userSelect="none"
     >
       <Frame
         style={{
-          width,
+          width: viewportWidth,
           borderRadius: "8px",
         }}
         {...extraProps}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -3,7 +3,6 @@ import { Grid, GridItem } from "@chakra-ui/react"
 import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
 import { EditPagePreview } from "~/features/editing-experience/components/EditPagePreview"
-import { IframeToolbar } from "~/features/editing-experience/components/IframeToolbar"
 import { editPageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
@@ -58,7 +57,6 @@ const PageEditingView = () => {
         <EditPageDrawer />
       </GridItem>
       <GridItem colSpan={2}>
-        <IframeToolbar />
         <EditPagePreview />
       </GridItem>
     </Grid>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -3,6 +3,7 @@ import { Grid, GridItem } from "@chakra-ui/react"
 import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
 import { EditPagePreview } from "~/features/editing-experience/components/EditPagePreview"
+import { IframeToolbar } from "~/features/editing-experience/components/IframeToolbar"
 import { editPageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
@@ -57,6 +58,7 @@ const PageEditingView = () => {
         <EditPageDrawer />
       </GridItem>
       <GridItem colSpan={2}>
+        <IframeToolbar />
         <EditPagePreview />
       </GridItem>
     </Grid>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -1,15 +1,9 @@
-import { Flex, Grid, GridItem } from "@chakra-ui/react"
-import merge from "lodash/merge"
+import { Grid, GridItem } from "@chakra-ui/react"
 
-import {
-  EditorDrawerProvider,
-  useEditorDrawerContext,
-} from "~/contexts/EditorDrawerContext"
+import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
 import EditPageDrawer from "~/features/editing-experience/components/EditPageDrawer"
-import Preview from "~/features/editing-experience/components/Preview"
-import { PreviewIframe } from "~/features/editing-experience/components/PreviewIframe"
+import { EditPagePreview } from "~/features/editing-experience/components/EditPagePreview"
 import { editPageSchema } from "~/features/editing-experience/schema"
-import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
@@ -50,10 +44,6 @@ function EditPage(): JSX.Element {
 }
 
 const PageEditingView = () => {
-  const { previewPageState, permalink, siteId, pageId, updatedAt, title } =
-    useEditorDrawerContext()
-  const themeCssVars = useSiteThemeCssVars({ siteId })
-
   return (
     <Grid
       h="full"
@@ -67,25 +57,7 @@ const PageEditingView = () => {
         <EditPageDrawer />
       </GridItem>
       <GridItem colSpan={2}>
-        <Flex
-          shrink={0}
-          justify="flex-start"
-          p="2rem"
-          bg="base.canvas.backdrop"
-          h="100%"
-          overflowX="auto"
-        >
-          <PreviewIframe style={themeCssVars}>
-            <Preview
-              {...merge(previewPageState, { page: { title } })}
-              siteId={siteId}
-              resourceId={pageId}
-              permalink={permalink}
-              lastModified={updatedAt}
-              version="0.1.0"
-            />
-          </PreviewIframe>
-        </Flex>
+        <EditPagePreview />
       </GridItem>
     </Grid>
   )

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -117,3 +117,20 @@ export const ErrorNestedState: Story = {
     })
   },
 }
+
+export const FullscreenPreview: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Required since menu is a portal
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const screen = within(canvasElement.parentElement!)
+
+    await waitFor(async () => {
+      await userEvent.click(
+        canvas.getByRole("button", { name: /default mode/i }),
+      )
+
+      await userEvent.click(screen.getByText(/full screen/i))
+    })
+  },
+}


### PR DESCRIPTION
## Problem

Closes ISOM-1512

## Solution

This PR introduces a new viewport control feature for the page preview in the editing experience.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Features**:

- Added a new IframeToolbar component with viewport control options (desktop, mobile, tablet, responsive)
- Implemented viewport switching functionality in the EditPagePreview component

**Improvements**:

- Enhanced the PreviewIframe component to support different viewport sizes
- Refactored the EditPagePreview component to include the new IframeToolbar
- Updated the page editing layout to use the new EditPagePreview component

## Before & After Screenshots
See storybook

## Tests

- Test the new IframeToolbar component
- Verify that viewport switching works correctly for all options
- Ensure that the preview renders correctly in different viewport sizes
- Check that the EditPagePreview component integrates well with the existing editing experience
