### PR TITLE
fix - use next/link for breadcrumbs for folders and headers

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[resourceId].tsx
@@ -1,3 +1,4 @@
+import NextLink from "next/link"
 import {
   Box,
   BreadcrumbItem,
@@ -51,7 +52,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
       <Stack w="100%" p="1.75rem" gap="1rem" height="$100vh" overflow="auto">
         <Breadcrumb size="sm">
           <BreadcrumbItem>
-            <BreadcrumbLink href={`/sites/${siteId}`}>
+            <BreadcrumbLink href={`/sites/${siteId}`} as={NextLink}>
               <Text textStyle="caption-2" color="interaction.links.default">
                 Home
               </Text>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -1,3 +1,4 @@
+import NextLink from "next/link"
 import {
   Box,
   BreadcrumbItem,
@@ -122,7 +123,7 @@ const FolderPage: NextPageWithLayout = () => {
             {breadcrumbs.map(({ href, label }, index) => {
               return (
                 <BreadcrumbItem key={index}>
-                  <BreadcrumbLink href={href}>
+                  <BreadcrumbLink href={href} as={NextLink}>
                     <Text
                       textStyle="caption-2"
                       color="interaction.links.default"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently breadcrumbs are not using `next/link`, thus causing long load time between pages

<img width="753" alt="Screenshot 2024-12-24 at 12 09 52 AM" src="https://github.com/user-attachments/assets/50dbd5cc-1d39-4b19-9630-8fcb5933d963" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add `next/link` to make use of nextjs's prefetching to reduce load time and improve UX
