### PR TITLE
feat(multi-tags): add filtering to collections

### DIFF
--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -4,7 +4,6 @@ import type { IsomerSiteProps, LinkComponentType } from "~/types"
 export interface Tag {
   selected: string[]
   category: string
-  values: string[]
 }
 
 export interface FileDetails {

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -2,7 +2,7 @@ import type { ImageProps } from "~/interfaces"
 import type { IsomerSiteProps, LinkComponentType } from "~/types"
 
 export interface Tag {
-  labels: string[]
+  selected: string[]
   category: string
   values: string[]
 }

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -2,7 +2,7 @@ import type { ImageProps } from "~/interfaces"
 import type { IsomerSiteProps, LinkComponentType } from "~/types"
 
 export interface Tag {
-  label: string
+  labels: string[]
   category: string
   values: string[]
 }

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -3,6 +3,8 @@ import type { IsomerSiteProps, LinkComponentType } from "~/types"
 
 export interface Tag {
   label: string
+  category: string
+  values: string[]
 }
 
 export interface FileDetails {

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -86,13 +86,10 @@ export const TagsWithImage: Story = {
     title: "Collection card with tags",
     description: "This is a random description that will be on the card",
     tags: [
-      { category: "tagged", values: ["tagged"], selected: ["tagged"] },
-      { category: "tag", values: ["A tag"], selected: ["A tag"] },
+      { category: "tagged", selected: ["tagged"] },
+      { category: "tag", selected: ["A tag"] },
       {
         category: "long",
-        values: [
-          "This is a very long tag that should be reflowed on smaller screens maybe",
-        ],
         selected: [
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
         ],
@@ -107,22 +104,16 @@ export const TagsWithoutImage: Story = {
     withoutImage: true,
     description: "This is a random description that will be on the card",
     tags: [
-      { category: "tag", values: ["A tag"], selected: ["A tag"] },
-      { category: "tagged", values: ["tagged"], selected: ["tagged"] },
+      { category: "tag", selected: ["A tag"] },
+      { category: "tagged", selected: ["tagged"] },
       {
         category: "long",
-        values: [
-          "This is a very long tag that should be reflowed on smaller screens maybe",
-        ],
         selected: [
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
         ],
       },
       {
         category: "very long",
-        values: [
-          "This is a second long link that should eat into the image area so that we can see how it looks",
-        ],
         selected: [
           "This is a second long link that should eat into the image area so that we can see how it looks",
         ],

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -86,14 +86,14 @@ export const TagsWithImage: Story = {
     title: "Collection card with tags",
     description: "This is a random description that will be on the card",
     tags: [
-      { category: "tagged", values: ["tagged"], labels: ["tagged"] },
-      { category: "tag", values: ["A tag"], labels: ["A tag"] },
+      { category: "tagged", values: ["tagged"], selected: ["tagged"] },
+      { category: "tag", values: ["A tag"], selected: ["A tag"] },
       {
         category: "long",
         values: [
           "This is a very long tag that should be reflowed on smaller screens maybe",
         ],
-        labels: [
+        selected: [
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
         ],
       },
@@ -107,14 +107,14 @@ export const TagsWithoutImage: Story = {
     withoutImage: true,
     description: "This is a random description that will be on the card",
     tags: [
-      { category: "tag", values: ["A tag"], labels: ["A tag"] },
-      { category: "tagged", values: ["tagged"], labels: ["tagged"] },
+      { category: "tag", values: ["A tag"], selected: ["A tag"] },
+      { category: "tagged", values: ["tagged"], selected: ["tagged"] },
       {
         category: "long",
         values: [
           "This is a very long tag that should be reflowed on smaller screens maybe",
         ],
-        labels: [
+        selected: [
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
         ],
       },
@@ -123,7 +123,7 @@ export const TagsWithoutImage: Story = {
         values: [
           "This is a second long link that should eat into the image area so that we can see how it looks",
         ],
-        labels: [
+        selected: [
           "This is a second long link that should eat into the image area so that we can see how it looks",
         ],
       },

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -86,15 +86,16 @@ export const TagsWithImage: Story = {
     title: "Collection card with tags",
     description: "This is a random description that will be on the card",
     tags: [
-      { category: "tagged", values: ["tagged"], label: "tagged" },
-      { category: "tag", values: ["A tag"], label: "A tag" },
+      { category: "tagged", values: ["tagged"], labels: ["tagged"] },
+      { category: "tag", values: ["A tag"], labels: ["A tag"] },
       {
         category: "long",
         values: [
           "This is a very long tag that should be reflowed on smaller screens maybe",
         ],
-        label:
+        labels: [
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
+        ],
       },
     ],
   }),
@@ -106,23 +107,25 @@ export const TagsWithoutImage: Story = {
     withoutImage: true,
     description: "This is a random description that will be on the card",
     tags: [
-      { category: "tag", values: ["A tag"], label: "A tag" },
-      { category: "tagged", values: ["tagged"], label: "tagged" },
+      { category: "tag", values: ["A tag"], labels: ["A tag"] },
+      { category: "tagged", values: ["tagged"], labels: ["tagged"] },
       {
         category: "long",
         values: [
           "This is a very long tag that should be reflowed on smaller screens maybe",
         ],
-        label:
+        labels: [
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
+        ],
       },
       {
         category: "very long",
         values: [
           "This is a second long link that should eat into the image area so that we can see how it looks",
         ],
-        label:
+        labels: [
           "This is a second long link that should eat into the image area so that we can see how it looks",
+        ],
       },
     ],
   }),

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -86,9 +86,13 @@ export const TagsWithImage: Story = {
     title: "Collection card with tags",
     description: "This is a random description that will be on the card",
     tags: [
-      { label: "A tag" },
-      { label: "tagged" },
+      { category: "tagged", values: ["tagged"], label: "tagged" },
+      { category: "tag", values: ["A tag"], label: "A tag" },
       {
+        category: "long",
+        values: [
+          "This is a very long tag that should be reflowed on smaller screens maybe",
+        ],
         label:
           "This is a very long tag that shuold be reflowed on smaller screens maybe",
       },
@@ -102,13 +106,21 @@ export const TagsWithoutImage: Story = {
     withoutImage: true,
     description: "This is a random description that will be on the card",
     tags: [
-      { label: "A tag" },
-      { label: "tagged" },
+      { category: "tag", values: ["A tag"], label: "A tag" },
+      { category: "tagged", values: ["tagged"], label: "tagged" },
       {
-        label:
+        category: "long",
+        values: [
           "This is a very long tag that should be reflowed on smaller screens maybe",
+        ],
+        label:
+          "This is a very long tag that shuold be reflowed on smaller screens maybe",
       },
       {
+        category: "very long",
+        values: [
+          "This is a second long link that should eat into the image area so that we can see how it looks",
+        ],
         label:
           "This is a second long link that should eat into the image area so that we can see how it looks",
       },

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -50,10 +50,10 @@ export const CollectionCard = ({
           </Link>
         </h3>
         {tags && tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5">
+          <>
             {tags.flatMap(({ category, selected: labels }) => {
               return (
-                <div className="flex w-full flex-wrap items-center gap-1">
+                <div className="flex w-full flex-wrap items-center gap-2">
                   <p className="prose-label-sm">{category}</p>
                   {labels.map((label) => {
                     return <Tag>{label}</Tag>
@@ -61,7 +61,7 @@ export const CollectionCard = ({
                 </div>
               )
             })}
-          </div>
+          </>
         )}
         {description && (
           <Text className="prose-body-base line-clamp-3" title={description}>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -51,9 +51,11 @@ export const CollectionCard = ({
         </h3>
         {tags && tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {tags.map(({ label }) => (
-              <Tag>{label}</Tag>
-            ))}
+            {tags.flatMap(({ labels }) => {
+              return labels.map((label) => {
+                return <Tag>{label}</Tag>
+              })
+            })}
           </div>
         )}
         {description && (

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -51,7 +51,7 @@ export const CollectionCard = ({
         </h3>
         {tags && tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {tags.flatMap(({ labels }) => {
+            {tags.flatMap(({ selected: labels }) => {
               return labels.map((label) => {
                 return <Tag>{label}</Tag>
               })

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -51,10 +51,15 @@ export const CollectionCard = ({
         </h3>
         {tags && tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
-            {tags.flatMap(({ selected: labels }) => {
-              return labels.map((label) => {
-                return <Tag>{label}</Tag>
-              })
+            {tags.flatMap(({ category, selected: labels }) => {
+              return (
+                <div className="flex w-full flex-wrap items-center gap-1">
+                  <p className="prose-label-sm">{category}</p>
+                  {labels.map((label) => {
+                    return <Tag>{label}</Tag>
+                  })}
+                </div>
+              )
             })}
           </div>
         )}

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -21,6 +21,30 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months.",
       date: "07/05/2024",
       category: "Category Name",
+      tags: [
+        {
+          category: "Body parts",
+          values: ["Head", "Shoulders"],
+          label: "Head",
+        },
+        { category: "Jokes", values: ["Lame", "Dad"], label: "Dad" },
+        {
+          category: "Long categories",
+          values: [
+            "This is a very long tag that should be reflowed on smaller screens maybe",
+          ],
+          label:
+            "This is a very long tag that shuold be reflowed on smaller screens maybe",
+        },
+        {
+          category: "very long",
+          values: [
+            "This is a second long link that should eat into the image area so that we can see how it looks",
+          ],
+          label:
+            "This is a second long link that should eat into the image area so that we can see how it looks",
+        },
+      ],
     },
     {
       id: `${index}`,
@@ -41,6 +65,30 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         type: "png",
         size: "1.2MB",
       },
+      tags: [
+        {
+          category: "Body parts",
+          values: ["Head", "Shoulders"],
+          label: "Shoulders",
+        },
+        { category: "Jokes", values: ["Lame", "Dad"], label: "Lame" },
+        {
+          category: "long",
+          values: [
+            "This is a very long tag that should be reflowed on smaller screens maybe",
+          ],
+          label:
+            "This is a very long tag that shuold be reflowed on smaller screens maybe",
+        },
+        {
+          category: "very long",
+          values: [
+            "This is a second long link that should eat into the image area so that we can see how it looks",
+          ],
+          label:
+            "This is a second long link that should eat into the image area so that we can see how it looks",
+        },
+      ],
     },
     {
       id: `${index}`,
@@ -53,6 +101,24 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       date: "12/08/2023",
       category: "Category Name",
       ref: "https://guide.isomer.gov.sg",
+      tags: [
+        {
+          category: "long categories",
+          values: [
+            "This is a very long tag that should be reflowed on smaller screens maybe",
+          ],
+          label:
+            "This is a very long tag that shuold be reflowed on smaller screens maybe",
+        },
+        {
+          category: "very long",
+          values: [
+            "This is a second long link that should eat into the image area so that we can see how it looks",
+          ],
+          label:
+            "This is a second long link that should eat into the image area so that we can see how it looks",
+        },
+      ],
     },
   ]),
 )
@@ -82,6 +148,26 @@ const generateArgs = ({
             layout: "collection",
             summary: "",
             children: collectionItems,
+            tags: [
+              { category: "tag", values: ["A tag"], label: "A tag" },
+              { category: "tagged", values: ["tagged"], label: "tagged" },
+              {
+                category: "long",
+                values: [
+                  "This is a very long tag that should be reflowed on smaller screens maybe",
+                ],
+                label:
+                  "This is a very long tag that shuold be reflowed on smaller screens maybe",
+              },
+              {
+                category: "very long",
+                values: [
+                  "This is a second long link that should eat into the image area so that we can see how it looks",
+                ],
+                label:
+                  "This is a second long link that should eat into the image area so that we can see how it looks",
+              },
+            ],
           },
         ],
       },
@@ -230,14 +316,6 @@ const generateArgs = ({
       title: "Publications and other press releases",
       permalink: "/publications",
       lastModified: "2024-05-02T14:12:57.160Z",
-      tags: [
-        { category: "Body parts", values: ["Brain", "Leg"], label: "Brain" },
-        {
-          category: "Surgery",
-          values: ["Extraction", "Amputatino"],
-          label: "Extraction",
-        },
-      ],
       subtitle:
         "Since this page type supports text-heavy articles that are primarily for reading and absorbing information, the max content width on desktop is kept even smaller than its General Content Page counterpart.",
     },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -21,32 +21,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months.",
       date: "07/05/2024",
       category: "Category Name",
-      tags: [
-        {
-          category: "Body parts",
-          values: ["Head", "Shoulders"],
-          selected: ["Head"],
-        },
-        { category: "Jokes", values: ["Dad"], selected: ["Dad"] },
-        {
-          category: "Long categories",
-          values: [
-            "This is a very long tag that should be reflowed on smaller screens maybe",
-          ],
-          selected: [
-            "This is a very long tag that shuold be reflowed on smaller screens maybe",
-          ],
-        },
-        {
-          category: "very long",
-          values: [
-            "This is a second long link that should eat into the image area so that we can see how it looks",
-          ],
-          selected: [
-            "This is a second long link that should eat into the image area so that we can see how it looks",
-          ],
-        },
-      ],
+      tags: [{ category: "Jokes", values: ["Dad"], selected: ["Dad"] }],
     },
     {
       id: `${index}`,
@@ -67,33 +42,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         type: "png",
         size: "1.2MB",
       },
-      tags: [
-        {
-          category: "Body parts",
-          values: ["Knees", "Shoulders"],
-          selected: ["Knees"],
-        },
-        { category: "Jokes", values: ["Lame"], selected: ["Lame"] },
-        {
-          category: "Long categories",
-          values: [
-            "This is a very long tag that should be reflowed on smaller screens maybe",
-          ],
-          selected: [
-            "This is a very long tag that shuold be reflowed on smaller screens maybe",
-          ],
-        },
-        {
-          category: "very long",
-          values: [
-            "This is a second long link that should eat into the image area so that we can see how it looks",
-          ],
-          selected: [
-            "This is a second long link that should eat into the image area so that we can see how it looks",
-            "additional label that's not in the first one",
-          ],
-        },
-      ],
+      tags: [{ category: "Jokes", values: ["Lame"], selected: ["Lame"] }],
     },
     {
       id: `${index}`,
@@ -108,20 +57,13 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       ref: "https://guide.isomer.gov.sg",
       tags: [
         {
-          category: "Long categories",
+          category: "Jokes",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
           selected: [
+            "Lame",
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
-          ],
-        },
-        {
-          category: "very long",
-          values: [
-            "This is a second long link that should eat into the image area so that we can see how it looks",
-          ],
-          selected: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
         },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -25,24 +25,26 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         {
           category: "Body parts",
           values: ["Head", "Shoulders"],
-          label: "Head",
+          labels: ["Head"],
         },
-        { category: "Jokes", values: ["Lame", "Dad"], label: "Dad" },
+        { category: "Jokes", values: ["Dad"], labels: ["Dad"] },
         {
           category: "Long categories",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
-          label:
+          labels: [
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
+          ],
         },
         {
           category: "very long",
           values: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
-          label:
+          labels: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
+          ],
         },
       ],
     },
@@ -68,25 +70,28 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       tags: [
         {
           category: "Body parts",
-          values: ["Head", "Shoulders"],
-          label: "Shoulders",
+          values: ["Knees", "Shoulders"],
+          labels: ["Knees"],
         },
-        { category: "Jokes", values: ["Lame", "Dad"], label: "Lame" },
+        { category: "Jokes", values: ["Lame"], labels: ["Lame"] },
         {
-          category: "long",
+          category: "Long categories",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
-          label:
+          labels: [
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
+          ],
         },
         {
           category: "very long",
           values: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
-          label:
+          labels: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
+            "additional label that's not in the first one",
+          ],
         },
       ],
     },
@@ -103,20 +108,22 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       ref: "https://guide.isomer.gov.sg",
       tags: [
         {
-          category: "long categories",
+          category: "Long categories",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
-          label:
+          labels: [
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
+          ],
         },
         {
           category: "very long",
           values: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
-          label:
+          labels: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
+          ],
         },
       ],
     },
@@ -149,23 +156,25 @@ const generateArgs = ({
             summary: "",
             children: collectionItems,
             tags: [
-              { category: "tag", values: ["A tag"], label: "A tag" },
-              { category: "tagged", values: ["tagged"], label: "tagged" },
+              { category: "tag", values: ["A tag"], labels: ["A tag"] },
+              { category: "tagged", values: ["tagged"], labels: ["tagged"] },
               {
                 category: "long",
                 values: [
                   "This is a very long tag that should be reflowed on smaller screens maybe",
                 ],
-                label:
+                labels: [
                   "This is a very long tag that shuold be reflowed on smaller screens maybe",
+                ],
               },
               {
                 category: "very long",
                 values: [
                   "This is a second long link that should eat into the image area so that we can see how it looks",
                 ],
-                label:
+                labels: [
                   "This is a second long link that should eat into the image area so that we can see how it looks",
+                ],
               },
             ],
           },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -21,7 +21,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months.",
       date: "07/05/2024",
       category: "Category Name",
-      tags: [{ category: "Jokes", values: ["Dad"], selected: ["Dad"] }],
+      tags: [{ category: "jokes", values: ["Dad"], selected: ["Dad"] }],
     },
     {
       id: `${index}`,
@@ -42,7 +42,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         type: "png",
         size: "1.2MB",
       },
-      tags: [{ category: "Jokes", values: ["Lame"], selected: ["Lame"] }],
+      tags: [{ category: "jokes", values: ["Lame"], selected: ["Lame"] }],
     },
     {
       id: `${index}`,
@@ -57,7 +57,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       ref: "https://guide.isomer.gov.sg",
       tags: [
         {
-          category: "Jokes",
+          category: "jokes",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -98,22 +98,16 @@ const generateArgs = ({
             summary: "",
             children: collectionItems,
             tags: [
-              { category: "tag", values: ["A tag"], selected: ["A tag"] },
-              { category: "tagged", values: ["tagged"], selected: ["tagged"] },
+              { category: "tag", selected: ["A tag"] },
+              { category: "tagged", selected: ["tagged"] },
               {
                 category: "long",
-                values: [
-                  "This is a very long tag that should be reflowed on smaller screens maybe",
-                ],
                 selected: [
                   "This is a very long tag that shuold be reflowed on smaller screens maybe",
                 ],
               },
               {
                 category: "very long",
-                values: [
-                  "This is a second long link that should eat into the image area so that we can see how it looks",
-                ],
                 selected: [
                   "This is a second long link that should eat into the image area so that we can see how it looks",
                 ],

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -25,15 +25,15 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         {
           category: "Body parts",
           values: ["Head", "Shoulders"],
-          labels: ["Head"],
+          selected: ["Head"],
         },
-        { category: "Jokes", values: ["Dad"], labels: ["Dad"] },
+        { category: "Jokes", values: ["Dad"], selected: ["Dad"] },
         {
           category: "Long categories",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
-          labels: [
+          selected: [
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
           ],
         },
@@ -42,7 +42,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
           values: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
-          labels: [
+          selected: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
         },
@@ -71,15 +71,15 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
         {
           category: "Body parts",
           values: ["Knees", "Shoulders"],
-          labels: ["Knees"],
+          selected: ["Knees"],
         },
-        { category: "Jokes", values: ["Lame"], labels: ["Lame"] },
+        { category: "Jokes", values: ["Lame"], selected: ["Lame"] },
         {
           category: "Long categories",
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
-          labels: [
+          selected: [
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
           ],
         },
@@ -88,7 +88,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
           values: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
-          labels: [
+          selected: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
             "additional label that's not in the first one",
           ],
@@ -112,7 +112,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
           values: [
             "This is a very long tag that should be reflowed on smaller screens maybe",
           ],
-          labels: [
+          selected: [
             "This is a very long tag that shuold be reflowed on smaller screens maybe",
           ],
         },
@@ -121,7 +121,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
           values: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
-          labels: [
+          selected: [
             "This is a second long link that should eat into the image area so that we can see how it looks",
           ],
         },
@@ -156,14 +156,14 @@ const generateArgs = ({
             summary: "",
             children: collectionItems,
             tags: [
-              { category: "tag", values: ["A tag"], labels: ["A tag"] },
-              { category: "tagged", values: ["tagged"], labels: ["tagged"] },
+              { category: "tag", values: ["A tag"], selected: ["A tag"] },
+              { category: "tagged", values: ["tagged"], selected: ["tagged"] },
               {
                 category: "long",
                 values: [
                   "This is a very long tag that should be reflowed on smaller screens maybe",
                 ],
-                labels: [
+                selected: [
                   "This is a very long tag that shuold be reflowed on smaller screens maybe",
                 ],
               },
@@ -172,7 +172,7 @@ const generateArgs = ({
                 values: [
                   "This is a second long link that should eat into the image area so that we can see how it looks",
                 ],
-                labels: [
+                selected: [
                   "This is a second long link that should eat into the image area so that we can see how it looks",
                 ],
               },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -230,6 +230,14 @@ const generateArgs = ({
       title: "Publications and other press releases",
       permalink: "/publications",
       lastModified: "2024-05-02T14:12:57.160Z",
+      tags: [
+        { category: "Body parts", values: ["Brain", "Leg"], label: "Brain" },
+        {
+          category: "Surgery",
+          values: ["Extraction", "Amputatino"],
+          label: "Extraction",
+        },
+      ],
       subtitle:
         "Since this page type supports text-heavy articles that are primarily for reading and absorbing information, the max content width on desktop is kept even smaller than its General Content Page counterpart.",
     },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -1,4 +1,5 @@
 import type { Exact } from "type-fest"
+import capitalize from "lodash/capitalize"
 
 import type { CollectionPageSchemaType, IsomerSiteProps } from "~/engine"
 import type { AllCardProps, ProcessedCollectionCardProps } from "~/interfaces"
@@ -66,7 +67,10 @@ const getCollectionItems = (
         description: item.summary,
         image: item.image,
         site,
-        tags: item.tags,
+        tags: item.tags?.map(({ selected, category }) => ({
+          selected,
+          category: capitalize(category),
+        })),
       }
 
       if (item.layout === "file") {

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -66,6 +66,7 @@ const getCollectionItems = (
         description: item.summary,
         image: item.image,
         site,
+        tags: item.tags,
       }
 
       if (item.layout === "file") {

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -123,6 +123,7 @@ const processedCollectionItems = (
       description,
       image,
       url,
+      tags,
     } = item
     const file = variant === "file" ? item.fileDetails : null
     return {
@@ -131,6 +132,7 @@ const processedCollectionItems = (
       title,
       description,
       image,
+      tags,
       referenceLinkHref: getReferenceLinkHref(
         url,
         site.siteMap,

--- a/packages/components/src/templates/next/layouts/Collection/utils.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils.ts
@@ -135,7 +135,6 @@ export const getFilteredItems = (
   appliedFilters: AppliedFilter[],
   searchValue: string,
 ): ProcessedCollectionCardProps[] => {
-  console.log(appliedFilters)
   return items.filter((item) => {
     // Step 1: Filter based on search value
     if (

--- a/packages/components/src/templates/next/layouts/Collection/utils.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils.ts
@@ -73,17 +73,16 @@ export const getAvailableFilters = (
     if (tags) {
       tags.forEach(({ label, category }) => {
         const lowercasedLabel = label.toLowerCase()
-        const lowercasedCategory = category.toLowerCase()
 
-        if (!tagCategories[lowercasedCategory]) {
-          tagCategories[lowercasedCategory] = {}
+        if (!tagCategories[category]) {
+          tagCategories[category] = {}
         }
 
-        if (!tagCategories[lowercasedCategory][lowercasedLabel]) {
-          tagCategories[lowercasedCategory][lowercasedLabel] = 0
+        if (!tagCategories[category][lowercasedLabel]) {
+          tagCategories[category][lowercasedLabel] = 0
         }
 
-        tagCategories[lowercasedCategory][lowercasedLabel] += 1
+        tagCategories[category][lowercasedLabel] += 1
       })
     }
   })

--- a/packages/components/src/templates/next/layouts/Collection/utils.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils.ts
@@ -71,8 +71,8 @@ export const getAvailableFilters = (
 
     // Step 3: Get all category tags
     if (tags) {
-      tags.forEach(({ labels, category }) => {
-        labels.forEach((label) => {
+      tags.forEach(({ selected: selectedLabels, category }) => {
+        selectedLabels.forEach((label) => {
           if (!tagCategories[category]) {
             tagCategories[category] = {}
           }
@@ -185,7 +185,7 @@ export const getFilteredItems = (
     // Take note that we use OR between items within the same filter and AND between filters.
     return remainingFilters
       .map(({ items: activeFilters, id }) => {
-        return item.tags?.some(({ category, labels: itemLabels }) => {
+        return item.tags?.some(({ category, selected: itemLabels }) => {
           return (
             category === id &&
             activeFilters

--- a/packages/components/src/templates/next/layouts/Collection/utils.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils.ts
@@ -71,16 +71,17 @@ export const getAvailableFilters = (
 
     // Step 3: Get all category tags
     if (tags) {
-      tags.forEach(({ label, category }) => {
-        if (!tagCategories[category]) {
-          tagCategories[category] = {}
-        }
+      tags.forEach(({ labels, category }) => {
+        labels.forEach((label) => {
+          if (!tagCategories[category]) {
+            tagCategories[category] = {}
+          }
+          if (!tagCategories[category][label]) {
+            tagCategories[category][label] = 0
+          }
 
-        if (!tagCategories[category][label]) {
-          tagCategories[category][label] = 0
-        }
-
-        tagCategories[category][label] += 1
+          tagCategories[category][label] += 1
+        })
       })
     }
   })
@@ -108,8 +109,8 @@ export const getAvailableFilters = (
     {
       id: FILTER_ID_YEAR,
       label: "Year",
+      // do not show "not specified" option if all items have undefined dates
       items:
-        // do not show "not specified" option if all items have undefined dates
         yearFilterItems.length === 0
           ? []
           : numberOfUndefinedDates === 0
@@ -184,10 +185,14 @@ export const getFilteredItems = (
     // Take note that we use OR between items within the same filter and AND between filters.
     return remainingFilters
       .map(({ items: activeFilters, id }) => {
-        return item.tags?.some(({ category, label: itemLabel }) => {
+        return item.tags?.some(({ category, labels: itemLabels }) => {
           return (
             category === id &&
-            activeFilters.map(({ id }) => id).includes(itemLabel)
+            activeFilters
+              .map(({ id }) => id)
+              .reduce((prev, cur) => {
+                return prev || itemLabels.includes(cur)
+              }, false) //includes(itemLabels)
           )
         })
       })

--- a/packages/components/src/templates/next/types/Filter.ts
+++ b/packages/components/src/templates/next/types/Filter.ts
@@ -1,4 +1,4 @@
-interface FilterItem {
+export interface FilterItem {
   id: string
   label: string
   count: number

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -105,11 +105,8 @@ export const HomePagePageSchema = Type.Object({})
 export const NotFoundPagePageSchema = Type.Object({})
 export const SearchPagePageSchema = Type.Object({})
 
-export const FileRefPageSchema = Type.Intersect([BaseRefPageSchema, TagsSchema])
-export const LinkRefPageSchema = Type.Intersect([
-  TagsSchema,
-  Type.Omit(BaseRefPageSchema, ["image"]),
-])
+export const FileRefPageSchema = BaseRefPageSchema
+export const LinkRefPageSchema = Type.Omit(BaseRefPageSchema, ["image"])
 
 // These are props that are required by the render engine, but not enforced by
 // the JSON schema (as the data is being stored outside of the page JSON)

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -67,7 +67,6 @@ const BaseRefPageSchema = Type.Composite([
 const TagSchema = Type.Object({
   selected: Type.Array(Type.String()),
   category: Type.String(),
-  values: Type.Array(Type.String()),
 })
 
 const TagsSchema = Type.Object({

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -65,7 +65,7 @@ const BaseRefPageSchema = Type.Composite([
 ])
 
 const TagSchema = Type.Object({
-  label: Type.String(),
+  label: Type.Array(Type.String()),
   category: Type.String(),
   values: Type.Array(Type.String()),
 })

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -77,6 +77,15 @@ export const CollectionPagePageSchema = Type.Object({
   subtitle: Type.String({
     title: "The subtitle of the collection",
   }),
+  tags: Type.Optional(
+    Type.Array(
+      Type.Object({
+        label: Type.String(),
+        category: Type.String(),
+        values: Type.Array(Type.String()),
+      }),
+    ),
+  ),
 })
 
 export const ContentPagePageSchema = Type.Object({

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -65,7 +65,7 @@ const BaseRefPageSchema = Type.Composite([
 ])
 
 const TagSchema = Type.Object({
-  label: Type.Array(Type.String()),
+  selected: Type.Array(Type.String()),
   category: Type.String(),
   values: Type.Array(Type.String()),
 })

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -64,6 +64,16 @@ const BaseRefPageSchema = Type.Composite([
   }),
 ])
 
+const TagSchema = Type.Object({
+  label: Type.String(),
+  category: Type.String(),
+  values: Type.Array(Type.String()),
+})
+
+const TagsSchema = Type.Object({
+  tags: Type.Optional(Type.Array(TagSchema)),
+})
+
 export const ArticlePagePageSchema = Type.Composite([
   dateSchemaObject,
   Type.Object({
@@ -73,20 +83,14 @@ export const ArticlePagePageSchema = Type.Composite([
   imageSchemaObject,
 ])
 
-export const CollectionPagePageSchema = Type.Object({
-  subtitle: Type.String({
-    title: "The subtitle of the collection",
+export const CollectionPagePageSchema = Type.Intersect([
+  Type.Object({
+    subtitle: Type.String({
+      title: "The subtitle of the collection",
+    }),
   }),
-  tags: Type.Optional(
-    Type.Array(
-      Type.Object({
-        label: Type.String(),
-        category: Type.String(),
-        values: Type.Array(Type.String()),
-      }),
-    ),
-  ),
-})
+  TagsSchema,
+])
 
 export const ContentPagePageSchema = Type.Object({
   contentPageHeader: ContentPageHeaderSchema,
@@ -101,8 +105,11 @@ export const HomePagePageSchema = Type.Object({})
 export const NotFoundPagePageSchema = Type.Object({})
 export const SearchPagePageSchema = Type.Object({})
 
-export const FileRefPageSchema = BaseRefPageSchema
-export const LinkRefPageSchema = Type.Omit(BaseRefPageSchema, ["image"])
+export const FileRefPageSchema = Type.Intersect([BaseRefPageSchema, TagsSchema])
+export const LinkRefPageSchema = Type.Intersect([
+  TagsSchema,
+  Type.Omit(BaseRefPageSchema, ["image"]),
+])
 
 // These are props that are required by the render engine, but not enforced by
 // the JSON schema (as the data is being stored outside of the page JSON)

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -15,7 +15,7 @@ interface IsomerBaseSitemap {
   image?: CollectionCardProps["image"]
   date?: CollectionCardProps["lastUpdated"]
   children?: IsomerSitemap[]
-  tags: CollectionCardProps["tags"]
+  tags?: CollectionCardProps["tags"]
 }
 
 interface IsomerPageSitemap extends IsomerBaseSitemap {

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -9,9 +9,13 @@ interface IsomerBaseSitemap {
   lastModified: string
   permalink: string
   category?: string
+  // TODO: we should aim to separate BaseSiteMap into different types
+  // so that the properties that are exclusive to, for example, `CollectionCard`
+  // will only be available there
   image?: CollectionCardProps["image"]
   date?: CollectionCardProps["lastUpdated"]
   children?: IsomerSitemap[]
+  tags: CollectionCardProps["tags"]
 }
 
 interface IsomerPageSitemap extends IsomerBaseSitemap {

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -2,7 +2,6 @@ import * as fs from "fs"
 import * as path from "path"
 import { performance } from "perf_hooks"
 import { ResourceType } from "~generated/generatedEnums"
-import { Site } from "~generated/selectableTypes"
 import * as dotenv from "dotenv"
 import { Client } from "pg"
 

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -123,6 +123,7 @@ async function main() {
             resource.content.page.description ||
             "",
           category: resource.content.page.category,
+          tags: resource.content.page.tags,
           date: resource.content.page.date,
           image: resource.content.page.image,
           ref: resource.content.page.ref, // For file and link layouts

--- a/tooling/build/scripts/publishing/package-lock.json
+++ b/tooling/build/scripts/publishing/package-lock.json
@@ -10,10 +10,395 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "pg": "^8.12.0"
+        "pg": "^8.12.0",
+        "tsx": "^4.19.2"
       },
       "devDependencies": {
         "@types/pg": "^8.11.6"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/node": {
@@ -45,6 +430,71 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.8.1.tgz",
+      "integrity": "sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==",
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/obuf": {
@@ -241,12 +691,40 @@
       "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
       "dev": true
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.19.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
+      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.23.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/undici-types": {

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -5,14 +5,15 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "ts-node index.ts "
+    "start": "tsx index.ts "
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "pg": "^8.12.0"
+    "pg": "^8.12.0",
+    "tsx": "^4.19.2"
   },
   "devDependencies": {
     "@types/pg": "^8.11.6"

--- a/tooling/build/scripts/publishing/tsconfig.json
+++ b/tooling/build/scripts/publishing/tsconfig.json
@@ -13,6 +13,9 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "paths": {
+      "~generated/*": ["../../../../apps/studio/prisma/generated/*"]
+    }
   }
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -9,7 +9,7 @@ export interface Resource extends Omit<DbResource, "parentId"> {
 }
 
 interface Tag {
-  label: string
+  labels: string[]
   category: string
   values: string[]
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -9,7 +9,7 @@ export interface Resource extends Omit<DbResource, "parentId"> {
 }
 
 interface Tag {
-  labels: string[]
+  selected: string[]
   category: string
   values: string[]
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -11,7 +11,6 @@ export interface Resource extends Omit<DbResource, "parentId"> {
 interface Tag {
   selected: string[]
   category: string
-  values: string[]
 }
 
 export type SitemapEntry = Pick<

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -1,9 +1,9 @@
-export interface Resource {
-  id: string
-  title: string
-  permalink: string
+import { Resource as DbResource } from "~generated/generatedTypes"
+
+// NOTE: this needs the `omit` because the `parentId`
+// we defined in studio
+export interface Resource extends Omit<DbResource, "parentId"> {
   parentId: number | null
-  type: string
   content?: any
   fullPermalink: string
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -8,6 +8,12 @@ export interface Resource {
   fullPermalink: string
 }
 
+interface Tag {
+  label: string
+  category: string
+  values: string[]
+}
+
 export type SitemapEntry = Pick<Resource, "id" | "title" | "permalink"> & {
   lastModified: string
   layout: string
@@ -17,4 +23,5 @@ export type SitemapEntry = Pick<Resource, "id" | "title" | "permalink"> & {
   image?: string
   ref?: string
   children?: SitemapEntry[]
+  tags?: Tag[]
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -1,4 +1,4 @@
-import { Resource as DbResource } from "~generated/generatedTypes"
+import { Resource as DbResource } from "~generated/selectableTypes"
 
 // NOTE: this needs the `omit` because the `parentId`
 // we defined in studio
@@ -14,7 +14,10 @@ interface Tag {
   values: string[]
 }
 
-export type SitemapEntry = Pick<Resource, "id" | "title" | "permalink"> & {
+export type SitemapEntry = Pick<
+  Resource,
+  "id" | "title" | "permalink" | "type"
+> & {
   lastModified: string
   layout: string
   summary: string

--- a/tooling/build/scripts/publishing/utils/getIndexPageContent.ts
+++ b/tooling/build/scripts/publishing/utils/getIndexPageContent.ts
@@ -1,9 +1,21 @@
 const ISOMER_SCHEMA_VERSION = "0.1.0"
 
-// Generate the index page content for a given directory
-export const getIndexPageContents = (title: string) => ({
+// Generate the index page content for a given folder
+export const getFolderIndexPageContents = (title: string) => ({
   version: ISOMER_SCHEMA_VERSION,
   layout: "index",
+  page: {
+    title,
+    contentPageHeader: {
+      summary: `Pages in ${title}`,
+    },
+  },
+  content: [],
+})
+
+export const getCollectionIndexPageContents = (title: string) => ({
+  version: ISOMER_SCHEMA_VERSION,
+  layout: "collection",
   page: {
     title,
     contentPageHeader: {


### PR DESCRIPTION
## Problem
This PR adds filtering to collections through the use of tags. 

## Solution
1. add `Tags` to the schema on `CollectionPagePageSchema`
    - note that in our publishing script, we explictly check for whether it's a `PAGE_RESOURCE_TYPE`, which means that even though the schema can only expose it on page items. we might want to expose it on files, which would necessitate a slight change inhow we generate hte `SitemapEntries`. not too sure if this is what we want, so i omitted it for now. need to think abit more here
2. add tags to `publishing/index.ts` so that it gets written to the sitemap entry (and hence, to disk)
3. in `Collection`, extract the `tags` from the `Sitemap`. add filtering logic onto our collection so that it will display the correct cards on filter click. take note that the logic here can be (and should be) reused for collection but not for years due to how the comparison is made
    - i didn't do it for collections because the id and the check is a lower-cased check via a hard-coded id + the property is different (takes from `item.category` and not `item.tags`  

## Videos

https://github.com/user-attachments/assets/db0c6179-e18d-497a-ac2f-38f683a4286c

