### PR TITLE
chore: add max length for alt text

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -59,6 +59,7 @@ const SingleCardWithImageSchema = Type.Composite([
       title: "Alternate text",
       description:
         "Add a descriptive alternative text for this image. This helps visually impaired users to understand your image.",
+      maxLength: 120,
     }),
   }),
 ])

--- a/packages/components/src/interfaces/complex/Infopic.ts
+++ b/packages/components/src/interfaces/complex/Infopic.ts
@@ -27,6 +27,7 @@ export const InfopicSchema = Type.Object(
         title: "Alternate text",
         description:
           "Add a descriptive alternative text for this image. This helps visually impaired users to understand your image.",
+        maxLength: 120,
       }),
     ),
     buttonLabel: Type.Optional(


### PR DESCRIPTION
## Problem
previously, our image alt text had no max length. 

## Solution
1. add a max length of 120 - same as our other components and close enough to wcag recommendation of 125