### PR TITLE
fix(dd): add tracing to backend

### DIFF
--- a/.aws/deploy/task-definition.json
+++ b/.aws/deploy/task-definition.json
@@ -110,8 +110,7 @@
         "com.datadoghq.tags.service": "isomer-next",
         "com.datadoghq.tags.version": "7",
         "com.datadoghq.ad.check_names": "[\"postgres\"]",
-        "com.datadoghq.ad.init_configs": "[{}]",
-        "com.datadoghq.ad.instances": "[{\"dbm\": true, \"host\": \"<RDS_READER_ENDPOINT>\", \"port\": 5432, \"username\": \"datadog\", \"password\": \"<RDS_DATADOG_PASSWORD>\"}]"
+        "com.datadoghq.ad.init_configs": "[{}]"
       },
       "mountPoints": [],
       "volumesFrom": [],

--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -49,6 +49,9 @@ const ContentSecurityPolicy = `
 const config = {
   output: "standalone",
   reactStrictMode: true,
+  experimental: {
+    instrumentationHook: true,
+  },
   /**
    * Dynamic configuration available for the browser and server.
    * Note: requires `ssr: true` or a `getInitialProps` in `_app.tsx`

--- a/apps/studio/src/server/modules/tracer.ts
+++ b/apps/studio/src/server/modules/tracer.ts
@@ -1,4 +1,13 @@
 import tracer from "dd-trace"
 
-tracer.init() // initialized in a different file to avoid hoisting.
+import { env } from "~/env.mjs"
+
+// initialized in a different file to avoid hoisting.
+tracer.init({
+  service: "isomer-next",
+  env: env.NEXT_PUBLIC_APP_ENV,
+  version: env.NEXT_PUBLIC_APP_VERSION,
+  runtimeMetrics: true,
+  logInjection: true,
+})
 export default tracer


### PR DESCRIPTION
## Problem
Currently, we don't have tracing on our backend which hinders troubleshooting

## Solution
1. remove db monitoring for now so dd doesn't get stuck on the connection phase to db 
2. add tags to tracer init (i'm pretty sure we don't need this cos we have env var tags but why not)
3. add instrumentation option to next js config (nextjs needs this option to be enbaled otherwise in the compiled output, they won't call the register hook)

see traces on staging [here](https://ogp.datadoghq.com/apm/traces?query=service:isomer-next&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service,core_resource_name,log_duration,log_http.method,log_http.status_code&fromUser=false&historicalData=false&messageDisplay=inline&query_translation_version=v0&sort=desc&spanType=all&storage=hot&view=spans&start=1730803137793&end=1730804037793&paused=false)