### PR TITLE
fix - no spacing between title and cross button for movemodal

### DIFF
--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -140,7 +140,7 @@ const MoveResourceContent = withSuspense(
 
     return (
       <ModalContent>
-        <ModalHeader>Move "{title}" to...</ModalHeader>
+        <ModalHeader mr="3.5rem">Move "{title}" to...</ModalHeader>
         <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.25rem">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

no ticket but came across this issue where the "move resource" modal does not have spacing between the cross button and the title

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add a margin right (similar to linkeditor modal)

## Before & After Screenshots

**BEFORE**:

![image](https://github.com/user-attachments/assets/afb4b34e-2b65-47b3-a3f4-57398693fac2)

**AFTER**:

<img width="702" alt="image" src="https://github.com/user-attachments/assets/1e3ee6ee-9a89-4cda-b06a-88d7c2cac596">

