### PR TITLE
chore: update workflow for production

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -5,31 +5,14 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  release:
     types:
-      - labeled
+      - released
 
 # NOTE: This is actually using our federated isomer-production account
 jobs:
-  comment-on-pr:
-    name: Comment on PR
-    if: startsWith(github.event.label.name, 'deploy-production')
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: mshick/add-pr-comment@v2
-        with:
-          allow-repeats: true
-          message: |
-            🚀 Deployment through Github Actions has been scheduled!
-
-            Please check back in ~10 minutes ☕️.
-
   deploy_production:
     name: Deploy app to production
-    needs:
-      - comment-on-pr
     uses: ./.github/workflows/aws_deploy.yml
     # NOTE: deploy in `production` env to set env specific secrets
     with:


### PR DESCRIPTION
## Problem
currently, we release using a label. this is not ideal because we have to raise a pr with no meaningful changes and then attach a label.

## Solution
update so that we now deploy to production on release rather than using a pr label. this is preferred because we don't have to make empty commits and a fake pr to create a release.

removed the action to comment on pr because no easy out of the box functionality was found. we can add it back next time if we feel that it's needed

## Notes
chose `released` over `published.` see here: https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release for the differences but i think both are fine, just that it's more semantic to publish releases as a version bump rather than attaching to the draft release. this means that we'll only deploy to prod when we publish a release!
