### PR TITLE
isom-1286 add indexes for tables

### DIFF
--- a/apps/studio/prisma/migrations/20241018013545_resource_remove_overlapping_indexes/migration.sql
+++ b/apps/studio/prisma/migrations/20241018013545_resource_remove_overlapping_indexes/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX "Resource_siteId_id_idx";
+
+-- DropIndex
+DROP INDEX "Resource_siteId_idx";

--- a/apps/studio/prisma/migrations/20241018091821_resource_add_type_index/migration.sql
+++ b/apps/studio/prisma/migrations/20241018091821_resource_add_type_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "Resource_type_idx" ON "Resource"("type");

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -77,8 +77,6 @@ model Resource {
   // treats nulls as not distinct.
   // This is required so prisma does not attempt to drop the custom index.
   @@unique([siteId, parentId, permalink])
-  @@index([siteId])
-  @@index([siteId, id])
   @@index([siteId, id, parentId])
 }
 

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -78,6 +78,7 @@ model Resource {
   // This is required so prisma does not attempt to drop the custom index.
   @@unique([siteId, parentId, permalink])
   @@index([siteId, id, parentId]) // note: ordering is important here!
+  @@index([type])
 }
 
 model Blob {

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -77,7 +77,7 @@ model Resource {
   // treats nulls as not distinct.
   // This is required so prisma does not attempt to drop the custom index.
   @@unique([siteId, parentId, permalink])
-  @@index([siteId, id, parentId])
+  @@index([siteId, id, parentId]) // note: ordering is important here!
 }
 
 model Blob {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1286/add-indexes-for-tables

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- Removed 2 composite indexes from `Resource` as they are already covered and overlapping with another index
- Added index on `type` for `Resource`