### PR TITLE
fix - generate sitemap check for summary being an array

### DIFF
--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -54,7 +54,9 @@ const getSiteMapEntry = async (fullPath, relativePath, name) => {
     schemaData.page.title ||
     pageName.charAt(0).toUpperCase() + pageName.slice(1)
   const summary =
-    schemaData.page.contentPageHeader?.summary ||
+    (Array.isArray(schemaData.page.contentPageHeader?.summary)
+      ? schemaData.page.contentPageHeader.summary.join(" ")
+      : schemaData.page.contentPageHeader?.summary) ||
     schemaData.page.articlePageHeader?.summary.join(" ") ||
     schemaData.page.description ||
     ""


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

https://opengovproducts.slack.com/archives/C07CWUNUL68/p1728886592310259

Manually input of summary is Array instead of string - no validation here

https://github.com/isomerpages/moh-prepare-next/blob/ddb9aa2a32c55af3a4603917c5606747898487df/schema/events-highlights/inaugural-workshop-to-strengthen-regional-collaboration-in-detection-technologies-for-surveillance-and-diagnostics-during-peacetime.json#L212-L214

## Solution

<!-- How did you solve the problem? -->

check for array and join if it is

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

