### PR TITLE
chore: object spreads for meta

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -102,7 +102,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
   }
 
   if (props.page.permalink === "/") {
-    return metadata
+    return { ...metadata }
   }
 
   return {


### PR DESCRIPTION
## Problem
our metadata stuff broke with next15. 

## Solution
using an object spread for metadata seemed to work for the homepage. i have no clue - discovered this by accident 
