### PR TITLE
fix: avoid using document to create element

### DIFF
--- a/packages/components/src/utils/getReferenceLinkHref.ts
+++ b/packages/components/src/utils/getReferenceLinkHref.ts
@@ -9,10 +9,10 @@ const getSanitizedLinkHref = (url?: string) => {
     return undefined
   }
 
-  const elem = document.createElement("a")
-  elem.setAttribute("href", url)
-  DOMPurify.sanitize(elem, { IN_PLACE: true })
-  const sanitizedUrl = elem.getAttribute("href")
+  const elem = DOMPurify.sanitize(`<a href="${url}"></a>`, {
+    RETURN_DOM_FRAGMENT: true,
+  })
+  const sanitizedUrl = elem.firstElementChild?.getAttribute("href")
 
   if (sanitizedUrl === null) {
     return undefined


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

I forgot we don't have `document` until we actually invoke DOMPurify.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Pass a string directly to DOMPurify instead and get it to return the DocumentFragment, rather than crafting the element ourselves using `document`.