### PR TITLE
Fix - infobar additional div when there's no CTA

### DIFF
--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
@@ -81,3 +81,13 @@ export const LongText: Story = {
     secondaryButtonUrl: "https://google.com",
   },
 }
+
+export const NoCTA: Story = {
+  args: {
+    sectionIdx: 0,
+    title:
+      "Longer title here that spans multiple lines and is quite long and verbose and takes up a lot of space",
+    description:
+      "About a sentence worth of description here About a sentence worth of description here About a sentence worth of description here",
+  },
+}

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -52,6 +52,8 @@ const Infobar = ({
   LinkComponent,
 }: InfobarProps) => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
+  const hasPrimaryCTA = !!buttonLabel && !!buttonUrl
+  const hasSecondaryCTA = !!secondaryButtonLabel && !!secondaryButtonUrl
 
   return (
     <section>
@@ -83,42 +85,44 @@ const Infobar = ({
             )}
           </div>
 
-          <div
-            className={compoundStyles.buttonContainer({
-              layout: simplifiedLayout,
-            })}
-          >
-            {buttonLabel && buttonUrl && (
-              <LinkButton
-                href={getReferenceLinkHref(
-                  buttonUrl,
-                  site.siteMap,
-                  site.assetsBaseUrl,
-                )}
-                size={simplifiedLayout === "homepage" ? "lg" : "base"}
-                LinkComponent={LinkComponent}
-                isWithFocusVisibleHighlight
-              >
-                {buttonLabel}
-              </LinkButton>
-            )}
+          {(hasPrimaryCTA || hasSecondaryCTA) && (
+            <div
+              className={compoundStyles.buttonContainer({
+                layout: simplifiedLayout,
+              })}
+            >
+              {hasPrimaryCTA && (
+                <LinkButton
+                  href={getReferenceLinkHref(
+                    buttonUrl,
+                    site.siteMap,
+                    site.assetsBaseUrl,
+                  )}
+                  size={simplifiedLayout === "homepage" ? "lg" : "base"}
+                  LinkComponent={LinkComponent}
+                  isWithFocusVisibleHighlight
+                >
+                  {buttonLabel}
+                </LinkButton>
+              )}
 
-            {secondaryButtonLabel && secondaryButtonUrl && (
-              <LinkButton
-                href={getReferenceLinkHref(
-                  secondaryButtonUrl,
-                  site.siteMap,
-                  site.assetsBaseUrl,
-                )}
-                size={simplifiedLayout === "homepage" ? "lg" : "base"}
-                variant="outline"
-                LinkComponent={LinkComponent}
-                isWithFocusVisibleHighlight
-              >
-                {secondaryButtonLabel}
-              </LinkButton>
-            )}
-          </div>
+              {hasSecondaryCTA && (
+                <LinkButton
+                  href={getReferenceLinkHref(
+                    secondaryButtonUrl,
+                    site.siteMap,
+                    site.assetsBaseUrl,
+                  )}
+                  size={simplifiedLayout === "homepage" ? "lg" : "base"}
+                  variant="outline"
+                  LinkComponent={LinkComponent}
+                  isWithFocusVisibleHighlight
+                >
+                  {secondaryButtonLabel}
+                </LinkButton>
+              )}
+            </div>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Came across this issue where infobar has an additional div when there's no CTA at all

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- do not render the CTA parent div if there's no primaryCTA or secondaryCTA

## Before & After Screenshots

**BEFORE**:

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/9e9b6b51-8d11-4881-b93d-56016f94a22d" />

**AFTER**:

<img width="1306" alt="image" src="https://github.com/user-attachments/assets/4ca4bdb1-4abb-4484-a0f9-cb1ce5880852" />

## Tests

review the "No CTA" story for infobar on storybook