### PR TITLE
feat: perform publish of site for implicit actions

### DIFF
--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -50,19 +50,20 @@ const SuspendablePublishButton = ({
     if (coercedSiteId && coercedPageId)
       mutate({ pageId: coercedPageId, siteId: coercedSiteId })
   }
+
+  const isChangesPendingPublish = !!currPage.draftBlobId
+
   return (
     <TouchableTooltip
-      hidden={!!currPage.draftBlobId}
-      // label="All changes have been published"
-      label="This feature is currently not available in beta"
+      hidden={isChangesPendingPublish}
+      label="All changes have been published"
     >
       <Button
         variant="solid"
         size="sm"
         onClick={handlePublish}
         isLoading={isLoading}
-        // TODO(ISOM-1552): Add back functionality when implemented
-        isDisabled
+        isDisabled={!isChangesPendingPublish}
       >
         Publish
       </Button>
@@ -72,6 +73,6 @@ const SuspendablePublishButton = ({
 
 const PublishButton = withSuspense(
   SuspendablePublishButton,
-  <Skeleton width={"100%"} height={"100%"} />,
+  <Skeleton width="100%" height="100%" />,
 )
 export default PublishButton

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -5,7 +5,8 @@ import { createCollectionSchema } from "~/schemas/collection"
 import { readFolderSchema } from "~/schemas/folder"
 import { createCollectionPageSchema } from "~/schemas/page"
 import { protectedProcedure, router } from "~/server/trpc"
-import { db, ResourceType } from "../database"
+import { publishSite } from "../aws/codebuild.service"
+import { db, ResourceState, ResourceType } from "../database"
 import {
   defaultResourceSelect,
   getSiteResourceById,
@@ -35,27 +36,35 @@ export const collectionRouter = router({
     }),
   create: protectedProcedure
     .input(createCollectionSchema)
-    .mutation(async ({ input: { collectionTitle, permalink, siteId } }) => {
-      return db
-        .insertInto("Resource")
-        .values({
-          permalink,
-          siteId,
-          type: "Collection",
-          title: collectionTitle,
-        })
-        .returning(defaultCollectionSelect)
-        .executeTakeFirstOrThrow()
-        .catch((err) => {
-          if (get(err, "code") === "23505") {
-            throw new TRPCError({
-              code: "CONFLICT",
-              message: "A resource with the same permalink already exists",
-            })
-          }
-          throw err
-        })
-    }),
+    .mutation(
+      async ({ ctx, input: { collectionTitle, permalink, siteId } }) => {
+        const result = await db
+          .insertInto("Resource")
+          .values({
+            permalink,
+            siteId,
+            type: ResourceType.Collection,
+            title: collectionTitle,
+            state: ResourceState.Published,
+          })
+          .returning(defaultCollectionSelect)
+          .executeTakeFirstOrThrow()
+          .catch((err) => {
+            if (get(err, "code") === "23505") {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message: "A resource with the same permalink already exists",
+              })
+            }
+            throw err
+          })
+
+        // TODO: Create the index page for the collection and publish it
+        await publishSite(ctx.logger, siteId)
+
+        return result
+      },
+    ),
   createCollectionPage: protectedProcedure
     .input(createCollectionPageSchema)
     .mutation(async ({ input }) => {

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -17,7 +17,6 @@ import {
 } from "~/schemas/page"
 import { protectedProcedure, router } from "~/server/trpc"
 import { safeJsonParse } from "~/utils/safeJsonParse"
-import { shouldStartNewBuild, startProjectById } from "../aws/codebuild.service"
 import { db, ResourceType } from "../database"
 import {
   getFooter,
@@ -26,11 +25,11 @@ import {
   getPageById,
   getResourceFullPermalink,
   getResourcePermalinkTree,
+  publishResource,
   updateBlobById,
   updatePageById,
 } from "../resource/resource.service"
-import { getSiteConfig, getSiteNameAndCodeBuildId } from "../site/site.service"
-import { incrementVersion } from "../version/version.service"
+import { getSiteConfig } from "../site/site.service"
 import { createDefaultPage } from "./page.service"
 
 const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
@@ -289,38 +288,9 @@ export const pageRouter = router({
 
   publishPage: protectedProcedure
     .input(publishPageSchema)
-    .mutation(async ({ ctx, input: { siteId, pageId } }) => {
-      // Step 1: Create a new version
-      const addedVersionResult = await incrementVersion({
-        siteId,
-        pageId,
-        userId: ctx.user.id,
-      })
-
-      // Step 2: Get the CodeBuild ID associated with the site
-      const site = await getSiteNameAndCodeBuildId(siteId)
-      const { codeBuildId } = site
-      if (!codeBuildId) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "No CodeBuild project ID found for site",
-        })
-      }
-
-      // Step 3: Determine if a new build should be started
-      const isNewBuildNeeded = await shouldStartNewBuild(
-        ctx.logger,
-        codeBuildId,
-      )
-
-      if (!isNewBuildNeeded) {
-        return addedVersionResult
-      }
-
-      // Step 4: Start a new build
-      await startProjectById(ctx.logger, codeBuildId)
-      return addedVersionResult
-    }),
+    .mutation(async ({ ctx, input: { siteId, pageId } }) =>
+      publishResource(ctx.logger, siteId, String(pageId), ctx.user.id),
+    ),
 
   updateSettings: protectedProcedure
     .input(pageSettingsSchema)

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -5,6 +5,7 @@ import {
   setNotificationSchema,
 } from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
+import { publishSite } from "../aws/codebuild.service"
 import { db } from "../database"
 import {
   getFooter,
@@ -69,13 +70,16 @@ export const siteRouter = router({
     }),
   setNotification: protectedProcedure
     .input(setNotificationSchema)
-    .mutation(async ({ input }) => {
+    .mutation(async ({ ctx, input }) => {
       const { siteId, notification, notificationEnabled } = input
       if (notificationEnabled) {
         await setSiteNotification(siteId, notification)
       } else {
         await clearSiteNotification(siteId)
       }
+
+      await publishSite(ctx.logger, siteId)
+
       return input
     }),
 })

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -25,8 +25,8 @@ const createVersion = async (
   db: SafeKysely,
   props: {
     versionNum: number
-    resourceId: number
-    blobId: number
+    resourceId: string
+    blobId: string
     publisherId: string
   },
 ) => {
@@ -35,8 +35,8 @@ const createVersion = async (
     .insertInto("Version")
     .values({
       versionNum,
-      resourceId: String(resourceId),
-      blobId: String(blobId),
+      resourceId: resourceId,
+      blobId,
       publishedAt: new Date(),
       publishedBy: publisherId,
     })
@@ -48,11 +48,11 @@ const createVersion = async (
 
 export const incrementVersion = async ({
   siteId,
-  pageId,
+  resourceId,
   userId,
 }: {
   siteId: number
-  pageId: number
+  resourceId: string
   userId: string
 }) => {
   return await db
@@ -61,7 +61,10 @@ export const incrementVersion = async ({
     // concurrent publishes from other users
     .setIsolationLevel("serializable")
     .execute(async (tx) => {
-      const page = await getPageById(tx, { siteId, resourceId: pageId })
+      const page = await getPageById(tx, {
+        siteId,
+        resourceId: Number(resourceId),
+      })
 
       if (!page.draftBlobId) {
         throw new TRPCError({
@@ -81,8 +84,8 @@ export const incrementVersion = async ({
       // Create the new version
       const newVersion = await createVersion(tx, {
         versionNum: newVersionNum,
-        resourceId: pageId,
-        blobId: Number(page.draftBlobId),
+        resourceId,
+        blobId: page.draftBlobId,
         publisherId: userId,
       })
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We don't currently do any site publishes for implicit actions.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Perform publishes for implicit actions such as:
    - Creates: Folder/Collection
    - Updates: Renaming of folder, moving of folder/pages
    - Deletes: Pages/Folder/Collection
- A new build is not triggered if there is a currently running build that was started within the last 60 seconds of the time of publish.
    - Reason: CodeBuild doesn't have the functionality to queue builds, so if we want to avoid the starvation of builds, we will have to implement our own queueing system which would be quite an involved effort. For context, starvation of builds happen because we originally kill off the existing running build when starting new ones.
    - 60 seconds is a number decided based on tests, whereby the publisher script takes about a minute to clone this repo and build the components package on a powerful machine (70 GB memory, 36 vCPUs) before it runs the script to pull the site data from the database. So any publishes that happen within this time period would have been captured by this earlier running build (since the DB fetch has not happened yet).
    - Race conditions can still happen as there is no locking mechanism implemented, but willing to take a wait-and-see approach first before diving into more involved engineering solutions.