### PR TITLE
logocloud storybook - replace placeholder.com with placehold.co

### DIFF
--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.stories.tsx
@@ -15,13 +15,13 @@ const meta: Meta<typeof LogoCloud> = {
 export default meta
 type Story = StoryObj<typeof LogoCloud>
 
-const IMAGE = { src: "https://via.placeholder.com/150", alt: "placeholder" }
+const IMAGE = { src: "https://placehold.co/150", alt: "placeholder" }
 const HORIZONTAL_IMAGE = {
-  src: "https://via.placeholder.com/1000x100",
+  src: "https://placehold.co/1000x100",
   alt: "placeholder",
 }
 const VERTICAL_IMAGE = {
-  src: "https://via.placeholder.com/100x1000",
+  src: "https://placehold.co/100x1000",
   alt: "placeholder",
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

storybook has intermittent issue with placeholder for logo cloud rendering

on local, seems like `via.placeholder.com` is not very fast and thus can be causing the error (sometimes not rendering on chromatic)

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- switch to placehold.co - align with the other stories we use
