### PR TITLE
fix: make noIndex optional and set boolean required

### DIFF
--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -25,7 +25,7 @@ const ISOMER_ADMINS = [
 const PAGE_BLOB: IsomerSchema = {
   version: "0.1.0",
   layout: "homepage",
-  page: { noIndex: false },
+  page: {},
   content: [
     {
       type: "hero",

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -25,7 +25,6 @@ export function JsonFormsBooleanControl({
   path,
   description,
   schema,
-  required,
 }: ControlProps): JSX.Element {
   if (schema.const !== undefined) {
     return <></>
@@ -33,8 +32,7 @@ export function JsonFormsBooleanControl({
 
   return (
     <Box mt="1.25rem" _first={{ mt: 0 }}>
-      {schema.required}
-      <FormControl isRequired={required}>
+      <FormControl isRequired>
         <FormLabel description={description} htmlFor={id}>
           {label}
         </FormLabel>

--- a/apps/studio/src/features/editing-experience/data/articleLayoutPreview.json
+++ b/apps/studio/src/features/editing-experience/data/articleLayoutPreview.json
@@ -2,7 +2,6 @@
   "version": "0.1.0",
   "layout": "article",
   "page": {
-    "noIndex": false,
     "permalink": "/resources/newsroom/relevant-news/todays-news",
     "title": "Performance and Outlook of the Electronics Cluster in Singapore",
     "date": "15 Feb 2024",

--- a/apps/studio/src/features/editing-experience/data/collectionPdfPreview.json
+++ b/apps/studio/src/features/editing-experience/data/collectionPdfPreview.json
@@ -2,7 +2,6 @@
   "version": "0.1.0",
   "layout": "article",
   "page": {
-    "noIndex": false,
     "permalink": "/resources/newsroom/relevant-news/todays-news",
     "title": "Speech by Minister for Trade and Industry at the Committee of Supply Debate 2024",
     "date": "15 Feb 2024",

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -6,7 +6,6 @@ export const createCollectionPageJson = ({}: {
   return {
     layout: "article",
     page: {
-      noIndex: false,
       date: format(new Date(), "dd-MM-yyyy"),
       // TODO: this is actually supposed to be passed from the frontend
       // which is not done at present
@@ -29,7 +28,6 @@ export const createCollectionPdfJson = ({
   return {
     layout: "content",
     page: {
-      noIndex: false,
       contentPageHeader: {
         summary: "",
       },

--- a/apps/studio/src/server/modules/page/page.service.ts
+++ b/apps/studio/src/server/modules/page/page.service.ts
@@ -12,7 +12,6 @@ export const createDefaultPage = ({
       const contentDefaultPage = {
         layout: "content",
         page: {
-          noIndex: false,
           contentPageHeader: {
             summary: "This is the page summary",
           },
@@ -27,7 +26,6 @@ export const createDefaultPage = ({
       const articleDefaultPage = {
         layout: "article",
         page: {
-          noIndex: false,
           date: format(new Date(), "dd-MM-yyyy"),
           category: "Feature Articles",
           articlePageHeader: {

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -95,7 +95,6 @@ export const Default: Story = {
       },
     },
     page: {
-      noIndex: false,
       title:
         "Singapore's Spectacular Citizens' Festival: a Celebration of Unity and Diversity",
       permalink:

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -228,7 +228,6 @@ const meta: Meta<CollectionPageSchemaType> = {
       },
     },
     page: {
-      noIndex: false,
       title: "Publications and other press releases",
       description: "A Next.js starter for Isomer",
       permalink: "/publications",

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -337,7 +337,6 @@ export const Default: Story = {
       },
     },
     page: {
-      noIndex: false,
       permalink: "/parent/rationality",
       lastModified: "2024-05-02T14:12:57.160Z",
       title:
@@ -1506,7 +1505,6 @@ export const NoTable: Story = {
       assetsBaseUrl: "https://cms.isomer.gov.sg",
     },
     page: {
-      noIndex: false,
       permalink: "/parent/rationality",
       title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
@@ -1917,7 +1915,6 @@ export const SmallTable: Story = {
       },
     },
     page: {
-      noIndex: false,
       permalink: "/parent/rationality",
       title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
@@ -2496,7 +2493,6 @@ export const FirstLevelPage: Story = {
       },
     },
     page: {
-      noIndex: false,
       permalink: "/content",
       title: "Content page",
       lastModified: "2024-05-02T14:12:57.160Z",

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -188,7 +188,6 @@ export const Default: Story = {
       },
     },
     page: {
-      noIndex: false,
       permalink: "/",
       lastModified: "2024-05-02T14:12:57.160Z",
       title: "Home page",

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
@@ -113,7 +113,6 @@ export const WithSiderail: Story = {
       },
     },
     page: {
-      noIndex: false,
       permalink: "/parent/rationality",
       title: "Index page",
       lastModified: "2024-05-02T14:12:57.160Z",
@@ -252,7 +251,6 @@ export const NoSiderail: Story = {
     },
     page: {
       permalink: "/parent",
-      noIndex: false,
       title: "Index page",
       lastModified: "2024-05-02T14:12:57.160Z",
       description: "A Next.js starter for Isomer",

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
@@ -53,7 +53,6 @@ export const Default: Story = {
     },
     page: {
       title: "Search",
-      noIndex: false,
       description: "Search results",
       permalink: "/404.html",
       lastModified: "2024-05-02T14:12:57.160Z",

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -74,7 +74,6 @@ export const SearchSG: Story = {
       },
     },
     page: {
-      noIndex: false,
       title: "Search",
       description: "Search results",
       permalink: "/search",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -16,12 +16,14 @@ const BaseItemSchema = Type.Object({
 const BasePageSchema = Type.Composite([
   BaseItemSchema,
   Type.Object({
-    noIndex: Type.Boolean({
-      description:
-        "If this is turned on, the page won't appear on Google search results.",
-      title: "Prevent search engines from indexing this page?",
-      default: false,
-    }),
+    noIndex: Type.Optional(
+      Type.Boolean({
+        description:
+          "If this is turned on, the page won't appear on Google search results.",
+        title: "Prevent search engines from indexing this page?",
+        default: false,
+      }),
+    ),
   }),
 ])
 

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -63,7 +63,7 @@ const NotFound = () => {
         }}
         layout="notfound"
         page={{
-          noIndex: false,
+          noIndex: true,
           title: PAGE_TITLE,
           description: PAGE_DESCRIPTION,
           permalink: "/404.html",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The noIndex prop was set to required in #645, but that was a breaking change that caused the migrators' schemas to fail.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make noIndex optional again (since it should be possible to deal with undefined).
- Design's requirement was to hide the "(optional)" for the boolean control, so that is done by setting the switch's form control to required, regardless of whether the underlying schema is required or optional.