### PR TITLE
isom-1675 - add GTM components

### DIFF
--- a/packages/components/src/interfaces/internal/GoogleTagManager.ts
+++ b/packages/components/src/interfaces/internal/GoogleTagManager.ts
@@ -1,8 +1,17 @@
 import type { ScriptComponentType } from "~/types"
 
+export interface GoogleTagManagerHeaderScriptProps {
+  gtmId: string
+  ScriptComponent?: ScriptComponentType
+}
+
 export interface GoogleTagManagerHeaderProps {
   siteGtmId: string | undefined
   ScriptComponent?: ScriptComponentType
+}
+
+export interface GoogleTagManagerBodyScriptProps {
+  gtmId: string
 }
 
 export interface GoogleTagManagerBodyProps {

--- a/packages/components/src/interfaces/internal/GoogleTagManager.ts
+++ b/packages/components/src/interfaces/internal/GoogleTagManager.ts
@@ -1,0 +1,10 @@
+import type { ScriptComponentType } from "~/types"
+
+export interface GoogleTagManagerHeaderProps {
+  siteGtmId: string | undefined
+  ScriptComponent?: ScriptComponentType
+}
+
+export interface GoogleTagManagerBodyProps {
+  siteGtmId: string | undefined
+}

--- a/packages/components/src/interfaces/internal/GoogleTagManager.ts
+++ b/packages/components/src/interfaces/internal/GoogleTagManager.ts
@@ -6,8 +6,8 @@ export interface GoogleTagManagerHeaderScriptProps {
 }
 
 export interface GoogleTagManagerHeaderProps {
-  siteGtmId: string | undefined
-  isomerGtmId: string | undefined
+  siteGtmId?: string
+  isomerGtmId?: string
   ScriptComponent?: ScriptComponentType
 }
 

--- a/packages/components/src/interfaces/internal/GoogleTagManager.ts
+++ b/packages/components/src/interfaces/internal/GoogleTagManager.ts
@@ -1,21 +1,23 @@
 import type { ScriptComponentType } from "~/types"
 
-export interface GoogleTagManagerHeaderScriptProps {
-  gtmId: string
-  ScriptComponent?: ScriptComponentType
-}
-
-export interface GoogleTagManagerHeaderProps {
-  siteGtmId?: string
-  isomerGtmId?: string
-  ScriptComponent?: ScriptComponentType
-}
-
-export interface GoogleTagManagerBodyScriptProps {
+interface GoogleTagManagerScriptProps {
   gtmId: string
 }
 
-export interface GoogleTagManagerBodyProps {
-  siteGtmId: string | undefined
-  isomerGtmId: string | undefined
+export interface GoogleTagManagerHeaderScriptProps
+  extends GoogleTagManagerScriptProps {
+  ScriptComponent?: ScriptComponentType
 }
+
+export type GoogleTagManagerBodyScriptProps = GoogleTagManagerScriptProps
+
+interface GoogleTagManagerProps {
+  siteGtmId?: GoogleTagManagerScriptProps["gtmId"]
+  isomerGtmId?: GoogleTagManagerScriptProps["gtmId"]
+}
+
+export interface GoogleTagManagerHeaderProps extends GoogleTagManagerProps {
+  ScriptComponent?: ScriptComponentType
+}
+
+export type GoogleTagManagerBodyProps = GoogleTagManagerProps

--- a/packages/components/src/interfaces/internal/GoogleTagManager.ts
+++ b/packages/components/src/interfaces/internal/GoogleTagManager.ts
@@ -7,6 +7,7 @@ export interface GoogleTagManagerHeaderScriptProps {
 
 export interface GoogleTagManagerHeaderProps {
   siteGtmId: string | undefined
+  isomerGtmId: string | undefined
   ScriptComponent?: ScriptComponentType
 }
 
@@ -16,4 +17,5 @@ export interface GoogleTagManagerBodyScriptProps {
 
 export interface GoogleTagManagerBodyProps {
   siteGtmId: string | undefined
+  isomerGtmId: string | undefined
 }

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -35,6 +35,8 @@ export type { SkipToContentProps } from "./SkipToContent"
 export type { TableOfContentsProps } from "./TableOfContents"
 export type { WogaaProps } from "./Wogaa"
 export type {
+  GoogleTagManagerHeaderScriptProps,
   GoogleTagManagerHeaderProps,
+  GoogleTagManagerBodyScriptProps,
   GoogleTagManagerBodyProps,
 } from "./GoogleTagManager"

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -34,3 +34,7 @@ export type { SiderailProps } from "./Siderail"
 export type { SkipToContentProps } from "./SkipToContent"
 export type { TableOfContentsProps } from "./TableOfContents"
 export type { WogaaProps } from "./Wogaa"
+export type {
+  GoogleTagManagerHeaderProps,
+  GoogleTagManagerBodyProps,
+} from "./GoogleTagManager"

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
@@ -2,7 +2,6 @@ import type {
   GoogleTagManagerBodyProps,
   GoogleTagManagerBodyScriptProps,
 } from "~/interfaces"
-import { getIsomerGoogleTagManagerId } from "./utils"
 
 // Needed in the event that the user has disabled scripts
 const GoogleTagManagerBodyScript = ({
@@ -22,8 +21,8 @@ const GoogleTagManagerBodyScript = ({
 
 export const GoogleTagManagerBody = ({
   siteGtmId,
+  isomerGtmId,
 }: GoogleTagManagerBodyProps) => {
-  const isomerGtmId: string | undefined = getIsomerGoogleTagManagerId()
   return (
     <>
       {siteGtmId && <GoogleTagManagerBodyScript gtmId={siteGtmId} />}

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
@@ -1,11 +1,13 @@
-import type { GoogleTagManagerBodyProps } from "~/interfaces"
-import {
-  getIsomerGoogleTagManagerId,
-  shouldNotIncludeGoogleTagManager,
-} from "./utils"
+import type {
+  GoogleTagManagerBodyProps,
+  GoogleTagManagerBodyScriptProps,
+} from "~/interfaces"
+import { getIsomerGoogleTagManagerId } from "./utils"
 
 // Needed in the event that the user has disabled scripts
-const GoogleTagManagerBodyScript = ({ gtmId }: { gtmId: string }) => {
+const GoogleTagManagerBodyScript = ({
+  gtmId,
+}: GoogleTagManagerBodyScriptProps) => {
   return (
     <noscript>
       <iframe
@@ -21,8 +23,6 @@ const GoogleTagManagerBodyScript = ({ gtmId }: { gtmId: string }) => {
 export const GoogleTagManagerBody = ({
   siteGtmId,
 }: GoogleTagManagerBodyProps) => {
-  if (shouldNotIncludeGoogleTagManager()) return <></>
-
   const isomerGtmId: string | undefined = getIsomerGoogleTagManagerId()
   return (
     <>

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
@@ -1,0 +1,33 @@
+import type { GoogleTagManagerBodyProps } from "~/interfaces"
+import {
+  getIsomerGoogleTagManagerId,
+  shouldNotIncludeGoogleTagManager,
+} from "./utils"
+
+// Needed in the event that the user has disabled scripts
+const GoogleTagManagerBodyScript = ({ gtmId }: { gtmId: string }) => {
+  return (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+        height="0"
+        width="0"
+        style={{ display: "none", visibility: "hidden" }}
+      ></iframe>
+    </noscript>
+  )
+}
+
+export const GoogleTagManagerBody = ({
+  siteGtmId,
+}: GoogleTagManagerBodyProps) => {
+  if (shouldNotIncludeGoogleTagManager()) return <></>
+
+  const isomerGtmId: string | undefined = getIsomerGoogleTagManagerId()
+  return (
+    <>
+      {siteGtmId && <GoogleTagManagerBodyScript gtmId={siteGtmId} />}
+      {isomerGtmId && <GoogleTagManagerBodyScript gtmId={isomerGtmId} />}
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerBody.tsx
@@ -25,8 +25,8 @@ export const GoogleTagManagerBody = ({
 }: GoogleTagManagerBodyProps) => {
   return (
     <>
-      {siteGtmId && <GoogleTagManagerBodyScript gtmId={siteGtmId} />}
-      {isomerGtmId && <GoogleTagManagerBodyScript gtmId={isomerGtmId} />}
+      {!!siteGtmId && <GoogleTagManagerBodyScript gtmId={siteGtmId} />}
+      {!!isomerGtmId && <GoogleTagManagerBodyScript gtmId={isomerGtmId} />}
     </>
   )
 }

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -2,7 +2,6 @@ import type {
   GoogleTagManagerHeaderProps,
   GoogleTagManagerHeaderScriptProps,
 } from "~/interfaces"
-import { getIsomerGoogleTagManagerId } from "./utils"
 
 const GoogleTagManagerHeaderScript = ({
   gtmId,
@@ -24,9 +23,9 @@ const GoogleTagManagerHeaderScript = ({
 
 export const GoogleTagManagerHeader = ({
   siteGtmId,
+  isomerGtmId,
   ScriptComponent,
 }: GoogleTagManagerHeaderProps) => {
-  const isomerGtmId: string | undefined = getIsomerGoogleTagManagerId()
   return (
     <>
       {siteGtmId && (

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -1,17 +1,13 @@
-import type { GoogleTagManagerHeaderProps } from "~/interfaces"
-import type { ScriptComponentType } from "~/types"
-import {
-  getIsomerGoogleTagManagerId,
-  shouldNotIncludeGoogleTagManager,
-} from "./utils"
+import type {
+  GoogleTagManagerHeaderProps,
+  GoogleTagManagerHeaderScriptProps,
+} from "~/interfaces"
+import { getIsomerGoogleTagManagerId } from "./utils"
 
 const GoogleTagManagerHeaderScript = ({
   gtmId,
   ScriptComponent,
-}: {
-  gtmId: string
-  ScriptComponent: ScriptComponentType
-}) => {
+}: GoogleTagManagerHeaderScriptProps) => {
   return (
     <ScriptComponent
       id={`_next-gtm-init-${gtmId}`}
@@ -30,8 +26,6 @@ export const GoogleTagManagerHeader = ({
   siteGtmId,
   ScriptComponent,
 }: GoogleTagManagerHeaderProps) => {
-  if (shouldNotIncludeGoogleTagManager()) return <></>
-
   const isomerGtmId: string | undefined = getIsomerGoogleTagManagerId()
   return (
     <>

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -28,13 +28,13 @@ export const GoogleTagManagerHeader = ({
 }: GoogleTagManagerHeaderProps) => {
   return (
     <>
-      {siteGtmId && (
+      {!!siteGtmId && (
         <GoogleTagManagerHeaderScript
           gtmId={siteGtmId}
           ScriptComponent={ScriptComponent}
         />
       )}
-      {isomerGtmId && (
+      {!!isomerGtmId && (
         <GoogleTagManagerHeaderScript
           gtmId={isomerGtmId}
           ScriptComponent={ScriptComponent}

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -1,0 +1,52 @@
+import type { GoogleTagManagerHeaderProps } from "~/interfaces"
+import type { ScriptComponentType } from "~/types"
+import {
+  getIsomerGoogleTagManagerId,
+  shouldNotIncludeGoogleTagManager,
+} from "./utils"
+
+const GoogleTagManagerHeaderScript = ({
+  gtmId,
+  ScriptComponent,
+}: {
+  gtmId: string
+  ScriptComponent: ScriptComponentType
+}) => {
+  return (
+    <ScriptComponent
+      id={`_next-gtm-init-${gtmId}`}
+      dangerouslySetInnerHTML={{
+        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+					new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+					j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+					'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','${gtmId}');`,
+      }}
+    />
+  )
+}
+
+export const GoogleTagManagerHeader = ({
+  siteGtmId,
+  ScriptComponent,
+}: GoogleTagManagerHeaderProps) => {
+  if (shouldNotIncludeGoogleTagManager()) return <></>
+
+  const isomerGtmId: string | undefined = getIsomerGoogleTagManagerId()
+  return (
+    <>
+      {siteGtmId && (
+        <GoogleTagManagerHeaderScript
+          gtmId={siteGtmId}
+          ScriptComponent={ScriptComponent}
+        />
+      )}
+      {isomerGtmId && (
+        <GoogleTagManagerHeaderScript
+          gtmId={isomerGtmId}
+          ScriptComponent={ScriptComponent}
+        />
+      )}
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/index.ts
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/index.ts
@@ -1,0 +1,2 @@
+export { GoogleTagManagerHeader } from "./GoogleTagManagerHeader"
+export { GoogleTagManagerBody } from "./GoogleTagManagerBody"

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
@@ -1,10 +1,3 @@
-export const shouldNotIncludeGoogleTagManager = (): boolean => {
-  if (typeof process === "undefined") return true
-  if (process.env.NODE_ENV !== "production") return true
-  return false
-}
-
 export const getIsomerGoogleTagManagerId = (): string | undefined => {
-  if (shouldNotIncludeGoogleTagManager()) return undefined
   return process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID
 }

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
@@ -1,3 +1,4 @@
+// TODO: Update this once we get our GTM ID
 export const getIsomerGoogleTagManagerId = (): string | undefined => {
-  return process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID
+  return undefined
 }

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
@@ -1,0 +1,10 @@
+export const shouldNotIncludeGoogleTagManager = (): boolean => {
+  if (typeof process === "undefined") return true
+  if (process.env.NODE_ENV !== "production") return true
+  return false
+}
+
+export const getIsomerGoogleTagManagerId = (): string | undefined => {
+  if (shouldNotIncludeGoogleTagManager()) return undefined
+  return process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID
+}

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/utils.ts
@@ -1,4 +1,0 @@
-// TODO: Update this once we get our GTM ID
-export const getIsomerGoogleTagManagerId = (): string | undefined => {
-  return undefined
-}

--- a/packages/components/src/templates/next/components/internal/index.ts
+++ b/packages/components/src/templates/next/components/internal/index.ts
@@ -23,3 +23,7 @@ export { default as TableOfContents } from "./TableOfContents"
 export { default as UnsupportedBrowserBanner } from "./UnsupportedBrowserBanner"
 export { Wogaa } from "./Wogaa"
 export { BackToTopLink } from "./BackToTopLink"
+export {
+  GoogleTagManagerHeader,
+  GoogleTagManagerBody,
+} from "./GoogleTagManager"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -33,6 +33,7 @@ export const Skeleton = ({
       {shouldIncludeGTM && (
         <GoogleTagManagerHeader
           siteGtmId={site.siteGtmId}
+          isomerGtmId={site.isomerGtmId}
           ScriptComponent={ScriptComponent}
         />
       )}
@@ -86,7 +87,12 @@ export const Skeleton = ({
       />
 
       {/* needs to be the last element in the body */}
-      {shouldIncludeGTM && <GoogleTagManagerBody siteGtmId={site.siteGtmId} />}
+      {shouldIncludeGTM && (
+        <GoogleTagManagerBody
+          siteGtmId={site.siteGtmId}
+          isomerGtmId={site.isomerGtmId}
+        />
+      )}
     </>
   )
 }

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -32,7 +32,7 @@ export const Skeleton = ({
     <>
       {shouldIncludeGTM && (
         <GoogleTagManagerHeader
-          siteGtmId={site.gtmId}
+          siteGtmId={site.siteGtmId}
           ScriptComponent={ScriptComponent}
         />
       )}
@@ -86,7 +86,7 @@ export const Skeleton = ({
       />
 
       {/* needs to be the last element in the body */}
-      {shouldIncludeGTM && <GoogleTagManagerBody siteGtmId={site.gtmId} />}
+      {shouldIncludeGTM && <GoogleTagManagerBody siteGtmId={site.siteGtmId} />}
     </>
   )
 }

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -26,13 +26,16 @@ export const Skeleton = ({
   >
 >) => {
   const isStaging = site.environment === "staging"
+  const shouldIncludeGTM = site.environment === "production"
 
   return (
     <>
-      <GoogleTagManagerHeader
-        siteGtmId={site.gtmId}
-        ScriptComponent={ScriptComponent}
-      />
+      {shouldIncludeGTM && (
+        <GoogleTagManagerHeader
+          siteGtmId={site.gtmId}
+          ScriptComponent={ScriptComponent}
+        />
+      )}
 
       {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
 
@@ -83,7 +86,7 @@ export const Skeleton = ({
       />
 
       {/* needs to be the last element in the body */}
-      <GoogleTagManagerBody siteGtmId={site.gtmId} />
+      {shouldIncludeGTM && <GoogleTagManagerBody siteGtmId={site.gtmId} />}
     </>
   )
 }

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -2,6 +2,8 @@ import type { IsomerPageSchemaType } from "~/engine"
 import {
   DatadogRum,
   Footer,
+  GoogleTagManagerBody,
+  GoogleTagManagerHeader,
   Masthead,
   Navbar,
   Notification,
@@ -27,6 +29,11 @@ export const Skeleton = ({
 
   return (
     <>
+      <GoogleTagManagerHeader
+        siteGtmId={site.gtmId}
+        ScriptComponent={ScriptComponent}
+      />
+
       {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
 
       {!isStaging && <DatadogRum />}
@@ -74,6 +81,9 @@ export const Skeleton = ({
         LinkComponent={LinkComponent}
         {...site.footerItems}
       />
+
+      {/* needs to be the last element in the body */}
+      <GoogleTagManagerBody siteGtmId={site.gtmId} />
     </>
   )
 }

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -26,7 +26,10 @@ export const Skeleton = ({
   >
 >) => {
   const isStaging = site.environment === "staging"
-  const shouldIncludeGTM = site.environment === "production"
+
+  const shouldIncludeGTM =
+    site.environment === "production" &&
+    (!!site.siteGtmId || !!site.isomerGtmId)
 
   return (
     <>

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -7,6 +7,7 @@ export interface IsomerGeneratedSiteProps {
   environment?: string
   lastUpdated: string
   assetsBaseUrl?: string
+  isomerGtmId?: string
 }
 
 export interface IsomerSiteWideComponentsProps {

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -24,6 +24,7 @@ export interface IsomerSiteConfigProps {
   favicon?: string
   search: NavbarProps["search"]
   notification?: Omit<NotificationProps, "LinkComponent" | "site">
+  gtmId?: string
 }
 
 export type IsomerSiteProps = IsomerGeneratedSiteProps &

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -24,7 +24,7 @@ export interface IsomerSiteConfigProps {
   favicon?: string
   search: NavbarProps["search"]
   notification?: Omit<NotificationProps, "LinkComponent" | "site">
-  gtmId?: string
+  siteGtmId?: string
 }
 
 export type IsomerSiteProps = IsomerGeneratedSiteProps &

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -112,6 +112,7 @@ const Page = async ({ params }: DynamicPageProps) => {
         footerItems: footer,
         lastUpdated,
         assetsBaseUrl: process.env.NEXT_PUBLIC_ASSETS_BASE_URL,
+        isomerGtmId: process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID,
       }}
       LinkComponent={Link}
       ScriptComponent={Script}

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -65,6 +65,7 @@ const NotFound = () => {
           // @ts-ignore to fix when types are proper
           footerItems: footer,
           assetsBaseUrl: process.env.NEXT_PUBLIC_ASSETS_BASE_URL,
+          isomerGtmId: process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID,
         }}
         layout="notfound"
         meta={{


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1675/implement-google-analytics-for-all-sites-on-next

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

Read through google documentation and it seems like one can add their GA into their GTM and use that too. Given that agencies might want to add other form of tracking e.g. social media pixel, supporting GTM is a more generic approach with better overall support. 

With strong reference to `https://developers.google.com/tag-platform/tag-manager/datalayer`

- Added `GoogleTagManagerHeader` - this is the main one that should run
- Added `GoogleTagManagerBody` - this is the backup in case user has disabled JS
- As per documentation above, `Only one dataLayer object is supported per page`. This means tracking are shared between both agency' GTM and isomer's GTM - generally not an issue in our use case.

How to use
- Agency's GTM id can be added via their site config `siteGtmId`
- I'm assuming we (Isomer) want to use a generic GTM across all domains, thus we set that in `NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID` - this will be passed in during codebuild (https://github.com/opengovsg/isomer-next-infra/pull/34)

Note:
- If agency wants to use GA, we should encourage them to use it via GTM.
- Current implementation assumes agencies can't define custom events to track - and likely not something we want to support anytime soon