### PR TITLE
add content security policy headers

### DIFF
--- a/tooling/template/next.config.mjs
+++ b/tooling/template/next.config.mjs
@@ -1,4 +1,59 @@
-/** @type {import('next').NextConfig} */
+const ContentSecurityPolicy = `
+  default-src 'none';
+  base-uri 'self';
+  font-src
+    'self'
+    https:
+    data:
+    ;
+  form-action
+    'self'
+    ;
+  frame-ancestors 'self';
+  img-src * data: blob:;
+  frame-src
+    'self'
+    https://form.gov.sg/ 
+    https://player.vimeo.com
+    https://fast.wistia.net
+    https://www.google.com
+    https://www.youtube.com
+    https://www.youtube-nocookie.com
+    https://www.onemap.gov.sg
+    https://www.facebook.com
+    ;
+  object-src 'none';
+  script-src
+    'self'
+    'unsafe-eval'
+    https://*.wogaa.sg
+    ;
+  style-src
+    'self'
+    https:
+    'unsafe-inline'
+    ;
+  media-src
+    ;
+  connect-src
+    'self'
+    https://browser-intake-datadoghq.com
+    https://*.browser-intake-datadoghq.com
+    https://*.wogaa.sg
+    https://cdn.growthbook.io
+    "https://*.by.gov.sg"
+    ;
+  worker-src
+    'self'
+    blob:
+    https://www.youtube.com
+    https://player.vimeo.com
+    ;
+`
+
+/**
+ * @link https://nextjs.org/docs/api-reference/next.config.js/introduction
+ */
 const nextConfig = {
   output: "export",
   /** We run eslint as a separate task in CI */
@@ -8,6 +63,27 @@ const nextConfig = {
   trailingSlash: true,
   turbo: {
     moduleIdStrategy: "deterministic",
+  },
+  async headers() {
+    return [
+      {
+        source: "/(*)",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value: ContentSecurityPolicy.replace(/\s{2,}/g, " ").trim(),
+          },
+          {
+            key: "Referrer-Policy",
+            value: "strict-origin-when-cross-origin",
+          },
+          {
+            key: "X-Content-Type-Options",
+            value: "nosniff",
+          },
+        ],
+      },
+    ]
   },
 }
 


### PR DESCRIPTION
## NOTE: DO NOT MERGE till testing is complete
## Problem

The application lacks proper Content Security Policy (CSP) headers and other security-related HTTP headers.

## Solution

Added comprehensive Content Security Policy configuration and security headers to the Next.js configuration.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Features**:

- Added Content Security Policy (CSP) header with specific directives for:
  - Fonts, forms, frames, images, scripts, styles, and media
  - Trusted domains for external resources
  - Worker and connection permissions
- Implemented additional security headers:
  - Referrer-Policy set to strict-origin-when-cross-origin
  - X-Content-Type-Options set to nosniff

## Tests

Verify that:
- All legitimate resources load correctly under the new CSP rules
- External integrations (Wogaa, DataDog, GrowthBook) continue to function
- Embedded content (YouTube, Vimeo, forms) displays properly