### PR TITLE
replace "alex" with "alexander"

### DIFF
--- a/apps/studio/prisma/constants.ts
+++ b/apps/studio/prisma/constants.ts
@@ -1,5 +1,5 @@
 export const ISOMER_ADMINS = [
-  "alex",
+  "alexander",
   "jan",
   "jiachin",
   "sehyun",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

currently prisma constants say @alexanderleegs email is `alex` which creates email `alex@open.gov.sg`

however that's incorrect so he won't be having access to sites, which can be important/required for on call

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- change name
