### PR TITLE
minor style fixes to site dashboard page

### DIFF
--- a/apps/studio/src/components/AppNavbar.tsx
+++ b/apps/studio/src/components/AppNavbar.tsx
@@ -1,7 +1,12 @@
 import Image from "next/image"
 import NextLink from "next/link"
 import { Flex, HStack } from "@chakra-ui/react"
-import { AvatarMenu, Button, Link, Menu } from "@opengovsg/design-system-react"
+import {
+  AvatarMenu,
+  Button,
+  IconButton,
+  Menu,
+} from "@opengovsg/design-system-react"
 import { BiLinkExternal } from "react-icons/bi"
 
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
@@ -19,29 +24,32 @@ export function AppNavbar(): JSX.Element {
         w="100%"
         justify="space-between"
         align="center"
-        px={{ base: "1.5rem", md: "1.8rem", xl: "2rem" }}
+        px={{ base: 0, md: "0.5rem" }}
         pl={{ base: `calc(1rem + ${ADMIN_NAVBAR_HEIGHT})`, sm: "1.5rem" }}
-        py="0.375rem"
+        py={{ base: 0, md: "0.5rem" }}
         bg="white"
         borderBottomWidth="1px"
         borderColor="base.divider.medium"
         transition="padding 0.1s"
       >
-        <Link
-          as={NextLink}
-          href={DASHBOARD}
-          mx={{ base: "auto", sm: 0 }}
-          transition="margin 0.1s"
-        >
-          <Image
-            src="/assets/isomer-logo-color.svg"
-            height={24}
-            width={22}
-            alt="Isomer Logo"
-            aria-hidden
-            priority
+        <Flex alignItems="center">
+          <IconButton
+            mr="0.5rem"
+            as={NextLink}
+            href={DASHBOARD}
+            variant="clear"
+            aria-label="Back to dashboard"
+            icon={
+              <Image
+                src="/assets/isomer-logo-color.svg"
+                height={24}
+                width={22}
+                alt="Back to dashboard"
+                priority
+              />
+            }
           />
-        </Link>
+        </Flex>
         <HStack
           textStyle="subhead-1"
           spacing={{ base: "0.75rem", md: "1.5rem" }}

--- a/apps/studio/src/components/SearchableHeader.tsx
+++ b/apps/studio/src/components/SearchableHeader.tsx
@@ -24,6 +24,7 @@ export const SearchableHeader = ({ siteId }: SearchableHeaderProps) => {
       py={{ base: 0, md: "0.5rem" }}
       px={{ base: 0, md: "0.5rem" }}
       background="white"
+      alignItems="start"
     >
       <Flex alignItems="center" as={GridItem}>
         <IconButton

--- a/apps/studio/src/constants/layouts.ts
+++ b/apps/studio/src/constants/layouts.ts
@@ -5,15 +5,3 @@ export const APP_GRID_TEMPLATE_COLUMN = {
 export const APP_GRID_COLUMN = { base: "1 / 5", md: "1 / 12", lg: "4 / 10" }
 
 export const ADMIN_NAVBAR_HEIGHT = "3.5rem"
-
-export const ADMIN_DASHBAR_WIDTHS = {
-  base: "2.75rem",
-  md: "10.5rem",
-  lg: "13.5rem",
-}
-
-export const APP_GRID_TEMPLATE_AREA = {
-  base: `${ADMIN_NAVBAR_HEIGHT} 1fr / ${ADMIN_DASHBAR_WIDTHS.base} 1fr`,
-  md: `${ADMIN_NAVBAR_HEIGHT} 1fr / ${ADMIN_DASHBAR_WIDTHS.md} 1fr`,
-  lg: `${ADMIN_NAVBAR_HEIGHT} 1fr / ${ADMIN_DASHBAR_WIDTHS.lg} 1fr`,
-}

--- a/apps/studio/src/features/dashboard/SiteList.tsx
+++ b/apps/studio/src/features/dashboard/SiteList.tsx
@@ -67,7 +67,7 @@ const Site = ({
           <Text
             as="h6"
             textStyle="h6"
-            noOfLines={1}
+            noOfLines={2}
             overflow="hidden"
             textOverflow="ellipsis"
           >

--- a/apps/studio/src/features/dashboard/SiteList.tsx
+++ b/apps/studio/src/features/dashboard/SiteList.tsx
@@ -65,8 +65,7 @@ const Site = ({
             </Box>
           </Box>
           <Text
-            as="h6"
-            textStyle="h6"
+            textStyle="subhead-1"
             noOfLines={2}
             overflow="hidden"
             textOverflow="ellipsis"

--- a/apps/studio/src/features/dashboard/SiteList.tsx
+++ b/apps/studio/src/features/dashboard/SiteList.tsx
@@ -65,7 +65,7 @@ const Site = ({
             </Box>
           </Box>
           <Text
-            textStyle="subhead-1"
+            textStyle="subhead-2"
             noOfLines={2}
             overflow="hidden"
             textOverflow="ellipsis"

--- a/apps/studio/tests/msw/handlers/sites.ts
+++ b/apps/studio/tests/msw/handlers/sites.ts
@@ -31,6 +31,28 @@ const siteListQuery = ({
           isGovernment: true,
         } as PrismaJson.SiteJsonConfig,
       },
+      {
+        id: 2,
+        name: "Having a really long name is cool i guess",
+        config: {
+          theme: "isomer-next",
+          siteName: "MTI",
+          logoUrl: "",
+          search: undefined,
+          isGovernment: true,
+        } as PrismaJson.SiteJsonConfig,
+      },
+      {
+        id: 3,
+        name: "But not if it's too long then nobody can read your name anyway so why even bother",
+        config: {
+          theme: "isomer-next",
+          siteName: "MTI",
+          logoUrl: "",
+          search: undefined,
+          isGovernment: true,
+        } as PrismaJson.SiteJsonConfig,
+      },
     ]
   })
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Addresses the quick style fixes in https://opengovproducts.slack.com/archives/C06R4DX966P/p1733101118649869?thread_ts=1732149974.756949&cid=C06R4DX966P

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Site name label should be subhead-1
- Site name label should allow up to 2 lines and then truncate

**Bug Fixes**:

- Header padding-y (spacing left of Isomer symbol, right of avatar) should be 20px to be consistent with Dashboard
