### PR TITLE
fix: allow custom titles in index pages

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -112,6 +112,9 @@ async function main() {
           resource.parentId,
         )
 
+        // NOTE: We remap the ID for _index pages to be the ID of the folder,
+        // as both will have the same permalink and the folder is recognized as
+        // the parent of all the children resources
         const idOfFolder = resources.find(
           (item) =>
             resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
@@ -246,7 +249,13 @@ function generateSitemapTree(
     )
     .map((danglingDirectory) => {
       const pageName = danglingDirectory.replace(/-/g, " ")
-      const title = pageName.charAt(0).toUpperCase() + pageName.slice(1)
+      const generatedTitle =
+        pageName.charAt(0).toUpperCase() + pageName.slice(1)
+      const folderResourceTitle = resources.find(
+        (resource) => resource.fullPermalink === danglingDirectory,
+      )?.title
+      const title = folderResourceTitle ?? generatedTitle
+
       logDebug(
         `Creating index page for dangling directory: ${danglingDirectory}`,
       )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The generated index pages do not follow the title of the folder resource, which results in the need to have custom index pages.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Take the title of the folder resource as the page title when auto-generating the index page.
    - This also allows the site editor to customise the casing of the title without the need to create a custom index page.

## Before & After Screenshots

<!-- [insert screenshot here] -->

**Custom title (permalink: about-us, title: About USSS)**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/240d7a33-a649-4667-9fa7-7018c16ba1cb" />

**Custom index page (permalink: csa, title: Index)**
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/58567da4-e5f7-41e3-9b12-36c8ebf0750f" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new folder in Studio with a custom title (using random casing) and a permalink with alphabets that are different from the title.
- [ ] Create a new page inside this new folder and publish it.
- [ ] Verify on the built staging site that the folder that you created shows the custom title that you input earlier.