### PR TITLE
attempt to polyfill flex gap

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -171,6 +171,7 @@
     "clean-webpack-plugin": "^4.0.0",
     "dotenv-cli": "^7.3.0",
     "eslint": "^9.10.0",
+    "flex-gap-polyfill": "^5.0.0",
     "k6-trpc": "^1.0.0",
     "mockdate": "^3.0.5",
     "msw": "^2.3.1",

--- a/apps/studio/postcss.config.mjs
+++ b/apps/studio/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     tailwindcss: {},
+    "flex-gap-polyfill": {},
     autoprefixer: {},
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18498,7 +18498,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/flex-gap-polyfill/-/flex-gap-polyfill-5.0.0.tgz",
       "integrity": "sha512-PtDKhCP+YQpGHV/8xL2lsT6V+kEXlRURYH6w0zRFHGJB6tZO6RPlQX/h/i2BpunwZplQuDaOLqAxWfmVkDnrCA==",
-      "dev": true,
       "license": "CC0-1.0",
       "dependencies": {
         "postcss-values-parser": "^6.0.2"
@@ -20398,7 +20397,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
       "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -23442,7 +23440,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
       "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "color-name": "^1.1.4",
@@ -24174,7 +24171,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
       "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/raf": {
@@ -31686,6 +31682,7 @@
         "@opengovsg/isomer-components": "*",
         "autoprefixer": "^10.4.19",
         "dompurify": "^3.0.10",
+        "flex-gap-polyfill": "^5.0.0",
         "next": "^14.2.13",
         "postcss": "^8.4.39",
         "tailwindcss": "^3.4.4",
@@ -31695,8 +31692,7 @@
         "@isomer/eslint-config": "*",
         "@isomer/prettier-config": "*",
         "@isomer/tsconfig": "*",
-        "@types/node": "^22.5.5",
-        "flex-gap-polyfill": "^5.0.0"
+        "@types/node": "^22.5.5"
       }
     },
     "tooling/template/node_modules/@types/node": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "clean-webpack-plugin": "^4.0.0",
         "dotenv-cli": "^7.3.0",
         "eslint": "^9.10.0",
+        "flex-gap-polyfill": "^5.0.0",
         "k6-trpc": "^1.0.0",
         "mockdate": "^3.0.5",
         "msw": "^2.3.1",
@@ -18493,6 +18494,22 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw=="
     },
+    "node_modules/flex-gap-polyfill": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/flex-gap-polyfill/-/flex-gap-polyfill-5.0.0.tgz",
+      "integrity": "sha512-PtDKhCP+YQpGHV/8xL2lsT6V+kEXlRURYH6w0zRFHGJB6tZO6RPlQX/h/i2BpunwZplQuDaOLqAxWfmVkDnrCA==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "postcss-values-parser": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.6"
+      }
+    },
     "node_modules/focus-lock": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.5.tgz",
@@ -20375,6 +20392,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-url-superb": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
+      "integrity": "sha512-GI+WjezhPPcbM+tqE9LnmsY5qqjwHzTvjJ36wxYX5ujNXefSUJ/T17r5bqDV8yLhcgB59KTPNOc9O9cmHTPWsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-weakmap": {
@@ -23408,6 +23438,24 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/postcss-values-parser": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-6.0.2.tgz",
+      "integrity": "sha512-YLJpK0N1brcNJrs9WatuJFtHaV9q5aAOj+S4DI5S7jgHlRfm0PIbDCAFRYMQD5SHq7Fy6xsDhyutgS0QOAs0qw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "color-name": "^1.1.4",
+        "is-url-superb": "^4.0.0",
+        "quote-unquote": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.9"
+      }
+    },
     "node_modules/postcss/node_modules/nanoid": {
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
@@ -24121,6 +24169,13 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
+    "node_modules/quote-unquote": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/quote-unquote/-/quote-unquote-1.0.0.tgz",
+      "integrity": "sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/raf": {
       "version": "3.4.1",
@@ -30730,6 +30785,7 @@
         "browserslist-useragent-regexp": "^4.1.3",
         "chromatic": "^11.5.3",
         "eslint": "^9.10.0",
+        "flex-gap-polyfill": "^5.0.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.39",
         "prettier": "^3.3.3",
@@ -31639,7 +31695,8 @@
         "@isomer/eslint-config": "*",
         "@isomer/prettier-config": "*",
         "@isomer/tsconfig": "*",
-        "@types/node": "^22.5.5"
+        "@types/node": "^22.5.5",
+        "flex-gap-polyfill": "^5.0.0"
       }
     },
     "tooling/template/node_modules/@types/node": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -55,6 +55,7 @@
     "browserslist-useragent-regexp": "^4.1.3",
     "chromatic": "^11.5.3",
     "eslint": "^9.10.0",
+    "flex-gap-polyfill": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.39",
     "prettier": "^3.3.3",

--- a/packages/components/postcss.config.js
+++ b/packages/components/postcss.config.js
@@ -1,6 +1,7 @@
 export default {
   plugins: {
     tailwindcss: {},
+    "flex-gap-polyfill": {},
     autoprefixer: {},
   },
 }

--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -27,7 +27,8 @@
     "@isomer/eslint-config": "*",
     "@isomer/prettier-config": "*",
     "@isomer/tsconfig": "*",
-    "@types/node": "^22.5.5"
+    "@types/node": "^22.5.5",
+    "flex-gap-polyfill": "^5.0.0"
   },
   "prettier": "@isomer/prettier-config"
 }

--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -18,6 +18,7 @@
     "@opengovsg/isomer-components": "*",
     "autoprefixer": "^10.4.19",
     "dompurify": "^3.0.10",
+    "flex-gap-polyfill": "^5.0.0",
     "next": "^14.2.13",
     "postcss": "^8.4.39",
     "tailwindcss": "^3.4.4",
@@ -27,8 +28,7 @@
     "@isomer/eslint-config": "*",
     "@isomer/prettier-config": "*",
     "@isomer/tsconfig": "*",
-    "@types/node": "^22.5.5",
-    "flex-gap-polyfill": "^5.0.0"
+    "@types/node": "^22.5.5"
   },
   "prettier": "@isomer/prettier-config"
 }

--- a/tooling/template/postcss.config.js
+++ b/tooling/template/postcss.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   plugins: {
     tailwindcss: {},
+    "flex-gap-polyfill": {},
     autoprefixer: {},
   },
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Older browsers don't support flexbox's gap, which we use in our Next Template components via tailwind

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- adding `flex-gap-polyfill` to postcss config

note: i can't fully verify it works on older browser for now, but i do see the compiled CSS in `/app/studio/.next/static/css/XXXX.css` replaced gap related style like `gap-row` with `fgp-gap-row`