### PR TITLE
fix getParsedDate - add 8h to account for timezone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,15 @@ jobs:
         env:
           # Required to allow Datadog to trace Vitest tests
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+          # Set timezone to Singapore to ensure that the tests are run in the correct timezone
+          TZ: Asia/Singapore
       - name: Test Components
         run: turbo test-ci:unit --filter=@opengovsg/isomer-components --env-mode=loose
         env:
           # Required to allow Datadog to trace Vitest tests
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+          # Set timezone to Singapore to ensure that the tests are run in the correct timezone
+          TZ: Asia/Singapore
 
   end-to-end-tests:
     name: End-to-end tests

--- a/packages/components/src/utils/__tests__/getParsedData.test.ts
+++ b/packages/components/src/utils/__tests__/getParsedData.test.ts
@@ -33,9 +33,9 @@ describe("getParsedDate", () => {
     expect(result).toStrictEqual(new Date(2023, 5, 15))
   })
 
-  it("parses ISO 8601 format correctly", () => {
-    const result = getParsedDate("2023-07-20T14:30:45.123Z")
-    expect(result).toStrictEqual(new Date(2023, 6, 20, 14, 30, 45, 123))
+  it("parses ISO 8601 format correctly in Singapore timezone", () => {
+    const result = getParsedDate("2023-07-20T16:00:00.000Z")
+    expect(result).toStrictEqual(new Date(2023, 6, 21, 0, 0, 0, 0))
   })
 
   it("returns current date for unsupported format", () => {

--- a/packages/components/src/utils/getParsedDate.ts
+++ b/packages/components/src/utils/getParsedDate.ts
@@ -1,5 +1,6 @@
 import { isMatch, parse } from "date-fns"
 
+const TIMEZONE_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
 const SUPPORTED_DATE_FORMATS = [
   "dd/MM/yyyy",
   "d MMM yyyy",
@@ -7,7 +8,7 @@ const SUPPORTED_DATE_FORMATS = [
   "dd MMM yyyy",
   "dd MMMM yyyy",
   "yyyy-MM-dd",
-  "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+  TIMEZONE_DATE_FORMAT,
 ]
 
 export const getParsedDate = (dateString: string) => {
@@ -20,7 +21,14 @@ export const getParsedDate = (dateString: string) => {
 
       try {
         if (isMatch(dateString, format)) {
-          return parse(dateString, format, new Date())
+          let offsetDate = dateString
+          if (format === TIMEZONE_DATE_FORMAT) {
+            offsetDate = new Date(
+              // Add 8 hours to account for the Singapore timezone offset
+              new Date(dateString).getTime() + 8 * 60 * 60 * 1000,
+            ).toISOString()
+          }
+          return parse(offsetDate, format, new Date())
         }
       } catch (e) {
         return new Date()

--- a/packages/components/src/utils/getParsedDate.ts
+++ b/packages/components/src/utils/getParsedDate.ts
@@ -23,9 +23,11 @@ export const getParsedDate = (dateString: string) => {
         if (isMatch(dateString, format)) {
           let offsetDate = dateString
           if (format === TIMEZONE_DATE_FORMAT) {
+            const localTimezoneOffsetInSeconds =
+              new Date().getTimezoneOffset() * 60 * 1000
+
             offsetDate = new Date(
-              // Add 8 hours to account for the Singapore timezone offset
-              new Date(dateString).getTime() + 8 * 60 * 60 * 1000,
+              new Date(dateString).getTime() - localTimezoneOffsetInSeconds,
             ).toISOString()
           }
           return parse(offsetDate, format, new Date())


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

date in collection preview is one day behind on studio

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add a 8h addition to date to account for SG timezone

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

<img width="1700" alt="Screenshot 2024-12-27 at 9 28 07 PM" src="https://github.com/user-attachments/assets/735ca69e-b4eb-49e0-950a-6ef0aa7dda30" />

**AFTER**:

<!-- [insert screenshot here] -->

<img width="1764" alt="Screenshot 2024-12-27 at 10 32 13 PM" src="https://github.com/user-attachments/assets/4b2f11fc-5dd0-44e3-bc60-880b43cd989e" />

## Tests

<!-- What tests should be run to confirm functionality? -->

1. create a link in a collection
2. select a date
3. the date in the date selector and that in the preview should be the same