### PR TITLE
chore(deps): upgrade turborepo to v2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "tooling/*"
       ],
       "devDependencies": {
-        "turbo": "^2.0.5"
+        "turbo": "^2.1.2"
       }
     },
     "apps/studio": {
@@ -27407,26 +27407,26 @@
       "dev": true
     },
     "node_modules/turbo": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.0.6.tgz",
-      "integrity": "sha512-/Ftmxd5Mq//a9yMonvmwENNUN65jOVTwhhBPQjEtNZutYT9YKyzydFGLyVM1nzhpLWahQSMamRc/RDBv5EapzA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.1.2.tgz",
+      "integrity": "sha512-Jb0rbU4iHEVQ18An/YfakdIv9rKnd3zUfSE117EngrfWXFHo3RndVH96US3GsT8VHpwTncPePDBT2t06PaFLrw==",
       "dev": true,
       "bin": {
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.0.6",
-        "turbo-darwin-arm64": "2.0.6",
-        "turbo-linux-64": "2.0.6",
-        "turbo-linux-arm64": "2.0.6",
-        "turbo-windows-64": "2.0.6",
-        "turbo-windows-arm64": "2.0.6"
+        "turbo-darwin-64": "2.1.2",
+        "turbo-darwin-arm64": "2.1.2",
+        "turbo-linux-64": "2.1.2",
+        "turbo-linux-arm64": "2.1.2",
+        "turbo-windows-64": "2.1.2",
+        "turbo-windows-arm64": "2.1.2"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.0.6.tgz",
-      "integrity": "sha512-XpgBwWj3Ggmz/gQVqXdMKXHC1iFPMDiuwugLwSzE7Ih0O13JuNtYZKhQnopvbDQnFQCeRq2Vsm5OTWabg/oB/g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.1.2.tgz",
+      "integrity": "sha512-3TEBxHWh99h2yIzkuIigMEOXt/ItYQp0aPiJjPd1xN4oDcsKK5AxiFKPH9pdtfIBzYsY59kQhZiFj0ELnSP7Bw==",
       "cpu": [
         "x64"
       ],
@@ -27437,9 +27437,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.0.6.tgz",
-      "integrity": "sha512-RfeZYXIAkiA21E8lsvfptGTqz/256YD+eI1x37fedfvnHFWuIMFZGAOwJxtZc6QasQunDZ9TRRREbJNI68tkIw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.1.2.tgz",
+      "integrity": "sha512-he0miWNq2WxJzsH82jS2Z4MXpnkzn9SH8a79iPXiJkq25QREImucscM4RPasXm8wARp91pyysJMq6aasD45CeA==",
       "cpu": [
         "arm64"
       ],
@@ -27450,9 +27450,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.0.6.tgz",
-      "integrity": "sha512-92UDa0xNQQbx0HdSp9ag3YSS3xPdavhc7q9q9mxIAcqyjjD6VElA4Y85m4F/DDGE5SolCrvBz2sQhVmkOd6Caw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.1.2.tgz",
+      "integrity": "sha512-fKUBcc0rK8Vdqv5a/E3CSpMBLG1bzwv+Q0Q83F8fG2ZfNCNKGbcEYABdonNZkkx141Rj03cZQFCgxu3MVEGU+A==",
       "cpu": [
         "x64"
       ],
@@ -27463,9 +27463,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.0.6.tgz",
-      "integrity": "sha512-eQKu6utCVUkIH2kqOzD8OS6E0ba6COjWm6PRDTNCHQRljZW503ycaTUIdMOiJrVg1MkEjDyOReUg8s8D18aJ4Q==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.1.2.tgz",
+      "integrity": "sha512-sV8Bpmm0WiuxgbhxymcC7wSsuxfBBieI98GegSwbr/bs1ANAgzCg93urIrdKdQ3/b31zZxQwcaP4FBF1wx1Qdg==",
       "cpu": [
         "arm64"
       ],
@@ -27476,9 +27476,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.0.6.tgz",
-      "integrity": "sha512-+9u4EPrpoeHYCQ46dRcou9kbkSoelhOelHNcbs2d86D6ruYD/oIAHK9qgYK8LeARRz0jxhZIA/dWYdYsxJJWkw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.1.2.tgz",
+      "integrity": "sha512-wcmIJZI9ORT9ykHGliFE6kWRQrlH930QGSjSgWC8uFChFFuOyUlvC7ttcxuSvU9VqC7NF4C+GVAcFJQ8lTjN7g==",
       "cpu": [
         "x64"
       ],
@@ -27489,9 +27489,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.0.6.tgz",
-      "integrity": "sha512-rdrKL+p+EjtdDVg0wQ/7yTbzkIYrnb0Pw4IKcjsy3M0RqUM9UcEi67b94XOAyTa5a0GqJL1+tUj2ebsFGPgZbg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.1.2.tgz",
+      "integrity": "sha512-zdnXjrhk7YO6CP+Q5wPueEvOCLH4lDa6C4rrwiakcWcPgcQGbVozJlo4uaQ6awo8HLWQEvOwu84RkWTdLAc/Hw==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "author": "Isomer Team",
   "license": "ISC",
   "devDependencies": {
-    "turbo": "^2.0.5"
+    "turbo": "^2.1.2"
   },
   "packageManager": "npm@10.2.3"
 }


### PR DESCRIPTION
**Improvements**:

- Upgraded Turbo from version 2.0.5 to 2.1.2

**New dev dependencies**:

- `turbo`: Upgraded from ^2.0.5 to ^2.1.2