### PR TITLE
fix: invalidate publish button on link save

### DIFF
--- a/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
@@ -186,6 +186,7 @@ export const LinkEditorDrawer = () => {
     trpc.collection.updateCollectionLink.useMutation({
       onSuccess: () => {
         void utils.collection.readCollectionLink.invalidate()
+        void utils.page.readPage.invalidate()
         toast({
           title: "Link updated!",
           status: "success",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The publish button is not shown as active when a collection link is updated.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Invalidate the `readPage` procedure upon a successful save of the collection link.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit a collection link that is already published (publish button is greyed out).
- [ ] Save the changes.
- [ ] Verify that the publish button turns blue.
- [ ] Refresh the page, verify that the publish button remains blue.