### PR TITLE
fix(rootpage): allow updating of settings for root page

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
@@ -67,7 +67,7 @@ const useCreateCollectionPageWizardContext = ({
     const jsonPreview =
       type === "page" ? articleLayoutPreview : collectionPdfPreview
     return merge(jsonPreview, {
-      title: title || "Page title here",
+      page: { title: title || "Page title here" },
     }) as IsomerSchema
   }, [type, title])
 

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -70,7 +70,9 @@ const useCreatePageWizardContext = ({
     const jsonPreview =
       layout === "content" ? contentLayoutPreview : articleLayoutPreview
     return merge(jsonPreview, {
-      title: title || "Page title here",
+      page: {
+        title: title || "Page title here",
+      },
     }) as IsomerSchema
   }, [layout, title])
 

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -1,3 +1,4 @@
+import { ResourceType } from "~prisma/generated/generatedEnums"
 import { z } from "zod"
 
 import { generateBasePermalinkSchema } from "./common"
@@ -106,8 +107,23 @@ export const getRootPageSchema = z.object({
   siteId: z.number().min(1),
 })
 
-export const pageSettingsSchema = basePageSchema.extend({
+export const basePageSettingsSchema = basePageSchema.extend({
   title: pageTitleSchema,
-  permalink: permalinkSchema,
   meta: z.string(),
 })
+
+export const rootPageSettingsSchema = basePageSettingsSchema.extend({
+  type: z.literal(ResourceType.RootPage),
+})
+
+export const pageSettingsSchema = z.discriminatedUnion("type", [
+  basePageSettingsSchema.extend({
+    type: z.literal(ResourceType.Page),
+    permalink: permalinkSchema,
+  }),
+  basePageSettingsSchema.extend({
+    type: z.literal(ResourceType.CollectionPage),
+    permalink: permalinkSchema,
+  }),
+  rootPageSettingsSchema,
+])

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -118,6 +118,17 @@ export const pageRouter = router({
 
         const { title, type, permalink, content, updatedAt } = page
 
+        if (
+          type !== ResourceType.Page &&
+          type !== ResourceType.CollectionPage &&
+          type !== ResourceType.RootPage
+        ) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "The specified resource could not be found",
+          })
+        }
+
         return {
           permalink,
           navbar,
@@ -335,6 +346,7 @@ export const pageRouter = router({
               cause: validateFn.errors,
             })
           }
+
           const newContent = !meta
             ? rest
             : ({ ...rest, meta: newMeta } as PrismaJson.BlobJsonContent)
@@ -349,7 +361,11 @@ export const pageRouter = router({
             .updateTable("Resource")
             .where("Resource.id", "=", String(pageId))
             .where("Resource.siteId", "=", siteId)
-            .where("Resource.type", "in", ["Page", "CollectionPage"])
+            .where("Resource.type", "in", [
+              "Page",
+              "CollectionPage",
+              "RootPage",
+            ])
             .set({ title, permalink })
             .returning([
               "Resource.id",


### PR DESCRIPTION
## Problem
Rootpage has no url, which causes validation to fail. This leads to users being unable to update the rootpage

## Solution
1. update the schema on backend to be a discriminated union so that we can distinguish between permalinks for non-root and root. (root has no permalink)
2. for frontend, return a more general schema that we then refine. this was chosen due to difficulties in getting the zod schema to work across fe/be 
    - when you use a `z.discriminatedUnion`, you lose the abiilty to `omit` and `refine`, which meant that the schema we use for backend cannot be used for frontend (as we want to omit some stuff)
    - type inference in a few places screwed up (eg: `meta` is `unknown` on frontend and we stringify it before sending to backend) if we tried making properties shared across fe/be