### PR TITLE
fix: add site base url to sitemap entries

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -55,11 +55,11 @@ export const getRobotsTxt = (props: IsomerPageSchemaType) => {
   }
 }
 
-export const getSitemapXml = (sitemap: IsomerSitemap) => {
+export const getSitemapXml = (sitemap: IsomerSitemap, siteUrl?: string) => {
   return getSitemapAsArray(sitemap)
     .filter((item) => item.layout !== "file" && item.layout !== "link")
     .map(({ permalink, lastModified }) => ({
-      url: permalink,
+      url: siteUrl !== undefined ? `${siteUrl}${permalink}` : permalink,
       lastModified,
     }))
 }

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -9,6 +9,8 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
       index:
         props.layout !== "file" &&
         props.layout !== "link" &&
+        props.layout !== "search" &&
+        props.layout !== "notfound" &&
         !props.meta?.noIndex,
     },
     icons: {
@@ -21,8 +23,18 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
 
   if (metadata.description === undefined && props.layout === "article") {
     metadata.description = props.page.articlePageHeader.summary
-  } else if (metadata.description === undefined && props.layout === "content") {
+  } else if (
+    metadata.description === undefined &&
+    (props.layout === "content" ||
+      props.layout === "database" ||
+      props.layout === "index")
+  ) {
     metadata.description = props.page.contentPageHeader.summary
+  } else if (
+    metadata.description === undefined &&
+    props.layout === "collection"
+  ) {
+    metadata.description = props.page.subtitle
   }
 
   if (props.page.permalink === "/") {

--- a/tooling/template/app/sitemap.ts
+++ b/tooling/template/app/sitemap.ts
@@ -1,9 +1,10 @@
 import type { MetadataRoute } from "next"
+import config from "@/data/config.json"
 import sitemapJson from "@/sitemap.json"
 import { getSitemapXml } from "@opengovsg/isomer-components"
 
 export default function sitemap(): MetadataRoute.Sitemap {
   // TODO: fixup all the typing errors
   // @ts-expect-error to fix when types are proper
-  return getSitemapXml(sitemapJson)
+  return getSitemapXml(sitemapJson, config.site.url)
 }

--- a/tooling/template/data/config.json
+++ b/tooling/template/data/config.json
@@ -1,6 +1,7 @@
 {
   "site": {
     "siteName": "Isomer",
+    "url": "https://www.isomer.gov.sg",
     "agencyName": "Open Government Products",
     "theme": "isomer-next",
     "logoUrl": "/images/isomer-logo.svg",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our sitemap.xml file is invalid because it does not include the site's domain in the entries.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add the site base url to the sitemap.xml generation function.