### PR TITLE
hotfix/publishersh revert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34439,21 +34439,6 @@
     "tooling/typescript": {
       "name": "@isomer/tsconfig",
       "version": "0.0.0"
-    },
-    "tooling/template/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.13",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.13.tgz",
-      "integrity": "sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -53,6 +53,7 @@ else
   echo "Installing dependencies..."
   start_time=$(date +%s)
   npm ci
+  npm install ts-node -g
   calculate_duration $start_time
 
   echo "Caching node_modules..."

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -5,15 +5,14 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "tsx index.ts "
+    "start": "ts-node index.ts "
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "pg": "^8.12.0",
-    "tsx": "^4.19.2"
+    "pg": "^8.12.0"
   },
   "devDependencies": {
     "@types/pg": "^8.11.6"


### PR DESCRIPTION
## Problem

cache referencing `v0.0.18` but `publisher.sh` using `main`

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

temporary hotfix