### PR TITLE
Fix - incorrect `getFullPermalink` for RootPage with _index permalink

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -353,7 +353,7 @@ export const getResourcePermalinkTree = async (
       return []
     }
 
-    const resourcePermalinks = await tx
+    const resources = await tx
       .withRecursive("Ancestors", (eb) =>
         eb
           // Base case: Get the actual resource
@@ -371,13 +371,21 @@ export const getResourcePermalinkTree = async (
           ),
       )
       .selectFrom("Ancestors")
-      .select("Ancestors.permalink")
+      .select(["Ancestors.permalink", "Ancestors.type"])
       .execute()
 
-    return resourcePermalinks
-      .map((r) => r.permalink)
+    if (
+      resources.length === 1 &&
+      resources[0]?.type === ResourceType.RootPage &&
+      resources[0]?.permalink === INDEX_PAGE_PERMALINK
+    ) {
+      return [""] // empty string to represent the root page's permalink
+    }
+
+    return resources
       .reverse()
-      .filter((v) => v !== INDEX_PAGE_PERMALINK)
+      .filter((r) => r.type !== ResourceType.IndexPage)
+      .map((r) => r.permalink)
   })
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C06R4DX966P/p1733189421170829

if a `RootPage` type resource has the permalink `_index`, it will cause the API endpoint to throw an error

![image](https://github.com/user-attachments/assets/d9bbdfaa-a3ff-46c2-a033-dbae252680af)

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- since `RootPage` is a special type, wrote a check to ensure it's not incorrectly filtered out if it's permalink is `_index`
- add unit tests

## Tests

<!-- What tests should be run to confirm functionality? -->

running `npm run test:unit` should pass
