### PR TITLE
fix: properly retrieve nested folder resources

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -251,10 +251,16 @@ function generateSitemapTree(
       const pageName = danglingDirectory.replace(/-/g, " ")
       const generatedTitle =
         pageName.charAt(0).toUpperCase() + pageName.slice(1)
-      const folderResourceTitle = resources.find(
-        (resource) => resource.fullPermalink === danglingDirectory,
-      )?.title
-      const title = folderResourceTitle ?? generatedTitle
+
+      const folder = resources.find(
+        (resource) =>
+          getConvertedPermalink(resource.fullPermalink) ===
+            (pathPrefixWithoutLeadingSlash.length === 0
+              ? danglingDirectory
+              : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`) &&
+          FOLDER_RESOURCE_TYPES.find((t) => t === resource.type),
+      )
+      const title = folder?.title ?? generatedTitle
 
       logDebug(
         `Creating index page for dangling directory: ${danglingDirectory}`,
@@ -264,15 +270,6 @@ function generateSitemapTree(
         pathPrefixWithoutLeadingSlash.length === 0
           ? danglingDirectory
           : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`,
-      )
-
-      const folder = resources.find(
-        (resource) =>
-          getConvertedPermalink(resource.fullPermalink) ===
-            (pathPrefixWithoutLeadingSlash.length === 0
-              ? danglingDirectory
-              : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`) &&
-          FOLDER_RESOURCE_TYPES.find((t) => t === resource.type),
       )
 
       return {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Nested folder resources are not properly retrieved, which causes the casing in the index page to not be correct for those cases.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Correctly retrieve the folder resource using the full permalink instead.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Repeat #1000 but for nested folders.