### PR TITLE
fix(component): colour block hero variant is missing focus visible state

### DIFF
--- a/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
@@ -100,6 +100,7 @@ const HeroBlock = ({
                 size="lg"
                 colorScheme="inverse"
                 LinkComponent={LinkComponent}
+                isWithFocusVisibleHighlight
               >
                 {buttonLabel}
               </LinkButton>
@@ -110,6 +111,7 @@ const HeroBlock = ({
                   size="lg"
                   href={getReferenceLinkHref(secondaryButtonUrl, site.siteMap)}
                   LinkComponent={LinkComponent}
+                  isWithFocusVisibleHighlight
                 >
                   {secondaryButtonLabel}
                 </LinkButton>


### PR DESCRIPTION
## Problem

The buttons on the colour block hero variant weren't getting a focus visible state when navigated using the Tab key.

## Solution

Added `isWithFocusVisibleHighlight` to the buttons