### PR TITLE
Add collection management scripts for MOH TOSP

### DIFF
--- a/apps/studio/prisma/scripts/FileLogger.ts
+++ b/apps/studio/prisma/scripts/FileLogger.ts
@@ -1,0 +1,46 @@
+import fs from "fs"
+import path from "path"
+
+export class FileLogger {
+  private logFilePath: string
+
+  constructor(logFilePath: string) {
+    this.logFilePath = logFilePath
+
+    // Ensure the directory for the log file exists
+    const logDir = path.dirname(logFilePath)
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true })
+    }
+  }
+
+  private formatLog(level: string, message: string): string {
+    const timestamp = new Date().toISOString()
+    return `[${timestamp}] [${level.toUpperCase()}] ${message}\n`
+  }
+
+  private writeLog(logMessage: string): void {
+    fs.appendFile(this.logFilePath, logMessage, (err) => {
+      if (err) {
+        console.error("Failed to write log:", err)
+      }
+    })
+  }
+
+  log(level: string, message: string): void {
+    const logMessage = this.formatLog(level, message)
+    this.writeLog(logMessage)
+  }
+
+  info(message: string): void {
+    this.log("info", message)
+  }
+
+  error(message: string): void {
+    this.log("error", message)
+  }
+
+  debug(message: string): void {
+    this.log("debug", message)
+  }
+}

