### PR TITLE
feat: use central repo for building Amplify apps

### DIFF
--- a/tooling/build/amplify/create-app.js
+++ b/tooling/build/amplify/create-app.js
@@ -20,10 +20,6 @@ frontend:
     baseDirectory: out
     files:
       - '**/*'
-#   cache:
-#     paths:
-#       - .next/cache/**/*
-#       - node_modules/**/*
 `
 
 const amplifyClient = new AmplifyClient({ region: "ap-southeast-1" })
@@ -42,7 +38,7 @@ const createApp = async (appName) => {
     },
     customRules: [
       {
-        source: "</^[^.]+$|.(?!(txt)$)([^.]+$)/>",
+        source: "</^[^.]+$|\\.(?!(txt)$)([^.]+$)/>",
         target: "/404.html",
         status: "404",
       },

--- a/tooling/build/scripts/build.sh
+++ b/tooling/build/scripts/build.sh
@@ -1,9 +1,59 @@
 #!/bin/sh
 
+# Exit immediately if a command exits with a non-zero status.
 set -x
 
-#######################################################################
-# Build the site                                                      #
-#######################################################################
+# Helper function to calculate duration
+calculate_duration() {
+  start_time=$1
+  end_time=$(date +%s)
+  duration=$((end_time - start_time))
+  echo "Time taken: $duration seconds"
+}
 
-npm run build
+# Store the current directory
+ISOMER_REPO_DIRECTORY=$(pwd)
+
+cd ../
+
+cd isomer/packages/components
+mv opengovsg-isomer-components-0.0.13.tgz ../../tooling/template/
+cd ../.. # back to root
+echo $(pwd)
+calculate_duration $start_time
+
+# Set up the schema folder
+rm -rf tooling/template/schema
+rm -rf tooling/template/data
+mv $ISOMER_REPO_DIRECTORY/schema/ tooling/template/
+mv $ISOMER_REPO_DIRECTORY/data/ tooling/template/
+
+# Generate sitemap.json
+cd tooling/template
+find . schema
+start_time=$(date +%s)
+mkdir -p scripts/
+cp ../build/scripts/generate-sitemap.js scripts/
+node scripts/generate-sitemap.js
+echo "Sitemap generated"
+calculate_duration $start_time
+
+# Copy sitemap.json to public folder
+cp sitemap.json public/
+echo "Copied sitemap to public folder"
+
+# Cleanup
+rm -rf scripts
+
+# Bridging the difference betwen the two types of homepage JSONs
+mv schema/index.json schema/_index.json
+
+# Build the site
+echo "Building site..."
+start_time=$(date +%s)
+npm i opengovsg-isomer-components-0.0.13.tgz
+npm run build:template
+calculate_duration $start_time
+
+# Bring the output folder to the original directory
+mv out/ $ISOMER_REPO_DIRECTORY/out/

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -17,7 +17,7 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
 fi
 
 # Cloning the repository
-echo "Cloning repository..."
+echo "Cloning central repository..."
 start_time=$(date +%s)
 
 git clone --depth 1 --branch "$ISOMER_BUILD_REPO_BRANCH" https://github.com/opengovsg/isomer.git
@@ -31,8 +31,6 @@ echo "Checking out branch..."
 start_time=$(date +%s)
 git checkout $ISOMER_BUILD_REPO_BRANCH
 calculate_duration $start_time
-
-echo $(git branch)
 
 # Perform a clean of npm cache
 npm cache clean --force


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Sites on GitHub are using a separate location to obtain the components package, which causes them to be on a different release cadence from Studio and actual live sites.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Adjust the build scripts of Amplify apps to pull from the central repo's latest release tag, and to build the components from there.
    - This allows performing of releases from a single location, which is this repo.