### PR TITLE
feat: move to whitelist database table from growthbook

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -114,6 +114,13 @@ export interface Version {
   publishedBy: string
   updatedAt: Generated<Timestamp>
 }
+export interface Whitelist {
+  id: GeneratedAlways<number>
+  email: string
+  expiry: Timestamp | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
 export interface DB {
   Blob: Blob
   Footer: Footer
@@ -126,4 +133,5 @@ export interface DB {
   User: User
   VerificationToken: VerificationToken
   Version: Version
+  Whitelist: Whitelist
 }

--- a/apps/studio/prisma/generated/selectableTypes.ts
+++ b/apps/studio/prisma/generated/selectableTypes.ts
@@ -14,3 +14,4 @@ export type SiteMember = Selectable<T.SiteMember>
 export type User = Selectable<T.User>
 export type VerificationToken = Selectable<T.VerificationToken>
 export type Version = Selectable<T.Version>
+export type Whitelist = Selectable<T.Whitelist>

--- a/apps/studio/prisma/migrations/20241107033200_add_whitelist_table/migration.sql
+++ b/apps/studio/prisma/migrations/20241107033200_add_whitelist_table/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "Whitelist" (
+    "id" SERIAL NOT NULL,
+    "email" TEXT NOT NULL,
+    "expiry" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Whitelist_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Whitelist_email_key" ON "Whitelist"("email");
+
+-- CreateIndex
+CREATE INDEX "Whitelist_email_idx" ON "Whitelist"("email");
+
+-- AlterTable
+CREATE TRIGGER update_timestamp BEFORE UPDATE ON "Whitelist" FOR EACH ROW EXECUTE PROCEDURE moddatetime("updatedAt");

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -212,3 +212,13 @@ model RateLimiterFlexible {
   points Int
   expire DateTime?
 }
+
+model Whitelist {
+  id        Int       @id @default(autoincrement())
+  email     String    @unique
+  expiry    DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+
+  @@index([email])
+}

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -259,6 +259,18 @@ async function main() {
     )
     .executeTakeFirstOrThrow()
 
+  await db
+    .insertInto("Whitelist")
+    .values({
+      email: "@open.gov.sg",
+    })
+    .onConflict((oc) =>
+      oc
+        .column("email")
+        .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
+    )
+    .executeTakeFirstOrThrow()
+
   await Promise.all(
     [...ISOMER_ADMINS, ...ISOMER_MIGRATORS, EDITOR_USER, PUBLISHER_USER].map(
       async (name) => {

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -3,6 +3,7 @@ import {
   applySession,
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
+import { setUpWhitelist } from "tests/integration/helpers/seed"
 import { describe, expect, it } from "vitest"
 
 import { env } from "~/env.mjs"
@@ -15,16 +16,17 @@ import { getIpFingerprint, LOCALHOST } from "../utils"
 describe("auth.email", () => {
   let caller: Awaited<ReturnType<typeof emailSessionRouter.createCaller>>
   let session: ReturnType<typeof applySession>
+  const TEST_VALID_EMAIL = "test@open.gov.sg"
 
   beforeEach(async () => {
-    await resetTables("User", "VerificationToken")
+    await resetTables("User", "VerificationToken", "Whitelist")
+    await setUpWhitelist({ email: TEST_VALID_EMAIL })
     session = applySession()
     const ctx = createMockRequest(session)
     caller = emailSessionRouter.createCaller(ctx)
   })
 
   describe("login", () => {
-    const TEST_VALID_EMAIL = "test@open.gov.sg"
     it("should throw if email is not provided", async () => {
       // Act
       const result = caller.login({ email: "" })
@@ -72,7 +74,6 @@ describe("auth.email", () => {
   })
 
   describe("verifyOtp", () => {
-    const TEST_VALID_EMAIL = "test@open.gov.sg"
     const VALID_OTP = "123456"
     const VALID_TOKEN_HASH = createTokenHash(VALID_OTP, TEST_VALID_EMAIL)
     const INVALID_OTP = "987643"

--- a/apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts
+++ b/apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts
@@ -1,0 +1,125 @@
+import { resetTables } from "tests/integration/helpers/db"
+import { setUpWhitelist } from "tests/integration/helpers/seed"
+
+import { isEmailWhitelisted } from "../whitelist.service"
+
+describe("whitelist.service", () => {
+  beforeAll(async () => {
+    const oneYearFromNow = new Date()
+    oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1)
+    const oneYearAgo = new Date()
+    oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1)
+
+    await resetTables("Whitelist")
+    await setUpWhitelist({ email: "whitelisted@example.com" })
+    await setUpWhitelist({
+      email: "vendor-whitelisted@example.com",
+      expiry: oneYearFromNow,
+    })
+    await setUpWhitelist({
+      email: "vendor-expired@example.com",
+      expiry: oneYearAgo,
+    })
+    await setUpWhitelist({ email: ".gov.sg" })
+    await setUpWhitelist({
+      email: "@vendor.com.sg",
+    })
+    await setUpWhitelist({
+      email: "@whitelisted.com.sg",
+      expiry: oneYearFromNow,
+    })
+    await setUpWhitelist({ email: "@expired.sg", expiry: oneYearAgo })
+    await setUpWhitelist({
+      email: "expired@whitelisted.com.sg",
+      expiry: oneYearAgo,
+    })
+  })
+
+  it("should show email as whitelisted if the exact email address is whitelisted and expiry is NULL", async () => {
+    // Arrange
+    const email = "whitelisted@example.com"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(true)
+  })
+
+  it("should show email as whitelisted if the exact email address is whitelisted and expiry is in the future", async () => {
+    // Arrange
+    const email = "vendor-whitelisted@example.com"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(true)
+  })
+
+  it("should show email as not whitelisted if the exact email address is whitelisted and expiry is in the past", async () => {
+    // Arrange
+    const email = "vendor-expired@example.com"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(false)
+  })
+
+  it("should show email as whitelisted if the exact email domain is whitelisted and expiry is NULL", async () => {
+    // Arrange
+    const email = "user@vendor.com.sg"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(true)
+  })
+
+  it("should show email as whitelisted if the exact email domain is whitelisted and expiry is in the future", async () => {
+    // Arrange
+    const email = "user@whitelisted.com.sg"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(true)
+  })
+
+  it("should show email as not whitelisted if the exact email domain is whitelisted and expiry is in the past", async () => {
+    // Arrange
+    const email = "user@expired.sg"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(false)
+  })
+
+  it("should show email as whitelisted if the suffix of the email domain is whitelisted and expiry is NULL", async () => {
+    // Arrange
+    const email = "user@agency.gov.sg"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(true)
+  })
+
+  it("should show email as whitelisted if the exact email address is expired, but the domain's expiry is in the future", async () => {
+    // Arrange
+    const email = "expired@whitelisted.com.sg"
+
+    // Act
+    const result = await isEmailWhitelisted(email)
+
+    // Assert
+    expect(result).toBe(true)
+  })
+})

--- a/apps/studio/src/server/modules/whitelist/whitelist.service.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.service.ts
@@ -1,9 +1,18 @@
 import { TRPCError } from "@trpc/server"
 
+import { isValidEmail } from "~/utils/email"
 import { db } from "../database"
 
 export const isEmailWhitelisted = async (email: string) => {
   const lowercaseEmail = email.toLowerCase()
+
+  // Extra guard even if Zod validation has already checked
+  if (!isValidEmail(lowercaseEmail)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Please sign in with a valid email address.",
+    })
+  }
 
   // Step 1: Check if the exact email address is whitelisted
   const exactMatch = await db
@@ -24,7 +33,7 @@ export const isEmailWhitelisted = async (email: string) => {
   if (emailParts.length !== 2 && !emailParts[1]) {
     throw new TRPCError({
       code: "BAD_REQUEST",
-      message: "An invalid email was provided",
+      message: "Please sign in with a valid email address.",
     })
   }
 

--- a/apps/studio/src/server/modules/whitelist/whitelist.service.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.service.ts
@@ -1,0 +1,66 @@
+import { TRPCError } from "@trpc/server"
+
+import { db } from "../database"
+
+export const isEmailWhitelisted = async (email: string) => {
+  const lowercaseEmail = email.toLowerCase()
+
+  // Step 1: Check if the exact email address is whitelisted
+  const exactMatch = await db
+    .selectFrom("Whitelist")
+    .where("email", "=", lowercaseEmail)
+    .where(({ eb }) =>
+      eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+    )
+    .select(["id"])
+    .executeTakeFirst()
+
+  if (exactMatch) {
+    return true
+  }
+
+  // Step 2: Check if the exact email domain is whitelisted
+  const emailParts = lowercaseEmail.split("@")
+  if (emailParts.length !== 2 && !emailParts[1]) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "An invalid email was provided",
+    })
+  }
+
+  const emailDomain = `@${emailParts[1]}`
+  const domainMatch = await db
+    .selectFrom("Whitelist")
+    .where("email", "=", emailDomain)
+    .where(({ eb }) =>
+      eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+    )
+    .select(["id"])
+    .executeTakeFirst()
+
+  if (domainMatch) {
+    return true
+  }
+
+  // Step 3: Check if the suffix of the email domain is whitelisted
+  const domainParts = emailDomain.split(".")
+  for (let i = 1; i < domainParts.length; i++) {
+    // Suffices should start with a dot (e.g. ".gov.sg")
+    const suffix = `.${domainParts.slice(i).join(".")}`
+
+    const suffixMatch = await db
+      .selectFrom("Whitelist")
+      .where("email", "=", suffix)
+      .where(({ eb }) =>
+        eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+      )
+      .select(["id"])
+      .executeTakeFirst()
+
+    if (suffixMatch) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/apps/studio/src/server/modules/whitelist/whitelist.service.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.service.ts
@@ -30,14 +30,14 @@ export const isEmailWhitelisted = async (email: string) => {
 
   // Step 2: Check if the exact email domain is whitelisted
   const emailParts = lowercaseEmail.split("@")
-  if (emailParts.length !== 2 && !emailParts[1]) {
+  if (emailParts.length !== 2) {
     throw new TRPCError({
       code: "BAD_REQUEST",
       message: "Please sign in with a valid email address.",
     })
   }
 
-  const emailDomain = `@${emailParts[1]}`
+  const emailDomain = `@${emailParts.pop()}`
   const domainMatch = await db
     .selectFrom("Whitelist")
     .where("email", "=", emailDomain)

--- a/apps/studio/tests/integration/helpers/auth.ts
+++ b/apps/studio/tests/integration/helpers/auth.ts
@@ -3,19 +3,10 @@ import cuid2 from "@paralleldrive/cuid2"
 import { db } from "~server/db"
 
 import type { User } from "~server/db"
+import { setUpWhitelist } from "./seed"
 
 export const auth = async ({ id, ...user }: SetOptional<User, "id">) => {
-  await db
-    .insertInto("Whitelist")
-    .values({
-      email: user.email,
-    })
-    .onConflict((oc) =>
-      oc
-        .column("email")
-        .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
-    )
-    .executeTakeFirstOrThrow()
+  await setUpWhitelist({ email: user.email })
 
   if (id !== undefined) {
     return db

--- a/apps/studio/tests/integration/helpers/auth.ts
+++ b/apps/studio/tests/integration/helpers/auth.ts
@@ -5,6 +5,18 @@ import { db } from "~server/db"
 import type { User } from "~server/db"
 
 export const auth = async ({ id, ...user }: SetOptional<User, "id">) => {
+  await db
+    .insertInto("Whitelist")
+    .values({
+      email: user.email,
+    })
+    .onConflict((oc) =>
+      oc
+        .column("email")
+        .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
+    )
+    .executeTakeFirstOrThrow()
+
   if (id !== undefined) {
     return db
       .updateTable("User")

--- a/apps/studio/tests/integration/helpers/growthbook/mockFeatureFlags.ts
+++ b/apps/studio/tests/integration/helpers/growthbook/mockFeatureFlags.ts
@@ -1,6 +1,3 @@
 const mockFeatureFlags = new Map<string, unknown>()
-mockFeatureFlags.set("whitelisted_users", {
-  whitelist: ["test@open.gov.sg"],
-})
 
 export { mockFeatureFlags }

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -293,3 +293,20 @@ export const setupFolder = async ({
     folder,
   }
 }
+
+export const setUpWhitelist = async ({
+  email,
+  expiry,
+}: {
+  email: string
+  expiry?: Date
+}) => {
+  return db
+    .insertInto("Whitelist")
+    .values({
+      email,
+      expiry: expiry ?? null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -304,9 +304,14 @@ export const setUpWhitelist = async ({
   return db
     .insertInto("Whitelist")
     .values({
-      email,
+      email: email.toLowerCase(),
       expiry: expiry ?? null,
     })
+    .onConflict((oc) =>
+      oc
+        .column("email")
+        .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
+    )
     .returningAll()
     .executeTakeFirstOrThrow()
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our email whitelist lives in Growthbook, which makes adding new users a little difficult as it involves both updating the database and updating the Growthbook feature flag.

Fixes ISOM-1668.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] Yes - this PR contains breaking changes
    - [ ] Add the existing whitelist emails on Growthbook into the database.
- [ ] No - this PR is backwards compatible

**Features**:

- Create a new Whitelist table that can take the email and expiry date.
- Enhance the whitelisting logic to allow for domain whitelists and domain suffix whitelisting.
- Added tests for the whitelist check logic.