### PR TITLE
isom-1710 lighthouse performance preconnect to google font

### DIFF
--- a/packages/components/src/templates/next/components/internal/FontPreload.tsx
+++ b/packages/components/src/templates/next/components/internal/FontPreload.tsx
@@ -1,0 +1,22 @@
+// The following links are included to improve SEO and Lighthouse performance by optimizing font loading.
+// Preconnecting to fonts.gstatic.com allows the browser to establish a connection early, reducing latency
+// when fetching fonts, which can lead to faster rendering and improved user experience.
+
+export const FontPreload = () => {
+  return (
+    <>
+      <link
+        // Establish an early connection to fonts.gstatic.com
+        rel="preconnect"
+        href="https://fonts.gstatic.com"
+        crossOrigin="anonymous" // required when making requests to a different origin
+      />
+      <link
+        // Serve as a fallback for browsers that don't support preconnect
+        // at least allowing early DNS resolution
+        rel="dns-prefetch"
+        href="https://fonts.gstatic.com"
+      />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/index.ts
+++ b/packages/components/src/templates/next/components/internal/index.ts
@@ -28,3 +28,4 @@ export {
   GoogleTagManagerBody,
 } from "./GoogleTagManager"
 export { BlogCard } from "./BlogCard"
+export { FontPreload } from "./FontPreload"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -1,6 +1,7 @@
 import type { IsomerPageSchemaType } from "~/engine"
 import {
   DatadogRum,
+  FontPreload,
   Footer,
   GoogleTagManagerBody,
   GoogleTagManagerHeader,
@@ -33,6 +34,8 @@ export const Skeleton = ({
 
   return (
     <>
+      <FontPreload />
+
       {shouldIncludeGTM && (
         <GoogleTagManagerHeader
           siteGtmId={site.siteGtmId}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1710/lighthouse-performance-preconnect-to-google-font

Currently we are using google font but not preconnecting thus causing latency between 80ms to 200ms, which impact Lighthouse Performance score

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Add `FontPreload` component and pass it into `Skeleton`

screenshot of `<head>` for local build
<img width="605" alt="Screenshot 2024-12-29 at 3 58 59 PM" src="https://github.com/user-attachments/assets/82524a05-8581-4897-8dcc-d4e9ed253d36" />

## Tests

<!-- What tests should be run to confirm functionality? -->

Trigger a new codebuild and verify that these two can be found in the `<head>`
```
      <link
        rel="preconnect"
        href="https://fonts.gstatic.com"
        crossOrigin="anonymous" // required when making requests to a different origin
      />
      <link
        rel="dns-prefetch"
        href="https://fonts.gstatic.com"
      />
```

Run a lighthouse on the page and the red warning should not show under Performance section too