### PR TITLE
fix - datadog RUM check for process first

### DIFF
--- a/packages/components/src/templates/next/components/internal/DatadogRum/DatadogRum.tsx
+++ b/packages/components/src/templates/next/components/internal/DatadogRum/DatadogRum.tsx
@@ -5,25 +5,25 @@ import { datadogRum } from "@datadog/browser-rum"
 const PUBLIC_DD_RUM_CLIENT_TOKEN = "pub277c32b9cf49ccee087ec9dc83d62438"
 const PUBLIC_RUM_APPLICATION_ID = "3516693f-2249-4677-b962-5bfa96d5f556"
 
-datadogRum.init({
-  applicationId: PUBLIC_RUM_APPLICATION_ID,
-  clientToken: PUBLIC_DD_RUM_CLIENT_TOKEN,
-  site: "datadoghq.com",
-  service: "isomer-next-sites",
-  env: "production",
-  sessionSampleRate:
-    typeof process !== "undefined"
-      ? Number(process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0)
-      : 0,
-  sessionReplaySampleRate:
-    typeof process !== "undefined"
-      ? Number(process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0)
-      : 0,
-  trackUserInteractions: true,
-  trackResources: true,
-  trackLongTasks: true,
-  defaultPrivacyLevel: "allow",
-})
+if (typeof process !== "undefined" && process.env.NODE_ENV === "production") {
+  datadogRum.init({
+    applicationId: PUBLIC_RUM_APPLICATION_ID,
+    clientToken: PUBLIC_DD_RUM_CLIENT_TOKEN,
+    site: "datadoghq.com",
+    service: "isomer-next-sites",
+    env: "production",
+    sessionSampleRate: Number(
+      process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0,
+    ),
+    sessionReplaySampleRate: Number(
+      process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0,
+    ),
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: "allow",
+  })
+}
 
 export const DatadogRum = () => {
   // Render nothing - this component is only included so that the init code

--- a/packages/components/src/templates/next/components/internal/DatadogRum/DatadogRum.tsx
+++ b/packages/components/src/templates/next/components/internal/DatadogRum/DatadogRum.tsx
@@ -11,12 +11,14 @@ datadogRum.init({
   site: "datadoghq.com",
   service: "isomer-next-sites",
   env: "production",
-  sessionSampleRate: Number(
-    process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0,
-  ),
-  sessionReplaySampleRate: Number(
-    process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0,
-  ),
+  sessionSampleRate:
+    typeof process !== "undefined"
+      ? Number(process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0)
+      : 0,
+  sessionReplaySampleRate:
+    typeof process !== "undefined"
+      ? Number(process.env.NEXT_PUBLIC_ISOMER_NEXT_RUM_SAMPLING_RATE ?? 0)
+      : 0,
   trackUserInteractions: true,
   trackResources: true,
   trackLongTasks: true,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Storybook Layout section breaks when datadog is loaded (re: https://github.com/opengovsg/isomer/pull/790)

Datadog is using `process.env` which is unavailable for client side

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- check for `process` is defined first (not ideal but Datadog RUM is a launch thing which will be removed soon)

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

<img width="1492" alt="Screenshot 2024-10-22 at 11 45 54 AM" src="https://github.com/user-attachments/assets/2363973b-8766-4010-a4b1-e37c879ccbb5">

