### PR TITLE
isom-1646 - infocards and infocols should behave consistently when opens in a new link

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1418,10 +1418,6 @@ video {
   -webkit-line-clamp: 3;
 }
 
-.\!block {
-  display: block !important;
-}
-
 .block {
   display: block;
 }
@@ -1816,6 +1812,13 @@ video {
 
 .rotate-180 {
   --tw-rotate: 180deg;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y))
+    rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
+    scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.rotate-\[-45deg\] {
+  --tw-rotate: -45deg;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y))
     rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y))
     scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
@@ -3154,11 +3157,6 @@ video {
 .text-link {
   --tw-text-opacity: 1;
   color: rgb(26 86 229 / var(--tw-text-opacity));
-}
-
-.text-link-hover {
-  --tw-text-opacity: 1;
-  color: rgb(21 71 190 / var(--tw-text-opacity));
 }
 
 .text-site-secondary {
@@ -5508,12 +5506,6 @@ video {
 
 .\[\&\:not\(\:first-child\)\]\:mt-9:not(:first-child) {
   margin-top: 2.25rem;
-}
-
-.\[\&\:not\(\:first-child\)\]\:first-of-type\:mt-7:first-of-type:not(
-    :first-child
-  ) {
-  margin-top: 1.75rem;
 }
 
 .\[\&\:not\(\:last-child\)\]\:mb-0:not(:last-child) {

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -165,6 +165,7 @@ export const InfoCardsSchema = Type.Intersect(
 
 export type SingleCardNoImageProps = Static<typeof SingleCardNoImageSchema> & {
   site: IsomerSiteProps
+  isExternalLink?: boolean
   LinkComponent?: LinkComponentType
 }
 export type SingleCardWithImageProps = Static<
@@ -172,6 +173,7 @@ export type SingleCardWithImageProps = Static<
 > & {
   site: IsomerSiteProps
   layout: IsomerPageLayoutType
+  isExternalLink?: boolean
   LinkComponent?: LinkComponentType
 }
 export type InfoCardsProps = Static<typeof InfoCardsSchema> & {

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -68,7 +68,7 @@ const generateArgs = ({
       imageUrl: "https://placehold.co/200x300",
       imageAlt: "alt text",
       imageFit: "contain",
-      url: "https://www.google.com",
+      url: "/faq",
     },
     {
       title: "Card with short title",

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -200,7 +200,12 @@ const InfoCardNoImage = ({
 }: SingleCardNoImageProps): JSX.Element => {
   const isExternalLink = isExternalUrl(url)
   return (
-    <InfoCardContainer url={url} site={site} LinkComponent={LinkComponent}>
+    <InfoCardContainer
+      url={url}
+      site={site}
+      isExternalLink={isExternalLink}
+      LinkComponent={LinkComponent}
+    >
       <InfoCardText
         title={title}
         description={description}
@@ -224,7 +229,12 @@ const InfoCardWithImage = ({
 }: SingleCardWithImageProps): JSX.Element => {
   const isExternalLink = isExternalUrl(url)
   return (
-    <InfoCardContainer url={url} site={site} LinkComponent={LinkComponent}>
+    <InfoCardContainer
+      url={url}
+      site={site}
+      isExternalLink={isExternalLink}
+      LinkComponent={LinkComponent}
+    >
       <InfoCardImage
         imageFit={imageFit}
         imageUrl={imageUrl}

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -108,14 +108,19 @@ const InfoCardContainer = ({
   site,
   LinkComponent,
   children,
+  isExternalLink,
 }: PropsWithChildren<
-  Pick<SingleCardNoImageProps, "url" | "site" | "LinkComponent">
+  Pick<
+    SingleCardNoImageProps,
+    "url" | "site" | "isExternalLink" | "LinkComponent"
+  >
 >): JSX.Element => {
   return url ? (
     <Link
       href={getReferenceLinkHref(url, site.siteMap, site.assetsBaseUrl)}
       className={compoundStyles.cardContainer()}
       LinkComponent={LinkComponent}
+      isExternal={isExternalLink}
     >
       {children}
     </Link>
@@ -164,9 +169,10 @@ const InfoCardText = ({
   title,
   description,
   url,
+  isExternalLink,
 }: Pick<
   SingleCardWithImageProps,
-  "title" | "description" | "url"
+  "title" | "description" | "url" | "isExternalLink"
 >): JSX.Element => (
   <div className={compoundStyles.cardTextContainer()}>
     <h3 className={infoCardTitleStyle({ isClickableCard: !!url })}>
@@ -176,7 +182,7 @@ const InfoCardText = ({
         <BiRightArrowAlt
           aria-hidden
           className={compoundStyles.cardTitleArrow({
-            isExternalLink: isExternalUrl(url),
+            isExternalLink,
           })}
         />
       )}
@@ -192,9 +198,15 @@ const InfoCardNoImage = ({
   site,
   LinkComponent,
 }: SingleCardNoImageProps): JSX.Element => {
+  const isExternalLink = isExternalUrl(url)
   return (
     <InfoCardContainer url={url} site={site} LinkComponent={LinkComponent}>
-      <InfoCardText title={title} description={description} url={url} />
+      <InfoCardText
+        title={title}
+        description={description}
+        url={url}
+        isExternalLink={isExternalLink}
+      />
     </InfoCardContainer>
   )
 }
@@ -210,6 +222,7 @@ const InfoCardWithImage = ({
   site,
   LinkComponent,
 }: SingleCardWithImageProps): JSX.Element => {
+  const isExternalLink = isExternalUrl(url)
   return (
     <InfoCardContainer url={url} site={site} LinkComponent={LinkComponent}>
       <InfoCardImage
@@ -220,7 +233,12 @@ const InfoCardWithImage = ({
         site={site}
         layout={layout}
       />
-      <InfoCardText title={title} description={description} url={url} />
+      <InfoCardText
+        title={title}
+        description={description}
+        url={url}
+        isExternalLink={isExternalLink}
+      />
     </InfoCardContainer>
   )
 }

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -88,6 +88,11 @@ const createInfoCardsStyles = tv({
         grid: "md:grid-cols-2 lg:grid-cols-3",
       },
     },
+    isExternalLink: {
+      true: {
+        cardTitleArrow: "rotate-[-45deg]",
+      },
+    },
   },
   defaultVariants: {
     layout: "default",
@@ -170,7 +175,9 @@ const InfoCardText = ({
       {url && (
         <BiRightArrowAlt
           aria-hidden
-          className={compoundStyles.cardTitleArrow()}
+          className={compoundStyles.cardTitleArrow({
+            isExternalLink: isExternalUrl(url),
+          })}
         />
       )}
     </h3>

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -78,39 +78,43 @@ const InfoBoxes = ({
   return (
     <div className={compoundStyles.infoBoxesContainer()}>
       {infoBoxes.map(
-        ({ title, icon, description, buttonUrl, buttonLabel }, idx) => (
-          <Link
-            LinkComponent={LinkComponent}
-            href={getReferenceLinkHref(
-              buttonUrl,
-              site.siteMap,
-              site.assetsBaseUrl,
-            )}
-            key={idx}
-            className={compoundStyles.infoBox()}
-          >
-            {icon && <InfoBoxIcon icon={icon} aria-hidden="true" />}
+        ({ title, icon, description, buttonUrl, buttonLabel }, idx) => {
+          const isExternalLink = isExternalUrl(buttonUrl)
+          return (
+            <Link
+              LinkComponent={LinkComponent}
+              href={getReferenceLinkHref(
+                buttonUrl,
+                site.siteMap,
+                site.assetsBaseUrl,
+              )}
+              key={idx}
+              className={compoundStyles.infoBox()}
+              isExternal={isExternalLink}
+            >
+              {icon && <InfoBoxIcon icon={icon} aria-hidden="true" />}
 
-            <h3 className={compoundStyles.infoBoxTitle()}>{title}</h3>
+              <h3 className={compoundStyles.infoBoxTitle()}>{title}</h3>
 
-            {description && (
-              <p className={compoundStyles.infoBoxDescription()}>
-                {description}
-              </p>
-            )}
+              {description && (
+                <p className={compoundStyles.infoBoxDescription()}>
+                  {description}
+                </p>
+              )}
 
-            {buttonLabel && buttonUrl && (
-              <div className={compoundStyles.infoBoxButton()}>
-                {buttonLabel}
-                <BiRightArrowAlt
-                  className={compoundStyles.infoBoxButtonIcon({
-                    isExternalLink: isExternalUrl(buttonUrl),
-                  })}
-                />
-              </div>
-            )}
-          </Link>
-        ),
+              {buttonLabel && buttonUrl && (
+                <div className={compoundStyles.infoBoxButton()}>
+                  {buttonLabel}
+                  <BiRightArrowAlt
+                    className={compoundStyles.infoBoxButtonIcon({
+                      isExternalLink,
+                    })}
+                  />
+                </div>
+              )}
+            </Link>
+          )
+        },
       )}
     </div>
   )

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -8,6 +8,7 @@ import {
   getReferenceLinkHref,
   getTailwindVariantLayout,
   groupFocusVisibleHighlight,
+  isExternalUrl,
 } from "~/utils"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
@@ -46,6 +47,11 @@ const createInfoColsStyles = tv({
         outerContainer: "mt-14",
         header: "gap-6",
         headerSubtitle: "prose-body-base",
+      },
+    },
+    isExternalLink: {
+      true: {
+        infoBoxButtonIcon: "rotate-[-45deg]",
       },
     },
   },
@@ -97,7 +103,9 @@ const InfoBoxes = ({
               <div className={compoundStyles.infoBoxButton()}>
                 {buttonLabel}
                 <BiRightArrowAlt
-                  className={compoundStyles.infoBoxButtonIcon()}
+                  className={compoundStyles.infoBoxButtonIcon({
+                    isExternalLink: isExternalUrl(buttonUrl),
+                  })}
                 />
               </div>
             )}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1646/infocards-and-infocols-should-behave-consistently-when-something-opens

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

add check if it's external URL, and if so:
1. rotate the icon if it is (couldn't find a corresponding diagonal arrow of similar styles)
2. opens in new tab

## Tests

<!-- What tests should be run to confirm functionality? -->

### Infocards

1. Go to a page and add a Infocards component
2. [ ] By default, the default endpoint is "https://www.google.com" so it should show right-up arrow
3. [ ] Update the link of one of the cards to link to one of the internal page - it should show right arrow 
4. [ ] Save and publish, and check if the external link on the new site opens in a new url

<img width="1751" alt="image" src="https://github.com/user-attachments/assets/978ab831-0d7d-4150-9c47-a8e53be2e40f" />

### Infocols

1. Go to a page and add a Infocols component
2. [ ] Add an external link for one of the cols - it should show right-up arrow
3. [ ] Add an internal link for one of the cols - it should show right arrow 
4. [ ] Save and publish, and check if the external link on the new site opens in a new url

<img width="1613" alt="image" src="https://github.com/user-attachments/assets/f546f940-ef6e-44d8-a054-fb0259242b29" />
