### PR TITLE
fix: allow legacy internal permalinks

### DIFF
--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -8,9 +8,12 @@ export const ALLOWED_URL_REGEXES = {
   // but `re.source` only gives us the actual string
   // regex for asset links: /^\/(\d+)\//
   files: "^\\/(\\d+)\\/",
+  // These are the standard internal links that are used by sites on GitHub.
+  // We can drop them once all sites have fully migrated to Studio.
+  legacy: "^\\/",
 } as const
 
 export const LINK_HREF_PATTERN =
-  `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.mail})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})` as const
+  `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.mail})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})|(${ALLOWED_URL_REGEXES.legacy})` as const
 export const REF_HREF_PATTERN =
-  `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})` as const
+  `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})|(${ALLOWED_URL_REGEXES.legacy})` as const


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We added the link pattern restriction on our schema, which resulted in migrators being unable to use internal links on their GitHub sites.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Allow the legacy permalink format which starts with a `/`.