### PR TITLE
fix(components): footer enhancements

### DIFF
--- a/packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx
@@ -199,3 +199,99 @@ export const NonGovernment: Story = {
     siteMapLink: "/",
   },
 }
+
+export const NoSocmed: Story = {
+  args: {
+    siteName: "Ministry of Trade and Industry",
+    isGovernment: true,
+    lastUpdated: "11 Mar 2024",
+    siteNavItems: [
+      {
+        title: "About us",
+        url: "/",
+      },
+      {
+        title: "Our partners",
+        url: "/",
+      },
+      {
+        title: "Grants and programmes",
+        url: "/",
+      },
+      {
+        title: "Contact us",
+        url: "/",
+      },
+      {
+        title: "Something else",
+        url: "/",
+      },
+      {
+        title: "Resources",
+        url: "/",
+      },
+    ],
+    customNavItems: [
+      {
+        title: "Careers",
+        url: "/",
+      },
+      {
+        title: "2024 budget increase",
+        url: "/",
+      },
+      {
+        title: "Events calendar",
+        url: "/",
+      },
+      {
+        title: "Our Corp Site",
+        url: "https://www.google.com",
+      },
+    ],
+    contactUsLink: "/",
+    feedbackFormLink: "https://www.google.com",
+    privacyStatementLink: "/",
+    termsOfUseLink: "/",
+    siteMapLink: "/",
+  },
+}
+
+export const NoCustomItems: Story = {
+  args: {
+    siteName: "Ministry of Trade and Industry",
+    isGovernment: true,
+    lastUpdated: "11 Mar 2024",
+    siteNavItems: [
+      {
+        title: "About us",
+        url: "/",
+      },
+      {
+        title: "Our partners",
+        url: "/",
+      },
+      {
+        title: "Grants and programmes",
+        url: "/",
+      },
+      {
+        title: "Contact us",
+        url: "/",
+      },
+      {
+        title: "Something else",
+        url: "/",
+      },
+      {
+        title: "Resources",
+        url: "/",
+      },
+    ],
+    contactUsLink: "/",
+    feedbackFormLink: "https://www.google.com",
+    privacyStatementLink: "/",
+    termsOfUseLink: "/",
+    siteMapLink: "/",
+  },
+}

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -379,7 +379,7 @@ const FooterDesktop = ({
   siteMapLink,
 }: FooterProps) => {
   return (
-    <div className="hidden px-[4rem] py-14 lg:block">
+    <div className="hidden px-10 py-14 lg:block">
       <div className="mx-auto flex max-w-[72.5rem] flex-col gap-6">
         <SiteNameSection siteName={siteName} />
         <div className="grid-cols-[1fr_min-content] grid-rows-[1fr_min-content] gap-x-8 gap-y-14 lg:grid">

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -96,7 +96,7 @@ const NavSection = ({
   customNavItems,
 }: Pick<FooterProps, "LinkComponent" | "siteNavItems" | "customNavItems">) => {
   return (
-    <div className="prose-body-sm flex flex-col gap-8 lg:flex-row lg:gap-12">
+    <div className="prose-body-sm flex flex-col gap-8 lg:flex-row lg:gap-10">
       <div className="flex flex-col gap-3 lg:w-64">
         {siteNavItems.map((item, index) => (
           <FooterItem
@@ -333,7 +333,7 @@ const FooterMobile = ({
   siteMapLink,
 }: FooterProps) => {
   return (
-    <div className="flex flex-col gap-16 px-6 py-11 md:px-10 lg:hidden lg:py-16">
+    <div className="flex flex-col gap-8 px-6 py-11 md:px-10 lg:hidden lg:py-16">
       <SiteNameSection siteName={siteName} />
       <NavSection
         siteNavItems={navItems}
@@ -382,7 +382,7 @@ const FooterDesktop = ({
     <div className="hidden px-10 py-14 lg:block">
       <div className="mx-auto flex max-w-[72.5rem] flex-col gap-6">
         <SiteNameSection siteName={siteName} />
-        <div className="grid-cols-[1fr_min-content] grid-rows-[1fr_min-content] gap-x-8 gap-y-14 lg:grid">
+        <div className="grid-cols-[1fr_min-content] grid-rows-[1fr_min-content] gap-x-10 gap-y-14 lg:grid">
           <div>
             <NavSection
               siteNavItems={navItems}


### PR DESCRIPTION
## Problem

This PR addresses some styling and copy enhancements for footer.

Previously, the footer wasn't collapsing right on the tablet-small desktop breakpoints. It had a larger x-padding which made the footer contents misaligned with the rest of the homepage content.

Also we had comments from migration sync that the capitalisation for "Contact Us" was inconsistent, and the term "Reach us" clashes with "REACH". 

Closes ISOM-1356

## Solution

- Changed padding to be consistent at the lg-xl breakpoint at 40px. 
- Also minimised some minor gaps that were very glaring between sections.
- Copy changes.

## Before & After Screenshots

**BEFORE**:

Notice the footer contents are misaligned with the side rail:
https://github.com/user-attachments/assets/bbd33e6e-c1cd-4122-88fe-dc3291afade0

**AFTER**:

Footer collapses consistently with homepage contents:
https://github.com/user-attachments/assets/51e54733-0836-47f7-8aa8-158b05f0a05e
