### PR TITLE
isom-1511 - fix styling of homepage hero banner editor drawer

### DIFF
--- a/apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/LinkHrefEditor.tsx
@@ -52,8 +52,9 @@ export const LinkHrefEditor = ({
 
   return (
     <FormControl isRequired={isRequired} isInvalid={isInvalid}>
-      <FormLabel description={description}>{label}</FormLabel>
-
+      <FormLabel description={description} mb="0.5rem">
+        {label}
+      </FormLabel>
       <HStack {...getRootProps()} spacing={0}>
         {Object.entries(LINK_TYPES).map(([key, { icon, label }]) => {
           const radio = getRadioProps({ value: key })
@@ -68,7 +69,6 @@ export const LinkHrefEditor = ({
           )
         })}
       </HStack>
-
       <Box my="0.5rem">
         <LinkTypeRadioContent
           selectedLinkType={selectedLinkType}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
@@ -50,7 +50,9 @@ export function JsonFormsTextControl({
   return (
     <Box mt="1.25rem" _first={{ mt: 0 }}>
       <FormControl isRequired={required} isInvalid={!!errors}>
-        <FormLabel description={description}>{label}</FormLabel>
+        <FormLabel description={description} margin="0rem 0rem 0.5rem 0rem">
+          {label}
+        </FormLabel>
         <Input
           type="text"
           value={String(data || "")}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
@@ -36,7 +36,7 @@ const GroupComponent = React.memo(function GroupComponent({
       <Divider borderColor="base.divider.strong" />
 
       <Box w="100%" mt="1.25rem">
-        <Heading textStyle="h3" as="h3" size="sm">
+        <Heading textStyle="h6" as="h6" size="m" fontWeight="500">
           {label}
         </Heading>
       </Box>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsGroupLayout.tsx
@@ -32,10 +32,10 @@ const GroupComponent = React.memo(function GroupComponent({
   }
 
   return (
-    <Box mt="1.25rem" _first={{ mt: 0 }}>
+    <Box mt="1.5rem" _first={{ mt: 0 }}>
       <Divider borderColor="base.divider.strong" />
 
-      <Box w="100%" mt="1.25rem">
+      <Box w="100%" mt="1.5rem">
         <Heading textStyle="h6" as="h6" size="m" fontWeight="500">
           {label}
         </Heading>


### PR DESCRIPTION
## Problem

Closes https://linear.app/ogp/issue/ISOM-1511/homepage-hero-banner-has-wrong-styling-for-h3

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add the necessary margin so that it's consistent with Figma
- update text styling of the header

<img width="1137" alt="image" src="https://github.com/user-attachments/assets/408298d6-f46b-4249-9ae5-ee23883d5f84">
