### PR TITLE
fix: decode RDS password when retrieving from SSM

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -52,7 +52,7 @@ async function main() {
     user: DB_USERNAME,
     host: DB_HOST,
     database: DB_NAME,
-    password: DB_PASSWORD,
+    password: decodeURIComponent(DB_PASSWORD ?? ""),
     port: Number(DB_PORT),
   })
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

RDS password is an encoded URI component.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Decode the URI component RDS password.