### PR TITLE
fix - add missing args for KeyStats getReferenceLinkHref call

### DIFF
--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -91,7 +91,7 @@ const KeyStatistics = ({
       {url !== undefined && url !== "" && (
         <div className={compoundStyles.urlButtonContainer()}>
           <LinkButton
-            href={getReferenceLinkHref(url, site.siteMap)}
+            href={getReferenceLinkHref(url, site.siteMap, site.assetsBaseUrl)}
             size="base"
             variant="outline"
             isWithFocusVisibleHighlight


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

CI and build fail because of missing args passed into `getReferenceLinkHref` for KeyStats in https://github.com/opengovsg/isomer/pull/794 due to outdated branch and a newer commit from https://github.com/opengovsg/isomer/pull/752

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add in missing arg

