### PR TITLE
chore: add command key to base search bar

### DIFF
--- a/apps/studio/src/components/Searchbar/CommandKey.tsx
+++ b/apps/studio/src/components/Searchbar/CommandKey.tsx
@@ -1,0 +1,19 @@
+import { Text, TextProps } from "@chakra-ui/react"
+
+import { isMac } from "./isMac"
+
+export const CommandKey = (props: TextProps) => (
+  <Text
+    textStyle="caption-1"
+    textColor="base.content.medium"
+    bg="white"
+    py="0.125rem"
+    px="0.375rem"
+    borderRadius="base"
+    border="1px solid"
+    borderColor="base.divider.medium"
+    {...props}
+  >
+    {isMac ? "⌘ + K" : "Ctrl + K"}
+  </Text>
+)

--- a/apps/studio/src/components/Searchbar/SearchModal.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModal.tsx
@@ -12,7 +12,7 @@ import { useDebounce } from "@uidotdev/usehooks"
 
 import type { SearchResultResource } from "~/server/modules/resource/resource.types"
 import { trpc } from "~/utils/trpc"
-import { isMac } from "./isMac"
+import { CommandKey } from "./CommandKey"
 import {
   InitialState,
   LoadingState,
@@ -110,19 +110,7 @@ export const SearchModal = ({ siteId, isOpen, onClose }: SearchModalProps) => {
               ? "Tip: Type in the full title to get the most accurate search results."
               : "Scroll to see more results. Too many results? Try typing something longer."}
           </Text>
-          <Text
-            textStyle="caption-1"
-            textColor="base.content.medium"
-            bg="white"
-            py="0.125rem"
-            px="0.375rem"
-            borderRadius="base"
-            border="1px solid"
-            borderColor="base.divider.medium"
-            boxShadow="sm"
-          >
-            {isMac ? "⌘ + K" : "Ctrl + K"}
-          </Text>
+          <CommandKey boxShadow="sm" />
         </ModalFooter>
       </ModalContent>
     </Modal>

--- a/apps/studio/src/components/Searchbar/Searchbar.tsx
+++ b/apps/studio/src/components/Searchbar/Searchbar.tsx
@@ -11,6 +11,7 @@ import {
 } from "@chakra-ui/react"
 import { BiSearch } from "react-icons/bi"
 
+import { CommandKey } from "./CommandKey"
 import { isMac } from "./isMac"
 import { SearchModal } from "./SearchModal"
 import { useSearchStyle } from "./useSearchStyle"
@@ -57,6 +58,7 @@ const SearchButton = (props: ButtonProps) => {
           Search pages, collections, or folders by name. e.g. "Speech by
           Minister"
         </Text>
+        <CommandKey mr="1.25rem" />
       </HStack>
     </chakra.button>
   )


### PR DESCRIPTION
## Problem
The base search bar does not have the command key UI and makes it confusing when users see the command key in the modal

## Solution
Add the command key to the base modal

## Screenshots
<img width="754" alt="image" src="https://github.com/user-attachments/assets/b2bce1d7-7903-4b6e-8db9-78b54c9c7f52">

