### PR TITLE
isom-1479 - fix: use `lg` for all ModalCloseButton

### DIFF
--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -101,7 +101,7 @@ const LinkEditorModalContent = ({
     <ModalContent>
       <form onSubmit={onSubmit}>
         <ModalHeader>{isEditingLink ? "Edit link" : "Add link"}</ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
 
         <ModalBody>
           <FormControl isRequired isInvalid={!!errors.linkText}>

--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -74,7 +74,7 @@ export const TableSettingsModal = ({
 
       <ModalContent>
         <ModalHeader>Table settings</ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
 
         <ModalBody>
           <FormControl isRequired isInvalid={!!errors.caption}>

--- a/apps/studio/src/components/VersionWrapper/VersionModal.tsx
+++ b/apps/studio/src/components/VersionWrapper/VersionModal.tsx
@@ -31,7 +31,7 @@ export const VersionModal = ({ isOpen, onClose }: VersionModalProps) => {
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalOverlay />
       <ModalContent>
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
         <ModalHeader>Update Available</ModalHeader>
         <ModalBody>
           Please refresh the page to get the latest version.

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -118,7 +118,7 @@ const DeleteResourceModalContent = ({
   return (
     <ModalContent>
       <ModalHeader pr="4.5rem">Delete {title}?</ModalHeader>
-      <ModalCloseButton />
+      <ModalCloseButton size="lg" />
 
       <ModalBody>
         <Text textStyle="body-2">{getWarningText(resourceType)}</Text>

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -119,7 +119,7 @@ const SuspendableModalContent = ({
     <ModalContent key={String(!!folderId)}>
       <form onSubmit={onSubmit}>
         <ModalHeader>Edit "{originalTitle}"</ModalHeader>
-        <ModalCloseButton size="sm" />
+        <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
             <FormControl isInvalid={!!errors.title}>
@@ -186,7 +186,6 @@ const SuspendableModalContent = ({
             </FormControl>
           </VStack>
         </ModalBody>
-
         <ModalFooter>
           <Button mr={3} onClick={onClose} variant="clear">
             Close

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -123,7 +123,7 @@ const CreateCollectionModalContent = ({
     <ModalContent>
       <form onSubmit={onSubmit}>
         <ModalHeader>Create a new collection</ModalHeader>
-        <ModalCloseButton size="sm" />
+        <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
             <FormControl isInvalid={!!errors.collectionTitle}>

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -125,7 +125,7 @@ const CreateFolderModalContent = ({
     <ModalContent>
       <form onSubmit={onSubmit}>
         <ModalHeader>Create a new folder </ModalHeader>
-        <ModalCloseButton size="sm" />
+        <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
             <FormControl isInvalid={!!errors.folderTitle}>
@@ -198,7 +198,6 @@ const CreateFolderModalContent = ({
             </FormControl>
           </VStack>
         </ModalBody>
-
         <ModalFooter>
           <Button mr={3} onClick={onClose} variant="clear">
             Close

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -31,7 +31,7 @@ export const DeleteBlockModal = ({
           Are you sure you want to delete {itemName}?
         </ModalHeader>
 
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
 
         <ModalBody>
           <Text textStyle="body-2">This cannot be undone.</Text>

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
@@ -29,7 +29,7 @@ export const DiscardChangesModal = ({
           Are you sure you want to discard your changes?
         </ModalHeader>
 
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
 
         <ModalBody>
           <Text textStyle="body-2">All edits will be lost.</Text>

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -137,7 +137,7 @@ const MoveResourceContent = withSuspense(
     return (
       <ModalContent>
         <ModalHeader>Move "{title}" to...</ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.25rem">
             <Infobox size="sm" w="full">

--- a/apps/studio/src/features/editing-experience/components/UnsavedSettingModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/UnsavedSettingModal.tsx
@@ -25,9 +25,9 @@ export const UnsavedSettingModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
-      <ModalContent size="lg" overflow="hidden">
+      <ModalContent overflow="hidden">
         <ModalHeader>Leave this page without saving your settings?</ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
         <ModalBody>All edits will be lost.</ModalBody>
         <ModalFooter>
           <Button

--- a/apps/studio/src/features/editing-experience/components/UnsavedSettingModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/UnsavedSettingModal.tsx
@@ -25,7 +25,7 @@ export const UnsavedSettingModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
-      <ModalContent overflow="hidden">
+      <ModalContent size="lg" overflow="hidden">
         <ModalHeader>Leave this page without saving your settings?</ModalHeader>
         <ModalCloseButton />
         <ModalBody>All edits will be lost.</ModalBody>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
@@ -82,7 +82,7 @@ const PageLinkModalContent = ({
     <ModalContent>
       <form onSubmit={onSubmit}>
         <ModalHeader pr="4.5rem">Edit link</ModalHeader>
-        <ModalCloseButton />
+        <ModalCloseButton size="lg" />
 
         <ModalBody>
           <FormControl isRequired>


### PR DESCRIPTION
## Problem

ModalCloseButtons have inconsistent styling with Figma

Closes https://linear.app/ogp/issue/ISOM-1479/all-modals-modal-close-buttons-should-be-lg

## Solution

Add `lg` size to all of them

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible