### PR TITLE
Fix notfound meta for homepage

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -83,6 +83,12 @@ mv data/ ../../../template/
 cp sitemap.json ../../../template/public/
 mv sitemap.json ../../../template/
 cd ../../../template
+# Create not-found.json by copying _index.json if it doesn't exist
+# Refer to tooling/template/app/not-found.tsx for more context
+if [ ! -f "schema/not-found.json" ]; then
+  echo "Creating not-found.json..."
+  cp schema/_index.json schema/not-found.json
+fi
 echo $(pwd)
 echo "Fetching cached tooling-template node_modules..."
 TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$ISOMER_BUILD_REPO_BRANCH/isomer-tooling-template/node_modules.tar.gz"

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -26,7 +26,12 @@ export const generateMetadata = async (
   _props: never,
   _parent: ResolvingMetadata,
 ): Promise<Metadata> => {
-  const schema = (await import(`@/schema/_index.json`).then(
+  // Context for using @/schema/not-found.json
+  // For some next15 magical reason, using @/schema/_index.json will cause
+  // duplicated generation of the homepage, resulting in wrong meta values
+  // During deployment, publisher.sh duplicate homepage "_index.json" to "not-found.json"
+  // For development, you would need to manually copy and rename
+  const schema = (await import(`@/schema/not-found.json`).then(
     (module) => module.default,
   )) as IsomerPageSchemaType
   schema.site = {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Meta content for homepage broken likely due to https://github.com/opengovsg/isomer/pull/860

more: https://opengovproducts.slack.com/archives/C06R4DX966P/p1733891365830479

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- fix passing of erroneous params from `generateStaticParams` to `Page` in `page.tsx` with a patch
- duplicate `schema/not-found.json` from `schema/_index.json` (homepage) to use for not-found

## Tests

- go to codebuild and trigger build for [isomer.gov.sg](http://isomer.gov.sg/)
- once done, (optional: invalidate on cloudfront before) going to the site and copy the URL and paste it in whatsapp/telegram/slack etc. The preview should not be showing 404 for homepage
- also validate other pages aren't affected
