### PR TITLE
isom-1484 - fix: remove extra spacing for move modal overflowing titles

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
@@ -31,7 +31,7 @@ const SuspendableMoveItem = ({
       leftIcon={<BiFolder />}
       {...rest}
     >
-      <Text noOfLines={1} textStyle="caption-1">
+      <Text noOfLines={1} textStyle="caption-1" textAlign="left">
         /{permalink}
       </Text>
     </Button>


### PR DESCRIPTION
## Problem

Closes https://linear.app/ogp/issue/ISOM-1484/move-modal-overflowing-titles-have-extra-spacing

## Solution

- add textalign left

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

<img width="711" alt="image" src="https://github.com/user-attachments/assets/ea0ccea8-c8d7-40c1-ac71-4f0751a0a49a">