### PR TITLE
fix(components): adjust gap and margin on keystatistics block

### DIFF
--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -20,7 +20,7 @@ const createKeyStatisticsStyles = tv({
     title:
       "prose-display-md w-full max-w-[47.5rem] break-words text-base-content-strong",
     urlText: "hidden whitespace-nowrap md:block",
-    urlButtonContainer: "mx-auto block",
+    urlButtonContainer: "mx-auto mt-2 block",
     statistics: "flex flex-col flex-wrap gap-x-8 gap-y-12 md:flex-row",
     itemContainer: "flex grow flex-col gap-3",
     itemValue: "prose-display-lg text-pretty text-brand-canvas-inverse",
@@ -45,10 +45,10 @@ const createKeyStatisticsStyles = tv({
     },
     layout: {
       homepage: {
-        container: "gap-10 py-12 xs:py-24 lg:gap-24",
+        container: "gap-10 py-12 xs:py-24 lg:gap-12",
       },
       default: {
-        container: "mt-14 gap-12",
+        container: "mt-14 gap-12 first:mt-0",
       },
     },
   },


### PR DESCRIPTION
## Problem

- Didn't pen down design specs properly, so the gaps in homepage variant were slightly off.
- KeyStatistics block on content page missing a mt-0 when it's the first child.

Closes [ISOM-1649]

## Solution

- Adjusted gap for homepage variant
- Adjusted mt for content page variant
- Checked locally, didn't write new stories for now

## Before & After

### On homepage

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/642227db-0650-4485-b1a6-b43f276639e2">

<img width="1133" alt="image" src="https://github.com/user-attachments/assets/ce924c50-084b-4f0f-a635-9ad2c13532fd">

### On content page

<img width="973" alt="image" src="https://github.com/user-attachments/assets/6a78f645-c829-4af8-9ec6-2fd18eac4949">

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/79a1cb28-52b7-4397-be4e-b0e73238573e">