### PR TITLE
Keystats limit linktypes option to internal page

### DIFF
--- a/apps/studio/src/features/editing-experience/components/LinkEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/constants.ts
@@ -28,3 +28,15 @@ export type LinkTypeMapping<T extends string = string> = Record<
     label: Capitalize<T>
   }
 >
+
+export function filterLinkTypes(linkTypes: LinkTypes[]): LinkTypeMapping {
+  // default to all link types if no link types are specified
+  if (linkTypes.length === 0) {
+    return LINK_TYPES
+  }
+  return Object.fromEntries(
+    Object.entries(LINK_TYPES).filter(([key]) =>
+      linkTypes.includes(key as LinkTypes),
+    ),
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/LinkEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/constants.ts
@@ -29,9 +29,11 @@ export type LinkTypeMapping<T extends string = string> = Record<
   }
 >
 
-export function filterLinkTypes(linkTypes: LinkTypes[]): LinkTypeMapping {
+export function filterLinkTypes(
+  linkTypes: LinkTypes[] | undefined,
+): LinkTypeMapping {
   // default to all link types if no link types are specified
-  if (linkTypes.length === 0) {
+  if (!linkTypes || linkTypes.length === 0) {
     return LINK_TYPES
   }
   return Object.fromEntries(

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsLinkControl.tsx
@@ -25,6 +25,7 @@ import {
 import { BiFile } from "react-icons/bi"
 import { z } from "zod"
 
+import type { IsomerExtendedLinkJsonSchema } from "~/types/schema"
 import { FileAttachment } from "~/components/PageEditor/FileAttachment"
 import { ResourceSelector } from "~/components/ResourceSelector"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
@@ -33,7 +34,7 @@ import { useZodForm } from "~/lib/form"
 import { getReferenceLink, getResourceIdFromReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
 import { LinkHrefEditor } from "../../../LinkEditor"
-import { LINK_TYPES } from "../../../LinkEditor/constants"
+import { filterLinkTypes } from "../../../LinkEditor/constants"
 
 export const jsonFormsLinkControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.LinkControl,
@@ -259,7 +260,9 @@ export function JsonFormsLinkControl({
   path,
   description,
   required,
+  schema,
 }: ControlProps) {
+  const schemaWithLinkTypes = schema as IsomerExtendedLinkJsonSchema
   const dataString = data && typeof data === "string" ? data : ""
   // NOTE: We need to pass in `siteId` but this component is automatically used by JsonForms
   // so we are unable to pass props down
@@ -279,7 +282,7 @@ export function JsonFormsLinkControl({
   return (
     <Box>
       <LinkHrefEditor
-        linkTypes={LINK_TYPES}
+        linkTypes={filterLinkTypes(schemaWithLinkTypes.linkTypes)}
         value={dataString}
         onChange={(value) => handleChange(path, value)}
         label={label}

--- a/apps/studio/src/types/schema.ts
+++ b/apps/studio/src/types/schema.ts
@@ -5,6 +5,8 @@ import {
   type VerticalLayout,
 } from "@jsonforms/core"
 
+import type { LinkTypes } from "~/features/editing-experience/components/LinkEditor/constants"
+
 export type IsomerExtendedJsonSchema = JsonSchema & {
   groups?: {
     label: string
@@ -22,4 +24,8 @@ export function isVerticalLayout(
   uischema: UISchemaElement,
 ): uischema is VerticalLayout {
   return uischema.type === "VerticalLayout" && "elements" in uischema
+}
+
+export type IsomerExtendedLinkJsonSchema = JsonSchema & {
+  linkTypes: LinkTypes[]
 }

--- a/packages/components/src/interfaces/complex/KeyStatistics.ts
+++ b/packages/components/src/interfaces/complex/KeyStatistics.ts
@@ -33,6 +33,7 @@ export const KeyStatisticsSchema = Type.Object(
         title: "Link destination",
         description: "When this is clicked, open:",
         format: "link",
+        linkTypes: ["page"],
       }),
     ),
   },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

KeyStats should not allow for any other links except for internal page link

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- pass in `linkTypes` to KeyStats schema on component
- add custom `IsomerExtendedLinkJsonSchema` and also check for presence of `linkTypes`
- add `filterLinkTypes` for reusability down the road - fallback to default all options if undefined or not specified

## Screenshots

![image](https://github.com/user-attachments/assets/77c9b52a-c874-44db-9bf2-45a383454d22)
