### PR TITLE
fix(component): Infobar top margin and button alignment

### DIFF
--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -7,11 +7,11 @@ import { LinkButton } from "../../internal/LinkButton"
 const createInfobarStyles = tv({
   slots: {
     outerContainer: `${ComponentContent}`,
-    innerContainer: "mx-auto flex flex-col",
+    innerContainer: "mx-auto flex flex-col items-start",
     headingContainer: "flex flex-col gap-6",
     title: "break-words",
     description: "text-base-content",
-    buttonContainer: "flex flex-col items-center gap-x-5 gap-y-4 sm:flex-row",
+    buttonContainer: "flex flex-col items-start gap-x-5 gap-y-4 sm:flex-row",
   },
   variants: {
     layout: {
@@ -21,13 +21,15 @@ const createInfobarStyles = tv({
         headingContainer: "gap-6",
         title: "prose-display-lg text-base-content-strong",
         description: "prose-headline-lg-regular",
+        buttonContainer: "items-center",
       },
       default: {
         outerContainer: "mt-12 rounded-lg bg-base-canvas-backdrop first:mt-0",
-        innerContainer: "gap-7 p-8",
+        innerContainer: "items-start gap-7 p-8",
         headingContainer: "gap-4",
         title: "prose-display-sm text-base-content",
         description: "prose-body-base",
+        buttonContainer: "items-start",
       },
     },
   },

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -23,7 +23,7 @@ const createInfobarStyles = tv({
         description: "prose-headline-lg-regular",
       },
       default: {
-        outerContainer: "rounded-lg bg-base-canvas-backdrop",
+        outerContainer: "mt-12 rounded-lg bg-base-canvas-backdrop first:mt-0",
         innerContainer: "gap-7 p-8",
         headingContainer: "gap-4",
         title: "prose-display-sm text-base-content",

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -11,7 +11,7 @@ const createInfobarStyles = tv({
     headingContainer: "flex flex-col gap-6",
     title: "break-words",
     description: "text-base-content",
-    buttonContainer: "flex flex-col items-start gap-x-5 gap-y-4 sm:flex-row",
+    buttonContainer: "flex flex-col gap-x-5 gap-y-4 sm:flex-row",
   },
   variants: {
     layout: {
@@ -83,7 +83,11 @@ const Infobar = ({
             )}
           </div>
 
-          <div className={compoundStyles.buttonContainer()}>
+          <div
+            className={compoundStyles.buttonContainer({
+              layout: simplifiedLayout,
+            })}
+          >
             {buttonLabel && buttonUrl && (
               <LinkButton
                 href={getReferenceLinkHref(buttonUrl, site.siteMap)}


### PR DESCRIPTION
## Problem

- Infobar didn't have margin-top when used in content pages, so there was zero space between its previous elements
- Infobar's buttons were not aligning to the left in smaller viewports

Closes [ISOM-1596]

## Solution

- Added a margin-top to infobar when it's not a first child (moved `outercontainer` to the outer `<section>` and removed the extra `div`)
- Specified how buttons should align in smaller screens

## After

### Margin-top issues

Infobar gets a margin-top when it's not a first child
<img width="789" alt="image" src="https://github.com/user-attachments/assets/c15b27ae-1ea6-4b2d-bbcf-9be8ce566f5f">

No margin-top when it's at the top of the page (first child)
<img width="756" alt="image" src="https://github.com/user-attachments/assets/80e4339c-4dbe-4748-8667-2b38b432eaff">

### Button alignment issues

Infobar buttons align left on content page
<img width="517" alt="image" src="https://github.com/user-attachments/assets/228b1a93-d511-4e6f-aab4-4b4440c77683">

and align center on Homepage
<img width="510" alt="image" src="https://github.com/user-attachments/assets/1d3d90fe-2bc1-449e-83f2-4cdd952f2d69">