### PR TITLE
feat(permissions): folder permissions

### DIFF
--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -33,7 +33,6 @@ export const folderRouter = router({
           .values({
             permalink,
             siteId,
-            siteId,
             type: ResourceType.Folder,
             title: folderTitle,
             parentId: parentFolderId ? String(parentFolderId) : null,

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -4,10 +4,6 @@ import { TRPCError } from "@trpc/server"
 import { get, isEmpty, isEqual } from "lodash"
 import { z } from "zod"
 
-import type {
-  CrudResourceActions,
-  PermissionsProps,
-} from "../permissions/permissions.type"
 import {
   basePageSchema,
   createPageSchema,
@@ -24,7 +20,7 @@ import { safeJsonParse } from "~/utils/safeJsonParse"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { definePermissionsFor } from "../permissions/permissions.service"
+import { validateUserPermissions } from "../permissions/permissions.service"
 import {
   getFooter,
   getFullPageById,
@@ -39,40 +35,6 @@ import { getSiteConfig } from "../site/site.service"
 import { createDefaultPage } from "./page.service"
 
 const schemaValidator = ajv.compile<IsomerSchema>(schema)
-
-const validateUserPermissions = async ({
-  action,
-  resourceId = null,
-  ...rest
-}: PermissionsProps & { action: CrudResourceActions }) => {
-  // TODO: this is using site wide permissions for now
-  // we should fetch the oldest `parent` of this resource eventually
-  const hasCustomParentId = resourceId === null || action === "create"
-  const resource = hasCustomParentId
-    ? // NOTE: If this is at root, we will always use `null` as the parent
-      // otherwise, this is a `create` action and the parent of the resource that
-      // we want to create is the resource passed in.
-      // However, because we don't have root level permissions for now,
-      // we will pass in `null` to signify the site level permissions
-      { parentId: resourceId ?? null }
-    : await db
-        .selectFrom("Resource")
-        .where("Resource.id", "=", resourceId)
-        .select(["Resource.parentId"])
-        .executeTakeFirstOrThrow()
-
-  const perms = await definePermissionsFor({
-    ...rest,
-  })
-
-  // TODO: create should check against the current resource id
-  if (perms.cannot(action, resource)) {
-    throw new TRPCError({
-      code: "FORBIDDEN",
-      message: "You do not have sufficient permissions to perform this action",
-    })
-  }
-}
 
 // TODO: Need to do validation like checking for existence of the page
 // and whether the user has write-access to said page: replace protectorProcedure in this with the new procedure

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -56,7 +56,14 @@ export const validateUserPermissions = async ({
         .selectFrom("Resource")
         .where("Resource.id", "=", resourceId)
         .select(["Resource.parentId"])
-        .executeTakeFirstOrThrow()
+        .executeTakeFirst()
+
+  if (!resource) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Resource not found",
+    })
+  }
 
   const perms = await definePermissionsFor({
     ...rest,

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -1,6 +1,11 @@
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
+import { TRPCError } from "@trpc/server"
 
-import type { PermissionsProps, ResourceAbility } from "./permissions.type"
+import type {
+  CrudResourceActions,
+  PermissionsProps,
+  ResourceAbility,
+} from "./permissions.type"
 import { db } from "../database"
 import { buildPermissionsFor } from "./permissions.util"
 
@@ -30,4 +35,38 @@ export const definePermissionsFor = async ({
   roles.map(({ role }) => buildPermissionsFor(role, builder))
 
   return builder.build({ detectSubjectType: () => "Resource" })
+}
+
+export const validateUserPermissions = async ({
+  action,
+  resourceId = null,
+  ...rest
+}: PermissionsProps & { action: CrudResourceActions }) => {
+  // TODO: this is using site wide permissions for now
+  // we should fetch the oldest `parent` of this resource eventually
+  const hasCustomParentId = resourceId === null || action === "create"
+  const resource = hasCustomParentId
+    ? // NOTE: If this is at root, we will always use `null` as the parent
+      // otherwise, this is a `create` action and the parent of the resource that
+      // we want to create is the resource passed in.
+      // However, because we don't have root level permissions for now,
+      // we will pass in `null` to signify the site level permissions
+      { parentId: resourceId ?? null }
+    : await db
+        .selectFrom("Resource")
+        .where("Resource.id", "=", resourceId)
+        .select(["Resource.parentId"])
+        .executeTakeFirstOrThrow()
+
+  const perms = await definePermissionsFor({
+    ...rest,
+  })
+
+  // TODO: create should check against the current resource id
+  if (perms.cannot(action, resource)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have sufficient permissions to perform this action",
+    })
+  }
 }

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1343,6 +1343,10 @@ describe("resource.router", async () => {
     it("should return 400 if resource to delete does not exist", async () => {
       // Arrange
       const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
 
       // Act
       const result = caller.delete({
@@ -1352,7 +1356,7 @@ describe("resource.router", async () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({ code: "BAD_REQUEST", message: "Resource not found" }),
       )
     })
 
@@ -1360,6 +1364,10 @@ describe("resource.router", async () => {
       // Arrange
       const { page, site } = await setupPageResource({
         resourceType: "Page",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
       })
 
       // Act
@@ -1380,6 +1388,10 @@ describe("resource.router", async () => {
     it("should delete a folder and all its children (recursively) successfully", async () => {
       // Arrange
       const { folder: folderToUse, site } = await setupFolder()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
       const nestedPages = await Promise.all(
         Array.from({ length: 3 }, (_, i) => i).map(async (i) => {
           const { page } = await setupPageResource({
@@ -1441,6 +1453,10 @@ describe("resource.router", async () => {
       // Arrange
       const { page, site } = await setupPageResource({
         resourceType: "RootPage",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
       })
 
       // Act


### PR DESCRIPTION
## Problem
This pr adds permissions checking for permissions on folders and collections **on the backend**. do note that this is only a backend change because the user is restricted from creating/deleting the folder/collectoin already on frontend as the `ability` restricts them.

## Solution
1. shift shared permissions check out to `permission.service` . this is not done for `move` yet, because the api is slightly different. i will aim to get behaviour correct first before shifting to another implementation (via `experimentalMiddleware`)
2. add permissions check to the methods on `collection.router` and `folder.router`
