### PR TITLE
chore: add build step to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,16 @@ jobs:
         uses: withgraphite/graphite-ci-action@main
         with:
           graphite_token: ${{ secrets.GRAPHITE_CI_OPTIMIZER_TOKEN }}
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Build
+        run: npm run build
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Problem
previously, the index pages PR was merged it but it had a failing build due to a dynamic import, which wasn't caught. this cuold have been solved w/ a build step

## Solution
1. add build step to ci