### PR TITLE
feat(logo cloud): add schema for rendering 

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1556,6 +1556,10 @@ video {
   height: 100vh;
 }
 
+.max-h-24 {
+  max-height: 6rem;
+}
+
 .max-h-\[400px\] {
   max-height: 400px;
 }
@@ -1688,10 +1692,6 @@ video {
 
 .max-w-40 {
   max-width: 10rem;
-}
-
-.max-w-52 {
-  max-width: 13rem;
 }
 
 .max-w-5xl {

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -325,7 +325,7 @@ export const BLOCK_TO_META: Record<
     // TODO: Add image source
     label: "Logo cloud",
     description: "Display logos of other agencies here",
-    usageText: "Add logos here to easily show logos from other agencies",
+    usageText: "Show an overview of related agencies",
   },
 }
 

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -216,6 +216,11 @@ export const DEFAULT_BLOCKS: Record<
       },
     ],
   },
+  logocloud: {
+    type: "logocloud",
+    images: [],
+    title: "With support from these agencies",
+  },
 }
 
 export const BLOCK_TO_META: Record<
@@ -315,6 +320,12 @@ export const BLOCK_TO_META: Record<
     label: "Dynamic Data Banner",
     description: "Display dynamic data banner",
     usageText: "This block supports fetching data from an API endpoint.",
+  },
+  logocloud: {
+    // TODO: Add image source
+    label: "Logo cloud",
+    description: "Display logos of other agencies here",
+    usageText: "Add logos here to easily show logos from other agencies",
   },
 }
 

