### PR TITLE
feat: provide layout info to components

### DIFF
--- a/packages/components/src/interfaces/internal/Navbar.ts
+++ b/packages/components/src/interfaces/internal/Navbar.ts
@@ -1,7 +1,7 @@
 import type { LocalSearchProps } from "./LocalSearchInputBox"
 import type { SearchSGInputBoxProps } from "./SearchSGInputBox"
-import type { IsomerPageSchemaType } from "~/engine"
 import type {
+  IsomerPageLayoutType,
   IsomerSiteProps,
   LinkComponentType,
   ScriptComponentType,
@@ -17,7 +17,7 @@ export interface NavbarItem {
 export interface NavbarProps {
   logoUrl: string
   logoAlt: string
-  layout: IsomerPageSchemaType["layout"]
+  layout: IsomerPageLayoutType
   search?: LocalSearchProps | SearchSGInputBoxProps
   items: NavbarItem[]
   site: IsomerSiteProps

--- a/packages/components/src/schemas/meta.ts
+++ b/packages/components/src/schemas/meta.ts
@@ -1,6 +1,6 @@
 import type { TSchema } from "@sinclair/typebox"
 
-import type { IsomerSchema } from "~/types"
+import type { IsomerPageLayoutType } from "~/types"
 import {
   ArticlePageMetaSchema,
   CollectionPageMetaSchema,
@@ -8,6 +8,8 @@ import {
   FileRefMetaSchema,
   HomePageMetaSchema,
   LinkRefMetaSchema,
+  NotFoundPageMetaSchema,
+  SearchPageMetaSchema,
 } from "~/types"
 
 const LAYOUT_METADATA_MAP = {
@@ -15,13 +17,15 @@ const LAYOUT_METADATA_MAP = {
   content: ContentPageMetaSchema,
   homepage: HomePageMetaSchema,
   index: ContentPageMetaSchema,
+  notfound: NotFoundPageMetaSchema,
+  search: SearchPageMetaSchema,
   link: LinkRefMetaSchema,
   collection: CollectionPageMetaSchema,
   file: FileRefMetaSchema,
 }
 
 export const getLayoutMetadataSchema = (
-  layout: IsomerSchema["layout"],
+  layout: IsomerPageLayoutType,
 ): TSchema => {
   return LAYOUT_METADATA_MAP[layout]
 }

--- a/packages/components/src/schemas/page.ts
+++ b/packages/components/src/schemas/page.ts
@@ -1,6 +1,6 @@
 import type { TSchema } from "@sinclair/typebox"
 
-import type { IsomerSchema } from "~/types"
+import type { IsomerPageLayoutType } from "~/types"
 import {
   ArticlePagePageSchema,
   CollectionPagePageSchema,
@@ -8,6 +8,8 @@ import {
   FileRefPageSchema,
   HomePagePageSchema,
   LinkRefPageSchema,
+  NotFoundPagePageSchema,
+  SearchPagePageSchema,
 } from "~/types"
 
 const LAYOUT_PAGE_MAP = {
@@ -15,13 +17,13 @@ const LAYOUT_PAGE_MAP = {
   content: ContentPagePageSchema,
   homepage: HomePagePageSchema,
   index: ContentPagePageSchema,
+  notfound: NotFoundPagePageSchema,
+  search: SearchPagePageSchema,
   link: LinkRefPageSchema,
   collection: CollectionPagePageSchema,
   file: FileRefPageSchema,
 }
 
-export const getLayoutPageSchema = (
-  layout: IsomerSchema["layout"],
-): TSchema => {
+export const getLayoutPageSchema = (layout: IsomerPageLayoutType): TSchema => {
   return LAYOUT_PAGE_MAP[layout]
 }

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -76,7 +76,7 @@ const InfoCols = ({
   subtitle,
   infoBoxes,
   site,
-  LinkComponent = "a",
+  LinkComponent,
 }: InfoColsProps) => {
   return (
     <section className="bg-white">

--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -59,7 +59,7 @@ function BaseBreadcrumb({
   )
 }
 
-const Breadcrumb = ({ links, LinkComponent = "a" }: BreadcrumbProps) => {
+const Breadcrumb = ({ links, LinkComponent }: BreadcrumbProps) => {
   return (
     <BaseBreadcrumbs>
       {links.map(({ title, url }, index) => (

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -57,7 +57,7 @@ const footerItemLinkStyle = tv({
 })
 
 const FooterItem = ({
-  LinkComponent = "a",
+  LinkComponent,
   title,
   url,
 }: FooterItemType & Pick<FooterProps, "LinkComponent">) => {

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -34,7 +34,7 @@ export const Navbar = ({
   search,
   items,
   site,
-  LinkComponent = "a",
+  LinkComponent,
 }: Omit<NavbarProps, "type">) => {
   const [openNavItemIdx, setOpenNavItemIdx] = useState(-1)
   const [isHamburgerOpen, setIsHamburgerOpen] = useState(false)

--- a/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
+++ b/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
@@ -51,7 +51,7 @@ export const Siderail = ({
   parentTitle,
   parentUrl,
   pages,
-  LinkComponent = "a",
+  LinkComponent,
 }: SiderailProps): JSX.Element => {
   const siderailItems = useMemo(() => generateSiderailItems(pages), [pages])
 

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -39,6 +39,7 @@ const ArticleLayout = ({
           <div className="w-full overflow-x-auto lg:max-w-[660px]">
             {renderPageContent({
               site,
+              layout,
               content,
               LinkComponent,
             })}

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -107,7 +107,7 @@ const ContentLayout = ({
   page,
   layout,
   content,
-  LinkComponent = "a",
+  LinkComponent,
   ScriptComponent,
 }: ContentPageSchemaType) => {
   const isParentPageRoot = page.permalink.split("/").length === 2
@@ -161,8 +161,9 @@ const ContentLayout = ({
           )}
           <div>
             {renderPageContent({
-              site,
               content: transformedContent,
+              layout,
+              site,
               LinkComponent,
             })}
           </div>

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -24,8 +24,9 @@ const HomepageLayout = ({
         className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
       >
         {renderPageContent({
-          site,
           content,
+          layout,
+          site,
           LinkComponent,
         })}
       </div>

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -35,7 +35,7 @@ const IndexPageLayout = ({
   page,
   layout,
   content,
-  LinkComponent = "a",
+  LinkComponent,
   ScriptComponent,
 }: IndexPageSchemaType) => {
   const isParentPageRoot = page.permalink.split("/").length === 2
@@ -76,8 +76,9 @@ const IndexPageLayout = ({
           className={compoundStyles.content({ isSideRailPresent: !!sideRail })}
         >
           {renderPageContent({
-            site,
             content,
+            layout,
+            site,
             LinkComponent,
           })}
         </div>

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
@@ -6,8 +6,8 @@ const NotFoundLayout = ({
   site,
   page,
   layout,
-  LinkComponent = "a",
-  ScriptComponent = "script",
+  LinkComponent,
+  ScriptComponent,
 }: NotFoundPageSchemaType) => {
   return (
     <Skeleton
@@ -23,7 +23,6 @@ const NotFoundLayout = ({
         className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
       >
         {renderComponent({
-          site,
           component: {
             type: "infobar",
             title: "404: Page not found",
@@ -31,6 +30,8 @@ const NotFoundLayout = ({
             buttonLabel: "Go to homepage",
             buttonUrl: "/",
           },
+          layout,
+          site,
           LinkComponent,
         })}
       </div>

--- a/packages/components/src/templates/next/layouts/Search/Search.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.tsx
@@ -6,7 +6,7 @@ const SearchLayout = ({
   site,
   page,
   layout,
-  LinkComponent = "a",
+  LinkComponent,
   ScriptComponent = "script",
 }: SearchPageSchemaType) => {
   const clientId =

--- a/packages/components/src/templates/next/render/render.tsx
+++ b/packages/components/src/templates/next/render/render.tsx
@@ -3,7 +3,7 @@ import type {
   IsomerPageSchemaType,
   IsomerSiteProps,
 } from "~/engine"
-import type { LinkComponentType } from "~/types"
+import type { IsomerPageLayoutType, LinkComponentType } from "~/types"
 import {
   Accordion,
   Callout,
@@ -29,120 +29,60 @@ import {
 } from "../layouts"
 
 interface RenderComponentProps {
-  site: IsomerSiteProps
-  component: IsomerComponent
   elementKey?: number
+  component: IsomerComponent
+  layout: IsomerPageLayoutType
+  site: IsomerSiteProps
   LinkComponent?: LinkComponentType
 }
 
 export const renderComponent = ({
-  site,
-  component,
-  LinkComponent,
   elementKey,
+  component,
+  ...rest
 }: RenderComponentProps) => {
   switch (component.type) {
     case "accordion":
-      return (
-        <Accordion
-          key={elementKey}
-          {...component}
-          LinkComponent={LinkComponent}
-          site={site}
-        />
-      )
+      return <Accordion key={elementKey} {...component} {...rest} />
     case "callout":
-      return (
-        <Callout
-          key={elementKey}
-          {...component}
-          LinkComponent={LinkComponent}
-          site={site}
-        />
-      )
+      return <Callout key={elementKey} {...component} {...rest} />
     case "contentpic":
-      return (
-        <Contentpic
-          key={elementKey}
-          {...component}
-          LinkComponent={LinkComponent}
-          site={site}
-        />
-      )
+      return <Contentpic key={elementKey} {...component} {...rest} />
     case "hero":
-      return (
-        <Hero
-          key={elementKey}
-          {...component}
-          site={site}
-          LinkComponent={LinkComponent}
-        />
-      )
+      return <Hero key={elementKey} {...component} {...rest} />
     case "iframe":
-      return <Iframe key={elementKey} {...component} />
+      return <Iframe key={elementKey} {...component} {...rest} />
     case "image":
-      return (
-        <Image
-          key={elementKey}
-          {...component}
-          site={site}
-          LinkComponent={LinkComponent}
-        />
-      )
+      return <Image key={elementKey} {...component} {...rest} />
     case "infobar":
-      return (
-        <Infobar
-          key={elementKey}
-          {...component}
-          site={site}
-          LinkComponent={LinkComponent}
-        />
-      )
+      return <Infobar key={elementKey} {...component} {...rest} />
     case "infocards":
-      return (
-        <InfoCards
-          key={elementKey}
-          {...component}
-          site={site}
-          LinkComponent={LinkComponent}
-        />
-      )
+      return <InfoCards key={elementKey} {...component} {...rest} />
     case "infocols":
-      return (
-        <InfoCols
-          key={elementKey}
-          {...component}
-          site={site}
-          LinkComponent={LinkComponent}
-        />
-      )
+      return <InfoCols key={elementKey} {...component} {...rest} />
     case "infopic":
-      return (
-        <Infopic
-          key={elementKey}
-          {...component}
-          site={site}
-          LinkComponent={LinkComponent}
-        />
-      )
+      return <Infopic key={elementKey} {...component} {...rest} />
     case "keystatistics":
-      return <KeyStatistics key={elementKey} {...component} />
+      return <KeyStatistics key={elementKey} {...component} {...rest} />
     case "prose":
-      return (
-        <Prose
-          key={elementKey}
-          {...component}
-          LinkComponent={LinkComponent}
-          site={site}
-        />
-      )
+      return <Prose key={elementKey} {...component} {...rest} />
     default:
       const _: never = component
       return <></>
   }
 }
 
-export const renderLayout = (props: IsomerPageSchemaType) => {
+export const renderLayout = ({
+  LinkComponent = "a",
+  ScriptComponent = "script",
+  ...rest
+}: IsomerPageSchemaType) => {
+  const props = {
+    ...rest,
+    LinkComponent,
+    ScriptComponent,
+  }
+
   switch (props.layout) {
     case "article":
       return <ArticleLayout {...props} />

--- a/packages/components/src/templates/next/render/renderPageContent.ts
+++ b/packages/components/src/templates/next/render/renderPageContent.ts
@@ -1,15 +1,22 @@
-import type { IsomerComponent, IsomerSiteProps } from "~/types"
+import type {
+  IsomerComponent,
+  IsomerPageLayoutType,
+  IsomerSiteProps,
+  LinkComponentType,
+} from "~/types"
 import { renderComponent } from "~/templates/next/render"
 
-export const renderPageContent = ({
-  site,
-  content,
-  LinkComponent,
-}: {
-  site: IsomerSiteProps
+interface RenderPageContentParams {
   content: IsomerComponent[]
-  LinkComponent: any
-}) => {
+  layout: IsomerPageLayoutType
+  site: IsomerSiteProps
+  LinkComponent: LinkComponentType
+}
+
+export const renderPageContent = ({
+  content,
+  ...rest
+}: RenderPageContentParams) => {
   let isInfopicTextOnRight = false
   return content.map((component, index) => {
     if (component.type === "infopic") {
@@ -19,17 +26,16 @@ export const renderPageContent = ({
         isTextOnRight: isInfopicTextOnRight,
       }
       return renderComponent({
-        site,
-        component: formattedComponent,
         elementKey: index,
-        LinkComponent,
+        component: formattedComponent,
+        ...rest,
       })
     }
+
     return renderComponent({
-      site,
-      component,
       elementKey: index,
-      LinkComponent,
+      component,
+      ...rest,
     })
   })
 }

--- a/packages/components/src/types/schema.ts
+++ b/packages/components/src/types/schema.ts
@@ -270,3 +270,5 @@ export type IsomerPageSchemaType =
   | SearchPageSchemaType
   | FileRefSchemaType
   | LinkRefSchemaType
+
+export type IsomerPageLayoutType = IsomerPageSchemaType["layout"]

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -1,5 +1,4 @@
-import type { ISOMER_PAGE_LAYOUTS } from "./schema"
-import type { ValueOf } from "./utils"
+import type { IsomerPageLayoutType } from "./schema"
 import type { CollectionCardProps } from "~/interfaces"
 import type { FileCardProps } from "~/interfaces/internal/CollectionCard"
 
@@ -16,7 +15,7 @@ interface IsomerBaseSitemap {
 }
 
 interface IsomerPageSitemap extends IsomerBaseSitemap {
-  layout: Exclude<ValueOf<typeof ISOMER_PAGE_LAYOUTS>, "file" | "link">
+  layout: Exclude<IsomerPageLayoutType, "file" | "link">
 }
 interface IsomerFileSitemap extends IsomerBaseSitemap {
   layout: "file"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We don't provide layout information to the components currently, but there is a growing need to render components slightly differently depending on the layout that it is being rendered in (e.g. homepage vs content page.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Provide layout information to the components so they are aware of the layout context they are rendering in.

**Improvements**:

- Standardised all LinkComponent and ScriptComponent to not provide a fallback value, and leave it to `renderLayout` to provide one.