### PR TITLE
chore: make growthbook client ID env-specific

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -102,6 +102,14 @@ on:
         required: false
         default: "example-assets-bucket"
         type: string
+      app-growthbook-client-key:
+        description: "Growthbook client key"
+        required: false
+        type: string
+      app-intercom-app-id:
+        description: "Intercom app ID"
+        required: false
+        type: string
     secrets:
       DD_API_KEY:
         description: "Datadog API key for uploading sourcemaps"
@@ -166,8 +174,8 @@ jobs:
             NEXT_PUBLIC_S3_REGION=${{ inputs.app-s3-region }}
             NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME=${{ inputs.app-s3-assets-domain-name }}
             NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME=${{ inputs.app-s3-assets-bucket-name }}
-            NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY=sdk-r07MHTLLgfdVDThi
-            NEXT_PUBLIC_INTERCOM_APP_ID=jv2tjc3g
+            NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY=${{ inputs.app-growthbook-client-key }}
+            NEXT_PUBLIC_INTERCOM_APP_ID=${{ inputs.app-intercom-app-id }}
 
   deploy:
     name: Deploy image to ECS

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -39,6 +39,8 @@ jobs:
       app-s3-region: "ap-southeast-1"
       app-s3-assets-bucket-name: "isomer-next-infra-prod-assets-private-a319984"
       app-s3-assets-domain-name: "isomer-user-content.by.gov.sg"
+      app-growthbook-client-key: "sdk-r07MHTLLgfdVDThi"
+      app-intercom-app-id: "jv2tjc3g"
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -39,6 +39,8 @@ jobs:
       app-s3-region: "ap-southeast-1"
       app-s3-assets-bucket-name: "isomer-next-infra-stg-assets-private-61710b8"
       app-s3-assets-domain-name: "isomer-user-content-stg.by.gov.sg"
+      app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
+      app-intercom-app-id: "jv2tjc3g"
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_vapt.yml
+++ b/.github/workflows/deploy_vapt.yml
@@ -39,6 +39,8 @@ jobs:
       app-s3-region: "ap-southeast-1"
       app-s3-assets-bucket-name: "isomer-next-infra-vapt-assets-private-ab628e1"
       app-s3-assets-domain-name: "isomer-user-content-vapt.by.gov.sg"
+      app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
+      app-intercom-app-id: "jv2tjc3g"
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Growthbook client ID is currently using the `production` environment, regardless of the actual deployment environment.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Make the Growthbook client ID be an input for the AWS deploy workflow, so that each environment can define their own client IDs.
    - Note: Both staging and vapt are using the staging client, hence they are the same.
- Also made Intercom take inputs the same way as standardisation.