### PR TITLE
Global search improvement (text hint + display personalized recently viewed)

### DIFF
--- a/apps/studio/src/components/Searchbar/SearchModal.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModal.tsx
@@ -41,7 +41,6 @@ export const SearchModal = ({ siteId, isOpen, onClose }: SearchModalProps) => {
       },
     },
   )
-  console.log("queryCount", 111, queryCount)
   const resources: SearchResultResource[] =
     data?.pages.flatMap((page) => page.resources) ?? []
 

--- a/apps/studio/src/components/Searchbar/SearchModal.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModal.tsx
@@ -27,12 +27,21 @@ interface SearchModalProps {
   siteId: string
 }
 export const SearchModal = ({ siteId, isOpen, onClose }: SearchModalProps) => {
+  const [queryCount, setQueryCount] = useState(0)
   const [searchValue, setSearchValue] = useState("")
   const debouncedSearchTerm = useDebounce(searchValue, 300)
-  const { data, isLoading } = trpc.resource.search.useInfiniteQuery({
-    siteId,
-    query: debouncedSearchTerm,
-  })
+  const { data, isLoading } = trpc.resource.search.useInfiniteQuery(
+    {
+      siteId,
+      query: debouncedSearchTerm,
+    },
+    {
+      onSuccess: () => {
+        setQueryCount((prev) => prev + 1)
+      },
+    },
+  )
+  console.log("queryCount", 111, queryCount)
   const resources: SearchResultResource[] =
     data?.pages.flatMap((page) => page.resources) ?? []
 
@@ -55,6 +64,9 @@ export const SearchModal = ({ siteId, isOpen, onClose }: SearchModalProps) => {
             ) ?? 0
           }
           searchTerm={debouncedSearchTerm}
