### PR TITLE
feat: make User phone optional and remove preferredName

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -88,8 +88,7 @@ export interface User {
   id: string
   name: string
   email: string
-  phone: string
-  preferredName: string | null
+  phone: string | null
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }

--- a/apps/studio/prisma/migrations/20240930090834_user_phone_optional_remove_preferredname/migration.sql
+++ b/apps/studio/prisma/migrations/20240930090834_user_phone_optional_remove_preferredname/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `preferredName` on the `User` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "preferredName",
+ALTER COLUMN "phone" DROP NOT NULL;

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -109,11 +109,10 @@ enum ResourceType {
 }
 
 model User {
-  id            String  @id @default(cuid())
-  name          String
-  email         String  @unique
-  phone         String
-  preferredName String?
+  id    String  @id @default(cuid())
+  name  String
+  email String  @unique
+  phone String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -9,8 +9,6 @@ import cuid2 from "@paralleldrive/cuid2"
 import type { Navbar } from "~/server/modules/resource/resource.types"
 import { db, jsonb } from "../src/server/modules/database"
 
-const MOCK_PHONE_NUMBER = "123456789"
-
 const ISOMER_ADMINS = [
   "alex",
   "jan",
@@ -234,7 +232,6 @@ async function main() {
           id: cuid2.createId(),
           name,
           email: `${name}@open.gov.sg`,
-          phone: MOCK_PHONE_NUMBER,
         })
         .onConflict((oc) =>
           oc

--- a/apps/studio/tests/msw/handlers/me.ts
+++ b/apps/studio/tests/msw/handlers/me.ts
@@ -1,14 +1,13 @@
-import { type User } from "@prisma/client"
 import { TRPCError } from "@trpc/server"
 
+import type { User } from "~server/db"
 import { trpcMsw } from "../mockTrpc"
 
 export const defaultUser: User = {
   id: "cljcnahpn0000xlwynuea40lv",
   email: "test@example.com",
   name: "Test User",
-  phone: "12345678",
-  preferredName: "test",
+  phone: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 }


### PR DESCRIPTION
## Solution

This PR updates the User model in the Prisma schema and related files to make the phone field optional and remove the preferredName field.

**Breaking Changes**

- [x] Yes - this PR contains breaking changes
  - The `preferredName` field has been removed from the User model
  - The `phone` field is now optional in the User model

**Improvements**:

- Made the `phone` field optional in the User model
- Removed the `preferredName` field from the User model
- Updated the Prisma schema, generated types, and related files to reflect these changes
