### PR TITLE
feat: enable raw JSON editor mode for collection links

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ActivateRawJsonEditorMode.tsx
+++ b/apps/studio/src/features/editing-experience/components/ActivateRawJsonEditorMode.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState } from "react"
 import { Box, Text } from "@chakra-ui/react"
 
-import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-
 const COMBO: KeyboardEvent["key"][] = [
   "ArrowUp",
   "ArrowUp",
@@ -16,10 +14,14 @@ const COMBO: KeyboardEvent["key"][] = [
   "a",
 ]
 
-// Activate the raw JSON editor mode when a key combo is pressed
-export const ActivateRawJsonEditorMode = () => {
-  const { setDrawerState } = useEditorDrawerContext()
+interface ActivateRawJsonEditorModeProps {
+  onActivate: () => void
+}
 
+// Activate the raw JSON editor mode when a key combo is pressed
+export const ActivateRawJsonEditorMode = ({
+  onActivate,
+}: ActivateRawJsonEditorModeProps) => {
   const [comboIndex, setComboIndex] = useState(0)
   const [showCounter, setShowCounter] = useState(false)
 
@@ -45,12 +47,12 @@ export const ActivateRawJsonEditorMode = () => {
     }
 
     if (comboIndex === COMBO.length) {
-      setDrawerState({ state: "rawJsonEditor" })
+      onActivate()
     }
 
     window.addEventListener("keydown", handleKeyDown)
     return () => window.removeEventListener("keydown", handleKeyDown)
-  }, [comboIndex, setDrawerState])
+  }, [comboIndex, onActivate])
 
   return (
     <Box

--- a/apps/studio/src/features/editing-experience/components/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditLinkPreview.tsx
@@ -10,7 +10,13 @@ import PreviewWithoutSitemap from "./PreviewWithoutSitemap"
 import { ViewportContainer } from "./ViewportContainer"
 
 export const EditCollectionLinkPreview = (): JSX.Element => {
-  const { description: summary, date, title, category } = useAtomValue(linkAtom)
+  const {
+    description: summary,
+    date,
+    title,
+    category,
+    ref,
+  } = useAtomValue(linkAtom)
   const { linkId, siteId } = useQueryParse(editLinkSchema)
   const [permalink] = trpc.page.getFullPermalink.useSuspenseQuery(
     {
@@ -48,7 +54,7 @@ export const EditCollectionLinkPreview = (): JSX.Element => {
             id: "9999999",
             title,
             date,
-            ref: "Test",
+            ref,
             summary: summary ?? "",
             layout: "link",
             permalink,

--- a/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
@@ -1,64 +1,63 @@
 import type { Static } from "@sinclair/typebox"
+import { useMemo, useState } from "react"
 import { Box, Flex, Text, VStack } from "@chakra-ui/react"
 import { Button, useToast } from "@opengovsg/design-system-react"
 import { LAYOUT_PAGE_MAP } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
 import { useAtom } from "jotai"
-import { isEmpty } from "lodash"
+import isEmpty from "lodash/isEmpty"
+import isEqual from "lodash/isEqual"
 import { z } from "zod"
 
 import type { CollectionLinkProps } from "../atoms"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
+import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { safeJsonParse } from "~/utils/safeJsonParse"
 import { trpc } from "~/utils/trpc"
 import { linkAtom } from "../atoms"
+import { ActivateRawJsonEditorMode } from "./ActivateRawJsonEditorMode"
 import { ErrorProvider, useBuilderErrors } from "./form-builder/ErrorProvider"
 import FormBuilder from "./form-builder/FormBuilder"
+import { RawJsonEditor } from "./RawJsonEditor"
 
 const ajv = new Ajv({ strict: false, logger: false })
+const schema = LAYOUT_PAGE_MAP.link
+type IsomerLinkSchema = Static<typeof schema>
+const validateFn = ajv.compile<IsomerLinkSchema>(schema)
 
 const editLinkSchema = z.object({
   linkId: z.coerce.number(),
   siteId: z.coerce.number(),
 })
 
-const InnerDrawer = () => {
-  const schema = LAYOUT_PAGE_MAP.link
-  const validateFn = ajv.compile<Static<typeof schema>>(schema)
-  const { linkId, siteId } = useQueryParse(editLinkSchema)
-  const [data, setLinkAtom] = useAtom(linkAtom)
+interface LinkEditorDrawerStateProps {
+  savedPageState: IsomerLinkSchema
+  previewPageState: IsomerLinkSchema
+  isLoading: boolean
+  handleChange: (data: IsomerLinkSchema) => void
+  handleSaveChanges: () => void
+  setDrawerState: (state: "root" | "rawJsonEditor") => void
+}
+
+const InnerDrawer = ({
+  previewPageState,
+  isLoading,
+  handleChange,
+  handleSaveChanges,
+  setDrawerState,
+}: LinkEditorDrawerStateProps) => {
   const { errors } = useBuilderErrors()
-  const utils = trpc.useUtils()
-  const toast = useToast()
-  const [] = trpc.collection.readCollectionLink.useSuspenseQuery(
-    {
-      linkId,
-      siteId,
-    },
-    {
-      onSuccess: (data) => {
-        setLinkAtom({
-          ...(data.content.page as CollectionLinkProps),
-          title: data.title,
-        })
-      },
-      refetchOnWindowFocus: false,
-    },
-  )
-  const { mutate, isLoading } =
-    trpc.collection.updateCollectionLink.useMutation({
-      onSuccess: () => {
-        void utils.collection.readCollectionLink.invalidate()
-        toast({
-          title: "Link updated!",
-          status: "success",
-          ...BRIEF_TOAST_SETTINGS,
-        })
-      },
-    })
+  const isUserIsomerAdmin = useIsUserIsomerAdmin()
 
   return (
     <Flex flexDir="column" position="relative" h="100%" w="100%">
+      {isUserIsomerAdmin && (
+        <ActivateRawJsonEditorMode
+          onActivate={() => setDrawerState("rawJsonEditor")}
+        />
+      )}
+
       <VStack h="full" gap="1.5rem" p="1.5rem" overflow="auto">
         <Flex flexDir="column" alignItems="flex-start" w="full">
           <Text as="h6" textStyle="h6">
@@ -66,13 +65,11 @@ const InnerDrawer = () => {
           </Text>
         </Flex>
         <Flex flexDir="column" alignItems="start" w="full">
-          <FormBuilder<Static<typeof schema>>
+          <FormBuilder<IsomerLinkSchema>
             schema={schema}
             validateFn={validateFn}
-            data={data}
-            handleChange={(data) =>
-              setLinkAtom((oldData) => ({ ...oldData, ...data }))
-            }
+            data={previewPageState}
+            handleChange={handleChange}
           />
         </Flex>
       </VStack>
@@ -87,8 +84,8 @@ const InnerDrawer = () => {
         <Button
           w="full"
           alignSelf="flex-start"
-          onClick={() => mutate({ siteId, linkId, ...data })}
-          isDisabled={!isEmpty(errors) || !data.ref}
+          onClick={handleSaveChanges}
+          isDisabled={!isEmpty(errors) || !previewPageState.ref}
           isLoading={isLoading}
         >
           Save
@@ -98,10 +95,121 @@ const InnerDrawer = () => {
   )
 }
 
+const RawJsonEditorDrawer = ({
+  savedPageState,
+  previewPageState,
+  isLoading,
+  handleChange,
+  handleSaveChanges,
+  setDrawerState,
+}: LinkEditorDrawerStateProps) => {
+  const [pendingChanges, setPendingChanges] = useState(
+    JSON.stringify(savedPageState, null, 2),
+  )
+  const isPendingChangesValid = useMemo(() => {
+    return validateFn(safeJsonParse(pendingChanges))
+  }, [pendingChanges])
+
+  const handleRawChange = (data: string) => {
+    setPendingChanges(data)
+    const parsedRawChange = safeJsonParse(data) as unknown
+
+    if (validateFn(parsedRawChange)) {
+      handleChange(parsedRawChange)
+    }
+  }
+
+  const handleDiscardChanges = () => {
+    handleChange(savedPageState)
+    setDrawerState("root")
+  }
+
+  const handleRawSaveChanges = () => {
+    handleSaveChanges()
+    setDrawerState("root")
+  }
+
+  return (
+    <RawJsonEditor
+      pendingChanges={pendingChanges}
+      isLoading={isLoading}
+      isModified={!isEqual(previewPageState, savedPageState)}
+      isPendingChangesValid={isPendingChangesValid}
+      handleChange={handleRawChange}
+      handleDiscardChanges={handleDiscardChanges}
+      handleSaveChanges={handleRawSaveChanges}
+    />
+  )
+}
+
+const DrawerState = (
+  props: Omit<LinkEditorDrawerStateProps, "setDrawerState">,
+) => {
+  const [drawerState, setDrawerState] = useState<"root" | "rawJsonEditor">(
+    "root",
+  )
+
+  switch (drawerState) {
+    case "root":
+      return <InnerDrawer {...props} setDrawerState={setDrawerState} />
+    case "rawJsonEditor":
+      return <RawJsonEditorDrawer {...props} setDrawerState={setDrawerState} />
+    default:
+      const _: never = drawerState
+      return <></>
+  }
+}
+
 export const LinkEditorDrawer = () => {
+  const { linkId, siteId } = useQueryParse(editLinkSchema)
+  const [data, setLinkAtom] = useAtom(linkAtom)
+  const utils = trpc.useUtils()
+  const toast = useToast()
+
+  const [{ content, title }] =
+    trpc.collection.readCollectionLink.useSuspenseQuery(
+      {
+        linkId,
+        siteId,
+      },
+      {
+        onSuccess: (data) => {
+          setLinkAtom({
+            ...(data.content.page as CollectionLinkProps),
+            title: data.title,
+          })
+        },
+        refetchOnWindowFocus: false,
+      },
+    )
+  const { mutate, isLoading } =
+    trpc.collection.updateCollectionLink.useMutation({
+      onSuccess: () => {
+        void utils.collection.readCollectionLink.invalidate()
+        toast({
+          title: "Link updated!",
+          status: "success",
+          ...BRIEF_TOAST_SETTINGS,
+        })
+      },
+    })
+
+  const savedPageState = {
+    ...(content.page as CollectionLinkProps),
+    title,
+  }
+  const handleChange = (data: IsomerLinkSchema) =>
+    setLinkAtom((oldData) => ({ ...oldData, ...data }))
+
   return (
     <ErrorProvider>
-      <InnerDrawer />
+      <DrawerState
+        savedPageState={savedPageState}
+        previewPageState={data}
+        isLoading={isLoading}
+        handleChange={handleChange}
+        handleSaveChanges={() => mutate({ siteId, linkId, ...data })}
+      />
     </ErrorProvider>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/RawJsonEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/RawJsonEditor.tsx
@@ -1,0 +1,121 @@
+import {
+  Box,
+  Button,
+  Heading,
+  HStack,
+  Icon,
+  IconButton,
+  Spacer,
+  Textarea,
+  useClipboard,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { BiDollar, BiX } from "react-icons/bi"
+
+import { DiscardChangesModal } from "./DiscardChangesModal"
+
+interface RawJsonEditorProps {
+  pendingChanges: string
+  isModified: boolean
+  isLoading: boolean
+  isPendingChangesValid: boolean
+  handleChange: (value: string) => void
+  handleDiscardChanges: () => void
+  handleSaveChanges: () => void
+}
+
+export const RawJsonEditor = ({
+  pendingChanges,
+  isModified,
+  isLoading,
+  isPendingChangesValid,
+  handleChange,
+  handleDiscardChanges,
+  handleSaveChanges,
+}: RawJsonEditorProps) => {
+  const {
+    isOpen: isDiscardChangesModalOpen,
+    onOpen: onDiscardChangesModalOpen,
+    onClose: onDiscardChangesModalClose,
+  } = useDisclosure()
+  const { onCopy, hasCopied } = useClipboard(pendingChanges)
+
+  return (
+    <>
+      <DiscardChangesModal
+        isOpen={isDiscardChangesModalOpen}
+        onClose={onDiscardChangesModalClose}
+        onDiscard={() => {
+          handleDiscardChanges()
+          onDiscardChangesModalClose()
+        }}
+      />
+
+      <Box h="100%" w="100%" overflow="auto">
+        <Box
+          bgColor="base.canvas.default"
+          borderBottomColor="base.divider.medium"
+          borderBottomWidth="1px"
+          px="2rem"
+          py="1.25rem"
+        >
+          <HStack justifyContent="start" w="100%">
+            <HStack spacing={3}>
+              <Icon
+                as={BiDollar}
+                fontSize="1.5rem"
+                p="0.25rem"
+                bgColor="slate.100"
+                textColor="blue.600"
+                borderRadius="base"
+              />
+              <Heading as="h3" size="sm" textStyle="h5" fontWeight="semibold">
+                Raw JSON Editor Mode
+              </Heading>
+            </HStack>
+            <Spacer />
+            <Button onClick={onCopy} variant="clear">
+              {!hasCopied ? "Copy to clipboard" : "Copied!"}
+            </Button>
+            <IconButton
+              icon={<Icon as={BiX} />}
+              variant="clear"
+              colorScheme="sub"
+              size="sm"
+              p="0.625rem"
+              onClick={() => {
+                if (isModified) {
+                  onDiscardChangesModalOpen()
+                } else {
+                  handleDiscardChanges()
+                }
+              }}
+              aria-label="Close drawer"
+            />
+          </HStack>
+        </Box>
+
+        <Box px="2rem" py="1rem" maxW="33vw" overflow="auto">
+          <Textarea
+            fontFamily="monospace"
+            boxSizing="border-box"
+            minH="68vh"
+            value={pendingChanges}
+            onChange={(e) => handleChange(e.target.value)}
+          />
+        </Box>
+
+        <Box bgColor="base.canvas.default" boxShadow="md" py="1.5rem" px="2rem">
+          <Button
+            w="100%"
+            isLoading={isLoading}
+            isDisabled={!isPendingChangesValid}
+            onClick={handleSaveChanges}
+          >
+            Save changes
+          </Button>
+        </Box>
+      </Box>
+    </>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -123,7 +123,11 @@ export default function RootStateDrawer() {
 
   return (
     <VStack gap="1.5rem" p="1.5rem">
-      {isUserIsomerAdmin && <ActivateRawJsonEditorMode />}
+      {isUserIsomerAdmin && (
+        <ActivateRawJsonEditorMode
+          onActivate={() => setDrawerState({ state: "rawJsonEditor" })}
+        />
+      )}
       {/* Fixed Blocks Section */}
       <VStack gap="1rem" w="100%" align="start">
         <VStack gap="0.25rem" align="start">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The raw JSON editor mode is not available for collection links, which adds ops load to engineers when migrators need to change tags (e.g. for REACH).

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Extended the existing raw JSON editor mode to the collection links editor. This involved:
    - Small refactor of ActivateRawJsonEditorMode.tsx to allow the consumer to determine the action to take after a successful activation (removed the dependency on the EditorStateDrawer context).
    - Refactored RawJsonEditorModeStateDrawer.tsx by extracting out the UI from the business logic, so that the UI can be reused by the LinkEditorDrawer.
    - Extended LinkEditorDrawer to handle two states - root and rawJsonEditor states. Also split the existing page state into a saved and preview version, so that the raw JSON editor can discard changes to revert back to the original saved state.

**Bug fixes**:

- The ref attribute in the link preview was hard-coded, so it could be misleading when users hover over the link. Have updated it to use the value provided by the user.

**Notes**:

- It is **NOT** possible to change the title using the raw JSON editor mode. This is not something I'm tackling now, since the title change needs to be done in a separate flow.
- It is also not possible to edit something on the link editor first, then go into the raw JSON editor mode and see those changes reflected. I was thinking if we want this behaviour, then we may have to handle 3 page states which makes this feature overly complicated (since it is only used by migrators), so opted to keep things simple.

## Before & After Screenshots

https://github.com/user-attachments/assets/6265aec3-316b-42ce-80f6-cf04492b79f9


## Tests

- [ ] Navigate to any collection link in a collection inside Studio.
- [ ] Press the special sequence to activate the raw JSON editor mode.
- [ ] Make changes to the category and/or year of the collection link item and verify that the changes are reflected on the preview on the right (provided the schema is valid).
- [ ] Save the changes made, verify that you should be able to save.
- [ ] Refresh the page, verify that the changes you made persist.