### PR TITLE
chore: removed unused tables for permissions

### DIFF
--- a/apps/studio/prisma/migrations/20241010180527_remove_unused_tables/migration.sql
+++ b/apps/studio/prisma/migrations/20241010180527_remove_unused_tables/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Permission` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Permission" DROP CONSTRAINT "Permission_resourceId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Permission" DROP CONSTRAINT "Permission_userId_fkey";
+
+-- DropTable
+DROP TABLE "Permission";

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -59,8 +59,6 @@ model Resource {
 
   children Resource[] @relation("ParentRelation")
 
-  permission Permission[]
-
   publishedVersionId BigInt?  @unique
   publishedVersion   Version? @relation(fields: [publishedVersionId], references: [id])
 
@@ -118,23 +116,8 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
 
-  permissions Permission[]
   siteMembers SiteMember[]
   versions    Version[]
-}
-
-model Permission {
-  id         Int      @id @default(autoincrement())
-  resourceId BigInt
-  resource   Resource @relation(fields: [resourceId], references: [id])
-  userId     String
-  user       User     @relation(fields: [userId], references: [id])
-  role       RoleType
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-
-  // Delete the row if either resource or user is deleted, default behavior cascade
 }
 
 model Site {


### PR DESCRIPTION
## Problem
The `Permissions` table is unused, the permissions feature will instead add `ResourcePermissions` and `UserPermissions` table, so we don't need this table

## Solution
drop the table and associated constraints