### PR TITLE
hotfix - remove isomer guide from sidebar

### DIFF
--- a/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react"
 import { useRouter } from "next/router"
 import { Flex } from "@chakra-ui/react"
-import { BiCog, BiFolder, BiHelpCircle, BiLogOut } from "react-icons/bi"
+import { BiCog, BiFolder, BiLogOut } from "react-icons/bi"
 import { z } from "zod"
 
 import type { CmsSidebarItem } from "~/components/CmsSidebar/CmsSidebarItems"
@@ -58,11 +58,6 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
 
   const userNavItems: CmsSidebarItem[] = [
     // TODO(ISOM-1552): Add back view live site functionality when implemented
-    {
-      icon: BiHelpCircle,
-      label: "Isomer Guide ",
-      href: "https://guide.isomer.gov.sg/",
-    },
     {
       icon: BiLogOut,
       label: "Sign out",

--- a/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react"
 import { useRouter } from "next/router"
 import { Flex } from "@chakra-ui/react"
-import { BiCog, BiFolder, BiHelpCircle, BiLogOut } from "react-icons/bi"
+import { BiCog, BiFolder, BiLogOut } from "react-icons/bi"
 import { z } from "zod"
 
 import type { CmsSidebarItem } from "~/components/CmsSidebar/CmsSidebarItems"
@@ -56,11 +56,6 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
 
   const userNavItems: CmsSidebarItem[] = [
     // TODO(ISOM-1552): Add back view live site functionality when implemented
-    {
-      icon: BiHelpCircle,
-      label: "Isomer Guide ",
-      href: "https://guide.isomer.gov.sg/",
-    },
     {
       icon: BiLogOut,
       label: "Sign out",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

isomer guide v4 not out yet and existing guide is about CMS - can be misleading to users

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- remove guide icon
