### PR TITLE
feat: alternate list marker type for nested lists

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1849,6 +1849,22 @@ video {
   resize: both;
 }
 
+.list-\[circle\] {
+  list-style-type: circle;
+}
+
+.list-\[lower-alpha\] {
+  list-style-type: lower-alpha;
+}
+
+.list-\[lower-roman\] {
+  list-style-type: lower-roman;
+}
+
+.list-\[square\] {
+  list-style-type: square;
+}
+
 .list-decimal {
   list-style-type: decimal;
 }

--- a/packages/components/src/interfaces/native/ListItem.ts
+++ b/packages/components/src/interfaces/native/ListItem.ts
@@ -57,6 +57,7 @@ export const ListItemSchema = Type.Unsafe<ListItem>(
 )
 
 export type ListItemProps = Static<typeof ListItemSchema> & {
+  level?: number
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }

--- a/packages/components/src/interfaces/native/OrderedList.ts
+++ b/packages/components/src/interfaces/native/OrderedList.ts
@@ -15,6 +15,7 @@ export const OrderedListSchema = orderedListSchemaBuilder(
 )
 
 export type OrderedListProps = Static<typeof OrderedListSchema> & {
+  level?: number
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }

--- a/packages/components/src/interfaces/native/UnorderedList.ts
+++ b/packages/components/src/interfaces/native/UnorderedList.ts
@@ -15,6 +15,7 @@ export const UnorderedListSchema = unorderedListSchemaBuilder(
 )
 
 export type UnorderedListProps = Static<typeof UnorderedListSchema> & {
+  level?: number
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -37,6 +37,7 @@ export const BaseParagraph = ({
   }
 
   const isAttributesPresent = !!id
+  const isContentEmpty = content.trim() === ""
 
   return (
     <Interweave
@@ -44,7 +45,7 @@ export const BaseParagraph = ({
         `hover:[&_a]text-link-hover [&:not(:first-child)]:mt-6 [&:not(:last-child)]:mb-6 after:[&_a[target*="blank"]]:content-['_↗'] [&_a]:text-link [&_a]:underline [&_a]:outline-none focus-visible:[&_a]:bg-utility-highlight focus-visible:[&_a]:text-base-content-strong focus-visible:[&_a]:decoration-transparent focus-visible:[&_a]:shadow-focus-visible focus-visible:[&_a]:transition-none`,
         className,
       )}
-      content={content}
+      content={isContentEmpty ? "<br />" : content}
       transform={transform}
       tagName="p"
       attributes={isAttributesPresent ? { id } : undefined}

--- a/packages/components/src/templates/next/components/native/ListItem/ListItem.tsx
+++ b/packages/components/src/templates/next/components/native/ListItem/ListItem.tsx
@@ -3,7 +3,7 @@ import OrderedList from "../OrderedList"
 import Paragraph from "../Paragraph"
 import UnorderedList from "../UnorderedList"
 
-const ListItem = ({ content, LinkComponent, site }: ListItemProps) => {
+const ListItem = ({ content, level, LinkComponent, site }: ListItemProps) => {
   return (
     <li className="my-[15px] pl-2 sm:my-5 [&_>_p]:inline">
       {content.map((item, index) => {
@@ -21,6 +21,7 @@ const ListItem = ({ content, LinkComponent, site }: ListItemProps) => {
             <OrderedList
               key={index}
               {...item}
+              level={!!level ? level + 1 : 1}
               LinkComponent={LinkComponent}
               site={site}
             />
@@ -30,6 +31,7 @@ const ListItem = ({ content, LinkComponent, site }: ListItemProps) => {
             <UnorderedList
               key={index}
               {...item}
+              level={!!level ? level + 1 : 1}
               LinkComponent={LinkComponent}
               site={site}
             />

--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
@@ -1,18 +1,34 @@
 import type { OrderedListProps } from "~/interfaces"
 import ListItem from "../ListItem"
 
+const getOrderedListType = (level?: number) => {
+  // We rotate between decimal, lower-alpha and lower-roman
+  if (!level || level % 3 === 0) {
+    return "list-decimal"
+  } else if (level % 3 === 1) {
+    return "list-[lower-alpha]"
+  } else {
+    return "list-[lower-roman]"
+  }
+}
+
 const OrderedList = ({
   attrs,
   content,
+  level,
   LinkComponent,
   site,
 }: OrderedListProps) => {
   return (
-    <ol className="mt-6 list-decimal ps-8" start={attrs?.start}>
+    <ol
+      className={`mt-6 ps-8 ${getOrderedListType(level)}`}
+      start={attrs?.start}
+    >
       {content.map((item, index) => (
         <ListItem
           key={index}
           {...item}
+          level={level}
           LinkComponent={LinkComponent}
           site={site}
         />

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
@@ -1,17 +1,30 @@
 import type { UnorderedListProps } from "~/interfaces"
 import ListItem from "../ListItem"
 
+const getUnorderedListType = (level?: number) => {
+  // We rotate between disc, circle and square
+  if (!level || level % 3 === 0) {
+    return "list-disc"
+  } else if (level % 3 === 1) {
+    return "list-[circle]"
+  } else {
+    return "list-[square]"
+  }
+}
+
 const UnorderedList = ({
   content,
+  level,
   LinkComponent,
   site,
 }: UnorderedListProps) => {
   return (
-    <ul className="mt-6 list-disc ps-8">
+    <ul className={`mt-6 ps-8 ${getUnorderedListType(level)}`}>
       {content.map((item, index) => (
         <ListItem
           key={index}
           {...item}
+          level={level}
           LinkComponent={LinkComponent}
           site={site}
         />


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Nested lists are currently using the same list marker type, which can be a little confusing and annoying to users.

Fixes ISOM-1662.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Make nested lists alternate between different list types:
    - For ordered lists: Use decimal, then lower-alpha, then lower-roman
    - For unordered lists: Use disc, then circle, then square

**Bug Fixes**:

- Sometimes when the parent list item is "empty" (i.e. just spaces but not entirely empty), the child bullet gets collapsed together with it. We now force a line break if it is empty.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="697" alt="image" src="https://github.com/user-attachments/assets/fdc1eaa0-d948-4bf0-aa6e-49c03df61d3f">
<img width="693" alt="image" src="https://github.com/user-attachments/assets/13b3de7c-a20f-4869-8d10-7500883b0aba">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="813" alt="image" src="https://github.com/user-attachments/assets/8dabdadf-7048-42c4-9b3e-b89b7c588032">
<img width="789" alt="image" src="https://github.com/user-attachments/assets/f6375ca1-2517-4282-9384-2c2b38b97489">