### PR TITLE
fix: instrumentation

### DIFF
--- a/apps/studio/src/instrumentation.ts
+++ b/apps/studio/src/instrumentation.ts
@@ -1,8 +1,7 @@
-import { env } from "./env.mjs"
-
 export async function register() {
   // make sure you only run on nodejs runtime or you will have errors with built-in modules not being defined
-  if (env.NODE_ENV === "production") {
+  // eslint-disable-next-line no-restricted-properties
+  if (process.env.NEXT_RUNTIME === "nodejs") {
     console.log("Instrumenting Next.js Server")
     await import("~/server/modules/tracer")
   }


### PR DESCRIPTION
## Problem
not entirely sure why using `env.NODE_ENV` doens't work. looking at [activesg](https://github.com/opengovsg/activesg/blob/f89843a059b74926f1fd8e5383269a64ff6e08e6/apps/admin/src/instrumentation.ts#L4) + ks code, they both use `NEXT_RUNTIME` instead 

## Solution 
use `NEXT_RUNTIME`?!