### PR TITLE
fix: use updatedAt column for last updated date

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -124,7 +124,7 @@ async function main() {
           type: resource.type,
           title: resource.title,
           permalink: `/${getConvertedPermalink(resource.fullPermalink)}`,
-          lastModified: new Date().toISOString(), // TODO: Update to updated_at column
+          lastModified: resource.updatedAt.toISOString(),
           layout: resource.content.layout || "content",
           summary:
             (Array.isArray(resource.content.page.contentPageHeader?.summary)

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -1,5 +1,5 @@
 export const GET_ALL_RESOURCES_WITH_FULL_PERMALINKS = `
-WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "fullPermalink", "publishedVersionId") AS (
+WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "fullPermalink", "publishedVersionId", "updatedAt") AS (
     -- Base case for all resources
     SELECT
         r.id,
@@ -12,7 +12,8 @@ WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "f
             ELSE NULL
         END AS content,
         r.permalink AS "fullPermalink",
-        r."publishedVersionId"
+        r."publishedVersionId",
+        r."updatedAt"
     FROM
         public."Resource" r
     LEFT JOIN public."Version" v ON v."id" = r."publishedVersionId"
@@ -34,7 +35,8 @@ WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "f
             ELSE NULL
         END AS content,
         CONCAT(path."fullPermalink", '/', r.permalink) AS "fullPermalink",
-        r."publishedVersionId"
+        r."publishedVersionId",
+        r."updatedAt"
     FROM
         public."Resource" r
     LEFT JOIN public."Version" v ON v."id" = r."publishedVersionId"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The last updated date on content pages is always taking the latest date in which the site is built.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Retrieve the last updated date using the `updatedAt` column for the resource that is stored inside the database.

## Before & After Screenshots

https://github.com/user-attachments/assets/d9c6b8ab-7100-4311-9997-a20c796ff66f

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] On Studio, navigate to a sample published content page and take note of the last updated date.
- [ ] Navigate to the actual page on the published site. The last updated date should be different (as it was previously taking the last updated date of the **site** and not the page.
- [ ] Trigger a new build with the changes of this PR.
- [ ] Invalidate the CloudFront cache for the published site.
- [ ] Verify that the last updated date should match the one in Studio.