### PR TITLE
Inverse hero banner variant for sites with yellow as a colour theme

### DIFF
--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -104,4 +104,5 @@ export type HeroBackgroundImageProps = Static<typeof HeroBackgroundImageSchema>
 export type HeroProps = Static<typeof HeroSchema> & {
   site: IsomerSiteProps
   LinkComponent?: LinkComponentType
+  theme?: "default" | "inverse"
 }

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
@@ -63,13 +63,100 @@ export const ColourBlock: Story = {
   args: {
     backgroundUrl:
       "https://images.unsplash.com/photo-1725652264563-9f8eea4e2995?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+
     title: "Your hero title goes here, please keep it short and sweet",
+
     subtitle:
       "A test for a long subtitle that will expand the hero banner. What will happen if the text is very very very long?",
+
     buttonLabel: "Main CTA",
     buttonUrl: "/",
     secondaryButtonLabel: "Sub CTA",
     secondaryButtonUrl: "/",
     variant: "block",
+    isInverseColor: false,
+
+    site: {
+      siteName: "Isomer Next",
+
+      siteMap: {
+        id: "1",
+        title: "Home",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [],
+      },
+
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      lastUpdated: "2021-10-01",
+      assetsBaseUrl: "https://cms.isomer.gov.sg",
+      navBarItems: [],
+
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+  },
+}
+
+export const ColourBlockInverse: Story = {
+  args: {
+    backgroundUrl:
+      "https://images.unsplash.com/photo-1725652264563-9f8eea4e2995?q=80&w=1887&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+
+    title: "Your hero title goes here, please keep it short and sweet",
+
+    subtitle:
+      "A test for a long subtitle that will expand the hero banner. What will happen if the text is very very very long?",
+
+    buttonLabel: "Main CTA",
+    buttonUrl: "/",
+    secondaryButtonLabel: "Sub CTA",
+    secondaryButtonUrl: "/",
+    variant: "block",
+    theme: "inverse",
+
+    site: {
+      siteName: "Isomer Next",
+
+      siteMap: {
+        id: "1",
+        title: "Home",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [],
+      },
+
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      lastUpdated: "2021-10-01",
+      assetsBaseUrl: "https://cms.isomer.gov.sg",
+      navBarItems: [],
+
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
   },
 }

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
@@ -74,7 +74,7 @@ export const ColourBlock: Story = {
     secondaryButtonLabel: "Sub CTA",
     secondaryButtonUrl: "/",
     variant: "block",
-    isInverseColor: false,
+    theme: "default",
 
     site: {
       siteName: "Isomer Next",

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
@@ -74,6 +74,21 @@ const HeroGradient = ({
   )
 }
 
+const HERO_THEME_MAPPINGS = {
+  hero: {
+    default: "bg-brand-canvas-inverse",
+    inverse: "bg-brand-canvas-alt",
+  },
+  text: {
+    default: "text-base-content-inverse",
+    inverse: "text-base-content",
+  },
+  button: {
+    default: "inverse",
+    inverse: "default",
+  },
+} as const
+
 const HeroBlock = ({
   title,
   subtitle,
@@ -84,16 +99,25 @@ const HeroBlock = ({
   backgroundUrl,
   site,
   LinkComponent,
+  theme = "default",
 }: HeroProps) => {
   const backgroundSrc =
     isExternalUrl(backgroundUrl) || site.assetsBaseUrl === undefined
       ? backgroundUrl
       : `${site.assetsBaseUrl}${backgroundUrl}`
 
+  const heroColour = HERO_THEME_MAPPINGS.hero[theme]
+  const heroTextColour = HERO_THEME_MAPPINGS.text[theme]
+  const heroButton = HERO_THEME_MAPPINGS.button[theme]
+
   return (
     <section className="flex min-h-[15rem] flex-col sm:min-h-[22.5rem] lg:min-h-[31.25rem] lg:flex-row">
-      <div className="flex flex-row bg-brand-canvas-inverse px-6 pb-12 pt-11 md:px-10 lg:w-1/2 lg:justify-end lg:pl-10 lg:pr-12">
-        <div className="flex w-full max-w-[532px] flex-col justify-center gap-9 text-base-content-inverse">
+      <div
+        className={`flex flex-row ${heroColour} px-6 pb-12 pt-11 md:px-10 lg:w-1/2 lg:justify-end lg:pl-10 lg:pr-12`}
+      >
+        <div
+          className={`flex w-full max-w-[532px] flex-col justify-center gap-9 ${heroTextColour}`}
+        >
           <div className="flex flex-col gap-6">
             <h1 className="prose-display-xl break-words">{title}</h1>
             {subtitle && <p className="prose-title-lg-regular">{subtitle}</p>}
@@ -107,6 +131,7 @@ const HeroBlock = ({
                   site.assetsBaseUrl,
                 )}
                 size="lg"
+                variant="solid"
                 colorScheme="inverse"
                 LinkComponent={LinkComponent}
                 isWithFocusVisibleHighlight
@@ -115,7 +140,7 @@ const HeroBlock = ({
               </LinkButton>
               {secondaryButtonLabel && secondaryButtonUrl && (
                 <LinkButton
-                  colorScheme="inverse"
+                  colorScheme={heroButton}
                   variant="outline"
                   size="lg"
                   href={getReferenceLinkHref(

--- a/tooling/template/data/config.json
+++ b/tooling/template/data/config.json
@@ -4,6 +4,7 @@
     "url": "https://www.isomer.gov.sg",
     "agencyName": "Open Government Products",
     "theme": "isomer-next",
+    "isInverseColor": false,
     "logoUrl": "/images/isomer-logo.svg",
     "favicon": "/images/favicon-isomer.ico",
     "isGovernment": true,

--- a/tooling/template/data/config.json
+++ b/tooling/template/data/config.json
@@ -4,7 +4,6 @@
     "url": "https://www.isomer.gov.sg",
     "agencyName": "Open Government Products",
     "theme": "isomer-next",
-    "isInverseColor": false,
     "logoUrl": "/images/isomer-logo.svg",
     "favicon": "/images/favicon-isomer.ico",
     "isGovernment": true,


### PR DESCRIPTION
## Problem

The template can't support extremely vibrant colours like Yellow. Some default variants will fail contrast with a yellow. Unlike other colours, yellow loses its unique vibrance when you lower its lightness. 

## Solution

- The Hero banner (block variant) should have a variant that support inverse.
- This variant uses a different mapping of colour tokens.
- This variant should NOT be exposed to the user on Studio. It is set by us only for sites that have a high luminosity theme colour. 

[More details on Notion
](https://www.notion.so/opengov/Mini-Inverse-hero-banner-variant-for-LiveOn-1af77dbba788803ba2a7dcf4ea782b25?pvs=4)

<img width="364" alt="image" src="https://github.com/user-attachments/assets/a0723e3e-cd0e-4342-af59-390ed0cff5f5" />
