### PR TITLE
fix: add correct types for getting children

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -100,7 +100,7 @@ export const resourceRouter = router({
           .selectFrom("Resource")
           .where("siteId", "=", Number(siteId))
           .where("id", "=", String(resourceId))
-          .where("Resource.type", "=", "Folder")
+          .where("Resource.type", "in", ["RootPage", "Collection", "Folder"])
           .executeTakeFirst()
 
         if (!resource) {


### PR DESCRIPTION
## Problem
our query now only cares about folders and omits collections/root pages, which leads to collections being expandable but showing nothing

## Solution
1. i think i updated this elsewhere too but just set the query to include folders/collections/rootpage


https://github.com/user-attachments/assets/b8d166c1-5732-4e2c-a075-ebd85a54f96b

