### PR TITLE
fix(ci): temporarily disable dd test visibility for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,20 +72,20 @@ jobs:
       - name: Install dependencies
         # Not using test:unit dependency in Turbo because Datadog Test Visibility requires only the test suite to be run
         run: turbo run generate --filter=isomer-studio
-      - name: Configure Datadog Test Visibility
-        env:
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-        uses: datadog/test-visibility-github-action@v1
-        with:
-          languages: js
-          service: isomer-studio
-          api_key: ${{ secrets.DD_API_KEY }}
+      # - name: Configure Datadog Test Visibility
+      #   env:
+      #     DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      #   uses: datadog/test-visibility-github-action@v1
+      #   with:
+      #     languages: js
+      #     service: isomer-studio
+      #     api_key: ${{ secrets.DD_API_KEY }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
         run: turbo test-ci:unit --filter=isomer-studio --env-mode=loose
-        env:
-          # Required to allow Datadog to trace Vitest tests
-          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+        # env:
+        # Required to allow Datadog to trace Vitest tests
+        # NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
 
   end-to-end-tests:
     name: End-to-end tests


### PR DESCRIPTION
`import-in-the-middle` v1.11.0 release broke datadog's vitest test visibility tracing. 

This PR temporarily disables the visibility harness for unit tests (playwright not affected) until it's fixed.

Related:
* https://github.com/DataDog/dd-trace-js/pull/4732
* https://github.com/nodejs/import-in-the-middle/pull/155


## Solution

This change disables the Datadog Test Visibility configuration and tracing in the CI workflow for the isomer-studio project.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Removed Datadog Test Visibility configuration step from the CI workflow
- Commented out Datadog-related environment variables for the test run

## Tests

No new tests are required for this change. Existing tests should continue to run without Datadog tracing.