### PR TITLE
feat: make cms sidebar scroll independent of resource table

### DIFF
--- a/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSideNav.tsx
@@ -10,7 +10,6 @@ import {
   Flex,
   Icon,
   Skeleton,
-  Spacer,
   Text,
 } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
@@ -27,7 +26,7 @@ interface CmsSideNavProps {
 }
 export const CmsSideNav = ({ siteId }: CmsSideNavProps) => {
   return (
-    <Flex flexDir="column" px="1.25rem" py="1.75rem">
+    <Flex flexDir="column" px="1.25rem" py="1.75rem" height="full">
       <Box mt="4px">
         {/* TODO: update the resource id here */}
         <SideNavItem
@@ -186,19 +185,18 @@ const SideNavItem = ({
                   {permalink}
                 </Text>
               </SideNavRow>
-              {isAllowedToHaveChildren(resourceType) &&
-                (isLoading || hasChildren) && (
-                  <AccordionButton
-                    disabled={isLoading}
-                    pos="absolute"
-                    w="fit-content"
-                    p={0}
-                    left="0.75rem"
-                    top="0.75rem"
-                  >
-                    <AccordionIcon color="interaction.support.unselected" />
-                  </AccordionButton>
-                )}
+              {isAllowedToHaveChildren(resourceType) && hasChildren && (
+                <AccordionButton
+                  disabled={isLoading}
+                  pos="absolute"
+                  w="fit-content"
+                  p={0}
+                  left="0.75rem"
+                  top="0.75rem"
+                >
+                  <AccordionIcon color="interaction.support.unselected" />
+                </AccordionButton>
+              )}
               {isExpanded && (
                 <AccordionPanel p="0" pl="1.25rem">
                   {pages.map(({ items }) => {

--- a/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
@@ -26,7 +26,7 @@ export function CmsSidebarContainer({
           borderColor="base.divider.medium"
           py={{ base: 0, md: "0.75rem" }}
           px={{ base: 0, md: "0.5rem" }}
-          height="100vh"
+          height="$100vh"
           overflow="auto"
           css={{
             "&::-webkit-scrollbar": {
@@ -44,12 +44,12 @@ export function CmsSidebarContainer({
       </GridItem>
       <GridItem as="aside" area="sidenav" overflow="hidden">
         <Box
+          height="$100vh"
           bg="utility.ui"
           pos="sticky"
           top={0}
           borderRight="1px solid"
           borderColor="base.divider.medium"
-          height="100%"
           overflow="auto"
           css={{
             "&::-webkit-scrollbar": {

--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -45,7 +45,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
 
   return (
     <>
-      <Stack w="100%" p="1.75rem" gap="1rem">
+      <Stack w="100%" p="1.75rem" gap="1rem" height="$100vh" overflow="auto">
         <Breadcrumb size="sm">
           <BreadcrumbItem>
             <BreadcrumbLink href={`/sites/${siteId}`}>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -5,7 +5,6 @@ import {
   Flex,
   HStack,
   Portal,
-  Spacer,
   Text,
   useDisclosure,
   VStack,
@@ -107,7 +106,7 @@ const FolderPage: NextPageWithLayout = () => {
 
   return (
     <>
-      <VStack w="100%" p="1.75rem" gap="1rem">
+      <VStack w="100%" p="1.75rem" gap="1rem" height="$100vh" overflow="auto">
         <VStack w="100%" align="start">
           <Breadcrumb size="sm" w="100%">
             {breadcrumbs.map(({ href, label }, index) => {

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -49,7 +49,7 @@ const SitePage: NextPageWithLayout = () => {
 
   return (
     <>
-      <VStack w="100%" p="1.75rem" gap="1rem">
+      <VStack w="100%" p="1.75rem" gap="1rem" height="$100vh" overflow="auto">
         <VStack w="100%" align="start">
           <Breadcrumb size="sm">
             <BreadcrumbItem>


### PR DESCRIPTION
## Solution

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Enhanced layout consistency across multiple pages
- Improved scrolling behavior in the CMS sidebar and content areas
- Removed unnecessary Spacer import in CmsSideNav component


## Before & After Screenshots
Storybook

## Tests

- Verify that the CMS sidebar and content areas scroll independently
- Check that the layout remains consistent across different pages (collections, folders, site home)