### PR TITLE
chore: update tailwind vscode plugin settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,7 @@
     { "pattern": "tooling/*/" }
   ],
   "tailwindCSS.experimental.classRegex": [
-    ["tv\\((([^()]*|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
+    ["([\"'`][^\"'`]*.*?[\"'`])", "[\"'`]([^\"'`]*).*?[\"'`]"]
   ],
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.preferences.autoImportFileExcludePatterns": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,10 +12,7 @@
     { "pattern": "tooling/*/" }
   ],
   "tailwindCSS.experimental.classRegex": [
-    ["cva\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-    ["cx\\(([^)]*)\\)", "(?:'|\"|`)([^']*)(?:'|\"|`)"],
-    ["tv\\((([^()]*|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"],
-    ["classNames={([^}]*)}", "[\"'`]([^\"'`]*).*?[\"'`]"]
+    ["tv\\((([^()]*|\\([^()]*\\))*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
   ],
   "typescript.enablePromptUseWorkspaceTsdk": true,
   "typescript.preferences.autoImportFileExcludePatterns": [

--- a/tooling/prettier/index.js
+++ b/tooling/prettier/index.js
@@ -12,7 +12,7 @@ module.exports = {
   semi: false,
   singleQuote: false,
   useTabs: false,
-  tailwindFunctions: ["cn", "cva", "tv"],
+  tailwindFunctions: ["tv"],
   importOrder: [
     "<TYPES>",
     "^(react/(.*)$)|^(react$)|^(react-native(.*)$)",


### PR DESCRIPTION
Saving takes forever due to Tailwind plugin. This PR attempts to simplify the amount of regex that the plugin has to parse. Remove unused regex patterns.

## Solution

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Simplified the Tailwind CSS class regex configuration in VS Code settings
- Removed unused regex patterns for `cva`, `cx`, and `classNames`
- Retained only the regex pattern for `tv` function
