### PR TITLE
chore: fix env

### DIFF
--- a/apps/studio/src/lib/logger.ts
+++ b/apps/studio/src/lib/logger.ts
@@ -54,7 +54,7 @@ export class PinoLogger {
         formatters: {
           bindings: () => {
             return {
-              env: env.NODE_ENV,
+              env: env.NEXT_PUBLIC_APP_ENV,
             }
           },
           level: (label) => {


### PR DESCRIPTION
## Problem
the default starter kit logger uses `NODE_ENV` for env and automatically injects it, which causes wrong parsing on dd logs as it should always be set to `production` - see [here](https://nodejs.org/en/learn/getting-started/nodejs-the-difference-between-development-and-production)

Closes [insert issue #]

## Solution
use our `NEXT_PUBLIC_APP_ENV` instead
