### PR TITLE
intercom drop preferredname

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,22 +1,22 @@
 export const ResourceState = {
-    Draft: "Draft",
-    Published: "Published"
-} as const;
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
+  Draft: "Draft",
+  Published: "Published",
+} as const
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
 export const ResourceType = {
-    RootPage: "RootPage",
-    Page: "Page",
-    Folder: "Folder",
-    Collection: "Collection",
-    CollectionLink: "CollectionLink",
-    CollectionPage: "CollectionPage",
-    IndexPage: "IndexPage",
-    FolderMeta: "FolderMeta"
-} as const;
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
+  RootPage: "RootPage",
+  Page: "Page",
+  Folder: "Folder",
+  Collection: "Collection",
+  CollectionLink: "CollectionLink",
+  CollectionPage: "CollectionPage",
+  IndexPage: "IndexPage",
+  FolderMeta: "FolderMeta",
+} as const
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
 export const RoleType = {
-    Admin: "Admin",
-    Editor: "Editor",
-    Publisher: "Publisher"
-} as const;
-export type RoleType = (typeof RoleType)[keyof typeof RoleType];
+  Admin: "Admin",
+  Editor: "Editor",
+  Publisher: "Publisher",
+} as const
+export type RoleType = (typeof RoleType)[keyof typeof RoleType]

