### PR TITLE
isom-1491 - fix: delete modals textstyle

### DIFF
--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -120,7 +120,7 @@ const DeleteResourceModalContent = ({
       <ModalHeader pr="4.5rem">Delete {title}?</ModalHeader>
       <ModalCloseButton size="lg" />
 
-      <ModalBody mt="1.5rem">
+      <ModalBody>
         <Text textStyle="body-1">{getWarningText(resourceType)}</Text>
         <HStack mt="1.5rem">
           <Checkbox onChange={() => setIsChecked((prev) => !prev)}>

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -121,7 +121,7 @@ const DeleteResourceModalContent = ({
       <ModalCloseButton />
 
       <ModalBody mt="1.5rem">
-        <Text textStyle="body-2">{getWarningText(resourceType)}</Text>
+        <Text textStyle="body-1">{getWarningText(resourceType)}</Text>
         <HStack mt="1.5rem">
           <Checkbox onChange={() => setIsChecked((prev) => !prev)}>
             Yes, delete this {label} permanently

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -120,7 +120,7 @@ const DeleteResourceModalContent = ({
       <ModalHeader pr="4.5rem">Delete {title}?</ModalHeader>
       <ModalCloseButton />
 
-      <ModalBody>
+      <ModalBody mt="1.5rem">
         <Text textStyle="body-2">{getWarningText(resourceType)}</Text>
         <HStack mt="1.5rem">
           <Checkbox onChange={() => setIsChecked((prev) => !prev)}>

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -124,7 +124,7 @@ const DeleteResourceModalContent = ({
         <Text textStyle="body-1">{getWarningText(resourceType)}</Text>
         <HStack mt="1.5rem">
           <Checkbox onChange={() => setIsChecked((prev) => !prev)}>
-            Yes, delete this {label} permanently
+            <Text textStyle="body-2">Yes, delete this {label} permanently</Text>
           </Checkbox>
         </HStack>
       </ModalBody>

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -33,7 +33,7 @@ export const DeleteBlockModal = ({
 
         <ModalCloseButton size="lg" />
 
-        <ModalBody mt="1.5rem">
+        <ModalBody>
           <Text textStyle="body-1">This cannot be undone.</Text>
         </ModalBody>
 

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -34,7 +34,7 @@ export const DeleteBlockModal = ({
         <ModalCloseButton />
 
         <ModalBody mt="1.5rem">
-          <Text textStyle="body-2">This cannot be undone.</Text>
+          <Text textStyle="body-1">This cannot be undone.</Text>
         </ModalBody>
 
         <ModalFooter>

--- a/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DeleteBlockModal/DeleteBlockModal.tsx
@@ -33,7 +33,7 @@ export const DeleteBlockModal = ({
 
         <ModalCloseButton />
 
-        <ModalBody>
+        <ModalBody mt="1.5rem">
           <Text textStyle="body-2">This cannot be undone.</Text>
         </ModalBody>
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1491/delete-modal-wrong-spacing-between-text-and-title

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- fix the font style inconsistency with figma

<img width="743" alt="image" src="https://github.com/user-attachments/assets/ed78b824-1004-4c85-8a34-8d1fc303ef5d">