### PR TITLE
fix: use permalink for folder settings and not title

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -45,10 +45,12 @@ import {
 interface SuspendablePermalinkProps {
   title: string
   folderId: string
+  permalink: string
 }
 const SuspendablePermalink = ({
   folderId,
   title,
+  permalink,
 }: SuspendablePermalinkProps) => {
   const [{ fullPermalink }] =
     trpc.resource.getWithFullPermalink.useSuspenseQuery({
@@ -60,7 +62,7 @@ const SuspendablePermalink = ({
       <chakra.span color="base.content.medium">
         {fullPermalink.split("/").slice(0, -1).join("/")}
       </chakra.span>
-      /{title}
+      /{permalink}
     </Text>
   )
 }
@@ -207,7 +209,11 @@ const SuspendableModalContent = ({
                     alignItems="center"
                   >
                     <Icon mr="0.5rem" as={BiLink} />
-                    <SuspendablePermalink title={title} folderId={folderId} />
+                    <SuspendablePermalink
+                      title={title}
+                      folderId={folderId}
+                      permalink={permalink}
+                    />
                   </Box>
                 </Suspense>
               )}

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -43,13 +43,11 @@ import {
 } from "../../atoms"
 
 interface SuspendablePermalinkProps {
-  title: string
   folderId: string
   permalink: string
 }
 const SuspendablePermalink = ({
   folderId,
-  title,
   permalink,
 }: SuspendablePermalinkProps) => {
   const [{ fullPermalink }] =
@@ -210,7 +208,6 @@ const SuspendableModalContent = ({
                   >
                     <Icon mr="0.5rem" as={BiLink} />
                     <SuspendablePermalink
-                      title={title}
                       folderId={folderId}
                       permalink={permalink}
                     />


### PR DESCRIPTION
## Problem
Previously, we were using the `title` of the folder to show in the folder settings modal

## Solution
pass the current `permalink` in so it shows the permalink in the modal

## Tests
1. create a folder at root
2. update the folder `permalink`
3. it should show the new `permalink` rather than the title
4. create a folder inside the previous folder
5. repeat steps 2-3 