### PR TITLE
fix - set selection on update for tiptap

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
@@ -94,7 +94,7 @@ export function JsonFormsProseControl({
       const selection = editor?.state.selection
       if (!selection) return
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      editor.commands.setContent(data, false)
+      editor.commands.setContent(data)
       editor.commands.setTextSelection(selection)
     }
   }, [data])

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsProseControl.tsx
@@ -91,8 +91,11 @@ export function JsonFormsProseControl({
   // Needed to force the value to be set when user clicks on "Go back to editing" in the exit modal
   useEffect(() => {
     if (data !== undefined) {
+      const selection = editor?.state.selection
+      if (!selection) return
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      editor?.commands.setContent(data)
+      editor.commands.setContent(data, false)
+      editor.commands.setTextSelection(selection)
     }
   }, [data])
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When users type in tiptap, the cursor will jump. This is caused by the `useEffect` we have which was necessary to ensure data is repopulated back when user dismisess the "are you sure you want to drop changes" modal

RE: https://opengovproducts.slack.com/archives/C07CWUNUL68/p1736426201036129

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- to note the cursor position and add it back

## Tests

<!-- What tests should be run to confirm functionality? -->

1. on studio, create a Callout component with some text. Save the component
2. open the component again. Put your cursor in the middle of the text and start typing - your cursor should not jump to the end of the text
