### PR TITLE
add soft delete for users and permissions

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,23 +1,23 @@
 export const ResourceState = {
-  Draft: "Draft",
-  Published: "Published",
-} as const
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
+    Draft: "Draft",
+    Published: "Published"
+} as const;
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
 export const ResourceType = {
-  RootPage: "RootPage",
-  Page: "Page",
-  Folder: "Folder",
-  Collection: "Collection",
-  CollectionMeta: "CollectionMeta",
-  CollectionLink: "CollectionLink",
-  CollectionPage: "CollectionPage",
-  IndexPage: "IndexPage",
-  FolderMeta: "FolderMeta",
-} as const
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
+    RootPage: "RootPage",
+    Page: "Page",
+    Folder: "Folder",
+    Collection: "Collection",
+    CollectionMeta: "CollectionMeta",
+    CollectionLink: "CollectionLink",
+    CollectionPage: "CollectionPage",
+    IndexPage: "IndexPage",
+    FolderMeta: "FolderMeta"
+} as const;
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
 export const RoleType = {
-  Admin: "Admin",
-  Editor: "Editor",
-  Publisher: "Publisher",
-} as const
-export type RoleType = (typeof RoleType)[keyof typeof RoleType]
+    Admin: "Admin",
+    Editor: "Editor",
+    Publisher: "Publisher"
+} as const;
+export type RoleType = (typeof RoleType)[keyof typeof RoleType];

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,129 +1,129 @@
-import type { ColumnType, GeneratedAlways } from "kysely"
+import type { ColumnType, GeneratedAlways } from "kysely";
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
 
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
-
-export interface Blob {
-  id: GeneratedAlways<string>
-  /**
-   * @kyselyType(PrismaJson.BlobJsonContent)
-   * [BlobJsonContent]
-   */
-  content: PrismaJson.BlobJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Footer {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.FooterJsonContent)
-   * [FooterJsonContent]
-   */
-  content: PrismaJson.FooterJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Navbar {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.NavbarJsonContent)
-   * [NavbarJsonContent]
-   */
-  content: PrismaJson.NavbarJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface RateLimiterFlexible {
-  key: string
-  points: number
-  expire: Timestamp | null
-}
-export interface Resource {
-  id: GeneratedAlways<string>
-  title: string
-  permalink: string
-  siteId: number
-  parentId: string | null
-  publishedVersionId: string | null
-  draftBlobId: string | null
-  state: Generated<ResourceState | null>
-  type: ResourceType
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface ResourcePermission {
-  id: GeneratedAlways<string>
-  userId: string
-  siteId: number
-  resourceId: string | null
-  role: RoleType
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Site {
-  id: GeneratedAlways<number>
-  name: string
-  /**
-   * @kyselyType(PrismaJson.SiteJsonConfig)
-   * [SiteJsonConfig]
-   */
-  config: PrismaJson.SiteJsonConfig
-  /**
-   * @kyselyType(PrismaJson.SiteThemeJson)
-   * [SiteThemeJson]
-   */
-  theme: PrismaJson.SiteThemeJson | null
-  codeBuildId: string | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface User {
-  id: string
-  name: string
-  email: string
-  phone: string
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface VerificationToken {
-  identifier: string
-  token: string
-  attempts: Generated<number>
-  expires: Timestamp
-}
-export interface Version {
-  id: GeneratedAlways<string>
-  versionNum: number
-  resourceId: string
-  blobId: string
-  publishedAt: Generated<Timestamp>
-  publishedBy: string
-  updatedAt: Generated<Timestamp>
-}
-export interface Whitelist {
-  id: GeneratedAlways<number>
-  email: string
-  expiry: Timestamp | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface DB {
-  Blob: Blob
-  Footer: Footer
-  Navbar: Navbar
-  RateLimiterFlexible: RateLimiterFlexible
-  Resource: Resource
-  ResourcePermission: ResourcePermission
-  Site: Site
-  User: User
-  VerificationToken: VerificationToken
-  Version: Version
-  Whitelist: Whitelist
-}
+export type Blob = {
+    id: GeneratedAlways<string>;
+    /**
+     * @kyselyType(PrismaJson.BlobJsonContent)
+     * [BlobJsonContent]
+     */
+    content: PrismaJson.BlobJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Footer = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.FooterJsonContent)
+     * [FooterJsonContent]
+     */
+    content: PrismaJson.FooterJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Navbar = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.NavbarJsonContent)
+     * [NavbarJsonContent]
+     */
+    content: PrismaJson.NavbarJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type RateLimiterFlexible = {
+    key: string;
+    points: number;
+    expire: Timestamp | null;
+};
+export type Resource = {
+    id: GeneratedAlways<string>;
+    title: string;
+    permalink: string;
+    siteId: number;
+    parentId: string | null;
+    publishedVersionId: string | null;
+    draftBlobId: string | null;
+    state: Generated<ResourceState | null>;
+    type: ResourceType;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type ResourcePermission = {
+    id: GeneratedAlways<string>;
+    userId: string;
+    siteId: number;
+    resourceId: string | null;
+    role: RoleType;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+    deletedAt: Timestamp | null;
+};
+export type Site = {
+    id: GeneratedAlways<number>;
+    name: string;
+    /**
+     * @kyselyType(PrismaJson.SiteJsonConfig)
+     * [SiteJsonConfig]
+     */
+    config: PrismaJson.SiteJsonConfig;
+    /**
+     * @kyselyType(PrismaJson.SiteThemeJson)
+     * [SiteThemeJson]
+     */
+    theme: PrismaJson.SiteThemeJson | null;
+    codeBuildId: string | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type User = {
+    id: string;
+    name: string;
+    email: string;
+    phone: string;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+    deletedAt: Timestamp | null;
+};
+export type VerificationToken = {
+    identifier: string;
+    token: string;
+    attempts: Generated<number>;
+    expires: Timestamp;
+};
+export type Version = {
+    id: GeneratedAlways<string>;
+    versionNum: number;
+    resourceId: string;
+    blobId: string;
+    publishedAt: Generated<Timestamp>;
+    publishedBy: string;
+    updatedAt: Generated<Timestamp>;
+};
+export type Whitelist = {
+    id: GeneratedAlways<number>;
+    email: string;
+    expiry: Timestamp | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type DB = {
+    Blob: Blob;
+    Footer: Footer;
+    Navbar: Navbar;
+    RateLimiterFlexible: RateLimiterFlexible;
+    Resource: Resource;
+    ResourcePermission: ResourcePermission;
+    Site: Site;
+    User: User;
+    VerificationToken: VerificationToken;
+    Version: Version;
+    Whitelist: Whitelist;
+};

--- a/apps/studio/prisma/migrations/20241220130729_add_deletedat_user_perms/migration.sql
+++ b/apps/studio/prisma/migrations/20241220130729_add_deletedat_user_perms/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ResourcePermission" ADD COLUMN     "deletedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "deletedAt" TIMESTAMP(3);

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -68,8 +68,8 @@ model Resource {
   state ResourceState? @default(Draft)
   type  ResourceType
 
-  createdAt                   DateTime                         @default(now())
-  updatedAt                   DateTime                         @default(now()) @updatedAt
+  createdAt          DateTime             @default(now())
+  updatedAt          DateTime             @default(now()) @updatedAt
   ResourcePermission ResourcePermission[]
 
   // This unique index is subsequently replaced with a custom index that
@@ -77,11 +77,10 @@ model Resource {
   // This is required so prisma does not attempt to drop the custom index.
   @@unique([siteId, parentId, permalink])
   @@index([siteId, id, parentId]) // note: ordering is important here!
-  @@index([type])  
-
+  @@index([type])
   // NOTE: This is used to create a inverted index using text trigrams for the title
   // so that we can perform searches on the title quickly
-  @@index([title(ops: raw("gin_trgm_ops"))], type: Gin, name: "resource_title_trgm_idx") 
+  @@index([title(ops: raw("gin_trgm_ops"))], type: Gin, name: "resource_title_trgm_idx")
 }
 
 model Blob {
@@ -115,21 +114,22 @@ enum ResourceType {
 }
 
 model User {
-  id            String  @id @default(cuid())
-  name          String
-  email         String  @unique
-  phone         String
+  id    String @id @default(cuid())
+  name  String
+  email String @unique
+  phone String
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @default(now()) @updatedAt
+  deletedAt DateTime?
 
   ResourcePermission ResourcePermission[]
-  versions    Version[]
+  versions           Version[]
 }
 
 model Site {
-  id          Int          @id @default(autoincrement())
-  name        String       @unique
+  id          Int        @id @default(autoincrement())
+  name        String     @unique
   resources   Resource[]
   // NOTE: This is `theme/isGovernment/sitemap`
   // This is currently put as `Json` for ease of extensibility
@@ -185,8 +185,9 @@ model ResourcePermission {
   resourceId BigInt?
   resource   Resource? @relation(fields: [resourceId], references: [id])
   role       RoleType
-  createdAt DateTime @default(now())
-  updatedAt DateTime @default(now()) @updatedAt
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @default(now()) @updatedAt
+  deletedAt  DateTime?
 
   @@unique([userId, siteId, resourceId, role])
 }

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -5,6 +5,7 @@
  */
 import cuid2 from "@paralleldrive/cuid2"
 
+import { normalizeEmail } from "~/utils/email"
 import { db, RoleType } from "../src/server/modules/database"
 import { createSite } from "./scripts/createSite"
 
@@ -33,7 +34,7 @@ async function main() {
         .values({
           id: cuid2.createId(),
           name,
-          email: `${name}@open.gov.sg`,
+          email: normalizeEmail(`${name}@open.gov.sg`),
           phone: "",
         })
         .onConflict((oc) =>

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -3,7 +3,7 @@ import {
   applySession,
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
-import { setUpWhitelist } from "tests/integration/helpers/seed"
+import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
 import { describe, expect, it } from "vitest"
 
 import { env } from "~/env.mjs"
@@ -70,6 +70,25 @@ describe("auth.email", () => {
         subject: expect.stringContaining("Sign in to"),
       })
       expect(result).toEqual(expectedReturn)
+    })
+
+    it("should throw if user is deleted", async () => {
+      // Arrange
+      await setupUser({
+        name: "Deleted",
+        userId: "deleted123",
+        email: TEST_VALID_EMAIL,
+        phone: "123",
+        isDeleted: true,
+      })
+
+      // Act
+      const result = caller.login({ email: TEST_VALID_EMAIL })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        "Unauthorized. Contact Isomer support.",
+      )
     })
   })
 

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -10,6 +10,7 @@ import {
 import { publicProcedure, router } from "~/server/trpc"
 import { getBaseUrl } from "~/utils/getBaseUrl"
 import { defaultMeSelect } from "../../me/me.select"
+import { isUserDeleted } from "../../user/user.service"
 import { isEmailWhitelisted } from "../../whitelist/whitelist.service"
 import { VerificationError } from "../auth.error"
 import { verifyToken } from "../auth.service"
@@ -23,8 +24,10 @@ export const emailSessionRouter = router({
     .meta({ rateLimitOptions: {} })
     .mutation(async ({ ctx, input: { email } }) => {
       const isWhitelisted = await isEmailWhitelisted(email)
+      const isDeleted = await isUserDeleted(email)
 
-      if (!isWhitelisted) {
+      // Assert that the user is both whitelisted and not deleted
+      if (!isWhitelisted || isDeleted) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Unauthorized. Contact Isomer support.",

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -26,6 +26,7 @@ export const definePermissionsForResource = async ({
     .selectFrom("ResourcePermission")
     .where("userId", "=", userId)
     .where("siteId", "=", siteId)
+    .where("deletedAt", "is", null)
 
   if (!resourceId) {
     query = query.where("resourceId", "is", null)
@@ -50,6 +51,7 @@ export const definePermissionsForSite = async ({
     .where("userId", "=", userId)
     .where("siteId", "=", siteId)
     .where("resourceId", "is", null)
+    .where("deletedAt", "is", null)
     .select("role")
     .execute()
 

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -469,6 +469,7 @@ export const resourceRouter = router({
         .selectFrom("ResourcePermission")
         .where("userId", "=", ctx.user.id)
         .where("siteId", "=", siteId)
+        .where("deletedAt", "is", null)
 
       if (!resourceId) {
         query.where("resourceId", "is", null)

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -128,6 +128,32 @@ describe("site.router", async () => {
         },
       ])
     })
+
+    it("should only return sites if the permissions are not deleted for the site", async () => {
+      const { site: site1 } = await setupSite()
+      const { site: site2 } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site1.id,
+        isDeleted: true,
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site2.id,
+      })
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: site2.id,
+          name: site2.name,
+          config: site2.config,
+        },
+      ])
+    })
   })
 
   describe("getSiteName", () => {

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -28,6 +28,7 @@ export const siteRouter = router({
     return db
       .selectFrom("Site")
       .innerJoin("ResourcePermission", "Site.id", "ResourcePermission.siteId")
+      .where("ResourcePermission.deletedAt", "is", null)
       .where("ResourcePermission.userId", "=", ctx.user.id)
       .select(["Site.id", "Site.name", "Site.config"])
       .groupBy(["Site.id", "Site.name", "Site.config"])

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -1,0 +1,40 @@
+import { resetTables } from "tests/integration/helpers/db"
+import { setupUser } from "tests/integration/helpers/seed"
+
+import { isUserDeleted } from "../user.service"
+
+describe("user.service", () => {
+  beforeAll(async () => {
+    await resetTables("User")
+  })
+
+  it("should return false if user is not deleted", async () => {
+    // Arrange
+    const email = "active@example.com"
+    // Setup active user
+    await setupUser({
+      email: email,
+      isDeleted: false,
+    })
+
+    // Act
+    const result = await isUserDeleted(email)
+    // Assert
+    expect(result).toBe(false)
+  })
+
+  it("should return true if user is deleted", async () => {
+    // Arrange
+    const email = "deleted@example.com"
+    // Setup deleted user
+    await setupUser({
+      email: email,
+      isDeleted: true,
+    })
+
+    // Act
+    const result = await isUserDeleted(email)
+    // Assert
+    expect(result).toBe(true)
+  })
+})

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -1,0 +1,18 @@
+import { db } from "../database"
+
+export const isUserDeleted = async (email: string) => {
+  const lowercaseEmail = email.toLowerCase()
+  const user = await db
+    .selectFrom("User")
+    .where("email", "=", lowercaseEmail)
+    .select(["deletedAt"])
+    // Email is a unique field in User table
+    .executeTakeFirst()
+
+  console.log(`isUserDeleted: ${JSON.stringify(user)}`)
+
+  if (user?.deletedAt) {
+    return true
+  }
+  return false
+}

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -9,7 +9,5 @@ export const isUserDeleted = async (email: string) => {
     // Email is a unique field in User table
     .executeTakeFirst()
 
-  console.log(`isUserDeleted: ${JSON.stringify(user)}`)
-
-  return user?.deletedAt
+  return !!user?.deletedAt
 }

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -9,5 +9,5 @@ export const isUserDeleted = async (email: string) => {
     // Email is a unique field in User table
     .executeTakeFirst()
 
-  return !!user?.deletedAt
+  return user?.deletedAt ? true : false
 }

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -11,8 +11,5 @@ export const isUserDeleted = async (email: string) => {
 
   console.log(`isUserDeleted: ${JSON.stringify(user)}`)
 
-  if (user?.deletedAt) {
-    return true
-  }
-  return false
+  return user?.deletedAt
 }

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -136,9 +136,10 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
     throw new TRPCError({ code: "UNAUTHORIZED" })
   }
 
-  // this code path is needed if a user does not exist in the database as they were deleted, but the session was active before
+  // with addition of soft deletes, we need to now check for deletedAt
+  // this check is required in case of an already ongoing session to logout the user
   const user = await prisma.user.findUnique({
-    where: { id: ctx.session.userId },
+    where: { id: ctx.session.userId, deletedAt: null },
     select: defaultMeSelect,
   })
 

--- a/apps/studio/src/utils/email.ts
+++ b/apps/studio/src/utils/email.ts
@@ -25,3 +25,7 @@ export const isGovEmail = (value: unknown) => {
 export const isValidEmail = (value: unknown) => {
   return typeof value === "string" && isEmail(value)
 }
+/*
+ * Normalizes an email address to lowercase.
+ */
+export const normalizeEmail = (email: string): string => email.toLowerCase()

--- a/apps/studio/tests/integration/helpers/auth.ts
+++ b/apps/studio/tests/integration/helpers/auth.ts
@@ -3,13 +3,14 @@ import cuid2 from "@paralleldrive/cuid2"
 import { db } from "~server/db"
 
 import type { User } from "~server/db"
+import { normalizeEmail } from "~/utils/email"
 import { setUpWhitelist } from "./seed"
 
 export const auth = async ({ id, ...user }: SetOptional<User, "id">) => {
   // Ensure email is lowercase
   const normalizedUser = {
     ...user,
-    email: user.email.toLowerCase(),
+    email: normalizeEmail(user.email),
   }
 
   await setUpWhitelist({ email: normalizedUser.email })

--- a/apps/studio/tests/integration/helpers/auth.ts
+++ b/apps/studio/tests/integration/helpers/auth.ts
@@ -6,19 +6,25 @@ import type { User } from "~server/db"
 import { setUpWhitelist } from "./seed"
 
 export const auth = async ({ id, ...user }: SetOptional<User, "id">) => {
-  await setUpWhitelist({ email: user.email })
+  // Ensure email is lowercase
+  const normalizedUser = {
+    ...user,
+    email: user.email.toLowerCase(),
+  }
+
+  await setUpWhitelist({ email: normalizedUser.email })
 
   if (id !== undefined) {
     return db
       .updateTable("User")
       .where("id", "=", id)
-      .set({ ...user, id })
+      .set({ ...normalizedUser, id })
       .returningAll()
       .executeTakeFirstOrThrow()
   }
   return db
     .insertInto("User")
-    .values({ ...user, id: cuid2.createId() })
+    .values({ ...normalizedUser, id: cuid2.createId() })
     .returningAll()
     .executeTakeFirstOrThrow()
 }

--- a/apps/studio/tests/integration/helpers/iron-session.ts
+++ b/apps/studio/tests/integration/helpers/iron-session.ts
@@ -101,6 +101,7 @@ export const createTestUser = () => ({
   createdAt: new Date(),
   updatedAt: new Date(),
   phone: "123456789",
+  deletedAt: null,
 })
 
 // NOTE: The argument to this function was changed from

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -9,9 +9,11 @@ import { nanoid } from "nanoid"
 export const setupAdminPermissions = async ({
   userId,
   siteId,
+  isDeleted = false,
 }: {
   userId?: string
   siteId: number
+  isDeleted?: boolean
 }) => {
   if (!userId) throw new Error("userId is a required field")
 
@@ -22,6 +24,7 @@ export const setupAdminPermissions = async ({
       siteId,
       role: RoleType.Admin,
       resourceId: null,
+      deletedAt: isDeleted ? new Date() : null,
     })
     .execute()
 }
@@ -436,6 +439,32 @@ export const setUpWhitelist = async ({
         .column("email")
         .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
     )
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const setupUser = async ({
+  name = "Test User",
+  userId = nanoid(),
+  email,
+  phone = "",
+  isDeleted,
+}: {
+  name?: string
+  userId?: string
+  email: string
+  phone?: string
+  isDeleted: boolean
+}) => {
+  return db
+    .insertInto("User")
+    .values({
+      id: userId,
+      name,
+      email,
+      phone: phone,
+      deletedAt: isDeleted ? new Date() : null,
+    })
     .returningAll()
     .executeTakeFirstOrThrow()
 }

--- a/apps/studio/tests/msw/handlers/me.ts
+++ b/apps/studio/tests/msw/handlers/me.ts
@@ -10,6 +10,7 @@ export const defaultUser: User = {
   phone: "12345678",
   createdAt: new Date(),
   updatedAt: new Date(),
+  deletedAt: null,
 }
 
 const defaultMeGetQuery = () => {


### PR DESCRIPTION
## Notes
### Do not merge till security review - Done
### Requires expanding migration

## Problem

Closes ISOM-1701

## Solution

**Breaking Changes**
- [x] No - this PR is backwards compatible

**Features**:
- Added soft delete functionality for Users and ResourcePermissions via `deletedAt` column
- Added user deletion check during email authentication flow

**Improvements**:
- Enhanced permission queries to exclude soft-deleted records
- Added filtering for deleted users in ongoing sessions

**Bug Fixes**:
- Fixed potential security issue where deleted users could still access the system with active sessions

## Tests

- Verify soft delete functionality for Users, by setting deletedAt to any valid timestamp
- Users with deletedAt in the User table should not be able to login
- Users who are already logged in with an active session should be logged out when the deletedAt is set in User table
- Users can have Resource Permissions to several sites. If a Resource Permission is set, then the User should not be able to see that specific site in the All Sites view. Visitng the deleted resource Site's URL directly should show that they are unauthorised to view the page

**New scripts**:
- `20241220130729_add_deletedat_user_perms` : Adds deletedAt columns to User and ResourcePermission tables