### PR TITLE
fix: classify not found layout as homepage

### DIFF
--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -12,7 +12,7 @@ import { Skeleton } from "../Skeleton"
 const createIndexPageLayoutStyles = tv({
   slots: {
     container:
-      "mx-auto grid max-w-screen-xl grid-cols-12 px-6 pb-0 pt-12 md:px-10 lg:gap-6 lg:pt-16 xl:gap-10",
+      "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
     content: "col-span-12 flex flex-col gap-16",
   },

--- a/packages/components/src/utils/getTailwindVariantLayout.ts
+++ b/packages/components/src/utils/getTailwindVariantLayout.ts
@@ -3,7 +3,7 @@ import type { IsomerPageLayoutType } from "~/types"
 // This is a simplified layout used for determining the variant to use for
 // components that vary the design depending on the layout of the page
 export const getTailwindVariantLayout = (layout: IsomerPageLayoutType) => {
-  if (layout === "homepage") {
+  if (layout === "homepage" || layout === "notfound") {
     return "homepage"
   }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The not found page is classified as a content page, but it is actually a homepage variant.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Classify the not found page as a homepage variant.
- Sync the design of the index page with the content page.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/d47bf61a-956c-4dba-9fc9-5686e73a692b">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="1204" alt="image" src="https://github.com/user-attachments/assets/4dcd7e3f-edbb-49cc-be6d-a69610b33778">
