### PR TITLE
fix(components): standardise hover interactions for links with arrows on megamenu

### DIFF
--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -145,11 +145,11 @@ const Megamenu = ({
                         isExternal={isExternal}
                         showExternalIcon={isExternal}
                         href={subItem.url}
-                        className="prose-label-md-medium inline-flex w-fit items-center gap-1 text-base-content hover:underline"
+                        className="group prose-label-md-medium inline-flex w-fit items-center gap-1 text-base-content hover:text-brand-interaction-hover hover:no-underline"
                       >
                         {subItem.name}
                         {!isExternal && (
-                          <BiRightArrowAlt className="text-[1.25rem]" />
+                          <BiRightArrowAlt className="text-[1.25rem] transition ease-in group-hover:translate-x-1" />
                         )}
                       </Link>
                       <p className="prose-label-sm-regular text-base-content-subtle">


### PR DESCRIPTION
## Problem

Closes [ISOM-1357]

Currently, all links with arrows on the Isomer Next template share an interaction where the arrow inches by 4px to the right with an ease-in transition. The megamenu was the only place where this interaction was different. This causes an inconsistency in interactions which impacts usability of the site.

## Solution

Changed megamenu item interactions from underline to nudging the arrow and getting an interaction-hover colour. This won't take effect on external links.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x ] No - this PR is backwards compatible

## Before & After Screenshots

**BEFORE**:

https://github.com/user-attachments/assets/191e54af-58d6-438d-8e32-e8e3127302ca

**AFTER**:

https://github.com/user-attachments/assets/6a14db76-afe0-4b1a-9cd3-94fa99329644