### PR TITLE
fix: get proper parsed date for collection items

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -19,7 +19,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       layout: "article",
       summary:
         "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. LASTWORD",
-      date: "2024-05-07",
+      date: "07/05/2024",
       category: "Category Name",
     },
     {
@@ -34,7 +34,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       },
       summary:
         "This is supposed to be a description of the hero banner that Isomer uses on their official website.",
-      date: "2024-05-07",
+      date: "07/05/2024",
       category: "Category Name",
       ref: "https://www.isomer.gov.sg/images/Homepage/hero%20banner_10.png",
       fileDetails: {
@@ -50,7 +50,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       layout: "link",
       summary:
         "Have a look at the Isomer guide to understand how to use the Isomer CMS.",
-      date: "2023-08-12",
+      date: "12/08/2023",
       category: "Category Name",
       ref: "https://guide.isomer.gov.sg",
     },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -18,7 +18,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       lastModified: "",
       layout: "article",
       summary:
-        "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. LASTWORD",
+        "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months.",
       date: "07/05/2024",
       category: "Category Name",
     },
@@ -367,7 +367,7 @@ export const AllResultsNoDate: Story = {
     const yearFilter = screen.queryByText(/Year/i)
     await expect(yearFilter).not.toBeInTheDocument()
 
-    const lastWordOccurences = await screen.findAllByText(/LASTWORD/)
-    await expect(lastWordOccurences.length).toBe(3)
+    const lastWordOccurences = await screen.findAllByText(/Isomer guide-/)
+    await expect(lastWordOccurences.length).toBe(10)
   },
 }

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -1,6 +1,10 @@
 import type { CollectionPageSchemaType, IsomerSiteProps } from "~/engine"
 import type { CollectionCardProps } from "~/interfaces"
-import { getBreadcrumbFromSiteMap, getSitemapAsArray } from "~/utils"
+import {
+  getBreadcrumbFromSiteMap,
+  getParsedDate,
+  getSitemapAsArray,
+} from "~/utils"
 import { Skeleton } from "../Skeleton"
 import CollectionClient from "./CollectionClient"
 import { getAvailableFilters, shouldShowDate } from "./utils"
@@ -47,7 +51,7 @@ const getCollectionItems = (
     )
     .map((item) => {
       const lastUpdated = item.date || item.lastModified
-      const date = new Date(lastUpdated)
+      const date = getParsedDate(lastUpdated)
 
       const baseItem = {
         type: "collectionCard" as const,

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -50,13 +50,13 @@ const getCollectionItems = (
         item.layout === "article",
     )
     .map((item) => {
-      const lastUpdated = item.date || item.lastModified
-      const date = getParsedDate(lastUpdated)
+      const date =
+        item.date !== undefined ? getParsedDate(item.date) : undefined
 
       const baseItem = {
         type: "collectionCard" as const,
         rawDate: date,
-        lastUpdated,
+        lastUpdated: date?.toISOString(),
         category: item.category || "Others",
         title: item.title,
         description: item.summary,
@@ -91,6 +91,16 @@ const getCollectionItems = (
     if (a.rawDate === b.rawDate) {
       return a.title > b.title ? 1 : -1
     }
+
+    // Rank items with no dates last
+    if (a.rawDate === undefined) {
+      return 1
+    }
+
+    if (b.rawDate === undefined) {
+      return -1
+    }
+
     return a.rawDate < b.rawDate ? 1 : -1
   }) as CollectionCardProps[]
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The sorting of collection items is incorrect, as the date is being parsed incorrectly by the default Date object.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Use a proper date parsing function to get the date.