### PR TITLE
isom-1650 - Old browser (iphone7) keystats mobile design broken

### DIFF
--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -29,18 +29,16 @@ const createKeyStatisticsStyles = tv({
   variants: {
     noOfItems: {
       1: {
-        itemContainer: "basis-full",
+        itemContainer: "md:basis-full",
       },
       2: {
-        itemContainer: "basis-[calc((100%-2.5rem)/2)]",
+        itemContainer: "md:basis-[calc((100%-2.5rem)/2)]",
       },
       3: {
-        itemContainer:
-          "basis-[calc((100%-5rem)/3)] md:max-w-[calc((100%-2.5rem)/2)]",
+        itemContainer: "md:basis-[calc((100%-5rem)/3)]",
       },
       4: {
-        itemContainer:
-          "basis-[calc((100%-7.5rem)/4)] md:max-w-[calc((100%-5rem)/3)]",
+        itemContainer: "md:basis-[calc((100%-7.5rem)/4)]",
       },
     },
     layout: {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1650/old-browser-iphone7-keystats-mobile-design-broken

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- only set width on tablet (`md`) beyond since default is 1 column on smaller screen size

## Before & After Screenshots

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/dd768610-9eea-4890-a4e5-657fda3d3cdb) | ![image](https://github.com/user-attachments/assets/f818262e-80f0-4156-bb77-f6e48d2aba39) |