### PR TITLE
fix - replace Divider with borderBottomWidth

### DIFF
--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -2,7 +2,6 @@ import type { LayoutProps, TableProps } from "@chakra-ui/react"
 import type { Table as ReactTable } from "@tanstack/react-table"
 import {
   Box,
-  Divider,
   Flex,
   Spinner,
   Table,
@@ -80,7 +79,7 @@ export const Datatable = <T extends object>({
       )}
       <Box overflow={overflow} sx={styles.container}>
         <Table sx={{ tableLayout: "fixed" }} {...tableProps} pos="relative">
-          <Thead>
+          <Thead borderBottomWidth="1px">
             {instance.getHeaderGroups().map((headerGroup) => (
               <Tr
                 key={headerGroup.id}
@@ -108,9 +107,6 @@ export const Datatable = <T extends object>({
               </Tr>
             ))}
           </Thead>
-          {rows.length > 0 && (
-            <Divider width={`${instance.getAllColumns().length * 100}%`} />
-          )}
           <Tbody>
             {rows.length === 0 && emptyPlaceholder}
             {rows.map((row) => {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

datatable has very long divider due to noob implementation in https://github.com/opengovsg/isomer/pull/741/files of using Divider

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/027a9d1a-6c87-493f-9bd5-824f094df2c4">

## Solution

<!-- How did you solve the problem? -->

replace Divider with `borderBottomWidth="1px"`

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
