### PR TITLE
isom-1688 add view all articles link to infocards

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -4720,6 +4720,10 @@ video {
     padding-right: 0px;
   }
 
+  .sm\:pt-12 {
+    padding-top: 3rem;
+  }
+
   .sm\:text-4xl {
     font-size: 2.25rem;
     line-height: 2.5rem;

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -98,6 +98,27 @@ const InfoCardsBaseSchema = Type.Object({
       },
     ),
   ),
+  // TODO: Remove "label" and "url"
+  // Context: This one is a stopgap measure in lieu of linking collections to the homepage
+  // Will be hidden in Studio for now
+  label: Type.Optional(
+    Type.String({
+      title: "Link text",
+      maxLength: 50,
+      description:
+        "Add a link under your block. Avoid generic text such as “Click here” or “Learn more”",
+      format: "hidden",
+    }),
+  ),
+  url: Type.Optional(
+    Type.String({
+      title: "Link destination",
+      description: "When this is clicked, open:",
+      // should be link but needs to be hidden for now
+      // shall not overcomlicate the schema for now since it's unavailable in Studio
+      format: "hidden",
+    }),
+  ),
 })
 
 const InfoCardsWithImageSchema = Type.Object(

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -51,11 +51,13 @@ const generateArgs = ({
   maxColumns,
   withoutImage = false,
   isImageFitContain = false,
+  hasCTA = false,
 }: {
   layout?: IsomerPageLayoutType
   maxColumns: "1" | "2" | "3"
   withoutImage?: boolean
   isImageFitContain?: boolean
+  hasCTA?: boolean
 }): InfoCardsProps => {
   const cards = [
     {
@@ -124,6 +126,12 @@ const generateArgs = ({
     maxColumns: maxColumns,
     variant: withoutImage ? "cardsWithoutImages" : "cardsWithImages",
     cards: cards,
+    ...(hasCTA
+      ? {
+          label: "This is a CTA",
+          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        }
+      : {}),
   } as InfoCardsProps
 }
 
@@ -163,4 +171,8 @@ export const NoImage: Story = {
 
 export const WithContainImageFit: Story = {
   args: generateArgs({ maxColumns: "3", isImageFitContain: true }),
+}
+
+export const WithLink: Story = {
+  args: generateArgs({ maxColumns: "3", withoutImage: true, hasCTA: true }),
 }

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/utils"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
+import { LinkButton } from "../../internal/LinkButton"
 import { ImageClient } from "../Image"
 
 const infoCardTitleStyle = tv({
@@ -42,6 +43,7 @@ const createInfoCardsStyles = tv({
     cardTitleArrow:
       "mb-0.5 ml-1 inline h-auto w-6 transition ease-in group-hover:translate-x-1",
     cardDescription: "prose-body-base text-base-content",
+    urlButtonContainer: "mx-auto block pt-8 sm:pt-12", // temp: following headingContainer's mb
   },
   variants: {
     layout: {
@@ -219,6 +221,8 @@ const InfoCards = ({
   variant,
   cards,
   maxColumns,
+  label,
+  url,
   layout,
   site,
   LinkComponent,
@@ -288,6 +292,19 @@ const InfoCards = ({
       <div className={compoundStyles.grid({ maxColumns })}>
         <InfoCardtoRender />
       </div>
+
+      {!!url && !!label && (
+        <div className={compoundStyles.urlButtonContainer()}>
+          <LinkButton
+            href={getReferenceLinkHref(url, site.siteMap, site.assetsBaseUrl)}
+            size="base"
+            variant="outline"
+            isWithFocusVisibleHighlight
+          >
+            {label}
+          </LinkButton>
+        </div>
+      )}
     </section>
   )
 }

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -286,6 +286,8 @@ export const Default: Story = {
         subtitle:
           "Section subtitle, maximum 150 chars. These are some of the things we are working on. As a ministry, we focus on delivering value to the members of public.",
         variant: "cardsWithImages",
+        label: "This is a CTA",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
         cards: [
           {
             title: "Card with short title",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1688/add-view-all-articles-link-to-infocards

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- add hidden `url` and `label` to Infocards schema
- add UI for infocards (inspiration from KeyStatistics)

## Before & After Screenshots

![image](https://github.com/user-attachments/assets/650f8bb8-79f9-47a2-93d3-7d9fa5c95fd7)

## Tests

<!-- What tests should be run to confirm functionality? -->

https://www.loom.com/share/ba385efc529f46adac234ebd07cdfd42?sid=ec9dc6bd-9148-4dec-987e-7f4d9b2dee9e

```
"label": "This is a CTA",
"url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
```