### PR TITLE
isom-1469 - fix: add divider in datatable

### DIFF
--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -2,6 +2,7 @@ import type { LayoutProps, TableProps } from "@chakra-ui/react"
 import type { Table as ReactTable } from "@tanstack/react-table"
 import {
   Box,
+  Divider,
   Flex,
   Spinner,
   Table,
@@ -107,6 +108,9 @@ export const Datatable = <T extends object>({
               </Tr>
             ))}
           </Thead>
+          {rows.length > 0 && (
+            <Divider width={`${instance.getAllColumns().length * 100}%`} />
+          )}
           <Tbody>
             {rows.length === 0 && emptyPlaceholder}
             {rows.map((row) => {


### PR DESCRIPTION

## Problem

Closes [#1469](https://linear.app/ogp/issue/ISOM-1469/my-pages-main-table-styling)

## Solution

- Add a `Divider` component when rows count is at least 1

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed visual inconsistencies in the table styling.

<img width="962" alt="image" src="https://github.com/user-attachments/assets/938b3526-bcc2-4fab-8313-99f493078901">
