### PR TITLE
fix: empty results message is at a wrong position in blog layout 

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -102,21 +102,21 @@ export const CollectionResults = ({
               />
             ),
           )}
-        {paginatedItems.length === 0 && (
-          <div className="flex flex-col gap-1 py-32 text-center text-content">
-            <p className="prose-body-base">
-              We couldn’t find any articles. Try different search terms or
-              filters.
-            </p>
-            <button
-              className="prose-headline-base-medium mx-auto w-fit text-link underline-offset-4 hover:underline"
-              onClick={handleClearFilter}
-            >
-              Clear search and filters
-            </button>
-          </div>
-        )}
       </div>
+      {paginatedItems.length === 0 && (
+        <div className="flex flex-col gap-1 py-32 text-center text-content">
+          <p className="prose-body-base">
+            We couldn’t find any articles. Try different search terms or
+            filters.
+          </p>
+          <button
+            className="prose-headline-base-medium mx-auto w-fit text-link underline-offset-4 hover:underline"
+            onClick={handleClearFilter}
+          >
+            Clear search and filters
+          </button>
+        </div>
+      )}
     </>
   )
 }

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -81,9 +81,9 @@ export const CollectionResults = ({
         </div>
       </div>
       {/* NOTE: DO NOT add h-full to this div as it will break old browsers */}
-      <div className={collectionResults()}>
-        {paginatedItems.length > 0 &&
-          paginatedItems.map((item) =>
+      {paginatedItems.length !== 0 ? (
+        <div className={collectionResults()}>
+          {paginatedItems.map((item) =>
             variant === "collection" ? (
               <CollectionCard
                 key={`${item.title}-${item.category}`}
@@ -102,8 +102,8 @@ export const CollectionResults = ({
               />
             ),
           )}
-      </div>
-      {paginatedItems.length === 0 && (
+        </div>
+      ) : (
         <div className="flex flex-col gap-1 py-32 text-center text-content">
           <p className="prose-body-base">
             We couldn’t find any articles. Try different search terms or

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -81,7 +81,7 @@ export const CollectionResults = ({
         </div>
       </div>
       {/* NOTE: DO NOT add h-full to this div as it will break old browsers */}
-      {paginatedItems.length !== 0 ? (
+      {paginatedItems.length > 0 ? (
         <div className={collectionResults()}>
           {paginatedItems.map((item) =>
             variant === "collection" ? (


### PR DESCRIPTION
## Problem

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/646851e6-d7d0-496e-8bce-d43af22fb7f4" />

Visual jank, the no results message should be center-aligned to the entire results area. Currently it's on the left column.

After:

Storybook screen capture for blog layout story:
<img width="1459" alt="image" src="https://github.com/user-attachments/assets/914a111a-b005-4060-a57e-6ef25e591f37" />
