### PR TITLE
fix(components): masthead styling changes

### DIFF
--- a/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
+++ b/packages/components/src/templates/next/components/internal/Masthead/Masthead.tsx
@@ -77,7 +77,7 @@ const RestrictedHeaderBarContent = ({ children }: PropsWithChildren) => {
         <path d="M16.093 6.845c8.005-0.24 10.863 9.357 5.693 13.676l-5.191 2.509c0 0-0.676-2.181 1.833-4.734 2.509-2.551 4.929-7.328-2.006-10.469 0 0 0.131-0.654-0.327-0.981z"></path>
         <path d="M15.678 9.004c0 0 0.393-0.371 0.524-0.676 5.954 2.486 5.017 6.697 1.461 10.23-2.181 2.246-1.505 4.668-1.505 4.668s-2.66 1.657-3.577 3.097c0 0-3.852-3.28 1.483-8.724 5.235-5.344 1.614-8.594 1.614-8.594z"></path>
       </svg>
-      <div className="flex flex-1 flex-wrap py-1 lg:flex-row">
+      <div className="prose-label-sm-regular flex flex-1 flex-wrap gap-1 py-1 text-base-content-medium lg:flex-row">
         <span>
           A Singapore Government Agency Website&nbsp;
           {isStaging ? <b>[NOTE: THIS IS A STAGING WEBSITE]&nbsp;</b> : null}
@@ -242,7 +242,7 @@ const RestrictedContent = () => {
 export const Masthead = (props: Omit<MastheadProps, "type">) => {
   return (
     <MastheadProvider {...props}>
-      <div className="bg-[#f0f0f0] text-[0.875rem]">
+      <div className="bg-base-canvas-backdrop">
         <RestrictedHeaderBar />
         <RestrictedContent />
       </div>


### PR DESCRIPTION
## Problem

The current SG govt masthead in Isomer Next uses large font sizes, dark font colour, and a dark background. This makes the masthead too prominent and breaks the visual balance by drawing too much attention to the masthead.

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/744f4d74-a18f-423f-beb6-c1b4f0df7dfd">

Closes [ISOM-1613]

## Solution

Adjustments to:
- Background colour
- Font size
- Gap
- Text colour,

using Isomer tokens, to meet changes on Figma. 

This PR does not touch any elements inside the "How to identify" accordion. We've observed that the content under the accordion is usually left similar to the original implementation by SGDS ([Example](https://redeem.gov.sg/disbursing), [Another example](https://www.moe.gov.sg/)), although the banner design itself is often altered for better visual harmony.

## Before & After Screenshots

Before:
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/744f4d74-a18f-423f-beb6-c1b4f0df7dfd">

After:
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/fb2a7b4b-796e-4350-8b93-bb837e2fbb4c">