### PR TITLE
Fix vica hydration bug

### DIFF
--- a/packages/components/src/templates/next/components/internal/Vica/VicaStylesheet.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaStylesheet.tsx
@@ -1,0 +1,11 @@
+export const VicaStylesheet = () => {
+  return (
+    <>
+      <link
+        href="https://webchat.vica.gov.sg/static/css/chat.css"
+        referrerPolicy="origin"
+        rel="stylesheet"
+      />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -1,17 +1,5 @@
 import type { VicaProps } from "~/interfaces"
 
-export const VicaStylesheet = () => {
-  return (
-    <>
-      <link
-        href="https://webchat.vica.gov.sg/static/css/chat.css"
-        referrerPolicy="origin"
-        rel="stylesheet"
-      />
-    </>
-  )
-}
-
 export const VicaWidget = ({
   ScriptComponent = "script",
   ...props

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -1,9 +1,14 @@
+"use client"
+
 import type { VicaProps } from "~/interfaces"
 
 export const VicaWidget = ({
   ScriptComponent = "script",
   ...props
 }: VicaProps) => {
+  // to not render during static site generation on the server
+  if (typeof window === "undefined") return null
+
   return (
     <>
       <ScriptComponent

--- a/packages/components/src/templates/next/components/internal/Vica/index.ts
+++ b/packages/components/src/templates/next/components/internal/Vica/index.ts
@@ -1,1 +1,2 @@
-export * from "./Vica"
+export * from "./VicaWidget"
+export * from "./VicaStylesheet"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

VICA widget sometimes loading sometimes not

Error log shows https://react.dev/errors/418?args%5B%5D= 
![image](https://github.com/user-attachments/assets/88a7b698-3a65-45d9-ba2d-691f582d86e3)

Suspected it's due to it being rendered SSG and causing incocrrect hydration error

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

tested on STG site and works

- explicitly declare `use client`
- explicitly declare for it not to be rendered during SSG

## Tests

<!-- What tests should be run to confirm functionality? -->

1. rebuild a site with VICA (https://test-isomer-vica-staging.isomer.gov.sg/)
2. try spamming reloading multiple times (soft reload, hard reload, hard reload with empty cache etc.) - the VICA widget should show up in the bottom right consistently **EVERY** time