### PR TITLE
fix(components): add background to On this page/ToC for visual balance and cohesion

### DIFF
--- a/packages/components/src/templates/next/components/internal/TableOfContents/TableOfContents.tsx
+++ b/packages/components/src/templates/next/components/internal/TableOfContents/TableOfContents.tsx
@@ -15,7 +15,7 @@ const linkStyle = tv({
 
 const TableOfContents = ({ items, LinkComponent }: TableOfContentsProps) => {
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 rounded-lg bg-base-canvas-alt p-6">
       <p className="prose-headline-lg-medium text-base-content-strong">
         On this page
       </p>


### PR DESCRIPTION
## Problem

Previously, the ToC ("On this page") lacked background colour which made it look floaty. 

Closes [insert issue #]

## Solution

This PR adds a background to the component so that all the links under a ToC seem like they are in the same group. This should bring more attention to the ToC, helping site visitors to find the exact subtopic they want.

The component also has an 8px rounded corner to make the component look modern and softer, which is the same value that we use for callouts.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Before & After Screenshots

**BEFORE**:

Previously, the ToC was floating around, and top-alignment with the siderail was off:
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/e224370e-36b8-44a7-996d-3759cbbeb8b2">

**AFTER**:

View chromatic.