### PR TITLE
ref: separate metadata from page object

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -3,7 +3,7 @@ import type { Static } from "@sinclair/typebox"
 import { useCallback } from "react"
 import { Box, Flex, useDisclosure } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
-import { getLayoutMetadataSchema } from "@opengovsg/isomer-components"
+import { getLayoutPageSchema } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 import isEmpty from "lodash/isEmpty"
 import isEqual from "lodash/isEqual"
@@ -41,7 +41,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
     },
   })
 
-  const metadataSchema = getLayoutMetadataSchema(previewPageState.layout)
+  const metadataSchema = getLayoutPageSchema(previewPageState.layout)
   const validateFn = ajv.compile<Static<typeof metadataSchema>>(metadataSchema)
 
   const handleSaveChanges = useCallback(() => {

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -4,12 +4,12 @@ import { getSitemapAsArray } from "~/utils"
 export const getMetadata = (props: IsomerPageSchemaType) => {
   const metadata = {
     metadataBase: props.site.url ? new URL(props.site.url) : undefined,
-    description: props.page.description || undefined,
+    description: props.meta?.description || undefined,
     robots: {
       index:
         props.layout !== "file" &&
         props.layout !== "link" &&
-        !props.page.noIndex,
+        !props.meta?.noIndex,
     },
     icons: {
       shortcut:
@@ -19,6 +19,18 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
     twitter: {
       card: "summary_large_image" as const,
     },
+  }
+
+  if (metadata.description === undefined && props.layout === "article") {
+    return {
+      ...metadata,
+      description: props.page.articlePageHeader.summary.join(" "),
+    }
+  } else if (metadata.description === undefined && props.layout === "content") {
+    return {
+      ...metadata,
+      description: props.page.contentPageHeader.summary,
+    }
   }
 
   if (props.page.permalink === "/") {

--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -1,3 +1,7 @@
+import type { TSchema } from "@sinclair/typebox"
+import { Type } from "@sinclair/typebox"
+
+import type { IsomerComponentTypes } from "~/types"
 import {
   AccordionSchema,
   CalloutSchema,
@@ -41,4 +45,25 @@ export const IsomerNativeComponentsMap = {
   paragraph: ParagraphSchema,
   table: TableSchema,
   unorderedList: UnorderedListSchema,
+}
+
+export const componentSchemaDefinitions = {
+  components: {
+    complex: IsomerComplexComponentsMap,
+    native: IsomerNativeComponentsMap,
+  },
+}
+
+export const getComponentSchema = (
+  component: IsomerComponentTypes,
+): TSchema => {
+  const componentSchema =
+    component === "prose"
+      ? Type.Ref(IsomerNativeComponentsMap.prose)
+      : IsomerComplexComponentsMap[component]
+
+  return {
+    ...componentSchema,
+    ...componentSchemaDefinitions,
+  }
 }

--- a/packages/components/src/schemas/index.ts
+++ b/packages/components/src/schemas/index.ts
@@ -1,1 +1,4 @@
-export { getComponentSchema, getLayoutMetadataSchema, schema } from "./main"
+export { getComponentSchema } from "./components"
+export { schema } from "./main"
+export { getLayoutMetadataSchema } from "./meta"
+export { getLayoutPageSchema } from "./page"

--- a/packages/components/src/schemas/main.ts
+++ b/packages/components/src/schemas/main.ts
@@ -1,61 +1,11 @@
 import type { TSchema } from "@sinclair/typebox"
-import { Type } from "@sinclair/typebox"
 
-import type { IsomerComponentTypes, IsomerSchema } from "~/types"
-import {
-  ArticlePageMetaSchema,
-  CollectionPageSchema,
-  ContentPageMetaSchema,
-  FileRefSchema,
-  HomePageMetaSchema,
-  IsomerPageSchema,
-  LinkRefSchema,
-} from "~/types"
-import {
-  IsomerComplexComponentsMap,
-  IsomerNativeComponentsMap,
-} from "./components"
-
-const definitions = {
-  components: {
-    complex: IsomerComplexComponentsMap,
-    native: IsomerNativeComponentsMap,
-  },
-}
+import { IsomerPageSchema } from "~/types"
+import { componentSchemaDefinitions } from "./components"
 
 export const schema: TSchema = {
   $schema: "http://json-schema.org/draft-07/schema#",
   title: "Isomer Next Page Schema",
   ...IsomerPageSchema,
-  ...definitions,
-}
-
-export const getComponentSchema = (
-  component: IsomerComponentTypes,
-): TSchema => {
-  const componentSchema =
-    component === "prose"
-      ? Type.Ref(IsomerNativeComponentsMap.prose)
-      : IsomerComplexComponentsMap[component]
-
-  return {
-    ...componentSchema,
-    ...definitions,
-  }
-}
-
-const LAYOUT_METADATA_MAP = {
-  article: ArticlePageMetaSchema,
-  content: ContentPageMetaSchema,
-  homepage: HomePageMetaSchema,
-  index: ContentPageMetaSchema,
-  link: LinkRefSchema,
-  collection: CollectionPageSchema,
-  file: FileRefSchema,
-}
-
-export const getLayoutMetadataSchema = (
-  layout: IsomerSchema["layout"],
-): TSchema => {
-  return LAYOUT_METADATA_MAP[layout]
+  ...componentSchemaDefinitions,
 }

--- a/packages/components/src/schemas/meta.ts
+++ b/packages/components/src/schemas/meta.ts
@@ -1,0 +1,27 @@
+import type { TSchema } from "@sinclair/typebox"
+
+import type { IsomerSchema } from "~/types"
+import {
+  ArticlePageMetaSchema,
+  CollectionPageMetaSchema,
+  ContentPageMetaSchema,
+  FileRefMetaSchema,
+  HomePageMetaSchema,
+  LinkRefMetaSchema,
+} from "~/types"
+
+const LAYOUT_METADATA_MAP = {
+  article: ArticlePageMetaSchema,
+  content: ContentPageMetaSchema,
+  homepage: HomePageMetaSchema,
+  index: ContentPageMetaSchema,
+  link: LinkRefMetaSchema,
+  collection: CollectionPageMetaSchema,
+  file: FileRefMetaSchema,
+}
+
+export const getLayoutMetadataSchema = (
+  layout: IsomerSchema["layout"],
+): TSchema => {
+  return LAYOUT_METADATA_MAP[layout]
+}

--- a/packages/components/src/schemas/page.ts
+++ b/packages/components/src/schemas/page.ts
@@ -1,0 +1,27 @@
+import type { TSchema } from "@sinclair/typebox"
+
+import type { IsomerSchema } from "~/types"
+import {
+  ArticlePagePageSchema,
+  CollectionPagePageSchema,
+  ContentPagePageSchema,
+  FileRefPageSchema,
+  HomePagePageSchema,
+  LinkRefPageSchema,
+} from "~/types"
+
+const LAYOUT_PAGE_MAP = {
+  article: ArticlePagePageSchema,
+  content: ContentPagePageSchema,
+  homepage: HomePagePageSchema,
+  index: ContentPagePageSchema,
+  link: LinkRefPageSchema,
+  collection: CollectionPagePageSchema,
+  file: FileRefPageSchema,
+}
+
+export const getLayoutPageSchema = (
+  layout: IsomerSchema["layout"],
+): TSchema => {
+  return LAYOUT_PAGE_MAP[layout]
+}

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -227,9 +227,11 @@ const meta: Meta<CollectionPageSchemaType> = {
         content: [{ type: "text", text: "This is a short notification" }],
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       title: "Publications and other press releases",
-      description: "A Next.js starter for Isomer",
       permalink: "/publications",
       lastModified: "2024-05-02T14:12:57.160Z",
       subtitle:

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -336,12 +336,14 @@ export const Default: Story = {
         content: [{ type: "text", text: "This is a short notification" }],
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/parent/rationality",
       lastModified: "2024-05-02T14:12:57.160Z",
       title:
         "Irrationality this should have a long long long long long long long title that wraps to the max width of the content header, and its' breadcrumb truncates, but ideally should not be this long",
-      description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary:
           "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",
@@ -1504,11 +1506,13 @@ export const NoTable: Story = {
       // TODO: Replace this with a more stable URL
       assetsBaseUrl: "https://cms.isomer.gov.sg",
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/parent/rationality",
       title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
-      description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary:
           "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",
@@ -1914,11 +1918,13 @@ export const SmallTable: Story = {
         searchUrl: "/search",
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/parent/rationality",
       title: "Irrationality",
       lastModified: "2024-05-02T14:12:57.160Z",
-      description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary:
           "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",
@@ -2492,11 +2498,13 @@ export const FirstLevelPage: Story = {
         searchUrl: "/search",
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/content",
       title: "Content page",
       lastModified: "2024-05-02T14:12:57.160Z",
-      description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary:
           "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -187,11 +187,13 @@ export const Default: Story = {
         clientId: TEST_CLIENT_ID,
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/",
       lastModified: "2024-05-02T14:12:57.160Z",
       title: "Home page",
-      description: "A Next.js starter for Isomer",
     },
     content: [
       {

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
@@ -112,11 +112,13 @@ export const WithSiderail: Story = {
         searchUrl: "/search",
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/parent/rationality",
       title: "Index page",
       lastModified: "2024-05-02T14:12:57.160Z",
-      description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary: "Pages in Index page",
       },
@@ -249,11 +251,13 @@ export const NoSiderail: Story = {
         searchUrl: "/search",
       },
     },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
     page: {
       permalink: "/parent",
       title: "Index page",
       lastModified: "2024-05-02T14:12:57.160Z",
-      description: "A Next.js starter for Isomer",
       contentPageHeader: {
         summary: "Pages in Index page",
       },

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.stories.tsx
@@ -51,9 +51,11 @@ export const Default: Story = {
         searchUrl: "/search",
       },
     },
+    meta: {
+      description: "Search results",
+    },
     page: {
       title: "Search",
-      description: "Search results",
       permalink: "/404.html",
       lastModified: "2024-05-02T14:12:57.160Z",
     },

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -73,9 +73,11 @@ export const SearchSG: Story = {
         clientId: TEST_CLIENT_ID,
       },
     },
+    meta: {
+      description: "Search results",
+    },
     page: {
       title: "Search",
-      description: "Search results",
       permalink: "/search",
       lastModified: "2024-05-02T14:12:57.160Z",
     },

--- a/packages/components/src/types/index.ts
+++ b/packages/components/src/types/index.ts
@@ -1,4 +1,5 @@
 export * from "./components"
+export * from "./meta"
 export * from "./page"
 export * from "./schema"
 export type * from "./site"

--- a/packages/components/src/types/meta.ts
+++ b/packages/components/src/types/meta.ts
@@ -1,0 +1,57 @@
+import type { Static } from "@sinclair/typebox"
+import { Type } from "@sinclair/typebox"
+
+const BaseItemMetaSchema = Type.Object({
+  description: Type.Optional(
+    Type.String({
+      title: "Meta description",
+      description:
+        "This is a description that appears on search engine results.",
+    }),
+  ),
+})
+
+const BasePageMetaSchema = Type.Composite([
+  BaseItemMetaSchema,
+  Type.Object({
+    noIndex: Type.Optional(
+      Type.Boolean({
+        description:
+          "If this is turned on, the page won't appear on Google search results.",
+        title: "Prevent search engines from indexing this page?",
+        default: false,
+      }),
+    ),
+  }),
+])
+
+const BaseRefMetaSchema = Type.Composite([
+  BaseItemMetaSchema,
+  Type.Object({
+    ref: Type.String({
+      title: "URL to the actual item",
+      description:
+        "The link that users will open immediately when they click on the item in the parent collection page",
+    }),
+  }),
+])
+
+export const ArticlePageMetaSchema = BasePageMetaSchema
+export const ContentPageMetaSchema = BasePageMetaSchema
+export const CollectionPageMetaSchema = BasePageMetaSchema
+export const HomePageMetaSchema = BasePageMetaSchema
+export const NotFoundPageMetaSchema = BasePageMetaSchema
+export const SearchPageMetaSchema = BasePageMetaSchema
+
+export const FileRefMetaSchema = BaseRefMetaSchema
+export const LinkRefMetaSchema = BaseRefMetaSchema
+
+export type ArticlePageMetaProps = Static<typeof ArticlePageMetaSchema>
+export type CollectionPageMetaProps = Static<typeof CollectionPageMetaSchema>
+export type ContentPageMetaProps = Static<typeof ContentPageMetaSchema>
+export type HomePageMetaProps = Static<typeof HomePageMetaSchema>
+export type NotFoundPageMetaProps = Static<typeof NotFoundPageMetaSchema>
+export type SearchPageMetaProps = Static<typeof SearchPageMetaSchema>
+
+export type FileRefMetaProps = Static<typeof FileRefMetaSchema>
+export type LinkRefMetaProps = Static<typeof LinkRefMetaSchema>

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -3,115 +3,68 @@ import { Type } from "@sinclair/typebox"
 
 import { ArticlePageHeaderSchema, ContentPageHeaderSchema } from "~/interfaces"
 
-const BaseItemSchema = Type.Object({
-  description: Type.Optional(
-    Type.String({
-      title: "Meta description",
-      description:
-        "This is a description that appears on search engine results.",
+const BaseCollectionItemPageSchema = Type.Object({
+  category: Type.String({
+    title: "Category of the actual item",
+    description:
+      "The category is used for filtering in the parent collection page",
+  }),
+  date: Type.String({
+    title: "Date of the actual item",
+  }),
+  image: Type.Optional(
+    Type.Object({
+      src: Type.String({
+        title: "Image source URL",
+        description: "The source URL of the image",
+        format: "image",
+      }),
+      alt: Type.String({
+        title: "Image alt text",
+        description: "The alt text of the image",
+        maxLength: 120,
+      }),
     }),
   ),
 })
 
-const BasePageSchema = Type.Composite([
-  BaseItemSchema,
-  Type.Object({
-    noIndex: Type.Optional(
-      Type.Boolean({
-        description:
-          "If this is turned on, the page won't appear on Google search results.",
-        title: "Prevent search engines from indexing this page?",
-        default: false,
-      }),
-    ),
-  }),
-])
-
-const BaseRefSchema = Type.Composite([
-  BaseItemSchema,
+const BaseRefPageSchema = Type.Composite([
+  BaseCollectionItemPageSchema,
   Type.Object({
     ref: Type.String({
       title: "URL to the actual item",
       description:
         "The link that users will open immediately when they click on the item in the parent collection page",
     }),
-    category: Type.String({
-      title: "Category of the actual item",
-      description:
-        "The category is used for filtering in the parent collection page",
-    }),
-    date: Type.String({
-      title: "Date of the actual item",
-    }),
-    image: Type.Optional(
-      Type.Object({
-        src: Type.String({
-          title: "Image source URL",
-          description: "The source URL of the image",
-          format: "image",
-        }),
-        alt: Type.String({
-          title: "Image alt text",
-          description: "The alt text of the image",
-          maxLength: 120,
-        }),
-      }),
-    ),
   }),
 ])
 
-export const ArticlePageMetaSchema = Type.Composite([
-  BasePageSchema,
+export const ArticlePagePageSchema = Type.Composite([
+  BaseCollectionItemPageSchema,
   Type.Object({
-    category: Type.String({
-      title: "Category of the article",
-      description:
-        "The category is used for filtering in the parent collection page.",
-    }),
-    date: Type.String({
-      title: "Date of the article",
-      format: "date",
-    }),
-    image: Type.Optional(
-      Type.Object({
-        src: Type.String({
-          title: "Image source URL",
-          description: "The source URL of the image",
-          format: "image",
-        }),
-        alt: Type.String({
-          title: "Image alt text",
-          description: "The alt text of the image",
-        }),
-      }),
-    ),
     articlePageHeader: ArticlePageHeaderSchema,
   }),
 ])
 
-export const CollectionPageMetaSchema = Type.Composite([
-  BasePageSchema,
-  Type.Object({
-    subtitle: Type.String({
-      title: "The subtitle of the collection",
-    }),
+export const CollectionPagePageSchema = Type.Object({
+  subtitle: Type.String({
+    title: "The subtitle of the collection",
   }),
-])
+})
 
-export const ContentPageMetaSchema = Type.Composite([
-  BasePageSchema,
-  Type.Object({
-    contentPageHeader: ContentPageHeaderSchema,
-  }),
-])
+export const ContentPagePageSchema = Type.Object({
+  contentPageHeader: ContentPageHeaderSchema,
+})
 
-export const HomePageMetaSchema = BasePageSchema
-export const NotFoundPageMetaSchema = BasePageSchema
-export const SearchPageMetaSchema = BasePageSchema
+export const HomePagePageSchema = Type.Object({})
+export const NotFoundPagePageSchema = Type.Object({})
+export const SearchPagePageSchema = Type.Object({})
 
-export const FileRefMetaSchema = BaseRefSchema
-export const LinkRefMetaSchema = BaseRefSchema
+export const FileRefPageSchema = BaseRefPageSchema
+export const LinkRefPageSchema = BaseRefPageSchema
 
+// These are props that are required by the render engine, but not enforced by
+// the JSON schema (as the data is being stored outside of the page JSON)
 interface BaseItemAdditionalProps {
   permalink: string
   lastModified: string
@@ -121,20 +74,20 @@ type BasePageAdditionalProps = BaseItemAdditionalProps & {
   language?: "en"
 }
 
-export type ArticlePageProps = Static<typeof ArticlePageMetaSchema> &
+export type ArticlePagePageProps = Static<typeof ArticlePagePageSchema> &
   BasePageAdditionalProps
-export type CollectionPageProps = Static<typeof CollectionPageMetaSchema> &
+export type CollectionPagePageProps = Static<typeof CollectionPagePageSchema> &
   BasePageAdditionalProps
-export type ContentPageProps = Static<typeof ContentPageMetaSchema> &
+export type ContentPagePageProps = Static<typeof ContentPagePageSchema> &
   BasePageAdditionalProps
-export type HomePageProps = Static<typeof HomePageMetaSchema> &
+export type HomePagePageProps = Static<typeof HomePagePageSchema> &
   BasePageAdditionalProps
-export type NotFoundPageProps = Static<typeof NotFoundPageMetaSchema> &
+export type NotFoundPagePageProps = Static<typeof NotFoundPagePageSchema> &
   BasePageAdditionalProps
-export type SearchPageProps = Static<typeof SearchPageMetaSchema> &
+export type SearchPagePageProps = Static<typeof SearchPagePageSchema> &
   BasePageAdditionalProps
 
-export type FileRefProps = Static<typeof FileRefMetaSchema> &
+export type FileRefPageProps = Static<typeof FileRefPageSchema> &
   BaseItemAdditionalProps
-export type LinkRefProps = Static<typeof LinkRefMetaSchema> &
+export type LinkRefPageProps = Static<typeof LinkRefPageSchema> &
   BaseItemAdditionalProps

--- a/packages/components/src/types/schema.ts
+++ b/packages/components/src/types/schema.ts
@@ -1,18 +1,20 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type {
-  ArticlePageProps,
-  CollectionPageProps,
-  ContentPageProps,
-  FileRefProps,
-  HomePageProps,
-  LinkRefProps,
-  NotFoundPageProps,
-  SearchPageProps,
-} from "./page"
+import type { NotFoundPageMetaProps, SearchPageMetaProps } from "./meta"
 import type { IsomerSiteProps } from "./site"
-import type { LinkComponentType, ScriptComponentType } from "~/types"
+import type {
+  ArticlePagePageProps,
+  CollectionPagePageProps,
+  ContentPagePageProps,
+  FileRefPageProps,
+  HomePagePageProps,
+  LinkComponentType,
+  LinkRefPageProps,
+  NotFoundPagePageProps,
+  ScriptComponentType,
+  SearchPagePageProps,
+} from "~/types"
 import { IsomerComponentsSchemas } from "./components"
 import {
   ArticlePageMetaSchema,
@@ -21,6 +23,14 @@ import {
   FileRefMetaSchema,
   HomePageMetaSchema,
   LinkRefMetaSchema,
+} from "./meta"
+import {
+  ArticlePagePageSchema,
+  CollectionPagePageSchema,
+  ContentPagePageSchema,
+  FileRefPageSchema,
+  HomePagePageSchema,
+  LinkRefPageSchema,
 } from "./page"
 
 export const ISOMER_USABLE_PAGE_LAYOUTS = {
@@ -39,7 +49,7 @@ export const ISOMER_PAGE_LAYOUTS = {
   Search: "search",
 } as const
 
-const BasePageSchema = Type.Object({
+const BaseItemSchema = Type.Object({
   version: Type.String({
     description: "The version of the Isomer Next schema to use",
     default: "0.1.0",
@@ -51,7 +61,8 @@ export const ArticlePageSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Article, {
       default: ISOMER_PAGE_LAYOUTS.Article,
     }),
-    page: ArticlePageMetaSchema,
+    meta: Type.Optional(ArticlePageMetaSchema),
+    page: ArticlePagePageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
     }),
@@ -68,7 +79,8 @@ export const CollectionPageSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Collection, {
       default: ISOMER_PAGE_LAYOUTS.Collection,
     }),
-    page: CollectionPageMetaSchema,
+    meta: Type.Optional(CollectionPageMetaSchema),
+    page: CollectionPagePageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
       description:
@@ -90,7 +102,8 @@ export const ContentPageSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Content, {
       default: ISOMER_PAGE_LAYOUTS.Content,
     }),
-    page: ContentPageMetaSchema,
+    meta: Type.Optional(ContentPageMetaSchema),
+    page: ContentPagePageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
     }),
@@ -106,7 +119,8 @@ export const HomePageSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Homepage, {
       default: ISOMER_PAGE_LAYOUTS.Homepage,
     }),
-    page: HomePageMetaSchema,
+    meta: Type.Optional(HomePageMetaSchema),
+    page: HomePagePageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
     }),
@@ -122,7 +136,8 @@ export const IndexPageSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Index, {
       default: ISOMER_PAGE_LAYOUTS.Index,
     }),
-    page: ContentPageMetaSchema,
+    meta: Type.Optional(ContentPageMetaSchema),
+    page: ContentPagePageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
     }),
@@ -139,7 +154,8 @@ export const FileRefSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.File, {
       default: ISOMER_PAGE_LAYOUTS.File,
     }),
-    page: FileRefMetaSchema,
+    meta: Type.Optional(FileRefMetaSchema),
+    page: FileRefPageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
       description:
@@ -161,7 +177,8 @@ export const LinkRefSchema = Type.Object(
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Link, {
       default: ISOMER_PAGE_LAYOUTS.Link,
     }),
-    page: LinkRefMetaSchema,
+    meta: Type.Optional(LinkRefMetaSchema),
+    page: LinkRefPageSchema,
     content: Type.Array(IsomerComponentsSchemas, {
       title: "Page content",
       description:
@@ -179,7 +196,7 @@ export const LinkRefSchema = Type.Object(
 )
 
 export const IsomerPageSchema = Type.Intersect([
-  BasePageSchema,
+  BaseItemSchema,
   Type.Union([
     ArticlePageSchema,
     CollectionPageSchema,
@@ -193,6 +210,8 @@ export const IsomerPageSchema = Type.Intersect([
 
 export type IsomerSchema = Static<typeof IsomerPageSchema>
 
+// These props are required by the render engine, but are not enforced by the
+// JSON schema, as the data should be provided by the template directly
 interface BasePageAdditionalProps {
   site: IsomerSiteProps
   LinkComponent?: LinkComponentType
@@ -201,42 +220,44 @@ interface BasePageAdditionalProps {
 
 export interface NotFoundPageSchemaType extends BasePageAdditionalProps {
   layout: typeof ISOMER_PAGE_LAYOUTS.NotFound
-  page: NotFoundPageProps
+  meta?: NotFoundPageMetaProps
+  page: NotFoundPagePageProps
 }
 
 export interface SearchPageSchemaType extends BasePageAdditionalProps {
   layout: typeof ISOMER_PAGE_LAYOUTS.Search
-  page: SearchPageProps
+  meta?: SearchPageMetaProps
+  page: SearchPagePageProps
 }
 
 export type ArticlePageSchemaType = Static<typeof ArticlePageSchema> &
   BasePageAdditionalProps & {
-    page: ArticlePageProps
+    page: ArticlePagePageProps
   }
 export type CollectionPageSchemaType = Static<typeof CollectionPageSchema> &
   BasePageAdditionalProps & {
-    page: CollectionPageProps
+    page: CollectionPagePageProps
   }
 export type ContentPageSchemaType = Static<typeof ContentPageSchema> &
   BasePageAdditionalProps & {
-    page: ContentPageProps
+    page: ContentPagePageProps
   }
 export type HomePageSchemaType = Static<typeof HomePageSchema> &
   BasePageAdditionalProps & {
-    page: HomePageProps
+    page: HomePagePageProps
   }
 
 export type IndexPageSchemaType = Static<typeof IndexPageSchema> &
   BasePageAdditionalProps & {
-    page: ContentPageProps
+    page: ContentPagePageProps
   }
 export type FileRefSchemaType = Static<typeof FileRefSchema> &
   BasePageAdditionalProps & {
-    page: FileRefProps
+    page: FileRefPageProps
   }
 export type LinkRefSchemaType = Static<typeof LinkRefSchema> &
   BasePageAdditionalProps & {
-    page: LinkRefProps
+    page: LinkRefPageProps
   }
 
 export type IsomerPageSchemaType =

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -41,7 +41,10 @@ export const generateMetadata = async (
   }
   schema.page.permalink = "/404.html"
   schema.page.title = PAGE_TITLE
-  schema.page.description = PAGE_DESCRIPTION
+  schema.meta = {
+    ...schema.meta,
+    description: PAGE_DESCRIPTION,
+  }
   return getMetadata(schema)
 }
 
@@ -62,10 +65,12 @@ const NotFound = () => {
           footerItems: footer,
         }}
         layout="notfound"
-        page={{
+        meta={{
           noIndex: true,
-          title: PAGE_TITLE,
           description: PAGE_DESCRIPTION,
+        }}
+        page={{
+          title: PAGE_TITLE,
           permalink: "/404.html",
           lastModified: new Date().toISOString(),
         }}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The page object is mixed with some page metadata, which is difficult to separate on the Studio.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
    - No schema changes are needed because the new `meta` object is optional and hence, backward compatible.

**Improvements**:

- Refactor all page metadata into a new `meta` object, which is exposed by `getLayoutMetadataSchema`. This object is set to be optional for all page layouts for now to minimise the need to upgrade existing schemas.
- The remaining `page` object is exposed by `getLayoutPageSchema`, which replaces the one currently used in MetadataEditorStateDrawer.
- Additionally, if the page meta description is not provided, the article/content page summary is used for those layouts.

**Notes**:

- At this stage, the page metadata cannot be edited. They will need to be added into the page settings screen.

## Screenshots

<!-- [insert screenshot here] -->
<img width="833" alt="image" src="https://github.com/user-attachments/assets/3ca48542-2d3c-4349-a093-48751d1059c3">
