### PR TITLE
feat(component): Table enhancements and border fixes

### DIFF
--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -11,7 +11,7 @@ import Paragraph from "../Paragraph"
 import UnorderedList from "../UnorderedList"
 
 const tableCellStyles = tv({
-  base: "max-w-40 break-words border border-base-divider-medium px-4 py-3 align-top last:max-w-full [&_li]:my-0 [&_li]:pl-1 [&_ol]:mt-0 [&_ol]:ps-5 [&_ul]:mt-0 [&_ul]:ps-5",
+  base: "max-w-40 break-words border border-base-divider-medium px-4 py-3 align-top [&_li]:my-0 [&_li]:pl-1 [&_ol]:mt-0 [&_ol]:ps-5 [&_ul]:mt-0 [&_ul]:ps-5",
   variants: {
     isHeader: {
       true: "bg-base-canvas-backdrop [&_ol]:prose-label-md-medium [&_p]:prose-label-md-medium",

--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -39,7 +39,7 @@ const Table = ({
       />
       <div className="overflow-x-auto" tabIndex={0}>
         <table
-          className="w-full border-collapse border-spacing-0"
+          className="w-full border-collapse border-spacing-0 border border-base-divider-medium"
           aria-describedby={tableDescriptionId}
           ref={tableRef}
         >


### PR DESCRIPTION
## Problem

- Making last column fill up the width of a table was an assumption that was not applicable to many use cases we saw; we decided to remove this feature and let site admins decide the width of a column on their own
- When multiple rows were spanned, the bottom border would disappear; example on: https://staging.dorwsv8lwiupx.amplifyapp.com/lifestage/5-seniors/

Closes [ISOM-1594]

## Solution

- Added border to table
- Removed max-w-full on the last column of a table 