### PR TITLE
chore: increase maxItems for InfoCards from 6 to 12

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -97,7 +97,7 @@ const InfoCardsWithImageSchema = Type.Object(
     variant: Type.Literal("cardsWithImages", { default: "cardsWithImages" }),
     cards: Type.Array(SingleCardWithImageSchema, {
       title: "Cards",
-      maxItems: 6,
+      maxItems: 12,
       default: [],
     }),
   },
@@ -113,7 +113,7 @@ const InfoCardsNoImageSchema = Type.Object(
     }),
     cards: Type.Array(SingleCardNoImageSchema, {
       title: "Cards",
-      maxItems: 6,
+      maxItems: 12,
       default: [],
     }),
   },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We have users complain that 6 cards is insufficient.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Increase the maxItems for InfoCards from 6 to 12.