### PR TITLE
fix: set hero subtitle as meta description of homepage

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -38,6 +38,13 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
     props.layout === "collection"
   ) {
     metadata.description = props.page.subtitle
+  } else if (
+    metadata.description === undefined &&
+    props.layout === "homepage"
+  ) {
+    metadata.description = props.content.find(
+      (item) => item.type === "hero",
+    )?.subtitle
   }
 
   if (props.page.permalink === "/") {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are not pulling the meta description of the homepage from the hero banner subtitle.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Pull the meta description from the hero banner subtitle, which we guarantee to exist on homepages.