### PR TITLE
quick fix - searchWithResourceIds returns 500 error if empty array

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -557,6 +557,9 @@ export const resourceRouter = router({
     .input(searchWithResourceIdsSchema)
     .output(searchWithResourceIdsOutputSchema)
     .query(async ({ input: { siteId, resourceIds } }) => {
+      if (resourceIds.length === 0) {
+        return []
+      }
       return (
         await getSearchWithResourceIds({
           siteId: Number(siteId),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

https://github.com/opengovsg/isomer/pull/912 introduces `searchWithResourceIds` endpoint but the endpoint throws 500 error code when empty array passed in for `resourceIds`

this PR aims to reduce the error and false positive noise in our logs

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- return empty array if `resourceIds` is empty array

## Before & After Screenshots
