### PR TITLE
fix(components): image caption should be center-aligned on tablet as well

### DIFF
--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -10,7 +10,7 @@ const createImageStyles = tv({
   slots: {
     container: "mt-0 [&:not(:first-child)]:mt-7",
     caption:
-      "overflow-wrap break-word prose-label-sm-medium mt-2 max-w-[100ch] text-base-content-subtle lg:mx-auto lg:text-center",
+      "overflow-wrap break-word prose-label-sm-medium mt-2 max-w-[100ch] text-base-content-subtle md:mx-auto md:text-center",
     image: "mx-auto h-auto max-w-full rounded",
   },
   variants: {


### PR DESCRIPTION
## Problem

Image caption is left-aligned on Tablet, which is incompatible with how we provide image sizing options (smaller vs. original). Specifically, the smaller image size aligns the image to the center of the page, so the caption gets misaligned.

Closes [ISOM-1546]

## Solution

Image caption is center aligned from the md breakpoint

## Before & After

Before:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/c4641303-9962-4f84-ab90-2f11688881be">

After:
<img width="799" alt="image" src="https://github.com/user-attachments/assets/208b2d4c-06e5-48ca-98b9-f9739c780406">