### PR TITLE
feat: vica integration

### DIFF
--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -1,5 +1,8 @@
 import type { ScriptComponentType } from "~/types"
 
+// NOTE: not all props will be used even if we passed them in
+// as we will override some of them with Isomer's configuration e.g. font-family
+// Nevertheless, keeping them here for reference
 interface VicaWidgetProps {
   // UI Theme
   "app-id": string

--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -1,0 +1,48 @@
+import type { ScriptComponentType } from "~/types"
+
+interface VicaWidgetProps {
+  // UI Theme
+  "app-id": string
+  "app-name": string
+  "app-icon"?: string
+  "app-subtitle"?: string // configuration disabled (according to docs)
+  "app-welcome-message"?: string
+  "app-font-family"?: string
+  "app-base-font-size"?: string
+  // General Color
+  "app-color"?: string
+  "app-foreground-color1"?: string
+  "app-background-color2"?: string
+  "app-foreground-color2"?: string
+  "app-canvas-background-color"?: string
+  "app-button-border-color"?: string
+  "app-quick-reply-button-background-color"?: string
+  // Autocomplete
+  "app-enable-auto-complete"?: boolean
+  "app-auto-complete-background-color"?: string
+  "app-auto-complete-foreground-color"?: string
+  "app-auto-complete-hover-color"?: string
+  "app-auto-complete-divider-color"?: string
+  // Recommendations
+  "app-enable-recommendations"?: boolean
+  "app-recommendations-background-color"?: string
+  "app-recommendations-foreground-color"?: string
+  "app-recommendations-hover-color"?: string
+  // UI Behaviours
+  "app-orchestrator-timeout"?: number
+  "app-alternate-copy-vault"?: string
+  "app-auto-launch"?: boolean
+  "app-launched-animation-iteration"?: number
+  "app-disable-csat"?: boolean
+  // Chatbot Behaviours
+  "app-quick-launch-event"?: string
+  "app-quick-launch-event-force-trigger"?: boolean
+  "app-bot-response-trigger-event"?: string
+  "app-environment-override"?: string
+  "app-translation-languages"?: string
+  "app-enable-hide-translation"?: boolean
+}
+
+export interface VicaProps extends VicaWidgetProps {
+  ScriptComponent?: ScriptComponentType
+}

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -34,6 +34,7 @@ export type { SiderailProps } from "./Siderail"
 export type { SkipToContentProps } from "./SkipToContent"
 export type { TableOfContentsProps } from "./TableOfContents"
 export type { WogaaProps } from "./Wogaa"
+export type { VicaProps } from "./Vica"
 export type {
   GoogleTagManagerHeaderScriptProps,
   GoogleTagManagerHeaderProps,

--- a/packages/components/src/templates/next/components/internal/Vica/Vica.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/Vica.tsx
@@ -1,0 +1,33 @@
+import type { VicaProps } from "~/interfaces"
+
+export const VicaStylesheet = () => {
+  return (
+    <>
+      <link
+        href="https://webchat.vica.gov.sg/static/css/chat.css"
+        referrerPolicy="origin"
+        rel="stylesheet"
+      />
+    </>
+  )
+}
+
+export const VicaWidget = ({
+  ScriptComponent = "script",
+  ...props
+}: VicaProps) => {
+  return (
+    <>
+      <ScriptComponent
+        async
+        type="text/javascript"
+        src="https://webchat.vica.gov.sg/static/js/chat.js"
+        referrerPolicy="origin"
+        // 'lazyOnload' is recommended by Next.js for chat widgets
+        // Reference: https://nextjs.org/docs/pages/api-reference/components/script#lazyonload
+        strategy="lazyOnload"
+      />
+      <div id="webchat" {...props} />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/Vica/Vica.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/Vica.tsx
@@ -27,7 +27,13 @@ export const VicaWidget = ({
         // Reference: https://nextjs.org/docs/pages/api-reference/components/script#lazyonload
         strategy="lazyOnload"
       />
-      <div id="webchat" {...props} />
+      <div
+        id="webchat"
+        {...props}
+        app-font-family="Inter, system-ui, sans-serif"
+        // NOTE: Clarifying with VICA regarding color scheme
+        // Once confirmed, will override with site's color scheme for consistency
+      />
     </>
   )
 }

--- a/packages/components/src/templates/next/components/internal/Vica/index.ts
+++ b/packages/components/src/templates/next/components/internal/Vica/index.ts
@@ -1,0 +1,1 @@
+export * from "./Vica"

--- a/packages/components/src/templates/next/components/internal/index.ts
+++ b/packages/components/src/templates/next/components/internal/index.ts
@@ -22,6 +22,7 @@ export { SkipToContent } from "./SkipToContent"
 export { default as TableOfContents } from "./TableOfContents"
 export { default as UnsupportedBrowserBanner } from "./UnsupportedBrowserBanner"
 export { Wogaa } from "./Wogaa"
+export { VicaStylesheet, VicaWidget } from "./Vica"
 export { BackToTopLink } from "./BackToTopLink"
 export {
   GoogleTagManagerHeader,

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -10,6 +10,8 @@ import {
   Notification,
   SkipToContent,
   UnsupportedBrowserBanner,
+  VicaStylesheet,
+  VicaWidget,
   Wogaa,
 } from "../../components/internal"
 import { SKIP_TO_CONTENT_ANCHOR_ID } from "../../constants"
@@ -47,6 +49,8 @@ export const Skeleton = ({
       {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
 
       {!isStaging && <DatadogRum />}
+
+      {site.vica && <VicaStylesheet />}
 
       <header>
         <SkipToContent LinkComponent={LinkComponent} />
@@ -92,13 +96,15 @@ export const Skeleton = ({
         {...site.footerItems}
       />
 
-      {/* needs to be the last element in the body */}
       {shouldIncludeGTM && (
         <GoogleTagManagerBody
           siteGtmId={site.siteGtmId}
           isomerGtmId={site.isomerGtmId}
         />
       )}
+
+      {/* Ensures that the webchat widget only loads after the page has loaded */}
+      {site.vica && <VicaWidget {...site.vica} />}
     </>
   )
 }

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -1,5 +1,5 @@
 import type { IsomerSitemap } from "./sitemap"
-import type { NavbarProps, NotificationProps } from "~/interfaces"
+import type { NavbarProps, NotificationProps, VicaProps } from "~/interfaces"
 import type { SiteConfigFooterProps } from "~/interfaces/internal/Footer"
 
 export interface IsomerGeneratedSiteProps {
@@ -26,6 +26,7 @@ export interface IsomerSiteConfigProps {
   search: NavbarProps["search"]
   notification?: Omit<NotificationProps, "LinkComponent" | "site">
   siteGtmId?: string
+  vica?: VicaProps
 }
 
 export type IsomerSiteProps = IsomerGeneratedSiteProps &


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Add integration for VICA

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

Refer to this slack message for installation guide: https://opengovproducts.slack.com/archives/C087MUEJAMA/p1736330772752669?thread_ts=1736245461.677389&cid=C087MUEJAMA

**_note: decided to follow vica's way of specifying the keys and values as will be easier to port over from agency_**

- Add Vica stylesheet and widget component
- Add vica props to siteprops
- todo - clarifying with VICA on usage of props to pass in colour config (installation guide wasn't clear). In the meantime, we can manually pass it in via the props

## Tests

note: slightly tricky to test as we will need to get the app-id and app-name from agencies

1. add the necessary vica config in `site` in the Site table 
2. rebuild and see if it shows up