### PR TITLE
feat(file-upload): implement file uploads on tiptap 

### DIFF
--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -150,7 +150,7 @@ async function main() {
       config: jsonb({
         theme: "isomer-next",
         siteName: "MTI",
-        logoUrl: "",
+        logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
         search: undefined,
         isGovernment: true,
       }),

--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react"
+import { FormControl, Skeleton, Text } from "@chakra-ui/react"
+import { Attachment, FormErrorMessage } from "@opengovsg/design-system-react"
+
+import { MAX_PDF_FILE_SIZE_BYTES } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
+import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
+import { getPresignedPutUrlSchema } from "~/schemas/asset"
+
+interface FileAttachmentProps {
+  setHref: (href: string) => void
+  siteId: number
+  error?: string
+  setError: (error: string) => void
+}
+
+export const FileAttachment = ({
+  setHref,
+  siteId,
+  error,
+  setError,
+}: FileAttachmentProps) => {
+  const [file, setFile] = useState<File | undefined>(undefined)
+  // TODO: Add a mutation for deletion next time of s3 resources
+  const { mutate: uploadFile, isLoading } = useUploadAssetMutation({
+    siteId,
+  })
+
+  useEffect(() => {
+    // NOTE: The outer link modal uses this to disable the button
+    if (isLoading) setHref("")
+  }, [isLoading, setHref])
+
+  return (
+    <FormControl>
+      <Skeleton isLoaded={!isLoading}>
+        <Attachment
+          isRequired
+          name="file-upload"
+          multiple={false}
+          value={file}
+          onChange={(file) => {
+            setFile(file)
+
+            if (file) {
+              uploadFile(
+                { file },
+                {
+                  onSuccess: ({ path }) => {
+                    setHref(path)
+                  },
+                },
+              )
+            }
+          }}
+          onError={setError}
+          maxSize={MAX_PDF_FILE_SIZE_BYTES}
+          accept={["application/pdf"]}
+          onFileValidation={(file) => {
+            const parseResult = getPresignedPutUrlSchema
+              .pick({ fileName: true })
+              .safeParse({ fileName: file.name })
+
+            if (parseResult.success) return null
+            // NOTE: safe assertion here because we're in error path and there's at least 1 error
+            return (
+              parseResult.error.errors[0]?.message ||
+              "Please ensure that your file begins with alphanumeric characters!"
+            )
+          }}
+        />
+      </Skeleton>
+      <Text textStyle="body-2" textColor="base.content.medium" pt="0.5rem">
+        {`Maximum file size: ${MAX_PDF_FILE_SIZE_BYTES / 1000000} MB`}
+      </Text>
+      {error && <FormErrorMessage>{error}</FormErrorMessage>}
+    </FormControl>
+  )
+}

--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -11,7 +11,7 @@ interface FileAttachmentProps {
   siteId: number
   error?: string
   setError: (error: string) => void
-  clearError
+  clearError: () => void
 }
 
 export const FileAttachment = ({

--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -11,6 +11,7 @@ interface FileAttachmentProps {
   siteId: number
   error?: string
   setError: (error: string) => void
+  clearError
 }
 
 export const FileAttachment = ({
@@ -18,6 +19,7 @@ export const FileAttachment = ({
   siteId,
   error,
   setError,
+  clearError,
 }: FileAttachmentProps) => {
   const [file, setFile] = useState<File | undefined>(undefined)
   // TODO: Add a mutation for deletion next time of s3 resources
@@ -40,17 +42,21 @@ export const FileAttachment = ({
           value={file}
           onChange={(file) => {
             setFile(file)
-
-            if (file) {
-              uploadFile(
-                { file },
-                {
-                  onSuccess: ({ path }) => {
-                    setHref(path)
-                  },
-                },
-              )
+            if (!file) {
+              setHref("")
+              setError("Please make sure you upload a file!")
+              return
             }
+
+            uploadFile(
+              { file },
+              {
+                onSuccess: ({ path }) => {
+                  setHref(path)
+                  clearError()
+                },
+              },
+            )
           }}
           onError={setError}
           maxSize={MAX_PDF_FILE_SIZE_BYTES}

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   ModalCloseButton,
 } from "@opengovsg/design-system-react"
+import { isEmpty } from "lodash"
 import { z } from "zod"
 
 import { LinkHrefEditor } from "~/features/editing-experience/components/LinkEditor"
@@ -80,8 +81,10 @@ const LinkEditorModalContent = ({
     watch,
     register,
     setError,
-    formState: { errors, isValid },
+    clearErrors,
+    formState: { errors },
   } = useZodForm({
+    mode: "onChange",
     schema: z.object({
       linkText: z.string().min(1),
       linkHref: z.string().min(1),
@@ -153,6 +156,7 @@ const LinkEditorModalContent = ({
                       message: errorMessage,
                     })
                   }
+                  clearError={() => clearErrors("linkHref")}
                   setHref={(linkHref) => {
                     setValue("linkHref", linkHref)
                   }}
@@ -170,7 +174,9 @@ const LinkEditorModalContent = ({
           <Button
             variant="solid"
             onClick={onSubmit}
-            isDisabled={!isValid}
+            // NOTE: Using `isEmpty` here because we trigger `setError`
+            // using `isValid` doesn't trigger the error
+            isDisabled={!isEmpty(errors)}
             type="submit"
           >
             {isEditingLink ? "Save link" : "Add link"}

--- a/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
+++ b/apps/studio/src/components/PageEditor/LinkEditorModal.tsx
@@ -26,6 +26,7 @@ import { useZodForm } from "~/lib/form"
 import { getReferenceLink, getResourceIdFromReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
 import { ResourceSelector } from "../ResourceSelector"
+import { FileAttachment } from "./FileAttachment"
 
 interface PageLinkElementProps {
   value: string
@@ -78,6 +79,7 @@ const LinkEditorModalContent = ({
     setValue,
     watch,
     register,
+    setError,
     formState: { errors, isValid },
   } = useZodForm({
     schema: z.object({
@@ -96,6 +98,8 @@ const LinkEditorModalContent = ({
   const onSubmit = handleSubmit(({ linkText, linkHref }) =>
     onSave(linkText, linkHref),
   )
+
+  const { siteId } = useQueryParse(editPageSchema)
 
   return (
     <ModalContent>
@@ -140,11 +144,18 @@ const LinkEditorModalContent = ({
                 />
               }
               fileLinkElement={
-                <Input
-                  type="text"
-                  value={watch("linkHref")}
-                  onChange={(e) => setValue("linkHref", e.target.value)}
-                  placeholder="File link"
+                <FileAttachment
+                  siteId={siteId}
+                  error={errors.linkHref?.message}
+                  setError={(errorMessage) =>
+                    setError("linkHref", {
+                      type: "custom",
+                      message: errorMessage,
+                    })
+                  }
+                  setHref={(linkHref) => {
+                    setValue("linkHref", linkHref)
+                  }}
                 />
               }
             />

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -44,7 +44,7 @@ export function JsonFormsImageControl({
   const { modifiedAssets, setModifiedAssets } = useEditorDrawerContext()
   const [pendingAsset, setPendingAsset] = useState<ModifiedAsset | undefined>()
 
-  // NOTE: For some reason, we cannot modified the modifiedAssets state directly
+  // NOTE: For some reason, we cannot modify the modifiedAssets state directly
   // from the Attachment component
   useEffect(() => {
     const modifiedAsset = modifiedAssets.find((image) => image.path === path)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
@@ -1,4 +1,5 @@
 export const MAX_IMG_FILE_SIZE_BYTES = 5000000
+export const MAX_PDF_FILE_SIZE_BYTES = 5000000
 export const IMAGE_UPLOAD_ACCEPTED_MIME_TYPES = [
   "image/jpeg",
   "image/png",


### PR DESCRIPTION
## Problem
Users should be able to upload their pdf to the page.

## Solution
1. add a `FileAttachment` component that does the attachment. I used a `Skeleton` and set the string to `""` so that we are disabling the save
2. we add a validation mode of `onChange` so that we'll start validation immediately. this is because the default mode is `onSubmit`, which won't trigger until we try to submit the form (and we'll have no error messages) 

## Screenshots

https://github.com/user-attachments/assets/dd7c35c2-a171-41e6-ae8d-5e5314f7c3af

