### PR TITLE
chore: add content disposition header for assets

### DIFF
--- a/apps/studio/src/hooks/useUploadAssetMutation.ts
+++ b/apps/studio/src/hooks/useUploadAssetMutation.ts
@@ -26,6 +26,7 @@ const handleUpload = async ({ file, presignedPutUrl }: HandleUploadParams) => {
   const response = await fetch(presignedPutUrl, {
     headers: {
       "Content-Type": file.type,
+      "Content-Disposition": `inline; filename="${file.name}"`,
     },
     method: "PUT",
     body: file,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We no longer are doing any PDF rendering component, so we need to encourage browsers to display PDF files in-line rather than download.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add the `Content-Disposition` header to the file upload so that we can hint to the user to show the PDF in the browser instead of downloading it.