### PR TITLE
add tests and handling for deleted users

### DIFF
--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -3,7 +3,7 @@ import {
   applySession,
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
-import { setUpWhitelist } from "tests/integration/helpers/seed"
+import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
 import { describe, expect, it } from "vitest"
 
 import { env } from "~/env.mjs"
@@ -70,6 +70,25 @@ describe("auth.email", () => {
         subject: expect.stringContaining("Sign in to"),
       })
       expect(result).toEqual(expectedReturn)
+    })
+
+    it("should throw if user is deleted", async () => {
+      // Arrange
+      await setupUser({
+        name: "Deleted",
+        userId: "deleted123",
+        email: TEST_VALID_EMAIL,
+        phone: "123",
+        isDeleted: true,
+      })
+
+      // Act
+      const result = caller.login({ email: TEST_VALID_EMAIL })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        "Unauthorized. Contact Isomer support.",
+      )
     })
   })
 

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -128,6 +128,32 @@ describe("site.router", async () => {
         },
       ])
     })
+
+    it("should only return sites if the permissions are not deleted for the site", async () => {
+      const { site: site1 } = await setupSite()
+      const { site: site2 } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site1.id,
+        isDeleted: true,
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site2.id,
+      })
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: site2.id,
+          name: site2.name,
+          config: site2.config,
+        },
+      ])
+    })
   })
 
   describe("getSiteName", () => {

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -1,0 +1,47 @@
+import { resetTables } from "tests/integration/helpers/db"
+import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
+
+import { isUserDeleted } from "../user.service"
+
+describe("user.service", () => {
+  beforeAll(async () => {
+    await resetTables("User")
+    await setUpWhitelist({ email: "@example.com" })
+
+    // Setup active user
+    await setupUser({
+      name: "Active User",
+      userId: "active123",
+      email: "active@example.com",
+      phone: "12345678",
+      isDeleted: false,
+    })
+
+    // Setup deleted user
+    await setupUser({
+      name: "Deleted User",
+      userId: "deleted123",
+      email: "deleted@example.com",
+      phone: "12345678",
+      isDeleted: true,
+    })
+  })
+
+  it("should return false if user is not deleted", async () => {
+    // Arrange
+    const email = "active@example.com"
+    // Act
+    const result = await isUserDeleted(email)
+    // Assert
+    expect(result).toBe(false)
+  })
+
+  it("should return true if user is deleted", async () => {
+    // Arrange
+    const email = "deleted@example.com"
+    // Act
+    const result = await isUserDeleted(email)
+    // Assert
+    expect(result).toBe(true)
+  })
+})

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -1,35 +1,25 @@
 import { resetTables } from "tests/integration/helpers/db"
-import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
+import { setupUser } from "tests/integration/helpers/seed"
 
 import { isUserDeleted } from "../user.service"
 
 describe("user.service", () => {
   beforeAll(async () => {
     await resetTables("User")
-    await setUpWhitelist({ email: "@example.com" })
-
-    // Setup active user
-    await setupUser({
-      name: "Active User",
-      userId: "active123",
-      email: "active@example.com",
-      phone: "12345678",
-      isDeleted: false,
-    })
-
-    // Setup deleted user
-    await setupUser({
-      name: "Deleted User",
-      userId: "deleted123",
-      email: "deleted@example.com",
-      phone: "12345678",
-      isDeleted: true,
-    })
   })
 
   it("should return false if user is not deleted", async () => {
     // Arrange
     const email = "active@example.com"
+    // Setup active user
+    await setupUser({
+      name: "Active User",
+      userId: "active123",
+      email: email,
+      phone: "12345678",
+      isDeleted: false,
+    })
+
     // Act
     const result = await isUserDeleted(email)
     // Assert
@@ -39,6 +29,15 @@ describe("user.service", () => {
   it("should return true if user is deleted", async () => {
     // Arrange
     const email = "deleted@example.com"
+    // Setup deleted user
+    await setupUser({
+      name: "Deleted User",
+      userId: "deleted123",
+      email: email,
+      phone: "12345678",
+      isDeleted: true,
+    })
+
     // Act
     const result = await isUserDeleted(email)
     // Assert

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -13,10 +13,7 @@ describe("user.service", () => {
     const email = "active@example.com"
     // Setup active user
     await setupUser({
-      name: "Active User",
-      userId: "active123",
       email: email,
-      phone: "12345678",
       isDeleted: false,
     })
 
@@ -31,10 +28,7 @@ describe("user.service", () => {
     const email = "deleted@example.com"
     // Setup deleted user
     await setupUser({
-      name: "Deleted User",
-      userId: "deleted123",
       email: email,
-      phone: "12345678",
       isDeleted: true,
     })
 

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -9,9 +9,11 @@ import { nanoid } from "nanoid"
 export const setupAdminPermissions = async ({
   userId,
   siteId,
+  isDeleted = false,
 }: {
   userId?: string
   siteId: number
+  isDeleted?: boolean
 }) => {
   if (!userId) throw new Error("userId is a required field")
 
@@ -22,6 +24,7 @@ export const setupAdminPermissions = async ({
       siteId,
       role: RoleType.Admin,
       resourceId: null,
+      deletedAt: isDeleted ? new Date() : null,
     })
     .execute()
 }

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -444,14 +444,14 @@ export const setUpWhitelist = async ({
 }
 
 export const setupUser = async ({
-  name,
-  userId,
+  name = "Test User",
+  userId = nanoid(),
   email,
-  phone,
+  phone = "",
   isDeleted,
 }: {
-  name: string
-  userId: string
+  name?: string
+  userId?: string
   email: string
   phone?: string
   isDeleted: boolean
@@ -462,7 +462,7 @@ export const setupUser = async ({
       id: userId,
       name,
       email,
-      phone: phone ?? "",
+      phone: phone,
       deletedAt: isDeleted ? new Date() : null,
     })
     .returningAll()

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -439,3 +439,29 @@ export const setUpWhitelist = async ({
     .returningAll()
     .executeTakeFirstOrThrow()
 }
+
+export const setupUser = async ({
+  name,
+  userId,
+  email,
+  phone,
+  isDeleted,
+}: {
+  name: string
+  userId: string
+  email: string
+  phone?: string
+  isDeleted: boolean
+}) => {
+  return db
+    .insertInto("User")
+    .values({
+      id: userId,
+      name,
+      email,
+      phone: phone ?? "",
+      deletedAt: isDeleted ? new Date() : null,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}


### PR DESCRIPTION
## Problem

Deleted users were still able to access the system and view sites they previously had access to.

Closes ISOM-1701

## Solution

Added checks to prevent deleted users from logging in and viewing sites they previously had access to.

**Breaking Changes**:
- [x] No - this PR is backwards compatible

**Features**:
- Added user deletion status check during login
- Filtered out sites where user permissions have been deleted

**Improvements**:
- Removed debug console log from user deletion check

## Tests

- Added test for login attempt with deleted user
- Added test for site listing with deleted permissions
- Added user service tests for checking deletion status
- Added helper function for setting up test users with deletion status

**New scripts**:
None

**New dependencies**:
None

**New dev dependencies**:
None