### PR TITLE
improve lighthouse performance - do not lazyload above-fold image

### DIFF
--- a/packages/components/src/interfaces/complex/Contentpic.ts
+++ b/packages/components/src/interfaces/complex/Contentpic.ts
@@ -22,4 +22,5 @@ export const ContentpicSchema = Type.Object(
 export type ContentpicProps = Static<typeof ContentpicSchema> & {
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
+  shouldLazyLoad?: boolean
 }

--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -61,4 +61,5 @@ export const ImageSchema = Type.Object(
 
 export type ImageProps = Static<typeof ImageSchema> & {
   site: IsomerSiteProps
+  shouldLazyLoad?: boolean
 }

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -175,10 +175,12 @@ export type SingleCardWithImageProps = Static<
   layout: IsomerPageLayoutType
   isExternalLink?: boolean
   LinkComponent?: LinkComponentType
+  shouldLazyLoad?: boolean
 }
 export type InfoCardsProps = Static<typeof InfoCardsSchema> & {
   layout: IsomerPageLayoutType
   site: IsomerSiteProps
   LinkComponent?: LinkComponentType
   sectionIdx?: number // TODO: Remove this property, only used in classic theme
+  shouldLazyLoad?: boolean
 }

--- a/packages/components/src/interfaces/complex/LogoCloud.ts
+++ b/packages/components/src/interfaces/complex/LogoCloud.ts
@@ -32,4 +32,5 @@ export const LogoCloudSchema = Type.Object(
 
 export type LogoCloudProps = Static<typeof LogoCloudSchema> & {
   site: IsomerSiteProps
+  shouldLazyLoad?: boolean
 }

--- a/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
+++ b/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
@@ -28,6 +28,7 @@ export const Contentpic = ({
   imageAlt,
   LinkComponent,
   site,
+  shouldLazyLoad = true,
 }: ContentpicProps): JSX.Element => {
   const imgSrc =
     isExternalUrl(imageSrc) || site.assetsBaseUrl === undefined
@@ -42,6 +43,7 @@ export const Contentpic = ({
         width="100%"
         className={compoundStyles.image()}
         assetsBaseUrl={site.assetsBaseUrl}
+        lazyLoading={shouldLazyLoad}
       />
 
       <div className={compoundStyles.content()}>

--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -34,7 +34,14 @@ const getSizeWidth = (size: ImageProps["size"]) => {
   }
 }
 
-export const Image = ({ src, alt, caption, size, site }: ImageProps) => {
+export const Image = ({
+  src,
+  alt,
+  caption,
+  size,
+  site,
+  shouldLazyLoad = true,
+}: ImageProps) => {
   const imgSrc =
     isExternalUrl(src) || site.assetsBaseUrl === undefined
       ? src
@@ -48,6 +55,7 @@ export const Image = ({ src, alt, caption, size, site }: ImageProps) => {
         width={getSizeWidth(size)}
         className={compoundStyles.image({ size: size ?? "default" })}
         assetsBaseUrl={site.assetsBaseUrl}
+        lazyLoading={shouldLazyLoad}
       />
 
       {caption && <p className={compoundStyles.caption()}>{caption}</p>}

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -136,9 +136,16 @@ const InfoCardImage = ({
   url,
   layout,
   site,
+  shouldLazyLoad,
 }: Pick<
   SingleCardWithImageProps,
-  "imageUrl" | "imageAlt" | "url" | "imageFit" | "layout" | "site"
+  | "imageUrl"
+  | "imageAlt"
+  | "url"
+  | "imageFit"
+  | "layout"
+  | "site"
+  | "shouldLazyLoad"
 >): JSX.Element => {
   const imgSrc =
     isExternalUrl(imageUrl) || site.assetsBaseUrl === undefined
@@ -160,6 +167,7 @@ const InfoCardImage = ({
           imageFit,
         })}
         assetsBaseUrl={site.assetsBaseUrl}
+        lazyLoading={shouldLazyLoad}
       />
     </div>
   )
@@ -226,6 +234,7 @@ const InfoCardWithImage = ({
   layout,
   site,
   LinkComponent,
+  shouldLazyLoad = true,
 }: SingleCardWithImageProps): JSX.Element => {
   const isExternalLink = isExternalUrl(url)
   return (
@@ -242,6 +251,7 @@ const InfoCardWithImage = ({
         url={url}
         site={site}
         layout={layout}
+        shouldLazyLoad={shouldLazyLoad}
       />
       <InfoCardText
         title={title}
@@ -264,6 +274,7 @@ const InfoCards = ({
   url,
   layout,
   site,
+  shouldLazyLoad,
   LinkComponent,
 }: InfoCardsProps): JSX.Element => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
@@ -280,6 +291,7 @@ const InfoCards = ({
                 layout={layout}
                 site={site}
                 LinkComponent={LinkComponent}
+                shouldLazyLoad={shouldLazyLoad}
               />
             ))}
           </>

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
@@ -6,6 +6,7 @@ export const LogoCloud = ({
   images: baseImages,
   title,
   site: { assetsBaseUrl },
+  shouldLazyLoad = true,
 }: LogoCloudProps) => {
   const images = baseImages.map(({ src, alt }) => {
     const transformedSrc =
@@ -13,7 +14,7 @@ export const LogoCloud = ({
         ? src
         : `${assetsBaseUrl}${src}`
 
-    return { src: transformedSrc, alt }
+    return { src: transformedSrc, alt, lazyLoading: shouldLazyLoad }
   })
   return (
     <div className="px-10 py-12">

--- a/packages/components/src/templates/next/render/doesComponentHaveImage.ts
+++ b/packages/components/src/templates/next/render/doesComponentHaveImage.ts
@@ -1,0 +1,36 @@
+import type { IsomerSchema } from "~/types"
+import { DYNAMIC_DATA_BANNER_TYPE } from "~/interfaces"
+
+export const doesComponentHaveImage = ({
+  component,
+}: {
+  component: IsomerSchema["content"][number]
+}): boolean => {
+  // While "iframe", "map", "video" do not have images, they take up page real estate
+  // so we treat them as having images and return true
+  // TODO: Do separate optimization for them to improve lighthouse SEO score
+  switch (component.type) {
+    case "accordion":
+    case "keystatistics":
+    case "callout":
+    case "infobar":
+    case "infocols":
+    case "infopic":
+    case "prose":
+    case DYNAMIC_DATA_BANNER_TYPE:
+      return false
+    case "image":
+    case "hero":
+    case "logocloud":
+    case "contentpic":
+    case "iframe":
+    case "map":
+    case "video":
+      return true
+    case "infocards":
+      return component.cards.some((card) => "imageUrl" in card)
+    default:
+      const _: never = component
+      return false
+  }
+}

--- a/packages/components/src/templates/next/render/render.tsx
+++ b/packages/components/src/templates/next/render/render.tsx
@@ -40,6 +40,7 @@ interface RenderComponentProps {
   layout: IsomerPageLayoutType
   site: IsomerSiteProps
   LinkComponent?: LinkComponentType
+  shouldLazyLoad?: boolean
 }
 
 export const renderComponent = ({

--- a/packages/components/src/templates/next/render/renderPageContent.ts
+++ b/packages/components/src/templates/next/render/renderPageContent.ts
@@ -5,6 +5,7 @@ import type {
   LinkComponentType,
 } from "~/types"
 import { renderComponent } from "~/templates/next/render"
+import { doesComponentHaveImage } from "./doesComponentHaveImage"
 
 interface RenderPageContentParams {
   content: IsomerComponent[]
@@ -17,8 +18,19 @@ export const renderPageContent = ({
   content,
   ...rest
 }: RenderPageContentParams) => {
+  // Find index of first component with image
+  const firstImageIndex = content.findIndex((component) =>
+    doesComponentHaveImage({ component }),
+  )
+
   let isInfopicTextOnRight = false
+
   return content.map((component, index) => {
+    // Lazy load components with images that appear after the first image.
+    // We assume that only the first image component will be visible above the fold,
+    // while subsequent components should be lazy loaded to enhance the Lighthouse performance score.
+    const shouldLazyLoad = index > firstImageIndex
+
     if (component.type === "infopic") {
       isInfopicTextOnRight = !isInfopicTextOnRight
       const formattedComponent = {
@@ -28,6 +40,7 @@ export const renderPageContent = ({
       return renderComponent({
         elementKey: index,
         component: formattedComponent,
+        shouldLazyLoad,
         ...rest,
       })
     }
@@ -35,6 +48,7 @@ export const renderPageContent = ({
     return renderComponent({
       elementKey: index,
       component,
+      shouldLazyLoad,
       ...rest,
     })
   })


### PR DESCRIPTION
_**Note: not urgent, good-to-have improvement**_

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Follow up enhancement of https://github.com/opengovsg/isomer/pull/967. 

We followed next.js convention and lazy loaded all images. While the overall sites' lighthouse performance score has shown improvement, there are further rooms for improvement for certain pages.

For example, some pages have images above the fold being lazy loaded, thus having poor lighthouse score

<img width="800" alt="image" src="https://github.com/user-attachments/assets/d3b2df5c-af60-43b3-82b3-aab8e668b298" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

**Tested to be working on STG**

- use `doesComponentHaveImage` to determine which component has images
- in `renderPage`, pass in `shouldLazyLoad` into the components (true if they are the first component, and false otherwise)

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to a page in Studio and add multiple different components with images
2. publish the page and go to the published page. inspect the dev console and you should see only image(s) in the first component is eager loaded, while image(s) in the subsequent components are lazy loaded
