### PR TITLE
fix: retrieve collection as resource ancestor

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -297,12 +297,7 @@ export const getLocalisedSitemap = async (
             // Recursive case: Get all the ancestors of the resource
             .selectFrom("Resource")
             .where("Resource.siteId", "=", siteId)
-            .where("Resource.type", "in", [
-              "Folder",
-              "Page",
-              "CollectionPage",
-              "RootPage",
-            ])
+            .where("Resource.type", "in", ["Folder", "Collection"])
             .innerJoin("ancestors", "ancestors.parentId", "Resource.id")
             .select(defaultResourceSelect),
         ),

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -46,17 +46,17 @@ const getSitemapTreeFromArray = (
       }
     }
 
-    const idOfPage = resources.find(
+    const titleOfPage = resources.find(
       (child) =>
         // NOTE: This child is the index page of this resource
         child.permalink === INDEX_PAGE_PERMALINK &&
         child.parentId === resource.id,
-    )?.id
+    )?.title
 
     return {
-      id: String(idOfPage ?? resource.id),
+      id: String(resource.id),
       layout: "content", // Note: We are not using the layout field in our previews
-      title: resource.title,
+      title: titleOfPage || resource.title,
       summary: "", // Note: We are not using the summary field in our previews
       lastModified: new Date() // TODO: Update this to the updated_at field in DB
         .toISOString(),

--- a/tooling/template/app/robots.ts
+++ b/tooling/template/app/robots.ts
@@ -19,6 +19,7 @@ export default function robots(): MetadataRoute.Robots {
     // @ts-ignore to fix when types are proper
     site: {
       ...config.site,
+      environment: process.env.NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT,
       // TODO: fixup all the typing errors
       // @ts-ignore to fix when types are proper
       siteMap: sitemap,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are not retrieving the parent resource correctly for collection pages.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Include Collection in the allowed types when retrieving ancestors.
- Also fixed robots.txt not being disallowed for staging environments.