### PR TITLE
isom-1719 non-prod sites can be indexed by search engine

### DIFF
--- a/packages/components/src/engine/index.ts
+++ b/packages/components/src/engine/index.ts
@@ -1,3 +1,8 @@
 export { RenderEngine, renderComponentPreviewText } from "./render"
-export { getMetadata, getRobotsTxt, getSitemapXml } from "./metadata"
+export {
+  getMetadata,
+  shouldBlockIndexing,
+  getRobotsTxt,
+  getSitemapXml,
+} from "./metadata"
 export * from "~/types"

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -111,6 +111,12 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
   }
 }
 
+export const shouldBlockIndexing = (
+  environment: IsomerPageSchemaType["site"]["environment"],
+): boolean => {
+  return environment === "staging"
+}
+
 export const getRobotsTxt = (props: IsomerPageSchemaType) => {
   const rules = [
     {

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -114,7 +114,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
 export const shouldBlockIndexing = (
   environment: IsomerPageSchemaType["site"]["environment"],
 ): boolean => {
-  return environment === "staging"
+  return environment !== "production"
 }
 
 export const getRobotsTxt = (props: IsomerPageSchemaType) => {

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -127,13 +127,12 @@ export const getRobotsTxt = (props: IsomerPageSchemaType) => {
 
   return {
     sitemap: props.site.url ? `${props.site.url}/sitemap.xml` : undefined,
-    rules:
-      props.site.environment === "staging"
-        ? {
-            userAgent: "*",
-            disallow: "/",
-          }
-        : rules,
+    rules: shouldBlockIndexing(props.site.environment)
+      ? {
+          userAgent: "*",
+          disallow: "/",
+        }
+      : rules,
   }
 }
 

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -10,6 +10,7 @@ import {
   getMetadata,
   getSitemapXml,
   RenderEngine,
+  shouldBlockIndexing,
 } from "@opengovsg/isomer-components"
 
 export const dynamic = "force-static"
@@ -128,6 +129,13 @@ const Page = async (props: DynamicPageProps) => {
         lastUpdated,
         assetsBaseUrl: process.env.NEXT_PUBLIC_ASSETS_BASE_URL,
         isomerGtmId: process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID,
+      }}
+      meta={{
+        // TODO: fixup all the typing errors
+        // @ts-ignore to fix when types are proper
+        noIndex: shouldBlockIndexing(
+          process.env.NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT,
+        ),
       }}
       LinkComponent={Link}
       ScriptComponent={Script}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1719/test-sites-can-be-indexed-by-search-engine

while staging sites have `disallow` in `robots.txt`, according to [google](https://developers.google.com/search/docs/crawling-indexing/robots/intro)
> A page that's disallowed in robots.txt can still be indexed if linked to from other sites.
While Google won't crawl or index the content blocked by a robots.txt file, we might still find and index a disallowed URL if it is linked from other places on the web. As a result, the URL address and, potentially, other publicly available information such as anchor text in links to the page can still appear in Google search results. To properly prevent your URL from appearing in Google search results, [password-protect the files on your server](https://developers.google.com/search/docs/crawling-indexing/control-what-you-share), [use the noindex meta tag or response header](https://developers.google.com/search/docs/crawling-indexing/block-indexing), or remove the page entirely.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- add `shouldBlockIndexing` based on site's environment
- pass in true/false into meta.noIndex for `/page.tsx` based on `shouldBlockIndexing`

## Tests

<!-- What tests should be run to confirm functionality? -->

trigger a new codebuild, and inspect the HTML. It should/should not have `<meta name="robots" content="noindex">` based on the table below

| type of site | should have noindex in HTML |
| - | - |
| PROD site | no |
| PROD staging site | yes |
| STG/UAT site | yes |
