### PR TITLE
fix: collections active state

### DIFF
--- a/apps/studio/src/features/dashboard/components/DirectorySidebar/useIsActive.ts
+++ b/apps/studio/src/features/dashboard/components/DirectorySidebar/useIsActive.ts
@@ -28,8 +28,9 @@ export const useIsActive = (
     case ResourceType.IndexPage:
       return siteProps.resourceId === currentResourceId
     case ResourceType.Folder:
-    case ResourceType.Collection:
       return siteProps.folderId === currentResourceId
+    case ResourceType.Collection:
+      return siteProps.resourceId === currentResourceId
     case ResourceType.CollectionLink:
       return siteProps.linkId === currentResourceId
     case ResourceType.FolderMeta:


### PR DESCRIPTION
## Problem
we were previously using the wrong property, leading to collections not having the correct state in side bar when we are already in the collection

## Solution
update to correct property 

## Checks
1. Click into a collection
2. the sidebar should be highlighted for the collection