### PR TITLE
feat(component): enhance Infopic component to look nice in edge cases

### DIFF
--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
@@ -90,7 +90,8 @@ export const LongImage: Story = {
     title: "Don't put all your baskets in one egg",
     description: "",
     buttonUrl: "",
-    imageSrc: "https://picsum.photos/1200/120",
+    imageSrc:
+      "https://images.unsplash.com/photo-1444858440655-e7cf0269024e?q=80&w=2048&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
   },
 }
 

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
@@ -75,3 +75,29 @@ export const NoButton: Story = {
     buttonUrl: "",
   },
 }
+
+export const TallImage: Story = {
+  args: {
+    buttonUrl: "",
+    description: "",
+    imageSrc:
+      "https://images.unsplash.com/photo-1724390495674-5f28d72c686f?q=80&w=2500&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  },
+}
+
+export const LongImage: Story = {
+  args: {
+    title: "Don't put all your baskets in one egg",
+    description: "",
+    buttonUrl: "",
+    imageSrc: "https://picsum.photos/1200/120",
+  },
+}
+
+export const LongImageWithDesc: Story = {
+  args: {
+    title: "Don't put all your baskets in one egg",
+    imageSrc:
+      "https://images.unsplash.com/photo-1713098372674-cbf10e8c2bba?q=80&w=3869&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  },
+}

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -12,7 +12,7 @@ const infopicStyles = tv({
       "grid min-h-[360px] bg-base-canvas-backdrop [grid-template-areas:'img''content'] [grid-template-rows:auto_1fr] lg:grid-cols-2 lg:[grid-template-rows:auto]",
     image: "inset-0 h-full w-full object-cover lg:absolute",
     imageContainer:
-      "relative max-h-[400px] min-h-52 w-full [grid-area:img] lg:max-h-full",
+      "relative max-h-[400px] min-h-[200px] w-full [grid-area:img] lg:max-h-full",
     // max-width of content in desktop is HALF of max-w-screen-xl for correct alignment of content
     // since content is half of screen width in desktop.
     content:

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -9,14 +9,14 @@ import { ImageClient } from "../Image"
 const infopicStyles = tv({
   slots: {
     container:
-      "grid min-h-[360px] bg-base-canvas-backdrop [grid-template-areas:'img''content'] [grid-template-rows:auto_1fr] lg:grid-cols-2",
+      "grid min-h-[360px] bg-base-canvas-backdrop [grid-template-areas:'img''content'] [grid-template-rows:auto_1fr] lg:grid-cols-2 lg:[grid-template-rows:auto]",
     image: "inset-0 h-full w-full object-cover lg:absolute",
     imageContainer:
-      "relative max-h-[400px] w-full [grid-area:img] lg:max-h-full",
+      "relative max-h-[400px] min-h-52 w-full [grid-area:img] lg:max-h-full",
     // max-width of content in desktop is HALF of max-w-screen-xl for correct alignment of content
     // since content is half of screen width in desktop.
     content:
-      "px-6 pb-16 pt-10 text-base-content [grid-area:content] md:max-w-[760px] md:px-10 md:pb-20 md:pt-16 lg:max-w-[620px] lg:py-24 lg:pl-10",
+      "px-6 pb-16 pt-10 text-base-content [grid-area:content] md:max-w-[760px] md:px-10 md:pb-20 md:pt-16 lg:max-w-[620px] lg:content-center lg:py-24 lg:pl-10",
     title: "prose-display-md break-words text-base-content-strong",
     description: "prose-body-base mt-4 md:mt-6",
     button: "mt-9",


### PR DESCRIPTION
## Problem

The [infopic looks fine](https://storybook-next.isomer.gov.sg/?path=/story/next-components-infopic--default) on all viewports when a title, description, and CTA are used properly. However, it doesn't look as good when some elements are omitted or when the elements have odd dimensions/lengths.

Mainly, the issues were:

- When an infopic doesn't have a long enough title and/or description, the image doesn't fill up the height and leaves an awkward grey space.
- When title is used without a description, it is not vertically centered in the content container (for desktop only)
- Images that are horizontally long look odd on mobile, because there is no min-height specified. It's better to take the risk of cutting off images by assigning a min-height

View screenshots of the issues on [the ticket](https://linear.app/ogp/issue/ISOM-1597/infopic-looks-awkward-in-certain-edge-cases). 

Closes [ISOM-1597]

## Solution

Resolves the above issues by:
- Assigning a `lg:[grid-template-rows:auto]` so that the infopic doesn't break into 2 rows on large screens
- Vertically aligning content within the content container only in `lg` and above
- Assigning a `min-height` of `200px` to the image. The value 200px was chosen above preexisting tailwind values to make it easier for agency users to follow the requirements
- Adding new stories to check for images with odd dimensions

## Before & After

Please view Storybook.