### PR TITLE
fix: isloading

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/CreatePageWizardContext.tsx
@@ -133,7 +133,7 @@ const useCreatePageWizardContext = ({
     currentStep,
     formMethods,
     handleCreatePage,
-    isLoading: isLoading || isPermalinkLoading,
+    isLoading: isLoading || (!!folderId && isPermalinkLoading),
     handleNextToDetailScreen,
     handleBackToLayoutScreen,
     layoutPreviewJson,


### PR DESCRIPTION
## Problem
Loading state for button on root page was stuck in loading

## Solution
1. set the `isLoading` state to be preferentially from `isLoading` and fallback to `isLoadingPermalink` only if `folderId` is defined

## Checks
1. create a page at root
2. make sure that you can create such a page