### PR TITLE
fix(component): add margin-top to iframe/embeds when it's not a first child

### DIFF
--- a/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
+++ b/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
@@ -30,7 +30,7 @@ const Iframe = ({ title, content }: IframeProps) => {
   const iframeUrl = sanitizedIframe.getAttribute("src")
 
   return (
-    <section className={ComponentContent}>
+    <section className={`mt-0 [&:not(:first-child)]:mt-7 ${ComponentContent}`}>
       <div
         className={`relative w-full overflow-hidden ${getPaddingForEmbed(
           iframeUrl,

--- a/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
+++ b/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
@@ -30,7 +30,7 @@ const Iframe = ({ title, content }: IframeProps) => {
   const iframeUrl = sanitizedIframe.getAttribute("src")
 
   return (
-    <section className={`mt-0 [&:not(:first-child)]:mt-7 ${ComponentContent}`}>
+    <section className={`mt-7 first:mt-0 ${ComponentContent}`}>
       <div
         className={`relative w-full overflow-hidden ${getPaddingForEmbed(
           iframeUrl,

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -11,10 +11,7 @@ const meta: Meta<typeof Content> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",
-    chromatic: {
-      delay: 300,
-      ...withChromaticModes(["mobile", "tablet", "desktop"]),
-    },
+    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
     themes: {
       themeOverride: "Isomer Next",
     },
@@ -389,12 +386,6 @@ export const Default: Story = {
             },
           ],
         },
-      },
-      {
-        type: "iframe",
-        content:
-          '<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ?si=ggGGn4uvFWAIelWD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
-        title: "Rick Astley - Never Gonna Give You Up",
       },
       {
         type: "prose",

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -388,6 +388,12 @@ export const Default: Story = {
         },
       },
       {
+        type: "iframe",
+        content:
+          '<iframe width="560" height="315" src="https://www.youtube.com/embed/dQw4w9WgXcQ?si=ggGGn4uvFWAIelWD" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>',
+        title: "Rick Astley - Never Gonna Give You Up",
+      },
+      {
         type: "prose",
         content: [
           {

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -11,7 +11,10 @@ const meta: Meta<typeof Content> = {
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",
-    chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
+    chromatic: {
+      delay: 300,
+      ...withChromaticModes(["mobile", "tablet", "desktop"]),
+    },
     themes: {
       themeOverride: "Isomer Next",
     },


### PR DESCRIPTION
## Problem

Embed/iframes don't have a margin-top when placed into pages, so it sticks to the element previous like the following: 
<img width="1270" alt="image" src="https://github.com/user-attachments/assets/52ed71cd-fd00-4d1b-b6f8-1b60aaa019d5">

Closes [ISOM-1595]

## Solution

- Add top margin (28px, standard that we use for most elements) when the iframe is not a first child
- Added an iframe to the Content page story to test it out

## After

<img width="850" alt="image" src="https://github.com/user-attachments/assets/07c1867c-13f2-4210-b389-58244f7e447d">

Mobile:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/d4c1e386-b1f7-4bcf-ad4c-de98b39de565">
