### PR TITLE
fix: duplicate image thumbnail logic for GitHub sites

### DIFF
--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -5,6 +5,22 @@ const JSON_SCHEMA_VERSION = "0.1.0"
 const schemaDirPath = path.join(__dirname, "../schema")
 const sitemapPath = path.join(__dirname, "../sitemap.json")
 
+const getResourceImage = (schemaData) => {
+  if (schemaData.page.image) return schemaData.page.image
+
+  if (!Array.isArray(schemaData.content)) return undefined
+
+  const firstImageComponent = schemaData.content.find(
+    (item) => item.type === "image",
+  )
+  return firstImageComponent
+    ? {
+        src: firstImageComponent.src,
+        alt: firstImageComponent.alt,
+      }
+    : undefined
+}
+
 const getSchemaJson = async (filePath) => {
   try {
     const schemaContent = await fs.readFile(filePath, "utf8")
@@ -70,7 +86,7 @@ const getSiteMapEntry = async (fullPath, relativePath, name) => {
     summary,
     category: schemaData.page.category,
     date: schemaData.page.date,
-    image: schemaData.page.image,
+    image: getResourceImage(schemaData),
     tags: schemaData.page.tags,
   }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The image thumbnail for collection is not applying for GitHub sites.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Duplicate the image thumbnail logic to generate-sitemap.js which is used for GitHub sites.