### PR TITLE
chore: remove ref from meta in collection items

### DIFF
--- a/packages/components/src/types/meta.ts
+++ b/packages/components/src/types/meta.ts
@@ -27,17 +27,6 @@ const BasePageMetaSchema = Type.Composite([
   }),
 ])
 
-const BaseRefMetaSchema = Type.Composite([
-  BaseItemMetaSchema,
-  Type.Object({
-    ref: Type.String({
-      title: "URL to the actual item",
-      description:
-        "The link that users will open immediately when they click on the item in the parent collection page",
-    }),
-  }),
-])
-
 export const ArticlePageMetaSchema = BasePageMetaSchema
 export const ContentPageMetaSchema = BasePageMetaSchema
 export const CollectionPageMetaSchema = BasePageMetaSchema
@@ -46,8 +35,8 @@ export const HomePageMetaSchema = BasePageMetaSchema
 export const NotFoundPageMetaSchema = BasePageMetaSchema
 export const SearchPageMetaSchema = BasePageMetaSchema
 
-export const FileRefMetaSchema = BaseRefMetaSchema
-export const LinkRefMetaSchema = BaseRefMetaSchema
+export const FileRefMetaSchema = BaseItemMetaSchema
+export const LinkRefMetaSchema = BaseItemMetaSchema
 
 export type ArticlePageMetaProps = Static<typeof ArticlePageMetaSchema>
 export type CollectionPageMetaProps = Static<typeof CollectionPageMetaSchema>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `ref` key is inside the `meta` object inside collection items, which is incorrect.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [x] Yes - this PR contains breaking changes
  - Checked through all the schema files in GitHub + DB, none of the schema files have this pattern, so we are safe.
- [ ] No - this PR is backwards compatible

**Improvements**:

- Removed the `ref` key inside the `meta` object, as it should be inside the `page` object instead. The `meta` object is for page/item settings that do not require the editing preview.
    - Our `generate-sitemap.js` and publishing scripts also use `page.ref` rather than `meta.ref`, so this removal makes the behaviour more correct.