### PR TITLE
fix: tooling pipeline

### DIFF
--- a/tooling/template/turbo.json
+++ b/tooling/template/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["@opengovsg/isomer-components#build"]
+    }
+  }
+}


### PR DESCRIPTION
## Problem
tooling build depends on components but the ordering isn't clear, resulting in failed builds

## Solution
add dependency for `tooling` on `isomer-components` using `turbo.json`