### PR TITLE
fix(component): change placeholder copy on collections search to be more generic

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -422,7 +422,7 @@ export const SearchingEmptyCollection: Story = {
   play: async ({ canvasElement }) => {
     const screen = within(canvasElement)
     const searchElem = screen.getByRole("searchbox", {
-      name: /search for publications and other press releases/i,
+      name: /Start typing to search/i,
     })
     await userEvent.type(searchElem, "anything")
   },
@@ -432,7 +432,7 @@ export const NoResults: Story = {
   play: async ({ canvasElement }) => {
     const screen = within(canvasElement)
     const searchElem = screen.getByRole("searchbox", {
-      name: /search for publications and other press releases/i,
+      name: /Start typing to search/i,
     })
     await userEvent.type(searchElem, "some whacky search term")
   },

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -82,7 +82,7 @@ const CollectionClient = ({
         LinkComponent={LinkComponent}
       >
         <CollectionSearch
-          placeholder={`Search for ${page.title.toLowerCase()}`}
+          placeholder="Start typing to search"
           search={searchValue}
           setSearch={handleSearchValueChange}
         />


### PR DESCRIPTION
## Problem

The default placeholder copy on Collections search was too specific with a piped text, so it read weirdly depending on the page title.

Closes [ISOM-1611]

## Solution

Change copy to say "Start typing to search"