### PR TITLE
fix: update title to be from folder title

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -173,8 +173,6 @@ async function main() {
       ),
     }
 
-    logDebug("Intermediate sitemap:", JSON.stringify(sitemap, null, 2))
-
     await processDanglingDirectories(resources, sitemap)
 
     try {

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -213,22 +213,27 @@ function generateSitemapTree(
   }
 
   // Get the immediate children of the current path
-  const childrenPaths = Array.from(
-    new Set(
-      entriesWithPathPrefix
-        .map((entry) => ({
-          childPath: entry.permalink
-            .slice(
-              pathPrefixWithoutLeadingSlash.length +
-                (pathPrefix.length === 1 ? 1 : 2),
-            )
-            .split("/")[0],
-          title: entry.title,
-        }))
-        // Perform stringify to compare object equality
-        .map((entry) => JSON.stringify(entry)),
-    ),
-  ).map((entry) => JSON.parse(entry)) as { childPath: string; title: string }[]
+  const childrenPaths = entriesWithPathPrefix
+    .map((entry) => ({
+      childPath: entry.permalink
+        .slice(
+          pathPrefixWithoutLeadingSlash.length +
+            (pathPrefix.length === 1 ? 1 : 2),
+        )
+        .split("/")[0],
+      title: entry.title,
+    }))
+    .reduce(
+      (acc, curr) => {
+        if (acc.some((entry) => entry.childPath === curr.childPath)) {
+          // Ensure that the array only contains unique child paths
+          return acc
+        }
+
+        return [...acc, curr]
+      },
+      [] as { childPath: string; title: string }[],
+    )
 
   // Identify children paths that might be dangling directories
   const danglingDirectories: SitemapEntry[] = childrenPaths

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -215,8 +215,8 @@ function generateSitemapTree(
   // Get the immediate children of the current path
   const childrenPaths = Array.from(
     new Set(
-      entriesWithPathPrefix.map((entry) => {
-        return {
+      entriesWithPathPrefix
+        .map((entry) => ({
           childPath: entry.permalink
             .slice(
               pathPrefixWithoutLeadingSlash.length +
@@ -224,10 +224,11 @@ function generateSitemapTree(
             )
             .split("/")[0],
           title: entry.title,
-        }
-      }),
+        }))
+        // Perform stringify to compare object equality
+        .map((entry) => JSON.stringify(entry)),
     ),
-  )
+  ).map((entry) => JSON.parse(entry)) as { childPath: string; title: string }[]
 
   // Identify children paths that might be dangling directories
   const danglingDirectories: SitemapEntry[] = childrenPaths
@@ -245,8 +246,7 @@ function generateSitemapTree(
         ),
     )
     .map((danglingDirectory) => {
-      const { title } = danglingDirectory
-      const directory = danglingDirectory.childPath
+      const { title, childPath: directory } = danglingDirectory
 
       logDebug(`Creating index page for dangling directory: ${directory}`)
       logDebug(

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -223,7 +223,7 @@ function generateSitemapTree(
                 (pathPrefix.length === 1 ? 1 : 2),
             )
             .split("/")[0],
-          entry,
+          title: entry.title,
         }
       }),
     ),
@@ -245,8 +245,9 @@ function generateSitemapTree(
         ),
     )
     .map((danglingDirectory) => {
-      const { title } = danglingDirectory.entry
+      const { title } = danglingDirectory
       const directory = danglingDirectory.childPath
+
       logDebug(`Creating index page for dangling directory: ${directory}`)
       logDebug(
         "Checking using permalink:",


### PR DESCRIPTION
## Problem
we want to update index page title to be from the folder title and not auto gen

## Solution
use the folder title

## Tests
1. go to staging and update a site's build branch to be `fix/custom-index-pages`
2. update a title for folder to be different from permalink
3. start a new build
4. check the index page 
5. it should be different