### PR TITLE
enhancement/add copyright year component

### DIFF
--- a/packages/components/src/templates/next/components/internal/Footer/ClientCopyrightYear.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/ClientCopyrightYear.tsx
@@ -1,5 +1,5 @@
 "use client"
 
 export const ClientCopyrightYear = () => {
-  return <>&copy; {new Date().getFullYear()} </>
+  return <>&copy; {new Date().getFullYear()}</>
 }

--- a/packages/components/src/templates/next/components/internal/Footer/ClientCopyrightYear.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/ClientCopyrightYear.tsx
@@ -1,0 +1,5 @@
+"use client"
+
+export const ClientCopyrightYear = () => {
+  return <>&copy; {new Date().getFullYear()} </>
+}

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -26,6 +26,7 @@ import {
   isExternalUrl,
 } from "~/utils"
 import { Link } from "../Link"
+import { ClientCopyrightYear } from "./ClientCopyrightYear"
 
 const SocialMediaTypeToIconMap: Record<SocialMediaType, IconType> = {
   facebook: FaFacebook,
@@ -256,7 +257,7 @@ const LegalSection = ({
     <div className="flex h-full">
       <div className="flex flex-col justify-end gap-4 lg:gap-2">
         <p className="prose-label-md-regular text-base-content-inverse-subtle">
-          &copy; {new Date().getFullYear()}{" "}
+          <ClientCopyrightYear />
           {isGovernment ? "Government of Singapore" : agencyName}, last updated{" "}
           {getFormattedDate(lastUpdated)}
         </p>

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -257,7 +257,7 @@ const LegalSection = ({
     <div className="flex h-full">
       <div className="flex flex-col justify-end gap-4 lg:gap-2">
         <p className="prose-label-md-regular text-base-content-inverse-subtle">
-          <ClientCopyrightYear />
+          <ClientCopyrightYear />{" "}
           {isGovernment ? "Government of Singapore" : agencyName}, last updated{" "}
           {getFormattedDate(lastUpdated)}
         </p>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently the year is generated on build time

But ideally, we want it to be generated on runtime since we don't know when will agencies trigger a new build + it's easier than having to remember to trigger a new build for all sites every new year

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- `use client` for the copyright and year
