### PR TITLE
isom-1714: Fix missing autoscrolling for next/link

### DIFF
--- a/packages/components/src/interfaces/complex/KeyStatistics.ts
+++ b/packages/components/src/interfaces/complex/KeyStatistics.ts
@@ -1,7 +1,11 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerPageLayoutType, IsomerSiteProps } from "~/types"
+import type {
+  IsomerPageLayoutType,
+  IsomerSiteProps,
+  LinkComponentType,
+} from "~/types"
 import { LINK_HREF_PATTERN } from "~/utils/validation"
 
 export const KeyStatisticsSchema = Type.Object(
@@ -68,4 +72,5 @@ export const KeyStatisticsSchema = Type.Object(
 export type KeyStatisticsProps = Static<typeof KeyStatisticsSchema> & {
   layout: IsomerPageLayoutType
   site: IsomerSiteProps
+  LinkComponent?: LinkComponentType
 }

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -339,6 +339,7 @@ const InfoCards = ({
             size="base"
             variant="outline"
             isWithFocusVisibleHighlight
+            LinkComponent={LinkComponent}
           >
             {label}
           </LinkButton>

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -65,6 +65,7 @@ const KeyStatistics = ({
   label,
   layout,
   site,
+  LinkComponent,
 }: KeyStatisticsProps) => {
   const noOfItems = Math.min(MAX_ITEMS, statistics.length) as NoOfItemVariants
   const simplifiedLayout = getTailwindVariantLayout(layout)
@@ -97,6 +98,7 @@ const KeyStatistics = ({
             href={getReferenceLinkHref(url, site.siteMap, site.assetsBaseUrl)}
             size="base"
             variant="outline"
+            LinkComponent={LinkComponent}
             isWithFocusVisibleHighlight
           >
             {!!label ? label : "Our achievements"}

--- a/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
+++ b/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
@@ -1,22 +1,19 @@
 "use client"
 
 import { useEffect } from "react"
-import { usePathname } from "next/navigation"
 
 /*
+  NOTE: This is a temporary fix until we have a better solution.
+
   Fix with issue w/ "next/Link" not scrolling to the top when clicking on <Link />
   if we have a header with "sticky" that's not in its sticky position.
   Ref: https://github.com/vercel/next.js/issues/45187#issuecomment-1639518030
 */
 export const ScrollToTop = () => {
-  const pathname = usePathname()
-
   useEffect(() => {
-    // Required because "window" is a browser-only API that's not available
-    // during static site generation (SSG)
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (window) window.scroll(0, 0)
-  }, [pathname])
+    if (window) window.scrollTo(0, 0)
+  }, [])
 
   return <></>
 }

--- a/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
+++ b/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useEffect } from "react"
+import { usePathname } from "next/navigation"
+
+/*
+  Fix with issue w/ "next/Link" not scrolling to the top when clicking on <Link />
+  if we have a header with "sticky" that's not in its sticky position.
+  Ref: https://github.com/vercel/next.js/issues/45187#issuecomment-1639518030
+*/
+export const ScrollToTop = () => {
+  const pathname = usePathname()
+
+  useEffect(() => {
+    // Required because "window" is a browser-only API that's not available
+    // during static site generation (SSG)
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (window) window.scroll(0, 0)
+  }, [pathname])
+
+  return <></>
+}

--- a/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
+++ b/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
@@ -10,9 +10,11 @@ import { useEffect } from "react"
   Ref: https://github.com/vercel/next.js/issues/45187#issuecomment-1639518030
 */
 export const ScrollToTop = () => {
+  // Ensures the component is mounted before executing scrollTo,
+  // as Next.js may attempt it during static site generation when "window" is unavailable.
+  // Ref: https://nextjs.org/docs/app/building-your-application/deploying/static-exports#browser-apis
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (window) window.scrollTo(0, 0)
+    window.scrollTo(0, 0)
   }, [])
 
   return <></>

--- a/packages/components/src/templates/next/components/internal/index.ts
+++ b/packages/components/src/templates/next/components/internal/index.ts
@@ -29,3 +29,4 @@ export {
 } from "./GoogleTagManager"
 export { BlogCard } from "./BlogCard"
 export { FontPreload } from "./FontPreload"
+export { ScrollToTop } from "./ScrollToTop"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -8,6 +8,7 @@ import {
   Masthead,
   Navbar,
   Notification,
+  ScrollToTop,
   SkipToContent,
   UnsupportedBrowserBanner,
   Wogaa,
@@ -47,6 +48,8 @@ export const Skeleton = ({
       {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
 
       {!isStaging && <DatadogRum />}
+
+      <ScrollToTop />
 
       <header>
         <SkipToContent LinkComponent={LinkComponent} />


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1714/bug-scroll-position-doesnt-reset-for-internal-links

related issue: https://github.com/vercel/next.js/issues/45187 (still happening with nextjs in next 14)

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:
- adding a `ScrollToTop` component to `Skeleton`
- update KeyStats and Infocards to use `LinkComponent` (currently left out)

## Tests

<!-- What tests should be run to confirm functionality? -->

**Tested on staging to work**

1. trigger a new build on codebuild
2. scroll down and click on any internal link. It should scroll user to the top of the page instead of retaining their existing scroll position