### PR TITLE
fix: move assets folder when building GitHub repos

### DIFF
--- a/tooling/build/scripts/build.sh
+++ b/tooling/build/scripts/build.sh
@@ -25,8 +25,10 @@ calculate_duration $start_time
 # Set up the schema folder
 rm -rf tooling/template/schema
 rm -rf tooling/template/data
+rm -rf tooling/template/public
 mv $ISOMER_REPO_DIRECTORY/schema/ tooling/template/
 mv $ISOMER_REPO_DIRECTORY/data/ tooling/template/
+mv $ISOMER_REPO_DIRECTORY/public/ tooling/template/
 
 # Generate sitemap.json
 cd tooling/template


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

GitHub repos built using Amplify have their assets stored together in the same repo, but that was not accounted for in the updated build script.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Move the `public` folder to the template folder together with the schema and data before the site is being built.