### PR TITLE
Fix index page not rendering link

### DIFF
--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -16,6 +16,7 @@ interface IsomerBaseSitemap {
   date?: CollectionCardProps["lastUpdated"]
   children?: IsomerSitemap[]
   tags?: CollectionCardProps["tags"]
+  indexPageId?: string
 }
 
 interface IsomerPageSitemap extends IsomerBaseSitemap {

--- a/packages/components/src/utils/getReferenceLinkHref.ts
+++ b/packages/components/src/utils/getReferenceLinkHref.ts
@@ -39,9 +39,11 @@ const convertReferenceLinks = (
     return originalLink
   }
 
-  const refPage = sitemapArray.find(
-    ({ id, indexPageId }) => refPageId === id || refPageId === indexPageId,
-  )
+  const refPage = sitemapArray.find(({ id, indexPageId }) => {
+    // in the case of a folder with IndexPage,
+    // we must check both the folder's id and the IndexPage's id
+    return refPageId === id || refPageId === indexPageId
+  })
 
   if (!refPage) {
     return originalLink

--- a/packages/components/src/utils/getReferenceLinkHref.ts
+++ b/packages/components/src/utils/getReferenceLinkHref.ts
@@ -39,7 +39,9 @@ const convertReferenceLinks = (
     return originalLink
   }
 
-  const refPage = sitemapArray.find(({ id }) => id === refPageId)
+  const refPage = sitemapArray.find(
+    ({ id, indexPageId }) => refPageId === id || refPageId === indexPageId,
+  )
 
   if (!refPage) {
     return originalLink

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -111,17 +111,19 @@ async function main() {
           resource.parentId,
         )
 
+        const isIndexPage =
+          resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
+          resource.type !== "RootPage"
+
         const resourceConvertedPermalink = getConvertedPermalink(resource.fullPermalink)
 
         const idOfFolder = resources.find(
-          (item) =>
-            resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
-            resource.type !== "RootPage" &&
-            item.fullPermalink === resourceConvertedPermalink,
+          (item) => isIndexPage && item.fullPermalink === resourceConvertedPermalink,
         )?.id
 
         const sitemapEntry: SitemapEntry = {
           id: idOfFolder ?? resource.id,
+          indexPageId: isIndexPage ? resource.id : undefined,
           type: resource.type,
           title: resource.title,
           permalink: `/${resourceConvertedPermalink}`,

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -115,10 +115,13 @@ async function main() {
           resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
           resource.type !== "RootPage"
 
-        const resourceConvertedPermalink = getConvertedPermalink(resource.fullPermalink)
+        const resourceConvertedPermalink =
+          getConvertedPermalink(resource.fullPermalink)
 
         const idOfFolder = resources.find(
-          (item) => isIndexPage && item.fullPermalink === resourceConvertedPermalink,
+          (item) =>
+            isIndexPage &&
+            item.fullPermalink === resourceConvertedPermalink,
         )?.id
 
         const sitemapEntry: SitemapEntry = {

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -115,13 +115,13 @@ async function main() {
           resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
           resource.type !== "RootPage"
 
-        const resourceConvertedPermalink =
-          getConvertedPermalink(resource.fullPermalink)
+        const resourceConvertedPermalink = getConvertedPermalink(
+          resource.fullPermalink,
+        )
 
         const idOfFolder = resources.find(
           (item) =>
-            isIndexPage &&
-            item.fullPermalink === resourceConvertedPermalink,
+            isIndexPage && item.fullPermalink === resourceConvertedPermalink,
         )?.id
 
         const sitemapEntry: SitemapEntry = {

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -111,19 +111,20 @@ async function main() {
           resource.parentId,
         )
 
+        const resourceConvertedPermalink = getConvertedPermalink(resource.fullPermalink)
+
         const idOfFolder = resources.find(
           (item) =>
             resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
             resource.type !== "RootPage" &&
-            item.fullPermalink ===
-              getConvertedPermalink(resource.fullPermalink),
+            item.fullPermalink === resourceConvertedPermalink,
         )?.id
 
         const sitemapEntry: SitemapEntry = {
           id: idOfFolder ?? resource.id,
           type: resource.type,
           title: resource.title,
-          permalink: `/${getConvertedPermalink(resource.fullPermalink)}`,
+          permalink: `/${resourceConvertedPermalink}`,
           lastModified: new Date().toISOString(), // TODO: Update to updated_at column
           layout: resource.content.layout || "content",
           summary:

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -17,6 +17,7 @@ export type SitemapEntry = Pick<
   Resource,
   "id" | "title" | "permalink" | "type"
 > & {
+  indexPageId?: string
   lastModified: string
   layout: string
   summary: string


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1712/bug-linking-to-an-index-page-cause-incorrect-rendering-of

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

**this has been tested on STAGING and verified to be working**

- add `indexPageId` attribute to SitemapEntry
- use that value for matching in `getReferenceLinkHref.ts`

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to studio
2. create a page, add a Text block and link to a IndexPage resource
3. trigger a codebuild
4. go to the published page and check that the URL is valid and not incorrect `.../[resource:...:.....]`