### PR TITLE
pass in first image "src" if page.image is undefined

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -16,6 +16,7 @@ import {
   getCollectionIndexPageContents,
   getFolderIndexPageContents,
 } from "./utils/getIndexPageContent"
+import { getResourceImage } from "./utils/getResourceImage"
 
 dotenv.config()
 
@@ -137,11 +138,7 @@ async function main() {
           category: resource.content.page.category,
           tags: resource.content.page.tags,
           date: resource.content.page.date,
-          image:
-            resource.content.page.image ||
-            resource.content.page.content.find(
-              (item: any) => item.type === "image",
-            )?.src,
+          image: getResourceImage(resource),
           ref: resource.content.page.ref, // For file and link layouts
         }
 

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -137,7 +137,11 @@ async function main() {
           category: resource.content.page.category,
           tags: resource.content.page.tags,
           date: resource.content.page.date,
-          image: resource.content.page.image,
+          image:
+            resource.content.page.image ||
+            resource.content.page.content.find(
+              (item: any) => item.type === "image",
+            )?.src,
           ref: resource.content.page.ref, // For file and link layouts
         }
 

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -22,7 +22,10 @@ export type SitemapEntry = Pick<
   summary: string
   category?: string
   date?: string
-  image?: string
+  image?: {
+    src?: string
+    alt?: string
+  }
   ref?: string
   children?: SitemapEntry[]
   tags?: Tag[]

--- a/tooling/build/scripts/publishing/utils/getResourceImage.ts
+++ b/tooling/build/scripts/publishing/utils/getResourceImage.ts
@@ -3,9 +3,9 @@ import type { Resource } from "../types"
 export const getResourceImage = (resource: Resource) => {
   if (resource.content.page.image) return resource.content.page.image
 
-  if (!Array.isArray(resource.content)) return undefined
+  if (!Array.isArray(resource.content?.content)) return undefined
 
-  const firstImageComponent = resource.content.find(
+  const firstImageComponent = resource.content.content.find(
     (item: any) => item.type === "image",
   )
   return firstImageComponent

--- a/tooling/build/scripts/publishing/utils/getResourceImage.ts
+++ b/tooling/build/scripts/publishing/utils/getResourceImage.ts
@@ -3,6 +3,8 @@ import type { Resource } from "../types"
 export const getResourceImage = (resource: Resource) => {
   if (resource.content.page.image) return resource.content.page.image
 
+  if (!Array.isArray(resource.content)) return undefined
+
   const firstImageComponent = resource.content.find(
     (item: any) => item.type === "image",
   )

--- a/tooling/build/scripts/publishing/utils/getResourceImage.ts
+++ b/tooling/build/scripts/publishing/utils/getResourceImage.ts
@@ -1,0 +1,15 @@
+import type { Resource } from "../types"
+
+export const getResourceImage = (resource: Resource) => {
+  if (resource.content.page.image) return resource.content.page.image
+
+  const firstImageComponent = resource.content.find(
+    (item: any) => item.type === "image",
+  )
+  return firstImageComponent
+    ? {
+        src: firstImageComponent.src,
+        alt: firstImageComponent.alt,
+      }
+    : undefined
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Not all collection has images in their `page.image`, which can result in ugly-and-inconsistent looking display on Collection layout

Closes https://opengovproducts.slack.com/archives/C07CWUNUL68/p1735799689732969?thread_ts=1735799448.795359&cid=C07CWUNUL68

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- fallback to the first `image` component (`src` and `alt`) if `page.image` is undefined

## Tests

<!-- What tests should be run to confirm functionality? -->

**Note: tested to work on staging**

1. create a collection item and use raw editor json mode to display
  ```json
{
  "page": {
    "date": "27/12/2024",
    "title": "asdf",
    "category": "Feature Articles",
    "lastModified": "2024-12-29T18:17:09.452Z",
    "articlePageHeader": {
      "summary": "A concise summary of the main points regarding this article."
    }
  },
  "layout": "article",
  "content": [
    {
      "alt": "my alt text",
      "src": "https://placehold.co/500",
      "size": "default",
      "type": "image"
    }
  ],
  "version": "0.1.0"
}
  ```

2. publish
3. review the published collection and see that it uses `https://placehold.co/500` as the source