--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,22 +1,22 @@
 export const ResourceState = {
-  Draft: "Draft",
-  Published: "Published",
-} as const
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
+    Draft: "Draft",
+    Published: "Published"
+} as const;
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
 export const ResourceType = {
-  RootPage: "RootPage",
-  Page: "Page",
-  Folder: "Folder",
-  Collection: "Collection",
-  CollectionLink: "CollectionLink",
-  CollectionPage: "CollectionPage",
-  IndexPage: "IndexPage",
-  FolderMeta: "FolderMeta",
-} as const
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
+    RootPage: "RootPage",
+    Page: "Page",
+    Folder: "Folder",
+    Collection: "Collection",
+    CollectionLink: "CollectionLink",
+    CollectionPage: "CollectionPage",
+    IndexPage: "IndexPage",
+    FolderMeta: "FolderMeta"
+} as const;
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
 export const RoleType = {
-  Admin: "Admin",
-  Editor: "Editor",
-  Publisher: "Publisher",
-} as const
-export type RoleType = (typeof RoleType)[keyof typeof RoleType]
+    Admin: "Admin",
+    Editor: "Editor",
+    Publisher: "Publisher"
+} as const;
+export type RoleType = (typeof RoleType)[keyof typeof RoleType];

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,137 +1,134 @@
-import type { ColumnType, GeneratedAlways } from "kysely"
+import type { ColumnType, GeneratedAlways } from "kysely";
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
 
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
-
-export interface Blob {
-  id: GeneratedAlways<string>
-  /**
-   * @kyselyType(PrismaJson.BlobJsonContent)
-   * [BlobJsonContent]
-   */
-  content: PrismaJson.BlobJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Footer {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.FooterJsonContent)
-   * [FooterJsonContent]
-   */
-  content: PrismaJson.FooterJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Navbar {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.NavbarJsonContent)
-   * [NavbarJsonContent]
-   */
-  content: PrismaJson.NavbarJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface RateLimiterFlexible {
-  key: string
-  points: number
-  expire: Timestamp | null
-}
-export interface Resource {
-  id: GeneratedAlways<string>
-  title: string
-  permalink: string
-  siteId: number
-  parentId: string | null
-  publishedVersionId: string | null
-  draftBlobId: string | null
-  state: Generated<ResourceState | null>
-  type: ResourceType
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface ResourcePermission {
-  id: GeneratedAlways<string>
-  userId: string
-  siteId: number
-  resourceId: string | null
-  role: RoleType
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Site {
-  id: GeneratedAlways<number>
-  name: string
-  /**
-   * @kyselyType(PrismaJson.SiteJsonConfig)
-   * [SiteJsonConfig]
-   */
-  config: PrismaJson.SiteJsonConfig
-  /**
-   * @kyselyType(PrismaJson.SiteThemeJson)
-   * [SiteThemeJson]
-   */
-  theme: PrismaJson.SiteThemeJson | null
-  codeBuildId: string | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface SiteMember {
-  userId: string
-  siteId: number
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface User {
-  id: string
-  name: string
-  email: string
-  phone: string
-  preferredName: string | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface VerificationToken {
-  identifier: string
-  token: string
-  attempts: Generated<number>
-  expires: Timestamp
-}
-export interface Version {
-  id: GeneratedAlways<string>
-  versionNum: number
-  resourceId: string
-  blobId: string
-  publishedAt: Generated<Timestamp>
-  publishedBy: string
-  updatedAt: Generated<Timestamp>
-}
-export interface Whitelist {
-  id: GeneratedAlways<number>
-  email: string
-  expiry: Timestamp | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface DB {
-  Blob: Blob
-  Footer: Footer
-  Navbar: Navbar
-  RateLimiterFlexible: RateLimiterFlexible
-  Resource: Resource
-  ResourcePermission: ResourcePermission
-  Site: Site
-  SiteMember: SiteMember
-  User: User
-  VerificationToken: VerificationToken
-  Version: Version
-  Whitelist: Whitelist
-}
+export type Blob = {
+    id: GeneratedAlways<string>;
+    /**
+     * @kyselyType(PrismaJson.BlobJsonContent)
+     * [BlobJsonContent]
+     */
+    content: PrismaJson.BlobJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Footer = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.FooterJsonContent)
+     * [FooterJsonContent]
+     */
+    content: PrismaJson.FooterJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Navbar = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.NavbarJsonContent)
+     * [NavbarJsonContent]
+     */
+    content: PrismaJson.NavbarJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type RateLimiterFlexible = {
+    key: string;
+    points: number;
+    expire: Timestamp | null;
+};
+export type Resource = {
+    id: GeneratedAlways<string>;
+    title: string;
+    permalink: string;
+    siteId: number;
+    parentId: string | null;
+    publishedVersionId: string | null;
+    draftBlobId: string | null;
+    state: Generated<ResourceState | null>;
+    type: ResourceType;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type ResourcePermission = {
+    id: GeneratedAlways<string>;
+    userId: string;
+    siteId: number;
+    resourceId: string | null;
+    role: RoleType;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Site = {
+    id: GeneratedAlways<number>;
+    name: string;
+    /**
+     * @kyselyType(PrismaJson.SiteJsonConfig)
+     * [SiteJsonConfig]
+     */
+    config: PrismaJson.SiteJsonConfig;
+    /**
+     * @kyselyType(PrismaJson.SiteThemeJson)
+     * [SiteThemeJson]
+     */
+    theme: PrismaJson.SiteThemeJson | null;
+    codeBuildId: string | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type SiteMember = {
+    userId: string;
+    siteId: number;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type User = {
+    id: string;
+    name: string;
+    email: string;
+    phone: string;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type VerificationToken = {
+    identifier: string;
+    token: string;
+    attempts: Generated<number>;
+    expires: Timestamp;
+};
+export type Version = {
+    id: GeneratedAlways<string>;
+    versionNum: number;
+    resourceId: string;
+    blobId: string;
+    publishedAt: Generated<Timestamp>;
+    publishedBy: string;
+    updatedAt: Generated<Timestamp>;
+};
+export type Whitelist = {
+    id: GeneratedAlways<number>;
+    email: string;
+    expiry: Timestamp | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type DB = {
+    Blob: Blob;
+    Footer: Footer;
+    Navbar: Navbar;
+    RateLimiterFlexible: RateLimiterFlexible;
+    Resource: Resource;
+    ResourcePermission: ResourcePermission;
+    Site: Site;
+    SiteMember: SiteMember;
+    User: User;
+    VerificationToken: VerificationToken;
+    Version: Version;
+    Whitelist: Whitelist;
+};

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,134 +1,129 @@
-import type { ColumnType, GeneratedAlways } from "kysely";
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
-export type Timestamp = ColumnType<Date, Date | string, Date | string>;
+import type { ColumnType, GeneratedAlways } from "kysely"
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
 
-export type Blob = {
-    id: GeneratedAlways<string>;
-    /**
-     * @kyselyType(PrismaJson.BlobJsonContent)
-     * [BlobJsonContent]
-     */
-    content: PrismaJson.BlobJsonContent;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type Footer = {
-    id: GeneratedAlways<number>;
-    siteId: number;
-    /**
-     * @kyselyType(PrismaJson.FooterJsonContent)
-     * [FooterJsonContent]
-     */
-    content: PrismaJson.FooterJsonContent;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type Navbar = {
-    id: GeneratedAlways<number>;
-    siteId: number;
-    /**
-     * @kyselyType(PrismaJson.NavbarJsonContent)
-     * [NavbarJsonContent]
-     */
-    content: PrismaJson.NavbarJsonContent;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type RateLimiterFlexible = {
-    key: string;
-    points: number;
-    expire: Timestamp | null;
-};
-export type Resource = {
-    id: GeneratedAlways<string>;
-    title: string;
-    permalink: string;
-    siteId: number;
-    parentId: string | null;
-    publishedVersionId: string | null;
-    draftBlobId: string | null;
-    state: Generated<ResourceState | null>;
-    type: ResourceType;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type ResourcePermission = {
-    id: GeneratedAlways<string>;
-    userId: string;
-    siteId: number;
-    resourceId: string | null;
-    role: RoleType;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type Site = {
-    id: GeneratedAlways<number>;
-    name: string;
-    /**
-     * @kyselyType(PrismaJson.SiteJsonConfig)
-     * [SiteJsonConfig]
-     */
-    config: PrismaJson.SiteJsonConfig;
-    /**
-     * @kyselyType(PrismaJson.SiteThemeJson)
-     * [SiteThemeJson]
-     */
-    theme: PrismaJson.SiteThemeJson | null;
-    codeBuildId: string | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type SiteMember = {
-    userId: string;
-    siteId: number;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type User = {
-    id: string;
-    name: string;
-    email: string;
-    phone: string;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type VerificationToken = {
-    identifier: string;
-    token: string;
-    attempts: Generated<number>;
-    expires: Timestamp;
-};
-export type Version = {
-    id: GeneratedAlways<string>;
-    versionNum: number;
-    resourceId: string;
-    blobId: string;
-    publishedAt: Generated<Timestamp>;
-    publishedBy: string;
-    updatedAt: Generated<Timestamp>;
-};
-export type Whitelist = {
-    id: GeneratedAlways<number>;
-    email: string;
-    expiry: Timestamp | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type DB = {
-    Blob: Blob;
-    Footer: Footer;
-    Navbar: Navbar;
-    RateLimiterFlexible: RateLimiterFlexible;
-    Resource: Resource;
-    ResourcePermission: ResourcePermission;
-    Site: Site;
-    SiteMember: SiteMember;
-    User: User;
-    VerificationToken: VerificationToken;
-    Version: Version;
-    Whitelist: Whitelist;
-};
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
+
+export interface Blob {
+  id: GeneratedAlways<string>
+  /**
+   * @kyselyType(PrismaJson.BlobJsonContent)
+   * [BlobJsonContent]
+   */
+  content: PrismaJson.BlobJsonContent
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface Footer {
+  id: GeneratedAlways<number>
+  siteId: number
+  /**
+   * @kyselyType(PrismaJson.FooterJsonContent)
+   * [FooterJsonContent]
+   */
+  content: PrismaJson.FooterJsonContent
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface Navbar {
+  id: GeneratedAlways<number>
+  siteId: number
+  /**
+   * @kyselyType(PrismaJson.NavbarJsonContent)
+   * [NavbarJsonContent]
+   */
+  content: PrismaJson.NavbarJsonContent
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface RateLimiterFlexible {
+  key: string
+  points: number
+  expire: Timestamp | null
+}
+export interface Resource {
+  id: GeneratedAlways<string>
+  title: string
+  permalink: string
+  siteId: number
+  parentId: string | null
+  publishedVersionId: string | null
+  draftBlobId: string | null
+  state: Generated<ResourceState | null>
+  type: ResourceType
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface ResourcePermission {
+  id: GeneratedAlways<string>
+  userId: string
+  siteId: number
+  resourceId: string | null
+  role: RoleType
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface Site {
+  id: GeneratedAlways<number>
+  name: string
+  /**
+   * @kyselyType(PrismaJson.SiteJsonConfig)
+   * [SiteJsonConfig]
+   */
+  config: PrismaJson.SiteJsonConfig
+  /**
+   * @kyselyType(PrismaJson.SiteThemeJson)
+   * [SiteThemeJson]
+   */
+  theme: PrismaJson.SiteThemeJson | null
+  codeBuildId: string | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface User {
+  id: string
+  name: string
+  email: string
+  phone: string
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface VerificationToken {
+  identifier: string
+  token: string
+  attempts: Generated<number>
+  expires: Timestamp
+}
+export interface Version {
+  id: GeneratedAlways<string>
+  versionNum: number
+  resourceId: string
+  blobId: string
+  publishedAt: Generated<Timestamp>
+  publishedBy: string
+  updatedAt: Generated<Timestamp>
+}
+export interface Whitelist {
+  id: GeneratedAlways<number>
+  email: string
+  expiry: Timestamp | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface DB {
+  Blob: Blob
+  Footer: Footer
+  Navbar: Navbar
+  RateLimiterFlexible: RateLimiterFlexible
+  Resource: Resource
+  ResourcePermission: ResourcePermission
+  Site: Site
+  User: User
+  VerificationToken: VerificationToken
+  Version: Version
+  Whitelist: Whitelist
+}

--- a/apps/studio/prisma/generated/selectableTypes.ts
+++ b/apps/studio/prisma/generated/selectableTypes.ts
@@ -10,7 +10,6 @@ export type RateLimiterFlexible = Selectable<T.RateLimiterFlexible>
 export type Resource = Selectable<T.Resource>
 export type ResourcePermission = Selectable<T.ResourcePermission>
 export type Site = Selectable<T.Site>
-export type SiteMember = Selectable<T.SiteMember>
 export type User = Selectable<T.User>
 export type VerificationToken = Selectable<T.VerificationToken>
 export type Version = Selectable<T.Version>

--- a/apps/studio/prisma/migrations/20241126162857_drop_preferred_name_column/migration.sql
+++ b/apps/studio/prisma/migrations/20241126162857_drop_preferred_name_column/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `preferredName` on the `User` table. All the data in the column will be lost.
+
+*/
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "preferredName";

--- a/apps/studio/prisma/migrations/20241127035129_drop_site_member_table/migration.sql
+++ b/apps/studio/prisma/migrations/20241127035129_drop_site_member_table/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the `SiteMember` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "SiteMember" DROP CONSTRAINT "SiteMember_siteId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "SiteMember" DROP CONSTRAINT "SiteMember_userId_fkey";
+
+-- DropTable
+DROP TABLE "SiteMember";

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -119,7 +119,6 @@ model User {
   updatedAt DateTime @default(now()) @updatedAt
 
   ResourcePermission ResourcePermission[]
-  siteMembers SiteMember[]
   versions    Version[]
 }
 
@@ -127,7 +126,6 @@ model Site {
   id          Int          @id @default(autoincrement())
   name        String       @unique
   resources   Resource[]
-  siteMembers SiteMember[]
   // NOTE: This is `theme/isGovernment/sitemap`
   // This is currently put as `Json` for ease of extensibility
   // when we lock in what we actually want for site-wide config,
@@ -171,18 +169,6 @@ model Footer {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
-}
-
-model SiteMember {
-  userId String
-  user   User   @relation(fields: [userId], references: [id])
-  siteId Int
-  site   Site   @relation(fields: [siteId], references: [id])
-
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
-
-  @@id([siteId, userId])
 }
 
 model ResourcePermission {

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -114,7 +114,6 @@ model User {
   name          String
   email         String  @unique
   phone         String
-  preferredName String?
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -12,7 +12,7 @@ export const Intercom = () => {
   const { me } = useMe()
 
   const getIntercomName = useCallback(() => {
-    return me.preferredName || me.name || me.email.split("@")[0]
+    return me.name || me.email.split("@")[0]
   }, [me])
 
   if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {

--- a/apps/studio/src/server/modules/me/me.select.ts
+++ b/apps/studio/src/server/modules/me/me.select.ts
@@ -9,6 +9,5 @@ export const defaultMeSelect = Prisma.validator<Prisma.UserSelect>()({
   id: true,
   email: true,
   name: true,
-  preferredName: true,
   createdAt: true,
 })

--- a/apps/studio/tests/integration/helpers/iron-session.ts
+++ b/apps/studio/tests/integration/helpers/iron-session.ts
@@ -101,7 +101,6 @@ export const createTestUser = () => ({
   createdAt: new Date(),
   updatedAt: new Date(),
   phone: "123456789",
-  preferredName: null,
 })
 
 // NOTE: The argument to this function was changed from

--- a/apps/studio/tests/msw/handlers/me.ts
+++ b/apps/studio/tests/msw/handlers/me.ts
@@ -8,7 +8,6 @@ export const defaultUser: User = {
   email: "test@example.com",
   name: "Test User",
   phone: "12345678",
-  preferredName: "test",
   createdAt: new Date(),
   updatedAt: new Date(),
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1685/cleanup-unused-tables-and-columns-in-database

Currently we have both `name` and `preferredName` columns in `User` table. However,
- they serve the same purpose and is overlapping
- it overcomplicates the name being used for Intercom

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- drop `preferredName` from `User` table 
- logic for intercom's name is "name" -> "email" username

FYI: have did a cleanup of the PROD database to ensure `name` column that will be used is beautified 
