### PR TITLE
feat(ci): separate e2e tests from unit/integration tests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -14,6 +14,3 @@ runs:
 
     - shell: bash
       run: npm ci
-
-    - shell: bash
-      run: npm run --workspace packages/components build

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -53,8 +53,7 @@ jobs:
         with:
           fetch-depth: 0 # Required for v4
       - name: Setup
-        uses: ./tooling/github/setup
-
+        uses: ./.github/actions/setup
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest
@@ -81,7 +80,9 @@ jobs:
         with:
           fetch-depth: 0 # Required for v4
       - name: Setup
-        uses: ./tooling/github/setup
+        uses: ./.github/actions/setup
+      - name: Build Isomer Components
+        run: npm run --workspace packages/components build
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,51 +56,63 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-  test:
+  unit-integration-tests:
+    name: Unit & integration tests
     needs: optimize_ci
-    if: needs.optimize_ci.outputs.skip == 'false'
     runs-on: ubuntu-latest
+    if: needs.optimize_ci.outputs.skip == 'false'
     steps:
       - uses: actions/checkout@v4
-
       - name: Setup
         uses: ./tooling/github/setup
+      - name: Test Studio
+        run: turbo test:unit --filter=isomer-studio
 
-      - name: Install playwright
+  end-to-end-tests:
+    name: End-to-end tests
+    needs: optimize_ci
+    runs-on: ubuntu-latest
+    if: needs.optimize_ci.outputs.skip == 'false'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup
+        uses: ./tooling/github/setup
+      - name: Install Playwright (Chromium)
         run: npx playwright install chromium
-
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
         with:
           mode: test
-
+      - name: Test
+        run: npm run test:e2e
       - name: Next.js cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # See here for caching with `yarn` https://github.com/actions/cache/blob/main/examples.md#node---yarn or you can leverage caching with actions/setup-node https://github.com/actions/setup-node
           path: |
             ~/.npm
             ${{ github.workspace }}/.next/cache
           # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - name: Start test containers
         run: npm run setup:test
 
-      - name: Build
-        run: npm run build
+      - name: Build Studio app
+        run: turbo build --filter=isomer-studio
 
-      - name: Test
-        run: npm run test-start
+      - name: Run Playwright tests
+        run: turbo test-ci:e2e --filter=isomer-studio
 
       - name: Stop test containers
         run: npm run teardown
 
       - name: Upload test results
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: test results
-          path: |
-            playwright/test-results
+          path: playwright/test-results
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup
         uses: ./tooling/github/setup
+      - name: Load .env file
+        uses: xom9ikk/dotenv@v2
+        with:
+          mode: test
       - name: Test Studio
         run: turbo test:unit --filter=isomer-studio
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,6 @@ jobs:
         uses: xom9ikk/dotenv@v2
         with:
           mode: test
-      - name: Test
-        run: npm run test:e2e
       - name: Next.js cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,11 +99,11 @@ jobs:
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
-      - name: Start test containers
-        run: npm run setup:test
-
       - name: Build Studio app
         run: turbo build --filter=isomer-studio
+
+      - name: Start test containers
+        run: npm run setup:test
 
       - name: Run Playwright tests
         run: turbo test-ci:e2e --filter=isomer-studio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup
-        uses: ./tooling/github/setup
+        uses: ./.github/actions/setup
 
       - name: Lint
         run: npm run lint && npm run lint:ws
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup
-        uses: ./tooling/github/setup
+        uses: ./.github/actions/setup
 
       - name: Format
         run: npm run format
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup
-        uses: ./tooling/github/setup
+        uses: ./.github/actions/setup
 
       - name: Typecheck
         run: npm run typecheck
@@ -64,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup
-        uses: ./tooling/github/setup
+        uses: ./.github/actions/setup
       - name: Load .env file
         uses: xom9ikk/dotenv@v2
         with:
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup
-        uses: ./tooling/github/setup
+        uses: ./.github/actions/setup
       - name: Install Playwright (Chromium)
         run: npx playwright install chromium
       - name: Load .env file

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -35,7 +35,7 @@
     "test:e2e": "dotenv -e .env.test playwright test",
     "test-dev": "start-server-and-test dev http://127.0.0.1:3000 test",
     "test-dev:unit": "dotenv -e .env.test vitest",
-    "test-start": "start-server-and-test start http://127.0.0.1:3000 test",
+    "test-ci:e2e": "start-server-and-test start http://127.0.0.1:3000 test:e2e",
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build",
     "clean": "git clean -xdf .next .turbo node_modules build",

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -2,6 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "test:unit": {},
+    "test-ci:e2e": {},
     "generate": {
       "inputs": ["prisma/schema.prisma"],
       "cache": false

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -6,7 +6,8 @@
       "dependsOn": ["generate"]
     },
     "test-ci:e2e": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "outputs": ["playwright/test-results/**"]
     },
     "generate": {
       "inputs": ["prisma/schema.prisma"],

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -6,7 +6,6 @@
       "dependsOn": ["generate"]
     },
     "test-ci:e2e": {
-      "dependsOn": ["build"],
       "outputs": ["playwright/test-results/**"]
     },
     "generate": {

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -2,8 +2,12 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "test:unit": {},
-    "test-ci:e2e": {},
+    "test:unit": {
+      "dependsOn": ["generate"]
+    },
+    "test-ci:e2e": {
+      "dependsOn": ["build"]
+    },
     "generate": {
       "inputs": ["prisma/schema.prisma"],
       "cache": false

--- a/package-lock.json
+++ b/package-lock.json
@@ -6419,10 +6419,6 @@
       "resolved": "tooling/eslint",
       "link": true
     },
-    "node_modules/@isomer/github": {
-      "resolved": "tooling/github",
-      "link": true
-    },
     "node_modules/@isomer/prettier-config": {
       "resolved": "tooling/prettier",
       "link": true
@@ -37262,9 +37258,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "tooling/github": {
-      "name": "@isomer/github"
     },
     "tooling/prettier": {
       "name": "@isomer/prettier-config",

--- a/tooling/github/package.json
+++ b/tooling/github/package.json
@@ -1,3 +1,0 @@
-{
-  "name": "@isomer/github"
-}


### PR DESCRIPTION
## Solution

This PR refactors the CI workflow to separate unit/integration tests from end-to-end tests, improving the overall testing process.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Separated unit/integration tests from end-to-end tests in the CI workflow
- Added a specific job for unit and integration tests
- Created a dedicated job for end-to-end tests
- Updated caching strategy for Next.js
- Improved artifact retention for test results

**Bug Fixes**:

- Fixed the cache key generation to include all relevant file types

## Tests

- Updated the CI workflow to run unit and integration tests separately from end-to-end tests
- Added Playwright installation step specifically for Chromium
- Updated the build and test commands to use Turbo for better performance

**New scripts**:

- `test-ci:e2e` : Runs end-to-end tests in CI environment
