### PR TITLE
isom-1477 - fix: add `mr` 3.5rem to ModalHeader

### DIFF
--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -100,7 +100,9 @@ const LinkEditorModalContent = ({
   return (
     <ModalContent>
       <form onSubmit={onSubmit}>
-        <ModalHeader>{isEditingLink ? "Edit link" : "Add link"}</ModalHeader>
+        <ModalHeader mr="3.5rem">
+          {isEditingLink ? "Edit link" : "Add link"}
+        </ModalHeader>
         <ModalCloseButton />
 
         <ModalBody>

--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -73,7 +73,7 @@ export const TableSettingsModal = ({
       <ModalOverlay />
 
       <ModalContent>
-        <ModalHeader>Table settings</ModalHeader>
+        <ModalHeader mr="3.5rem">Table settings</ModalHeader>
         <ModalCloseButton />
 
         <ModalBody>

--- a/apps/studio/src/components/VersionWrapper/VersionModal.tsx
+++ b/apps/studio/src/components/VersionWrapper/VersionModal.tsx
@@ -31,8 +31,8 @@ export const VersionModal = ({ isOpen, onClose }: VersionModalProps) => {
     <Modal isOpen={isOpen} onClose={onClose} size={modalSize}>
       <ModalOverlay />
       <ModalContent>
+        <ModalHeader mr="3.5rem">Update Available</ModalHeader>
         <ModalCloseButton size="lg" />
-        <ModalHeader ml="3.5rem">Update Available</ModalHeader>
         <ModalBody>
           Please refresh the page to get the latest version.
         </ModalBody>

--- a/apps/studio/src/components/VersionWrapper/VersionModal.tsx
+++ b/apps/studio/src/components/VersionWrapper/VersionModal.tsx
@@ -32,7 +32,7 @@ export const VersionModal = ({ isOpen, onClose }: VersionModalProps) => {
       <ModalOverlay />
       <ModalContent>
         <ModalCloseButton />
-        <ModalHeader>Update Available</ModalHeader>
+        <ModalHeader ml="3.5rem">Update Available</ModalHeader>
         <ModalBody>
           Please refresh the page to get the latest version.
         </ModalBody>

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -117,7 +117,7 @@ const DeleteResourceModalContent = ({
 
   return (
     <ModalContent>
-      <ModalHeader pr="4.5rem">Delete {title}?</ModalHeader>
+      <ModalHeader mr="3.5rem">Delete {title}?</ModalHeader>
       <ModalCloseButton />
 
       <ModalBody>

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -118,7 +118,7 @@ const SuspendableModalContent = ({
   return (
     <ModalContent key={String(!!folderId)}>
       <form onSubmit={onSubmit}>
-        <ModalHeader>Edit "{originalTitle}"</ModalHeader>
+        <ModalHeader mr="3.5rem">Edit "{originalTitle}"</ModalHeader>
         <ModalCloseButton size="sm" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -122,7 +122,7 @@ const CreateCollectionModalContent = ({
   return (
     <ModalContent>
       <form onSubmit={onSubmit}>
-        <ModalHeader>Create a new collection</ModalHeader>
+        <ModalHeader mr="3.5rem">Create a new collection</ModalHeader>
         <ModalCloseButton size="sm" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -124,7 +124,7 @@ const CreateFolderModalContent = ({
   return (
     <ModalContent>
       <form onSubmit={onSubmit}>
-        <ModalHeader>Create a new folder </ModalHeader>
+        <ModalHeader mr="3.5rem">Create a new folder </ModalHeader>
         <ModalCloseButton size="sm" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -27,7 +27,7 @@ export const DeleteBlockModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader pr="4.5rem">
+        <ModalHeader mr="3.5rem">
           Are you sure you want to delete {itemName}?
         </ModalHeader>
 

--- a/apps/studio/src/features/editing-experience/components/UnsavedSettingModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/UnsavedSettingModal.tsx
@@ -26,7 +26,9 @@ export const UnsavedSettingModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent overflow="hidden">
-        <ModalHeader>Leave this page without saving your settings?</ModalHeader>
+        <ModalHeader mr="3.5rem">
+          Leave this page without saving your settings?
+        </ModalHeader>
         <ModalCloseButton />
         <ModalBody>All edits will be lost.</ModalBody>
         <ModalFooter>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1477/edit-folder-title-eats-into-close-modal-button

## Solution

- add a 3.5rem margin-right to the ModalHeader
  - or margin-left if the close button is on the left
  - don't add if there's no close button e.g. details modal

<img width="807" alt="image" src="https://github.com/user-attachments/assets/fa2dd198-768b-4e72-a7c7-bea33d9d09da">

Note: 
- as not be 8px for everything for now due to wrong close button size, but that's fixed independently in https://github.com/opengovsg/isomer/pull/744

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible


