### PR TITLE
isom-1651 - add acceptable file type messages

### DIFF
--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -15,6 +15,12 @@ interface FileAttachmentProps {
 
 type FileRejections = AttachmentProps<false>["rejections"]
 
+const ACCEPTED_FILE_TYPES: string[] = ["application/pdf"]
+const ACCEPTED_FILE_TYPES_MESSAGE = ACCEPTED_FILE_TYPES.map((filetype) => {
+  const extension = filetype.split("/").at(-1)
+  return extension ? `*.${extension}` : ""
+}).join(", ")
+
 export const FileAttachment = ({
   setHref,
   siteId,
@@ -59,7 +65,7 @@ export const FileAttachment = ({
             )
           }}
           maxSize={MAX_PDF_FILE_SIZE_BYTES}
-          accept={["application/pdf"]}
+          accept={ACCEPTED_FILE_TYPES}
           onFileValidation={(file) => {
             const parseResult = getPresignedPutUrlSchema
               .pick({ fileName: true })
@@ -76,6 +82,8 @@ export const FileAttachment = ({
       </Skeleton>
       <Text textStyle="body-2" textColor="base.content.medium" pt="0.5rem">
         {`Maximum file size: ${MAX_PDF_FILE_SIZE_BYTES / 1000000} MB`}
+        <br />
+        {`Accepted file types: ${ACCEPTED_FILE_TYPES_MESSAGE}`}
       </Text>
     </FormControl>
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1651/inform-users-that-only-pdfs-are-supported

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- add a copywriting text

**AFTER**:

<!-- [insert screenshot here] -->

<img width="652" alt="image" src="https://github.com/user-attachments/assets/c6fd3a69-9bdc-4b99-845a-d1330a8b6e41">
