### PR TITLE
fix: only display sites that the user has permissions for

### DIFF
--- a/apps/studio/src/features/dashboard/SiteList.tsx
+++ b/apps/studio/src/features/dashboard/SiteList.tsx
@@ -101,7 +101,6 @@ const SiteListSection = ({
 }
 
 const SuspendableSiteList = (): JSX.Element => {
-  // TODO: Only return sites that the user has access to
   const [sites] = trpc.site.list.useSuspenseQuery()
 
   if (sites.length === 0) {

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -1,0 +1,107 @@
+import { TRPCError } from "@trpc/server"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupAdminPermissions,
+  setupSite,
+} from "tests/integration/helpers/seed"
+
+import { createCallerFactory } from "~/server/trpc"
+import { siteRouter } from "../site.router"
+
+const createCaller = createCallerFactory(siteRouter)
+
+describe("site.router", async () => {
+  let caller: ReturnType<typeof createCaller>
+  const session = await applyAuthedSession()
+
+  beforeAll(() => {
+    caller = createCaller(createMockRequest(session))
+  })
+
+  beforeEach(async () => {
+    await resetTables("Site", "ResourcePermission")
+  })
+
+  describe("list", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.list()
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should return an empty array if there are no sites in the database", async () => {
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([])
+    })
+
+    it("should include the Site if the user has any role permission for the site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: site.id,
+          name: site.name,
+          config: site.config,
+        },
+      ])
+    })
+
+    it("should only include sites that the user has any role permission for", async () => {
+      // Arrange
+      const { site: site1 } = await setupSite()
+      const { site: _site2 } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site1.id,
+      })
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: site1.id,
+          name: site1.name,
+          config: site1.config,
+        },
+      ])
+    })
+
+    it("should return an empty array if the user does not have any role for the site", async () => {
+      // Arrange
+      const _ = await setupSite()
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([])
+    })
+  })
+})

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -47,14 +47,14 @@ const validateUserPermissionsForSite = async ({
 }
 
 export const siteRouter = router({
-  list: protectedProcedure.query(() => {
-    return (
-      db
-        .selectFrom("Site")
-        // TODO: Only return sites that the user has access to
-        .select(["Site.id", "Site.name", "Site.config"])
-        .execute()
-    )
+  list: protectedProcedure.query(async ({ ctx }) => {
+    // NOTE: Any role should be able to read site
+    return db
+      .selectFrom("Site")
+      .innerJoin("ResourcePermission", "Site.id", "ResourcePermission.siteId")
+      .where("ResourcePermission.userId", "=", ctx.user.id)
+      .select(["Site.id", "Site.name", "Site.config"])
+      .execute()
   }),
   getConfig: protectedProcedure
     .input(getConfigSchema)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We currently display all sites in the database, rather than only the sites that the user has access to.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Filter for only the sites that the user has a role for.