### PR TITLE
fix(collection-pages): misc fixes

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
@@ -101,12 +101,26 @@ const useCreateCollectionPageWizardContext = ({
           void router.push(`/sites/${siteId}/${nextType}/${pageId}`)
         },
         onError: (error) => {
-          if (error.data?.code === "CONFLICT") {
+          if (
+            error.data?.code === "CONFLICT" &&
+            values.type === "CollectionPage"
+          ) {
             formMethods.setError(
               "permalink",
               { message: error.message },
               { shouldFocus: true },
             )
+            return
+          } else if (
+            error.data?.code === "CONFLICT" &&
+            values.type === "CollectionLink"
+          ) {
+            formMethods.setError(
+              "title",
+              { message: error.message },
+              { shouldFocus: true },
+            )
+            return
           } else {
             console.error(error)
           }

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -91,6 +91,7 @@ export const collectionRouter = router({
         siteId: input.siteId,
         action: "create",
         userId: ctx.user.id,
+        resourceId: !!input.collectionId ? String(input.collectionId) : null,
       })
 
       let newPage: UnwrapTagged<PrismaJson.BlobJsonContent>

--- a/apps/studio/src/stories/Flows/CreateCollectionItemFlow.stories.tsx
+++ b/apps/studio/src/stories/Flows/CreateCollectionItemFlow.stories.tsx
@@ -64,3 +64,20 @@ export const SelectLayout: Story = {
     })
   },
 }
+
+export const EnterPageDetails: Story = {
+  play: async (context) => {
+    const { canvasElement } = context
+    const screen = within(canvasElement.ownerDocument.body)
+    await SelectLayout.play?.(context)
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /next: page details/i }),
+    )
+
+    await userEvent.type(
+      screen.getByLabelText(/page title/i),
+      "My_new page WITH w@eird characters!",
+    )
+  },
+}


### PR DESCRIPTION
## Problem
1. duplicate permalinks error weren't being shown on link
2. permissions prevented people from creating collection pages 
3. double render on initial load

## Solution
1. shift the suspense out so that on initial loda, it's not doubly rendered (the modal doesn't close and reopen) 
2. update resource id for permisisons
3. conditionally; set error message on `title` when duplicate permalink

