### PR TITLE
fix: add mr-3 (12px) to navbar logo (except mobile)

### DIFF
--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -16,7 +16,7 @@ import { NavItem } from "./NavItem"
 
 const navbarStyles = tv({
   slots: {
-    logo: "max-h-[48px] max-w-[128px] object-contain object-center",
+    logo: "max-h-[48px] max-w-[128px] object-contain object-center lg:mr-3",
     navbarContainer: "flex min-h-16 w-full bg-white lg:min-h-[4.25rem]",
     navbar:
       "mx-auto flex w-full max-w-screen-xl items-center justify-between gap-x-2 pl-6 pr-3 md:px-10",


### PR DESCRIPTION
## Problem

Closes https://linear.app/ogp/issue/ISOM-1612/add-extra-12px-gap-between-first-item-and-logospace

## Solution

add mr-3 to logo class (except if its mobile view)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

