### PR TITLE
feat: improve scrolling behavior and layout consistency with banner

### DIFF
--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -2,7 +2,7 @@ import "@fontsource/ibm-plex-mono"
 import "inter-ui/inter.css"
 
 import { useCallback, useMemo, useState } from "react"
-import { Box, Skeleton } from "@chakra-ui/react"
+import { Box, Skeleton, Stack } from "@chakra-ui/react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
 import { withThemeFromJSXProvider } from "@storybook/addon-themes"
 import {
@@ -75,7 +75,9 @@ const SetupDecorator: Decorator = (Story) => {
       <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
         <trpc.Provider client={trpcClient} queryClient={queryClient}>
           <QueryClientProvider client={queryClient}>
-            <Story />
+            <Stack spacing={0} height="$100vh">
+              <Story />
+            </Stack>
           </QueryClientProvider>
         </trpc.Provider>
       </Suspense>

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -3,6 +3,8 @@ import "inter-ui/inter.css"
 
 import { useCallback, useMemo, useState } from "react"
 import { Box, Skeleton, Stack } from "@chakra-ui/react"
+import { GrowthBook } from "@growthbook/growthbook"
+import { GrowthBookProvider } from "@growthbook/growthbook-react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
 import { withThemeFromJSXProvider } from "@storybook/addon-themes"
 import {
@@ -25,6 +27,7 @@ import { z } from "zod"
 import { viewport, withChromaticModes } from "@isomer/storybook-config"
 
 import type { EnvContextReturn } from "~/components/AppProviders"
+import { AppBanner } from "~/components/AppBanner"
 import { EnvProvider, FeatureContext } from "~/components/AppProviders"
 import { DefaultFallback } from "~/components/ErrorBoundary"
 import Suspense from "~/components/Suspense"
@@ -52,7 +55,11 @@ const StorybookEnvDecorator: Decorator = (story) => {
   return <EnvProvider env={mockEnv}>{story()}</EnvProvider>
 }
 
-const SetupDecorator: Decorator = (Story) => {
+const SetupDecorator: Decorator = (Story, { parameters }) => {
+  const gb = new GrowthBook()
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  gb.setForcedFeatures(new Map(parameters.growthbook ?? []))
+
   const [queryClient] = useState(
     new QueryClient({
       defaultOptions: {
@@ -71,17 +78,20 @@ const SetupDecorator: Decorator = (Story) => {
     }),
   )
   return (
-    <ErrorBoundary FallbackComponent={DefaultFallback}>
-      <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
-        <trpc.Provider client={trpcClient} queryClient={queryClient}>
-          <QueryClientProvider client={queryClient}>
-            <Stack spacing={0} height="$100vh">
-              <Story />
-            </Stack>
-          </QueryClientProvider>
-        </trpc.Provider>
-      </Suspense>
-    </ErrorBoundary>
+    <GrowthBookProvider growthbook={gb}>
+      <ErrorBoundary FallbackComponent={DefaultFallback}>
+        <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
+          <trpc.Provider client={trpcClient} queryClient={queryClient}>
+            <QueryClientProvider client={queryClient}>
+              <Stack spacing={0} height="$100vh" flexDirection="column">
+                <AppBanner />
+                <Story />
+              </Stack>
+            </QueryClientProvider>
+          </trpc.Provider>
+        </Suspense>
+      </ErrorBoundary>
+    </GrowthBookProvider>
   )
 }
 

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -80,7 +80,7 @@ const SetupDecorator: Decorator = (Story, { parameters }) => {
   return (
     <GrowthBookProvider growthbook={gb}>
       <ErrorBoundary FallbackComponent={DefaultFallback}>
-        <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
+        <Suspense fallback={<Skeleton width="100%" height="100vh" />}>
           <trpc.Provider client={trpcClient} queryClient={queryClient}>
             <QueryClientProvider client={queryClient}>
               <Stack spacing={0} height="$100vh" flexDirection="column">

--- a/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSidebarContainer.tsx
@@ -26,7 +26,8 @@ export function CmsSidebarContainer({
           borderColor="base.divider.medium"
           py={{ base: 0, md: "0.75rem" }}
           px={{ base: 0, md: "0.5rem" }}
-          height="$100vh"
+          height={0}
+          minH="100%"
           overflow="auto"
           css={{
             "&::-webkit-scrollbar": {
@@ -44,7 +45,8 @@ export function CmsSidebarContainer({
       </GridItem>
       <GridItem as="aside" area="sidenav" overflow="hidden">
         <Box
-          height="$100vh"
+          height={0}
+          minH="100%"
           bg="utility.ui"
           pos="sticky"
           top={0}

--- a/apps/studio/src/components/CmsSidebar/CmsSidebarOnlyContainer.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsSidebarOnlyContainer.tsx
@@ -24,7 +24,8 @@ export function CmsSidebarOnlyContainer({
           borderColor="base.divider.medium"
           py={{ base: 0, md: "0.75rem" }}
           px={{ base: 0, md: "0.5rem" }}
-          height="100vh"
+          height={0}
+          minH="100%"
           overflow="auto"
           css={{
             "&::-webkit-scrollbar": {

--- a/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebar.tsx
+++ b/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebar.tsx
@@ -10,7 +10,7 @@ export const DirectorySidebar = ({
   siteId,
 }: DirectorySidebarProps): JSX.Element => {
   return (
-    <Flex flexDir="column" px="1.25rem" py="1.75rem" height="full">
+    <Flex flexDir="column" px="1.25rem" py="1.75rem">
       <DirectorySidebarContent
         siteId={siteId}
         resourceId={null}

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -102,84 +102,86 @@ export const CreatePageDetailsScreen = () => {
       </ModalHeader>
       <ModalBody p={0} overflow="hidden" bg="white">
         <Flex height="100%">
-          <Stack height="100%" gap="2rem" mt="10vh" px="3rem" py="1rem">
-            <Stack>
-              <Text as="h2" textStyle="h4">
-                What is your page about?
-              </Text>
-              <Text textStyle="body-2">You can change these later.</Text>
-            </Stack>
-            <Stack gap="1.5rem">
-              {/* Section 1: Page Title */}
-              <FormControl isInvalid={!!errors.title}>
-                <FormLabel color="base.content.strong">
-                  Page title
-                  <FormHelperText color="base.content.default">
-                    Title should be descriptive
-                  </FormHelperText>
-                </FormLabel>
+          <Stack height={0} minH="100%" overflow="auto">
+            <Stack gap="2rem" px="3rem" pb="2rem" pt="10vh">
+              <Stack>
+                <Text as="h2" textStyle="h4">
+                  What is your page about?
+                </Text>
+                <Text textStyle="body-2">You can change these later.</Text>
+              </Stack>
+              <Stack gap="1.5rem">
+                {/* Section 1: Page Title */}
+                <FormControl isInvalid={!!errors.title}>
+                  <FormLabel color="base.content.strong">
+                    Page title
+                    <FormHelperText color="base.content.default">
+                      Title should be descriptive
+                    </FormHelperText>
+                  </FormLabel>
 
-                <Input
-                  placeholder="This is a title for your new page"
-                  {...register("title")}
-                  maxLength={MAX_TITLE_LENGTH}
-                />
-                {errors.title?.message ? (
-                  <FormErrorMessage>{errors.title.message}</FormErrorMessage>
-                ) : (
-                  <FormHelperText mt="0.5rem" color="base.content.medium">
-                    {MAX_TITLE_LENGTH - title.length} characters left
-                  </FormHelperText>
-                )}
-              </FormControl>
-
-              {/* Section 2: Page URL */}
-              <FormControl isInvalid={!!errors.permalink}>
-                <FormLabel>
-                  Page URL
-                  <FormHelperText>
-                    URL should be short and simple
-                  </FormHelperText>
-                </FormLabel>
-                <InputGroup>
-                  <InputLeftAddon
-                    bg="interaction.support.disabled"
-                    color="base.divider.strong"
-                  >
-                    your-site.gov.sg/
-                  </InputLeftAddon>
-                  <Controller
-                    control={control}
-                    name="permalink"
-                    render={({ field: { onChange, ...field } }) => (
-                      <Input
-                        maxLength={MAX_PAGE_URL_LENGTH}
-                        borderLeftRadius={0}
-                        placeholder="URL will be autopopulated if left untouched"
-                        {...field}
-                        onChange={(e) => {
-                          onChange(
-                            generateResourceUrl(e.target.value).slice(
-                              0,
-                              MAX_PAGE_URL_LENGTH,
-                            ),
-                          )
-                        }}
-                      />
-                    )}
+                  <Input
+                    placeholder="This is a title for your new page"
+                    {...register("title")}
+                    maxLength={MAX_TITLE_LENGTH}
                   />
-                </InputGroup>
+                  {errors.title?.message ? (
+                    <FormErrorMessage>{errors.title.message}</FormErrorMessage>
+                  ) : (
+                    <FormHelperText mt="0.5rem" color="base.content.medium">
+                      {MAX_TITLE_LENGTH - title.length} characters left
+                    </FormHelperText>
+                  )}
+                </FormControl>
 
-                {errors.permalink?.message ? (
-                  <FormErrorMessage>
-                    {errors.permalink.message}
-                  </FormErrorMessage>
-                ) : (
-                  <FormHelperText mt="0.5rem" color="base.content.medium">
-                    {MAX_PAGE_URL_LENGTH - url.length} characters left
-                  </FormHelperText>
-                )}
-              </FormControl>
+                {/* Section 2: Page URL */}
+                <FormControl isInvalid={!!errors.permalink}>
+                  <FormLabel>
+                    Page URL
+                    <FormHelperText>
+                      URL should be short and simple
+                    </FormHelperText>
+                  </FormLabel>
+                  <InputGroup>
+                    <InputLeftAddon
+                      bg="interaction.support.disabled"
+                      color="base.divider.strong"
+                    >
+                      your-site.gov.sg/
+                    </InputLeftAddon>
+                    <Controller
+                      control={control}
+                      name="permalink"
+                      render={({ field: { onChange, ...field } }) => (
+                        <Input
+                          maxLength={MAX_PAGE_URL_LENGTH}
+                          borderLeftRadius={0}
+                          placeholder="URL will be autopopulated if left untouched"
+                          {...field}
+                          onChange={(e) => {
+                            onChange(
+                              generateResourceUrl(e.target.value).slice(
+                                0,
+                                MAX_PAGE_URL_LENGTH,
+                              ),
+                            )
+                          }}
+                        />
+                      )}
+                    />
+                  </InputGroup>
+
+                  {errors.permalink?.message ? (
+                    <FormErrorMessage>
+                      {errors.permalink.message}
+                    </FormErrorMessage>
+                  ) : (
+                    <FormHelperText mt="0.5rem" color="base.content.medium">
+                      {MAX_PAGE_URL_LENGTH - url.length} characters left
+                    </FormHelperText>
+                  )}
+                </FormControl>
+              </Stack>
             </Stack>
           </Stack>
           <PreviewLayout />

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/LayoutScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/LayoutScreen.tsx
@@ -50,21 +50,24 @@ export const CreatePageLayoutScreen = () => {
         </Stack>
       </ModalHeader>
       <ModalBody p={0} overflow="hidden">
-        <Flex height="100%">
+        <Flex h="100%">
           <Stack
+            height={0}
+            minH="100%"
             borderRight="1px solid"
             borderColor="base.divider.medium"
             bg="white"
             maxWidth={{ base: "100%", md: "22.75rem" }}
-            p="2rem"
-            flexDir="row"
             overflow="auto"
+            flexDir="row"
           >
-            <Controller
-              control={control}
-              name="layout"
-              render={({ field }) => <LayoutOptionsInput {...field} />}
-            />
+            <Flex p="2rem" h="fit-content">
+              <Controller
+                control={control}
+                name="layout"
+                render={({ field }) => <LayoutOptionsInput {...field} />}
+              />
+            </Flex>
           </Stack>
           <PreviewLayout />
         </Flex>

--- a/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/SiteEditNavbar.tsx
@@ -98,48 +98,41 @@ export const SiteEditNavbar = (): JSX.Element => {
   const { pathname } = useRouter()
 
   return (
-    <Flex flex="0 0 auto" gridColumn="1/-1">
-      <Flex
-        h={ADMIN_NAVBAR_HEIGHT}
-        pos="fixed"
-        zIndex="docked"
-        w="100%"
-        justify="space-between"
-        align="center"
-        px={{ base: "1.5rem", md: "1.8rem", xl: "2rem" }}
-        pl={{ base: `calc(1rem + ${ADMIN_NAVBAR_HEIGHT})`, sm: "1.5rem" }}
-        py="0.375rem"
-        bg="white"
-        borderBottomWidth="1px"
-        borderColor="base.divider.medium"
-        transition="padding 0.1s"
-        gap="0.5rem"
-      >
-        <NavigationBreadcrumbs
-          siteId={String(siteId)}
-          pageId={String(pageId)}
-        />
+    <Flex
+      h={ADMIN_NAVBAR_HEIGHT}
+      w="100%"
+      justify="space-between"
+      align="center"
+      px={{ base: "1.5rem", md: "1.8rem", xl: "2rem" }}
+      pl={{ base: `calc(1rem + ${ADMIN_NAVBAR_HEIGHT})`, sm: "1.5rem" }}
+      py="0.375rem"
+      bg="white"
+      borderBottomWidth="1px"
+      borderColor="base.divider.medium"
+      transition="padding 0.1s"
+      gap="0.5rem"
+    >
+      <NavigationBreadcrumbs siteId={String(siteId)} pageId={String(pageId)} />
 
-        <Flex gap="2rem">
-          <TabLink
-            isActive={pathname === "/sites/[siteId]/pages/[pageId]"}
-            href={`/sites/${siteId}/pages/${pageId}`}
-          >
-            Edit
-          </TabLink>
-          <TabLink
-            isActive={pathname === "/sites/[siteId]/pages/[pageId]/settings"}
-            href={`/sites/${siteId}/pages/${pageId}/settings`}
-          >
-            Page Settings
-          </TabLink>
-        </Flex>
-        {pageId && siteId && (
-          <Flex justifyContent={"end"} alignItems={"center"} flex={1}>
-            <PublishButton pageId={pageId} siteId={siteId} />
-          </Flex>
-        )}
+      <Flex gap="2rem">
+        <TabLink
+          isActive={pathname === "/sites/[siteId]/pages/[pageId]"}
+          href={`/sites/${siteId}/pages/${pageId}`}
+        >
+          Edit
+        </TabLink>
+        <TabLink
+          isActive={pathname === "/sites/[siteId]/pages/[pageId]/settings"}
+          href={`/sites/${siteId}/pages/${pageId}/settings`}
+        >
+          Page Settings
+        </TabLink>
       </Flex>
+      {pageId && siteId && (
+        <Flex justifyContent={"end"} alignItems={"center"} flex={1}>
+          <PublishButton pageId={pageId} siteId={siteId} />
+        </Flex>
+      )}
     </Flex>
   )
 }

--- a/apps/studio/src/hooks/useBanner.ts
+++ b/apps/studio/src/hooks/useBanner.ts
@@ -1,10 +1,11 @@
 import type { BannerProps } from "@opengovsg/design-system-react"
 import { useFeatureValue } from "@growthbook/growthbook-react"
 
+import { BANNER_FEATURE_KEY } from "~/lib/growthbook"
+
 type BannerFeature = Pick<BannerProps, "variant"> & {
   message: BannerProps["children"]
 }
-const BANNER_FEATURE_KEY = "isomer-next-banner"
 export const useBanner = () => {
   return useFeatureValue<BannerFeature | null>(BANNER_FEATURE_KEY, null)
 }

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -1,0 +1,1 @@
+export const BANNER_FEATURE_KEY = "isomer-next-banner"

--- a/apps/studio/src/pages/404.tsx
+++ b/apps/studio/src/pages/404.tsx
@@ -10,7 +10,7 @@ const Custom404 = () => {
   const router = useRouter()
 
   return (
-    <Flex flexDirection="column" w="100%" h="$100vh">
+    <Flex flexDirection="column" w="100%" flex={1}>
       <Flex
         flex={1}
         bg="base.canvas.backdrop"

--- a/apps/studio/src/pages/_app.tsx
+++ b/apps/studio/src/pages/_app.tsx
@@ -55,7 +55,7 @@ const MyApp = ((props: AppPropsWithAuthAndLayout) => {
             <GrowthBookProvider growthbook={gb}>
               <ErrorBoundary FallbackComponent={DefaultFallback}>
                 <Suspense fallback={<Skeleton width="100vw" height="$100vh" />}>
-                  <Stack spacing={0} height="$100vh">
+                  <Stack spacing={0} height="$100vh" flexDirection="column">
                     <AppBanner />
                     <VersionWrapper />
                     <ChildWithLayout {...props} />

--- a/apps/studio/src/pages/_app.tsx
+++ b/apps/studio/src/pages/_app.tsx
@@ -54,7 +54,7 @@ const MyApp = ((props: AppPropsWithAuthAndLayout) => {
           <FeatureProvider>
             <GrowthBookProvider growthbook={gb}>
               <ErrorBoundary FallbackComponent={DefaultFallback}>
-                <Suspense fallback={<Skeleton width="100vw" height="$100vh" />}>
+                <Suspense fallback={<Skeleton width="100%" height="$100vh" />}>
                   <Stack spacing={0} height="$100vh" flexDirection="column">
                     <AppBanner />
                     <VersionWrapper />

--- a/apps/studio/src/pages/_app.tsx
+++ b/apps/studio/src/pages/_app.tsx
@@ -54,8 +54,8 @@ const MyApp = ((props: AppPropsWithAuthAndLayout) => {
           <FeatureProvider>
             <GrowthBookProvider growthbook={gb}>
               <ErrorBoundary FallbackComponent={DefaultFallback}>
-                <Suspense fallback={<Skeleton width="100vw" height="100vh" />}>
-                  <Stack spacing={0} minH="$100vh">
+                <Suspense fallback={<Skeleton width="100vw" height="$100vh" />}>
+                  <Stack spacing={0} height="$100vh">
                     <AppBanner />
                     <VersionWrapper />
                     <ChildWithLayout {...props} />

--- a/apps/studio/src/pages/sign-in/select-profile.tsx
+++ b/apps/studio/src/pages/sign-in/select-profile.tsx
@@ -21,7 +21,7 @@ const SelectProfilePage: NextPageWithLayout = () => {
             p="2rem"
             bg="white"
             gap="2rem"
-            maxW="100vw"
+            maxW="100%"
             w="24.5rem"
           >
             <Text textStyle="h4" color="base.content.strong">

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -106,7 +106,14 @@ const FolderPage: NextPageWithLayout = () => {
 
   return (
     <>
-      <VStack w="100%" p="1.75rem" gap="1rem" height="$100vh" overflow="auto">
+      <VStack
+        w="100%"
+        p="1.75rem"
+        gap="1rem"
+        height={0}
+        minH="100%"
+        overflow="auto"
+      >
         <VStack w="100%" align="start">
           <Breadcrumb size="sm" w="100%">
             {breadcrumbs.map(({ href, label }, index) => {

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -49,7 +49,14 @@ const SitePage: NextPageWithLayout = () => {
 
   return (
     <>
-      <VStack w="100%" p="1.75rem" gap="1rem" height="$100vh" overflow="auto">
+      <VStack
+        w="100%"
+        p="1.75rem"
+        gap="1rem"
+        height={0}
+        minH="100%"
+        overflow="auto"
+      >
         <VStack w="100%" align="start">
           <Breadcrumb size="sm">
             <BreadcrumbItem>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -45,7 +45,7 @@ function EditPage(): JSX.Element {
 
 const PageEditingView = () => {
   return (
-    <Grid h="full" w="100vw" templateColumns="repeat(3, 1fr)" gap={0}>
+    <Grid h="full" w="100%" templateColumns="repeat(3, 1fr)" gap={0}>
       <GridItem colSpan={1} overflow="auto" minW="30rem">
         <EditPageDrawer />
       </GridItem>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -45,13 +45,7 @@ function EditPage(): JSX.Element {
 
 const PageEditingView = () => {
   return (
-    <Grid
-      h="full"
-      w="100vw"
-      templateColumns="repeat(3, 1fr)"
-      gap={0}
-      maxH="calc(100vh - 57px)"
-    >
+    <Grid h="full" w="100vw" templateColumns="repeat(3, 1fr)" gap={0}>
       <GridItem colSpan={1} overflow="auto" minW="30rem">
         <EditPageDrawer />
       </GridItem>

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -163,7 +163,7 @@ const PageSettings = () => {
   })
 
   return (
-    <form onBlur={onSubmit}>
+    <chakra.form onBlur={onSubmit} overflow="auto">
       <Grid w="100vw" my="3rem" templateColumns="repeat(4, 1fr)">
         <GridItem colSpan={1}></GridItem>
         <GridItem colSpan={2}>
@@ -265,7 +265,7 @@ const PageSettings = () => {
         </GridItem>
         <GridItem colSpan={1}></GridItem>
       </Grid>
-    </form>
+    </chakra.form>
   )
 }
 

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -163,10 +163,9 @@ const PageSettings = () => {
   })
 
   return (
-    <chakra.form onBlur={onSubmit} overflowY="auto">
+    <chakra.form onBlur={onSubmit} overflowY="auto" width="100%">
       <Grid w="100%" my="3rem" templateColumns="repeat(4, 1fr)">
-        <GridItem colSpan={1}></GridItem>
-        <GridItem colSpan={2}>
+        <GridItem gridColumn="2/4">
           <VStack w="100%" gap="2rem" alignItems="flex-start">
             <Box>
               <Text as="h3" textStyle="h3-semibold">
@@ -263,7 +262,6 @@ const PageSettings = () => {
             />
           </VStack>
         </GridItem>
-        <GridItem colSpan={1}></GridItem>
       </Grid>
     </chakra.form>
   )

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -163,8 +163,8 @@ const PageSettings = () => {
   })
 
   return (
-    <chakra.form onBlur={onSubmit} overflow="auto">
-      <Grid w="100vw" my="3rem" templateColumns="repeat(4, 1fr)">
+    <chakra.form onBlur={onSubmit} overflowY="auto">
+      <Grid w="100%" my="3rem" templateColumns="repeat(4, 1fr)">
         <GridItem colSpan={1}></GridItem>
         <GridItem colSpan={2}>
           <VStack w="100%" gap="2rem" alignItems="flex-start">

--- a/apps/studio/src/pages/sites/[siteId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router"
 import {
   Button,
   Center,
+  chakra,
   FormControl,
   HStack,
   Text,
@@ -119,8 +120,13 @@ const SiteSettingsPage: NextPageWithLayout = () => {
         onClose={() => setNextUrl("")}
         nextUrl={nextUrl}
       />
-      <form onSubmit={onClickUpdate}>
-        <Center pt="5.5rem" px="2rem">
+      <chakra.form
+        onSubmit={onClickUpdate}
+        overflow="auto"
+        height={0}
+        minH="100%"
+      >
+        <Center py="5.5rem" px="2rem">
           <VStack w="48rem" alignItems="flex-start" spacing="1.5rem">
             <FormControl isInvalid={!!errors.notification}>
               <Text w="full" textStyle="h3-semibold">
@@ -207,7 +213,7 @@ const SiteSettingsPage: NextPageWithLayout = () => {
             </FormControl>
           </VStack>
         </Center>
-      </form>
+      </chakra.form>
     </>
   )
 }

--- a/apps/studio/src/stories/Page/DashboardPage.stories.ts
+++ b/apps/studio/src/stories/Page/DashboardPage.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import DashboardPage from "~/pages/index"
+import { createBannerGbParameters } from "../utils/growthbook"
 
 const meta: Meta<typeof DashboardPage> = {
   title: "Pages/Dashboard",
@@ -32,5 +33,17 @@ export const EmptyState: Story = {
     msw: {
       handlers: [sitesHandlers.list.empty()],
     },
+  },
+}
+
+export const WithBanner: Story = {
+  parameters: {
+    ...Dashboard.parameters,
+    growthbook: [
+      createBannerGbParameters({
+        variant: "error",
+        message: "This is a test banner",
+      }),
+    ],
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -6,6 +6,7 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
+import { createBannerGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),
@@ -71,5 +72,16 @@ export const PublishedState: Story = {
         ...COMMON_HANDLERS,
       ],
     },
+  },
+}
+
+export const WithBanner: Story = {
+  parameters: {
+    growthbook: [
+      createBannerGbParameters({
+        variant: "info",
+        message: "This is a test banner",
+      }),
+    ],
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -6,6 +6,7 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
+import { createBannerGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),
@@ -71,5 +72,16 @@ export const PublishedState: Story = {
         ...COMMON_HANDLERS,
       ],
     },
+  },
+}
+
+export const WithBanner: Story = {
+  parameters: {
+    growthbook: [
+      createBannerGbParameters({
+        variant: "info",
+        message: "This is a test banner",
+      }),
+    ],
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -6,6 +6,7 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
+import { createBannerGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),
@@ -132,5 +133,16 @@ export const FullscreenPreview: Story = {
 
       await userEvent.click(screen.getByText(/full screen/i))
     })
+  },
+}
+
+export const WithBanner: Story = {
+  parameters: {
+    growthbook: [
+      createBannerGbParameters({
+        variant: "info",
+        message: "This is a test banner",
+      }),
+    ],
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -3,6 +3,7 @@ import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 
 import PageSettings from "~/pages/sites/[siteId]/pages/[pageId]/settings"
+import { createBannerGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   resourceHandlers.getMetadataById.content(),
@@ -65,5 +66,17 @@ export const WithGrandparent: Story = {
         ...COMMON_HANDLERS,
       ],
     },
+  },
+}
+
+export const WithBanner: Story = {
+  parameters: {
+    ...Root.parameters,
+    growthbook: [
+      createBannerGbParameters({
+        variant: "warn",
+        message: "This is a warning test banner",
+      }),
+    ],
   },
 }

--- a/apps/studio/src/stories/Page/SitePage.stories.tsx
+++ b/apps/studio/src/stories/Page/SitePage.stories.tsx
@@ -5,6 +5,7 @@ import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 
 import SitePage from "~/pages/sites/[siteId]"
+import { createBannerGbParameters } from "../utils/growthbook"
 
 const meta: Meta<typeof SitePage> = {
   title: "Pages/Site Management/Site Page",
@@ -59,5 +60,17 @@ export const FolderResourceMenu: Story = {
       })
       await userEvent.click(folderMenuButton)
     })
+  },
+}
+
+export const WithBanner: Story = {
+  parameters: {
+    growthbook: [
+      createBannerGbParameters({
+        variant: "info",
+        message:
+          "This is a test banner that is very long. This is a test banner that is very long. This is a test banner that is very long. This is a test banner that is very long. This is a test banner that is very long.",
+      }),
+    ],
   },
 }

--- a/apps/studio/src/stories/components/VersionModal.stories.tsx
+++ b/apps/studio/src/stories/components/VersionModal.stories.tsx
@@ -13,7 +13,7 @@ const meta: Meta<typeof VersionModal> = {
   // bounding box of the button that opens the modal.
   decorators: [
     (storyFn) => (
-      <Box w="100vw" h="100vh">
+      <Box w="100%" h="100vh">
         {storyFn()}
       </Box>
     ),

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -1,0 +1,13 @@
+import type { BannerProps } from "@opengovsg/design-system-react"
+
+import { BANNER_FEATURE_KEY } from "~/lib/growthbook"
+
+export const createBannerGbParameters = ({
+  variant,
+  message,
+}: {
+  variant: BannerProps["variant"]
+  message: string
+}) => {
+  return [BANNER_FEATURE_KEY, { variant, message }]
+}

--- a/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
@@ -17,8 +17,13 @@ export const AdminCmsSidebarLayout: GetLayout = (page) => {
   return (
     <EnforceLoginStatePageWrapper>
       <LayoutHead />
-
-      <Flex minH="$100vh" flexDir="row" bg="base.canvas.alt" pos="relative">
+      <Flex
+        flex={1}
+        overflow="hidden"
+        flexDir="row"
+        bg="base.canvas.alt"
+        pos="relative"
+      >
         <CmsSidebarWrapper>{page}</CmsSidebarWrapper>
       </Flex>
     </EnforceLoginStatePageWrapper>

--- a/apps/studio/src/templates/layouts/AdminLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminLayout.tsx
@@ -12,7 +12,7 @@ export const AdminLayout: GetLayout = (page) => {
     <EnforceLoginStatePageWrapper>
       <LayoutHead />
 
-      <Flex minH="$100vh" flexDir="column" bg="base.canvas.alt" pos="relative">
+      <Flex flex={1} flexDir="column" bg="base.canvas.alt" pos="relative">
         <AppNavbar />
         <AppGrid flex={1}>
           <Flex

--- a/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
@@ -16,7 +16,13 @@ export const AdminSidebarOnlyLayout: GetLayout = (page) => {
   return (
     <EnforceLoginStatePageWrapper>
       <LayoutHead />
-      <Flex minH="$100vh" flexDir="row" bg="base.canvas.alt" pos="relative">
+      <Flex
+        flex={1}
+        flexDir="row"
+        bg="base.canvas.alt"
+        pos="relative"
+        overflow="hidden"
+      >
         <CmsSidebarWrapper>{page}</CmsSidebarWrapper>
       </Flex>
     </EnforceLoginStatePageWrapper>

--- a/apps/studio/src/templates/layouts/DefaultLayout.tsx
+++ b/apps/studio/src/templates/layouts/DefaultLayout.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react"
+import { chakra } from "@chakra-ui/react"
 
 import { LayoutHead } from "~/components/LayoutHead"
 
@@ -10,8 +11,9 @@ export const DefaultLayout = ({ children }: DefaultLayoutProps) => {
   return (
     <>
       <LayoutHead />
-
-      <main>{children}</main>
+      <chakra.main display="flex" flex={1}>
+        {children}
+      </chakra.main>
     </>
   )
 }

--- a/apps/studio/src/templates/layouts/PageEditingLayout.tsx
+++ b/apps/studio/src/templates/layouts/PageEditingLayout.tsx
@@ -23,12 +23,12 @@ export const PageEditingLayout: GetLayout = (page) => {
             flex={1}
             height={0}
             minH="100%"
-            width="100vw"
+            width="100%"
             gridColumnGap={{ base: 0, md: "1rem" }}
             gridTemplate={APP_GRID_TEMPLATE_AREA}
           >
             <SiteEditNavbar />
-            <Flex bg="base.canvas.alt" w="100vw" height={0} minH="100%">
+            <Flex bg="base.canvas.alt" w="100%" height={0} minH="100%">
               {page}
             </Flex>
           </Grid>

--- a/apps/studio/src/templates/layouts/PageEditingLayout.tsx
+++ b/apps/studio/src/templates/layouts/PageEditingLayout.tsx
@@ -3,7 +3,6 @@ import { Tabs } from "@opengovsg/design-system-react"
 
 import { EnforceLoginStatePageWrapper } from "~/components/AuthWrappers"
 import { LayoutHead } from "~/components/LayoutHead"
-import { APP_GRID_TEMPLATE_AREA } from "~/constants/layouts"
 import { SiteEditNavbar } from "~/features/editing-experience/components/SiteEditNavbar"
 import { type GetLayout } from "~/lib/types"
 
@@ -25,7 +24,7 @@ export const PageEditingLayout: GetLayout = (page) => {
             minH="100%"
             width="100%"
             gridColumnGap={{ base: 0, md: "1rem" }}
-            gridTemplate={APP_GRID_TEMPLATE_AREA}
+            gridTemplateRows="auto 1fr"
           >
             <SiteEditNavbar />
             <Flex bg="base.canvas.alt" w="100%" height={0} minH="100%">

--- a/apps/studio/src/templates/layouts/PageEditingLayout.tsx
+++ b/apps/studio/src/templates/layouts/PageEditingLayout.tsx
@@ -11,16 +11,24 @@ export const PageEditingLayout: GetLayout = (page) => {
   return (
     <EnforceLoginStatePageWrapper>
       <LayoutHead />
-      <Tabs>
-        <Flex minH="100vh" flexDir="column" bg="base.canvas.alt" pos="relative">
+      <Tabs flex={1} height={0}>
+        <Flex
+          flexDir="column"
+          bg="base.canvas.alt"
+          pos="relative"
+          height={0}
+          minH="100%"
+        >
           <Grid
             flex={1}
+            height={0}
+            minH="100%"
             width="100vw"
             gridColumnGap={{ base: 0, md: "1rem" }}
             gridTemplate={APP_GRID_TEMPLATE_AREA}
           >
             <SiteEditNavbar />
-            <Flex flex={1} bg="base.canvas.alt" w="100vw">
+            <Flex bg="base.canvas.alt" w="100vw" height={0} minH="100%">
               {page}
             </Flex>
           </Grid>


### PR DESCRIPTION


## Solution

This PR addresses layout issues related to scrolling and height calculations across multiple components in the studio app when the banner is visible.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Updated height calculations in various components to use `height={0}` and `minH="100%"` instead of fixed `100vh` values
- Improved scrolling behavior in modal screens, sidebars, and page layouts
- Enhanced responsiveness of layout components

**Bug Fixes**:

- Fixed potential overflow issues in CmsSidebar components
- Resolved layout inconsistencies in CreatePageModal screens
- Corrected height calculations in various page templates

## Before & After Screenshots
Should be no different in snapshots, but scrolling behaviour should now be consistent.

## Tests

- Test scrolling behavior in CmsSidebar components
- Verify layout consistency in CreatePageModal screens
- Check responsiveness of page templates and layouts
- Ensure proper rendering of content in various viewport sizes
