### PR TITLE
fix collection pagination hidden

### DIFF
--- a/apps/studio/src/components/CmsSidebar/CmsContainer.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsContainer.tsx
@@ -75,7 +75,7 @@ export function CmsContainer({
           {sidenav}
         </Box>
       </GridItem>
-      <GridItem as="main" area="main" overflow="hidden">
+      <GridItem as="main" area="main" overflow="auto">
         <Box
           height={0}
           minH="100%"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Pagination in collection are cut-off if there's too many items in the page

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- replace parent's overflow from `hidden` to `auto`

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

<img width="479" alt="image" src="https://github.com/user-attachments/assets/4a1a18ef-0687-4aa3-bebe-e8616d2db2f7" />

**AFTER**:

<!-- [insert screenshot here] -->

<img width="483" alt="image" src="https://github.com/user-attachments/assets/f407502f-54ca-4b57-8f45-6d8997281aa3" />
