### PR TITLE
Fix dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
+    versioning-strategy: increase
     groups:
       aws-sdk:
         applies-to: version-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: daily
     versioning-strategy: increase
+    open-pull-requests-limit: 10
     groups:
       aws-sdk:
         applies-to: version-updates


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently dependabot isn't working. for example, there's a new version in `@opengovsg/starter-kitty-validators` but it's not automatically bumped

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- increase `open-pull-requests-limit` to 10 (default 5)

**Bug Fixes**:

- add `versioning-strategy: increase` according to https://github.com/dependabot/dependabot-core/issues/5226 as this seems to be due to us using monorepo npm workspaces
