### PR TITLE
fix: use dd/MM/yyyy for article dates

### DIFF
--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -9,7 +9,7 @@ export const createCollectionPageJson = ({}: {
   return {
     layout: "article",
     page: {
-      date: format(new Date(), "dd-MM-yyyy"),
+      date: format(new Date(), "dd/MM/yyyy"),
       // TODO: this is actually supposed to be passed from the frontend
       // which is not done at present
       category: "Feature Articles",
@@ -31,7 +31,7 @@ export const createCollectionLinkJson = ({}: {
       ref: "",
       summary: "",
       category: "",
-      date: format(new Date(), "dd-MM-yyyy"),
+      date: format(new Date(), "dd/MM/yyyy"),
     },
     content: [],
     // TODO: Add pdf blob to content

--- a/apps/studio/src/server/modules/page/page.service.ts
+++ b/apps/studio/src/server/modules/page/page.service.ts
@@ -25,7 +25,7 @@ export const createDefaultPage = ({
       const articleDefaultPage = {
         layout: "article",
         page: {
-          date: format(new Date(), "dd-MM-yyyy"),
+          date: format(new Date(), "dd/MM/yyyy"),
           category: "Feature Articles",
           articlePageHeader: {
             summary: "This is the page summary",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our dates is not using the correct format when creating pages with dates.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fix to use `dd/MM/yyyy` format as the date when creating pages with dates in them.