### PR TITLE
feat: hide less used functions in overflow dropdown

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1766,6 +1766,10 @@ video {
   flex-shrink: 0;
 }
 
+.flex-grow {
+  flex-grow: 1;
+}
+
 .grow {
   flex-grow: 1;
 }

--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -73,22 +73,6 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         isActive: () => editor.isActive("strike"),
       },
       {
-        type: "item",
-        icon: MdSuperscript,
-        title: "Superscript",
-        action: () =>
-          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
-        isActive: () => editor.isActive("superscript"),
-      },
-      {
-        type: "item",
-        icon: MdSubscript,
-        title: "Subscript",
-        action: () =>
-          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
-        isActive: () => editor.isActive("subscript"),
-      },
-      {
         type: "divider",
       },
       {
@@ -201,6 +185,28 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
             icon: BiCog,
             title: "Table settings",
             action: onTableSettingsModalOpen,
+          },
+        ],
+      },
+      // Lesser-used commands are kept inside the overflow items list
+      {
+        type: "overflow-list",
+        items: [
+          {
+            type: "item",
+            icon: MdSuperscript,
+            title: "Superscript",
+            action: () =>
+              editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+            isActive: () => editor.isActive("superscript"),
+          },
+          {
+            type: "item",
+            icon: MdSubscript,
+            title: "Subscript",
+            action: () =>
+              editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+            isActive: () => editor.isActive("subscript"),
           },
         ],
       },

--- a/apps/studio/src/components/PageEditor/MenuBar/CalloutMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/CalloutMenuBar.tsx
@@ -54,22 +54,6 @@ export const CalloutMenuBar = ({ editor }: { editor: Editor }) => {
         isActive: () => editor.isActive("strike"),
       },
       {
-        type: "item",
-        icon: MdSuperscript,
-        title: "Superscript",
-        action: () =>
-          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
-        isActive: () => editor.isActive("superscript"),
-      },
-      {
-        type: "item",
-        icon: MdSubscript,
-        title: "Subscript",
-        action: () =>
-          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
-        isActive: () => editor.isActive("subscript"),
-      },
-      {
         type: "divider",
       },
       {
@@ -103,6 +87,28 @@ export const CalloutMenuBar = ({ editor }: { editor: Editor }) => {
         title: "Link",
         action: onLinkModalOpen,
         isActive: () => editor.isActive("link"),
+      },
+      // Lesser-used commands are kept inside the overflow items list
+      {
+        type: "overflow-list",
+        items: [
+          {
+            type: "item",
+            icon: MdSuperscript,
+            title: "Superscript",
+            action: () =>
+              editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+            isActive: () => editor.isActive("superscript"),
+          },
+          {
+            type: "item",
+            icon: MdSubscript,
+            title: "Subscript",
+            action: () =>
+              editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+            isActive: () => editor.isActive("subscript"),
+          },
+        ],
       },
     ],
     [editor, onLinkModalOpen],

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/Factory.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/Factory.tsx
@@ -3,6 +3,7 @@ import { MenubarDetailedList } from "./DetailedList"
 import { MenubarDivider } from "./Divider"
 import { MenubarHorizontalList } from "./HorizontalList"
 import { MenubarItem } from "./Item"
+import { MenubarOverflowList } from "./OverflowList"
 import { MenubarVerticalList } from "./VerticalList"
 
 export const MenubarItemFactory = (
@@ -19,5 +20,10 @@ export const MenubarItemFactory = (
       return <MenubarDetailedList {...item} />
     case "item":
       return <MenubarItem {...item} />
+    case "overflow-list":
+      return <MenubarOverflowList {...item} />
+    default:
+      const _: never = item
+      return <></>
   }
 }

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
@@ -1,0 +1,68 @@
+import {
+  HStack,
+  Icon,
+  Popover,
+  PopoverBody,
+  PopoverContent,
+  PopoverTrigger,
+} from "@chakra-ui/react"
+import { IconButton } from "@opengovsg/design-system-react"
+import { BiDotsHorizontalRounded } from "react-icons/bi"
+
+import type { MenubarNestedItem } from "./types"
+import { MenuItem } from "../../MenuItem"
+
+export interface MenubarOverflowListProps {
+  type: "overflow-list"
+  items: MenubarNestedItem[]
+}
+
+export const MenubarOverflowList = ({
+  items,
+}: MenubarOverflowListProps): JSX.Element => {
+  return (
+    <Popover placement="bottom">
+      {({ isOpen }) => (
+        <>
+          <PopoverTrigger>
+            <IconButton
+              variant="clear"
+              colorScheme="neutral"
+              isActive={isOpen}
+              _active={{
+                bg: "interaction.muted.main.active",
+              }}
+              h="1.75rem"
+              w="1.75rem"
+              minH="1.75rem"
+              minW="1.75rem"
+              p="0.25rem"
+              aria-label="More options"
+            >
+              <Icon
+                as={BiDotsHorizontalRounded}
+                fontSize="1.25rem"
+                color="base.content.medium"
+              />
+            </IconButton>
+          </PopoverTrigger>
+          <PopoverContent w="fit-content">
+            <PopoverBody>
+              <HStack>
+                {items.map((subItem, index) => (
+                  <MenuItem
+                    key={index}
+                    icon={subItem.icon}
+                    title={subItem.title}
+                    action={subItem.action}
+                    isActive={subItem.isActive}
+                  />
+                ))}
+              </HStack>
+            </PopoverBody>
+          </PopoverContent>
+        </>
+      )}
+    </Popover>
+  )
+}

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/types.ts
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/types.ts
@@ -4,6 +4,7 @@ import type { MenubarDetailedListProps } from "./DetailedList"
 import type { MenubarDividerProps } from "./Divider"
 import type { MenubarHorizontalListProps } from "./HorizontalList"
 import type { MenubarItemProps } from "./Item"
