### PR TITLE
fix: show index page

### DIFF
--- a/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
@@ -34,6 +34,7 @@ const SuspendableResourceItem = ({
         return BiFolder
       case ResourceType.CollectionPage:
       case ResourceType.Page:
+      case ResourceType.IndexPage:
         return BiFile
       case ResourceType.Collection:
         return BiData

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -205,6 +205,7 @@ export const collectionRouter = router({
           return eb.or([
             eb("Resource.type", "=", ResourceType.CollectionPage),
             eb("Resource.type", "=", ResourceType.CollectionLink),
+            eb("Resource.type", "=", ResourceType.IndexPage),
           ])
         })
         .orderBy("Resource.type", "asc")

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -180,15 +180,15 @@ export const resourceRouter = router({
         .where("Resource.type", "!=", ResourceType.RootPage)
         .where("Resource.type", "!=", ResourceType.FolderMeta)
         .where("Resource.type", "!=", ResourceType.CollectionMeta)
+        .where("Resource.type", "!=", ResourceType.IndexPage)
         .where("Resource.siteId", "=", Number(siteId))
         .$narrowType<{
-          type: Extract<
-            | typeof ResourceType.Folder
-            | typeof ResourceType.Page
-            | typeof ResourceType.Collection
-            | typeof ResourceType.CollectionPage
-            | typeof ResourceType.CollectionLink,
-            ResourceType
+          type: Exclude<
+            ResourceType,
+            | typeof ResourceType.RootPage
+            | typeof ResourceType.FolderMeta
+            | typeof ResourceType.CollectionMeta
+            | typeof ResourceType.IndexPage
           >
         }>()
         .orderBy("type", "asc")

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -180,7 +180,6 @@ export const resourceRouter = router({
         .where("Resource.type", "!=", ResourceType.RootPage)
         .where("Resource.type", "!=", ResourceType.FolderMeta)
         .where("Resource.type", "!=", ResourceType.CollectionMeta)
-        .where("Resource.type", "!=", ResourceType.IndexPage)
         .where("Resource.siteId", "=", Number(siteId))
         .$narrowType<{
           type: Exclude<
@@ -188,7 +187,6 @@ export const resourceRouter = router({
             | typeof ResourceType.RootPage
             | typeof ResourceType.FolderMeta
             | typeof ResourceType.CollectionMeta
-            | typeof ResourceType.IndexPage
           >
         }>()
         .orderBy("type", "asc")


### PR DESCRIPTION
## Problem
index pages display in the sidebar but not in the main view - we should **not** be showing such index pages for reasons outlined [here](https://opengovproducts.slack.com/archives/C06R4DX966P/p1736932453085539)

## Solution
1. update typing using `Exclude` in router method
2. add filter for `IndexPage`

## Tests
1. add a custom index page in db
2. verify that this cannot be seenin the sidebar