### PR TITLE
permissions(settings/publishing): add site level permissions and publishing permissions

### DIFF
--- a/.github/workflows/deploy_vapt.yml
+++ b/.github/workflows/deploy_vapt.yml
@@ -35,7 +35,7 @@ jobs:
       app-url: "https://vapt-studio.isomer.gov.sg"
       app-name: "Isomer Studio (VAPT)"
       app-version: ${{ github.sha }}
-      app-enable-sgid: true
+      app-enable-sgid: false
       app-s3-region: "ap-southeast-1"
       app-s3-assets-bucket-name: "isomer-next-infra-vapt-assets-private-ab628e1"
       app-s3-assets-domain-name: "isomer-user-content-vapt.by.gov.sg"

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -39,8 +39,8 @@
     "storybook": "storybook dev -p 6007",
     "build-storybook": "storybook build",
     "clean": "git clean -xdf .next .turbo node_modules build",
-    "jump:vapt": "source .ssh/.env.staging && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/studio-vapt-bastion.pem",
-    "migrate:vapt": "source .ssh/.env.staging && npx prisma migrate deploy"
+    "jump:vapt": "source .ssh/.env.vapt && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/studio-vapt-bastion.pem",
+    "migrate:vapt": "source .ssh/.env.vapt && npx prisma migrate deploy"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -1,3 +1,4 @@
+import { Can } from "@casl/react"
 import { Skeleton } from "@chakra-ui/react"
 import {
   Button,
@@ -5,6 +6,7 @@ import {
   useToast,
 } from "@opengovsg/design-system-react"
 
+import { usePermissions } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
 
@@ -19,6 +21,7 @@ const SuspendablePublishButton = ({
 }: PublishButtonProps): JSX.Element => {
   const toast = useToast()
   const utils = trpc.useUtils()
+  const { ability } = usePermissions()
 
   const [currPage] = trpc.page.readPage.useSuspenseQuery({ pageId, siteId })
 
@@ -54,20 +57,21 @@ const SuspendablePublishButton = ({
   const isChangesPendingPublish = !!currPage.draftBlobId
 
   return (
-    <TouchableTooltip
-      hidden={isChangesPendingPublish}
-      label="All changes have been published"
-    >
-      <Button
-        variant="solid"
-        size="sm"
-        onClick={handlePublish}
-        isLoading={isLoading}
-        isDisabled={!isChangesPendingPublish}
+    <Can do="publish" ability={ability} on="Resource">
+      <TouchableTooltip
+        hidden={isChangesPendingPublish}
+        label="All changes have been published"
       >
-        Publish
-      </Button>
-    </TouchableTooltip>
+        <Button
+          variant="solid"
+          size="sm"
+          onClick={handlePublish}
+          isLoading={isLoading}
+        >
+          Publish
+        </Button>
+      </TouchableTooltip>
+    </Can>
   )
 }
 

--- a/apps/studio/src/features/permissions/PermissionsContext.tsx
+++ b/apps/studio/src/features/permissions/PermissionsContext.tsx
@@ -1,10 +1,10 @@
+import type { RoleType } from "@prisma/client"
 import type { PropsWithChildren } from "react"
 import { createContext, useContext } from "react"
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
-import { RoleType } from "@prisma/client"
 
 import type { ResourceAbility } from "~/server/modules/permissions/permissions.type"
-import { buildPermissionsFor } from "~/server/modules/permissions/permissions.util"
+import { buildPermissionsForResource } from "~/server/modules/permissions/permissions.util"
 import { trpc } from "~/utils/trpc"
 
 interface PermissionsContextReturn {
@@ -19,7 +19,7 @@ interface PermissionsProviderProps {
 const getPermissions = (roles: { role: RoleType }[]) => {
   const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
   roles.forEach(({ role }) => {
-    buildPermissionsFor(role, builder)
+    buildPermissionsForResource(role, builder)
   })
   return builder.build({ detectSubjectType: () => "Resource" })
 }

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -9,7 +9,7 @@ import { protectedProcedure, router } from "~/server/trpc"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceState, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { validateUserPermissions } from "../permissions/permissions.service"
+import { validateUserPermissionsForResource } from "../permissions/permissions.service"
 import {
   defaultResourceSelect,
   getSiteResourceById,
@@ -24,7 +24,7 @@ export const collectionRouter = router({
   getMetadata: protectedProcedure
     .input(readFolderSchema)
     .query(async ({ ctx, input: { siteId, resourceId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         siteId,
         action: "read",
         userId: ctx.user.id,
@@ -47,7 +47,7 @@ export const collectionRouter = router({
     .input(createCollectionSchema)
     .mutation(
       async ({ ctx, input: { collectionTitle, permalink, siteId } }) => {
-        await validateUserPermissions({
+        await validateUserPermissionsForResource({
           siteId,
           action: "create",
           userId: ctx.user.id,
@@ -83,7 +83,7 @@ export const collectionRouter = router({
   createCollectionPage: protectedProcedure
     .input(createCollectionPageSchema)
     .mutation(async ({ ctx, input }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         siteId: input.siteId,
         action: "create",
         userId: ctx.user.id,
@@ -137,7 +137,7 @@ export const collectionRouter = router({
   list: protectedProcedure
     .input(readFolderSchema)
     .query(async ({ ctx, input: { resourceId, siteId, limit, offset } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         siteId,
         action: "read",
         userId: ctx.user.id,

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -10,7 +10,7 @@ import { protectedProcedure, router } from "~/server/trpc"
 import { publishSite } from "../aws/codebuild.service"
 import { db, ResourceState, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { validateUserPermissions } from "../permissions/permissions.service"
+import { validateUserPermissionsForResource } from "../permissions/permissions.service"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({
@@ -21,7 +21,7 @@ export const folderRouter = router({
         ctx,
         input: { siteId, folderTitle, parentFolderId, permalink },
       }) => {
-        await validateUserPermissions({
+        await validateUserPermissionsForResource({
           siteId,
           action: "create",
           userId: ctx.user.id,
@@ -58,7 +58,7 @@ export const folderRouter = router({
   getMetadata: protectedProcedure
     .input(readFolderSchema)
     .query(async ({ ctx, input }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         siteId: input.siteId,
         action: "read",
         userId: ctx.user.id,
@@ -77,7 +77,7 @@ export const folderRouter = router({
     .input(editFolderSchema)
     .mutation(
       async ({ ctx, input: { resourceId, permalink, title, siteId } }) => {
-        await validateUserPermissions({
+        await validateUserPermissionsForResource({
           siteId: Number(siteId),
           action: "update",
           userId: ctx.user.id,

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -20,7 +20,7 @@ import { safeJsonParse } from "~/utils/safeJsonParse"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { validateUserPermissions } from "../permissions/permissions.service"
+import { validateUserPermissionsForResource } from "../permissions/permissions.service"
 import {
   getFooter,
   getFullPageById,
@@ -73,7 +73,7 @@ export const pageRouter = router({
       }),
     )
     .query(async ({ ctx, input: { siteId, resourceId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "read",
@@ -102,7 +102,7 @@ export const pageRouter = router({
     .input(basePageSchema)
     .output(readPageOutputSchema)
     .query(async ({ ctx, input: { pageId, siteId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "read",
@@ -126,7 +126,7 @@ export const pageRouter = router({
   readPageAndBlob: protectedProcedure
     .input(basePageSchema)
     .query(async ({ ctx, input: { pageId, siteId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "read",
@@ -177,7 +177,7 @@ export const pageRouter = router({
   reorderBlock: protectedProcedure
     .input(reorderBlobSchema)
     .mutation(async ({ ctx, input: { pageId, from, to, blocks, siteId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "update",
@@ -246,7 +246,7 @@ export const pageRouter = router({
   updatePageBlob: validatedPageProcedure
     .input(updatePageBlobSchema)
     .mutation(async ({ input, ctx }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId: input.siteId,
         action: "update",
@@ -265,7 +265,7 @@ export const pageRouter = router({
         ctx,
         input: { permalink, siteId, folderId, title, layout },
       }) => {
-        await validateUserPermissions({
+        await validateUserPermissionsForResource({
           userId: ctx.user.id,
           siteId,
           action: "create",
@@ -340,7 +340,7 @@ export const pageRouter = router({
   getRootPage: protectedProcedure
     .input(getRootPageSchema)
     .query(async ({ ctx, input: { siteId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "read",
@@ -372,7 +372,7 @@ export const pageRouter = router({
     .input(pageSettingsSchema)
     .mutation(
       async ({ ctx, input: { pageId, siteId, title, meta, ...settings } }) => {
-        await validateUserPermissions({
+        await validateUserPermissionsForResource({
           userId: ctx.user.id,
           siteId,
           action: "update",
@@ -479,7 +479,7 @@ export const pageRouter = router({
     .input(basePageSchema)
     .query(async ({ ctx, input }) => {
       const { pageId, siteId } = input
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "read",
@@ -499,7 +499,7 @@ export const pageRouter = router({
     .input(basePageSchema)
     .query(async ({ ctx, input }) => {
       const { pageId, siteId } = input
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         userId: ctx.user.id,
         siteId,
         action: "read",

--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -3,11 +3,11 @@ import { AbilityBuilder, createMongoAbility } from "@casl/ability"
 import type { RoleType } from "../../database"
 import type { ResourceAbility } from "../permissions.type"
 import { CRUD_ACTIONS } from "../permissions.type"
-import { buildPermissionsFor } from "../permissions.util"
+import { buildPermissionsForResource } from "../permissions.util"
 
 const buildPermissions = (role: RoleType) => {
   const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
-  buildPermissionsFor(role, builder)
+  buildPermissionsForResource(role, builder)
   return builder.build({ detectSubjectType: () => "Resource" })
 }
 
@@ -84,7 +84,7 @@ describe("permissions.service", () => {
     // the later role's permissions don't overwrite the earlier one
     const roles = ["Admin", "Editor"] as const
     const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
-    roles.forEach((role) => buildPermissionsFor(role, builder))
+    roles.forEach((role) => buildPermissionsForResource(role, builder))
     const perms = builder.build({ detectSubjectType: () => "Resource" })
 
     // Act

--- a/apps/studio/src/server/modules/permissions/permissions.type.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.type.ts
@@ -9,9 +9,13 @@ type AllowedResourceActions = (typeof ALL_ACTIONS)[number]
 export type CrudResourceActions = (typeof CRUD_ACTIONS)[number]
 type Subjects = "Resource" | Resource
 
-export const ALL_ACTIONS = [...CRUD_ACTIONS, "move"] as const
+export const ALL_ACTIONS = [...CRUD_ACTIONS, "move", "publish"] as const
 export type ResourcePermissionTuple = [AllowedResourceActions, Subjects]
 export type ResourceAbility = PureAbility<ResourcePermissionTuple>
+
+export type SitePermissionTuple = [CrudResourceActions, "Site"]
+export type SiteAbility = PureAbility<SitePermissionTuple>
+
 export interface PermissionsProps {
   userId: string
   siteId: number

--- a/apps/studio/src/server/modules/permissions/permissions.util.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.util.ts
@@ -2,28 +2,37 @@ import type { AbilityBuilder } from "@casl/ability"
 
 import type { RoleType } from "../database"
 import type { ResourceAbility } from "./permissions.type"
-import { ALL_ACTIONS } from "./permissions.type"
+import { ALL_ACTIONS, CRUD_ACTIONS } from "./permissions.type"
 
-export const buildPermissionsFor = (
+const giveBasePermissions = (
+  builder: AbilityBuilder<ResourceAbility>,
+): void => {
+  // NOTE: Users can perform every action on non root resources that they have edit access to
+  CRUD_ACTIONS.map((action) => {
+    builder.can(action, "Resource", { parentId: { $ne: null } })
+  })
+  builder.can("move", "Resource", { parentId: { $ne: null } })
+
+  // NOTE: For root resources, they can only update and read
+  builder.can("update", "Resource", { parentId: { $eq: null } })
+  builder.can("read", "Resource", { parentId: { $eq: null } })
+}
+
+export const buildPermissionsForResource = (
   role: RoleType,
   builder: AbilityBuilder<ResourceAbility>,
 ) => {
   switch (role) {
     case "Editor":
-      // NOTE: Users can perform every action on non root resources that they have edit access to
-      ALL_ACTIONS.map((action) => {
-        builder.can(action, "Resource", { parentId: { $ne: null } })
-      })
-      // NOTE: For root resources, they can only update and read
-      builder.can("update", "Resource", { parentId: { $eq: null } })
-      builder.can("read", "Resource", { parentId: { $eq: null } })
-      return
+      return giveBasePermissions(builder)
     case "Admin":
       ALL_ACTIONS.map((action) => {
         builder.can(action, "Resource")
       })
       return
     case "Publisher":
+      giveBasePermissions(builder)
+      builder.can("publish", "Resource")
       return
   }
 }

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -21,8 +21,8 @@ import { publishSite } from "../aws/codebuild.service"
 import { db, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
-  definePermissionsFor,
-  validateUserPermissions,
+  definePermissionsForResource,
+  validateUserPermissionsForResource,
 } from "../permissions/permissions.service"
 
 const fetchResource = async (resourceId: string | null) => {
@@ -55,8 +55,14 @@ const validateUserPermissionsForMove = async ({
   // we should fetch the oldest `parent` of this resource eventually.
   // Putting this in here first because eventually we'll have to lookup both
   // even though for now they are the same thing
-  const permsFrom = await definePermissionsFor({ ...rest, resourceId: null })
-  const permsTo = await definePermissionsFor({ ...rest, resourceId: null })
+  const permsFrom = await definePermissionsForResource({
+    ...rest,
+    resourceId: null,
+  })
+  const permsTo = await definePermissionsForResource({
+    ...rest,
+    resourceId: null,
+  })
 
   const resourceFrom = await fetchResource(from)
 
@@ -354,7 +360,7 @@ export const resourceRouter = router({
   delete: protectedProcedure
     .input(deleteResourceSchema)
     .mutation(async ({ ctx, input: { siteId, resourceId } }) => {
-      await validateUserPermissions({
+      await validateUserPermissionsForResource({
         action: "delete",
         userId: ctx.user.id,
         siteId,

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -1,3 +1,9 @@
+import { TRPCError } from "@trpc/server"
+
+import type {
+  CrudResourceActions,
+  PermissionsProps,
+} from "../permissions/permissions.type"
 import {
   getConfigSchema,
   getLocalisedSitemapSchema,
@@ -7,6 +13,7 @@ import {
 import { protectedProcedure, router } from "~/server/trpc"
 import { publishSite } from "../aws/codebuild.service"
 import { db } from "../database"
+import { definePermissionsForSite } from "../permissions/permissions.service"
 import {
   getFooter,
   getLocalisedSitemap,
@@ -20,6 +27,25 @@ import {
   setSiteNotification,
 } from "./site.service"
 
+const validateUserPermissionsForSite = async ({
+  siteId,
+  userId,
+  action,
+}: Omit<PermissionsProps, "resourceId"> & { action: CrudResourceActions }) => {
+  const perms = await definePermissionsForSite({
+    siteId,
+    userId,
+  })
+
+  // TODO: create should check against the current resource id
+  if (perms.cannot(action, "Site")) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have sufficient permissions to perform this action",
+    })
+  }
+}
+
 export const siteRouter = router({
   list: protectedProcedure.query(() => {
     return (
@@ -32,39 +58,69 @@ export const siteRouter = router({
   }),
   getConfig: protectedProcedure
     .input(getConfigSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { id } = input
+      await validateUserPermissionsForSite({
+        siteId: id,
+        userId: ctx.user.id,
+        action: "read",
+      })
       return getSiteConfig(id)
     }),
   getTheme: protectedProcedure
     .input(getConfigSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { id } = input
+      await validateUserPermissionsForSite({
+        siteId: id,
+        userId: ctx.user.id,
+        action: "read",
+      })
       const theme = await getSiteTheme(id)
       return theme
     }),
   getFooter: protectedProcedure
     .input(getConfigSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { id } = input
+      await validateUserPermissionsForSite({
+        siteId: id,
+        userId: ctx.user.id,
+        action: "read",
+      })
       return getFooter(id)
     }),
   getNavbar: protectedProcedure
     .input(getConfigSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { id } = input
+      await validateUserPermissionsForSite({
+        siteId: id,
+        userId: ctx.user.id,
+        action: "read",
+      })
       return getNavBar(id)
     }),
   getLocalisedSitemap: protectedProcedure
     .input(getLocalisedSitemapSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { siteId, resourceId } = input
+      await validateUserPermissionsForSite({
+        siteId,
+        userId: ctx.user.id,
+        action: "read",
+      })
       return getLocalisedSitemap(siteId, resourceId)
     }),
   getNotification: protectedProcedure
     .input(getNotificationSchema)
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const { siteId } = input
+      await validateUserPermissionsForSite({
+        siteId,
+        userId: ctx.user.id,
+        action: "read",
+      })
       const notification = await getNotification(siteId)
       return notification
     }),
@@ -72,6 +128,11 @@ export const siteRouter = router({
     .input(setNotificationSchema)
     .mutation(async ({ ctx, input }) => {
       const { siteId, notification, notificationEnabled } = input
+      await validateUserPermissionsForSite({
+        siteId,
+        userId: ctx.user.id,
+        action: "update",
+      })
       if (notificationEnabled) {
         await setSiteNotification(siteId, notification)
       } else {

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -19,6 +19,7 @@ const COMMON_HANDLERS = [
   sitesHandlers.getFooter.default(),
   sitesHandlers.getNavbar.default(),
   sitesHandlers.getLocalisedSitemap.default(),
+  resourceHandlers.getRolesFor.default(),
   resourceHandlers.getChildrenOf.default(),
   resourceHandlers.getMetadataById.article(),
   pageHandlers.readPageAndBlob.article(),

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -21,6 +21,7 @@ const COMMON_HANDLERS = [
   sitesHandlers.getLocalisedSitemap.default(),
   resourceHandlers.getChildrenOf.default(),
   resourceHandlers.getMetadataById.content(),
+  resourceHandlers.getRolesFor.default(),
   pageHandlers.readPageAndBlob.content(),
   pageHandlers.readPage.content(),
   pageHandlers.getFullPermalink.content(),

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -24,6 +24,7 @@ const COMMON_HANDLERS = [
   pageHandlers.readPageAndBlob.homepage(),
   pageHandlers.readPage.homepage(),
   pageHandlers.getFullPermalink.homepage(),
+  resourceHandlers.getRolesFor.default(),
 ]
 
 const meta: Meta<typeof EditPage> = {

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -7,6 +7,7 @@ import { createBannerGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   resourceHandlers.getMetadataById.content(),
+  resourceHandlers.getRolesFor.default(),
   pageHandlers.readPageAndBlob.content(),
   pageHandlers.readPage.content(),
 ]

--- a/apps/studio/src/templates/layouts/PageEditingLayout.tsx
+++ b/apps/studio/src/templates/layouts/PageEditingLayout.tsx
@@ -4,35 +4,42 @@ import { Tabs } from "@opengovsg/design-system-react"
 import { EnforceLoginStatePageWrapper } from "~/components/AuthWrappers"
 import { LayoutHead } from "~/components/LayoutHead"
 import { SiteEditNavbar } from "~/features/editing-experience/components/SiteEditNavbar"
+import { editPageSchema } from "~/features/editing-experience/schema"
+import { PermissionsProvider } from "~/features/permissions"
+import { useQueryParse } from "~/hooks/useQueryParse"
 import { type GetLayout } from "~/lib/types"
 
 export const PageEditingLayout: GetLayout = (page) => {
+  const { pageId, siteId } = useQueryParse(editPageSchema)
+
   return (
     <EnforceLoginStatePageWrapper>
-      <LayoutHead />
-      <Tabs flex={1} height={0}>
-        <Flex
-          flexDir="column"
-          bg="base.canvas.alt"
-          pos="relative"
-          height={0}
-          minH="100%"
-        >
-          <Grid
-            flex={1}
+      <PermissionsProvider siteId={siteId} resourceId={String(pageId)}>
+        <LayoutHead />
+        <Tabs flex={1} height={0}>
+          <Flex
+            flexDir="column"
+            bg="base.canvas.alt"
+            pos="relative"
             height={0}
             minH="100%"
-            width="100%"
-            gridColumnGap={{ base: 0, md: "1rem" }}
-            gridTemplateRows="auto 1fr"
           >
-            <SiteEditNavbar />
-            <Flex bg="base.canvas.alt" w="100%" height={0} minH="100%">
-              {page}
-            </Flex>
-          </Grid>
-        </Flex>
-      </Tabs>
+            <Grid
+              flex={1}
+              height={0}
+              minH="100%"
+              width="100%"
+              gridColumnGap={{ base: 0, md: "1rem" }}
+              gridTemplateRows="auto 1fr"
+            >
+              <SiteEditNavbar />
+              <Flex bg="base.canvas.alt" w="100%" height={0} minH="100%">
+                {page}
+              </Flex>
+            </Grid>
+          </Flex>
+        </Tabs>
+      </PermissionsProvider>
     </EnforceLoginStatePageWrapper>
   )
 }


### PR DESCRIPTION
## Problem
This PR adds in permissions for site-wide actions such as viewing sites, retrieving navbar etc. This PR also adds in publishing permissions. 

## Solution
- in similar fashion to what's been done previously, add in more resource types and actions
- define a helper to check the permissions of the user after retrieval of their role from teh db

## Notes
- going to refactor abit in subsequent PRs. i think the commonality is clearer here and we'll probably define a helper to retrieve roles for db that can be shared across all + extract into a `experimentalMiddleware`. 
- another thing we're oging to change is that `move` is going to be updated to `delete` on original resource + `create` on destination resource