### PR TITLE
fix(cards): remove default from components package

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1524,10 +1524,6 @@ video {
   height: 500px;
 }
 
-.h-\[4\.25rem\] {
-  height: 4.25rem;
-}
-
 .h-\[68px\] {
   height: 68px;
 }
@@ -3216,15 +3212,6 @@ video {
 
 .outline-link {
   outline-color: #1a56e5;
-}
-
-.ring {
-  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0
-    var(--tw-ring-offset-width) var(--tw-ring-offset-color);
-  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0
-    calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color);
-  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow),
-    var(--tw-shadow, 0 0 #0000);
 }
 
 .ring-1 {

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -65,13 +65,11 @@ const InfoCardsBaseSchema = Type.Object({
   type: Type.Literal("infocards", { default: "infocards" }),
   title: Type.String({
     title: "Title",
-    default: "This is an optional title of the Cards component",
     maxLength: 100,
   }),
   subtitle: Type.Optional(
     Type.String({
       title: "Description",
-      default: "This is an optional description for the Cards component",
       maxLength: 200,
     }),
   ),


### PR DESCRIPTION
## Problem
right now, when we delete the card, it uses the schema default, resulting in the delete not going through and showing the default. 

## Solution
1. remove `default` from the schema 
    - by right, the schema should tell us what the default is. at present, this is being done by studio. another alternative _could_ be to just use the schema default and remove the constants in studio but the drawback is that it doesnt add much value as of now, is quite some drudgery and teh behaviour changes (see below):
    - if we use `schema.default`, what happens is that when you clear the input, it'll use the default value from the schema leading to potentially unintuitive behaviour. (tbh, i'm ok with this but we need to check if this is obvious to the user)
    - [relevant issue](https://github.com/rjsf-team/react-jsonschema-form/issues/2980)

## Screenshots

https://github.com/user-attachments/assets/185b01c3-146e-4600-820a-bce2a9a846bb

