### PR TITLE
fix: hide skip to content button on mobile

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1289,6 +1289,10 @@ video {
   margin-bottom: 2rem;
 }
 
+.mb-9 {
+  margin-bottom: 2.25rem;
+}
+
 .mb-\[0\.1875rem\] {
   margin-bottom: 0.1875rem;
 }

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -2,6 +2,8 @@ import type { IsomerPageSchemaType, IsomerSitemap } from "~/types"
 import { getSitemapAsArray } from "~/utils"
 
 export const getMetadata = (props: IsomerPageSchemaType) => {
+  const faviconUrl = `${props.site.assetsBaseUrl ?? ""}${props.site.favicon || "/favicon.ico"}`
+
   const metadata = {
     metadataBase: props.site.url ? new URL(props.site.url) : undefined,
     description: props.meta?.description || undefined,
@@ -14,7 +16,8 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
         !props.meta?.noIndex,
     },
     icons: {
-      shortcut: `${props.site.assetsBaseUrl ?? ""}${props.site.favicon || "/favicon.ico"}`,
+      icon: faviconUrl,
+      shortcut: faviconUrl,
     },
     twitter: {
       card: "summary_large_image" as const,

--- a/packages/components/src/interfaces/internal/SkipToContent.ts
+++ b/packages/components/src/interfaces/internal/SkipToContent.ts
@@ -1,0 +1,5 @@
+import type { LinkComponentType } from "~/types"
+
+export interface SkipToContentProps {
+  LinkComponent?: LinkComponentType
+}

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -26,5 +26,6 @@ export {
 export type { SearchSGInputBoxProps } from "./SearchSGInputBox"
 export type { SidePaneProps } from "./SidePane"
 export type { SiderailProps } from "./Siderail"
+export type { SkipToContentProps } from "./SkipToContent"
 export type { TableOfContentsProps } from "./TableOfContents"
 export type { WogaaProps } from "./Wogaa"

--- a/packages/components/src/templates/next/components/internal/SkipToContent/SkipToContent.tsx
+++ b/packages/components/src/templates/next/components/internal/SkipToContent/SkipToContent.tsx
@@ -1,16 +1,13 @@
-import { tv } from "~/lib/tv"
+import type { SkipToContentProps } from "~/interfaces"
 import { SKIP_TO_CONTENT_ANCHOR_ID } from "~/templates/next/constants"
-import { focusVisibleHighlight } from "~/utils"
 
-const skipToContentStyle = tv({
-  extend: focusVisibleHighlight,
-  base: "absolute -left-[150%] -top-[150%] -z-50 bg-base-canvas p-2 focus-visible:left-0 focus-visible:top-0 focus-visible:z-50",
-})
-
-export const SkipToContent = () => {
+export const SkipToContent = ({ LinkComponent }: SkipToContentProps) => {
   return (
-    <a href={`#${SKIP_TO_CONTENT_ANCHOR_ID}`} className={skipToContentStyle()}>
+    <LinkComponent
+      href={`#${SKIP_TO_CONTENT_ANCHOR_ID}`}
+      className="focus:shadow-focus absolute -left-[150%] -top-[150%] -z-50 bg-base-canvas p-2 focus:left-0 focus:top-0 focus:z-50 focus:bg-utility-highlight focus:text-base-content-strong focus:decoration-transparent focus:outline-0 focus:transition-none focus:hover:decoration-transparent"
+    >
       Skip to main content
-    </a>
+    </LinkComponent>
   )
 }

--- a/packages/components/src/templates/next/components/internal/SkipToContent/SkipToContent.tsx
+++ b/packages/components/src/templates/next/components/internal/SkipToContent/SkipToContent.tsx
@@ -1,7 +1,7 @@
 import type { SkipToContentProps } from "~/interfaces"
 import { SKIP_TO_CONTENT_ANCHOR_ID } from "~/templates/next/constants"
 
-export const SkipToContent = ({ LinkComponent }: SkipToContentProps) => {
+export const SkipToContent = ({ LinkComponent = "a" }: SkipToContentProps) => {
   return (
     <LinkComponent
       href={`#${SKIP_TO_CONTENT_ANCHOR_ID}`}

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -31,29 +31,31 @@ export const Skeleton = ({
 
       {!isStaging && <DatadogRum />}
 
-      <SkipToContent />
+      <header>
+        <SkipToContent LinkComponent={LinkComponent} />
 
-      {site.isGovernment && <Masthead isStaging={isStaging} />}
+        {site.isGovernment && <Masthead isStaging={isStaging} />}
 
-      {site.notification && (
-        <Notification
-          {...site.notification}
-          LinkComponent={LinkComponent}
+        {site.notification && (
+          <Notification
+            {...site.notification}
+            LinkComponent={LinkComponent}
+            site={site}
+          />
+        )}
+
+        <UnsupportedBrowserBanner />
+
+        <Navbar
+          logoUrl={site.logoUrl}
+          logoAlt={site.siteName}
+          layout={layout}
+          search={site.search}
+          items={site.navBarItems}
           site={site}
+          LinkComponent={LinkComponent}
         />
-      )}
-
-      <UnsupportedBrowserBanner />
-
-      <Navbar
-        logoUrl={site.logoUrl}
-        logoAlt={site.siteName}
-        layout={layout}
-        search={site.search}
-        items={site.navBarItems}
-        site={site}
-        LinkComponent={LinkComponent}
-      />
+      </header>
 
       <main id={SKIP_TO_CONTENT_ANCHOR_ID}>{children}</main>
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The skip to content button appears on mobile when clicking on a link in mobile.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Move the masthead, notification banner, navbar, unsupported browser banner and the skip to content button inside a `<header>` tag.
    - This is because the Next.js link always does a `document.body.focus()` as part of the scroll to top functionality, and the skip to content button is the first element inside the `<body>` tag, which causes it to appear when clicking on a Next.js link (which is effectively all our links on the site).
    - Live demo is on togetherforbetter.gov.sg.