### PR TITLE
speed up codebuild - aws s3 sync higher concurrency

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -116,6 +116,7 @@ S3_SYNC_CONCURRENCY=$(( 4 * NUMBER_OF_CORES )) # 4x is an arbitrary number that 
 S3_SYNC_CONCURRENCY=$(( S3_SYNC_CONCURRENCY < 20 ? 10 : S3_SYNC_CONCURRENCY )) # Minimum of 20
 S3_SYNC_CONCURRENCY=$(( S3_SYNC_CONCURRENCY > 100 ? 100 : S3_SYNC_CONCURRENCY )) # Maximum of 100 (to prevent AWS from throttling us)
 echo "S3 sync concurrency: $S3_SYNC_CONCURRENCY"
+aws configure set default.s3.max_concurrent_requests $S3_SYNC_CONCURRENCY
 
 # Set all files to have 10 minutes of cache, except for those in the _next folder
 aws s3 sync . s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest --delete --no-progress --cache-control "max-age=600" --exclude "_next/*"

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -113,6 +113,8 @@ aws s3 sync . s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest --d
 # Set all files in the _next folder to have 1 day of cache
 aws s3 sync _next s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest/_next --delete --no-progress --cache-control "max-age=86400"
 
+calculate_duration $start_time
+
 # Update CloudFront origin path
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Hoping to leverage the concurrent uploads stated in https://docs.aws.amazon.com/cli/latest/topic/s3-config.html to speed up `aws s3 sync`

partially closes https://linear.app/ogp/issue/ISOM-1661/optimise-site-build-times

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- set a higher S3 `max_concurrent_requests` based on the number of cores (arbitrary 4x multiplier since file size is small)
  - We set a floor (20, which is higher than the default 10) and a ceiling (re: https://jasonralph.org/?p=791)
  - experimented with 10x multiplier with no cap (which means 320 concurrency with 32 CPU core, but value is the same). Likely due to resource bottleneck beyond a certain point
- benchmarking
  - before: 140s to 240s
  - after: 80s to 90s 
  - improvement: 50s to 160s reduction