### PR TITLE
feat: introduce big add block button when empty

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -1,9 +1,9 @@
 import type { DropResult } from "@hello-pangea/dnd"
 import { useCallback } from "react"
-import { Box, Button, Flex, Text, VStack } from "@chakra-ui/react"
+import { Box, Button, Flex, Icon, Text, VStack } from "@chakra-ui/react"
 import { DragDropContext, Droppable } from "@hello-pangea/dnd"
 import { useToast } from "@opengovsg/design-system-react"
-import { BiPin, BiPlusCircle } from "react-icons/bi"
+import { BiPin, BiPlus, BiPlusCircle } from "react-icons/bi"
 
 import { BlockEditingPlaceholder } from "~/components/Svg"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -159,24 +159,40 @@ export default function RootStateDrawer() {
                 <Box w="100%">
                   {((isHeroFixedBlock && savedPageState.content.length === 1) ||
                     savedPageState.content.length === 0) && (
-                    <VStack justifyContent="center" spacing={0} mt="2.75rem">
-                      <BlockEditingPlaceholder />
-                      <Text
-                        mt="0.75rem"
-                        textStyle="subhead-1"
-                        color="base.content.default"
+                    <>
+                      <VStack
+                        justifyContent="center"
+                        spacing={0}
+                        mt="2.75rem"
+                        mb="1.5rem"
                       >
-                        Blocks you add will appear here
-                      </Text>
-                      <Text
-                        mt="0.25rem"
-                        textStyle="caption-2"
-                        color="base.content.medium"
+                        <BlockEditingPlaceholder />
+                        <Text
+                          mt="0.75rem"
+                          textStyle="subhead-1"
+                          color="base.content.default"
+                        >
+                          Blocks you add will appear here
+                        </Text>
+                        <Text
+                          mt="0.25rem"
+                          textStyle="caption-2"
+                          color="base.content.medium"
+                        >
+                          Click the ‘Add block’ button above to add blocks to
+                          this page
+                        </Text>
+                      </VStack>
+
+                      <Button
+                        variant="outline"
+                        w="100%"
+                        onClick={() => setDrawerState({ state: "addBlock" })}
+                        leftIcon={<Icon as={BiPlus} fontSize="1.25rem" />}
                       >
-                        Click the ‘Add block’ button above to add blocks to this
-                        page
-                      </Text>
-                    </VStack>
+                        Add a new block
+                      </Button>
+                    </>
                   )}
 
                   <Flex flexDirection="column" mt="-0.25rem">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Fixes ISOM-1581.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add the "Add a new block" big button when the page state is empty.

## Screenshots

![image](https://github.com/user-attachments/assets/9f935ca9-6ab3-4858-a9b8-8b0d8771e891)