### PR TITLE
fix(tests): enable dd tests + fix failing tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,20 +72,20 @@ jobs:
       - name: Install dependencies
         # Not using test:unit dependency in Turbo because Datadog Test Visibility requires only the test suite to be run
         run: turbo run generate --filter=isomer-studio
-      # - name: Configure Datadog Test Visibility
-      #   env:
-      #     DD_API_KEY: ${{ secrets.DD_API_KEY }}
-      #   uses: datadog/test-visibility-github-action@v1
-      #   with:
-      #     languages: js
-      #     service: isomer-studio
-      #     api_key: ${{ secrets.DD_API_KEY }}
+      - name: Configure Datadog Test Visibility
+        env:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
+        uses: datadog/test-visibility-github-action@v1
+        with:
+          languages: js
+          service: isomer-studio
+          api_key: ${{ secrets.DD_API_KEY }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
         run: turbo test-ci:unit --filter=isomer-studio --env-mode=loose
-        # env:
-        # Required to allow Datadog to trace Vitest tests
-        # NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+        env:
+          # Required to allow Datadog to trace Vitest tests
+          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
 
   end-to-end-tests:
     name: End-to-end tests

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -9,6 +9,7 @@ import * as mailLib from "~/lib/mail"
 import { prisma } from "~/server/prisma"
 import { createTokenHash } from "../../auth.util"
 import { emailSessionRouter } from "../email.router"
+import { getIpFingerprint, LOCALHOST } from "../utils"
 
 describe("auth.email", () => {
   let caller: Awaited<ReturnType<typeof emailSessionRouter.createCaller>>
@@ -73,13 +74,14 @@ describe("auth.email", () => {
     const VALID_OTP = "123456"
     const VALID_TOKEN_HASH = createTokenHash(VALID_OTP, TEST_VALID_EMAIL)
     const INVALID_OTP = "987643"
+    const TEST_OTP_FINGERPRINT = getIpFingerprint(TEST_VALID_EMAIL, LOCALHOST)
 
     it("should successfully set session on valid OTP", async () => {
       // Arrange
       await prisma.verificationToken.create({
         data: {
           expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_VALID_EMAIL,
+          identifier: TEST_OTP_FINGERPRINT,
           token: VALID_TOKEN_HASH,
         },
       })
@@ -118,7 +120,7 @@ describe("auth.email", () => {
       await prisma.verificationToken.create({
         data: {
           expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_VALID_EMAIL,
+          identifier: TEST_OTP_FINGERPRINT,
           token: VALID_TOKEN_HASH,
         },
       })
@@ -141,7 +143,7 @@ describe("auth.email", () => {
       await prisma.verificationToken.create({
         data: {
           expires: new Date(Date.now() - 1000),
-          identifier: TEST_VALID_EMAIL,
+          identifier: TEST_OTP_FINGERPRINT,
           token: VALID_TOKEN_HASH,
         },
       })
@@ -163,7 +165,7 @@ describe("auth.email", () => {
       await prisma.verificationToken.create({
         data: {
           expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_VALID_EMAIL,
+          identifier: TEST_OTP_FINGERPRINT,
           token: VALID_TOKEN_HASH,
           attempts: 6, // Currently hardcoded to 5 attempts.
         },

--- a/apps/studio/src/server/modules/auth/email/utils.ts
+++ b/apps/studio/src/server/modules/auth/email/utils.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest } from "next"
 
-const LOCALHOST = "127.0.0.1"
+export const LOCALHOST = "127.0.0.1"
 
 export const getOtpFingerPrint = (
   email: string,
@@ -20,5 +20,12 @@ export const getOtpFingerPrint = (
     // for more details: https://developers.cloudflare.com/fundamentals/reference/http-request-headers/#x-forwarded-for
     typeof originIp === "string" ? originIp : originIp.join(", ")
 
+  return getIpFingerprint(email, flattenedIp)
+}
+
+export const getIpFingerprint = (
+  email: string,
+  flattenedIp: string,
+): `${string}|${string}` => {
   return `${email}|${flattenedIp}`
 }


### PR DESCRIPTION
## Problem
1. we disabled dd tests previously due to `import-in-the-middle` failing, now that it has been fixed, we're allowing the action again
2. the pr to change the `identifier` from `email` to a concat of `email, ip` broke the email router tests. this pr fixes the failing tests

## Solution
1. enable dd tests
2. update the tests to use the new identifier