### PR TITLE
fix: add size "xs" to fix moveitem wrong height

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveItem.tsx
@@ -27,6 +27,7 @@ const SuspendableMoveItem = ({
       justifyContent="flex-start"
       color="base.content.default"
       pl="2.25rem"
+      size="xs"
       onClick={onChangeResourceId}
       leftIcon={<BiFolder />}
       {...rest}


### PR DESCRIPTION

## Problem

The item in the move modal has a height that's inconsistent with the height in figma

Closes https://linear.app/ogp/issue/ISOM-1489/move-modal-move-item-has-wrong-height

## Solution

Added the size "xs" to the `Button` parent component to resolve the height issue.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ... 
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed the wrong height of the move item modal by applying size "xs".

<img width="1199" alt="Screenshot 2024-10-09 at 2 56 40 AM" src="https://github.com/user-attachments/assets/2deb1605-faa6-4c79-8185-c18d39e9c9d9">