### PR TITLE
isom-1697 huge images on next sites (lazy loading)

### DIFF
--- a/packages/components/src/templates/next/components/complex/Image/ImageClient.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/ImageClient.tsx
@@ -6,6 +6,7 @@ export interface ImageClientProps {
   width: string
   className: string
   assetsBaseUrl?: string
+  lazyLoading?: boolean
 }
 
 export const ImageClient = ({
@@ -14,6 +15,7 @@ export const ImageClient = ({
   width,
   className,
   assetsBaseUrl,
+  lazyLoading = true, // next/image defaults to lazy loading true too
 }: ImageClientProps) => {
   return (
     <img
@@ -26,6 +28,7 @@ export const ImageClient = ({
         currentTarget.onerror = null
         currentTarget.src = `${assetsBaseUrl ?? ""}/placeholder_no_image.png`
       }}
+      loading={lazyLoading ? "lazy" : "eager"}
     />
   )
 }

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -41,6 +41,7 @@ export const Navbar = ({
         className:
           "max-h-[48px] max-w-[128px] object-contain object-center lg:mr-3",
         assetsBaseUrl: site.assetsBaseUrl,
+        lazyLoading: false, // will always be above the fold
       }}
       LinkComponent={LinkComponent}
     />


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Partially closes https://linear.app/ogp/issue/ISOM-1697/huge-images-on-next-sites

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- lazy load image on sites by default
  - except for Navbar since it will always be above the fold
  - hero is using backgroundUrl and not ImageClient so not affected 

## Before & After Screenshots

1. trigger a codebuild
2. open the newly built site 
3. check dev console and that images have `loading: lazy` attribute