### PR TITLE
feat: introduce raw JSON editor mode to replace admin mode

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ActivateRawJsonEditorMode.tsx
+++ b/apps/studio/src/features/editing-experience/components/ActivateRawJsonEditorMode.tsx
@@ -16,8 +16,8 @@ const COMBO: KeyboardEvent["key"][] = [
   "a",
 ]
 
-// Activate admin mode when a key combo is pressed
-export const ActivateAdminMode = () => {
+// Activate the raw JSON editor mode when a key combo is pressed
+export const ActivateRawJsonEditorMode = () => {
   const { setDrawerState } = useEditorDrawerContext()
 
   const [comboIndex, setComboIndex] = useState(0)
@@ -45,7 +45,7 @@ export const ActivateAdminMode = () => {
     }
 
     if (comboIndex === COMBO.length) {
-      setDrawerState({ state: "adminMode" })
+      setDrawerState({ state: "rawJsonEditor" })
     }
 
     window.addEventListener("keydown", handleKeyDown)

--- a/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/AdminModeStateDrawer.tsx
@@ -1,67 +1,177 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+import { useCallback, useMemo, useState } from "react"
 import {
   Box,
   Heading,
   HStack,
   Icon,
   Spacer,
-  Text,
+  Textarea,
   useClipboard,
+  useDisclosure,
 } from "@chakra-ui/react"
-import { Button, IconButton } from "@opengovsg/design-system-react"
+import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
+import { schema } from "@opengovsg/isomer-components"
+import isEqual from "lodash/isEqual"
 import { BiDollar, BiX } from "react-icons/bi"
 
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { ajv } from "~/utils/ajv"
+import { safeJsonParse } from "~/utils/safeJsonParse"
+import { trpc } from "~/utils/trpc"
+import { editPageSchema } from "../schema"
+import { CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE } from "./constants"
+import { DiscardChangesModal } from "./DiscardChangesModal"
+
+const validateFn = ajv.compile<IsomerSchema>(schema)
 
 export default function AdminModeStateDrawer(): JSX.Element {
-  const { savedPageState, setDrawerState } = useEditorDrawerContext()
-  const { onCopy, hasCopied } = useClipboard(
+  const {
+    isOpen: isDiscardChangesModalOpen,
+    onOpen: onDiscardChangesModalOpen,
+    onClose: onDiscardChangesModalClose,
+  } = useDisclosure()
+  const {
+    setDrawerState,
+    savedPageState,
+    setSavedPageState,
+    previewPageState,
+    setPreviewPageState,
+  } = useEditorDrawerContext()
+  const { pageId, siteId } = useQueryParse(editPageSchema)
+  const toast = useToast()
+  const [pendingChanges, setPendingChanges] = useState(
     JSON.stringify(savedPageState, null, 2),
   )
+  const { onCopy, hasCopied } = useClipboard(pendingChanges)
+
+  const utils = trpc.useUtils()
+  const { mutate, isLoading } = trpc.page.updatePageBlob.useMutation({
+    onSuccess: async () => {
+      await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+      await utils.page.readPage.invalidate({ pageId, siteId })
+      toast({
+        title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
+        ...BRIEF_TOAST_SETTINGS,
+      })
+    },
+  })
+
+  const handleSaveChanges = useCallback(() => {
+    setSavedPageState(previewPageState)
+    mutate(
+      {
+        pageId,
+        siteId,
+        content: JSON.stringify(previewPageState),
+      },
+      {
+        onSuccess: () => setDrawerState({ state: "root" }),
+      },
+    )
+  }, [
+    mutate,
+    pageId,
+    previewPageState,
+    setDrawerState,
+    setSavedPageState,
+    siteId,
+  ])
+
+  const handleChange = (data: string) => {
+    setPendingChanges(data)
+    const parsedPendingChanges = safeJsonParse(data) as unknown
+
+    if (validateFn(parsedPendingChanges)) {
+      setPreviewPageState(parsedPendingChanges)
+    }
+  }
+
+  const isPendingChangesValid = useMemo(() => {
+    return validateFn(safeJsonParse(pendingChanges))
+  }, [pendingChanges])
+
+  const handleDiscardChanges = () => {
+    setPreviewPageState(savedPageState)
+    onDiscardChangesModalClose()
+    setDrawerState({ state: "root" })
+  }
 
   return (
-    <Box h="100%" w="100%" overflow="auto">
-      <Box
-        bgColor="base.canvas.default"
-        borderBottomColor="base.divider.medium"
-        borderBottomWidth="1px"
-        px="2rem"
-        py="1.25rem"
-      >
-        <HStack justifyContent="start" w="100%">
-          <HStack spacing={3}>
-            <Icon
-              as={BiDollar}
-              fontSize="1.5rem"
-              p="0.25rem"
-              bgColor="slate.100"
-              textColor="blue.600"
-              borderRadius="base"
-            />
-            <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-              Admin Mode
-            </Heading>
-          </HStack>
-          <Spacer />
-          <Button onClick={onCopy} variant="clear">
-            {!hasCopied ? "Copy to clipboard" : "Copied!"}
-          </Button>
-          <IconButton
-            icon={<Icon as={BiX} />}
-            variant="clear"
-            colorScheme="sub"
-            size="sm"
-            p="0.625rem"
-            onClick={() => {
-              setDrawerState({ state: "root" })
-            }}
-            aria-label="Close drawer"
-          />
-        </HStack>
-      </Box>
+    <>
+      <DiscardChangesModal
+        isOpen={isDiscardChangesModalOpen}
+        onClose={onDiscardChangesModalClose}
+        onDiscard={handleDiscardChanges}
+      />
 
-      <Box px="2rem" py="1rem" maxW="33vw" overflow="auto">
-        <Text as="pre">{JSON.stringify(savedPageState, null, 2)}</Text>
+      <Box h="100%" w="100%" overflow="auto">
+        <Box
+          bgColor="base.canvas.default"
+          borderBottomColor="base.divider.medium"
+          borderBottomWidth="1px"
+          px="2rem"
+          py="1.25rem"
+        >
+          <HStack justifyContent="start" w="100%">
+            <HStack spacing={3}>
+              <Icon
+                as={BiDollar}
+                fontSize="1.5rem"
+                p="0.25rem"
+                bgColor="slate.100"
+                textColor="blue.600"
+                borderRadius="base"
+              />
+              <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+                Admin Mode
+              </Heading>
+            </HStack>
+            <Spacer />
+            <Button onClick={onCopy} variant="clear">
+              {!hasCopied ? "Copy to clipboard" : "Copied!"}
+            </Button>
+            <IconButton
+              icon={<Icon as={BiX} />}
+              variant="clear"
+              colorScheme="sub"
+              size="sm"
+              p="0.625rem"
+              onClick={() => {
+                if (!isEqual(previewPageState, savedPageState)) {
+                  onDiscardChangesModalOpen()
+                } else {
+                  handleDiscardChanges()
+                }
+              }}
+              aria-label="Close drawer"
+            />
+          </HStack>
+        </Box>
+
+        <Box px="2rem" py="1rem" maxW="33vw" overflow="auto">
+          <Textarea
+            fontFamily="monospace"
+            boxSizing="border-box"
+            minH="68vh"
+            value={pendingChanges}
+            onChange={(e) => handleChange(e.target.value)}
+          />
+        </Box>
+
+        <Box bgColor="base.canvas.default" boxShadow="md" py="1.5rem" px="2rem">
+          <Button
+            w="100%"
+            isLoading={isLoading}
+            isDisabled={!isPendingChangesValid}
+            onClick={handleSaveChanges}
+          >
+            Save changes
+          </Button>
+        </Box>
       </Box>
-    </Box>
+    </>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -5,10 +5,10 @@ import Ajv from "ajv"
 
 import ComponentSelector from "~/components/PageEditor/ComponentSelector"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import AdminModeStateDrawer from "./AdminModeStateDrawer"
 import ComplexEditorStateDrawer from "./ComplexEditorStateDrawer"
 import HeroEditorDrawer from "./HeroEditorDrawer"
 import MetadataEditorStateDrawer from "./MetadataEditorStateDrawer"
+import RawJsonEditorModeStateDrawer from "./RawJsonEditorModeStateDrawer"
 import RootStateDrawer from "./RootStateDrawer"
 import TipTapProseComponent from "./TipTapProseComponent"
 
@@ -40,8 +40,8 @@ export function EditPageDrawer(): JSX.Element {
   switch (currState.state) {
     case "root":
       return <RootStateDrawer />
-    case "adminMode":
-      return <AdminModeStateDrawer />
+    case "rawJsonEditor":
+      return <RawJsonEditorModeStateDrawer />
     case "addBlock":
       return <ComponentSelector />
     case "nativeEditor": {

--- a/apps/studio/src/features/editing-experience/components/RawJsonEditorModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RawJsonEditorModeStateDrawer.tsx
@@ -27,7 +27,7 @@ import { DiscardChangesModal } from "./DiscardChangesModal"
 
 const validateFn = ajv.compile<IsomerSchema>(schema)
 
-export default function AdminModeStateDrawer(): JSX.Element {
+export default function RawJsonEditorModeStateDrawer(): JSX.Element {
   const {
     isOpen: isDiscardChangesModalOpen,
     onOpen: onDiscardChangesModalOpen,
@@ -126,7 +126,7 @@ export default function AdminModeStateDrawer(): JSX.Element {
                 borderRadius="base"
               />
               <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
-                Admin Mode
+                Raw JSON Editor Mode
               </Heading>
             </HStack>
             <Spacer />

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -7,6 +7,7 @@ import { BiPin, BiPlus, BiPlusCircle } from "react-icons/bi"
 
 import { BlockEditingPlaceholder } from "~/components/Svg"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 import { TYPE_TO_ICON } from "../constants"
@@ -42,6 +43,7 @@ export default function RootStateDrawer() {
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const utils = trpc.useUtils()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin()
   const { mutate } = trpc.page.reorderBlock.useMutation({
     onSuccess: async () => {
       await utils.page.readPage.invalidate({ pageId, siteId })
@@ -119,7 +121,7 @@ export default function RootStateDrawer() {
 
   return (
     <VStack gap="1.5rem" p="1.5rem">
-      <ActivateRawJsonEditorMode />
+      {isUserIsomerAdmin && <ActivateRawJsonEditorMode />}
       {/* Fixed Blocks Section */}
       <VStack gap="1rem" w="100%" align="start">
         <VStack gap="0.25rem" align="start">

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -11,7 +11,7 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 import { TYPE_TO_ICON } from "../constants"
 import { editPageSchema } from "../schema"
-import { ActivateAdminMode } from "./ActivateAdminMode"
+import { ActivateRawJsonEditorMode } from "./ActivateRawJsonEditorMode"
 import { BaseBlock } from "./Block/BaseBlock"
 import { DraggableBlock } from "./Block/DraggableBlock"
 
@@ -119,7 +119,7 @@ export default function RootStateDrawer() {
 
   return (
     <VStack gap="1.5rem" p="1.5rem">
-      <ActivateAdminMode />
+      <ActivateRawJsonEditorMode />
       {/* Fixed Blocks Section */}
       <VStack gap="1rem" w="100%" align="start">
         <VStack gap="0.25rem" align="start">

--- a/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
+++ b/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
@@ -1,0 +1,24 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+
+import { useMe } from "~/features/me/api"
+import { ISOMER_ADMIN_FEATURE_KEY } from "~/lib/growthbook"
+
+// Growthbook has a constraint in the typings that requires the index signature
+// of the object to be defined as a string instead of being specific to the keys
+// that we want. Hence, we have to define it as a type instead of an interface.
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type GrowthbookIsomerAdminFeature = {
+  users: string[]
+}
+
+export const useIsUserIsomerAdmin = () => {
+  const {
+    me: { email },
+  } = useMe()
+  const { users } = useFeatureValue<GrowthbookIsomerAdminFeature>(
+    ISOMER_ADMIN_FEATURE_KEY,
+    { users: [] },
+  )
+
+  return users.includes(email)
+}

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -1,1 +1,2 @@
 export const BANNER_FEATURE_KEY = "isomer-next-banner"
+export const ISOMER_ADMIN_FEATURE_KEY = "isomer_admins"

--- a/apps/studio/src/types/editorDrawer.ts
+++ b/apps/studio/src/types/editorDrawer.ts
@@ -2,8 +2,8 @@ export interface RootDrawerState {
   state: "root"
 }
 
-export interface AdminModeDrawerState {
-  state: "adminMode"
+export interface RawJsonEditorModeDrawerState {
+  state: "rawJsonEditor"
 }
 
 export interface AddNewBlockState {
@@ -28,7 +28,7 @@ export interface HeroEditorState {
 
 export type DrawerState =
   | RootDrawerState
-  | AdminModeDrawerState
+  | RawJsonEditorModeDrawerState
   | AddNewBlockState
   | NativeEditorState
   | ComplexEditorState


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The migrators need to be able to edit certain pages directly and Studio may not be able to support their editing use cases at the moment.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Allow editing and saving of the raw JSON content inside the admin mode.
    - NOTE: This is still a safe operation as entering the admin mode is a hidden feature, and there is both frontend and backend schema validation to ensure that the data sent via this mode conforms to the schema. Hence, even if agency users find out about this, there is no way to corrupt the page data.
- Also renamed "admin mode" to "raw JSON editor mode" to differentiate with the future God mode feature.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/a8dfb21b-5d01-4dd6-b7fc-bd19db786edc)

**AFTER**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/752428c7-e0c6-451f-817f-b4b57b80f649