### PR TITLE
Increase file attachment to 20mb

### DIFF
--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -3,7 +3,10 @@ import { useEffect, useState } from "react"
 import { FormControl, Skeleton, Text } from "@chakra-ui/react"
 import { Attachment } from "@opengovsg/design-system-react"
 
-import { MAX_FILE_SIZE_BYTES } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
+import {
+  FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
+  MAX_FILE_SIZE_BYTES,
+} from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
 import { getPresignedPutUrlSchema } from "~/schemas/asset"
 
@@ -15,11 +18,9 @@ interface FileAttachmentProps {
 
 type FileRejections = AttachmentProps<false>["rejections"]
 
-const ACCEPTED_FILE_TYPES: string[] = ["application/pdf"]
-const ACCEPTED_FILE_TYPES_MESSAGE = ACCEPTED_FILE_TYPES.map((filetype) => {
-  const extension = filetype.split("/").at(-1)
-  return extension ? `*.${extension}` : ""
-}).join(", ")
+const ACCEPTED_FILE_TYPES_MESSAGE = Object.keys(
+  FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
+).join(", ")
 
 export const FileAttachment = ({
   setHref,
@@ -65,7 +66,7 @@ export const FileAttachment = ({
             )
           }}
           maxSize={MAX_FILE_SIZE_BYTES}
-          accept={ACCEPTED_FILE_TYPES}
+          accept={Object.values(FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING)}
           onFileValidation={(file) => {
             const parseResult = getPresignedPutUrlSchema
               .pick({ fileName: true })

--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react"
 import { FormControl, Skeleton, Text } from "@chakra-ui/react"
 import { Attachment } from "@opengovsg/design-system-react"
 
-import { MAX_PDF_FILE_SIZE_BYTES } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
+import { MAX_FILE_SIZE_BYTES } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
 import { getPresignedPutUrlSchema } from "~/schemas/asset"
 
@@ -64,7 +64,7 @@ export const FileAttachment = ({
               },
             )
           }}
-          maxSize={MAX_PDF_FILE_SIZE_BYTES}
+          maxSize={MAX_FILE_SIZE_BYTES}
           accept={ACCEPTED_FILE_TYPES}
           onFileValidation={(file) => {
             const parseResult = getPresignedPutUrlSchema
@@ -81,7 +81,7 @@ export const FileAttachment = ({
         />
       </Skeleton>
       <Text textStyle="body-2" textColor="base.content.medium" pt="0.5rem">
-        {`Maximum file size: ${MAX_PDF_FILE_SIZE_BYTES / 1000000} MB`}
+        {`Maximum file size: ${MAX_FILE_SIZE_BYTES / 1000000} MB`}
         <br />
         {`Accepted file types: ${ACCEPTED_FILE_TYPES_MESSAGE}`}
       </Text>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
@@ -1,5 +1,5 @@
 export const MAX_IMG_FILE_SIZE_BYTES = 5000000
-export const MAX_PDF_FILE_SIZE_BYTES = 20000000
+export const MAX_FILE_SIZE_BYTES = 20000000
 export const IMAGE_UPLOAD_ACCEPTED_MIME_TYPES = [
   "image/jpeg",
   "image/png",

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
@@ -1,5 +1,4 @@
 export const MAX_IMG_FILE_SIZE_BYTES = 5000000
-export const MAX_FILE_SIZE_BYTES = 20000000
 export const IMAGE_UPLOAD_ACCEPTED_MIME_TYPES = [
   "image/jpeg",
   "image/png",
@@ -9,3 +8,11 @@ export const IMAGE_UPLOAD_ACCEPTED_MIME_TYPES = [
   "image/bmp",
   "image/webp",
 ]
+export const MAX_FILE_SIZE_BYTES = 20000000
+export const FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".csv": "text/csv",
+  ".tsv": "text/tab-separated-values",
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
@@ -1,5 +1,5 @@
 export const MAX_IMG_FILE_SIZE_BYTES = 5000000
-export const MAX_PDF_FILE_SIZE_BYTES = 5000000
+export const MAX_PDF_FILE_SIZE_BYTES = 20000000
 export const IMAGE_UPLOAD_ACCEPTED_MIME_TYPES = [
   "image/jpeg",
   "image/png",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Previously there's an arbitrary limit of 5mb, which is insufficient for some agencies' use cases

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- allow different file sizes
- allow up to 20mb

## Tests

https://www.loom.com/share/a9dd8151f00d47ad92a6d82b58ad2212?sid=5b27a564-c0f0-434b-b369-cb69f4c5ef94

| test case | sample doc |
| - | - |
| .csv | https://github.com/datablist/sample-csv-files |
| .xls | https://community.tableau.com/s/contentdocument/0694T000001GnpUQAS |
| .xlsx | https://examplefile.com/file-download/564 |
| .tsv | https://getsamplefiles.com/download/tsv/sample-1.tsv |
| over 20mb | https://examplefile.com/document/pdf/30-mb-pdf |