### PR TITLE
fix: include content for CollectionLink resources

### DIFF
--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -4,7 +4,12 @@ import { Text } from "react-aria-components"
 
 import type { CollectionCardProps as BaseCollectionCardProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
-import { focusVisibleHighlight, getFormattedDate, isExternalUrl } from "~/utils"
+import {
+  focusVisibleHighlight,
+  getFormattedDate,
+  getReferenceLinkHref,
+  isExternalUrl,
+} from "~/utils"
 import { ImageClient } from "../../complex/Image"
 import { Link } from "../Link"
 
@@ -47,7 +52,7 @@ export const CollectionCard = ({
         <h3 className="inline-block">
           <Link
             LinkComponent={LinkComponent}
-            href={url}
+            href={getReferenceLinkHref(url, site.siteMap, site.assetsBaseUrl)}
             className={collectionCardLinkStyle()}
           >
             <span title={itemTitle}>{itemTitle}</span>

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -27,7 +27,13 @@ const SITE_ID = Number(process.env.SITE_ID)
 // Guaranteed to not be present in the database because we start from 1
 const DANGLING_DIRECTORY_PAGE_ID = "-1"
 const INDEX_PAGE_PERMALINK = "_index"
-const PAGE_RESOURCE_TYPES = ["Page", "CollectionPage", "IndexPage", "RootPage"]
+const PAGE_RESOURCE_TYPES = [
+  "Page",
+  "CollectionPage",
+  "CollectionLink",
+  "IndexPage",
+  "RootPage",
+]
 const FOLDER_RESOURCE_TYPES = ["Folder", "Collection"]
 
 const getConvertedPermalink = (fullPermalink: string) => {

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -8,7 +8,7 @@ WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "f
         r."parentId",
         r.type,
         CASE
-            WHEN r.type IN ('Page', 'CollectionPage', 'IndexPage', 'RootPage') THEN b."content"
+            WHEN r.type IN ('Page', 'CollectionPage', 'CollectionLink', 'IndexPage', 'RootPage') THEN b."content"
             ELSE NULL
         END AS content,
         r.permalink AS "fullPermalink",
@@ -30,7 +30,7 @@ WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "f
         r."parentId",
         r.type,
         CASE
-            WHEN r.type IN ('Page', 'CollectionPage', 'IndexPage', 'RootPage') THEN b."content"
+            WHEN r.type IN ('Page', 'CollectionPage', 'CollectionLink', 'IndexPage', 'RootPage') THEN b."content"
             ELSE NULL
         END AS content,
         CONCAT(path."fullPermalink", '/', r.permalink) AS "fullPermalink",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are not fetching the CollectionLink blob contents, causing it to not be rendered in the final site output.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add the CollectionLink type in the SQL query when fetching all resources.