### PR TITLE
fix - remove "default" values in infocards

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -11,13 +11,11 @@ import { LINK_HREF_PATTERN } from "~/utils/validation"
 const SingleCardNoImageSchema = Type.Object({
   title: Type.String({
     title: "Title",
-    default: "This is the title of the card",
     maxLength: 100,
   }),
   description: Type.Optional(
     Type.String({
       title: "Description",
-      default: "This is an optional description for the card",
       maxLength: 150,
     }),
   ),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1670/infocards-title-and-description-default-to-placeholder-when-empty

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- removed the `default` fields

note: there's a underlying issue with how we are rendering fields such that the "required" error message is not showing up. Should fix in a separate PR

## Tests

<!-- What tests should be run to confirm functionality? -->

https://www.loom.com/share/847ca1fac61b427aa0e3c68907605f59?sid=5908c1bc-892e-4893-9717-7961b79f3851
