### PR TITLE
feat(perms): add permission checking for moving resources

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -285,6 +285,7 @@ const MoveResourceContent = withSuspense(
               movedItem?.resourceId &&
               curResourceId &&
               mutate({
+                siteId,
                 movedResourceId: movedItem.resourceId,
                 destinationResourceId: moveDest.resourceId,
               })

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -35,6 +35,7 @@ export const getChildrenSchema = z
   .merge(infiniteOffsetPaginationSchema)
 
 export const moveSchema = z.object({
+  siteId: z.number(),
   movedResourceId: bigIntSchema,
   destinationResourceId: bigIntSchema,
 })

--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -95,4 +95,52 @@ describe("permissions.service", () => {
     // Assert
     expect(results.every((v) => v)).toBe(expected)
   })
+
+  it("should allow editors to move between folders", () => {
+    // Arrange
+    const from = { parentId: "2" }
+    const to = { parentId: "3" }
+    const expected = true
+    const perms = buildPermissions("Editor")
+
+    // Act
+    const canMoveFrom = perms.can("move", from)
+    const canMoveTo = perms.can("move", to)
+
+    // Assert
+    expect(canMoveFrom).toBe(expected)
+    expect(canMoveTo).toBe(expected)
+  })
+
+  it("should disallow editors from moving items at the root folder", () => {
+    // Arrange
+    const from = { parentId: null }
+    const to = { parentId: "3" }
+    const expected = true
+    const perms = buildPermissions("Editor")
+
+    // Act
+    const canMoveFrom = perms.can("move", from)
+    const canMoveTo = perms.can("move", to)
+
+    // Assert
+    expect(canMoveFrom).toBe(false)
+    expect(canMoveTo).toBe(expected)
+  })
+
+  it("should disallow editors from moving items to the root folder", () => {
+    // Arrange
+    const from = { parentId: "2" }
+    const to = { parentId: null }
+    const expected = true
+    const perms = buildPermissions("Editor")
+
+    // Act
+    const canMoveFrom = perms.can("move", from)
+    const canMoveTo = perms.can("move", to)
+
+    // Assert
+    expect(canMoveFrom).toBe(expected)
+    expect(canMoveTo).toBe(false)
+  })
 })

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -10,15 +10,15 @@ export const definePermissionsFor = async ({
   resourceId,
 }: PermissionsProps) => {
   const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
-  const query = db
+  let query = db
     .selectFrom("ResourcePermission")
     .where("userId", "=", userId)
     .where("siteId", "=", siteId)
 
   if (!resourceId) {
-    query.where("resourceId", "is", null)
+    query = query.where("resourceId", "is", null)
   } else {
-    query.where("resourceId", "=", resourceId)
+    query = query.where("resourceId", "=", resourceId)
   }
 
   const roles = await query.selectAll().execute()

--- a/apps/studio/src/server/modules/permissions/permissions.util.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.util.ts
@@ -2,7 +2,7 @@ import type { AbilityBuilder } from "@casl/ability"
 
 import type { RoleType } from "../database"
 import type { ResourceAbility } from "./permissions.type"
-import { CRUD_ACTIONS } from "./permissions.type"
+import { ALL_ACTIONS } from "./permissions.type"
 
 export const buildPermissionsFor = (
   role: RoleType,
@@ -11,7 +11,7 @@ export const buildPermissionsFor = (
   switch (role) {
     case "Editor":
       // NOTE: Users can perform every action on non root resources that they have edit access to
-      CRUD_ACTIONS.map((action) => {
+      ALL_ACTIONS.map((action) => {
         builder.can(action, "Resource", { parentId: { $ne: null } })
       })
       // NOTE: For root resources, they can only update and read
@@ -19,7 +19,7 @@ export const buildPermissionsFor = (
       builder.can("read", "Resource", { parentId: { $eq: null } })
       return
     case "Admin":
-      CRUD_ACTIONS.map((action) => {
+      ALL_ACTIONS.map((action) => {
         builder.can(action, "Resource")
       })
       return

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -733,9 +733,11 @@ describe("resource.router", () => {
   describe("move", () => {
     it("should throw 401 if not logged in", async () => {
       const unauthedSession = applySession()
+      const { site } = await setupSite()
       const unauthedCaller = createCaller(createMockRequest(unauthedSession))
 
       const result = unauthedCaller.move({
+        siteId: site.id,
         movedResourceId: "1",
         destinationResourceId: "1",
       })
@@ -747,10 +749,12 @@ describe("resource.router", () => {
 
     it("should return 400 if moved resource does not exist", async () => {
       // Arrange
+      const { site } = await setupSite()
       const { folder } = await setupFolder()
 
       // Act
       const result = caller.move({
+        siteId: site.id,
         movedResourceId: "99999", // should not exist
         destinationResourceId: folder.id,
       })
@@ -764,9 +768,11 @@ describe("resource.router", () => {
     it("should return 400 if destination resource does not exist", async () => {
       // Arrange
       const { folder } = await setupFolder()
+      const { site } = await setupSite()
 
       // Act
       const result = caller.move({
+        siteId: site.id,
         movedResourceId: folder.id,
         destinationResourceId: "99999", // should not exist
       })
@@ -790,6 +796,7 @@ describe("resource.router", () => {
 
       // Act
       const result = caller.move({
+        siteId: site.id,
         movedResourceId: pageToMove.id,
         destinationResourceId: anotherPage.id,
       })
@@ -811,6 +818,7 @@ describe("resource.router", () => {
 
       // Act
       const result = caller.move({
+        siteId: originSite.id,
         movedResourceId: originPage.id,
         destinationResourceId: destinationFolder.id,
       })
@@ -838,6 +846,7 @@ describe("resource.router", () => {
 
       // Act
       const result = await caller.move({
+        siteId: site.id,
         movedResourceId: pageToMove.id,
         destinationResourceId: destinationFolder.id,
       })
@@ -869,6 +878,7 @@ describe("resource.router", () => {
 
       // Act
       const result = await caller.move({
+        siteId: site.id,
         movedResourceId: pageToMove.id,
         destinationResourceId: destinationFolder.id,
       })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -22,7 +22,7 @@ describe("resource.router", async () => {
   let caller: ReturnType<typeof createCaller>
   const session = await applyAuthedSession()
 
-  beforeAll(async () => {
+  beforeAll(() => {
     caller = createCaller(createMockRequest(session))
   })
 

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -6,6 +6,7 @@ import {
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
 import {
+  setupAdminPermissions,
   setupFolder,
   setupPageResource,
   setupSite,
@@ -17,11 +18,11 @@ import { resourceRouter } from "../resource.router"
 
 const createCaller = createCallerFactory(resourceRouter)
 
-describe("resource.router", () => {
+describe("resource.router", async () => {
   let caller: ReturnType<typeof createCaller>
+  const session = await applyAuthedSession()
 
   beforeAll(async () => {
-    const session = await applyAuthedSession()
     caller = createCaller(createMockRequest(session))
   })
 
@@ -751,6 +752,10 @@ describe("resource.router", () => {
       // Arrange
       const { site } = await setupSite()
       const { folder } = await setupFolder()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
 
       // Act
       const result = caller.move({
@@ -769,6 +774,10 @@ describe("resource.router", () => {
       // Arrange
       const { folder } = await setupFolder()
       const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
 
       // Act
       const result = caller.move({
@@ -793,6 +802,10 @@ describe("resource.router", () => {
         siteId: site.id,
         permalink: "another-page",
       })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
 
       // Act
       const result = caller.move({
@@ -815,6 +828,10 @@ describe("resource.router", () => {
       const { folder: destinationFolder, site: destinationSite } =
         await setupFolder()
       expect(originSite.id).not.toEqual(destinationSite.id)
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: originSite.id,
+      })
 
       // Act
       const result = caller.move({
@@ -842,6 +859,10 @@ describe("resource.router", () => {
       const { folder: destinationFolder } = await setupFolder({
         siteId: site.id,
         permalink: "destination-folder",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
       })
 
       // Act
@@ -874,6 +895,10 @@ describe("resource.router", () => {
       const { folder: destinationFolder } = await setupFolder({
         siteId: site.id,
         permalink: "destination-folder",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
       })
 
       // Act

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -25,15 +25,19 @@ import { definePermissionsFor } from "../permissions/permissions.service"
 const fetchResource = async (resourceId: string | null) => {
   if (resourceId === null) return { parentId: null }
 
-  return (
-    db
-      .selectFrom("Resource")
-      .where("Resource.id", "=", resourceId)
-      .select("parentId")
-      // NOTE: if we don't have a resource,
-      // this means that they tried to fetch a resource that cannot be found
-      .executeTakeFirstOrThrow()
-  )
+  const resource = await db
+    .selectFrom("Resource")
+    .where("Resource.id", "=", resourceId)
+    .select("parentId")
+    // NOTE: if we don't have a resource,
+    // this means that they tried to fetch a resource that cannot be found
+    .executeTakeFirst()
+
+  if (!resource) {
+    throw new TRPCError({ code: "BAD_REQUEST" })
+  }
+
+  return resource
 }
 
 const validateUserPermissions = async ({

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -4,6 +4,7 @@ import { get } from "lodash"
 import { z } from "zod"
 
 import type { ResourceType } from "../database"
+import type { PermissionsProps } from "../permissions/permissions.type"
 import {
   countResourceSchema,
   deleteResourceSchema,
@@ -19,6 +20,45 @@ import { protectedProcedure, router } from "~/server/trpc"
 import { publishSite } from "../aws/codebuild.service"
 import { db, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
+import { definePermissionsFor } from "../permissions/permissions.service"
+
+const fetchResource = async (resourceId: string | null) => {
+  if (resourceId === null) return { parentId: null }
+
+  return (
+    db
+      .selectFrom("Resource")
+      .where("Resource.id", "=", resourceId)
+      .select("parentId")
+      // NOTE: if we don't have a resource,
+      // this means that they tried to fetch a resource that cannot be found
+      .executeTakeFirstOrThrow()
+  )
+}
+
+const validateUserPermissions = async ({
+  from,
+  to,
+  ...rest
+}: Omit<PermissionsProps, "resourceId"> & {
+  from: string
+  to: string | null
+}) => {
+  // TODO: this is using site wide permissions for now
+  // we should fetch the oldest `parent` of this resource eventually.
+  // Putting this in here first because eventually we'll have to lookup both
+  // even though for now they are the same thing
+  const permsFrom = await definePermissionsFor({ ...rest, resourceId: null })
+  const permsTo = await definePermissionsFor({ ...rest, resourceId: null })
+
+  const resourceFrom = await fetchResource(from)
+
+  return (
+    // NOTE: This is because we want to check whether we can move to within `to`
+    // and hence, the parent id is `to`
+    permsFrom.can("move", resourceFrom) && permsTo.can("move", { parentId: to })
+  )
+}
 
 export const resourceRouter = router({
   getMetadataById: protectedProcedure
@@ -148,6 +188,21 @@ export const resourceRouter = router({
     .input(moveSchema)
     .mutation(
       async ({ ctx, input: { movedResourceId, destinationResourceId } }) => {
+        const isValid = await validateUserPermissions({
+          from: movedResourceId,
+          to: destinationResourceId,
+          userId: ctx.user.id,
+          siteId,
+        })
+
+        if (!isValid) {
+          throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+              "Please ensure that you have the required permissions to perform a move!",
+          })
+        }
+
         const result = await db
           .transaction()
           .execute(async (tx) => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -187,7 +187,10 @@ export const resourceRouter = router({
   move: protectedProcedure
     .input(moveSchema)
     .mutation(
-      async ({ ctx, input: { movedResourceId, destinationResourceId } }) => {
+      async ({
+        ctx,
+        input: { siteId, movedResourceId, destinationResourceId },
+      }) => {
         const isValid = await validateUserPermissions({
           from: movedResourceId,
           to: destinationResourceId,


### PR DESCRIPTION
## Problem
we need to add permissions checking for moving items between folders. 

Closes [insert issue #]

## Solution
add initial permissions check. this allows editors to freely move **non-root** items between **non-root** resources. we allow admins to freely move items between folders.

## Screenshots

https://github.com/user-attachments/assets/666f286a-efbe-4be3-b3d1-0fbd36f5d6e6

