### PR TITLE
fix: automatically create collection index page on collection create

### DIFF
--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -3,6 +3,25 @@ import { format } from "date-fns"
 
 import type { ResourceType } from "../database"
 
+export const createCollectionIndexPageJson = ({
+  title,
+}: {
+  type: typeof ResourceType.IndexPage // Act as soft typeguard
+  title: string
+}) => {
+  return {
+    layout: "collection",
+    page: {
+      title,
+      defaultSortBy: "date",
+      defaultSortDirection: "asc",
+      subtitle: "Read all our articles here.",
+    },
+    content: [],
+    version: "0.1.0",
+  } satisfies UnwrapTagged<PrismaJson.BlobJsonContent>
+}
+
 export const createCollectionPageJson = ({}: {
   type: typeof ResourceType.CollectionPage // Act as soft typeguard
 }) => {


### PR DESCRIPTION
> [!NOTE]
>
> This is pending design's confirmation on whether we should automatically publish the index page.

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The collection index page is currently not automatically created, so site owners have to write in to ops to create one for them.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Automatically create the index page for the collection when the collection itself is created
    - Pending @sehyunidaaa confirmation on whether we should automatically publish the index page immediately when the collection is created.

## Demo

https://github.com/user-attachments/assets/0f5956c1-6b79-4a84-b489-15dfdeb071b4

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Log in to Studio and access any site.
- [ ] Create a new collection.
- [ ] Access the new collection.
- [ ] Verify that the index page for the collection is also created.