### PR TITLE
feat(resource): basic implementation and tests

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -49,6 +49,7 @@
     "@aws-sdk/client-codebuild": "^3.629.0",
     "@aws-sdk/client-s3": "3.629.0",
     "@aws-sdk/s3-request-presigner": "3.629.0",
+    "@casl/ability": "^6.7.1",
     "@chakra-ui/anatomy": "^2.2.2",
     "@chakra-ui/react": "^2.8.2",
     "@chakra-ui/styled-system": "^2.9.2",

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -185,11 +185,11 @@ model SiteMember {
 }
 
 model ResourcePermission {
-  id         BigInt     @id @default(autoincrement())
+  id         BigInt    @id @default(autoincrement())
   userId     String
-  user       User     @relation(fields: [userId], references: [id])
+  user       User      @relation(fields: [userId], references: [id])
   siteId     Int
-  site       Site     @relation(fields: [siteId], references: [id])
+  site       Site      @relation(fields: [siteId], references: [id])
   resourceId BigInt?
   resource   Resource? @relation(fields: [resourceId], references: [id])
   role       RoleType

--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -1,0 +1,76 @@
+import { AbilityBuilder, createMongoAbility } from "@casl/ability"
+
+import type { RoleType } from "../../database"
+import type { ResourceAbility } from "../permissions.service"
+import { buildPermissionsFor, CRUD_ACTIONS } from "../permissions.service"
+
+const buildPermissions = (role: RoleType) => {
+  const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
+  buildPermissionsFor(role, builder)
+  return builder.build({ detectSubjectType: () => "Resource" })
+}
+
+describe("permissions.service", () => {
+  it("should allow editors to perform CRUD actions on non root pages", () => {
+    // Arrange
+    const perms = buildPermissions("Editor")
+    const expected = true
+    const page = { parentId: "2" }
+
+    // Act
+    const results = CRUD_ACTIONS.map((action) => {
+      return perms.can(action, page)
+    })
+
+    // Assert
+    expect(results.every((v) => v)).toBe(expected)
+  })
+
+  it("should allow editors to update and read root pages", () => {
+    // Arrange
+    const actions = ["update", "read"] as const
+    const rootPage = { parentId: null }
+    const perms = buildPermissions("Editor")
+    const expected = true
+
+    // Act
+    const results = actions.map((action) => {
+      return perms.can(action, rootPage)
+    })
+
+    // Assert
+    expect(results.every((v) => v)).toBe(expected)
+  })
+
+  it("should disallow editors from creating and deleting root pages", () => {
+    // Arrange
+    const actions = ["delete", "create"] as const
+    const rootPage = { parentId: null }
+    const perms = buildPermissions("Editor")
+    const expected = false
+
+    // Act
+    const results = actions.map((action) => {
+      return perms.can(action, rootPage)
+    })
+
+    // Assert
+    expect(results.every((v) => v)).toBe(expected)
+  })
+
+  it("should allow admins to create and delete root pages", () => {
+    // Arrange
+    const actions = ["delete", "create"] as const
+    const rootPage = { parentId: null }
+    const perms = buildPermissions("Admin")
+    const expected = true
+
+    // Act
+    const results = actions.map((action) => {
+      return perms.can(action, rootPage)
+    })
+
+    // Assert
+    expect(results.every((v) => v)).toBe(expected)
+  })
+})

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -1,0 +1,70 @@
+import type { PureAbility } from "@casl/ability"
+import { AbilityBuilder, createMongoAbility } from "@casl/ability"
+
+import type { Resource as RawResource, RoleType } from "../database"
+import { db } from "../database"
+
+type Resource = Pick<RawResource, "parentId">
+type AllowedResourceActions = (typeof ALL_ACTIONS)[number]
+type Subjects = "Resource" | Resource
+
+export const CRUD_ACTIONS = ["create", "read", "update", "delete"] as const
+export const ALL_ACTIONS = [...CRUD_ACTIONS, "move"] as const
+
+export type ResourceAbility = PureAbility<[AllowedResourceActions, Subjects]>
+
+interface PermissionsProps {
+  userId: string
+  siteId: number
+  resourceId: string | null
+}
+export const definePermissionsFor = async ({
+  userId,
+  siteId,
+  resourceId,
+}: PermissionsProps) => {
+  const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
+  const query = db
+    .selectFrom("ResourcePermission")
+    .where("userId", "=", userId)
+    .where("siteId", "=", siteId)
+
+  if (resourceId === null) {
+    query.where("resourceId", "is", null)
+  } else {
+    query.where("resourceId", "=", resourceId)
+  }
+
+  const roles = await query.selectAll().execute()
+
+  roles.map(({ role }) => buildPermissionsFor(role, builder))
+
+  return builder.build({ detectSubjectType: () => "Resource" })
+}
+
+export const buildPermissionsFor = (
+  role: RoleType,
+  builder: AbilityBuilder<ResourceAbility>,
+) => {
+  switch (role) {
+    case "Editor":
+      // NOTE: Users can perform every action on non root resources that they have edit access to
+      CRUD_ACTIONS.map((action) => {
+        builder.can(action, "Resource", { parentId: { $ne: null } })
+      })
+      // NOTE: For root resources, they can only update and read
+      builder.can("update", "Resource", { parentId: { $eq: null } })
+      builder.can("read", "Resource", { parentId: { $eq: null } })
+      return
+    case "Admin":
+      CRUD_ACTIONS.map((action) => {
+        builder.can(action, "Resource")
+      })
+      return
+    case "Publisher":
+      throw new Error("Not implemented")
+    default:
+      const _unhandled: never = role
+      throw new Error(`Unhandled case for permissions`)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@aws-sdk/client-codebuild": "^3.629.0",
         "@aws-sdk/client-s3": "3.629.0",
         "@aws-sdk/s3-request-presigner": "3.629.0",
+        "@casl/ability": "^6.7.1",
         "@chakra-ui/anatomy": "^2.2.2",
         "@chakra-ui/react": "^2.8.2",
         "@chakra-ui/styled-system": "^2.9.2",
@@ -3592,6 +3593,18 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
         "tough-cookie": "^4.1.4"
+      }
+    },
+    "node_modules/@casl/ability": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-6.7.1.tgz",
+      "integrity": "sha512-e+Vgrehd1/lzOSwSqKHtmJ6kmIuZbGBlM2LBS5IuYGGKmVHuhUuyh3XgTn1VIw9+TO4gqU+uptvxfIRBUEdJuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@ucast/mongo2js": "^1.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
       }
     },
     "node_modules/@chakra-ui/accordion": {
@@ -13124,6 +13137,41 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@ucast/core": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
+      "integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@ucast/js": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.4.tgz",
+      "integrity": "sha512-TgG1aIaCMdcaEyckOZKQozn1hazE0w90SVdlpIJ/er8xVumE11gYAtSbw/LBeUnA4fFnFWTcw3t6reqseeH/4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.3.tgz",
+      "integrity": "sha512-XcI8LclrHWP83H+7H2anGCEeDq0n+12FU2mXCTz6/Tva9/9ddK/iacvvhCyW6cijAAOILmt0tWplRyRhVyZLsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.4.tgz",
+      "integrity": "sha512-ahazOr1HtelA5AC1KZ9x0UwPMqqimvfmtSm/PRRSeKKeE5G2SCqTgwiNzO7i9jS8zA3dzXpKVPpXMkcYLnyItA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
       }
     },
     "node_modules/@ungap/structured-clone": {


### PR DESCRIPTION
## Problem
this pr adds tests and logic (using casl) for basic resource permissions for editors and admins

## Solution
1. use `casl` to define permissions for admin and editors
    - for editors, they can perform every action on non-root pages but are unable to create/delete root pages. editors can stiil r/w on root pages 
    - for admins, they can perform read/writes on root pages.

## Notes
how this is implemented is non-overlapping, so at run time, we will construct the permission based on what access the user has to the resource. 

