### PR TITLE
Fix multi accordion top margin

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -5328,6 +5328,10 @@ video {
   }
 }
 
+.\[\&\+details\]\:mt-0 + details {
+  margin-top: 0px;
+}
+
 .\[\&\.minus\]\:hidden.minus {
   display: none;
 }
@@ -5378,12 +5382,6 @@ video {
 
 .\[\&\:not\(\:first-child\)\]\:mt-9:not(:first-child) {
   margin-top: 2.25rem;
-}
-
-.\[\&\:not\(\:first-child\)\]\:first-of-type\:mt-7:first-of-type:not(
-    :first-child
-  ) {
-  margin-top: 1.75rem;
 }
 
 .\[\&\:not\(\:last-child\)\]\:mb-0:not(:last-child) {

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -14,7 +14,7 @@ const summaryStyle = tv({
 const createAccordionStyles = tv({
   slots: {
     details:
-      "group mt-7 border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0 [&+details]:mt-0",
+      "group mt-7 border-y border-divider-medium px-4 py-5 first:mt-0 has-[+_details]:border-b-0 [&+details]:mt-0",
     icon: "h-6 w-6 flex-shrink-0 [&.minus]:hidden [&.minus]:group-open:block [&.plus]:block [&.plus]:group-open:hidden",
     content: "pt-5 text-base-content-strong",
   },

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -14,7 +14,7 @@ const summaryStyle = tv({
 const createAccordionStyles = tv({
   slots: {
     details:
-      "group border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0 [&:not(:first-child)]:first-of-type:mt-7",
+      "group mt-7 border-y border-divider-medium px-4 py-5 has-[+_details]:border-b-0 [&+details]:mt-0",
     icon: "h-6 w-6 flex-shrink-0 [&.minus]:hidden [&.minus]:group-open:block [&.plus]:block [&.plus]:group-open:hidden",
     content: "pt-5 text-base-content-strong",
   },

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -2799,3 +2799,180 @@ export const FirstLevelPage: Story = {
     ],
   },
 }
+
+export const MultipleAccordions: Story = {
+  args: {
+    layout: "content",
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        id: "1",
+        title: "Isomer Next",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [
+          {
+            id: "2",
+            title: "Content page",
+            permalink: "/content",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+            children: [
+              {
+                id: "3",
+                title: "Irrationality",
+                permalink: "/parent/rationality",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    id: "4",
+                    title: "For Individuals",
+                    permalink: "/parent/rationality/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                  {
+                    id: "5",
+                    title: "Steven Pinker's Rationality",
+                    permalink: "/parent/rationality/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+              {
+                id: "6",
+                title: "Sibling",
+                permalink: "/parent/sibling",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    id: "7",
+                    title: "Child that should not appear",
+                    permalink: "/parent/sibling/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: "8",
+            title: "Aunt/Uncle that should not appear",
+            permalink: "/aunt-uncle",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+          },
+        ],
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      navBarItems: [],
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      lastUpdated: "1 Jan 2021",
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
+    page: {
+      permalink: "/content",
+      title: "Content page",
+      lastModified: "2024-05-02T14:12:57.160Z",
+      contentPageHeader: {
+        summary:
+          "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",
+        buttonLabel: "Submit a proposal",
+        buttonUrl: "/submit-proposal",
+      },
+    },
+    content: [
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: {
+              level: 3,
+            },
+            content: [
+              {
+                type: "text",
+                text: "Some heading",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "accordion",
+        summary: "Some accordion",
+        details: {
+          type: "prose",
+          content: [],
+        },
+      },
+      {
+        type: "accordion",
+        summary: "More accordion",
+        details: {
+          type: "prose",
+          content: [],
+        },
+      },
+      {
+        type: "accordion",
+        summary: "Last accordion in this section",
+        details: {
+          type: "prose",
+          content: [],
+        },
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: {
+              level: 3,
+            },
+            content: [
+              {
+                type: "text",
+                text: "More heading",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "accordion",
+        summary: "Should have a spacing above",
+        details: {
+          type: "prose",
+          content: [],
+        },
+      },
+    ],
+  },
+}

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -2908,6 +2908,14 @@ export const MultipleAccordions: Story = {
     },
     content: [
       {
+        type: "accordion",
+        summary: "This accordion should not have a margin above",
+        details: {
+          type: "prose",
+          content: [],
+        },
+      },
+      {
         type: "prose",
         content: [
           {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C07CWUNUL68/p1733212670307009

> I think it's cos we applied a margin-top only when an accordion is :first-of-type. So when you have groups of accordions, only the first groups gets a top margin.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- update to use `mt-7` by default and only `mt-0` if preceeded by another `<details>` (accordion)

## Before & After Screenshots

**BEFORE**:

![image](https://github.com/user-attachments/assets/9935efd0-42d7-4cca-a57e-cc46206e8f74)

**AFTER**:

<img width="934" alt="image" src="https://github.com/user-attachments/assets/6537e7cf-61f1-45a4-b15c-cdf138c31715">

## Tests

<!-- What tests should be run to confirm functionality? -->

- added a story in Content layout