### PR TITLE
fix: standardise date formats displayed on site

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16024,9 +16024,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.11",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.11.tgz",
-      "integrity": "sha512-okzr3f11N6WuqYtZSvm+F776mB41wRZMhKP+hc34YdW+KmtYYK9iqvHSwo2k9FEH3fhGXvOPV6yz2IcSrfRUDg=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/dayzed": {
       "version": "3.2.3",
@@ -29567,6 +29567,7 @@
         "@govtechsg/sgds-react": "^2.5.1",
         "@headlessui/react": "^2.1.2",
         "@sinclair/typebox": "^0.33.12",
+        "dayjs": "^1.11.13",
         "interweave": "^13.1.0",
         "interweave-ssr": "^2.0.0",
         "isomorphic-dompurify": "^2.12.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -96,6 +96,7 @@
     "@govtechsg/sgds-react": "^2.5.1",
     "@headlessui/react": "^2.1.2",
     "@sinclair/typebox": "^0.33.12",
+    "dayjs": "^1.11.13",
     "interweave": "^13.1.0",
     "interweave-ssr": "^2.0.0",
     "isomorphic-dompurify": "^2.12.0",

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -1,4 +1,5 @@
 import type { ArticlePageHeaderProps } from "~/interfaces"
+import { getFormattedDate } from "~/utils"
 import BaseParagraph from "../BaseParagraph"
 import Breadcrumb from "../Breadcrumb"
 
@@ -45,7 +46,10 @@ const ArticlePageHeader = ({
         <h1 className="break-words text-3xl font-semibold tracking-tight text-content-strong lg:text-4xl">
           {title}
         </h1>
-        <p className="text-sm text-gray-800">{date}</p>
+
+        {date && (
+          <p className="text-sm text-gray-800">{getFormattedDate(date)}</p>
+        )}
 
         <div className="text-xl tracking-tight text-gray-500 md:text-2xl">
           <ArticleSummaryContent

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -4,7 +4,7 @@ import { composeRenderProps, Text } from "react-aria-components"
 
 import type { CollectionCardProps as BaseCollectionCardProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
-import { isExternalUrl } from "~/utils"
+import { getFormattedDate, isExternalUrl } from "~/utils"
 import { focusVisibleHighlight } from "~/utils/rac"
 import { ImageClient } from "../../complex/Image"
 import { Link } from "../Link"
@@ -38,7 +38,7 @@ export const CollectionCard = ({
     <div className="flex border-collapse flex-col gap-3 border-b border-divider-medium py-5 first:border-t lg:flex-row lg:gap-6">
       {lastUpdated && (
         <Text className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
-          {lastUpdated}
+          {getFormattedDate(lastUpdated)}
         </Text>
       )}
       <div className="flex flex-col gap-3 text-base-content lg:gap-2">

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -21,7 +21,7 @@ import type {
 import { IsomerLogo } from "~/assets/IsomerLogo"
 import { OgpLogo } from "~/assets/OgpLogo"
 import { tv } from "~/lib/tv"
-import { isExternalUrl } from "~/utils"
+import { getFormattedDate, isExternalUrl } from "~/utils"
 import { focusVisibleHighlight } from "~/utils/rac"
 import { BaseLink } from "../Link"
 
@@ -232,7 +232,7 @@ const LegalSection = ({
         <p className="prose-label-md-regular text-base-content-inverse-subtle">
           &copy; {new Date().getFullYear()}{" "}
           {isGovernment ? "Government of Singapore" : agencyName}, last updated{" "}
-          {lastUpdated}
+          {getFormattedDate(lastUpdated)}
         </p>
         <div className="prose-body-sm flex flex-col gap-3 lg:flex-row lg:gap-8">
           {isGovernment && (

--- a/packages/components/src/utils/getFormattedDate.ts
+++ b/packages/components/src/utils/getFormattedDate.ts
@@ -1,7 +1,13 @@
-export const getFormattedDate = (date: string) => {
-  return new Date(date).toLocaleDateString(undefined, {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  })
-}
+import dayjs from "dayjs"
+import customParseFormat from "dayjs/plugin/customParseFormat"
+
+dayjs.extend(customParseFormat)
+
+// Standardise the format of dates displayed on the site
+export const getFormattedDate = (date: string) =>
+  dayjs(date, [
+    "DD/MM/YYYY",
+    "D MMM YYYY",
+    "DD MMM YYYY",
+    "YYYY-MM-DDTHH:mm:ss.SSSZ",
+  ]).format("D MMMM YYYY")


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The way we display dates on the site is very different, and can lead to date parsing issues.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Standardise the way we display dates on the site, and provide a range of date formats to parse the date string using dayjs.