### PR TITLE
fix: preserve reference links when copy-pasting from preview

### DIFF
--- a/apps/studio/src/features/editing-experience/components/PreviewWithoutSitemap.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewWithoutSitemap.tsx
@@ -26,7 +26,7 @@ export type PreviewProps = IsomerSchema & {
 // Add a fake link component to prevent the preview from navigating away
 const FakeLink = forwardRef<HTMLAnchorElement, PropsWithChildren<unknown>>(
   ({ children, ...rest }, ref) => (
-    <a {...rest} ref={ref} href="#" onClick={(e) => e.preventDefault()}>
+    <a {...rest} ref={ref} onClick={(e) => e.preventDefault()}>
       {children}
     </a>
   ),

--- a/apps/studio/src/features/editing-experience/constants.ts
+++ b/apps/studio/src/features/editing-experience/constants.ts
@@ -39,3 +39,5 @@ export const TYPE_TO_ICON: Record<
   // iframe-formsg
   // iframe-youtube
 }
+
+export const REFERENCE_LINK_REGEX = /\[resource:(\d+):(\d+)\]/

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
@@ -27,6 +27,8 @@ import { Underline } from "@tiptap/extension-underline"
 import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { textblockTypeInputRule, useEditor } from "@tiptap/react"
 
+import { getHtmlWithRelativeReferenceLinks } from "../utils"
+
 const HEADING_LEVELS: Level[] = [2, 3, 4, 5]
 
 export interface BaseEditorProps {
@@ -49,12 +51,7 @@ const BASE_EXTENSIONS: Extensions = [
           key: new PluginKey("transformReferenceLinks"),
           props: {
             transformPastedHTML(html, _) {
-              return html.replaceAll(
-                /href="(?:http|https):\/\/[^[]*\/\[resource:(\d+):(\d+)\]"/g,
-                (_, siteId, resourceId) => {
-                  return `href="[resource:${siteId}:${resourceId}]"`
-                },
-              )
+              return getHtmlWithRelativeReferenceLinks(html)
             },
           },
         }),

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor.ts
@@ -24,6 +24,7 @@ import { TableHeader } from "@tiptap/extension-table-header"
 import { TableRow } from "@tiptap/extension-table-row"
 import { Text } from "@tiptap/extension-text"
 import { Underline } from "@tiptap/extension-underline"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { textblockTypeInputRule, useEditor } from "@tiptap/react"
 
 const HEADING_LEVELS: Level[] = [2, 3, 4, 5]
@@ -34,7 +35,33 @@ export interface BaseEditorProps {
 }
 
 const BASE_EXTENSIONS: Extensions = [
-  Link.configure({
+  Link.extend({
+    addProseMirrorPlugins() {
+      return [
+        // NOTE: This plugin is used to transform links inside the HTML content
+        // copied by the user from the preview, as browsers will automatically
+        // transform relative links (in the form of [resource:siteId:resourceId])
+        // into absolute links:
+        // https://studio.isomer.gov.sg/sites/1/pages/[resource:siteId:resourceId]
+        // This plugin will transform the absolute links back into the relative
+        // links, so that the original link is preserved in the editor.
+        new Plugin({
+          key: new PluginKey("transformReferenceLinks"),
+          props: {
+            transformPastedHTML(html, _) {
+              return html.replaceAll(
+                /href="(?:http|https):\/\/[^[]*\/\[resource:(\d+):(\d+)\]"/g,
+                (_, siteId, resourceId) => {
+                  return `href="[resource:${siteId}:${resourceId}]"`
+                },
+              )
+            },
+          },
+        }),
+        ...(this.parent?.() ?? []),
+      ]
+    },
+  }).configure({
     HTMLAttributes: {
       rel: "",
       target: "_self",

--- a/apps/studio/src/features/editing-experience/utils.ts
+++ b/apps/studio/src/features/editing-experience/utils.ts
@@ -1,1 +1,17 @@
+import { REFERENCE_LINK_REGEX } from "./constants"
+
 export const dataAttr = (value: unknown) => (!!value ? true : undefined)
+
+// This function converts HTML with absolute reference links (something like
+// https://studio.isomer.gov.sg/sites/1/pages/[resource:siteId:resourceId]) into
+// relative reference links ([resource:siteId:resourceId])
+export const getHtmlWithRelativeReferenceLinks = (html: string) =>
+  html.replaceAll(
+    new RegExp(
+      `href="(?:http|https):\/\/[^[]*\/${REFERENCE_LINK_REGEX.source}"`,
+      "g",
+    ),
+    (_, siteId, resourceId) => {
+      return `href="[resource:${siteId}:${resourceId}]"`
+    },
+  )

--- a/apps/studio/src/utils/link.ts
+++ b/apps/studio/src/utils/link.ts
@@ -1,3 +1,5 @@
+import { REFERENCE_LINK_REGEX } from "~/features/editing-experience/constants"
+
 interface GetReferenceLinkParams {
   siteId: string
   resourceId: string
@@ -19,7 +21,7 @@ export const getReferenceLink = ({
 export const getResourceIdFromReferenceLink = (
   referenceLink: string,
 ): string => {
-  const match = /\[resource:(\d+):(\d+)\]/.exec(referenceLink)
+  const match = REFERENCE_LINK_REGEX.exec(referenceLink)
   if (!match) {
     return ""
   }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We had an issue where users can be overwhelmed with multiple text components in a page, so in an attempt to consolidate them into a single text component, they copy-pasted from the preview into the Tiptap editor.

This caused issues with rendering links, as all links in the preview are transformed to the `#` value, which gets published to the actual site.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Remove the transformation to the `#` value in the FakeLink, as the `e.preventDefault()` is sufficient to prevent links from being clickable in the Preview.
- Add a ProseMirror plugin to the link extension to handle reference links being copied.
    - This is needed as links inside the HTML copied from the preview is transformed to the absolute link (e.g. `[resource:1:2]` becomes `https://studio.isomer.gov.sg/sites/1/pages/[resource:1:2]`).
    - Hence, we will need to transform these absolute links back into reference links during the paste.
    - The `addPasteRules` function is insufficient, as it does not have access to the full HTML pasted. Only the ProseMirror state has this full information.

## Video demo

https://github.com/user-attachments/assets/7a815d54-6907-4d39-a872-8effd232a576