### PR TITLE
chore: make publish toast message dismissable

### DIFF
--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -20,6 +20,7 @@ import { useAtom } from "jotai"
 import upperFirst from "lodash/upperFirst"
 
 import type { DeleteResourceModalState } from "../../types"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { isAllowedToHaveChildren } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
 import {
@@ -106,7 +107,11 @@ const DeleteResourceModalContent = ({
       await utils.resource.listWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate()
       await utils.collection.list.invalidate()
-      toast({ title: `${upperFirst(label)} deleted!`, status: "success" })
+      toast({
+        title: `${upperFirst(label)} deleted!`,
+        status: "success",
+        ...BRIEF_TOAST_SETTINGS,
+      })
     },
     onError: (err) => {
       toast({
@@ -114,6 +119,7 @@ const DeleteResourceModalContent = ({
         status: "error",
         // TODO: check if this property is correct
         description: err.message,
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
   })

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -27,6 +27,7 @@ import { useAtomValue, useSetAtom } from "jotai"
 import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { generateResourceUrl } from "~/features/editing-experience/components/utils"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useZodForm } from "~/lib/form"
@@ -126,7 +127,11 @@ const SuspendableModalContent = ({
       await utils.collection.getMetadata.invalidate({
         resourceId: Number(folderId),
       })
-      toast({ title: "Folder updated!", status: "success" })
+      toast({
+        title: "Folder updated!",
+        status: "success",
+        ...BRIEF_TOAST_SETTINGS,
+      })
     },
     onError: (err) => {
       toast({
@@ -134,6 +139,7 @@ const SuspendableModalContent = ({
         status: "error",
         // TODO: check if this property is correct
         description: err.message,
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
   })

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -178,6 +178,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
             title: "Error uploading files/images",
             description: `An error occurred while uploading ${failedUploadsCount}/${totalUploadsCount} files/images. Please try again later.`,
             status: "error",
+            ...BRIEF_TOAST_SETTINGS,
           })
 
           // NOTE: Do not save page if there are errors uploading assets

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -25,6 +25,7 @@ import {
 import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useZodForm } from "~/lib/form"
 import { createCollectionSchema } from "~/schemas/collection"
 import {
@@ -90,7 +91,11 @@ const CreateCollectionModalContent = ({
       await utils.resource.listWithoutRoot.invalidate()
       await utils.resource.countWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate()
-      toast({ title: "Collection created!", status: "success" })
+      toast({
+        title: "Collection created!",
+        status: "success",
+        ...BRIEF_TOAST_SETTINGS,
+      })
     },
     onError: (err) => {
       toast({
@@ -98,6 +103,7 @@ const CreateCollectionModalContent = ({
         status: "error",
         // TODO: check if this property is correct
         description: err.message,
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
   })

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -25,6 +25,7 @@ import {
 import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useZodForm } from "~/lib/form"
 import {
   createFolderSchema,
@@ -89,7 +90,11 @@ const CreateFolderModalContent = ({
       await utils.resource.listWithoutRoot.invalidate()
       await utils.resource.countWithoutRoot.invalidate()
       await utils.resource.getChildrenOf.invalidate()
-      toast({ title: "Folder created!", status: "success" })
+      toast({
+        title: "Folder created!",
+        status: "success",
+        ...BRIEF_TOAST_SETTINGS,
+      })
     },
     onError: (err) => {
       toast({
@@ -97,6 +102,7 @@ const CreateFolderModalContent = ({
         status: "error",
         // TODO: check if this property is correct
         description: err.message,
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
   })

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -98,6 +98,7 @@ export default function HeroEditorDrawer(): JSX.Element {
             title: "Error uploading files/images",
             description: `An error occurred while uploading ${failedUploadsCount}/${totalUploadsCount} files/images. Please try again later.`,
             status: "error",
+            ...BRIEF_TOAST_SETTINGS,
           })
 
           // NOTE: Do not save page if there are errors uploading assets

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -21,6 +21,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { BiHomeAlt, BiLeftArrowAlt } from "react-icons/bi"
 
 import type { PendingMoveResource } from "../../types"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { usePermissions } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -92,6 +93,7 @@ const MoveResourceContent = withSuspense(
           title: "Failed to move resource",
           status: "error",
           description: err.message,
+          ...BRIEF_TOAST_SETTINGS,
         })
       },
       onSettled: () => {
@@ -128,7 +130,7 @@ const MoveResourceContent = withSuspense(
         await utils.resource.getMetadataById.invalidate({
           resourceId: movedItem?.resourceId,
         })
-        toast({ title: "Resource moved!" })
+        toast({ title: "Resource moved!", ...BRIEF_TOAST_SETTINGS })
       },
     })
 

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -32,6 +32,7 @@ const SuspendablePublishButton = ({
       toast({
         status: "success",
         title: publishSuccessMsg,
+        isClosable: true,
       })
       await utils.page.readPage.invalidate({ pageId, siteId })
     },
@@ -40,6 +41,7 @@ const SuspendablePublishButton = ({
       toast({
         status: "error",
         title: publishFailureMsg,
+        isClosable: true,
       })
       await utils.page.readPage.invalidate({ pageId, siteId })
     },

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -5,6 +5,7 @@ import {
   useToast,
 } from "@opengovsg/design-system-react"
 
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { Can } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
@@ -32,7 +33,7 @@ const SuspendablePublishButton = ({
       toast({
         status: "success",
         title: publishSuccessMsg,
-        isClosable: true,
+        ...BRIEF_TOAST_SETTINGS,
       })
       await utils.page.readPage.invalidate({ pageId, siteId })
     },
@@ -41,7 +42,7 @@ const SuspendablePublishButton = ({
       toast({
         status: "error",
         title: publishFailureMsg,
-        isClosable: true,
+        ...BRIEF_TOAST_SETTINGS,
       })
       await utils.page.readPage.invalidate({ pageId, siteId })
     },

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -6,6 +6,7 @@ import { Infobox, useToast } from "@opengovsg/design-system-react"
 import { BiPin, BiPlus, BiPlusCircle } from "react-icons/bi"
 
 import { BlockEditingPlaceholder } from "~/components/Svg"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -44,6 +45,8 @@ export default function RootStateDrawer() {
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const utils = trpc.useUtils()
   const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const toast = useToast({ status: "error" })
+
   const { mutate } = trpc.page.reorderBlock.useMutation({
     onSuccess: async () => {
       await utils.page.readPage.invalidate({ pageId, siteId })
@@ -66,11 +69,10 @@ export default function RootStateDrawer() {
       toast({
         title: "Failed to update blocks",
         description: error.message,
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
   })
-
-  const toast = useToast({ status: "error" })
 
   const onDragEnd = useCallback(
     (result: DropResult) => {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -12,6 +12,7 @@ import {
 
 import type { ModifiedAsset } from "~/types/assets"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { getPresignedPutUrlSchema } from "~/schemas/asset"
 import { generateAssetUrl } from "~/utils/generateAssetUrl"
@@ -133,6 +134,7 @@ export function JsonFormsImageControl({
               title: "Image error",
               description: error,
               status: "error",
+              ...BRIEF_TOAST_SETTINGS,
             })
           }}
           maxSize={MAX_IMG_FILE_SIZE_BYTES}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -20,7 +20,6 @@ import { updatePageMetaSchema } from "~/schemas/page"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
 
-const THREE_SECONDS_IN_MS = 3000
 const SUCCESS_TOAST_ID = "save-page-settings-success"
 const ajv = new Ajv({ strict: false, logger: false })
 

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -9,6 +9,7 @@ import { z } from "zod"
 
 import type { NextPageWithLayout } from "~/lib/types"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
 import { ErrorProvider } from "~/features/editing-experience/components/form-builder/ErrorProvider"
 import FormBuilder from "~/features/editing-experience/components/form-builder/FormBuilder"
@@ -60,7 +61,7 @@ const PageSettings: NextPageWithLayout = () => {
     },
   })
 
-  const toast = useToast({ duration: THREE_SECONDS_IN_MS, isClosable: true })
+  const toast = useToast(BRIEF_TOAST_SETTINGS)
   const utils = trpc.useUtils()
 
   const { mutate: updateMeta } = trpc.page.updateMeta.useMutation({

--- a/apps/studio/src/pages/sites/[siteId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings.tsx
@@ -20,6 +20,7 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 import { z } from "zod"
 
 import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { UnsavedSettingModal } from "~/features/editing-experience/components/UnsavedSettingModal"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useZodForm } from "~/lib/form"
@@ -46,6 +47,7 @@ const SiteSettingsPage: NextPageWithLayout = () => {
         title: "Saved site settings!",
         description: "Check your site in 5-10 minutes to view it live.",
         status: "success",
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
     onError: () => {
@@ -54,6 +56,7 @@ const SiteSettingsPage: NextPageWithLayout = () => {
         description:
           "If this persists, please report this issue at support@isomer.gov.sg",
         status: "error",
+        ...BRIEF_TOAST_SETTINGS,
       })
     },
   })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We have a migrator that complained that the publish toast message is blocking the search bar, and valuable productive time is lost waiting for the toast message to disappear.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Make the publish toast message dismissable.

## Screenshots


https://github.com/user-attachments/assets/8d4860e7-0690-47a6-956e-2b6a04374489

