### PR TITLE
fix: set tabIndex -1 and no outline for content anchor

### DIFF
--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -57,7 +57,13 @@ export const Skeleton = ({
         />
       </header>
 
-      <main id={SKIP_TO_CONTENT_ANCHOR_ID}>{children}</main>
+      <main
+        id={SKIP_TO_CONTENT_ANCHOR_ID}
+        tabIndex={-1}
+        className="focus-visible:outline-none"
+      >
+        {children}
+      </main>
 
       <Footer
         isGovernment={site.isGovernment}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When users use the "Skip to main content" button and press enter then continue pressing Tab, the focus reverts back to the masthead.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Set the `tabindex` of the main content anchor tag to be `-1` so that the Tab focus continues from this point, rather than reverting back to the masthead.
- Also removed the outline on focus.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/6cddb96e-a9cd-41a0-8156-265ef1a07273

**AFTER**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/176defd7-ee4d-45ab-93b3-f1420e8967e2