### PR TITLE
feat: use latest release tag instead of main for publish

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -11,9 +11,9 @@ calculate_duration() {
   echo "Time taken: $duration seconds"
 }
 
-# Use the main branch unless one was provided in the env var
+# Use the latest release tag unless one was provided in the env var
 if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
-  ISOMER_BUILD_REPO_BRANCH="main"
+  ISOMER_BUILD_REPO_BRANCH=$(curl https://api.github.com/repos/opengovsg/isomer/releases/latest | jq -r '.tag_name')
 fi
 
 # Cloning the repository


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are always using the latest main branch to build our components and templates, which can be dangerous.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Fetch the latest release tag from the repository and use that release tag for the site builds.
    - NOTE: We still retain the ability to set a custom branch to build from using the `ISOMER_BUILD_REPO_BRANCH` env var.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="622" alt="image" src="https://github.com/user-attachments/assets/2471e751-c6fc-42c3-b89e-54d8b58ee6b4">

**AFTER**:

<!-- [insert screenshot here] -->

<img width="683" alt="image" src="https://github.com/user-attachments/assets/d6cd6ac9-b81e-4125-920c-cafa8e8c0fcb">