### PR TITLE
fix(component): update site notification background so it doesn't blend in with masthead

### DIFF
--- a/packages/components/src/presets/next/colors.ts
+++ b/packages/components/src/presets/next/colors.ts
@@ -54,6 +54,7 @@ export const colors = {
       info: {
         DEFAULT: twColors.blue["500"],
         subtle: twColors.blue["100"],
+        faint: "#EAF2FF",
       },
       warning: "#FFCC15",
     },

--- a/packages/components/src/templates/next/components/internal/Notification/Notification.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/Notification.tsx
@@ -21,7 +21,7 @@ const NotificationBanner = ({
 
   return (
     isShown && (
-      <div className="bg-base-canvas-backdrop">
+      <div className="bg-utility-feedback-info-faint">
         <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
           <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
           <div className="flex flex-1 flex-col gap-1">


### PR DESCRIPTION
## Problem

Site notification was blending with the masthead after we changed the masthead colour

Closes [ISOM-1630]

## Solution

Landed at a subtle blue colour as a background colour. See [explorations on Figma].(https://www.figma.com/design/G7kZTNhgm6V5VeI9yEE6rS/Template-Explorations?node-id=299-1814).
- Why not saturated blue? Saturated blue is too visible and eye-catching. Our strategy is to roll out a subtle notification first, and introduce "stronger" variant in the future when we need more attention-grabbing ones
- Why not darker blue? Contrast issue.
- Why not some variant of a brand colour? It's possible for a brand/theme colour to be green, yellow, or red. This would add a semantic meaning to the notification banner.
- Why not grey? Looked disable and didn't catch enough attention. 


