### PR TITLE
permissions(move): add ui for moving items

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import NextLink from "next/link"
+import { Can } from "@casl/react"
 import { MenuButton, MenuList, Portal } from "@chakra-ui/react"
 import { IconButton, Menu } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
@@ -15,6 +16,7 @@ import {
 import type { ResourceTableData } from "./types"
 import { MenuItem } from "~/components/Menu"
 import { moveResourceAtom } from "~/features/editing-experience/atoms"
+import { usePermissions } from "~/features/permissions"
 import { getLinkToResource } from "~/utils/resource"
 import { deleteResourceModalAtom, folderSettingsModalAtom } from "../../atoms"
 
@@ -48,6 +50,8 @@ export const ResourceTableMenu = ({
     [siteId, resourceId, type],
   )
 
+  const { ability } = usePermissions()
+
   return (
     <Menu isLazy size="sm">
       <MenuButton
@@ -70,10 +74,13 @@ export const ResourceTableMenu = ({
               >
                 Edit page settings
               </MenuItem>
+
               {/* TODO(ISOM-1552): Add back duplicate page functionality when implemented */}
-              <MenuItem isDisabled icon={<BiDuplicate fontSize="1rem" />}>
-                Duplicate page
-              </MenuItem>
+              <Can do="create" on={{ parentId }} ability={ability}>
+                <MenuItem isDisabled icon={<BiDuplicate fontSize="1rem" />}>
+                  Duplicate page
+                </MenuItem>
+              </Can>
             </>
           ) : (
             <MenuItem
@@ -88,28 +95,33 @@ export const ResourceTableMenu = ({
             </MenuItem>
           )}
           {(type === "Page" || type === "Folder") && (
-            <MenuItem
-              as="button"
-              onClick={handleMoveResourceClick}
-              icon={<BiFolderOpen fontSize="1rem" />}
-            >
-              Move to...
-            </MenuItem>
+            // TODO: we need to change the resourceid next time when we implement root level permissions
+            <Can do="move" on={{ parentId }} ability={ability}>
+              <MenuItem
+                as="button"
+                onClick={handleMoveResourceClick}
+                icon={<BiFolderOpen fontSize="1rem" />}
+              >
+                Move to...
+              </MenuItem>
+            </Can>
           )}
           {resourceType !== ResourceType.RootPage && (
-            <MenuItem
-              onClick={() => {
-                setResourceModalState({
-                  title,
-                  resourceId,
-                  resourceType,
-                })
-              }}
-              colorScheme="critical"
-              icon={<BiTrash fontSize="1rem" />}
-            >
-              Delete
-            </MenuItem>
+            <Can do="delete" on={{ parentId }} ability={ability}>
+              <MenuItem
+                onClick={() => {
+                  setResourceModalState({
+                    title,
+                    resourceId,
+                    resourceType,
+                  })
+                }}
+                colorScheme="critical"
+                icon={<BiTrash fontSize="1rem" />}
+              >
+                Delete
+              </MenuItem>
+            </Can>
           )}
         </MenuList>
       </Portal>

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -21,6 +21,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
 import type { PendingMoveResource } from "../../types"
+import { usePermissions } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
@@ -82,6 +83,7 @@ const MoveResourceContent = withSuspense(
           getNextPageParam: (lastPage) => lastPage.nextOffset,
         },
       )
+    const { ability } = usePermissions()
     const utils = trpc.useUtils()
     const toast = useToast({ status: "success" })
     const { mutate, isLoading } = trpc.resource.move.useMutation({
@@ -278,16 +280,21 @@ const MoveResourceContent = withSuspense(
             Cancel
           </Button>
           <Button
-            // NOTE: disable this button if either resourceId is missing
-            isDisabled={!curResourceId || !movedItem?.resourceId}
+            // NOTE: disable this button if the resourceId to be moved is missing
+            // or if the user does not have sufficient permissions to move to the destination
+            isDisabled={
+              ability.cannot("move", {
+                parentId: moveDest?.resourceId ?? null,
+              }) ||
+              ability.cannot("move", { parentId: movedItem?.parentId ?? null })
+            }
             isLoading={isLoading}
             onClick={() =>
               movedItem?.resourceId &&
-              curResourceId &&
               mutate({
                 siteId,
                 movedResourceId: movedItem.resourceId,
-                destinationResourceId: moveDest.resourceId,
+                destinationResourceId: moveDest?.resourceId ?? null,
               })
             }
           >

--- a/apps/studio/src/features/permissions/PermissionsContext.tsx
+++ b/apps/studio/src/features/permissions/PermissionsContext.tsx
@@ -1,0 +1,57 @@
+import type { PropsWithChildren } from "react"
+import { createContext, useContext } from "react"
+import { AbilityBuilder, createMongoAbility } from "@casl/ability"
+import { RoleType } from "@prisma/client"
+
+import type { ResourceAbility } from "~/server/modules/permissions/permissions.type"
+import { buildPermissionsFor } from "~/server/modules/permissions/permissions.util"
+import { trpc } from "~/utils/trpc"
+
+interface PermissionsContextReturn {
+  ability: ResourceAbility
+}
+
+interface PermissionsProviderProps {
+  siteId: number
+  resourceId?: string
+}
+
+const getPermissions = (roles: { role: RoleType }[]) => {
+  const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
+  roles.forEach(({ role }) => {
+    buildPermissionsFor(role, builder)
+  })
+  return builder.build({ detectSubjectType: () => "Resource" })
+}
+
+export const PermissionsContext =
+  createContext<PermissionsContextReturn | null>(null)
+
+export const PermissionsProvider = ({
+  children,
+  siteId,
+  resourceId,
+}: PropsWithChildren<PermissionsProviderProps>) => {
+  const [roles] = trpc.resource.getRolesFor.useSuspenseQuery({
+    siteId,
+    resourceId: resourceId ?? null,
+  })
+
+  const ability = getPermissions(roles)
+
+  return (
+    <PermissionsContext.Provider value={{ ability }}>
+      {children}
+    </PermissionsContext.Provider>
+  )
+}
+
+export const usePermissions = (): PermissionsContextReturn => {
+  const context = useContext(PermissionsContext)
+  if (!context) {
+    throw new Error(
+      `usePermissionsState must be used within a PermissionsStateProvider component`,
+    )
+  }
+  return context
+}

--- a/apps/studio/src/features/permissions/index.ts
+++ b/apps/studio/src/features/permissions/index.ts
@@ -1,0 +1,1 @@
+export * from "./PermissionsContext"

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -22,6 +22,7 @@ import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
 import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
 import { MoveResourceModal } from "~/features/editing-experience/components/MoveResourceModal"
+import { PermissionsProvider } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminCmsSidebarLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
@@ -105,14 +106,14 @@ const FolderPage: NextPageWithLayout = () => {
   const breadcrumbs = getBreadcrumbsFrom(resource, siteId)
 
   return (
-    <>
+    <PermissionsProvider siteId={Number(siteId)}>
       <VStack
         w="100%"
         p="1.75rem"
         gap="1rem"
-        height={0}
-        minH="100%"
+        height="0"
         overflow="auto"
+        minH="100%"
       >
         <VStack w="100%" align="start">
           <Breadcrumb size="sm" w="100%">
@@ -238,7 +239,7 @@ const FolderPage: NextPageWithLayout = () => {
       <FolderSettingsModal />
       <MoveResourceModal />
       <DeleteResourceModal siteId={parseInt(siteId)} />
-    </>
+    </PermissionsProvider>
   )
 }
 

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -37,7 +37,7 @@ export const getChildrenSchema = z
 export const moveSchema = z.object({
   siteId: z.number(),
   movedResourceId: bigIntSchema,
-  destinationResourceId: bigIntSchema,
+  destinationResourceId: bigIntSchema.nullable(),
 })
 
 export const countResourceSchema = z.object({

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -54,14 +54,16 @@ const validateUserPermissions = async ({
       // we want to create is the resource passed in.
       // However, because we don't have root level permissions for now,
       // we will pass in `null` to signify the site level permissions
-      { parentId: null }
+      { parentId: resourceId ?? null }
     : await db
         .selectFrom("Resource")
         .where("Resource.id", "=", resourceId)
         .select(["Resource.parentId"])
         .executeTakeFirstOrThrow()
 
-  const perms = await definePermissionsFor({ ...rest, resourceId: null })
+  const perms = await definePermissionsFor({
+    ...rest,
+  })
 
   // TODO: create should check against the current resource id
   if (perms.cannot(action, resource)) {

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -4,6 +4,10 @@ import type { PermissionsProps, ResourceAbility } from "./permissions.type"
 import { db } from "../database"
 import { buildPermissionsFor } from "./permissions.util"
 
+// NOTE: Fetches roles for the given resource
+// and returns the permissions wihch the user has for the given resource.
+// If the resourceId is `null` or `undefined`,
+// we will instead fetch the roles for the given site
 export const definePermissionsFor = async ({
   userId,
   siteId,

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -788,7 +788,11 @@ describe("resource.router", async () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Please ensure that you are trying to move your resource into a valid destination",
+        }),
       )
     })
 
@@ -816,7 +820,11 @@ describe("resource.router", async () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Please ensure that you are trying to move your resource into a valid destination",
+        }),
       )
     })
 

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -218,6 +218,7 @@ export const resourceRouter = router({
               .where("id", "=", movedResourceId)
               .select(["id", "siteId"])
               .executeTakeFirst()
+
             if (!toMove) {
               throw new TRPCError({ code: "BAD_REQUEST" })
             }

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -221,14 +221,26 @@ export const resourceRouter = router({
             if (!toMove) {
               throw new TRPCError({ code: "BAD_REQUEST" })
             }
-            const parent = await tx
-              .selectFrom("Resource")
-              .where("id", "=", destinationResourceId)
+
+            let query = tx.selectFrom("Resource")
+            query = !!destinationResourceId
+              ? query.where("id", "=", destinationResourceId)
+              : query.where("type", "=", "RootPage")
+            const parent = await query
               .select(["id", "type", "siteId"])
               .executeTakeFirst()
 
-            if (!parent || parent.type !== "Folder") {
-              throw new TRPCError({ code: "BAD_REQUEST" })
+            if (
+              !parent ||
+              // NOTE: we only allow moves to folders/root.
+              // for moves to root, we only allow this for admin
+              (parent.type !== "RootPage" && parent.type !== "Folder")
+            ) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message:
+                  "Please ensure that you are trying to move your resource into a valid destination",
+              })
             }
 
             if (movedResourceId === destinationResourceId) {
@@ -243,8 +255,13 @@ export const resourceRouter = router({
               .updateTable("Resource")
               .where("id", "=", String(movedResourceId))
               .where("Resource.type", "in", ["Page", "Folder"])
-              .set({ parentId: String(destinationResourceId) })
+              .set({
+                parentId: !!destinationResourceId
+                  ? String(destinationResourceId)
+                  : null,
+              })
               .execute()
+
             return tx
               .selectFrom("Resource")
               .where("id", "=", String(movedResourceId))


### PR DESCRIPTION
## Problem
we need a ui for permissions for moving items. specifically, we need to disable certain functionality when the user **is not allowed** to move items.

For editors, they can only move resources that **are not at root**. For admins, they can move resources freely regardless of where the resources might be.

Closes [insert issue #]

## Solution
1. add a `Context` for permissions so that inner components can call it and we have no need to prop drill. **not** using `jotai` here because i want the component tree to re-render in the event that this changes 
2. UI-wise, buttons are removed if they fail the check for permissions. additionally, the ui for move modals have been very slightly updated. previously, we relied on the resource id being present (or not) to disable the button. now, this is done via a permissions check. 
3. allowed moves to root and because of that, updated teh schema to allow `null` for the destination resource.
 
 ## Screenshots

https://github.com/user-attachments/assets/0886e4d5-6abc-4ac3-b172-08fa687bf708

