### PR TITLE
isom-1722 - fix infobar margin top

### DIFF
--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -56,74 +56,72 @@ const Infobar = ({
   const hasSecondaryCTA = !!secondaryButtonLabel && !!secondaryButtonUrl
 
   return (
-    <section>
+    <section
+      className={compoundStyles.outerContainer({ layout: simplifiedLayout })}
+    >
       <div
-        className={compoundStyles.outerContainer({ layout: simplifiedLayout })}
+        className={compoundStyles.innerContainer({
+          layout: simplifiedLayout,
+        })}
       >
         <div
-          className={compoundStyles.innerContainer({
+          className={compoundStyles.headingContainer({
             layout: simplifiedLayout,
           })}
         >
-          <div
-            className={compoundStyles.headingContainer({
-              layout: simplifiedLayout,
-            })}
-          >
-            <h2 className={compoundStyles.title({ layout: simplifiedLayout })}>
-              {title}
-            </h2>
+          <h2 className={compoundStyles.title({ layout: simplifiedLayout })}>
+            {title}
+          </h2>
 
-            {description && (
-              <p
-                className={compoundStyles.description({
-                  layout: simplifiedLayout,
-                })}
-              >
-                {description}
-              </p>
-            )}
-          </div>
-
-          {(hasPrimaryCTA || hasSecondaryCTA) && (
-            <div
-              className={compoundStyles.buttonContainer({
+          {description && (
+            <p
+              className={compoundStyles.description({
                 layout: simplifiedLayout,
               })}
             >
-              {hasPrimaryCTA && (
-                <LinkButton
-                  href={getReferenceLinkHref(
-                    buttonUrl,
-                    site.siteMap,
-                    site.assetsBaseUrl,
-                  )}
-                  size={simplifiedLayout === "homepage" ? "lg" : "base"}
-                  LinkComponent={LinkComponent}
-                  isWithFocusVisibleHighlight
-                >
-                  {buttonLabel}
-                </LinkButton>
-              )}
-
-              {hasSecondaryCTA && (
-                <LinkButton
-                  href={getReferenceLinkHref(
-                    secondaryButtonUrl,
-                    site.siteMap,
-                    site.assetsBaseUrl,
-                  )}
-                  size={simplifiedLayout === "homepage" ? "lg" : "base"}
-                  variant="outline"
-                  LinkComponent={LinkComponent}
-                  isWithFocusVisibleHighlight
-                >
-                  {secondaryButtonLabel}
-                </LinkButton>
-              )}
-            </div>
+              {description}
+            </p>
           )}
         </div>
+
+        {(hasPrimaryCTA || hasSecondaryCTA) && (
+          <div
+            className={compoundStyles.buttonContainer({
+              layout: simplifiedLayout,
+            })}
+          >
+            {hasPrimaryCTA && (
+              <LinkButton
+                href={getReferenceLinkHref(
+                  buttonUrl,
+                  site.siteMap,
+                  site.assetsBaseUrl,
+                )}
+                size={simplifiedLayout === "homepage" ? "lg" : "base"}
+                LinkComponent={LinkComponent}
+                isWithFocusVisibleHighlight
+              >
+                {buttonLabel}
+              </LinkButton>
+            )}
+
+            {hasSecondaryCTA && (
+              <LinkButton
+                href={getReferenceLinkHref(
+                  secondaryButtonUrl,
+                  site.siteMap,
+                  site.assetsBaseUrl,
+                )}
+                size={simplifiedLayout === "homepage" ? "lg" : "base"}
+                variant="outline"
+                LinkComponent={LinkComponent}
+                isWithFocusVisibleHighlight
+              >
+                {secondaryButtonLabel}
+              </LinkButton>
+            )}
+          </div>
+        )}
       </div>
     </section>
   )

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -2984,3 +2984,143 @@ export const MultipleAccordions: Story = {
     ],
   },
 }
+
+export const MultipleInfobars: Story = {
+  args: {
+    layout: "content",
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        id: "1",
+        title: "Isomer Next",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+        children: [
+          {
+            id: "2",
+            title: "Content page",
+            permalink: "/content",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+            children: [
+              {
+                id: "3",
+                title: "Irrationality",
+                permalink: "/parent/rationality",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    id: "4",
+                    title: "For Individuals",
+                    permalink: "/parent/rationality/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                  {
+                    id: "5",
+                    title: "Steven Pinker's Rationality",
+                    permalink: "/parent/rationality/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+              {
+                id: "6",
+                title: "Sibling",
+                permalink: "/parent/sibling",
+                lastModified: "",
+                layout: "content",
+                summary: "",
+                children: [
+                  {
+                    id: "7",
+                    title: "Child that should not appear",
+                    permalink: "/parent/sibling/child-page-2",
+                    lastModified: "",
+                    layout: "content",
+                    summary: "",
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            id: "8",
+            title: "Aunt/Uncle that should not appear",
+            permalink: "/aunt-uncle",
+            lastModified: "",
+            layout: "content",
+            summary: "",
+          },
+        ],
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+      navBarItems: [],
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      lastUpdated: "1 Jan 2021",
+      search: {
+        type: "localSearch",
+        searchUrl: "/search",
+      },
+    },
+    meta: {
+      description: "A Next.js starter for Isomer",
+    },
+    page: {
+      permalink: "/content",
+      title: "Content page",
+      lastModified: "2024-05-02T14:12:57.160Z",
+      contentPageHeader: {
+        summary:
+          "Steven Pinker's exploration of rationality delves into the intricacies of human cognition, shedding light on the mechanisms behind our decision-making processes. Through empirical research and insightful analysis, Pinker illuminates the rationality that underpins human behavior, challenging conventional wisdom and offering new perspectives on the rational mind.",
+        buttonLabel: "Submit a proposal",
+        buttonUrl: "/submit-proposal",
+      },
+    },
+    content: [
+      {
+        type: "infobar",
+        title: "First item in the page - should not have a gap above",
+        description: "About a sentence worth of description here",
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "should have a gap below",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "infobar",
+        title: "This is a place where you can put nice content",
+        description: "About a sentence worth of description here",
+      },
+      {
+        type: "infobar",
+        title: "Should have a gap above",
+        description: "About a sentence worth of description here",
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1722/bug-multiple-infobar-in-a-row-will-cause-the-non-first-infobar-to-not

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- moving `compoundStyles.outerContainer({ layout: simplifiedLayout })` into outer `section`
- add stories

## Before & After Screenshots

**BEFORE**:

<img width="752" alt="image" src="https://github.com/user-attachments/assets/875e45b8-807c-4d53-8a7f-2ed551886bc2" />

**AFTER**:

<img width="757" alt="image" src="https://github.com/user-attachments/assets/f3806773-53be-494c-8aa9-8b0922ee2552" />

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to a content page and add multiple infobars
2. the first infobars in the page should not have a margin top. the subsequent ones should have magins
