### PR TITLE
fix(components): collectionCard spacing and line truncation enhancements

### DIFF
--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -12,7 +12,7 @@ type CollectionCardProps = BaseCollectionCardProps
 
 const collectionCardLinkStyle = tv({
   extend: focusVisibleHighlight,
-  base: "prose-title-md-semibold line-clamp-2 w-fit underline-offset-4 hover:underline",
+  base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 hover:underline",
 })
 
 export const CollectionCard = ({
@@ -50,9 +50,11 @@ export const CollectionCard = ({
             <span title={itemTitle}>{itemTitle}</span>
           </Link>
         </h3>
-        <Text className="prose-body-base line-clamp-2" title={description}>
-          {description}
-        </Text>
+        {description && (
+          <Text className="prose-body-base line-clamp-2" title={description}>
+            {description}
+          </Text>
+        )}
         {/* TODO: Feature enhancement? Filter by category when clicked */}
         <Text className="prose-label-md mt-3 text-base-content-subtle lg:mt-2">
           {category}

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -51,7 +51,7 @@ export const CollectionCard = ({
           </Link>
         </h3>
         {description && (
-          <Text className="prose-body-base line-clamp-2" title={description}>
+          <Text className="prose-body-base line-clamp-3" title={description}>
             {description}
           </Text>
         )}
@@ -61,7 +61,7 @@ export const CollectionCard = ({
         </Text>
       </div>
       {image && (
-        <div className="relative mt-3 h-[140px] w-full shrink-0 lg:ml-4 lg:mt-0 lg:h-auto lg:w-[320px]">
+        <div className="relative mt-3 min-h-40 w-full shrink-0 lg:ml-4 lg:mt-0 lg:h-auto lg:w-1/4">
           <ImageClient
             src={imgSrc || ""}
             alt={image.alt}

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -25,10 +25,14 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
     },
     {
       id: `${index}`,
-      title: `Isomer hero banner-${index}`,
+      title: `This is the title for a collection item that shows the Isomer hero banner-${index}`,
       permalink: `/publications/item-two-${index}`,
       lastModified: "",
       layout: "file",
+      image: {
+        src: "https://images.unsplash.com/photo-1728931710331-7f74dca643eb?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+        alt: "placeholder",
+      },
       summary:
         "This is supposed to be a description of the hero banner that Isomer uses on their official website.",
       date: "2024-05-07",


### PR DESCRIPTION
## Problem

During migration, we observed enhancement opportunities to the CollectionCard:

- We clamp the title and description at 2 lines, which results in critical content becoming obscured (especially when there is an image or the screen is small) 
- There is a gap that appears when there is no summary (`description` field) in an article because a `<span>` is created regardless of whether the field is empty
- Image is too wide, so content is obscured even further

Closes [ISOM-1600]

## Solution

- Change line clamping of title to line-clamp-3
- Change description <span> to only show when there is a description present
- Change width of image to be responsive (25% of card in desktop) and have a minimum height on tablet
- Add a story that shows CollectionCards with image

## Before & After

### Before
<img width="786" alt="image" src="https://github.com/user-attachments/assets/5a31e0e8-075b-4364-bbbe-1c53fb252d8e">

### After
CollectionCard with image, desktop:
<img width="807" alt="image" src="https://github.com/user-attachments/assets/b6031c50-24b2-426a-a1b8-55e49d475a79">

No major changes on mobile:
<img width="425" alt="image" src="https://github.com/user-attachments/assets/bb564320-c8c3-475b-b54e-0daee72472c8">