### PR TITLE
fix - amplify sites build fail due to missing schema/not-found.json

### DIFF
--- a/tooling/build/scripts/build.sh
+++ b/tooling/build/scripts/build.sh
@@ -50,6 +50,13 @@ rm -rf scripts
 # Bridging the difference betwen the two types of homepage JSONs
 mv schema/index.json schema/_index.json
 
+# Create not-found.json by copying _index.json if it doesn't exist
+# Refer to tooling/template/app/not-found.tsx for more context
+if [ ! -f "schema/not-found.json" ]; then
+  echo "Creating not-found.json..."
+  cp schema/_index.json schema/not-found.json
+fi
+
 # Build the site
 echo "Building site..."
 start_time=$(date +%s)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

- amplify sites build fail due to missing `schema/not-found.json` after https://github.com/opengovsg/isomer/pull/933
- build scripts is using a different script from publisher.sh

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- copy the logic from publisher.sh over
