### PR TITLE
feat: introduce temporary admin mode for site config

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/admin.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/admin.tsx
@@ -47,7 +47,7 @@ const SiteAdminPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteAdminSchema)
   const isUserIsomerAdmin = useIsUserIsomerAdmin()
 
-  if (isUserIsomerAdmin) {
+  if (!isUserIsomerAdmin) {
     toast({
       title: "You do not have permission to access this page.",
       status: "error",

--- a/apps/studio/src/pages/sites/[siteId]/admin.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/admin.tsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react"
+import { useRouter } from "next/router"
+import {
+  Button,
+  Center,
+  chakra,
+  FormControl,
+  HStack,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
+import {
+  FormErrorMessage,
+  Infobox,
+  Textarea,
+  useToast,
+} from "@opengovsg/design-system-react"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { z } from "zod"
+
+import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
+import { UnsavedSettingModal } from "~/features/editing-experience/components/UnsavedSettingModal"
+import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { useZodForm } from "~/lib/form"
+import { type NextPageWithLayout } from "~/lib/types"
+import { setSiteConfigAdminSchema } from "~/schemas/site"
+import { AdminSidebarOnlyLayout } from "~/templates/layouts/AdminSidebarOnlyLayout"
+import { trpc } from "~/utils/trpc"
+
+const siteAdminSchema = z.object({
+  siteId: z.coerce.number(),
+})
+
+const SUPPORTED_SITE_CONFIG_TYPES = [
+  "config",
+  "theme",
+  "navbar",
+  "footer",
+] as const
+
+const SiteAdminPage: NextPageWithLayout = () => {
+  const toast = useToast()
+  const router = useRouter()
+  const trpcUtils = trpc.useUtils()
+  const { siteId } = useQueryParse(siteAdminSchema)
+  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+
+  const { mutate, isLoading } = trpc.site.setSiteConfigAdmin.useMutation({
+    onSuccess: async () => {
+      // reset({ config, theme, navbar, footer })
+      await trpcUtils.site.getConfig.invalidate({ id: siteId })
+      await trpcUtils.site.getTheme.invalidate({ id: siteId })
+      await trpcUtils.site.getNavbar.invalidate({ id: siteId })
+      await trpcUtils.site.getFooter.invalidate({ id: siteId })
+      toast({
+        title: "Saved site config!",
+        description: "Check your site in 5-10 minutes to view it live.",
+        status: "success",
+        ...BRIEF_TOAST_SETTINGS,
+      })
+    },
+    onError: () => {
+      toast({
+        title: "Error saving site config!",
+        description:
+          "If this persists, please report this issue at support@isomer.gov.sg",
+        status: "error",
+        ...BRIEF_TOAST_SETTINGS,
+      })
+    },
+  })
+
+  const [previousConfig] = trpc.site.getConfig.useSuspenseQuery({
+    id: siteId,
+  })
+  const [previousTheme] = trpc.site.getTheme.useSuspenseQuery({
+    id: siteId,
+  })
+  const [previousNavbar] = trpc.site.getNavbar.useSuspenseQuery({
+    id: siteId,
+  })
+  const [previousFooter] = trpc.site.getFooter.useSuspenseQuery({
+    id: siteId,
+  })
+
+  // NOTE: Refining the setNotificationSchema here instead of in site.ts since omit does not work after refine
+  const {
+    register,
+    handleSubmit,
+    formState: { isDirty, errors },
+  } = useZodForm({
+    schema: setSiteConfigAdminSchema
+      .omit({ siteId: true })
+      .refine((data) => !!data.config, {
+        message: "Site config must be present",
+        path: ["config"],
+      })
+      .refine((data) => !!data.theme, {
+        message: "Site theme must be present",
+        path: ["theme"],
+      })
+      .refine((data) => !!data.navbar, {
+        message: "Site navbar must be present",
+        path: ["navbar"],
+      })
+      .refine((data) => !!data.footer, {
+        message: "Site footer must be present",
+        path: ["footer"],
+      }),
+    defaultValues: {
+      config: JSON.stringify(previousConfig, null, 2),
+      theme: JSON.stringify(previousTheme, null, 2),
+      navbar: JSON.stringify(previousNavbar.content, null, 2),
+      footer: JSON.stringify(previousFooter.content, null, 2),
+    },
+  })
+
+  const [nextUrl, setNextUrl] = useState("")
+  const isOpen = !!nextUrl
+
+  useEffect(() => {
+    const handleRouteChange = (url: string) => {
+      if (isDirty) {
+        router.events.off("routeChangeStart", handleRouteChange)
+        setNextUrl(url)
+        router.events.emit("routeChangeError")
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        throw "Error to abort router route change. Ignore this!"
+      }
+    }
+
+    if (!isOpen) {
+      router.events.on("routeChangeStart", handleRouteChange)
+    }
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChange)
+    }
+  }, [isOpen, router.events, isDirty])
+
+  const onClickUpdate = handleSubmit((input) => {
+    mutate({
+      siteId,
+      ...input,
+    })
+  })
+
+  if (!isUserIsomerAdmin) {
+    return (
+      <Center h="full">
+        <Text>You do not have permission to access this page.</Text>
+      </Center>
+    )
+  }
+
+  return (
+    <>
+      <UnsavedSettingModal
+        isOpen={isOpen}
+        onClose={() => setNextUrl("")}
+        nextUrl={nextUrl}
+      />
+      <chakra.form
+        onSubmit={onClickUpdate}
+        overflow="auto"
+        height={0}
+        minH="100%"
+      >
+        <Center py="5.5rem" px="2rem">
+          <VStack w="48rem" alignItems="flex-start" spacing="1.5rem">
+            <Text w="full" textStyle="h3-semibold">
+              Manage site configurations
+            </Text>
+            <Infobox variant="warning" textStyle="body-2" size="sm">
+              No validation is done on the JSON input. Please ensure that they
+              are valid before saving.
+            </Infobox>
+
+            {SUPPORTED_SITE_CONFIG_TYPES.map((type) => (
+              <FormControl key={type} isInvalid={!!errors[type]}>
+                <VStack w="full" alignItems="flex-start" spacing="0.75rem">
+                  <Text
+                    textColor="base.content.strong"
+                    textStyle="subhead-1"
+                    pt="0.5rem"
+                  >
+                    Site {type}
+                  </Text>
+
+                  <Textarea
+                    fontFamily="monospace"
+                    boxSizing="border-box"
+                    minH="18rem"
+                    {...register(type)}
+                  />
+
+                  <FormErrorMessage>{errors[type]?.message}</FormErrorMessage>
+                </VStack>
+              </FormControl>
+            ))}
+
+            <HStack justifyContent="flex-end" w="full" gap="1.5rem">
+              <Text textColor="base.content.medium" textStyle="caption-2">
+                Changes will be reflected on your site immediately.
+              </Text>
+
+              <Button type="submit" isLoading={isLoading} isDisabled={!isDirty}>
+                Save settings
+              </Button>
+            </HStack>
+          </VStack>
+        </Center>
+      </chakra.form>
+    </>
+  )
+}
+
+SiteAdminPage.getLayout = (page) => {
+  return (
+    <PermissionsBoundary
+      resourceType={ResourceType.RootPage}
+      page={AdminSidebarOnlyLayout(page)}
+    />
+  )
+}
+
+export default SiteAdminPage

--- a/apps/studio/src/pages/sites/[siteId]/admin.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/admin.tsx
@@ -47,6 +47,15 @@ const SiteAdminPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteAdminSchema)
   const isUserIsomerAdmin = useIsUserIsomerAdmin()
 
+  if (isUserIsomerAdmin) {
+    toast({
+      title: "You do not have permission to access this page.",
+      status: "error",
+      ...BRIEF_TOAST_SETTINGS,
+    })
+    void router.push(`/sites/${siteId}`)
+  }
+
   const { mutate, isLoading } = trpc.site.setSiteConfigAdmin.useMutation({
     onSuccess: async () => {
       // reset({ config, theme, navbar, footer })
@@ -145,14 +154,6 @@ const SiteAdminPage: NextPageWithLayout = () => {
       ...input,
     })
   })
-
-  if (!isUserIsomerAdmin) {
-    return (
-      <Center h="full">
-        <Text>You do not have permission to access this page.</Text>
-      </Center>
-    )
-  }
 
   return (
     <>

--- a/apps/studio/src/schemas/site.ts
+++ b/apps/studio/src/schemas/site.ts
@@ -27,7 +27,7 @@ export const getNameSchema = z.object({
 
 // NOTE: This is a temporary schema for editing the JSON content directly,
 // until the proper editing experience is implemented
-export const setSiteConfigAdminSchema = z.object({
+export const setSiteConfigByAdminSchema = z.object({
   siteId: z.number().min(1),
   config: z.string(),
   theme: z.string(),

--- a/apps/studio/src/schemas/site.ts
+++ b/apps/studio/src/schemas/site.ts
@@ -24,3 +24,13 @@ export const setNotificationSchema = z.object({
 export const getNameSchema = z.object({
   siteId: z.number().min(1),
 })
+
+// NOTE: This is a temporary schema for editing the JSON content directly,
+// until the proper editing experience is implemented
+export const setSiteConfigAdminSchema = z.object({
+  siteId: z.number().min(1),
+  config: z.string(),
+  theme: z.string(),
+  navbar: z.string(),
+  footer: z.string(),
+})

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -10,7 +10,7 @@ import {
   getNameSchema,
   getNotificationSchema,
   setNotificationSchema,
-  setSiteConfigAdminSchema,
+  setSiteConfigByAdminSchema,
 } from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
 import { safeJsonParse } from "~/utils/safeJsonParse"
@@ -144,8 +144,8 @@ export const siteRouter = router({
 
       return input
     }),
-  setSiteConfigAdmin: protectedProcedure
-    .input(setSiteConfigAdminSchema)
+  setSiteConfigByAdmin: protectedProcedure
+    .input(setSiteConfigByAdminSchema)
     .mutation(async ({ ctx, input }) => {
       const { siteId, config, theme, navbar, footer } = input
       await validateUserPermissionsForSite({

--- a/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react"
 import { useRouter } from "next/router"
 import { Flex } from "@chakra-ui/react"
-import { BiCog, BiFolder, BiLogOut } from "react-icons/bi"
+import { BiCog, BiFolder, BiLogOut, BiStar } from "react-icons/bi"
 import { z } from "zod"
 
 import type { CmsSidebarItem } from "~/components/CmsSidebar/CmsSidebarItems"
@@ -11,6 +11,7 @@ import { LayoutHead } from "~/components/LayoutHead"
 import { SearchableHeader } from "~/components/SearchableHeader"
 import { DirectorySidebar } from "~/features/dashboard/components/DirectorySidebar"
 import { useMe } from "~/features/me/api"
+import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type GetLayout } from "~/lib/types"
 
@@ -41,6 +42,7 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
   const { siteId } = useQueryParse(siteSchema)
 
   const { logout } = useMe()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin()
 
   const pageNavItems: CmsSidebarItem[] = [
     {
@@ -54,6 +56,15 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
 
     // TODO(ISOM-1552): Add back manage users functionality when implemented
     { icon: BiCog, label: "Settings", href: `/sites/${siteId}/settings` },
+    ...(isUserIsomerAdmin
+      ? [
+          {
+            icon: BiStar,
+            label: "Isomer Admin Settings",
+            href: `/sites/${siteId}/admin`,
+          },
+        ]
+      : []),
   ]
 
   const userNavItems: CmsSidebarItem[] = [

--- a/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
@@ -1,7 +1,7 @@
 import type { PropsWithChildren } from "react"
 import { useRouter } from "next/router"
 import { Flex } from "@chakra-ui/react"
-import { BiCog, BiFolder, BiLogOut } from "react-icons/bi"
+import { BiCog, BiFolder, BiLogOut, BiStar } from "react-icons/bi"
 import { z } from "zod"
 
 import type { CmsSidebarItem } from "~/components/CmsSidebar/CmsSidebarItems"
@@ -10,6 +10,7 @@ import { CmsSidebar, CmsSidebarContainer } from "~/components/CmsSidebar"
 import { LayoutHead } from "~/components/LayoutHead"
 import { SearchableHeader } from "~/components/SearchableHeader"
 import { useMe } from "~/features/me/api"
+import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type GetLayout } from "~/lib/types"
 
@@ -40,6 +41,7 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
   const { siteId } = useQueryParse(siteSchema)
 
   const { logout } = useMe()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin()
 
   const pageNavItems: CmsSidebarItem[] = [
     {
@@ -52,6 +54,15 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
     },
     // TODO(ISOM-1552): Add back manage users functionality when implemented
     { icon: BiCog, label: "Settings", href: `/sites/${siteId}/settings` },
+    ...(isUserIsomerAdmin
+      ? [
+          {
+            icon: BiStar,
+            label: "Isomer Admin Settings",
+            href: `/sites/${siteId}/admin`,
+          },
+        ]
+      : []),
   ]
 
   const userNavItems: CmsSidebarItem[] = [


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Ops load on engineers is quite high for editing the site config, navbar and footer.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add a new `/admin` route for Isomer Admins to directly modify the site's config, theme, navbar and footer items.
    - Access to this feature is gated for just Isomer Admins, all other users will not know of its existence and even if they do, they will not have the permission to access the form to edit.

## Before & After Screenshots

**View for Isomer Admins**:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e3965f05-883e-428f-a910-b3e2d5d5ad3a" />

**View for unauthorised users**:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ca00e9e1-cbbb-4da6-8718-d8e1d5267ff7" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Log in to Studio as a whitelisted Isomer Admin (your email should be whitelisted inside Growthbook).
- [ ] Go to any site.
- [ ] Verify that a star icon appears on the navigation bar on the left side.
- [ ] Click on the star icon, verify that you are able to see the form to change the site configurations.
- [ ] Change any configuration and save, verify that you are able to save successfully.
- [ ] Navigate to any page and verify that those changes have persisted (or change another configuration that is more visible, such as the navigation bar or footer).
- [ ] Log in to Studio as a non-whitelisted user.
- [ ] Go to any site, verify that there are only 2 icons on the navigation bar on the left side.
- [ ] Append `/admin` to the URL and navigate to the page.
- [ ] Verify that the page shows that you do not have permission to access the page.