### PR TITLE
chore: increase accordion title content length

### DIFF
--- a/packages/components/src/interfaces/complex/Accordion.ts
+++ b/packages/components/src/interfaces/complex/Accordion.ts
@@ -9,7 +9,7 @@ export const AccordionSchema = Type.Object(
     type: Type.Literal("accordion", { default: "accordion" }),
     summary: Type.String({
       title: "Title",
-      maxLength: 100,
+      maxLength: 300,
     }),
     details: AccordionProseSchema,
   },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The accordion title content length of 100 characters is too limiting.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Increase the max length limit from 100 to 300 characters.