### PR TITLE
fix(folder): update the folder title to not be empty

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -166,19 +166,19 @@ const SuspendableModalContent = ({
                   />
                 )}
               />
-              {errors.permalink?.message && (
+              {errors.permalink?.message ? (
                 <FormErrorMessage>{errors.permalink.message}</FormErrorMessage>
+              ) : (
+                <Box
+                  mt="0.5rem"
+                  py="0.5rem"
+                  px="0.75rem"
+                  bg="interaction.support.disabled"
+                >
+                  <Icon mr="0.5rem" as={BiLink} />
+                  {permalink}
+                </Box>
               )}
-
-              <Box
-                mt="0.5rem"
-                py="0.5rem"
-                px="0.75rem"
-                bg="interaction.support.disabled"
-              >
-                <Icon mr="0.5rem" as={BiLink} />
-                {permalink}
-              </Box>
 
               <FormHelperText mt="0.5rem" color="base.content.medium">
                 {MAX_FOLDER_PERMALINK_LENGTH - (permalink || "").length}{" "}

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -2,7 +2,6 @@ import { Suspense } from "react"
 import {
   Box,
   FormControl,
-  FormErrorMessage,
   FormHelperText,
   FormLabel,
   Icon,
@@ -17,7 +16,11 @@ import {
   Skeleton,
   VStack,
 } from "@chakra-ui/react"
-import { Button, useToast } from "@opengovsg/design-system-react"
+import {
+  Button,
+  FormErrorMessage,
+  useToast,
+} from "@opengovsg/design-system-react"
 import { useAtomValue, useSetAtom } from "jotai"
 import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -75,6 +75,7 @@ const SuspendableModalContent = ({
       resourceId: Number(folderId),
     })
   const { register, handleSubmit, watch, control, formState } = useZodForm({
+    mode: "onChange",
     defaultValues: {
       title: originalTitle,
       permalink: originalPermalink,

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -213,7 +213,7 @@ const PageSettings = () => {
 
             <FormControl isRequired isInvalid={!!errors.title}>
               <FormLabel
-                description="By default, this is the title of your your page. Edit this if
+                description="Edit this if
                 you want to show a different title on search engines."
               >
                 Page title

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -35,8 +35,8 @@ export const readFolderSchema = z
 
 export const baseEditFolderSchema = z.object({
   resourceId: z.string(),
-  permalink: z.optional(permalinkSchema),
-  title: z.optional(z.string()),
+  permalink: permalinkSchema,
+  title: z.string().min(1, { message: "Enter a title for this folder" }),
   siteId: z.string(),
 })
 
@@ -45,12 +45,7 @@ export const editFolderSchema = baseEditFolderSchema.superRefine(
     if (!permalink && !title) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ["siteId"],
-        message: "Either permalink or title must be provided.",
-      })
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["title"],
+        path: ["permalink", "title"],
         message: "Either permalink or title must be provided.",
       })
     }


### PR DESCRIPTION
## Problem
1. folder titles were allowed to be empty but we want to disallow that so we need more stringent validation

## Solution
1. update the validation mode to `onChange` - this is because validation (by [default](https://react-hook-form.com/docs/useform#mode)) for react hook form starts **after** submit, which won't be true for our modal (we close after a successful submit) 
2. don't show the permalink box if there is an error 

## Screenshots

https://github.com/user-attachments/assets/92278e35-56fb-4799-85c0-5fcb69e32603

