### PR TITLE
improve lighthouse performance score - preload GTM 

### DIFF
--- a/packages/components/src/templates/next/components/internal/FontPreload.tsx
+++ b/packages/components/src/templates/next/components/internal/FontPreload.tsx
@@ -1,22 +1,5 @@
-// The following links are included to improve SEO and Lighthouse performance by optimizing font loading.
-// Preconnecting to fonts.gstatic.com allows the browser to establish a connection early, reducing latency
-// when fetching fonts, which can lead to faster rendering and improved user experience.
+import { PreloadHelper } from "./utils"
 
 export const FontPreload = () => {
-  return (
-    <>
-      <link
-        // Establish an early connection to fonts.gstatic.com
-        rel="preconnect"
-        href="https://fonts.gstatic.com"
-        crossOrigin="anonymous" // required when making requests to a different origin
-      />
-      <link
-        // Serve as a fallback for browsers that don't support preconnect
-        // at least allowing early DNS resolution
-        rel="dns-prefetch"
-        href="https://fonts.gstatic.com"
-      />
-    </>
-  )
+  return <PreloadHelper href="https://fonts.gstatic.com" />
 }

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerPreload.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerPreload.tsx
@@ -1,18 +1,5 @@
+import { PreloadHelper } from "../utils"
+
 export const GoogleTagManagerPreload = () => {
-  return (
-    <>
-      <link
-        // Establish an early connection
-        rel="preconnect"
-        href="https://www.googletagmanager.com"
-        crossOrigin="anonymous" // required when making requests to a different origin
-      />
-      <link
-        // Serve as a fallback for browsers that don't support preconnect
-        // at least allowing early DNS resolution
-        rel="dns-prefetch"
-        href="https://www.googletagmanager.com"
-      />
-    </>
-  )
+  return <PreloadHelper href="https://www.googletagmanager.com" />
 }

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerPreload.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerPreload.tsx
@@ -1,0 +1,18 @@
+export const GoogleTagManagerPreload = () => {
+  return (
+    <>
+      <link
+        // Establish an early connection
+        rel="preconnect"
+        href="https://www.googletagmanager.com"
+        crossOrigin="anonymous" // required when making requests to a different origin
+      />
+      <link
+        // Serve as a fallback for browsers that don't support preconnect
+        // at least allowing early DNS resolution
+        rel="dns-prefetch"
+        href="https://www.googletagmanager.com"
+      />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/index.ts
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/index.ts
@@ -1,2 +1,3 @@
+export { GoogleTagManagerPreload } from "./GoogleTagManagerPreload"
 export { GoogleTagManagerHeader } from "./GoogleTagManagerHeader"
 export { GoogleTagManagerBody } from "./GoogleTagManagerBody"

--- a/packages/components/src/templates/next/components/internal/index.ts
+++ b/packages/components/src/templates/next/components/internal/index.ts
@@ -24,6 +24,7 @@ export { default as UnsupportedBrowserBanner } from "./UnsupportedBrowserBanner"
 export { Wogaa } from "./Wogaa"
 export { BackToTopLink } from "./BackToTopLink"
 export {
+  GoogleTagManagerPreload,
   GoogleTagManagerHeader,
   GoogleTagManagerBody,
 } from "./GoogleTagManager"

--- a/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
+++ b/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
@@ -1,0 +1,22 @@
+// The following links are included to improve SEO and Lighthouse performance by optimizing preloading.
+// Preconnecting to the provided URL allows the browser to establish a connection early, reducing latency
+// when fetching them, which can lead to faster rendering and improved user experience.
+
+export const PreloadHelper = ({ href }: { href: string }) => {
+  return (
+    <>
+      <link
+        // Establish an early connection
+        rel="preconnect"
+        href={href}
+        crossOrigin="anonymous" // required when making requests to a different origin
+      />
+      <link
+        // Serve as a fallback for browsers that don't support preconnect
+        // at least allowing early DNS resolution
+        rel="dns-prefetch"
+        href={href}
+      />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/utils/index.ts
+++ b/packages/components/src/templates/next/components/internal/utils/index.ts
@@ -1,0 +1,1 @@
+export * from "./PreloadHelper"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -5,6 +5,7 @@ import {
   Footer,
   GoogleTagManagerBody,
   GoogleTagManagerHeader,
+  GoogleTagManagerPreload,
   Masthead,
   Navbar,
   Notification,
@@ -37,11 +38,14 @@ export const Skeleton = ({
       <FontPreload />
 
       {shouldIncludeGTM && (
-        <GoogleTagManagerHeader
-          siteGtmId={site.siteGtmId}
-          isomerGtmId={site.isomerGtmId}
-          ScriptComponent={ScriptComponent}
-        />
+        <>
+          <GoogleTagManagerPreload />
+          <GoogleTagManagerHeader
+            siteGtmId={site.siteGtmId}
+            isomerGtmId={site.isomerGtmId}
+            ScriptComponent={ScriptComponent}
+          />
+        </>
       )}
 
       {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Similar to https://github.com/opengovsg/isomer/pull/966, we can preload GTM to improve loading speed

<img width="800" alt="image" src="https://github.com/user-attachments/assets/745b2b0d-9833-48f7-9627-f8d1e911fb8c" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- preload GTM
- refactor into `PreloadHelper`
