### PR TITLE
add placeholder for article summary

### DIFF
--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -14,7 +14,7 @@ export const createCollectionPageJson = ({}: {
       // which is not done at present
       category: "Feature Articles",
       articlePageHeader: {
-        summary: "",
+        summary: "A concise summary of the main points regarding this article.",
       },
     },
     content: [],


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Collection (article page header) can be saved when article summary is required. 

This is because we set it to be an empty string by default, which technically passes the validation

However, this is not aligned with the gold standards as we want users to provide this value

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- set a default non-empty string value

## Before & After Screenshots

**BEFORE**:

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/eecf7472-61c8-4359-9253-0b91efab2b78" />

**AFTER**:

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/60cdc303-5483-48f6-b722-2e608501f04c" />