--- a/apps/studio/prisma/scripts/moh-tosp/README.md
+++ b/apps/studio/prisma/scripts/moh-tosp/README.md
@@ -1,0 +1,71 @@
+# MOH-TOSP Scripts
+
+## Summary
+
+This folder contains developer/ops scripts to update MOH TOSP collection in our DB.
+
+Note: The full steps are covered in [runbook](https://www.notion.so/opengov/Isomer-Next-Runbook-13177dbba78880f4835cdd370c11eef6?pvs=4#16477dbba7888045aadad0fee69c5f79).
+
+To perform the update, this is the overall sequence we will undertake:
+
+1. We will backup the existing collection
+2. Load the new collection into DB with all resources in "Draft" state in a different permalink e.g. `cost-financing-new`
+3. We will verify the new collection on Studio
+4. We will rename the old collection's permalink and swap it with the new collection. E.g. `/cost-financing` becomes `/cost-financing-old`, `/cost-financing-new` is renamed to become `/cost-financing`
+5. We will then publish this new draft collection
+
+### Pre-requisites
+
+- Ensure you have the necessary environment variables set up before running these scripts.
+
+### Running the scripts
+
+Use `source .env && npx tsx prisma/scripts/moh-tosp/<script-name>` within `isomer/apps/studio` directory to run any of the scripts.
+
+## Scripts
+
+### 1. `backupCollectionById.ts`
+
+This script takes in 2 input arguments which is the `collectionId` and the `backupDirectory`. Given these params, the script "downloads" the existing collection into the local path of your computer for backup purposes.
+
+### 2. `createCollectionFromLocal.ts`
+
+Pre-requisites:
+You will need a folder with the collection to be loaded in the following structure:
+
+```
+/content                  ----> contentDir
+    /cost-financing       ----> collectionName
+    cost-financing.json   ----> indexPageName
+```
+
+This script takes in the following arguments:
+
+1. `contentDir`: path to the folder that contains the collection to be loaded into DB
+2. `collectionName`: name of the collection to be loaded into DB (e.g. `cost-financing`)
+3. `indexPageName`: name of the index page of the collection to be loaded into DB (e.g. `cost-financing`)
+4. `indexPageTitle`: name of the index page to show visually (e.g. `Cost financing`)
+5. `nameOfNewCollectionToCreate`: This is the name of collection to be created in the DB. This will also become the permalink for the new collection. e.g. `cost-financing-new`
+6. `siteId`: ID of the site to create the collection into
+
+### 3. `publishDraftCollection.ts`
+
+This script publishes the draft collection that was created. To do so, it requires the following arguments:
+
+1. `publisherId`: ID of the Studio user who is publishing the collection. This ID can be obtained from the `User` table. Make sure this user has access to the site as well.
+2. `collectionId`: ID of the collection to be published. You can check this in the `Resource` table on the `id` column.
+
+### 4. `deleteCollectionById.ts`
+
+**Note: Use this with caution as it is NON-RECOVERABLE**.
+
+This script deletes a collection and its contents. It takes the following arguments:
+
+1. `collectionIdToDelete`: ID of the collection to be deleted. Can be checked in the `Resource` table
+2. `siteId`: ID of the site to which the collection belongs to
+
+## Recovery Options
+
+In case that the migration needs to be unrolled back to original state, we can execute the same steps described in "Summary" section using the backup taken.
+
+For full details, refer to the [runbook](https://www.notion.so/opengov/Isomer-Next-Runbook-13177dbba78880f4835cdd370c11eef6?pvs=4#16477dbba7888045aadad0fee69c5f79).

--- a/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
@@ -58,7 +58,7 @@ export async function backupCollection(
 
       // Parse blob content and write to a file
       const blobBuffer = blob.content // Assuming blob.content is a buffer
-      const blobJsonPath = path.join(backupDir, `${child.title}.json`)
+      const blobJsonPath = path.join(backupDir, `${child.permalink}.json`)
       await fs.writeFile(blobJsonPath, JSON.stringify(blobBuffer, null, 2))
     }
 
@@ -72,9 +72,8 @@ export async function backupCollection(
 
 // Run the backup
 // NOTE: TODO: Put in the collection ID to backup
-const collectionId = "5"
-const backupDirectory =
-  "/Users/harishv/Documents/Code/isomer/isomer-next/test-backup-tosp/backup"
+const collectionId = "0"
+const backupDirectory = "/Users/XYZ/<your-path>"
 
 await backupCollection(collectionId, backupDirectory).catch((err) => {
   if (err instanceof Error) {

--- a/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
@@ -1,0 +1,74 @@
+import fs from "fs/promises" // Use the promise-based version of fs for async/await
+import path from "path"
+
+import { db } from "~/server/modules/database"
+
+/**
+ * Backup a collection and its relevant resources to JSON files.
+ * @param {string} resourceId - ID of the collection resource to back up.
+ * @param {string} backupDir - Directory to save the backup files.
+ */
+export async function backupCollection(
+  resourceId: string,
+  backupDir: string,
+): Promise<void> {
+  try {
+    // Ensure the backup directory exists
+    await fs.mkdir(backupDir, { recursive: true })
+
+    // Fetch the collection resource
+    const collection = await db
+      .selectFrom("Resource")
+      .selectAll()
+      .where("id", "=", resourceId)
+      .executeTakeFirst()
+
+    if (!collection) {
+      throw new Error(`Collection with ID ${resourceId} not found.`)
+    }
+
+    // Fetch all child resources
+    const children = await db
+      .selectFrom("Resource")
+      .selectAll()
+      .where("parentId", "=", resourceId)
+      .execute()
+
+    // Write all the children's published version to the backup directory as JSON files
+    for (const child of children) {
+      // fetch the blob
+      const blob = await db
+        .selectFrom("Blob")
+        .select("content")
+        .innerJoin("Version", "Blob.id", "Version.blobId")
+        .where("Version.id", "=", child.publishedVersionId)
+        .executeTakeFirst()
+
+      if (!blob) {
+        throw new Error(
+          `Published version of child with ID ${child.id} not found.`,
+        )
+      }
+
+      console.log(`Writing backup for child with ID ${child.id}`)
+
+      // Parse blob content and write to a file
+      const blobBuffer = blob.content // Assuming blob.content is a buffer
+      const blobJsonPath = path.join(backupDir, `${child.title}.json`)
+      await fs.writeFile(blobJsonPath, JSON.stringify(blobBuffer, null, 2))
+    }
+
+    console.log(`Backup completed successfully in directory: ${backupDir}`)
+  } catch (error: any) {
+    console.error(`Error backing up collection: ${error.message}`)
+  }
+}
+
+// Run the backup
+// NOTE: TODO: Put in the collection ID to backup
+const collectionId = "0"
+const backupDirectory = ""
+
+await backupCollection(collectionId, backupDirectory).catch((err) => {
+  console.error("Unhandled error:", err.message)
+})

--- a/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
@@ -2,6 +2,10 @@ import fs from "fs/promises" // Use the promise-based version of fs for async/aw
 import path from "path"
 
 import { db } from "~/server/modules/database"
+import { FileLogger } from "../FileLogger"
+
+// Update the logger path if required
+const logger = new FileLogger("./backupCollectionById.log")
 
 /**
  * Backup a collection and its relevant resources to JSON files.
@@ -50,7 +54,7 @@ export async function backupCollection(
         )
       }
 
-      console.log(`Writing backup for child with ID ${child.id}`)
+      logger.info(`Writing backup for child with ID ${child.id}`)
 
       // Parse blob content and write to a file
       const blobBuffer = blob.content // Assuming blob.content is a buffer
@@ -58,17 +62,18 @@ export async function backupCollection(
       await fs.writeFile(blobJsonPath, JSON.stringify(blobBuffer, null, 2))
     }
 
-    console.log(`Backup completed successfully in directory: ${backupDir}`)
+    logger.info(`Backup completed successfully in directory: ${backupDir}`)
   } catch (error: any) {
-    console.error(`Error backing up collection: ${error.message}`)
+    logger.error(`Error backing up collection: ${error.message}`)
   }
 }
 
 // Run the backup
 // NOTE: TODO: Put in the collection ID to backup
-const collectionId = "0"
-const backupDirectory = ""
+const collectionId = "5"
+const backupDirectory =
+  "/Users/harishv/Documents/Code/isomer/isomer-next/test-backup-tosp/backup"
 
 await backupCollection(collectionId, backupDirectory).catch((err) => {
-  console.error("Unhandled error:", err.message)
+  logger.error("Unhandled error:", err.message)
 })

--- a/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
@@ -63,8 +63,10 @@ export async function backupCollection(
     }
 
     logger.info(`Backup completed successfully in directory: ${backupDir}`)
-  } catch (error: any) {
-    logger.error(`Error backing up collection: ${error.message}`)
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error(`Error backing up collection: ${error.message}`)
+    }
   }
 }
 
@@ -75,5 +77,7 @@ const backupDirectory =
   "/Users/harishv/Documents/Code/isomer/isomer-next/test-backup-tosp/backup"
 
 await backupCollection(collectionId, backupDirectory).catch((err) => {
-  logger.error("Unhandled error:", err.message)
+  if (err instanceof Error) {
+    logger.error(`Unhandled error: ${err.message}`)
+  }
 })

--- a/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/backupCollectionById.ts
@@ -7,15 +7,20 @@ import { FileLogger } from "../FileLogger"
 // Update the logger path if required
 const logger = new FileLogger("./backupCollectionById.log")
 
+interface BackupCollectionInput {
+  resourceId: string
+  backupDir: string
+}
+
 /**
  * Backup a collection and its relevant resources to JSON files.
  * @param {string} resourceId - ID of the collection resource to back up.
  * @param {string} backupDir - Directory to save the backup files.
  */
-export async function backupCollection(
-  resourceId: string,
-  backupDir: string,
-): Promise<void> {
+export async function backupCollection({
+  resourceId,
+  backupDir,
+}: BackupCollectionInput): Promise<void> {
   try {
     // Ensure the backup directory exists
     await fs.mkdir(backupDir, { recursive: true })
@@ -75,7 +80,10 @@ export async function backupCollection(
 const collectionId = "0"
 const backupDirectory = "/Users/XYZ/<your-path>"
 
-await backupCollection(collectionId, backupDirectory).catch((err) => {
+await backupCollection({
+  resourceId: collectionId,
+  backupDir: backupDirectory,
+}).catch((err) => {
   if (err instanceof Error) {
     logger.error(`Unhandled error: ${err.message}`)
   }

--- a/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
@@ -68,7 +68,7 @@ export const createCollectionFromLocal = async (
       //   Step 3: Insert files from "cost-financing/" into the DB as Blobs
       const folderFiles = await fs.readdir(folderPath)
       logger.info(`Reading from folderPath: ${folderPath}`)
-      logger.info(`Folder files`, folderFiles)
+      logger.info(`Folder files: ${folderFiles}`)
       for (const file of folderFiles) {
         const filePath = path.join(folderPath, file)
         logger.info(`Reading file path: ${filePath}`)
@@ -78,7 +78,6 @@ export const createCollectionFromLocal = async (
         if (!file.endsWith(".json")) {
           continue
         }
-        logger.info("File path: ", filePath)
         const fileContent = await fs.readFile(filePath, "utf-8")
 
         const parsedFileContent = JSON.parse(fileContent)
@@ -119,7 +118,9 @@ export const createCollectionFromLocal = async (
 
     logger.info("All operations completed successfully.")
   } catch (error) {
-    logger.error("Error during transaction:", error)
+    if (error instanceof Error) {
+      logger.error(`Error during transaction: ${error.message}`)
+    }
   }
 }
 

--- a/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
@@ -1,0 +1,125 @@
+import fs from "fs/promises"
+import path from "path"
+
+import { db, jsonb } from "~/server/modules/database"
+
+export const createCollectionFromLocal = async (
+  contentDir: string,
+  siteId: number,
+) => {
+  console.log(`Reading from ${contentDir}`)
+  const jsonFilePath = path.join(contentDir, "cost-financing.json")
+  const folderPath = path.join(contentDir, "cost-financing-original")
+
+  try {
+    await db.transaction().execute(async (tx) => {
+      // Step 1: Create a new collection with title "cost-financing-new"
+      const collection = await tx
+        .insertInto("Resource")
+        .values({
+          title: "cost-financing-new",
+          permalink: "cost-financing-new",
+          siteId: siteId,
+          type: "Collection",
+          state: "Draft",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+
+      const collectionId = collection.id
+      console.log(`Collection created with ID: ${collectionId}`)
+
+      // Step 2: Insert "cost-financing.json" as an IndexPage with permalink "_index"\
+      const jsonFileContent = await fs.readFile(jsonFilePath, "utf-8")
+      const indexPageBlob = await tx
+        .insertInto("Blob")
+        .values({
+          content: jsonb(JSON.parse(jsonFileContent)),
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+
+      const indexPage = await tx
+        .insertInto("Resource")
+        .values({
+          title: "cost-financing-new",
+          permalink: "_index",
+          siteId: siteId,
+          type: "IndexPage",
+          parentId: collectionId,
+          draftBlobId: indexPageBlob.id,
+          state: "Draft",
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+
+      const indexPageId = indexPage.id
+
+      console.log(`Index page created with ID: ${indexPageId}`)
+
+      //   Step 3: Insert files from "cost-financing/" into the DB as Blobs
+      const folderFiles = await fs.readdir(folderPath)
+      console.log(`Reading from folderPath: ${folderPath}`)
+      console.log(`Folder files`, folderFiles)
+      for (const file of folderFiles) {
+        const filePath = path.join(folderPath, file)
+        console.log(`Reading file path: ${filePath}`)
+
+        console.log(`Filename: ${file}`)
+        //Sometimes might have hidden internal files like .DSStore
+        if (!file.endsWith(".json")) {
+          continue
+        }
+        console.log("File path: ", filePath)
+        const fileContent = await fs.readFile(filePath, "utf-8")
+
+        const parsedFileContent = JSON.parse(fileContent)
+
+        const blob = await tx
+          .insertInto("Blob")
+          .values({
+            content: parsedFileContent,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .returning("id")
+          .executeTakeFirstOrThrow()
+
+        const resource = await tx
+          .insertInto("Resource")
+          .values({
+            title: parsedFileContent.page.title,
+            permalink: file,
+            siteId: siteId, // Replace with appropriate site ID
+            type: "CollectionPage",
+            parentId: collectionId,
+            state: "Draft",
+            draftBlobId: blob.id,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .returning("id")
+          .executeTakeFirstOrThrow()
+
+        const resourceId = resource.id
+
+        console.log(
+          `Blob created for file ${file} with resource ID: ${resourceId}`,
+        )
+      }
+    })
+
+    console.log("All operations completed successfully.")
+  } catch (error) {
+    console.error("Error during transaction:", error)
+  }
+}
+
+// NOTE: TODO: Update the content directory and siteId here before usage!
+const contentDir = ""
+const siteId = 0
+await createCollectionFromLocal(contentDir, siteId)

--- a/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises"
 import path from "path"
+import { ResourceState, ResourceType } from "@prisma/client"
 
 import { db, jsonb } from "~/server/modules/database"
 import { FileLogger } from "../FileLogger"
@@ -28,8 +29,8 @@ export const createCollectionFromLocal = async (
           title: nameOfNewCollectionToCreate,
           permalink: nameOfNewCollectionToCreate,
           siteId: siteId,
-          type: "Collection",
-          state: "Draft",
+          type: ResourceType.Collection,
+          state: ResourceState.Draft,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -55,10 +56,10 @@ export const createCollectionFromLocal = async (
           title: nameOfNewCollectionToCreate,
           permalink: "_index",
           siteId: siteId,
-          type: "IndexPage",
+          type: ResourceType.IndexPage,
           parentId: collectionId,
           draftBlobId: indexPageBlob.id,
-          state: "Draft",
+          state: ResourceState.Draft,
           createdAt: new Date(),
           updatedAt: new Date(),
         })
@@ -112,7 +113,7 @@ export const createCollectionFromLocal = async (
             title: parsedFileContent.page.title,
             permalink: file.replace(/\.json$/, ""), // remove the .json at the back on permalinks
             siteId: siteId, // Replace with appropriate site ID
-            type: "CollectionPage",
+            type: ResourceType.CollectionPage,
             parentId: collectionId,
             state: "Draft",
             draftBlobId: blob.id,

--- a/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
@@ -2,12 +2,16 @@ import fs from "fs/promises"
 import path from "path"
 
 import { db, jsonb } from "~/server/modules/database"
+import { FileLogger } from "../FileLogger"
+
+// Update the logger path if required
+const logger = new FileLogger("./createCollectionFromLocal.log")
 
 export const createCollectionFromLocal = async (
   contentDir: string,
   siteId: number,
 ) => {
-  console.log(`Reading from ${contentDir}`)
+  logger.info(`Reading from ${contentDir}`)
   const jsonFilePath = path.join(contentDir, "cost-financing.json")
   const folderPath = path.join(contentDir, "cost-financing-original")
 
@@ -29,7 +33,7 @@ export const createCollectionFromLocal = async (
         .executeTakeFirstOrThrow()
 
       const collectionId = collection.id
-      console.log(`Collection created with ID: ${collectionId}`)
+      logger.info(`Collection created with ID: ${collectionId}`)
 
       // Step 2: Insert "cost-financing.json" as an IndexPage with permalink "_index"\
       const jsonFileContent = await fs.readFile(jsonFilePath, "utf-8")
@@ -59,22 +63,22 @@ export const createCollectionFromLocal = async (
 
       const indexPageId = indexPage.id
 
-      console.log(`Index page created with ID: ${indexPageId}`)
+      logger.info(`Index page created with ID: ${indexPageId}`)
 
       //   Step 3: Insert files from "cost-financing/" into the DB as Blobs
       const folderFiles = await fs.readdir(folderPath)
-      console.log(`Reading from folderPath: ${folderPath}`)
-      console.log(`Folder files`, folderFiles)
+      logger.info(`Reading from folderPath: ${folderPath}`)
+      logger.info(`Folder files`, folderFiles)
       for (const file of folderFiles) {
         const filePath = path.join(folderPath, file)
-        console.log(`Reading file path: ${filePath}`)
+        logger.info(`Reading file path: ${filePath}`)
 
-        console.log(`Filename: ${file}`)
+        logger.info(`Filename: ${file}`)
         //Sometimes might have hidden internal files like .DSStore
         if (!file.endsWith(".json")) {
           continue
         }
-        console.log("File path: ", filePath)
+        logger.info("File path: ", filePath)
         const fileContent = await fs.readFile(filePath, "utf-8")
 
         const parsedFileContent = JSON.parse(fileContent)
@@ -107,19 +111,20 @@ export const createCollectionFromLocal = async (
 
         const resourceId = resource.id
 
-        console.log(
+        logger.info(
           `Blob created for file ${file} with resource ID: ${resourceId}`,
         )
       }
     })
 
-    console.log("All operations completed successfully.")
+    logger.info("All operations completed successfully.")
   } catch (error) {
-    console.error("Error during transaction:", error)
+    logger.error("Error during transaction:", error)
   }
 }
 
 // NOTE: TODO: Update the content directory and siteId here before usage!
-const contentDir = ""
-const siteId = 0
+const contentDir =
+  "/Users/harishv/Documents/Code/isomer/isomer-next/test-backup-tosp/content"
+const siteId = 1
 await createCollectionFromLocal(contentDir, siteId)

--- a/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
@@ -8,14 +8,22 @@ import { FileLogger } from "../FileLogger"
 // Update the logger path if required
 const logger = new FileLogger("./createCollectionFromLocal.log")
 
-export const createCollectionFromLocal = async (
-  contentDir: string,
-  siteId: number,
-  indexPageName: string, // should be placed outside the folder
-  indexPageTitle: string, // title of the index page
-  collectionName: string,
-  nameOfNewCollectionToCreate: string,
-) => {
+interface CreateCollectionFromLocalInput {
+  collectionName: string
+  contentDir: string
+  indexPageName: string // should be placed outside the folder e.g. "cost-financing.json"
+  indexPageTitle: string // title of the index page e.g. "Cost financing"
+  nameOfNewCollectionToCreate: string
+  siteId: number
+}
+export const createCollectionFromLocal = async ({
+  contentDir,
+  collectionName,
+  nameOfNewCollectionToCreate,
+  indexPageName,
+  indexPageTitle,
+  siteId,
+}: CreateCollectionFromLocalInput) => {
   logger.info(`Reading from ${contentDir}`)
   const jsonFilePath = path.join(contentDir, indexPageName)
   const folderPath = path.join(contentDir, collectionName)
@@ -53,7 +61,7 @@ export const createCollectionFromLocal = async (
       const indexPage = await tx
         .insertInto("Resource")
         .values({
-          title: nameOfNewCollectionToCreate,
+          title: indexPageTitle,
           permalink: "_index",
           siteId: siteId,
           type: ResourceType.IndexPage,
@@ -141,16 +149,17 @@ export const createCollectionFromLocal = async (
 
 // NOTE: TODO: Update the content directory and siteId here before usage!
 const contentDir = "/Users/XYZ/<your-path>"
-const indexPagePath = "cost-financing.json"
+const indexPageName = "cost-financing.json"
 const indexPageTitle = "Cost financing"
 const collectionName = "cost-financing"
 const nameOfNewCollectionToCreate = "cost-financing-new" // will also be the permalink
 const siteId = 0
-await createCollectionFromLocal(
+
+await createCollectionFromLocal({
   contentDir,
-  siteId,
-  indexPagePath,
+  indexPageName,
   indexPageTitle,
   collectionName,
   nameOfNewCollectionToCreate,
-)
+  siteId,
+})

--- a/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/createCollectionFromLocal.ts
@@ -10,10 +10,14 @@ const logger = new FileLogger("./createCollectionFromLocal.log")
 export const createCollectionFromLocal = async (
   contentDir: string,
   siteId: number,
+  indexPageName: string, // should be placed outside the folder
+  indexPageTitle: string, // title of the index page
+  collectionName: string,
+  nameOfNewCollectionToCreate: string,
 ) => {
   logger.info(`Reading from ${contentDir}`)
-  const jsonFilePath = path.join(contentDir, "cost-financing.json")
-  const folderPath = path.join(contentDir, "cost-financing-original")
+  const jsonFilePath = path.join(contentDir, indexPageName)
+  const folderPath = path.join(contentDir, collectionName)
 
   try {
     await db.transaction().execute(async (tx) => {
@@ -21,8 +25,8 @@ export const createCollectionFromLocal = async (
       const collection = await tx
         .insertInto("Resource")
         .values({
-          title: "cost-financing-new",
-          permalink: "cost-financing-new",
+          title: nameOfNewCollectionToCreate,
+          permalink: nameOfNewCollectionToCreate,
           siteId: siteId,
           type: "Collection",
           state: "Draft",
@@ -35,7 +39,7 @@ export const createCollectionFromLocal = async (
       const collectionId = collection.id
       logger.info(`Collection created with ID: ${collectionId}`)
 
-      // Step 2: Insert "cost-financing.json" as an IndexPage with permalink "_index"\
+      // Step 2: Insert "cost-financing.json" as an IndexPage with permalink "_index"
       const jsonFileContent = await fs.readFile(jsonFilePath, "utf-8")
       const indexPageBlob = await tx
         .insertInto("Blob")
@@ -48,7 +52,7 @@ export const createCollectionFromLocal = async (
       const indexPage = await tx
         .insertInto("Resource")
         .values({
-          title: "cost-financing-new",
+          title: nameOfNewCollectionToCreate,
           permalink: "_index",
           siteId: siteId,
           type: "IndexPage",
@@ -106,7 +110,7 @@ export const createCollectionFromLocal = async (
           .values({
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             title: parsedFileContent.page.title,
-            permalink: file,
+            permalink: file.replace(/\.json$/, ""), // remove the .json at the back on permalinks
             siteId: siteId, // Replace with appropriate site ID
             type: "CollectionPage",
             parentId: collectionId,
@@ -135,7 +139,17 @@ export const createCollectionFromLocal = async (
 }
 
 // NOTE: TODO: Update the content directory and siteId here before usage!
-const contentDir =
-  "/Users/harishv/Documents/Code/isomer/isomer-next/test-backup-tosp/content"
-const siteId = 1
-await createCollectionFromLocal(contentDir, siteId)
+const contentDir = "/Users/XYZ/<your-path>"
+const indexPagePath = "cost-financing.json"
+const indexPageTitle = "Cost financing"
+const collectionName = "cost-financing"
+const nameOfNewCollectionToCreate = "cost-financing-new" // will also be the permalink
+const siteId = 0
+await createCollectionFromLocal(
+  contentDir,
+  siteId,
+  indexPagePath,
+  indexPageTitle,
+  collectionName,
+  nameOfNewCollectionToCreate,
+)

--- a/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
@@ -96,10 +96,12 @@ export const deleteCollectionById = async (
       )
     })
   } catch (error) {
-    logger.error("Error deleting collection:", error)
+    if (error instanceof Error) {
+      logger.error(`Error deleting collection: ${error.message}`)
+    }
   }
 }
 
-const collectionIdToDelete = "3640"
+const collectionIdToDelete = "7249"
 const siteId = 1
 await deleteCollectionById(collectionIdToDelete, siteId)

--- a/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
@@ -1,0 +1,101 @@
+import { db } from "~/server/modules/database"
+
+export const deleteCollectionById = async (
+  collectionId: string,
+  siteId: number,
+) => {
+  try {
+    await db.transaction().execute(async (tx) => {
+      // Step 1: Find all child resources of the collection
+      const childResources = await tx
+        .selectFrom("Resource")
+        .select(["id", "state", "draftBlobId", "publishedVersionId"])
+        .where("parentId", "=", collectionId)
+        .where("siteId", "=", siteId)
+        .execute()
+
+      // Step 2: Handle each child resource
+      for (const resource of childResources) {
+        // Delete published version and its blob, if applicable
+        if (resource.publishedVersionId) {
+          const publishedVersion = await tx
+            .selectFrom("Version")
+            .select(["blobId"])
+            .where("id", "=", resource.publishedVersionId)
+            .executeTakeFirst()
+
+          const blobIdToDelete = publishedVersion?.blobId
+
+          await tx
+            .deleteFrom("Version")
+            .where("id", "=", resource.publishedVersionId)
+            .execute()
+
+          if (blobIdToDelete) {
+            await tx
+              .deleteFrom("Blob")
+              .where("id", "=", blobIdToDelete)
+              .execute()
+          }
+        }
+
+        // Delete draft blob, if applicable
+        if (resource.draftBlobId) {
+          await tx
+            .deleteFrom("Blob")
+            .where("id", "=", resource.draftBlobId)
+            .execute()
+        }
+
+        // Delete the resource itself
+        await tx.deleteFrom("Resource").where("id", "=", resource.id).execute()
+
+        console.log(`Resource with ID ${resource.id} deleted successfully.`)
+      }
+
+      // Step 3: Delete the collection itself
+      const collection = await tx
+        .selectFrom("Resource")
+        .select(["draftBlobId", "publishedVersionId"])
+        .where("id", "=", collectionId)
+        .executeTakeFirst()
+
+      if (!collection) {
+        throw new Error(`Collection with ID ${collectionId} not found.`)
+      }
+
+      // Handle published version and its blob for the collection
+      if (collection.publishedVersionId) {
+        const publishedVersion = await tx
+          .selectFrom("Version")
+          .select(["blobId"])
+          .where("id", "=", collection.publishedVersionId)
+          .executeTakeFirst()
+
+        const blobIdToDelete = publishedVersion?.blobId
+
+        await tx
+          .deleteFrom("Version")
+          .where("id", "=", collection.publishedVersionId)
+          .execute()
+
+        if (blobIdToDelete) {
+          await tx.deleteFrom("Blob").where("id", "=", blobIdToDelete).execute()
+        }
+      }
+
+      // Delete the collection resource itself
+      await tx.deleteFrom("Resource").where("id", "=", collectionId).execute()
+
+      console.log(
+        `Collection with ID ${collectionId} and all related data deleted successfully.`,
+      )
+    })
+  } catch (error) {
+    console.error("Error deleting collection:", error)
+  }
+}
+
+const collectionIdToDelete = ""
+const siteId = 0
+await deleteCollectionById(collectionIdToDelete, siteId)

--- a/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
@@ -4,10 +4,14 @@ import { FileLogger } from "../FileLogger"
 // Update the logger path if required
 const logger = new FileLogger("./deleteCollectionById.log")
 
-export const deleteCollectionById = async (
-  collectionId: string,
-  siteId: number,
-) => {
+interface DeleteCollectionByIdInput {
+  collectionId: string
+  siteId: number
+}
+export const deleteCollectionById = async ({
+  collectionId,
+  siteId,
+}: DeleteCollectionByIdInput) => {
   try {
     await db.transaction().execute(async (tx) => {
       // Step 1: Find all child resources of the collection
@@ -104,4 +108,4 @@ export const deleteCollectionById = async (
 
 const collectionIdToDelete = "0"
 const siteId = 0
-await deleteCollectionById(collectionIdToDelete, siteId)
+await deleteCollectionById({ collectionId: collectionIdToDelete, siteId })

--- a/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
@@ -102,6 +102,6 @@ export const deleteCollectionById = async (
   }
 }
 
-const collectionIdToDelete = "7249"
-const siteId = 1
+const collectionIdToDelete = "0"
+const siteId = 0
 await deleteCollectionById(collectionIdToDelete, siteId)

--- a/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/deleteCollectionById.ts
@@ -1,4 +1,8 @@
 import { db } from "~/server/modules/database"
+import { FileLogger } from "../FileLogger"
+
+// Update the logger path if required
+const logger = new FileLogger("./deleteCollectionById.log")
 
 export const deleteCollectionById = async (
   collectionId: string,
@@ -50,7 +54,7 @@ export const deleteCollectionById = async (
         // Delete the resource itself
         await tx.deleteFrom("Resource").where("id", "=", resource.id).execute()
 
-        console.log(`Resource with ID ${resource.id} deleted successfully.`)
+        logger.info(`Resource with ID ${resource.id} deleted successfully.`)
       }
 
       // Step 3: Delete the collection itself
@@ -87,15 +91,15 @@ export const deleteCollectionById = async (
       // Delete the collection resource itself
       await tx.deleteFrom("Resource").where("id", "=", collectionId).execute()
 
-      console.log(
+      logger.info(
         `Collection with ID ${collectionId} and all related data deleted successfully.`,
       )
     })
   } catch (error) {
-    console.error("Error deleting collection:", error)
+    logger.error("Error deleting collection:", error)
   }
 }
 
-const collectionIdToDelete = ""
-const siteId = 0
+const collectionIdToDelete = "3640"
+const siteId = 1
 await deleteCollectionById(collectionIdToDelete, siteId)

--- a/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
@@ -1,0 +1,80 @@
+import { db } from "~/server/modules/database"
+
+export const publishCollectionById = async (
+  publisherId: string,
+  collectionId: string,
+) => {
+  // First publish the collection
+  await db.transaction().execute(async (tx) => {
+    // Get collection
+    const collection = await tx
+      .selectFrom("Resource")
+      .selectAll()
+      .where("id", "=", collectionId)
+      .executeTakeFirstOrThrow()
+
+    if (collection.state !== "Draft") {
+      throw new Error(
+        `Collection with ID ${collectionId} cannot be published as it is either in Published state or draftBlobId is not present.`,
+      )
+    }
+
+    // Update collection state to Published
+    await tx
+      .updateTable("Resource")
+      .set({
+        state: "Published",
+        draftBlobId: null,
+        updatedAt: new Date(),
+      })
+      .where("id", "=", collectionId)
+      .executeTakeFirstOrThrow()
+
+    // Update all child resources to Published
+    const children = await tx
+      .selectFrom("Resource")
+      .selectAll()
+      .where("parentId", "=", collectionId)
+      .execute()
+
+    for (const child of children) {
+      if (child.state === "Published" || child.draftBlobId === null) {
+        console.log(
+          `Child resource with ID ${child.id} cannot be published as it is either in Published state or draftBlobId is not present.`,
+        )
+        continue
+      }
+
+      const childVersion = await tx
+        .insertInto("Version")
+        .values({
+          blobId: child.draftBlobId,
+          versionNum: 1,
+          resourceId: child.id,
+          publishedAt: new Date(),
+          publishedBy: publisherId,
+          updatedAt: new Date(),
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+
+      await tx
+        .updateTable("Resource")
+        .set({
+          state: "Published",
+          publishedVersionId: childVersion.id,
+          draftBlobId: null,
+          updatedAt: new Date(),
+        })
+        .where("id", "=", child.id)
+        .executeTakeFirstOrThrow()
+
+      console.log(`Published child resource with ID ${child.id}`)
+    }
+  })
+}
+
+// NOTE: TODO: Put in the publisher ID and collection ID to publish
+const publisherId = "0"
+const collectionId = "0"
+await publishCollectionById(publisherId, collectionId)

--- a/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
@@ -6,10 +6,14 @@ import { FileLogger } from "../FileLogger"
 // Update the logger path if required
 const logger = new FileLogger("./publishDraftCollection.log")
 
-export const publishCollectionById = async (
-  publisherId: string,
-  collectionId: string,
-) => {
+interface PublishDraftCollectionInput {
+  publisherId: string
+  collectionId: string
+}
+export const publishCollectionById = async ({
+  publisherId,
+  collectionId,
+}: PublishDraftCollectionInput) => {
   try {
     // First publish the collection
     await db.transaction().execute(async (tx) => {
@@ -92,4 +96,4 @@ export const publishCollectionById = async (
 // NOTE: TODO: Put in the publisher ID and collection ID to publish
 const publisherId = "xyz"
 const collectionId = "0"
-await publishCollectionById(publisherId, collectionId)
+await publishCollectionById({ publisherId, collectionId })

--- a/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
@@ -2,7 +2,7 @@ import { db } from "~/server/modules/database"
 import { FileLogger } from "../FileLogger"
 
 // Update the logger path if required
-const logger = new FileLogger("./publishCollectionById.log")
+const logger = new FileLogger("./publishDraftCollection.log")
 
 export const publishCollectionById = async (
   publisherId: string,

--- a/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
@@ -1,4 +1,8 @@
 import { db } from "~/server/modules/database"
+import { FileLogger } from "../FileLogger"
+
+// Update the logger path if required
+const logger = new FileLogger("./publishCollectionById.log")
 
 export const publishCollectionById = async (
   publisherId: string,
@@ -14,9 +18,9 @@ export const publishCollectionById = async (
       .executeTakeFirstOrThrow()
 
     if (collection.state !== "Draft") {
-      throw new Error(
-        `Collection with ID ${collectionId} cannot be published as it is either in Published state or draftBlobId is not present.`,
-      )
+      const errMsg = `Collection with ID ${collectionId} cannot be published as it is either in Published state or draftBlobId is not present.`
+      logger.error(errMsg)
+      throw new Error(errMsg)
     }
 
     // Update collection state to Published
@@ -39,7 +43,7 @@ export const publishCollectionById = async (
 
     for (const child of children) {
       if (child.state === "Published" || child.draftBlobId === null) {
-        console.log(
+        logger.error(
           `Child resource with ID ${child.id} cannot be published as it is either in Published state or draftBlobId is not present.`,
         )
         continue
@@ -69,12 +73,12 @@ export const publishCollectionById = async (
         .where("id", "=", child.id)
         .executeTakeFirstOrThrow()
 
-      console.log(`Published child resource with ID ${child.id}`)
+      logger.info(`Published child resource with ID ${child.id}`)
     }
   })
 }
 
 // NOTE: TODO: Put in the publisher ID and collection ID to publish
-const publisherId = "0"
-const collectionId = "0"
+const publisherId = "mblrtd177gju657mf20m32jo"
+const collectionId = "3640"
 await publishCollectionById(publisherId, collectionId)

--- a/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
@@ -8,77 +8,83 @@ export const publishCollectionById = async (
   publisherId: string,
   collectionId: string,
 ) => {
-  // First publish the collection
-  await db.transaction().execute(async (tx) => {
-    // Get collection
-    const collection = await tx
-      .selectFrom("Resource")
-      .selectAll()
-      .where("id", "=", collectionId)
-      .executeTakeFirstOrThrow()
-
-    if (collection.state !== "Draft") {
-      const errMsg = `Collection with ID ${collectionId} cannot be published as it is either in Published state or draftBlobId is not present.`
-      logger.error(errMsg)
-      throw new Error(errMsg)
-    }
-
-    // Update collection state to Published
-    await tx
-      .updateTable("Resource")
-      .set({
-        state: "Published",
-        draftBlobId: null,
-        updatedAt: new Date(),
-      })
-      .where("id", "=", collectionId)
-      .executeTakeFirstOrThrow()
-
-    // Update all child resources to Published
-    const children = await tx
-      .selectFrom("Resource")
-      .selectAll()
-      .where("parentId", "=", collectionId)
-      .execute()
-
-    for (const child of children) {
-      if (child.state === "Published" || child.draftBlobId === null) {
-        logger.error(
-          `Child resource with ID ${child.id} cannot be published as it is either in Published state or draftBlobId is not present.`,
-        )
-        continue
-      }
-
-      const childVersion = await tx
-        .insertInto("Version")
-        .values({
-          blobId: child.draftBlobId,
-          versionNum: 1,
-          resourceId: child.id,
-          publishedAt: new Date(),
-          publishedBy: publisherId,
-          updatedAt: new Date(),
-        })
-        .returning("id")
+  try {
+    // First publish the collection
+    await db.transaction().execute(async (tx) => {
+      // Get collection
+      const collection = await tx
+        .selectFrom("Resource")
+        .selectAll()
+        .where("id", "=", collectionId)
         .executeTakeFirstOrThrow()
 
+      if (collection.state !== "Draft") {
+        const errMsg = `Collection with ID ${collectionId} cannot be published as it is either in Published state or draftBlobId is not present.`
+        logger.error(errMsg)
+        throw new Error(errMsg)
+      }
+
+      // Update collection state to Published
       await tx
         .updateTable("Resource")
         .set({
           state: "Published",
-          publishedVersionId: childVersion.id,
           draftBlobId: null,
           updatedAt: new Date(),
         })
-        .where("id", "=", child.id)
+        .where("id", "=", collectionId)
         .executeTakeFirstOrThrow()
 
-      logger.info(`Published child resource with ID ${child.id}`)
+      // Update all child resources to Published
+      const children = await tx
+        .selectFrom("Resource")
+        .selectAll()
+        .where("parentId", "=", collectionId)
+        .execute()
+
+      for (const child of children) {
+        if (child.state === "Published" || child.draftBlobId === null) {
+          logger.error(
+            `Child resource with ID ${child.id} cannot be published as it is either in Published state or draftBlobId is not present.`,
+          )
+          continue
+        }
+
+        const childVersion = await tx
+          .insertInto("Version")
+          .values({
+            blobId: child.draftBlobId,
+            versionNum: 1,
+            resourceId: child.id,
+            publishedAt: new Date(),
+            publishedBy: publisherId,
+            updatedAt: new Date(),
+          })
+          .returning("id")
+          .executeTakeFirstOrThrow()
+
+        await tx
+          .updateTable("Resource")
+          .set({
+            state: "Published",
+            publishedVersionId: childVersion.id,
+            draftBlobId: null,
+            updatedAt: new Date(),
+          })
+          .where("id", "=", child.id)
+          .executeTakeFirstOrThrow()
+
+        logger.info(`Published child resource with ID ${child.id}`)
+      }
+    })
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error(`Error publishing collection by ID: ${error.message}`)
     }
-  })
+  }
 }
 
 // NOTE: TODO: Put in the publisher ID and collection ID to publish
 const publisherId = "mblrtd177gju657mf20m32jo"
-const collectionId = "3640"
+const collectionId = "7249"
 await publishCollectionById(publisherId, collectionId)

--- a/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
+++ b/apps/studio/prisma/scripts/moh-tosp/publishDraftCollection.ts
@@ -85,6 +85,6 @@ export const publishCollectionById = async (
 }
 
 // NOTE: TODO: Put in the publisher ID and collection ID to publish
-const publisherId = "mblrtd177gju657mf20m32jo"
-const collectionId = "7249"
+const publisherId = "xyz"
+const collectionId = "0"
 await publishCollectionById(publisherId, collectionId)


### PR DESCRIPTION
## Problem

Needed scripts to manage collection resources in the database for content migration.

Closes ISOM-1700

## Solution

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Features**:

- Added script to backup collections and their resources to JSON files
- Added script to create new collections from local JSON files
- Added script to safely delete collections and their associated resources
- Added script to publish draft collections and their child resources

**New scripts**:

- `backupCollectionById.ts`: Backs up a collection and its resources to JSON files
- `createCollectionFromLocal.ts`: Creates a new collection from local JSON content
- `deleteCollectionById.ts`: Safely deletes a collection and all associated resources
- `publishDraftCollection.ts`: Publishes a draft collection and its child resources

## Tests

Scripts should be tested with:
1. Backup of an existing collection
2. Creation of a new collection from backed up files
3. Publishing the newly created collection
4. Deletion of test collections

Each script includes error handling and transaction support to maintain data integrity.