+          // 3 is an arbitrary number that we are trying out and our guess
+          // of the number of queries the user has to do before they are deemed "lost"
+          shouldShowHint={queryCount >= 3}
         />
       )
     }

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -61,10 +61,12 @@ const ModalBody = ({ children, ...props }: PropsWithChildren & ChakraProps) => {
 
 const HeaderTextAndContent = ({
   headerText,
+  showSearchResultHint = false,
   content,
   ...props
 }: {
   headerText?: string
+  showSearchResultHint?: boolean
   content: React.ReactNode
 } & ChakraProps) => {
   return (
@@ -74,6 +76,7 @@ const HeaderTextAndContent = ({
           {headerText}
         </Text>
       )}
+      {showSearchResultHint && <SearchResultHint />}
       {content}
     </VStack>
   )
@@ -154,6 +157,7 @@ export const SearchResultsState = ({
     <ModalBody>
       <HeaderTextAndContent
         headerText={`${totalResultsCount} search result${totalResultsCount === 1 ? "" : "s"} with "${searchTerm}" in title`}
+        showSearchResultHint
         content={
           <SearchResults
             siteId={siteId}

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -192,15 +192,23 @@ export const NoResultsState = () => {
           content={
             <VStack
               align="center"
-              gap="0.5rem"
+              gap="1rem"
               w="full"
               h="full"
               justify="center"
             >
-              <NoSearchResultSvgr />
-              <Text textStyle="subhead-2">
-                We’ve looked everywhere, but we’re getting nothing.
-              </Text>
+              <VStack
+                align="center"
+                gap="0.5rem"
+                w="full"
+                h="full"
+                justify="center"
+              >
+                <NoSearchResultSvgr />
+                <Text textStyle="subhead-2">
+                  We’ve looked everywhere, but we’re getting nothing.
+                </Text>
+              </VStack>
               <SearchResultHint maxW="27.5rem" />
             </VStack>
           }

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -66,6 +66,7 @@ const BaseState = ({
   )
 }
 
+const numberOfItemsToShowForEachSection = 3
 export const InitialState = ({
   siteId,
   items,
@@ -79,7 +80,7 @@ export const InitialState = ({
       content={
         <SearchResults
           siteId={siteId}
-          items={items}
+          items={items.slice(0, numberOfItemsToShowForEachSection)}
           isSimplifiedView={true}
           shouldHideLastEditedText={true}
         />

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -7,6 +7,7 @@ import type { SearchResultProps } from "./SearchResult"
 import type { SearchResultResource } from "~/server/modules/resource/resource.types"
 import { NoSearchResultSvgr } from "../Svg/NoSearchResultSvgr"
 import { SearchResult } from "./SearchResult"
+import { SearchResultHint } from "./SearchResultHint"
 
 const SearchResults = ({
   siteId,
@@ -183,9 +184,7 @@ export const NoResultsState = () => {
               <Text textStyle="subhead-2">
                 We’ve looked everywhere, but we’re getting nothing.
               </Text>
-              <Text textStyle="caption-2">
-                Try searching for something else.
-              </Text>
+              <SearchResultHint maxW="27.5rem" />
             </VStack>
           }
         />

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -75,7 +75,7 @@ export const InitialState = ({
 }) => {
   return (
     <BaseState
-      headerText="Recently edited"
+      headerText="Pages recently edited on your site"
       content={
         <SearchResults
           siteId={siteId}

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -5,6 +5,8 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { SearchResultProps } from "./SearchResult"
 import type { SearchResultResource } from "~/server/modules/resource/resource.types"
+import { useResourceLocalViewHistory } from "~/hooks/useResourceLocalViewHistory"
+import { trpc } from "~/utils/trpc"
 import { NoSearchResultSvgr } from "../Svg/NoSearchResultSvgr"
 import { SearchResult } from "./SearchResult"
 import { SearchResultHint } from "./SearchResultHint"
@@ -82,7 +84,6 @@ const HeaderTextAndContent = ({
   )
 }
 
-const numberOfItemsToShowForEachSection = 3
 export const InitialState = ({
   siteId,
   items,
@@ -90,25 +91,34 @@ export const InitialState = ({
   siteId: string
   items: SearchResultResource[]
 }) => {
+  const { get } = useResourceLocalViewHistory({ siteId })
+  const { data: localViewHistorySearchResults = [] } =
+    trpc.resource.searchWithResourceIds.useQuery({
+      siteId,
+      resourceIds: get().map((history) => history.resourceId),
+    })
+
   return (
     <ModalBody>
-      <HeaderTextAndContent
-        headerText="Pages you’ve recently opened"
-        content={
-          <SearchResults
-            siteId={siteId}
-            items={items.slice(0, numberOfItemsToShowForEachSection)}
-            isSimplifiedView={true}
-            shouldHideLastEditedText={true}
-          />
-        }
-      />
+      {localViewHistorySearchResults.length > 0 && (
+        <HeaderTextAndContent
+          headerText="Pages you’ve recently opened"
+          content={
+            <SearchResults
+              siteId={siteId}
+              items={localViewHistorySearchResults.slice(0, 3)}
+              isSimplifiedView={true}
+              shouldHideLastEditedText={true}
+            />
+          }
+        />
+      )}
       <HeaderTextAndContent
         headerText="Pages recently edited on your site"
         content={
           <SearchResults
             siteId={siteId}
-            items={items.slice(0, numberOfItemsToShowForEachSection)}
+            items={items.slice(0, 3)}
             isSimplifiedView={true}
             shouldHideLastEditedText={true}
           />

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -63,12 +63,12 @@ const ModalBody = ({ children, ...props }: PropsWithChildren & ChakraProps) => {
 
 const HeaderTextAndContent = ({
   headerText,
-  showSearchResultHint = false,
+  shouldShowHint = false,
   content,
   ...props
 }: {
   headerText?: string
-  showSearchResultHint?: boolean
+  shouldShowHint?: boolean
   content: React.ReactNode
 } & ChakraProps) => {
   return (
@@ -78,7 +78,7 @@ const HeaderTextAndContent = ({
           {headerText}
         </Text>
       )}
-      {showSearchResultHint && <SearchResultHint />}
+      {shouldShowHint && <SearchResultHint />}
       {content}
     </VStack>
   )
@@ -157,17 +157,19 @@ export const SearchResultsState = ({
   items,
   totalResultsCount,
   searchTerm,
+  shouldShowHint = false,
 }: {
   siteId: string
   items: SearchResultResource[]
   totalResultsCount: number
   searchTerm: string
+  shouldShowHint?: boolean
 }) => {
   return (
     <ModalBody>
       <HeaderTextAndContent
         headerText={`${totalResultsCount} search result${totalResultsCount === 1 ? "" : "s"} with "${searchTerm}" in title`}
-        showSearchResultHint
+        shouldShowHint={shouldShowHint}
         content={
           <SearchResults
             siteId={siteId}

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -11,9 +11,11 @@ const SearchResults = ({
   items,
   searchTerms,
   isLoading,
+  isSimplifiedView = false,
   shouldHideLastEditedText = false,
 }: Omit<SearchResultProps, "item"> & {
   items: SearchResultResource[]
+  isSimplifiedView?: boolean
   shouldHideLastEditedText?: boolean
 }) => {
   return (
@@ -25,6 +27,7 @@ const SearchResults = ({
           item={item}
           searchTerms={searchTerms}
           isLoading={isLoading}
+          isSimplifiedView={isSimplifiedView}
           shouldHideLastEditedText={shouldHideLastEditedText}
         />
       ))}
@@ -77,6 +80,7 @@ export const InitialState = ({
         <SearchResults
           siteId={siteId}
           items={items}
+          isSimplifiedView={true}
           shouldHideLastEditedText={true}
         />
       }

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -38,7 +38,7 @@ const SearchResults = ({
   )
 }
 
-const ModalBody = ({ children, ...props }: PropsWithChildren) => {
+const ModalBody = ({ children, ...props }: PropsWithChildren & ChakraProps) => {
   return (
     <ChakraModalBody
       border="1px solid"

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -147,6 +147,7 @@ export const LoadingState = () => {
             isLoading={true}
           />
         }
+        gap="0.5rem"
       />
     </ModalBody>
   )

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -1,4 +1,6 @@
-import { ModalBody, Text, VStack } from "@chakra-ui/react"
+import type { ChakraProps } from "@chakra-ui/react"
+import type { PropsWithChildren } from "react"
+import { ModalBody as ChakraModalBody, Text, VStack } from "@chakra-ui/react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { SearchResultProps } from "./SearchResult"
@@ -35,15 +37,9 @@ const SearchResults = ({
   )
 }
 
-const BaseState = ({
-  headerText,
-  content,
-}: {
-  headerText?: string
-  content: React.ReactNode
-}): React.ReactNode => {
+const ModalBody = ({ children, ...props }: PropsWithChildren) => {
   return (
-    <ModalBody
+    <ChakraModalBody
       border="1px solid"
       borderColor="base.divider.medium"
       borderTop={0}
@@ -54,15 +50,31 @@ const BaseState = ({
       overflowY="auto"
       display="flex"
       flexDir="column"
-      gap="0.5rem"
+      gap="1rem"
+      {...props}
     >
+      {children}
+    </ChakraModalBody>
+  )
+}
+
+const HeaderTextAndContent = ({
+  headerText,
+  content,
+  ...props
+}: {
+  headerText?: string
+  content: React.ReactNode
+} & ChakraProps) => {
+  return (
+    <VStack gap="0.75rem" align="start" w="full" {...props}>
       {headerText && (
         <Text textColor="base.content.medium" textStyle="body-2">
           {headerText}
         </Text>
       )}
       {content}
-    </ModalBody>
+    </VStack>
   )
 }
 
@@ -75,39 +87,54 @@ export const InitialState = ({
   items: SearchResultResource[]
 }) => {
   return (
-    <BaseState
-      headerText="Pages recently edited on your site"
-      content={
-        <SearchResults
-          siteId={siteId}
-          items={items.slice(0, numberOfItemsToShowForEachSection)}
-          isSimplifiedView={true}
-          shouldHideLastEditedText={true}
-        />
-      }
-    />
+    <ModalBody>
+      <HeaderTextAndContent
+        headerText="Pages you’ve recently opened"
+        content={
+          <SearchResults
+            siteId={siteId}
+            items={items.slice(0, numberOfItemsToShowForEachSection)}
+            isSimplifiedView={true}
+            shouldHideLastEditedText={true}
+          />
+        }
+      />
+      <HeaderTextAndContent
+        headerText="Pages recently edited on your site"
+        content={
+          <SearchResults
+            siteId={siteId}
+            items={items.slice(0, numberOfItemsToShowForEachSection)}
+            isSimplifiedView={true}
+            shouldHideLastEditedText={true}
+          />
+        }
+      />
+    </ModalBody>
   )
 }
 
 export const LoadingState = () => {
   return (
-    <BaseState
-      headerText="Searching your website high and low"
-      content={
-        <SearchResults
-          siteId=""
-          items={Array.from({ length: 5 }).map((_, index) => ({
-            id: `loading-${index}`,
-            parentId: null,
-            lastUpdatedAt: null,
-            title: `Loading... ${index + 1}`,
-            fullPermalink: "",
-            type: ResourceType.Page,
-          }))}
-          isLoading={true}
-        />
-      }
-    />
+    <ModalBody>
+      <HeaderTextAndContent
+        headerText="Searching your website high and low"
+        content={
+          <SearchResults
+            siteId=""
+            items={Array.from({ length: 5 }).map((_, index) => ({
+              id: `loading-${index}`,
+              parentId: null,
+              lastUpdatedAt: null,
+              title: `Loading... ${index + 1}`,
+              fullPermalink: "",
+              type: ResourceType.Page,
+            }))}
+            isLoading={true}
+          />
+        }
+      />
+    </ModalBody>
   )
 }
 
@@ -123,31 +150,47 @@ export const SearchResultsState = ({
   searchTerm: string
 }) => {
   return (
-    <BaseState
-      headerText={`${totalResultsCount} search result${totalResultsCount === 1 ? "" : "s"} with "${searchTerm}" in title`}
-      content={
-        <SearchResults
-          siteId={siteId}
-          items={items}
-          searchTerms={searchTerm.split(" ")}
-        />
-      }
-    />
+    <ModalBody>
+      <HeaderTextAndContent
+        headerText={`${totalResultsCount} search result${totalResultsCount === 1 ? "" : "s"} with "${searchTerm}" in title`}
+        content={
+          <SearchResults
+            siteId={siteId}
+            items={items}
+            searchTerms={searchTerm.split(" ")}
+          />
+        }
+        gap="0.5rem"
+      />
+    </ModalBody>
   )
 }
 
 export const NoResultsState = () => {
   return (
-    <BaseState
-      content={
-        <VStack align="center" gap="0.5rem" h="100%" justify="center">
-          <NoSearchResultSvgr />
-          <Text textStyle="subhead-2">
-            We’ve looked everywhere, but we’re getting nothing.
-          </Text>
-          <Text textStyle="caption-2">Try searching for something else.</Text>
-        </VStack>
+    <ModalBody
+      children={
+        <HeaderTextAndContent
+          content={
+            <VStack
+              align="center"
+              gap="0.5rem"
+              w="full"
+              h="full"
+              justify="center"
+            >
+              <NoSearchResultSvgr />
+              <Text textStyle="subhead-2">
+                We’ve looked everywhere, but we’re getting nothing.
+              </Text>
+              <Text textStyle="caption-2">
+                Try searching for something else.
+              </Text>
+            </VStack>
+          }
+        />
       }
+      justifyContent="center"
     />
   )
 }

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -98,9 +98,11 @@ export const InitialState = ({
       resourceIds: get().map((history) => history.resourceId),
     })
 
+  const hasLocalViewHistory = localViewHistorySearchResults.length > 0
+
   return (
     <ModalBody>
-      {localViewHistorySearchResults.length > 0 && (
+      {hasLocalViewHistory && (
         <HeaderTextAndContent
           headerText="Pages you’ve recently opened"
           content={
@@ -118,7 +120,7 @@ export const InitialState = ({
         content={
           <SearchResults
             siteId={siteId}
-            items={items.slice(0, 3)}
+            items={items.slice(0, hasLocalViewHistory ? 3 : 5)}
             isSimplifiedView={true}
             shouldHideLastEditedText={true}
           />

--- a/apps/studio/src/components/Searchbar/SearchResult.tsx
+++ b/apps/studio/src/components/Searchbar/SearchResult.tsx
@@ -12,6 +12,7 @@ export interface SearchResultProps {
   item: SearchResultResource
   searchTerms?: string[]
   isLoading?: boolean
+  isSimplifiedView?: boolean
   shouldHideLastEditedText?: boolean
 }
 
@@ -20,6 +21,7 @@ export const SearchResult = ({
   item,
   searchTerms = [],
   isLoading = false,
+  isSimplifiedView = false,
   shouldHideLastEditedText = false,
 }: SearchResultProps) => {
   const { id, title, type, fullPermalink, lastUpdatedAt } = item
@@ -64,6 +66,38 @@ export const SearchResult = ({
   const shouldShowLastEditedText: boolean =
     !shouldHideLastEditedText && isAllowedToHaveLastEditedText(type)
 
+  const renderTitleContent = () => {
+    if (isLoading) {
+      return <Skeleton width="12.5rem" height="1.125rem" variant="pulse" />
+    }
+    if (isSimplifiedView) {
+      return (
+        <Text
+          textStyle="subhead-2"
+          textColor="base.content.default"
+          noOfLines={1}
+        >
+          {title}
+        </Text>
+      )
+    }
+    return titleWithHighlightedText
+  }
+
+  const renderPermalink = () => {
+    if (isSimplifiedView) return null
+
+    return (
+      <Text textStyle="caption-2" textColor="base.content.medium" noOfLines={1}>
+        {isLoading ? (
+          <Skeleton width="18rem" height="1.125rem" variant="pulse" />
+        ) : (
+          `/${fullPermalink}`
+        )}
+      </Text>
+    )
+  }
+
   return (
     <HStack
       py="0.75rem"
@@ -94,23 +128,9 @@ export const SearchResult = ({
             columnGap="0.25rem"
             flexWrap="wrap"
           >
-            {isLoading ? (
-              <Skeleton width="12.5rem" height="1.125rem" variant="pulse" />
-            ) : (
-              titleWithHighlightedText
-            )}
+            {renderTitleContent()}
           </Box>
-          <Text
-            textStyle="caption-2"
-            textColor="base.content.medium"
-            noOfLines={1}
-          >
-            {isLoading ? (
-              <Skeleton width="18rem" height="1.125rem" variant="pulse" />
-            ) : (
-              `/${fullPermalink}`
-            )}
-          </Text>
+          {renderPermalink()}
         </VStack>
         {!!lastUpdatedAt && shouldShowLastEditedText && (
           <Text textStyle="legal" textColor="interaction.support.placeholder">

--- a/apps/studio/src/components/Searchbar/SearchResultHint.tsx
+++ b/apps/studio/src/components/Searchbar/SearchResultHint.tsx
@@ -13,7 +13,7 @@ export const SearchResultHint = (props: ChakraProps) => {
       <VStack gap="0.5rem" align="start">
         <Text textStyle="caption-1">💡 Not getting the results you want?</Text>
         <Text textStyle="caption-2">
-          <UnorderedList>
+          <UnorderedList marginInlineStart="1rem">
             <ListItem>
               Type in the <u>exact</u> word. For example, “Subsidy” and
               “Subsidies” will show you different results.

--- a/apps/studio/src/components/Searchbar/SearchResultHint.tsx
+++ b/apps/studio/src/components/Searchbar/SearchResultHint.tsx
@@ -1,0 +1,26 @@
+import type { ChakraProps } from "@chakra-ui/react"
+import { Box, ListItem, Text, UnorderedList, VStack } from "@chakra-ui/react"
+
+export const SearchResultHint = (props: ChakraProps) => {
+  return (
+    <Box
+      borderRadius="0.25rem"
+      bg="utility.feedback.info-subtle"
+      p="0.75rem"
+      {...props}
+    >
+      <VStack gap="0.5rem" align="start">
+        <Text textStyle="caption-1">💡 Not getting the results you want?</Text>
+        <Text textStyle="caption-2">
+          <UnorderedList>
+            <ListItem>
+              Type in the <u>exact</u> word. For example, “Subsidy” and
+              “Subsidies” will show you different results.
+            </ListItem>
+            <ListItem>Check for typos.</ListItem>
+          </UnorderedList>
+        </Text>
+      </VStack>
+    </Box>
+  )
+}

--- a/apps/studio/src/components/Searchbar/SearchResultHint.tsx
+++ b/apps/studio/src/components/Searchbar/SearchResultHint.tsx
@@ -7,6 +7,7 @@ export const SearchResultHint = (props: ChakraProps) => {
       borderRadius="0.25rem"
       bg="utility.feedback.info-subtle"
       p="0.75rem"
+      w="100%"
       {...props}
     >
       <VStack gap="0.5rem" align="start">

--- a/apps/studio/src/hooks/useResourceLocalViewHistory.ts
+++ b/apps/studio/src/hooks/useResourceLocalViewHistory.ts
@@ -1,0 +1,50 @@
+const LOCAL_VIEW_HISTORY_KEY = "localViewHistory"
+
+interface LocalViewHistory {
+  resourceId: string
+  dateTime: Date
+}
+
+export const useResourceLocalViewHistory = ({ siteId }: { siteId: string }) => {
+  const storageKeyForSiteId = `${LOCAL_VIEW_HISTORY_KEY}-${siteId}`
+
+  const get = (): LocalViewHistory[] => {
+    let history: LocalViewHistory[] = []
+    const storedHistory = localStorage.getItem(storageKeyForSiteId)
+
+    if (storedHistory) {
+      try {
+        history = JSON.parse(storedHistory) as LocalViewHistory[]
+      } catch (error) {
+        console.error("Failed to parse local view history from storage:", error)
+      }
+    }
+    return history
+  }
+
+  const upsert = ({ resourceId }: { resourceId: string }): void => {
+    const localViewHistory: LocalViewHistory[] = get()
+
+    const existingEntryIndex: number = localViewHistory.findIndex(
+      (entry) => entry.resourceId === resourceId,
+    )
+
+    const entryToUpdate: LocalViewHistory | undefined =
+      localViewHistory[existingEntryIndex]
+
+    if (entryToUpdate) {
+      // Remove the existing entry
+      localViewHistory.splice(existingEntryIndex, 1)
+    }
+    // Add the new entry to the beginning of the array
+    localViewHistory.unshift({ resourceId, dateTime: new Date() })
+
+    // Limit history to 10 items by removing older entries
+    // 10 is a arbitrary number to ensure localStorage doesn't get too big
+    localViewHistory.splice(10)
+
+    localStorage.setItem(storageKeyForSiteId, JSON.stringify(localViewHistory))
+  }
+
+  return { get, upsert }
+}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -8,11 +8,15 @@ import EditPageDrawer from "~/features/editing-experience/components/EditPageDra
 import { EditPagePreview } from "~/features/editing-experience/components/EditPagePreview"
 import { editPageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { useResourceLocalViewHistory } from "~/hooks/useResourceLocalViewHistory"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
 
 const EditPage: NextPageWithLayout = () => {
   const { pageId, siteId } = useQueryParse(editPageSchema)
+
+  const { upsert } = useResourceLocalViewHistory({ siteId: String(siteId) })
+  upsert({ resourceId: String(pageId) })
 
   const [{ content: page, type, updatedAt, title }] =
     trpc.page.readPageAndBlob.useSuspenseQuery(

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -84,3 +84,12 @@ export const searchOutputSchema = z.object({
   resources: z.array(z.custom<SearchResultResource>()),
   recentlyEdited: z.array(z.custom<SearchResultResource>()),
 })
+
+export const searchWithResourceIdsSchema = z.object({
+  siteId: z.string(),
+  resourceIds: z.array(bigIntSchema),
+})
+
+export const searchWithResourceIdsOutputSchema = z.array(
+  z.custom<SearchResultResource>(),
+)

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -16,6 +16,8 @@ import {
   moveSchema,
   searchOutputSchema,
   searchSchema,
+  searchWithResourceIdsOutputSchema,
+  searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
 import { publishSite } from "../aws/codebuild.service"
@@ -29,6 +31,7 @@ import { validateUserPermissionsForSite } from "../site/site.service"
 import {
   getSearchRecentlyEdited,
   getSearchResults,
+  getSearchWithResourceIds,
   getWithFullPermalink,
 } from "./resource.service"
 
@@ -549,4 +552,19 @@ export const resourceRouter = router({
         }
       },
     ),
+
+  searchWithResourceIds: protectedProcedure
+    .input(searchWithResourceIdsSchema)
+    .output(searchWithResourceIdsOutputSchema)
+    .query(async ({ input: { siteId, resourceIds } }) => {
+      return (
+        await getSearchWithResourceIds({
+          siteId: Number(siteId),
+          resourceIds,
+        })
+      ).sort(
+        // Sort resources to match order of input resourceIds
+        (a, b) => resourceIds.indexOf(a.id) - resourceIds.indexOf(b.id),
+      )
+    }),
 })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -596,3 +596,30 @@ export const getSearchRecentlyEdited = async ({
       .execute()) as SearchResultResource[],
   })
 }
+
+export const getSearchWithResourceIds = async ({
+  siteId,
+  resourceIds,
+}: {
+  siteId: number
+  resourceIds: string[]
+}): Promise<SearchResultResource[]> => {
+  const resources = await db
+    .selectFrom("Resource")
+    .where("Resource.siteId", "=", Number(siteId))
+    .where("Resource.id", "in", resourceIds)
+    .select([
+      "Resource.id",
+      "Resource.type",
+      "Resource.title",
+      "Resource.parentId",
+    ])
+    .execute()
+
+  return await getResourcesWithFullPermalink({
+    resources: resources.map((resource) => ({
+      ...resource,
+      lastUpdatedAt: null,
+    })),
+  })
+}

--- a/apps/studio/src/stories/Page/Search.stories.tsx
+++ b/apps/studio/src/stories/Page/Search.stories.tsx
@@ -54,6 +54,25 @@ export const Initial: Story = {
   },
 }
 
+export const WithRecentlyViewed: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...COMMON_HANDLERS,
+        resourceHandlers.search.initial(),
+        resourceHandlers.searchWithResourceIds.default(),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement)
+    const searchButton = await screen.findByRole("button", {
+      name: "search-button",
+    })
+    await userEvent.click(searchButton)
+  },
+}
+
 export const Results: Story = {
   parameters: {
     msw: {

--- a/apps/studio/src/stories/Page/Search.stories.tsx
+++ b/apps/studio/src/stories/Page/Search.stories.tsx
@@ -102,6 +102,26 @@ export const NoResults: Story = {
   },
 }
 
+export const ShowHint: Story = {
+  parameters: {
+    msw: {
+      handlers: [...COMMON_HANDLERS, resourceHandlers.search.results()],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement)
+    const searchButton = await screen.findByRole("button", {
+      name: "search-button",
+    })
+    await userEvent.click(searchButton)
+    await userEvent.keyboard("covid")
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await userEvent.keyboard(" test")
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+    await userEvent.keyboard(" 1")
+  },
+}
+
 // Commented out for now because of https://github.com/storybookjs/storybook/issues/25815
 // export const ModalOpenOnShortcut: Story = {
 //   play: async ({ canvasElement }) => {

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -185,4 +185,39 @@ export const resourceHandlers = {
       })
     },
   },
+  searchWithResourceIds: {
+    default: () => {
+      return trpcMsw.resource.searchWithResourceIds.query(() => {
+        return [
+          {
+            id: "1",
+            title: "Recently viewed page",
+            permalink: "recently-viewed-page",
+            type: "Page",
+            parentId: null,
+            lastUpdatedAt: new Date("2024-01-01"),
+            fullPermalink: "recently-viewed-page",
+          },
+          {
+            id: "2",
+            title: "Another recently viewed page",
+            permalink: "another-recently-viewed-page",
+            type: "Page",
+            parentId: null,
+            lastUpdatedAt: new Date("2024-01-01"),
+            fullPermalink: "another-recently-viewed-page",
+          },
+          {
+            id: "3",
+            title: "Third recently viewed page",
+            permalink: "third-recently-viewed-page",
+            type: "Page",
+            parentId: null,
+            lastUpdatedAt: new Date("2024-01-01"),
+            fullPermalink: "third-recently-viewed-page",
+          },
+        ]
+      })
+    },
+  },
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Improve global search based on https://opengovproducts.slack.com/archives/C06R4DX966P/p1732866658371749

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- added `useResourceLocalViewHistory` to store user recently viewed history (based on site) on their localstorage
  - add to view history when opening and viewing a resource (only page, not folder or links)
- added a hint component that will show during
  - no search result
  - searching on the 3rd search query everytime the modal open (resets on close) 
- added stories 

## Screenshots

### showing recently viewed

https://github.com/user-attachments/assets/370dd08c-4601-4cdd-8da8-300a06c92b01

### showing hint after 3rd query

note: adjusted to be after the 3rd one since 2nd one might be a bit annoying IMO during development

https://github.com/user-attachments/assets/fad2972e-4b4c-4611-9f64-dff54570d4bb