### PR TITLE
refactor: logocloud

### DIFF
--- a/packages/components/src/interfaces/complex/LogoCloud.ts
+++ b/packages/components/src/interfaces/complex/LogoCloud.ts
@@ -1,6 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
+import { IsomerSiteProps } from "~/types"
 import { AltTextSchema, ImageSrcSchema } from "./Image"
 
 export const LOGO_CLOUD_TYPE = "logocloud"
@@ -25,10 +26,10 @@ export const LogoCloudSchema = Type.Object(
     }),
   },
   {
-    title: "Title",
+    title: "Logocloud component",
   },
 )
 
 export type LogoCloudProps = Static<typeof LogoCloudSchema> & {
-  assetsBaseUrl?: string
+  site: IsomerSiteProps
 }

--- a/packages/components/src/interfaces/complex/LogoCloud.ts
+++ b/packages/components/src/interfaces/complex/LogoCloud.ts
@@ -1,7 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import { IsomerSiteProps } from "~/types"
+import type { IsomerSiteProps } from "~/types"
 import { AltTextSchema, ImageSrcSchema } from "./Image"
 
 export const LOGO_CLOUD_TYPE = "logocloud"

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
+import type { IsomerSiteProps } from "~/types"
 import { LogoCloud } from "./LogoCloud"
 
 const meta: Meta<typeof LogoCloud> = {
@@ -24,17 +25,44 @@ const VERTICAL_IMAGE = {
   src: "https://placehold.co/100x1000",
   alt: "placeholder",
 }
+const site: IsomerSiteProps = {
+  siteName: "Isomer Next",
+  siteMap: {
+    id: "1",
+    title: "Home",
+    permalink: "/",
+    lastModified: "",
+    layout: "homepage",
+    summary: "",
+  },
+  theme: "isomer-next",
+  isGovernment: true,
+  logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+  navBarItems: [],
+  footerItems: {
+    privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+    termsOfUseLink: "https://www.isomer.gov.sg/terms",
+    siteNavItems: [],
+  },
+  lastUpdated: "1 Jan 2021",
+  search: {
+    type: "searchSG",
+    clientId: "",
+  },
+}
 
 // Default scenario
 export const Default: Story = {
   args: {
     images: [IMAGE],
+    site,
   },
 }
 
 export const ManyImages: Story = {
   args: {
     images: Array(10).fill(IMAGE),
+    site,
   },
 }
 
@@ -54,17 +82,20 @@ export const Agency: Story = {
         src: "https://www.ncss.gov.sg/images/default-source/asset/celebrating-volunteers-logo.png?sfvrsn=44b85185_2 ",
       },
     ],
+    site,
   },
 }
 
 export const HugeHorizontalLogo: Story = {
   args: {
     images: [...Array(4).fill(IMAGE), HORIZONTAL_IMAGE],
+    site,
   },
 }
 
 export const HugeVerticalLogo: Story = {
   args: {
     images: [...Array(4).fill(IMAGE), VERTICAL_IMAGE],
+    site,
   },
 }

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
@@ -5,7 +5,7 @@ import { ImageClient } from "../Image"
 export const LogoCloud = ({
   images: baseImages,
   title,
-  assetsBaseUrl,
+  site: { assetsBaseUrl },
 }: LogoCloudProps) => {
   const images = baseImages.map(({ src, alt }) => {
     const transformedSrc =


### PR DESCRIPTION
## Problem
1. logocloud requires `assetsBaseUrl` for relative links but `site` already has this - we should account for this and just derive it from `site` 
2. studio uses `title` to render so now for logocloud it's showing `Title` (see SS)

## Solution
1. update logocloud from using `assetsBaseUrl` to using `site.assetsBaseUrl`
2. update `title` in the schema to `Logocloud component`

## How to test
1. open up studio
2. add a logocloud component
3. add a relative url
4. the image shuold render without issue
5. for the title, it shuold display logocloud component

## Migration plan
- none -> because now it's no longer picking up the property post release and it's isntead deriving from sites.

## screenshots
<img width="463" alt="image" src="https://github.com/user-attachments/assets/a2da156b-0a72-4190-8beb-f9f4cab3ca45" />


https://github.com/user-attachments/assets/1101fb41-e89e-48dc-89f6-cc997230502d
