### PR TITLE
isom-1720 bug back to top doesnt work on template

### DIFF
--- a/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
+++ b/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
@@ -1,10 +1,8 @@
 import { BiUpArrowAlt } from "react-icons/bi"
 
-import type { LinkComponentType } from "~/types"
 import { tv } from "~/lib/tv"
 import { twMerge } from "~/lib/twMerge"
 import { focusVisibleHighlight } from "~/utils"
-import { Link } from "./Link"
 
 const linkStyle = tv({
   extend: focusVisibleHighlight,
@@ -13,21 +11,21 @@ const linkStyle = tv({
 
 interface BackToTopLinkProps {
   className?: string
-  LinkComponent?: LinkComponentType
 }
 
 export const BackToTopLink = ({
   className,
-  LinkComponent,
 }: BackToTopLinkProps): JSX.Element => {
   return (
-    <Link
+    // Using default <a> tag instead of next/link
+    // Because next/link for root anchor tags does not work when
+    // we do <link preconnect> in the head
+    <a
       href="#"
       className={twMerge(linkStyle(), className)}
-      LinkComponent={LinkComponent}
     >
       <BiUpArrowAlt aria-hidden className="h-6 w-6" />
       Back to top
-    </Link>
+    </a>
   )
 }

--- a/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
+++ b/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
@@ -20,10 +20,7 @@ export const BackToTopLink = ({
     // Using default <a> tag instead of next/link
     // Because next/link for root anchor tags does not work when
     // we do <link preconnect> in the head
-    <a
-      href="#"
-      className={twMerge(linkStyle(), className)}
-    >
+    <a href="#" className={twMerge(linkStyle(), className)}>
       <BiUpArrowAlt aria-hidden className="h-6 w-6" />
       Back to top
     </a>

--- a/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
+++ b/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
@@ -3,6 +3,9 @@
 // when fetching them, which can lead to faster rendering and improved user experience.
 
 export const PreloadHelper = ({ href }: { href: string }) => {
+  // TODO: replace with ReactDom.preconnect and ReactDom.dnsPrefetch
+  // However, note that they are only available in React 19 which is not yet supported by Next.js
+  // Ref: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#resource-hints
   return (
     <>
       <link

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -110,10 +110,7 @@ const CollectionClient = ({
             setAppliedFilters={setAppliedFilters}
             handleClearFilter={handleClearFilter}
           />
-          <BackToTopLink
-            className="hidden lg:inline-flex"
-            LinkComponent={LinkComponent}
-          />
+          <BackToTopLink className="hidden lg:inline-flex"/>
         </div>
         <div
           className={compoundStyles.content({

--- a/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionClient.tsx
@@ -110,7 +110,7 @@ const CollectionClient = ({
             setAppliedFilters={setAppliedFilters}
             handleClearFilter={handleClearFilter}
           />
-          <BackToTopLink className="hidden lg:inline-flex"/>
+          <BackToTopLink className="hidden lg:inline-flex" />
         </div>
         <div
           className={compoundStyles.content({

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -97,7 +97,7 @@ const ContentLayout = ({
         {sideRail && (
           <div className={compoundStyles.siderailContainer()}>
             <Siderail {...sideRail} LinkComponent={LinkComponent} />
-            <BackToTopLink LinkComponent={LinkComponent} />
+            <BackToTopLink />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1720/bug-back-to-top-doesnt-work-on-template

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

Findings
- Bug occured after https://github.com/opengovsg/isomer/commit/b7f73e2d298826b16e7d8d5e0677bb89ea4bb668
- doesn't seem to be anything relating to next/link directly, and couldn't find anything online about how adding <link> will break nextjs
- [nextjs provides a way to add preconnect and dnsprefetch](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#link-relpreconnect). However, it did not state that it must be done this way. In addition, this is only available in React19 which we aren't on.
- Decided to not spend more time on this issue

**Bug Fixes**:

- hotfix: replace next/link with pure <a>

## Tests

<!-- What tests should be run to confirm functionality? -->

1. publish a new build
2. go to a collection and click "back to top" under the filters -> it should work
3. go to a content page in a folder and click on "back to top" in the siderail -> it should work