### PR TITLE
improvement (perf) - move filters to server side

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -3,7 +3,7 @@ import type { CollectionCardProps } from "~/interfaces"
 import { getBreadcrumbFromSiteMap, getSitemapAsArray } from "~/utils"
 import { Skeleton } from "../Skeleton"
 import CollectionClient from "./CollectionClient"
-import { shouldShowDate } from "./utils"
+import { getAvailableFilters, shouldShowDate } from "./utils"
 
 const getCollectionItems = (
   site: IsomerSiteProps,
@@ -118,6 +118,7 @@ const CollectionLayout = ({
         page={page}
         breadcrumb={breadcrumb}
         items={items}
+        filters={getAvailableFilters(items)}
         shouldShowDate={shouldShowDate(items)}
         LinkComponent={LinkComponent}
         site={site}

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from "react"
 
+import type { Filter as FilterType } from "../../types/Filter"
 import type { CollectionPageSchemaType } from "~/engine"
 import type { BreadcrumbProps, CollectionCardProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
@@ -18,6 +19,7 @@ import { ITEMS_PER_PAGE, useCollection } from "./useCollection"
 interface CollectionClientProps {
   page: CollectionPageSchemaType["page"]
   items: CollectionCardProps[]
+  filters: FilterType[]
   shouldShowDate: boolean
   breadcrumb: BreadcrumbProps
   LinkComponent: CollectionPageSchemaType["LinkComponent"]
@@ -46,13 +48,13 @@ const compoundStyles = createCollectionLayoutStyles()
 const CollectionClient = ({
   page,
   items,
+  filters,
   shouldShowDate,
   breadcrumb,
   LinkComponent,
   site,
 }: CollectionClientProps) => {
   const {
-    filters,
     paginatedItems,
     filteredCount,
     searchValue,

--- a/packages/components/src/templates/next/layouts/Collection/useCollection.ts
+++ b/packages/components/src/templates/next/layouts/Collection/useCollection.ts
@@ -9,7 +9,6 @@ import {
 import type { AppliedFilter } from "../../types/Filter"
 import type { CollectionCardProps } from "~/interfaces"
 import {
-  getAvailableFilters,
   getFilteredItems,
   getPaginatedItems,
   updateAppliedFilters,
@@ -60,8 +59,6 @@ export const useCollection = ({ items }: UseCollectionProps) => {
     setCurrPage(1)
   }, [filteredItems])
 
-  const filters = useMemo(() => getAvailableFilters(items), [items])
-
   const paginatedItems = useMemo(
     () => getPaginatedItems(filteredItems, ITEMS_PER_PAGE, currPage),
     [currPage, filteredItems],
@@ -76,7 +73,6 @@ export const useCollection = ({ items }: UseCollectionProps) => {
     paginatedItems,
     filteredCount: filteredItems.length,
     totalCount: items.length,
-    filters,
     searchValue,
     handleSearchValueChange,
     handleClearFilter,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently `filters` are generated on client side. If there's huge number of records or users are using poorly supported browsers/low-end devices, the experience won't be ideal

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- move it from client side to server rendered