### PR TITLE
feat: add more validation to resource.router and add test cases

### DIFF
--- a/apps/studio/.env.test
+++ b/apps/studio/.env.test
@@ -9,3 +9,5 @@ NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME=assets-bucket
 
 # Used for E2E testing
 DATABASE_URL=postgres://root:root@localhost:5432/test
+
+PINO_LOG_LEVEL=silent

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -42,7 +42,7 @@ const getFolderHref = (siteId: string, folderId: string) => {
  * and the last element is always the parent of the current folder
  */
 const getBreadcrumbsFrom = (
-  resource: RouterOutput["resource"]["getParentOf"]["resource"],
+  resource: RouterOutput["resource"]["getParentOf"],
   siteId: string,
 ): { href: string; label: string }[] => {
   // NOTE: We only consider the 3 cases below:
@@ -92,7 +92,7 @@ const FolderPage: NextPageWithLayout = () => {
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
 
   const { folderId, siteId } = useQueryParse(folderPageSchema)
-  const [{ resource }] = trpc.resource.getParentOf.useSuspenseQuery({
+  const [resource] = trpc.resource.getParentOf.useSuspenseQuery({
     siteId: Number(siteId),
     resourceId: folderId,
   })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -346,4 +346,386 @@ describe("resource.router", () => {
 
     it.skip("should throw 403 if user does not have read access to resource", async () => {})
   })
+
+  describe("getChildrenOf", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      const result = unauthedCaller.getChildrenOf({
+        resourceId: "1",
+        siteId: "1",
+        limit: 25,
+      })
+
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should return 404 if resource does not exist", async () => {
+      // Act
+      const result = caller.getChildrenOf({
+        resourceId: "1",
+        siteId: "1",
+        limit: 25,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "NOT_FOUND" }),
+      )
+    })
+
+    it("should return 404 if resource is not a folder", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+      })
+
+      // Act
+      const result = caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: page.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "NOT_FOUND" }),
+      )
+    })
+
+    it("should not return RootPage as its own children", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      // Create a root page
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "RootPage",
+        title: "___Root page, should not be returned",
+      })
+      // Create first-level pages
+      const childPages = await Promise.all(
+        Array.from({ length: 3 }, (_, i) => i).map(async (i) => {
+          const { page } = await setupPageResource({
+            siteId: site.id,
+            permalink: `child-page-${i}`,
+            title: `Child page ${i}`,
+            resourceType: "Page",
+          })
+          return pick(page, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: null,
+      })
+
+      // Assert
+      const expected = {
+        // should not have rootPage returned
+        items: childPages.sort((a, b) => a.title.localeCompare(b.title)),
+        nextOffset: null,
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it("should return empty items array if `cursor` is invalid", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      const { folder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+
+      // Act
+      const result = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: folder.id,
+        cursor: 600, // does not exist
+      })
+
+      // Assert
+      const expected = {
+        items: [],
+        nextOffset: null,
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it("should return first-level children if resourceId is null", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      const rootLevelFolders = await Promise.all(
+        Array.from({ length: 15 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: null,
+            permalink: `folder-${i}`,
+            title: `Test folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+      // Extra root-level resources to assert that they are also returned
+      const { page: rootLevelPage } = await setupPageResource({
+        siteId: site.id,
+        title: "__this should be returned",
+        resourceType: "Page",
+      })
+
+      // Extra nested resources to assert these are not returned
+      await setupPageResource({
+        siteId: site.id,
+        title: "__this should not return",
+        parentId: rootLevelFolders[3]!.id,
+        resourceType: "Page",
+      })
+
+      // Act
+      const result = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: null,
+      })
+
+      // Assert
+      const expected = {
+        items: [
+          ...rootLevelFolders,
+          pick(rootLevelPage, ["title", "permalink", "type", "id"]),
+        ]
+          // case sensitive sort to follow db order
+          .sort((a, b) => a.title.localeCompare(b.title))
+          .slice(0, 10), // should only have 10 items
+        nextOffset: 10, // default limit is 10
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it("should return nested children if resourceId is given", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+      const childPages = await Promise.all(
+        Array.from({ length: 2 }, (_, i) => i).map(async (i) => {
+          const { page } = await setupPageResource({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-page-${i}`,
+            title: `__should be returned Child page ${i}`,
+            resourceType: "Page",
+          })
+          return pick(page, ["title", "permalink", "type", "id"])
+        }),
+      )
+      // Extra folders to assert that they are not returned
+      await Promise.all(
+        Array.from({ length: 3 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: null,
+            permalink: `root-folder-${i}`,
+            title: `____Root folder, should not be returned ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+      })
+
+      // Assert
+      const expected = {
+        items: [...childFolders, ...childPages]
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(0, 10), // should only have 10 items
+        nextOffset: 10, // default limit is 10
+      }
+      await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it("should return limit number of children according to the the `limit` parameter", async () => {
+      // Arrange
+      const setLimit = 5
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+      const childPages = await Promise.all(
+        Array.from({ length: 5 }, (_, i) => i).map(async (i) => {
+          const { page } = await setupPageResource({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-page-${i}`,
+            title: `__underscore to return first and should be returned page ${i}`,
+            resourceType: "Page",
+          })
+          return pick(page, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+        limit: setLimit,
+      })
+
+      // Assert
+      const expected = {
+        items: [...childFolders, ...childPages]
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(0, setLimit), // should only have 5 items
+        nextOffset: setLimit, // limit is 5
+      }
+      await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it("should return the next set of children if valid `cursor` is provided", async () => {
+      // Arrange
+      const cursor = 5
+      const nextLimit = 10
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+      const childPages = await Promise.all(
+        Array.from({ length: 5 }, (_, i) => i).map(async (i) => {
+          const { page } = await setupPageResource({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-page-${i}`,
+            title: `__underscore to return first and should be returned page ${i}`,
+            resourceType: "Page",
+          })
+          return pick(page, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+        limit: nextLimit,
+        cursor,
+      })
+
+      // Assert
+      const expected = {
+        items: [...childFolders, ...childPages]
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(cursor, cursor + nextLimit), // should only have 5 items
+        nextOffset: cursor + nextLimit, // limit is 5
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it("should return all items if limit is greater than the number of items", async () => {
+      // Arrange
+      const setLimit = 10
+      const numberOfFolders = 3
+      const numberOfPages = 2
+      expect(numberOfFolders + numberOfPages).toBeLessThan(setLimit)
+
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: numberOfFolders }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+      const childPages = await Promise.all(
+        Array.from({ length: numberOfPages }, (_, i) => i).map(async (i) => {
+          const { page } = await setupPageResource({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-page-${i}`,
+            title: `__underscore to return first and should be returned page ${i}`,
+            resourceType: "Page",
+          })
+          return pick(page, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = await caller.getChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+        limit: setLimit,
+      })
+
+      // Assert
+      const expected = {
+        items: [...childFolders, ...childPages].sort((a, b) =>
+          a.title.localeCompare(b.title),
+        ), // should be sorted by title
+        nextOffset: null,
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it.skip("should throw 403 if user does not have read access to resource", async () => {})
+  })
 })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1,10 +1,15 @@
 import { TRPCError } from "@trpc/server"
+import { pick } from "lodash"
 import {
   applyAuthedSession,
   applySession,
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
-import { setupPageResource } from "tests/integration/helpers/seed"
+import {
+  setupFolder,
+  setupPageResource,
+  setupSite,
+} from "tests/integration/helpers/seed"
 
 import { createCallerFactory } from "~/server/trpc"
 import { resourceRouter } from "../resource.router"
@@ -65,6 +70,278 @@ describe("resource.router", () => {
         type: "Page",
       }
       await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it.skip("should throw 403 if user does not have read access to resource", async () => {})
+  })
+
+  describe("getFolderChildrenOf", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      const result = unauthedCaller.getFolderChildrenOf({
+        resourceId: "1",
+        siteId: "1",
+        limit: 25,
+      })
+
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should return 404 if resource does not exist", async () => {
+      // Act
+      const result = caller.getFolderChildrenOf({
+        resourceId: "1",
+        siteId: "1",
+        limit: 25,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "NOT_FOUND" }),
+      )
+    })
+
+    it("should return 404 if resource is not a folder", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+      })
+
+      // Act
+      const result = caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: page.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "NOT_FOUND" }),
+      )
+    })
+
+    it("should return empty items array if `cursor` is invalid", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      const { folder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+
+      // Act
+      const result = await caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: folder.id,
+        cursor: 600, // does not exist
+      })
+
+      // Assert
+      const expected = {
+        items: [],
+        nextOffset: null,
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it("should return first-level folders if resourceId is null", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      const rootLevelFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: null,
+            permalink: `folder-${i}`,
+            title: `Test folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+      // Extra resources to assert that they are not returned
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        parentId: rootLevelFolders[3]!.id,
+        resourceType: "Page",
+      })
+
+      // Act
+      const result = caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: null,
+      })
+
+      // Assert
+      const expected = {
+        items: rootLevelFolders
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(0, 10), // should only have 10 items
+        nextOffset: 10, // default limit is 10
+      }
+      await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it("should return folder children if resourceId is given", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+      })
+
+      // Assert
+      const expected = {
+        items: childFolders
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(0, 10), // should only have 10 items
+        nextOffset: 10, // default limit is 10
+      }
+      await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it("should return limit number of folders according to the the `limit` parameter", async () => {
+      // Arrange
+      const setLimit = 5
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+        limit: setLimit,
+      })
+
+      // Assert
+      const expected = {
+        items: childFolders
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(0, setLimit), // should only have 5 items
+        nextOffset: setLimit, // limit is 5
+      }
+      await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it("should return the next set of folders if valid `cursor` is provided", async () => {
+      // Arrange
+      const cursor = 5
+      const nextLimit = 10
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: 30 }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = await caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+        limit: nextLimit,
+        cursor,
+      })
+
+      // Assert
+      const expected = {
+        items: childFolders
+          .sort((a, b) => a.title.localeCompare(b.title)) // should be sorted by title
+          .slice(cursor, cursor + nextLimit), // should only have 5 items
+        nextOffset: cursor + nextLimit, // limit is 5
+      }
+      expect(result).toMatchObject(expected)
+    })
+
+    it("should return all items if limit is greater than the number of items", async () => {
+      // Arrange
+      const setLimit = 5
+      const numberOfItems = 3
+      const { site } = await setupSite()
+      const { folder: parentFolder } = await setupFolder({
+        siteId: site.id,
+        parentId: null,
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      const childFolders = await Promise.all(
+        Array.from({ length: numberOfItems }, (_, i) => i).map(async (i) => {
+          const { folder } = await setupFolder({
+            siteId: site.id,
+            parentId: parentFolder.id,
+            permalink: `child-folder-${i}`,
+            title: `Child folder ${i}`,
+          })
+          return pick(folder, ["title", "permalink", "type", "id"])
+        }),
+      )
+
+      // Act
+      const result = await caller.getFolderChildrenOf({
+        siteId: String(site.id),
+        resourceId: parentFolder.id,
+        limit: setLimit,
+      })
+
+      // Assert
+      const expected = {
+        items: childFolders.sort((a, b) => a.title.localeCompare(b.title)), // should be sorted by title
+        nextOffset: null,
+      }
+      expect(result).toMatchObject(expected)
     })
 
     it.skip("should throw 403 if user does not have read access to resource", async () => {})

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1,0 +1,72 @@
+import { TRPCError } from "@trpc/server"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import { setupPageResource } from "tests/integration/helpers/seed"
+
+import { createCallerFactory } from "~/server/trpc"
+import { resourceRouter } from "../resource.router"
+
+const createCaller = createCallerFactory(resourceRouter)
+
+describe("resource.router", () => {
+  let caller: ReturnType<typeof createCaller>
+
+  beforeAll(async () => {
+    const session = await applyAuthedSession()
+    caller = createCaller(createMockRequest(session))
+  })
+
+  describe("getMetadataById", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      const result = unauthedCaller.getMetadataById({
+        resourceId: "1",
+      })
+
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should return 404 if resource does not exist", async () => {
+      // Act
+      const result = caller.getMetadataById({
+        resourceId: "1",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "NOT_FOUND" }),
+      )
+    })
+
+    it("should return metadata if page resource exists", async () => {
+      // Arrange
+      const { page } = await setupPageResource({
+        resourceType: "Page",
+      })
+
+      // Act
+      const result = caller.getMetadataById({
+        resourceId: page.id,
+      })
+
+      // Assert
+      const expected = {
+        id: page.id,
+        title: page.title,
+        permalink: page.permalink,
+        parentId: page.parentId,
+        type: "Page",
+      }
+      await expect(result).resolves.toMatchObject(expected)
+    })
+
+    it.skip("should throw 403 if user does not have read access to resource", async () => {})
+  })
+})

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -183,7 +183,7 @@ export const resourceRouter = router({
             .selectFrom("Resource")
             .where("id", "=", String(movedResourceId))
             .select([
-              "parentId",
+              "Resource.parentId",
               "Resource.id",
               "Resource.type",
               "Resource.permalink",
@@ -210,6 +210,7 @@ export const resourceRouter = router({
         .selectFrom("Resource")
         .where("Resource.siteId", "=", siteId)
         .where("Resource.type", "!=", "RootPage")
+        .select((eb) => [eb.fn.countAll().as("totalCount")])
 
       if (resourceId) {
         query = query.where("Resource.parentId", "=", String(resourceId))
@@ -217,9 +218,7 @@ export const resourceRouter = router({
         query = query.where("Resource.parentId", "is", null)
       }
 
-      const result = await query
-        .select((eb) => [eb.fn.countAll().as("totalCount")])
-        .executeTakeFirst()
+      const result = await query.executeTakeFirst()
       return Number(result?.totalCount ?? 0)
     }),
 

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -296,11 +296,13 @@ export const resourceRouter = router({
               ]),
           ).as("parent"),
         )
-        .executeTakeFirstOrThrow()
+        .executeTakeFirst()
 
-      return {
-        resource,
+      if (!resource) {
+        throw new TRPCError({ code: "NOT_FOUND" })
       }
+
+      return resource
     }),
 
   getWithFullPermalink: protectedProcedure

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -229,6 +229,8 @@ export const resourceRouter = router({
         .selectFrom("Resource")
         .where("Resource.siteId", "=", siteId)
         .where("Resource.type", "!=", "RootPage")
+        .orderBy("Resource.updatedAt", "desc")
+        .orderBy("Resource.title", "asc")
         .offset(offset)
         .limit(limit)
 
@@ -238,6 +240,7 @@ export const resourceRouter = router({
         query = query.where("Resource.parentId", "is", null)
       }
 
+      // TODO: Add pagination support
       return query
         .select([
           "Resource.id",
@@ -247,6 +250,7 @@ export const resourceRouter = router({
           "Resource.draftBlobId",
           "Resource.type",
           "Resource.parentId",
+          "Resource.updatedAt",
         ])
         .execute()
     }),

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -42,6 +42,20 @@ export const resourceRouter = router({
   getFolderChildrenOf: protectedProcedure
     .input(getChildrenSchema)
     .query(async ({ input: { siteId, resourceId, cursor: offset, limit } }) => {
+      // Validate site and resourceId exists
+      if (resourceId !== null) {
+        const resource = await db
+          .selectFrom("Resource")
+          .where("siteId", "=", Number(siteId))
+          .where("id", "=", String(resourceId))
+          .where("Resource.type", "=", "Folder")
+          .executeTakeFirst()
+
+        if (!resource) {
+          throw new TRPCError({ code: "NOT_FOUND" })
+        }
+      }
+
       let query = db
         .selectFrom("Resource")
         .select(["title", "permalink", "type", "id"])

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -42,7 +42,7 @@ export const resourceRouter = router({
   getFolderChildrenOf: protectedProcedure
     .input(getChildrenSchema)
     .query(async ({ input: { siteId, resourceId, cursor: offset, limit } }) => {
-      // Validate site and resourceId exists
+      // Validate site and resourceId exists and is a Folder
       if (resourceId !== null) {
         const resource = await db
           .selectFrom("Resource")
@@ -91,6 +91,19 @@ export const resourceRouter = router({
   getChildrenOf: protectedProcedure
     .input(getChildrenSchema)
     .query(async ({ input: { resourceId, siteId, cursor: offset, limit } }) => {
+      // Validate site and resourceId exists and is a folder
+      if (resourceId !== null) {
+        const resource = await db
+          .selectFrom("Resource")
+          .where("siteId", "=", Number(siteId))
+          .where("id", "=", String(resourceId))
+          .where("Resource.type", "=", "Folder")
+          .executeTakeFirst()
+
+        if (!resource) {
+          throw new TRPCError({ code: "NOT_FOUND" })
+        }
+      }
       let query = db
         .selectFrom("Resource")
         .select(["title", "permalink", "type", "id"])

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -308,7 +308,7 @@ export const resourceRouter = router({
   getWithFullPermalink: protectedProcedure
     .input(getFullPermalinkSchema)
     .query(async ({ input: { resourceId } }) => {
-      return db
+      const result = await db
         .withRecursive("resourcePath", (eb) =>
           eb
             .selectFrom("Resource as r")
@@ -339,6 +339,12 @@ export const resourceRouter = router({
         .select(["rp.id", "rp.title", "rp.fullPermalink"])
         .where("rp.id", "=", resourceId)
         .executeTakeFirst()
+
+      if (!result) {
+        throw new TRPCError({ code: "NOT_FOUND" })
+      }
+
+      return result
     }),
 
   getAncestryOf: protectedProcedure

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -262,10 +262,15 @@ export const resourceRouter = router({
         .deleteFrom("Resource")
         .where("Resource.id", "=", String(resourceId))
         .where("Resource.siteId", "=", siteId)
+        .where("Resource.type", "!=", "RootPage")
         .executeTakeFirst()
-      // NOTE: We need to do this `toString` as the property is a `bigint`
+
+      if (Number(result.numDeletedRows) === 0) {
+        throw new TRPCError({ code: "BAD_REQUEST" })
+      }
+      // NOTE: We need to do this cast as the property is a `bigint`
       // and trpc cannot serialise it, which leads to errors
-      return result.numDeletedRows.toString()
+      return Number(result.numDeletedRows)
     }),
 
   getParentOf: protectedProcedure

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -174,6 +174,7 @@ export const setupPageResource = async ({
   userId,
   permalink,
   parentId,
+  title,
 }: {
   siteId?: number
   blobId?: string
@@ -182,6 +183,7 @@ export const setupPageResource = async ({
   userId?: string
   permalink?: string
   parentId?: string | null
+  title?: string
 }) => {
   const { site, navbar, footer } = await setupSite(siteIdProp, !!siteIdProp)
   const blob = await setupBlob(blobIdProp)
@@ -189,7 +191,7 @@ export const setupPageResource = async ({
   let page = await db
     .insertInto("Resource")
     .values({
-      title: resourceType === "RootPage" ? "Home" : "test page",
+      title: title ?? (resourceType === "RootPage" ? "Home" : "test page"),
       permalink: permalink ?? (resourceType === "RootPage" ? "" : "test-page"),
       siteId: site.id,
       parentId,
@@ -235,18 +237,24 @@ export const setupPageResource = async ({
 
 export const setupFolder = async ({
   siteId: siteIdProp,
+  permalink = "test-folder",
+  parentId = null,
+  title = "test folder",
 }: {
   siteId?: number
+  permalink?: string
+  parentId?: string | null
+  title?: string
 } = {}) => {
-  const { site, navbar, footer } = await setupSite(siteIdProp)
+  const { site, navbar, footer } = await setupSite(siteIdProp, !!siteIdProp)
 
   const folder = await db
     .insertInto("Resource")
     .values({
-      permalink: "test-folder",
+      permalink,
       siteId: site.id,
-      parentId: null,
-      title: "test folder",
+      parentId,
+      title,
       draftBlobId: null,
       state: "Draft",
       type: "Folder",

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -22,6 +22,7 @@ export const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     draftBlobId: null,
     type: "Collection",
     parentId: null,
+    updatedAt: new Date("2024-09-12T07:00:00.000Z"),
   },
   {
     id: "4",
@@ -31,6 +32,7 @@ export const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     draftBlobId: "3",
     type: "Page",
     parentId: null,
+    updatedAt: new Date("2024-09-12T07:00:10.000Z"),
   },
   {
     id: "5",
@@ -40,6 +42,7 @@ export const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     draftBlobId: "4",
     type: "Page",
     parentId: null,
+    updatedAt: new Date("2024-09-12T07:00:20.000Z"),
   },
   {
     id: "6",
@@ -49,6 +52,7 @@ export const DEFAULT_PAGE_ITEMS: RouterOutput["resource"]["listWithoutRoot"] = [
     draftBlobId: null,
     type: "Folder",
     parentId: null,
+    updatedAt: new Date("2024-09-12T07:00:30.000Z"),
   },
 ]
 

--- a/tooling/eslint/base.js
+++ b/tooling/eslint/base.js
@@ -88,6 +88,7 @@ export default tseslint.config(
     rules: {
       "@typescript-eslint/no-unsafe-assignment": "off",
       "@typescript-eslint/no-empty-function": "off",
+      "@typescript-eslint/no-non-null-assertion": "off",
       "no-restricted-syntax": "off",
     },
   },


### PR DESCRIPTION
Second part of the PR. This PR adds tests for `resource.router`

Blocked by #729