### PR TITLE
feat: implement nanoid for User model and adjust User schema

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -66,7 +66,6 @@
     "@opengovsg/isomer-components": "*",
     "@opengovsg/sgid-client": "^2.2.0",
     "@opengovsg/starter-kitty-validators": "^1.1.0",
-    "@paralleldrive/cuid2": "^2.2.2",
     "@prisma/client": "5.10.2",
     "@sendgrid/mail": "^8.1.3",
     "@tanstack/match-sorter-utils": "^8.15.1",

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -85,7 +85,7 @@ export interface SiteMember {
   updatedAt: Generated<Timestamp>
 }
 export interface User {
-  id: string
+  id: GeneratedAlways<string>
   name: string
   email: string
   phone: string

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -88,8 +88,7 @@ export interface User {
   id: GeneratedAlways<string>
   name: string
   email: string
-  phone: string
-  preferredName: string | null
+  phone: string | null
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }

--- a/apps/studio/prisma/migrations/20240930071523_custom_migration/migration.sql
+++ b/apps/studio/prisma/migrations/20240930071523_custom_migration/migration.sql
@@ -1,8 +1,3 @@
--- Override Prisma's unique index with unique NOT DISTINCT index
-DROP INDEX IF EXISTS "Resource_siteId_parentId_permalink_key";
-
-CREATE UNIQUE INDEX IF NOT EXISTS "Resource_siteId_parentId_permalink_key" ON "Resource"("siteId", "parentId", "permalink") NULLS NOT DISTINCT;
-
 /*
  * Copyright 2024 Viascom Ltd liab. Co
  *
@@ -11,7 +6,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS "Resource_siteId_parentId_permalink_key" ON "R
  * distributed with this work for additional information
  * regarding copyright ownership.  The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
+ * "License");
+
+you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
@@ -32,6 +29,7 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto;
 -- While it comes with a default configuration, the function is designed to be flexible,
 -- allowing for customization to meet specific needs.
 DROP FUNCTION IF EXISTS nanoid(int, text, float);
+
 CREATE OR REPLACE FUNCTION nanoid(
     size int DEFAULT 21, -- The number of symbols in the NanoId String. Must be greater than 0.
     alphabet text DEFAULT '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ', -- The symbols used in the NanoId String. Must contain between 1 and 255 symbols.
@@ -47,32 +45,45 @@ AS
 $$
 DECLARE
     alphabetArray  text[];
-    alphabetLength int := 64;
-    mask           int := 63;
-    step           int := 34;
+
+alphabetLength int := 64;
+
+mask           int := 63;
+
+step           int := 34;
+
 BEGIN
     IF size IS NULL OR size < 1 THEN
         RAISE EXCEPTION 'The size must be defined and greater than 0!';
-    END IF;
 
-    IF alphabet IS NULL OR length(alphabet) = 0 OR length(alphabet) > 255 THEN
+END IF;
+
+IF alphabet IS NULL OR length(alphabet) = 0 OR length(alphabet) > 255 THEN
         RAISE EXCEPTION 'The alphabet can''t be undefined, zero or bigger than 255 symbols!';
-    END IF;
 
-    IF additionalBytesFactor IS NULL OR additionalBytesFactor < 1 THEN
+END IF;
+
+IF additionalBytesFactor IS NULL OR additionalBytesFactor < 1 THEN
         RAISE EXCEPTION 'The additional bytes factor can''t be less than 1!';
+
+END IF;
+
+alphabetArray := regexp_split_to_array(alphabet, '');
+
+alphabetLength := array_length(alphabetArray, 1);
+
+mask := (2 << cast(floor(log(alphabetLength - 1) / log(2)) as int)) - 1;
+
+step := cast(ceil(additionalBytesFactor * mask * size / alphabetLength) AS int);
+
+IF step > 1024 THEN
+        step := 1024;
+
+-- The step size % can''t be bigger then 1024!
     END IF;
 
-    alphabetArray := regexp_split_to_array(alphabet, '');
-    alphabetLength := array_length(alphabetArray, 1);
-    mask := (2 << cast(floor(log(alphabetLength - 1) / log(2)) as int)) - 1;
-    step := cast(ceil(additionalBytesFactor * mask * size / alphabetLength) AS int);
+RETURN nanoid_optimized(size, alphabet, mask, step);
 
-    IF step > 1024 THEN
-        step := 1024; -- The step size % can''t be bigger then 1024!
-    END IF;
-
-    RETURN nanoid_optimized(size, alphabet, mask, step);
 END
 $$;
 
@@ -80,6 +91,7 @@ $$;
 -- This optimized version is designed for higher performance and lower memory overhead.
 -- No checks are performed! Use it only if you really know what you are doing.
 DROP FUNCTION IF EXISTS nanoid_optimized(int, text, int, int);
+
 CREATE OR REPLACE FUNCTION nanoid_optimized(
     size int, -- The desired length of the generated string.
     alphabet text, -- The set of characters to choose from for generating the string.
@@ -96,27 +108,43 @@ AS
 $$
 DECLARE
     idBuilder      text := '';
-    counter        int  := 0;
-    bytes          bytea;
-    alphabetIndex  int;
-    alphabetArray  text[];
-    alphabetLength int  := 64;
+
+counter        int  := 0;
+
+bytes          bytea;
+
+alphabetIndex  int;
+
+alphabetArray  text[];
+
+alphabetLength int  := 64;
+
 BEGIN
     alphabetArray := regexp_split_to_array(alphabet, '');
-    alphabetLength := array_length(alphabetArray, 1);
 
-    LOOP
+alphabetLength := array_length(alphabetArray, 1);
+
+LOOP
         bytes := gen_random_bytes(step);
-        FOR counter IN 0..step - 1
+
+FOR counter IN 0..step - 1
             LOOP
                 alphabetIndex := (get_byte(bytes, counter) & mask) + 1;
-                IF alphabetIndex <= alphabetLength THEN
+
+IF alphabetIndex <= alphabetLength THEN
                     idBuilder := idBuilder || alphabetArray[alphabetIndex];
-                    IF length(idBuilder) = size THEN
+
+IF length(idBuilder) = size THEN
                         RETURN idBuilder;
-                    END IF;
-                END IF;
-            END LOOP;
-    END LOOP;
+
+END IF;
+
+END IF;
+
+END LOOP;
+
+END LOOP;
+
 END
 $$;
+

--- a/apps/studio/prisma/migrations/20240930071854_use_nanoid_for_user_id/migration.sql
+++ b/apps/studio/prisma/migrations/20240930071854_use_nanoid_for_user_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "id" SET DEFAULT nanoid();

--- a/apps/studio/prisma/migrations/20240930072323_make_phone_optional_and_remove_preferred_name_from_user/migration.sql
+++ b/apps/studio/prisma/migrations/20240930072323_make_phone_optional_and_remove_preferred_name_from_user/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `preferredName` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "preferredName",
+ALTER COLUMN "phone" DROP NOT NULL;

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -109,7 +109,7 @@ enum ResourceType {
 }
 
 model User {
-  id            String  @id @default(cuid())
+  id            String  @id @default(dbgenerated("nanoid()"))
   name          String
   email         String  @unique
   phone         String

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -109,11 +109,10 @@ enum ResourceType {
 }
 
 model User {
-  id            String  @id @default(dbgenerated("nanoid()"))
-  name          String
-  email         String  @unique
-  phone         String
-  preferredName String?
+  id    String  @id @default(dbgenerated("nanoid()"))
+  name  String
+  email String  @unique
+  phone String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -4,12 +4,9 @@
  * @link https://www.prisma.io/docs/guides/database/seed-database
  */
 import type { IsomerSchema } from "@opengovsg/isomer-components"
-import cuid2 from "@paralleldrive/cuid2"
 
 import type { Navbar } from "~/server/modules/resource/resource.types"
 import { db, jsonb } from "../src/server/modules/database"
-
-const MOCK_PHONE_NUMBER = "123456789"
 
 const ISOMER_ADMINS = [
   "alex",
@@ -231,10 +228,8 @@ async function main() {
       return db
         .insertInto("User")
         .values({
-          id: cuid2.createId(),
           name,
           email: `${name}@open.gov.sg`,
-          phone: MOCK_PHONE_NUMBER,
         })
         .onConflict((oc) =>
           oc

--- a/apps/studio/src/server/modules/me/me.service.ts
+++ b/apps/studio/src/server/modules/me/me.service.ts
@@ -1,9 +1,0 @@
-import { init } from "@paralleldrive/cuid2"
-
-// 202176 generations before 50% chance of collision using square root approximation
-// sqrt(36^5)*26)
-const cuidLen6 = init({ length: 6 })
-
-export const generateUsername = (prefix: string) => {
-  return `${prefix.replace(/\s/g, "")}${cuidLen6()}`
-}

--- a/apps/studio/tests/msw/handlers/me.ts
+++ b/apps/studio/tests/msw/handlers/me.ts
@@ -7,8 +7,7 @@ export const defaultUser: User = {
   id: "cljcnahpn0000xlwynuea40lv",
   email: "test@example.com",
   name: "Test User",
-  phone: "12345678",
-  preferredName: "test",
+  phone: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "@opengovsg/isomer-components": "*",
         "@opengovsg/sgid-client": "^2.2.0",
         "@opengovsg/starter-kitty-validators": "^1.1.0",
-        "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "5.10.2",
         "@sendgrid/mail": "^8.1.3",
         "@tanstack/match-sorter-utils": "^8.15.1",
@@ -6809,17 +6808,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6980,14 +6968,6 @@
       "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
-      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {


### PR DESCRIPTION
## Solution

**Breaking Changes**

- [x] Yes - this PR contains breaking changes
  - The `User` model has been modified, removing the `preferredName` field and making the `phone` field optional

**Features**:

- Added `nanoid()` and `nanoid_optimized()` functions to generate compact, URL-friendly unique identifiers in Postgres

**Improvements**:

- Updated the `User` model to use `nanoid()` for ID generation instead of `cuid()`
- Removed the `@paralleldrive/cuid2` dependency

**Bug Fixes**:

- None

## Before & After Screenshots

N/A

## Tests

- Run database migrations to apply the new schema changes
- Test user creation and retrieval to ensure the new ID generation works correctly
- Verify that existing user-related functionality still works with the updated `User` model

**New scripts**:

None

**New dependencies**:

None

**New dev dependencies**:

None