### PR TITLE
fix: group by the sites when returning list of sites

### DIFF
--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -103,5 +103,30 @@ describe("site.router", async () => {
       // Assert
       expect(result).toEqual([])
     })
+
+    it("should only show a site once if there are multiple permissions for the same site and user", async () => {
+      // Arrange
+      const { site: site1 } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site1.id,
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site1.id,
+      })
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: site1.id,
+          name: site1.name,
+          config: site1.config,
+        },
+      ])
+    })
   })
 })

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -54,6 +54,7 @@ export const siteRouter = router({
       .innerJoin("ResourcePermission", "Site.id", "ResourcePermission.siteId")
       .where("ResourcePermission.userId", "=", ctx.user.id)
       .select(["Site.id", "Site.name", "Site.config"])
+      .groupBy(["Site.id", "Site.name", "Site.config"])
       .execute()
   }),
   getConfig: protectedProcedure


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The list of sites can be duplicated when the user has multiple ResourcePermissions for the same site.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add a group-by condition for the list of sites accessible by the user.