### PR TITLE
fix: get the collection subtitle as the page summary

### DIFF
--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -58,6 +58,7 @@ const getSiteMapEntry = async (fullPath, relativePath, name) => {
       ? schemaData.page.contentPageHeader.summary.join(" ")
       : schemaData.page.contentPageHeader?.summary) ||
     schemaData.page.articlePageHeader?.summary.join(" ") ||
+    schemaData.page.subtitle ||
     schemaData.page.description ||
     ""
 

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -96,8 +96,11 @@ async function main() {
           lastModified: new Date().toISOString(), // TODO: Update to updated_at column
           layout: resource.content.layout || "content",
           summary:
-            resource.content.page.contentPageHeader?.summary ||
+            (Array.isArray(resource.content.page.contentPageHeader?.summary)
+              ? resource.content.page.contentPageHeader.summary.join(" ")
+              : resource.content.page.contentPageHeader?.summary) ||
             resource.content.page.articlePageHeader?.summary.join(" ") ||
+            resource.content.page.subtitle ||
             resource.content.page.description ||
             "",
           category: resource.content.page.category,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We don't get the collection subtitle as the page summary, which results in index pages being unable to show them.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Capture the collection subtitle as the page summary inside the sitemap.