### PR TITLE
chore: add strict transport security header

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -172,6 +172,10 @@ const config = {
             key: "X-Frame-Options",
             value: "SAMEORIGIN",
           },
+          {
+            key: "Strict-Transport-Security",
+            value: "max-age=31536000",
+          },
         ],
       },
     ]


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Isomer Studio lacks the Strict Transport Security header.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add the Strict Transport Security header to Next.js list of headers.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Open Studio and open the Network tab in your browser's console.
- [ ] Verify that the Strict Transport Security header is present in the response for the request to Studio.