### PR TITLE
Intercom - Add user info

### DIFF
--- a/apps/studio/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/apps/studio/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -7,7 +7,7 @@ import { SIGN_IN } from "~/lib/routes"
 import { callbackUrlSchema } from "~/schemas/url"
 import { appendWithRedirect } from "~/utils/url"
 import { FullscreenSpinner } from "../FullscreenSpinner"
-import { initIntercom } from "../Intercom"
+import { Intercom } from "../Intercom"
 
 interface EnforceLoginStatePageWrapperProps {
   /**
@@ -47,8 +47,12 @@ export const EnforceLoginStatePageWrapper = ({
   const { hasLoginStateFlag } = useLoginState()
 
   if (hasLoginStateFlag) {
-    initIntercom()
-    return <>{children}</>
+    return (
+      <>
+        <Intercom />
+        {children}
+      </>
+    )
   }
 
   return <Redirect redirectTo={redirectTo} />

--- a/apps/studio/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
+++ b/apps/studio/src/components/AuthWrappers/EnforceLoginStatePageWrapper.tsx
@@ -1,14 +1,13 @@
 import type { PropsWithChildren } from "react"
 import { useMemo } from "react"
 import { useRouter } from "next/router"
-import Intercom from "@intercom/messenger-js-sdk"
 
-import { env } from "~/env.mjs"
 import { useLoginState } from "~/features/auth"
 import { SIGN_IN } from "~/lib/routes"
 import { callbackUrlSchema } from "~/schemas/url"
 import { appendWithRedirect } from "~/utils/url"
 import { FullscreenSpinner } from "../FullscreenSpinner"
+import { initIntercom } from "../Intercom"
 
 interface EnforceLoginStatePageWrapperProps {
   /**
@@ -48,13 +47,7 @@ export const EnforceLoginStatePageWrapper = ({
   const { hasLoginStateFlag } = useLoginState()
 
   if (hasLoginStateFlag) {
-    // Initialize Intercom
-    if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-      Intercom({
-        app_id: env.NEXT_PUBLIC_INTERCOM_APP_ID,
-      })
-    }
-
+    initIntercom()
     return <>{children}</>
   }
 

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -1,0 +1,12 @@
+import Intercom from "@intercom/messenger-js-sdk"
+
+import { env } from "~/env.mjs"
+
+export const initIntercom = () => {
+  // Initialize Intercom
+  if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+    Intercom({
+      app_id: env.NEXT_PUBLIC_INTERCOM_APP_ID,
+    })
+  }
+}

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -1,12 +1,24 @@
-import Intercom from "@intercom/messenger-js-sdk"
+import { Intercom as IntercomSDK } from "@intercom/messenger-js-sdk"
 
 import { env } from "~/env.mjs"
+import { useMe } from "~/features/me/api"
 
-export const initIntercom = () => {
-  // Initialize Intercom
+const convertDateToUnixTimestamp = (date: Date): number => {
+  return Math.floor(date.getTime() / 1000)
+}
+
+export const Intercom = () => {
+  const { me } = useMe()
+
   if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-    Intercom({
+    IntercomSDK({
       app_id: env.NEXT_PUBLIC_INTERCOM_APP_ID,
+      user_id: me.id,
+      name: me.name,
+      email: me.email,
+      created_at: convertDateToUnixTimestamp(me.createdAt),
     })
   }
+
+  return <></>
 }

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react"
 import { Intercom as IntercomSDK } from "@intercom/messenger-js-sdk"
 
 import { env } from "~/env.mjs"
@@ -10,11 +11,15 @@ const convertDateToUnixTimestamp = (date: Date): number => {
 export const Intercom = () => {
   const { me } = useMe()
 
+  const getIntercomName = useCallback(() => {
+    return me.preferredName || me.name || me.email.split("@")[0]
+  }, [me])
+
   if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
     IntercomSDK({
       app_id: env.NEXT_PUBLIC_INTERCOM_APP_ID,
       user_id: me.id,
-      name: me.name,
+      name: getIntercomName(),
       email: me.email,
       created_at: convertDateToUnixTimestamp(me.createdAt),
     })

--- a/apps/studio/src/server/modules/me/me.select.ts
+++ b/apps/studio/src/server/modules/me/me.select.ts
@@ -9,4 +9,5 @@ export const defaultMeSelect = Prisma.validator<Prisma.UserSelect>()({
   id: true,
   email: true,
   name: true,
+  createdAt: true,
 })

--- a/apps/studio/src/server/modules/me/me.select.ts
+++ b/apps/studio/src/server/modules/me/me.select.ts
@@ -9,5 +9,6 @@ export const defaultMeSelect = Prisma.validator<Prisma.UserSelect>()({
   id: true,
   email: true,
   name: true,
+  preferredName: true,
   createdAt: true,
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently intercom is implemented but does not take in user's information. However Intercom stores information in browser cookie (might be wiped out), thus conversations not preserved across devices and sessions

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- pass in information into IntercomSDK after retrieving from `getMe()`
- extract into a standalone component to abstract away logics
