### PR TITLE
fix: adjust design for collection blog variant

### DIFF
--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react"
 import { withChromaticModes } from "@isomer/storybook-config"
 
 import type { CollectionCardProps } from "~/interfaces"
-import { Tag } from "~/interfaces/internal/CollectionCard"
+import type { Tag } from "~/interfaces/internal/CollectionCard"
 import { BlogCard } from "./BlogCard"
 
 const meta: Meta<typeof BlogCard> = {
@@ -100,7 +100,7 @@ export const TagsWithoutImage: Story = {
   args: generateArgs({
     title: "Collection card without tags",
     withoutImage: true,
-    description: "This is a random description that will be on the card",
+    description: "This is a random description\nthat will be on the card",
     tags: [
       {
         category: "very long",

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -65,7 +65,7 @@ export const BlogCard = ({
           </Link>
         </h3>
         {tags && tags.length > 0 && (
-          <div className="-mt-1">
+          <div className="-mt-1 flex flex-col gap-1">
             {tags.flatMap(({ category, selected: labels }) => {
               return (
                 <div className="flex w-full flex-wrap items-center gap-2">

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -1,7 +1,3 @@
-"use client"
-
-import { Text } from "react-aria-components"
-
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
 import { tv } from "~/lib/tv"
@@ -50,9 +46,9 @@ export const BlogCard = ({
         </div>
       )}
       {shouldShowDate && (
-        <Text className="prose-label-md-regular shrink-0 text-base-content-subtle">
+        <p className="prose-label-md-regular shrink-0 text-base-content-subtle">
           {lastUpdated ? getFormattedDate(lastUpdated) : "-"}
-        </Text>
+        </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content">
         <h3 className="inline-block">
@@ -79,14 +75,14 @@ export const BlogCard = ({
           </div>
         )}
         {description && (
-          <Text className="prose-body-base line-clamp-3" title={description}>
+          <p className="prose-body-base line-clamp-3 whitespace-pre-wrap">
             {description}
-          </Text>
+          </p>
         )}
         {/* TODO: Feature enhancement? Filter by category when clicked */}
-        <Text className="prose-label-sm-medium text-base-content-subtle">
+        <p className="prose-label-sm-medium text-base-content-subtle">
           {category}
-        </Text>
+        </p>
       </div>
     </div>
   )

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -61,10 +61,10 @@ export const BlogCard = ({
           </Link>
         </h3>
         {tags && tags.length > 0 && (
-          <div className="-mt-1 flex flex-col gap-1">
+          <div className="-mt-1 flex flex-col gap-2">
             {tags.flatMap(({ category, selected: labels }) => {
               return (
-                <div className="flex w-full flex-wrap items-center gap-2">
+                <div className="flex w-full flex-wrap items-center gap-1.5">
                   <p className="prose-label-sm">{category}</p>
                   {labels.map((label) => {
                     return <Tag>{label}</Tag>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -1,7 +1,3 @@
-"use client"
-
-import { Text } from "react-aria-components"
-
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
 import { tv } from "~/lib/tv"
@@ -35,9 +31,9 @@ export const CollectionCard = ({
   return (
     <div className="flex border-collapse flex-col gap-3 border-b border-divider-medium py-5 first:border-t lg:flex-row lg:gap-6">
       {shouldShowDate && (
-        <Text className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
+        <p className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
           {lastUpdated ? getFormattedDate(lastUpdated) : "-"}
-        </Text>
+        </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content lg:gap-2">
         <h3 className="inline-block">
@@ -64,14 +60,14 @@ export const CollectionCard = ({
           </>
         )}
         {description && (
-          <Text className="prose-body-base line-clamp-3" title={description}>
+          <p className="prose-body-base line-clamp-3 whitespace-pre-wrap">
             {description}
-          </Text>
+          </p>
         )}
         {/* TODO: Feature enhancement? Filter by category when clicked */}
-        <Text className="prose-label-md mt-3 text-base-content-subtle lg:mt-2">
+        <p className="prose-label-md mt-3 text-base-content-subtle lg:mt-2">
           {category}
-        </Text>
+        </p>
       </div>
       {image && (
         <div className="relative mt-3 min-h-40 w-full shrink-0 lg:ml-4 lg:mt-0 lg:h-auto lg:w-1/4">

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -69,10 +69,7 @@ const getCollectionItems = (
         description: item.summary,
         image: item.image,
         site,
-        tags: item.tags?.map(({ selected, category }) => ({
-          selected,
-          category: capitalize(category),
-        })),
+        tags: item.tags,
       }
 
       if (item.layout === "file") {

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -35,7 +35,7 @@ interface CollectionClientProps {
 const createCollectionLayoutStyles = tv({
   slots: {
     container:
-      "relative mx-auto grid max-w-screen-xl grid-cols-12 px-6 pb-16 pt-8 md:px-10 lg:gap-6 xl:gap-10",
+      "relative mx-auto grid max-w-screen-xl grid-cols-12 px-6 pb-16 pt-8 md:px-10",
     filterContainer: "relative col-span-12 pb-2 pt-8 lg:col-span-3 lg:pb-10",
     content: "col-span-12 flex flex-col gap-8 pt-8 lg:col-span-9 lg:ml-24",
   },

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -33,7 +33,7 @@ const collection = tv(
           collectionResults:
             // NOTE: we remove the gap so that the blog cards can
             // render their own border between each item
-            "grid grid-cols-1 sm:gap-0 md:grid-cols-2 md:gap-5",
+            "grid grid-cols-1 sm:gap-0 md:grid-cols-2 md:gap-x-10 md:gap-y-5",
         },
       },
     },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The collection blog variant has a couple of design issues that were raised by CSA.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Removed the `capitalize` function to respect the original capitalisation of the tag category provided by the user.
- Added a small gap between different tag categories.
- Added `whitespace: pre-wrap` so that newlines can be handled properly in the collection card description. Also switched Text back to the `p` tag for simplicity.

## Before & After Screenshots

![image](https://github.com/user-attachments/assets/17241319-6139-47e9-a149-73b6b59a60f3)

## Tests

- [ ] On Studio, create a collection with an article that contains multiple tags and tag categories with random capitalisation in the tag category, then publish the collection and article.
- [ ] Create another article with a different tag, but with the same tag categories. In the article page summary, write a random description and use Shift+Enter to create new lines, then publish this article.
- [ ] Verify on the published site that the capitalisation of the tag category is respected, there is a small gap between the tag categories and the newlines in the description are rendered correctly rather than in one line.