### PR TITLE
feat: only have a maximum of 2 CodeBuild running

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -61,6 +61,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     trpc.page.updatePageBlob.useMutation({
       onSuccess: async () => {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+        await utils.page.readPage.invalidate({ pageId, siteId })
         toast({
           title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
           ...BRIEF_TOAST_SETTINGS,

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -54,6 +54,7 @@ export default function HeroEditorDrawer(): JSX.Element {
     trpc.page.updatePageBlob.useMutation({
       onSuccess: async () => {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+        await utils.page.readPage.invalidate({ pageId, siteId })
         toast({
           title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
           ...BRIEF_TOAST_SETTINGS,

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -43,6 +43,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
   const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+      await utils.page.readPage.invalidate({ pageId, siteId })
     },
   })
 

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -41,7 +41,11 @@ export default function RootStateDrawer() {
   } = useEditorDrawerContext()
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
+  const utils = trpc.useUtils()
   const { mutate } = trpc.page.reorderBlock.useMutation({
+    onSuccess: async () => {
+      await utils.page.readPage.invalidate({ pageId, siteId })
+    },
     onError: (error, variables) => {
       // NOTE: rollback to last known good state
       // @ts-expect-error Our zod validator runs between frontend and backend

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -51,6 +51,7 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
   const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+      await utils.page.readPage.invalidate({ pageId, siteId })
       toast({
         title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
         ...BRIEF_TOAST_SETTINGS,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are spinning up multiple CodeBuild builds which is quite wasteful.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Ensure that there are only a maximum of 2 CodeBuild builds running at any time.
    - Case 1: If there are no running builds at all, start 1 build.
    - Case 2: If there is already 1 existing running build, and this running build is started more than 1 minute ago, start a new build.
    - Case 3: If there is already 2 existing running builds, and the latest running build is started more than 1 minute ago, stop the latest build and start a new one.
    - Otherwise, don't do anything.

**Bug Fixes**:

- Invalidate the `readPage` procedure when saving changes to the page so the publish button becomes active after save.