### PR TITLE
add back tsx

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -70,7 +70,6 @@ start_time=$(date +%s)
 cd tooling/build/scripts/publishing
 echo $(pwd)
 npm ci
-npm install ts-node -g
 npm run start
 calculate_duration $start_time
 

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -5,14 +5,15 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "ts-node index.ts "
+    "start": "tsx index.ts "
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "pg": "^8.12.0"
+    "pg": "^8.12.0",
+    "tsx": "^4.19.2"
   },
   "devDependencies": {
     "@types/pg": "^8.11.6"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

last week we did a hotfix (https://github.com/opengovsg/isomer/pull/948, https://github.com/opengovsg/isomer/pull/949) due to PROD deployment failure

it's safe to revert it back after https://github.com/opengovsg/isomer-next-infra/pull/49 since we will be referencing the latest tag

in fact, this is stopping us from building on staging as `tooling/build/scripts/publishing/index.ts` is using referencing from `import { ResourceType } from "~generated/generatedEnums"`

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- update back to use `tsx`