+import type { MenubarOverflowListProps } from "./OverflowList"
 import type { MenubarVerticalListProps } from "./VerticalList"
 
 export interface MenubarNestedItem {
@@ -24,3 +25,4 @@ export type PossibleMenubarItemProps =
   | MenubarHorizontalListProps
   | MenubarDetailedListProps
   | MenubarItemProps
+  | MenubarOverflowListProps

--- a/apps/studio/src/components/PageEditor/MenuBar/ProseMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/ProseMenuBar.tsx
@@ -108,22 +108,6 @@ export const ProseMenuBar = ({ editor }: { editor: Editor }) => {
         isActive: () => editor.isActive("strike"),
       },
       {
-        type: "item",
-        icon: MdSuperscript,
-        title: "Superscript",
-        action: () =>
-          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
-        isActive: () => editor.isActive("superscript"),
-      },
-      {
-        type: "item",
-        icon: MdSubscript,
-        title: "Subscript",
-        action: () =>
-          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
-        isActive: () => editor.isActive("subscript"),
-      },
-      {
         type: "horizontal-list",
         label: "Lists",
         defaultIcon: BiListOl,
@@ -151,6 +135,28 @@ export const ProseMenuBar = ({ editor }: { editor: Editor }) => {
         title: "Link",
         action: onLinkModalOpen,
         isActive: () => editor.isActive("link"),
+      },
+      // Lesser-used commands are kept inside the overflow items list
+      {
+        type: "overflow-list",
+        items: [
+          {
+            type: "item",
+            icon: MdSuperscript,
+            title: "Superscript",
+            action: () =>
+              editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+            isActive: () => editor.isActive("superscript"),
+          },
+          {
+            type: "item",
+            icon: MdSubscript,
+            title: "Subscript",
+            action: () =>
+              editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+            isActive: () => editor.isActive("subscript"),
+          },
+        ],
       },
     ],
     [editor, onLinkModalOpen],

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -128,22 +128,6 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         isActive: () => editor.isActive("strike"),
       },
       {
-        type: "item",
-        icon: MdSuperscript,
-        title: "Superscript",
-        action: () =>
-          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
-        isActive: () => editor.isActive("superscript"),
-      },
-      {
-        type: "item",
-        icon: MdSubscript,
-        title: "Subscript",
-        action: () =>
-          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
-        isActive: () => editor.isActive("subscript"),
-      },
-      {
         type: "horizontal-list",
         label: "Lists",
         defaultIcon: BiListOl,
@@ -251,6 +235,28 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
             icon: BiCog,
             title: "Table settings",
             action: onTableSettingsModalOpen,
+          },
+        ],
+      },
+      // Lesser-used commands are kept inside the overflow items list
+      {
+        type: "overflow-list",
+        items: [
+          {
+            type: "item",
+            icon: MdSuperscript,
+            title: "Superscript",
+            action: () =>
+              editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+            isActive: () => editor.isActive("superscript"),
+          },
+          {
+            type: "item",
+            icon: MdSubscript,
+            title: "Subscript",
+            action: () =>
+              editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+            isActive: () => editor.isActive("subscript"),
           },
         ],
       },

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -99,3 +99,15 @@ export const WithBanner: Story = {
     ],
   },
 }
+
+export const AddTextBlock: Story = {
+  play: async (context) => {
+    const { canvasElement } = context
+    const canvas = within(canvasElement)
+    await AddBlock.play?.(context)
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: /Add a block of text/i }),
+    )
+  },
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our Tiptap editor menu bar is a little crowded.

Also, this is preparation for adding the divider component back into Tiptap.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Hide some of the less commonly used functions inside a dropdown menu. Currently, this is the superscript and subscript functions.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="644" alt="image" src="https://github.com/user-attachments/assets/d353732d-f492-4252-8d4a-8288d928530a">

**AFTER**:

<!-- [insert screenshot here] -->
<img width="488" alt="image" src="https://github.com/user-attachments/assets/4e9216ce-5201-4c70-8505-e31ed6647099">