--- a/apps/studio/src/features/editing-experience/constants.ts
+++ b/apps/studio/src/features/editing-experience/constants.ts
@@ -3,6 +3,7 @@ import type { IconType } from "react-icons"
 import { DYNAMIC_DATA_BANNER_TYPE } from "@opengovsg/isomer-components"
 import {
   BiChevronDown,
+  BiCloud,
   BiCrown,
   BiHash,
   BiImage,
@@ -38,6 +39,7 @@ export const TYPE_TO_ICON: Record<
   iframe: FaYoutube,
   map: BiMap,
   video: BiMoviePlay,
+  logocloud: BiCloud,
   [DYNAMIC_DATA_BANNER_TYPE]: TbApi,
   // TODO: Add in these new block types
   // table: BiTable,

--- a/packages/components/src/interfaces/complex/LogoCloud.ts
+++ b/packages/components/src/interfaces/complex/LogoCloud.ts
@@ -1,9 +1,10 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
+export const LOGO_CLOUD_TYPE = "logocloud"
 export const LogoCloudSchema = Type.Object(
   {
-    type: Type.Literal("logocloud", { default: "logocloud" }),
+    type: Type.Literal(LOGO_CLOUD_TYPE, { default: LOGO_CLOUD_TYPE }),
     images: Type.Array(
       Type.Object({
         src: Type.String({

--- a/packages/components/src/interfaces/complex/LogoCloud.ts
+++ b/packages/components/src/interfaces/complex/LogoCloud.ts
@@ -1,0 +1,39 @@
+import type { Static } from "@sinclair/typebox"
+import { Type } from "@sinclair/typebox"
+
+export const LogoCloudSchema = Type.Object(
+  {
+    type: Type.Literal("logocloud", { default: "logocloud" }),
+    images: Type.Array(
+      Type.Object({
+        src: Type.String({
+          title: "Upload image",
+          format: "image",
+        }),
+        alt: Type.String({
+          title: "Alternate text",
+          maxLength: 120,
+          description:
+            "Add a descriptive alternative text for this image. This helps visually impaired users to understand your image.",
+        }),
+      }),
+      {
+        title: "Images for logo cloud",
+        minItems: 1,
+        maxItems: 10,
+      },
+    ),
+    title: Type.String({
+      title: "Title for the logo cloud",
+      description: "Upload the images for the logo cloud here or provide a url",
+      maxLength: 120,
+    }),
+  },
+  {
+    title: "Title",
+  },
+)
+
+export type LogoCloudProps = Static<typeof LogoCloudSchema> & {
+  assetsBaseUrl?: string
+}

--- a/packages/components/src/interfaces/complex/index.ts
+++ b/packages/components/src/interfaces/complex/index.ts
@@ -1,4 +1,5 @@
 export { AccordionSchema, type AccordionProps } from "./Accordion"
+export { LogoCloudSchema, type LogoCloudProps } from "./LogoCloud"
 export { CalloutSchema, type CalloutProps } from "./Callout"
 export { type CardsProps } from "./Cards"
 export { ContentpicSchema, type ContentpicProps } from "./Contentpic"

--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -26,6 +26,7 @@ import {
   UnorderedListSchema,
   VideoSchema,
 } from "~/interfaces"
+import { LogoCloudSchema } from "~/interfaces/complex/LogoCloud"
 
 export const IsomerComplexComponentsMap = {
   accordion: AccordionSchema,
@@ -42,6 +43,7 @@ export const IsomerComplexComponentsMap = {
   map: MapSchema,
   video: VideoSchema,
   [DYNAMIC_DATA_BANNER_TYPE]: DynamicDataBannerSchema,
+  logocloud: LogoCloudSchema,
 }
 
 export const IsomerNativeComponentsMap = {

--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -18,6 +18,7 @@ import {
   InfoColsSchema,
   InfopicSchema,
   KeyStatisticsSchema,
+  LogoCloudSchema,
   MapSchema,
   OrderedListSchema,
   ParagraphSchema,
@@ -26,7 +27,6 @@ import {
   UnorderedListSchema,
   VideoSchema,
 } from "~/interfaces"
-import { LogoCloudSchema } from "~/interfaces/complex/LogoCloud"
 
 export const IsomerComplexComponentsMap = {
   accordion: AccordionSchema,

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
@@ -1,15 +1,7 @@
-import type { IsomerSiteProps } from "~/types"
+import type { LogoCloudProps } from "~/interfaces/complex/LogoCloud"
 import { isExternalUrl } from "~/utils"
 import { ImageClient } from "../Image"
 
-interface Image {
-  src: string
-  alt: string
-}
-interface LogoCloudProps extends Pick<IsomerSiteProps, "assetsBaseUrl"> {
-  images: Image[]
-  title?: string
-}
 export const LogoCloud = ({
   images: baseImages,
   title,

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
@@ -34,7 +34,7 @@ export const LogoCloud = ({
             <ImageClient
               {...props}
               width="100%"
-              className="inset-0 w-fit max-w-52 object-contain p-2"
+              className="inset-0 max-h-24 w-fit object-contain p-2"
               assetsBaseUrl={assetsBaseUrl}
             />
           ))}

--- a/packages/components/src/templates/next/render/render.tsx
+++ b/packages/components/src/templates/next/render/render.tsx
@@ -22,6 +22,7 @@ import {
   Prose,
   Video,
 } from "../components"
+import { LogoCloud } from "../components/complex/LogoCloud"
 import {
   ArticleLayout,
   CollectionLayout,
@@ -47,6 +48,8 @@ export const renderComponent = ({
   ...rest
 }: RenderComponentProps) => {
   switch (component.type) {
+    case "logocloud":
+      return <LogoCloud key={elementKey} {...component} {...rest} />
     case "accordion":
       return <Accordion key={elementKey} {...component} {...rest} />
     case "callout":

--- a/packages/components/src/templates/next/render/renderComponentPreviewText.ts
+++ b/packages/components/src/templates/next/render/renderComponentPreviewText.ts
@@ -95,6 +95,8 @@ export function renderComponentPreviewText({
       return component.title
     case "map":
       return component.title || "Map embed"
+    case "logocloud":
+      return component.title || "Logo cloud"
     case "prose":
       return getTextContentOfProse(component.content)
     case "video":

--- a/packages/components/src/templates/next/render/renderComponentPreviewText.ts
+++ b/packages/components/src/templates/next/render/renderComponentPreviewText.ts
@@ -96,7 +96,7 @@ export function renderComponentPreviewText({
     case "map":
       return component.title || "Map embed"
     case "logocloud":
-      return component.title || "Logo cloud"
+      return component.title
     case "prose":
       return getTextContentOfProse(component.content)
     case "video":


### PR DESCRIPTION
## Problem
logo cloud requires an update in `renderComponent` so that it can be rendered successfully from the `content` of the page

Closes [insert issue #]

## Solution
1. add the associated schema over to schemas 
