### PR TITLE
fix(url): show full urls everywhere in UI

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -42,6 +42,29 @@ import {
   folderSettingsModalAtom,
 } from "../../atoms"
 
+interface SuspendablePermalinkProps {
+  title: string
+  folderId: string
+}
+const SuspendablePermalink = ({
+  folderId,
+  title,
+}: SuspendablePermalinkProps) => {
+  const [{ fullPermalink }] =
+    trpc.resource.getWithFullPermalink.useSuspenseQuery({
+      resourceId: folderId ? String(folderId) : "",
+    })
+
+  return (
+    <Text textStyle="subhead-2" overflow="hidden">
+      <chakra.span color="base.content.medium">
+        {fullPermalink.split("/").slice(0, -1).join("/")}
+      </chakra.span>
+      /{title}
+    </Text>
+  )
+}
+
 export const FolderSettingsModal = () => {
   const { folderId } = useAtomValue(folderSettingsModalAtom)
   const { siteId } = useQueryParse(sitePageSchema)
@@ -119,10 +142,6 @@ const SuspendableModalContent = ({
     mutate({ ...data, resourceId: String(folderId), siteId: String(siteId) })
   })
 
-  const [{ fullPermalink }] =
-    trpc.resource.getWithFullPermalink.useSuspenseQuery({
-      resourceId: folderId ? String(folderId) : "",
-    })
   const [title, permalink] = watch(["title", "permalink"])
 
   return (
@@ -178,22 +197,19 @@ const SuspendableModalContent = ({
               {errors.permalink?.message ? (
                 <FormErrorMessage>{errors.permalink.message}</FormErrorMessage>
               ) : (
-                <Box
-                  mt="0.5rem"
-                  py="0.5rem"
-                  px="0.75rem"
-                  bg="interaction.support.disabled"
-                  display="flex"
-                  alignItems="center"
-                >
-                  <Icon mr="0.5rem" as={BiLink} />
-                  <Text textStyle="subhead-2" overflow="hidden">
-                    <chakra.span color="base.content.medium">
-                      {fullPermalink.split("/").slice(0, -1).join("/")}
-                    </chakra.span>
-                    /{permalink}
-                  </Text>
-                </Box>
+                <Suspense fallback={<Skeleton w="100%" h="2rem" mt="0.5rem" />}>
+                  <Box
+                    mt="0.5rem"
+                    py="0.5rem"
+                    px="0.75rem"
+                    bg="interaction.support.disabled"
+                    display="flex"
+                    alignItems="center"
+                  >
+                    <Icon mr="0.5rem" as={BiLink} />
+                    <SuspendablePermalink title={title} folderId={folderId} />
+                  </Box>
+                </Suspense>
               )}
 
               <FormHelperText mt="0.5rem" color="base.content.medium">

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react"
 import {
   Box,
+  chakra,
   FormControl,
   FormHelperText,
   FormLabel,
@@ -14,6 +15,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Skeleton,
+  Text,
   VStack,
 } from "@chakra-ui/react"
 import {
@@ -117,6 +119,10 @@ const SuspendableModalContent = ({
     mutate({ ...data, resourceId: String(folderId), siteId: String(siteId) })
   })
 
+  const [{ fullPermalink }] =
+    trpc.resource.getWithFullPermalink.useSuspenseQuery({
+      resourceId: folderId ? String(folderId) : "",
+    })
   const [title, permalink] = watch(["title", "permalink"])
 
   return (
@@ -177,9 +183,16 @@ const SuspendableModalContent = ({
                   py="0.5rem"
                   px="0.75rem"
                   bg="interaction.support.disabled"
+                  display="flex"
+                  alignItems="center"
                 >
                   <Icon mr="0.5rem" as={BiLink} />
-                  {permalink}
+                  <Text textStyle="subhead-2" overflow="hidden">
+                    <chakra.span color="base.content.medium">
+                      {fullPermalink.split("/").slice(0, -1).join("/")}
+                    </chakra.span>
+                    /{permalink}
+                  </Text>
                 </Box>
               )}
 

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -227,8 +227,8 @@ const PageSettingsModalContent = ({
       </ModalBody>
 
       <ModalFooter>
-        <Button mr={3} variant="clear" onClick={onSubmit}>
-          Back to editing
+        <Button mr={3} variant="clear" onClick={onClose}>
+          Close
         </Button>
         <Button onClick={onSubmit}>Publish changes immediately</Button>
       </ModalFooter>

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
@@ -64,8 +64,8 @@ const useCreateCollectionPageWizardContext = ({
   })
 
   const [type, title] = formMethods.watch(["type", "title"])
-  const [{ fullPermalink }] =
-    trpc.resource.getWithFullPermalink.useSuspenseQuery({
+  const { data, isLoading: isPermalinkLoading } =
+    trpc.resource.getWithFullPermalink.useQuery({
       resourceId: collectionId ? String(collectionId) : "",
     })
 
@@ -146,13 +146,13 @@ const useCreateCollectionPageWizardContext = ({
     currentStep,
     formMethods,
     handleCreatePage,
-    isLoading,
+    isLoading: isLoading || isPermalinkLoading,
     handleNextToDetailScreen,
     handleBackToTypeScreen,
     pagePreviewJson,
     onClose,
     currentType: type,
-    fullPermalink,
+    fullPermalink: data?.fullPermalink || "",
   }
 }
 

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
@@ -64,6 +64,10 @@ const useCreateCollectionPageWizardContext = ({
   })
 
   const [type, title] = formMethods.watch(["type", "title"])
+  const [{ fullPermalink }] =
+    trpc.resource.getWithFullPermalink.useSuspenseQuery({
+      resourceId: collectionId ? String(collectionId) : "",
+    })
 
   const pagePreviewJson: IsomerSchema = useMemo(() => {
     const jsonPreview =
@@ -148,6 +152,7 @@ const useCreateCollectionPageWizardContext = ({
     pagePreviewJson,
     onClose,
     currentType: type,
+    fullPermalink,
   }
 }
 

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -1,12 +1,11 @@
 import { useEffect } from "react"
 import {
+  chakra,
   Flex,
   FormControl,
   FormHelperText,
   FormLabel,
   Input,
-  InputGroup,
-  InputLeftAddon,
   ListItem,
   ModalBody,
   ModalHeader,
@@ -15,9 +14,14 @@ import {
   UnorderedList,
   Wrap,
 } from "@chakra-ui/react"
-import { Button, FormErrorMessage } from "@opengovsg/design-system-react"
+import {
+  Button,
+  FormErrorMessage,
+  Infobox,
+} from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { Controller } from "react-hook-form"
+import { BiLink } from "react-icons/bi"
 
 import { MAX_PAGE_URL_LENGTH, MAX_TITLE_LENGTH } from "~/schemas/page"
 import { AppGrid } from "~/templates/AppGrid"
@@ -40,6 +44,7 @@ export const CreateCollectionPageDetailsScreen = () => {
     handleBackToTypeScreen,
     handleCreatePage,
     isLoading,
+    fullPermalink,
   } = useCreateCollectionPageWizard()
 
   const {
@@ -179,34 +184,39 @@ export const CreateCollectionPageDetailsScreen = () => {
                     URL should be short and simple
                   </FormHelperText>
                 </FormLabel>
-                <InputGroup>
-                  <InputLeftAddon
-                    bg="interaction.support.disabled"
-                    color="base.divider.strong"
-                  >
-                    your-site.gov.sg/
-                  </InputLeftAddon>
-                  <Controller
-                    control={control}
-                    name="permalink"
-                    render={({ field: { onChange, ...field } }) => (
-                      <Input
-                        isDisabled={type === ResourceType.CollectionLink}
-                        borderLeftRadius={0}
-                        placeholder="URL will be autopopulated if left untouched"
-                        {...field}
-                        onChange={(e) => {
-                          onChange(
-                            generatePageUrl(e.target.value).slice(
-                              0,
-                              MAX_PAGE_URL_LENGTH,
-                            ),
-                          )
-                        }}
-                      />
-                    )}
-                  />
-                </InputGroup>
+                <Controller
+                  control={control}
+                  name="permalink"
+                  render={({ field: { onChange, ...field } }) => (
+                    <Input
+                      isDisabled={type === ResourceType.CollectionLink}
+                      borderLeftRadius={0}
+                      placeholder="URL will be autopopulated if left untouched"
+                      {...field}
+                      onChange={(e) => {
+                        onChange(
+                          generatePageUrl(e.target.value).slice(
+                            0,
+                            MAX_PAGE_URL_LENGTH,
+                          ),
+                        )
+                      }}
+                    />
+                  )}
+                />
+                <Infobox
+                  my="0.5rem"
+                  icon={<BiLink />}
+                  variant="info-secondary"
+                  size="sm"
+                >
+                  <Text textStyle="subhead-2" overflow="hidden">
+                    <chakra.span color="base.content.medium">
+                      {fullPermalink}
+                    </chakra.span>
+                    /{watch("permalink")}
+                  </Text>
+                </Infobox>
 
                 {errors.permalink?.message ? (
                   <FormErrorMessage>

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -214,7 +214,7 @@ export const CreateCollectionPageDetailsScreen = () => {
                     <chakra.span color="base.content.medium">
                       {fullPermalink}
                     </chakra.span>
-                    /{watch("permalink")}
+                    /{url}
                   </Text>
                 </Infobox>
 

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -65,6 +65,10 @@ const useCreatePageWizardContext = ({
   })
 
   const [layout, title] = formMethods.watch(["layout", "title"])
+  const [{ fullPermalink }] =
+    trpc.resource.getWithFullPermalink.useSuspenseQuery({
+      resourceId: folderId ? String(folderId) : "",
+    })
 
   const layoutPreviewJson: IsomerSchema = useMemo(() => {
     const jsonPreview =
@@ -132,6 +136,7 @@ const useCreatePageWizardContext = ({
     layoutPreviewJson,
     onClose,
     currentLayout: layout,
+    fullPermalink,
   }
 }
 

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -65,10 +65,13 @@ const useCreatePageWizardContext = ({
   })
 
   const [layout, title] = formMethods.watch(["layout", "title"])
-  const [{ fullPermalink }] =
-    trpc.resource.getWithFullPermalink.useSuspenseQuery({
-      resourceId: folderId ? String(folderId) : "",
-    })
+  const { data, isLoading: isPermalinkLoading } =
+    trpc.resource.getWithFullPermalink.useQuery(
+      {
+        resourceId: folderId ? String(folderId) : "",
+      },
+      { enabled: !!folderId },
+    )
 
   const layoutPreviewJson: IsomerSchema = useMemo(() => {
     const jsonPreview =
@@ -88,7 +91,7 @@ const useCreatePageWizardContext = ({
       await utils.resource.listWithoutRoot.invalidate()
       onClose()
     },
-    // TOOD: Error handling
+    // TODO: Error handling
   })
 
   const handleCreatePage = formMethods.handleSubmit((values) => {
@@ -130,13 +133,13 @@ const useCreatePageWizardContext = ({
     currentStep,
     formMethods,
     handleCreatePage,
-    isLoading,
+    isLoading: isLoading || isPermalinkLoading,
     handleNextToDetailScreen,
     handleBackToLayoutScreen,
     layoutPreviewJson,
     onClose,
     currentLayout: layout,
-    fullPermalink,
+    fullPermalink: !!folderId ? data?.fullPermalink : "",
   }
 }
 

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -180,7 +180,7 @@ export const CreatePageDetailsScreen = () => {
                       <chakra.span color="base.content.medium">
                         {fullPermalink}
                       </chakra.span>
-                      /{watch("permalink")}
+                      /{url}
                     </Text>
                   </Infobox>
                   {errors.permalink?.message ? (

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -1,22 +1,27 @@
 import { useEffect } from "react"
 import {
+  chakra,
   Flex,
   FormControl,
   FormHelperText,
   FormLabel,
   Input,
-  InputGroup,
-  InputLeftAddon,
   ModalBody,
   ModalHeader,
   Stack,
   Text,
   Wrap,
 } from "@chakra-ui/react"
-import { Button, FormErrorMessage } from "@opengovsg/design-system-react"
+import {
+  Button,
+  FormErrorMessage,
+  Infobox,
+} from "@opengovsg/design-system-react"
 import { Controller } from "react-hook-form"
+import { BiLink } from "react-icons/bi"
 
 import { MAX_PAGE_URL_LENGTH, MAX_TITLE_LENGTH } from "~/schemas/page"
+import { AppGrid } from "~/templates/AppGrid"
 import { generateResourceUrl } from "../utils"
 import { useCreatePageWizard } from "./CreatePageWizardContext"
 import { PreviewLayout } from "./PreviewLayout"
@@ -28,6 +33,7 @@ export const CreatePageDetailsScreen = () => {
     handleBackToLayoutScreen,
     handleCreatePage,
     isLoading,
+    fullPermalink,
   } = useCreatePageWizard()
 
   const {
@@ -101,8 +107,8 @@ export const CreatePageDetailsScreen = () => {
         </Stack>
       </ModalHeader>
       <ModalBody p={0} overflow="hidden" bg="white">
-        <Flex height="100%">
-          <Stack height={0} minH="100%" overflow="auto">
+        <AppGrid height="100%" px={0}>
+          <Stack gridColumn="1 / 5" height={0} minH="100%" overflow="auto">
             <Stack gap="2rem" px="3rem" pb="2rem" pt="10vh">
               <Stack>
                 <Text as="h2" textStyle="h4">
@@ -142,35 +148,41 @@ export const CreatePageDetailsScreen = () => {
                       URL should be short and simple
                     </FormHelperText>
                   </FormLabel>
-                  <InputGroup>
-                    <InputLeftAddon
-                      bg="interaction.support.disabled"
-                      color="base.divider.strong"
-                    >
-                      your-site.gov.sg/
-                    </InputLeftAddon>
-                    <Controller
-                      control={control}
-                      name="permalink"
-                      render={({ field: { onChange, ...field } }) => (
-                        <Input
-                          maxLength={MAX_PAGE_URL_LENGTH}
-                          borderLeftRadius={0}
-                          placeholder="URL will be autopopulated if left untouched"
-                          {...field}
-                          onChange={(e) => {
-                            onChange(
-                              generateResourceUrl(e.target.value).slice(
-                                0,
-                                MAX_PAGE_URL_LENGTH,
-                              ),
-                            )
-                          }}
-                        />
-                      )}
-                    />
-                  </InputGroup>
+                  <Controller
+                    control={control}
+                    name="permalink"
+                    render={({ field: { onChange, ...field } }) => (
+                      <Input
+                        minW="23rem"
+                        maxLength={MAX_PAGE_URL_LENGTH}
+                        borderLeftRadius={0}
+                        placeholder="URL will be autopopulated if left untouched"
+                        {...field}
+                        onChange={(e) => {
+                          onChange(
+                            generateResourceUrl(e.target.value).slice(
+                              0,
+                              MAX_PAGE_URL_LENGTH,
+                            ),
+                          )
+                        }}
+                      />
+                    )}
+                  />
 
+                  <Infobox
+                    my="0.5rem"
+                    icon={<BiLink />}
+                    variant="info-secondary"
+                    size="sm"
+                  >
+                    <Text textStyle="subhead-2" overflow="hidden">
+                      <chakra.span color="base.content.medium">
+                        {fullPermalink}
+                      </chakra.span>
+                      /{watch("permalink")}
+                    </Text>
+                  </Infobox>
                   {errors.permalink?.message ? (
                     <FormErrorMessage>
                       {errors.permalink.message}
@@ -184,8 +196,10 @@ export const CreatePageDetailsScreen = () => {
               </Stack>
             </Stack>
           </Stack>
-          <PreviewLayout />
-        </Flex>
+          <Flex gridColumn="5 / 13">
+            <PreviewLayout />
+          </Flex>
+        </AppGrid>
       </ModalBody>
     </>
   )


### PR DESCRIPTION
## Problem
Some places don't show the full UI but we should always show the full UI everywhere. this also fixes a bug with the page settings modal where we were calling the wrong function for the close button

## Solution
1. update the creation modal to fetch the full permalink from the backend and show it
2. update the **pagecreationmodal** so that it uses a grid. this is because removing the left adornment makes the left section squished and shorter than required. 
3. update the folder settings modal to use the full url also (similar fashion as ^) 
4. update the box to use a `Suspense` so that we can load in the folder setings modal quickly

## Checks 
1. create a page in both folder and collection 
2. the page should show the full url on the details screen
3. type an extremely long url 
4. click on settings for a nested folder
5. the folder settings modal should show the full url
6. open the page settings modal 
7. click on the Close button 
8. the modal should close

## Video

https://github.com/user-attachments/assets/675c16cf-6c4d-4e95-80a5-97de87c404ee

