### PR TITLE
fix(component): remove awkward gap in articles

### DIFF
--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -150,3 +150,261 @@ export const Default: Story = {
     ],
   },
 }
+
+export const NoImage: Story = {
+  name: "NoImage",
+  args: {
+    layout: "article",
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        id: "1",
+        title: "Home",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [
+          {
+            id: "2",
+            title: "Newsroom",
+            permalink: "/newsroom",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+            children: [
+              {
+                id: "3",
+                title: "News",
+                permalink: "/newsroom/news",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    id: "4",
+                    title:
+                      "Man sentenced to 24 months' imprisonment for smuggling 34.7 kg of rhinoceros horns",
+                    permalink:
+                      "/newsroom/news/man-sentenced-to-24-months-imprisonment-for-smuggling-34-7-kg-of-rhinoceros-horns",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      navBarItems: [
+        {
+          name: "Home",
+          url: "/",
+        },
+        {
+          name: "Newsroom",
+          url: "/newsroom",
+          items: [
+            {
+              name: "News",
+              url: "/newsroom/news",
+            },
+          ],
+        },
+      ],
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      lastUpdated: "1 Jan 2021",
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+    page: {
+      title:
+        "Singapore's Spectacular Citizens' Festival: a Celebration of Unity and Diversity",
+      permalink:
+        "/newsroom/news/man-sentenced-to-24-months-imprisonment-for-smuggling-34-7-kg-of-rhinoceros-horns",
+      lastModified: "2024-05-02T14:12:57.160Z",
+      category: "Citizen Engagement",
+      date: "1 May 2024",
+      articlePageHeader: {
+        summary: [
+          "Singapore is preparing to host its inaugural Citizens' Festival in Marina Boulevard.",
+          "The festival aims to unite Singaporeans of all backgrounds through cultural showcases, food markets, live music, and wellness activities.",
+        ],
+      },
+    },
+    content: [
+      {
+        type: "image",
+        src: "",
+        alt: "",
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Singapore - In a bid to foster community spirit and celebrate the rich tapestry of its diverse population, Singapore is gearing up to host its first-ever Citizens' Festival. This unprecedented event promises to be a dazzling extravaganza filled with entertainment, cultural showcases, and gastronomic delights.",
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "One of the highlights of the festival is the Cultural Village, where visitors can immerse themselves in the sights, sounds, and flavors of Singapore's various ethnic communities. From traditional Malay dance performances to Chinese calligraphy demonstrations and Indian culinary workshops, attendees will have the opportunity to gain a deeper appreciation for the country's multicultural heritage.",
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "This is a Chat-GPT4 generated article for visual testing purposes.",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+
+export const NoSummary: Story = {
+  name: "NoSummary",
+  args: {
+    layout: "article",
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        id: "1",
+        title: "Home",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [
+          {
+            id: "2",
+            title: "Newsroom",
+            permalink: "/newsroom",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+            children: [
+              {
+                id: "3",
+                title: "News",
+                permalink: "/newsroom/news",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    id: "4",
+                    title:
+                      "Man sentenced to 24 months' imprisonment for smuggling 34.7 kg of rhinoceros horns",
+                    permalink:
+                      "/newsroom/news/man-sentenced-to-24-months-imprisonment-for-smuggling-34-7-kg-of-rhinoceros-horns",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      navBarItems: [
+        {
+          name: "Home",
+          url: "/",
+        },
+        {
+          name: "Newsroom",
+          url: "/newsroom",
+          items: [
+            {
+              name: "News",
+              url: "/newsroom/news",
+            },
+          ],
+        },
+      ],
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      lastUpdated: "1 Jan 2021",
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+    page: {
+      title:
+        "Singapore's Spectacular Citizens' Festival: a Celebration of Unity and Diversity",
+      permalink:
+        "/newsroom/news/man-sentenced-to-24-months-imprisonment-for-smuggling-34-7-kg-of-rhinoceros-horns",
+      lastModified: "2024-05-02T14:12:57.160Z",
+      category: "Citizen Engagement",
+      date: "1 May 2024",
+      articlePageHeader: {
+        summary: [""],
+      },
+    },
+    content: [
+      {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Singapore - In a bid to foster community spirit and celebrate the rich tapestry of its diverse population, Singapore is gearing up to host its first-ever Citizens' Festival. This unprecedented event promises to be a dazzling extravaganza filled with entertainment, cultural showcases, and gastronomic delights.",
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "One of the highlights of the festival is the Cultural Village, where visitors can immerse themselves in the sights, sounds, and flavors of Singapore's various ethnic communities. From traditional Malay dance performances to Chinese calligraphy demonstrations and Indian culinary workshops, attendees will have the opportunity to gain a deeper appreciation for the country's multicultural heritage.",
+              },
+            ],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "This is a Chat-GPT4 generated article for visual testing purposes.",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -25,7 +25,7 @@ const ArticleLayout = ({
       LinkComponent={LinkComponent}
       ScriptComponent={ScriptComponent}
     >
-      <div className="mx-auto flex max-w-[47.8rem] flex-col gap-20 px-6 md:px-10">
+      <div className="mx-auto flex max-w-[47.8rem] flex-col gap-7 px-6 md:px-10">
         <ArticlePageHeader
           {...page.articlePageHeader}
           breadcrumb={breadcrumb}


### PR DESCRIPTION
## Problem

- The article page was designed for articles with a summary, so without the summary, there is an odd gap which looks very janky.
- Regardless of whether article summaries are mandated, this should be fixed to keep components and layouts flexible.

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/1cab8c04-90e6-4beb-89dd-929731f26379">

Closes [ISOM-1593]

## Solution

- Adjusted gap in article to be smaller overall. This way, when an element is removed (e.g., summary), the gap between elements isn't as jarring
- Added new stories to test for above situations

## After

An article without summary:
<img width="1215" alt="image" src="https://github.com/user-attachments/assets/3b740653-3207-4c11-bed2-930375b35c82">

Mobile:
<img width="429" alt="image" src="https://github.com/user-attachments/assets/cb6e3f11-a609-4e4f-868a-cd773a2630d9">
