### PR TITLE
feat: use type assertion for recursive types

### DIFF
--- a/packages/components/src/interfaces/native/ListItem.ts
+++ b/packages/components/src/interfaces/native/ListItem.ts
@@ -1,21 +1,12 @@
 import type { Static, TSchema } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { OrderedListProps } from "./OrderedList"
+import type { BaseOrderedListProps } from "./OrderedList"
 import type { ParagraphProps } from "./Paragraph"
-import type { UnorderedListProps } from "./UnorderedList"
-import type { IsomerSiteProps, LinkComponentType } from "~/types"
+import type { BaseUnorderedListProps } from "./UnorderedList"
+import type { IsomerSiteProps, IsTypeEqual, LinkComponentType } from "~/types"
 import { orderedListSchemaBuilder, unorderedListSchemaBuilder } from "~/utils"
 import { ParagraphSchema } from "./Paragraph"
-
-interface ListItem {
-  type: "listItem"
-  content: (
-    | Omit<ParagraphProps, "site">
-    | Omit<OrderedListProps, "site">
-    | Omit<UnorderedListProps, "site">
-  )[]
-}
 
 export const listItemSchemaBuilder = <T extends TSchema, U extends TSchema>(
   orderedListSchema: T,
@@ -47,16 +38,28 @@ export const listItemSchemaBuilder = <T extends TSchema, U extends TSchema>(
 // NOTE: The ListItem interface and the underlying ListItemSchema needs to be
 // in sync with each other. Unsafe is used here to bypass errors in TypeScript
 // where the type instantiation is too deep.
-export const ListItemSchema = Type.Unsafe<ListItem>(
-  Type.Recursive((listItemSchema) =>
-    listItemSchemaBuilder(
-      orderedListSchemaBuilder(listItemSchema),
-      unorderedListSchemaBuilder(listItemSchema),
-    ),
+export const ListItemSchema = Type.Recursive((listItemSchema) =>
+  listItemSchemaBuilder(
+    orderedListSchemaBuilder(listItemSchema),
+    unorderedListSchemaBuilder(listItemSchema),
   ),
 )
 
-export type ListItemProps = Static<typeof ListItemSchema> & {
+export interface BaseListItemProps {
+  type: "listItem"
+  content: (
+    | Omit<ParagraphProps, "site">
+    | BaseOrderedListProps
+    | BaseUnorderedListProps
+  )[]
+}
+
+type GeneratedListItemProps = Static<typeof ListItemSchema>
+type ListItemTypeResult = IsTypeEqual<BaseListItemProps, GeneratedListItemProps>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const listItemTypeCheck: boolean = true satisfies ListItemTypeResult
+
+export type ListItemProps = any & {
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }

--- a/packages/components/src/interfaces/native/OrderedList.ts
+++ b/packages/components/src/interfaces/native/OrderedList.ts
@@ -1,7 +1,8 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerSiteProps, LinkComponentType } from "~/types"
+import type { BaseListItemProps } from "./ListItem"
+import type { IsomerSiteProps, IsTypeEqual, LinkComponentType } from "~/types"
 import { orderedListSchemaBuilder, unorderedListSchemaBuilder } from "~/utils"
 import { listItemSchemaBuilder } from "./ListItem"
 
@@ -14,7 +15,22 @@ export const OrderedListSchema = orderedListSchemaBuilder(
   ),
 )
 
-export type OrderedListProps = Static<typeof OrderedListSchema> & {
+export interface BaseOrderedListProps {
+  type: "orderedList"
+  attrs?: {
+    start?: number
+  }
+  content: BaseListItemProps[]
+}
+type GeneratedOrderedListProps = Static<typeof OrderedListSchema>
+type OrderedListTypeResult = IsTypeEqual<
+  BaseOrderedListProps,
+  GeneratedOrderedListProps
+>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const orderedListTypeCheck: boolean = true satisfies OrderedListTypeResult
+
+export type OrderedListProps = any & {
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }

--- a/packages/components/src/interfaces/native/UnorderedList.ts
+++ b/packages/components/src/interfaces/native/UnorderedList.ts
@@ -1,7 +1,8 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerSiteProps, LinkComponentType } from "~/types"
+import type { BaseListItemProps } from "./ListItem"
+import type { IsomerSiteProps, IsTypeEqual, LinkComponentType } from "~/types"
 import { orderedListSchemaBuilder, unorderedListSchemaBuilder } from "~/utils"
 import { listItemSchemaBuilder } from "./ListItem"
 
@@ -14,7 +15,19 @@ export const UnorderedListSchema = unorderedListSchemaBuilder(
   ),
 )
 
-export type UnorderedListProps = Static<typeof UnorderedListSchema> & {
+export interface BaseUnorderedListProps {
+  type: "unorderedList"
+  content: BaseListItemProps[]
+}
+type GeneratedUnorderedListProps = Static<typeof UnorderedListSchema>
+type UnorderedListTypeResult = IsTypeEqual<
+  BaseUnorderedListProps,
+  GeneratedUnorderedListProps
+>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const unorderedListTypeCheck: boolean = true satisfies UnorderedListTypeResult
+
+export type UnorderedListProps = any & {
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }

--- a/packages/components/src/types/utils.ts
+++ b/packages/components/src/types/utils.ts
@@ -1,5 +1,11 @@
 export type ValueOf<T> = T[keyof T]
 
+export type IsTypeEqual<T, U> = [Required<T>] extends [Required<U>]
+  ? [Required<U>] extends [Required<T>]
+    ? true
+    : false
+  : false
+
 // This is the Next.js Link component that resembles the HTML anchor tag
 export type LinkComponentType = any
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We keep having type instantiation is too deep.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Switch to using type assertions so we can break up the TypeScript tree.