### PR TITLE
feat: add db schema for resource permissions

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -62,9 +62,10 @@ export type Resource = {
   updatedAt: Generated<Timestamp>
 }
 export type ResourcePermission = {
+  id: GeneratedAlways<string>
   userId: string
   siteId: number
-  resourceId: string
+  resourceId: string | null
   role: RoleType
 }
 export type Site = {

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -8,7 +8,7 @@ export type Generated<T> =
     : ColumnType<T, T | undefined, T>
 export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
-export type Blob = {
+export interface Blob {
   id: GeneratedAlways<string>
   /**
    * @kyselyType(PrismaJson.BlobJsonContent)
@@ -18,7 +18,7 @@ export type Blob = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Footer = {
+export interface Footer {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -29,7 +29,7 @@ export type Footer = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Navbar = {
+export interface Navbar {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -40,7 +40,7 @@ export type Navbar = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Permission = {
+export interface Permission {
   id: GeneratedAlways<number>
   resourceId: string
   userId: string
@@ -48,7 +48,12 @@ export type Permission = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Resource = {
+export interface RateLimiterFlexible {
+  key: string
+  points: number
+  expire: Timestamp | null
+}
+export interface Resource {
   id: GeneratedAlways<string>
   title: string
   permalink: string
@@ -61,14 +66,16 @@ export type Resource = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type ResourcePermission = {
+export interface ResourcePermission {
   id: GeneratedAlways<string>
   userId: string
   siteId: number
   resourceId: string | null
   role: RoleType
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
 }
-export type Site = {
+export interface Site {
   id: GeneratedAlways<number>
   name: string
   /**
@@ -85,13 +92,13 @@ export type Site = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type SiteMember = {
+export interface SiteMember {
   userId: string
   siteId: number
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type User = {
+export interface User {
   id: string
   name: string
   email: string
@@ -100,13 +107,13 @@ export type User = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type VerificationToken = {
+export interface VerificationToken {
   identifier: string
   token: string
   attempts: Generated<number>
   expires: Timestamp
 }
-export type Version = {
+export interface Version {
   id: GeneratedAlways<string>
   versionNum: number
   resourceId: string
@@ -115,11 +122,12 @@ export type Version = {
   publishedBy: string
   updatedAt: Generated<Timestamp>
 }
-export type DB = {
+export interface DB {
   Blob: Blob
   Footer: Footer
   Navbar: Navbar
   Permission: Permission
+  RateLimiterFlexible: RateLimiterFlexible
   Resource: Resource
   ResourcePermission: ResourcePermission
   Site: Site

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -8,7 +8,7 @@ export type Generated<T> =
     : ColumnType<T, T | undefined, T>
 export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
-export interface Blob {
+export type Blob = {
   id: GeneratedAlways<string>
   /**
    * @kyselyType(PrismaJson.BlobJsonContent)
@@ -18,7 +18,7 @@ export interface Blob {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface Footer {
+export type Footer = {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -29,7 +29,7 @@ export interface Footer {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface Navbar {
+export type Navbar = {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -40,7 +40,7 @@ export interface Navbar {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface Permission {
+export type Permission = {
   id: GeneratedAlways<number>
   resourceId: string
   userId: string
@@ -48,12 +48,7 @@ export interface Permission {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface RateLimiterFlexible {
-  key: string
-  points: number
-  expire: Timestamp | null
-}
-export interface Resource {
+export type Resource = {
   id: GeneratedAlways<string>
   title: string
   permalink: string
@@ -66,7 +61,13 @@ export interface Resource {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface Site {
+export type ResourcePermission = {
+  userId: string
+  siteId: number
+  resourceId: string
+  role: RoleType
+}
+export type Site = {
   id: GeneratedAlways<number>
   name: string
   /**
@@ -83,13 +84,13 @@ export interface Site {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface SiteMember {
+export type SiteMember = {
   userId: string
   siteId: number
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface User {
+export type User = {
   id: string
   name: string
   email: string
@@ -98,13 +99,13 @@ export interface User {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface VerificationToken {
+export type VerificationToken = {
   identifier: string
   token: string
   attempts: Generated<number>
   expires: Timestamp
 }
-export interface Version {
+export type Version = {
   id: GeneratedAlways<string>
   versionNum: number
   resourceId: string
@@ -113,13 +114,13 @@ export interface Version {
   publishedBy: string
   updatedAt: Generated<Timestamp>
 }
-export interface DB {
+export type DB = {
   Blob: Blob
   Footer: Footer
   Navbar: Navbar
   Permission: Permission
-  RateLimiterFlexible: RateLimiterFlexible
   Resource: Resource
+  ResourcePermission: ResourcePermission
   Site: Site
   SiteMember: SiteMember
   User: User

--- a/apps/studio/prisma/generated/selectableTypes.ts
+++ b/apps/studio/prisma/generated/selectableTypes.ts
@@ -9,6 +9,7 @@ export type Navbar = Selectable<T.Navbar>
 export type Permission = Selectable<T.Permission>
 export type RateLimiterFlexible = Selectable<T.RateLimiterFlexible>
 export type Resource = Selectable<T.Resource>
+export type ResourcePermission = Selectable<T.ResourcePermission>
 export type Site = Selectable<T.Site>
 export type SiteMember = Selectable<T.SiteMember>
 export type User = Selectable<T.User>

--- a/apps/studio/prisma/migrations/20240923090529_add_resource_perms/migration.sql
+++ b/apps/studio/prisma/migrations/20240923090529_add_resource_perms/migration.sql
@@ -1,0 +1,18 @@
+-- CreateTable
+CREATE TABLE "ResourcePermission" (
+    "userId" TEXT NOT NULL,
+    "siteId" INTEGER NOT NULL,
+    "resourceId" BIGINT NOT NULL,
+    "role" "RoleType" NOT NULL,
+
+    CONSTRAINT "ResourcePermission_pkey" PRIMARY KEY ("siteId","userId","resourceId")
+);
+
+-- AddForeignKey
+ALTER TABLE "ResourcePermission" ADD CONSTRAINT "ResourcePermission_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResourcePermission" ADD CONSTRAINT "ResourcePermission_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ResourcePermission" ADD CONSTRAINT "ResourcePermission_resourceId_fkey" FOREIGN KEY ("resourceId") REFERENCES "Resource"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/studio/prisma/migrations/20240924045858_make_resource_optional/migration.sql
+++ b/apps/studio/prisma/migrations/20240924045858_make_resource_optional/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - The primary key for the `ResourcePermission` table will be changed. If it partially fails, the table could be left without primary key constraint.
+
+*/
+-- DropForeignKey
+ALTER TABLE "ResourcePermission" DROP CONSTRAINT "ResourcePermission_resourceId_fkey";
+
+-- AlterTable
+ALTER TABLE "ResourcePermission" DROP CONSTRAINT "ResourcePermission_pkey",
+ALTER COLUMN "resourceId" DROP NOT NULL,
+ADD CONSTRAINT "ResourcePermission_pkey" PRIMARY KEY ("siteId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "ResourcePermission" ADD CONSTRAINT "ResourcePermission_resourceId_fkey" FOREIGN KEY ("resourceId") REFERENCES "Resource"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/studio/prisma/migrations/20240924051641_add_unique_for_resource_perms/migration.sql
+++ b/apps/studio/prisma/migrations/20240924051641_add_unique_for_resource_perms/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - The primary key for the `ResourcePermission` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - A unique constraint covering the columns `[userId,siteId,resourceId,role]` on the table `ResourcePermission` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "ResourcePermission" DROP CONSTRAINT "ResourcePermission_pkey",
+ADD COLUMN     "id" BIGSERIAL NOT NULL,
+ADD CONSTRAINT "ResourcePermission_pkey" PRIMARY KEY ("id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ResourcePermission_userId_siteId_resourceId_role_key" ON "ResourcePermission"("userId", "siteId", "resourceId", "role");

--- a/apps/studio/prisma/migrations/20241018152737_add_created_updated_at/migration.sql
+++ b/apps/studio/prisma/migrations/20241018152737_add_created_updated_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ResourcePermission" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+CREATE TRIGGER update_timestamp BEFORE UPDATE ON "ResourcePermission" FOR EACH ROW EXECUTE PROCEDURE moddatetime("updatedAt");

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -70,8 +70,9 @@ model Resource {
   state ResourceState? @default(Draft)
   type  ResourceType
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @default(now()) @updatedAt
+  ResourcePermission ResourcePermission[]
 
   // This unique index is subsequently replaced with a custom index that
   // treats nulls as not distinct.
@@ -118,9 +119,10 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  permissions Permission[]
-  siteMembers SiteMember[]
-  versions    Version[]
+  permissions        Permission[]
+  siteMembers        SiteMember[]
+  versions           Version[]
+  ResourcePermission ResourcePermission[]
 }
 
 model Permission {
@@ -156,8 +158,9 @@ model Site {
   footer      Footer?
   codeBuildId String?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @default(now()) @updatedAt
+  ResourcePermission ResourcePermission[]
 }
 
 model Navbar {
@@ -196,6 +199,18 @@ model SiteMember {
   updatedAt DateTime @default(now()) @updatedAt
 
   @@id([siteId, userId])
+}
+
+model ResourcePermission {
+  userId     String
+  user       User     @relation(fields: [userId], references: [id])
+  siteId     Int
+  site       Site     @relation(fields: [siteId], references: [id])
+  resourceId BigInt
+  resource   Resource @relation(fields: [resourceId], references: [id])
+  role       RoleType
+
+  @@id([siteId, userId, resourceId])
 }
 
 enum RoleType {

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -202,15 +202,16 @@ model SiteMember {
 }
 
 model ResourcePermission {
+  id         BigInt     @id @default(autoincrement())
   userId     String
   user       User     @relation(fields: [userId], references: [id])
   siteId     Int
   site       Site     @relation(fields: [siteId], references: [id])
-  resourceId BigInt
-  resource   Resource @relation(fields: [resourceId], references: [id])
+  resourceId BigInt?
+  resource   Resource? @relation(fields: [resourceId], references: [id])
   role       RoleType
 
-  @@id([siteId, userId, resourceId])
+  @@unique([userId, siteId, resourceId, role])
 }
 
 enum RoleType {

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -210,6 +210,8 @@ model ResourcePermission {
   resourceId BigInt?
   resource   Resource? @relation(fields: [resourceId], references: [id])
   role       RoleType
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
 
   @@unique([userId, siteId, resourceId, role])
 }


### PR DESCRIPTION
## Problem
we have no resource schema for permissions.

## Solution
add a db schema for resouce permissions. we track the `(siteid, userid, resourceid)`. this returns a `role`, which can be one of `publisher, editor, admin`. 

at present, we will take `resourceId === null` as meaning that this user has site wide permissions 
