### PR TITLE
feat: remove href attribute in image component

### DIFF
--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -1,8 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerSiteProps, LinkComponentType } from "~/types"
-import { LINK_HREF_PATTERN } from "~/utils/validation"
+import type { IsomerSiteProps } from "~/types"
 
 export const ImageSchema = Type.Object(
   {
@@ -40,14 +39,6 @@ export const ImageSchema = Type.Object(
         },
       ),
     ),
-    href: Type.Optional(
-      Type.String({
-        title: "URL Link",
-        description: "The URL to navigate to when the image is clicked",
-        format: "link",
-        pattern: LINK_HREF_PATTERN,
-      }),
-    ),
   },
   {
     title: "Image component",
@@ -56,5 +47,4 @@ export const ImageSchema = Type.Object(
 
 export type ImageProps = Static<typeof ImageSchema> & {
   site: IsomerSiteProps
-  LinkComponent?: LinkComponentType
 }

--- a/packages/components/src/templates/next/components/complex/Image/Image.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.stories.tsx
@@ -61,30 +61,6 @@ export const Smaller: Story = {
   },
 }
 
-export const ImageWithExternalLink: Story = {
-  args: {
-    src: "https://placehold.co/200x200",
-    alt: "alt",
-    href: "https://www.google.com",
-  },
-}
-
-export const ImageWithIllegalLink: Story = {
-  args: {
-    src: "https://placehold.co/200x200",
-    alt: "alt",
-    href: "javascript:alert()",
-  },
-}
-
-export const ImageWithInternalLink: Story = {
-  args: {
-    src: "https://placehold.co/200x200",
-    alt: "alt",
-    href: "[resource:1:1]",
-  },
-}
-
 export const InvalidImage: Story = {
   args: {
     src: "/invalid-image",

--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -1,9 +1,6 @@
-import type { PropsWithChildren } from "react"
-
 import type { ImageProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
-import { getReferenceLinkHref, isExternalUrl } from "~/utils"
-import { Link } from "../../internal/Link"
+import { isExternalUrl } from "~/utils"
 import { ImageClient } from "./ImageClient"
 
 const createImageStyles = tv({
@@ -37,45 +34,14 @@ const getSizeWidth = (size: ImageProps["size"]) => {
   }
 }
 
-const ImageContainer = ({
-  href,
-  LinkComponent,
-  children,
-}: PropsWithChildren<Pick<ImageProps, "href" | "LinkComponent">>) => (
-  <div className={compoundStyles.container()}>
-    {href !== undefined ? (
-      <Link
-        href={href}
-        isExternal={isExternalUrl(href)}
-        LinkComponent={LinkComponent}
-      >
-        {children}
-      </Link>
-    ) : (
-      <>{children}</>
-    )}
-  </div>
-)
-
-export const Image = ({
-  src,
-  alt,
-  caption,
-  size,
-  href,
-  site,
-  LinkComponent,
-}: ImageProps) => {
+export const Image = ({ src, alt, caption, size, site }: ImageProps) => {
   const imgSrc =
     isExternalUrl(src) || site.assetsBaseUrl === undefined
       ? src
       : `${site.assetsBaseUrl}${src}`
 
   return (
-    <ImageContainer
-      href={getReferenceLinkHref(href, site.siteMap, site.assetsBaseUrl)}
-      LinkComponent={LinkComponent}
-    >
+    <div className={compoundStyles.container()}>
       <ImageClient
         src={imgSrc}
         alt={alt}
@@ -85,6 +51,6 @@ export const Image = ({
       />
 
       {caption && <p className={compoundStyles.caption()}>{caption}</p>}
-    </ImageContainer>
+    </div>
   )
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The image component is not supposed to have a `href` attribute, as it is not obvious that it is a link.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
    - [ ] NOTE: We have a couple of pages that have a `href` attribute defined that links to another page, so these pages will be affected (see below).

**Features**:

- Removed the `href` attribute from the image component.

## Affected pages
```
Checking repository: ipos-corp-next
Schema patterns found in /schema/about-ip/patents/how-to-register/national-security-clearance.json
Schema patterns found in /schema/about-ip/trade-marks/how-to-register/how-to-register.json
Schema patterns found in /schema/about-ip/trade-marks/how-to-register/trade-marks-step-2.json
Schema patterns found in /schema/about-ip/patents/managing-patents/resolve-disputes/revoking-a-granted-patent.json

Checking repository: ncss-corp-next
Schema patterns found in /schema/campaigns-and-events/Beyond-the-Label.json
Schema patterns found in /schema/information-hub/sustainable-philanthropy/sustainable-philanthropy-framework.json
Schema patterns found in /schema/about-us/hear-from-our-community/sector-professionals/Tribe-SSA-stories/viriya-community-services.json

Checking repository: muis-corp-next
Schema patterns found in /schema/education/alive-and-adil/adil/academic-year.json
Schema patterns found in /schema/education/alive-and-adil/adil/resources-and-downloads.json
Schema patterns found in /schema/education/alive-and-adil/alive/alive-registration.json
Schema patterns found in /schema/education/madrasahs/about/supporting-our-madrasahs.json
Schema patterns found in /schema/way-of-life/haj/haj-registration/my-haj-sg.json
Schema patterns found in /schema/education/asatizah/asatizah-recognition-scheme-office/continuing-professional-education-cpe/continuing-professional-education--cpe.json

Connected to the database
Schema patterns found in blob 43
Schema patterns found in blob 23079
Schema patterns found in blob 10525
Schema patterns found in blob 23390
Schema patterns found in blob 10636
Schema patterns found in blob 10686
Schema patterns found in blob 21670
Schema patterns found in blob 23388
Schema patterns found in blob 23185
Schema patterns found in blob 21781
Schema patterns found in blob 21831
Schema patterns found in blob 22705
Schema patterns found in blob 22942
Schema patterns found in blob 23494
Schema patterns found in blob 22751
Schema patterns found in blob 22752
Schema patterns found in blob 22968
Schema patterns found in blob 23008
Schema patterns found in blob 23012
```