### PR TITLE
fix(component): change height of colour block hero banner image

### DIFF
--- a/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
@@ -119,7 +119,7 @@ const HeroBlock = ({
         </div>
       </div>
       <div
-        className="h-[500px] bg-cover bg-center bg-no-repeat lg:h-auto lg:max-h-full lg:w-1/2"
+        className="h-80 bg-cover bg-center bg-no-repeat lg:h-auto lg:max-h-full lg:w-1/2"
         style={{
           backgroundImage: `url('${backgroundSrc}')`,
         }}


### PR DESCRIPTION
## Problem

The hero banner image was too long, so it was resulting in a long scroll on small mobile screens to get to site content. 

Closes [ISOM-1635]

## Solution

Adjust height to 320px only on mobile view.

## After

<img width="498" alt="image" src="https://github.com/user-attachments/assets/dd8c4670-a1b1-4a9a-b42f-af6be2376d82">