### PR TITLE
Enhancement - Sort Collection filters options

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/utils.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils.ts
@@ -35,11 +35,13 @@ export const getAvailableFilters = (
     }
   })
 
-  const yearFilterItems = Object.entries(years).map(([label, count]) => ({
-    id: label.toLowerCase(),
-    label,
-    count,
-  }))
+  const yearFilterItems = Object.entries(years)
+    .map(([label, count]) => ({
+      id: label.toLowerCase(),
+      label,
+      count,
+    }))
+    .sort((a, b) => parseInt(b.label) - parseInt(a.label))
 
   const availableFilters: FilterType[] = [
     {

--- a/packages/components/src/templates/next/layouts/Collection/utils.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils.ts
@@ -47,11 +47,13 @@ export const getAvailableFilters = (
     {
       id: FILTER_ID_CATEGORY,
       label: "Category",
-      items: Object.entries(categories).map(([label, count]) => ({
-        id: label.toLowerCase(),
-        label: label.charAt(0).toUpperCase() + label.slice(1),
-        count,
-      })),
+      items: Object.entries(categories)
+        .map(([label, count]) => ({
+          id: label.toLowerCase(),
+          label: label.charAt(0).toUpperCase() + label.slice(1),
+          count,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
     },
     {
       id: FILTER_ID_YEAR,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

A follow-up TODOs from the comments from https://github.com/opengovsg/isomer/pull/800

Collection filters aren't sorted by any order, which can be a non-ideal UX for users

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- for Year, sort by descending
- for Category, sort by alphabetical order
