### PR TITLE
fix: prevent page from crashing when we go back

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -10,6 +10,12 @@ export const DEFAULT_BLOCKS: Record<
     content: [
       {
         type: "paragraph",
+        content: [
+          {
+            type: "text",
+            text: "",
+          },
+        ],
       },
     ],
   },

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -25,9 +25,8 @@ export function EditPageDrawer(): JSX.Element {
 
   const inferAsProse = (component?: IsomerComponent): ProseProps => {
     if (!component) {
-      throw new Error(`Expected component of type prose but got undefined`)
+      return { type: "prose", content: [] }
     }
-
     if (validate(component)) {
       return component
     }

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -25,8 +25,9 @@ export function EditPageDrawer(): JSX.Element {
 
   const inferAsProse = (component?: IsomerComponent): ProseProps => {
     if (!component) {
-      return { type: "prose", content: [] }
+      throw new Error("Expected component of type prose but got undefined")
     }
+
     if (validate(component)) {
       return component
     }
@@ -45,6 +46,7 @@ export function EditPageDrawer(): JSX.Element {
       return <ComponentSelector />
     case "nativeEditor": {
       const component = previewPageState.content[currActiveIdx]
+      if (!component) return <div />
       return <TipTapProseComponent content={inferAsProse(component)} />
     }
     case "complexEditor":


### PR DESCRIPTION
## Problem
right now, when we create a empty tiptap block, the component is `undefined` which fails validation when we click the back button

## Solution
1. add a default state if the component is undefined. we just add an empty paragraph block which looks identical to what we have atm 
2. also add validation so that if `component` is `undefined`, we return an empty `div`. note that this case will **only ever appear on initial creation** (tiptap will set content of paragraph to `undefined`) and in all other cases, an initial block will have a paragraph node with `content: [""]`
