### PR TITLE
fix: use numeric sorting for sitemap generation

### DIFF
--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -236,7 +236,9 @@ const getSiteMapChildrenEntries = async (fullPath, relativePath) => {
   children.push(...danglingDirEntries)
 
   // Ensure that the result is ordered in alphabetical order
-  children.sort((a, b) => a.title.localeCompare(b.title))
+  children.sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { numeric: true }),
+  )
 
   return children
 }

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -213,6 +213,10 @@ function generateSitemapTree(
   )
   const children = [...existingChildren, ...danglingDirectories]
 
+  children.sort((a, b) =>
+    a.title.localeCompare(b.title, undefined, { numeric: true }),
+  )
+
   return children.map((child) => ({
     ...child,
     children: generateSitemapTree(sitemapEntries, child.permalink),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We use a simple alphabetical sorting for the title but this does not account for numbers.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Enable numeric comparison of strings so we can handle sorting of titles with numbers in them