### PR TITLE
fix prisma linux-musl loading issue

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -1,3 +1,6 @@
+# needed to pin to 3.20 because Prisma uses OpenSSL but it has been shifted to another location in 3.21
+# Ref: https://github.com/prisma/prisma/issues/25817
+# Solution: https://github.com/prisma/prisma/issues/25817#issuecomment-2529926082
 FROM node:22-alpine3.20 AS base
 
 ARG NEXT_PUBLIC_APP_ENV

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -34,6 +34,10 @@ FROM base AS builder
 RUN apk update
 RUN apk add --no-cache libc6-compat
 
+# needed because Prisma uses OpenSSL but it has been removed from Alpine 3.21
+# Ref: https://github.com/prisma/prisma/issues/25817
+RUN apk add --no-cache openssl
+
 # Set working directory
 WORKDIR /app
 # Replace <your-major-version> with the major version installed in your repository. For example:

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -34,10 +34,6 @@ FROM base AS builder
 RUN apk update
 RUN apk add --no-cache libc6-compat
 
-# needed because Prisma uses OpenSSL but it has been removed from Alpine 3.21
-# Ref: https://github.com/prisma/prisma/issues/25817
-RUN apk add --no-cache openssl
-
 # Set working directory
 WORKDIR /app
 # Replace <your-major-version> with the major version installed in your repository. For example:
@@ -53,6 +49,12 @@ RUN turbo prune isomer-studio --docker
 FROM base AS installer
 RUN apk update
 RUN apk add --no-cache libc6-compat
+
+# needed because Prisma uses OpenSSL but it has been shifted to another location
+# Ref: https://github.com/prisma/prisma/issues/25817
+# Ref: solution: https://github.com/nodejs/docker-node/issues/2175#issuecomment-2530130523
+RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
+
 WORKDIR /app
 
 # First install the dependencies (as they change less often)

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM node:22-alpine3.20 AS base
 
 ARG NEXT_PUBLIC_APP_ENV
 ENV NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV
@@ -49,12 +49,6 @@ RUN turbo prune isomer-studio --docker
 FROM base AS installer
 RUN apk update
 RUN apk add --no-cache libc6-compat
-
-# needed because Prisma uses OpenSSL but it has been shifted to another location
-# Ref: https://github.com/prisma/prisma/issues/25817
-# Ref: solution: https://github.com/nodejs/docker-node/issues/2175#issuecomment-2530130523
-RUN ln -s /usr/lib/libssl.so.3 /lib/libssl.so.3
-
 WORKDIR /app
 
 # First install the dependencies (as they change less often)

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -9,9 +9,6 @@ datasource db {
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
-  // # needed because Prisma uses OpenSSL but it has been shifted to another location
-  // # Ref: https://github.com/prisma/prisma/issues/25817
-  binaryTargets = ["linux-musl"]
 }
 
 /// Always after the prisma-client-js generator

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -9,6 +9,9 @@ datasource db {
 generator client {
   provider        = "prisma-client-js"
   previewFeatures = ["driverAdapters"]
+  // # needed because Prisma uses OpenSSL but it has been shifted to another location
+  // # Ref: https://github.com/prisma/prisma/issues/25817
+  binaryTargets = ["linux-musl"]
 }
 
 /// Always after the prisma-client-js generator


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

```
Unable to require(`/app/apps/studio/node_modules/.prisma/client/libquery_engine-linux-musl.so.node`).
The Prisma engines do not seem to be compatible with your system. 
Please refer to the documentation about Prisma's system requirements: https://pris.ly/d/system-requirements
Details: Error loading shared library [libssl.so](http://libssl.so/).1.1: 
No such file or directory (needed by /app/apps/studio/node_modules/.prisma/client/libquery_engine-linux-musl.so.node)
```

More: https://opengovproducts.slack.com/archives/CK9GGK6EP/p1733812366391449

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- fix alpine image to version 3.20 (https://github.com/prisma/prisma/issues/25817#issuecomment-2529926082)
- reason: since there's a PR in `prisma` for this issue, i'm **assuming** this will be fixed soon in later releases, and we can just update `prisma` package and undo this change. instead of 1) spending more time on this, and 2) doing a different (and potentially breaking) workaround 

## Before & After Screenshots

## Tests

<!-- What tests should be run to confirm functionality? -->

should no longer throw an issue when accessing Studio after deployment