### PR TITLE
feat: dropdown for collections

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,23 +1,23 @@
 export const ResourceState = {
-    Draft: "Draft",
-    Published: "Published"
-} as const;
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
+  Draft: "Draft",
+  Published: "Published",
+} as const
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
 export const ResourceType = {
-    RootPage: "RootPage",
-    Page: "Page",
-    Folder: "Folder",
-    Collection: "Collection",
-    CollectionMeta: "CollectionMeta",
-    CollectionLink: "CollectionLink",
-    CollectionPage: "CollectionPage",
-    IndexPage: "IndexPage",
-    FolderMeta: "FolderMeta"
-} as const;
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
+  RootPage: "RootPage",
+  Page: "Page",
+  Folder: "Folder",
+  Collection: "Collection",
+  CollectionMeta: "CollectionMeta",
+  CollectionLink: "CollectionLink",
+  CollectionPage: "CollectionPage",
+  IndexPage: "IndexPage",
+  FolderMeta: "FolderMeta",
+} as const
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
 export const RoleType = {
-    Admin: "Admin",
-    Editor: "Editor",
-    Publisher: "Publisher"
-} as const;
-export type RoleType = (typeof RoleType)[keyof typeof RoleType];
+  Admin: "Admin",
+  Editor: "Editor",
+  Publisher: "Publisher",
+} as const
+export type RoleType = (typeof RoleType)[keyof typeof RoleType]

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,129 +1,131 @@
-import type { ColumnType, GeneratedAlways } from "kysely";
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
-export type Timestamp = ColumnType<Date, Date | string, Date | string>;
+import type { ColumnType, GeneratedAlways } from "kysely"
 
-import type { ResourceState, ResourceType, RoleType } from "./generatedEnums";
+import type { ResourceState, ResourceType, RoleType } from "./generatedEnums"
 
-export type Blob = {
-    id: GeneratedAlways<string>;
-    /**
-     * @kyselyType(PrismaJson.BlobJsonContent)
-     * [BlobJsonContent]
-     */
-    content: PrismaJson.BlobJsonContent;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type Footer = {
-    id: GeneratedAlways<number>;
-    siteId: number;
-    /**
-     * @kyselyType(PrismaJson.FooterJsonContent)
-     * [FooterJsonContent]
-     */
-    content: PrismaJson.FooterJsonContent;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type Navbar = {
-    id: GeneratedAlways<number>;
-    siteId: number;
-    /**
-     * @kyselyType(PrismaJson.NavbarJsonContent)
-     * [NavbarJsonContent]
-     */
-    content: PrismaJson.NavbarJsonContent;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type RateLimiterFlexible = {
-    key: string;
-    points: number;
-    expire: Timestamp | null;
-};
-export type Resource = {
-    id: GeneratedAlways<string>;
-    title: string;
-    permalink: string;
-    siteId: number;
-    parentId: string | null;
-    publishedVersionId: string | null;
-    draftBlobId: string | null;
-    state: Generated<ResourceState | null>;
-    type: ResourceType;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type ResourcePermission = {
-    id: GeneratedAlways<string>;
-    userId: string;
-    siteId: number;
-    resourceId: string | null;
-    role: RoleType;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-    deletedAt: Timestamp | null;
-};
-export type Site = {
-    id: GeneratedAlways<number>;
-    name: string;
-    /**
-     * @kyselyType(PrismaJson.SiteJsonConfig)
-     * [SiteJsonConfig]
-     */
-    config: PrismaJson.SiteJsonConfig;
-    /**
-     * @kyselyType(PrismaJson.SiteThemeJson)
-     * [SiteThemeJson]
-     */
-    theme: PrismaJson.SiteThemeJson | null;
-    codeBuildId: string | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type User = {
-    id: string;
-    name: string;
-    email: string;
-    phone: string;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-    deletedAt: Timestamp | null;
-};
-export type VerificationToken = {
-    identifier: string;
-    token: string;
-    attempts: Generated<number>;
-    expires: Timestamp;
-};
-export type Version = {
-    id: GeneratedAlways<string>;
-    versionNum: number;
-    resourceId: string;
-    blobId: string;
-    publishedAt: Generated<Timestamp>;
-    publishedBy: string;
-    updatedAt: Generated<Timestamp>;
-};
-export type Whitelist = {
-    id: GeneratedAlways<number>;
-    email: string;
-    expiry: Timestamp | null;
-    createdAt: Generated<Timestamp>;
-    updatedAt: Generated<Timestamp>;
-};
-export type DB = {
-    Blob: Blob;
-    Footer: Footer;
-    Navbar: Navbar;
-    RateLimiterFlexible: RateLimiterFlexible;
-    Resource: Resource;
-    ResourcePermission: ResourcePermission;
-    Site: Site;
-    User: User;
-    VerificationToken: VerificationToken;
-    Version: Version;
-    Whitelist: Whitelist;
-};
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>
+export type Timestamp = ColumnType<Date, Date | string, Date | string>
+
+export interface Blob {
+  id: GeneratedAlways<string>
+  /**
+   * @kyselyType(PrismaJson.BlobJsonContent)
+   * [BlobJsonContent]
+   */
+  content: PrismaJson.BlobJsonContent
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface Footer {
+  id: GeneratedAlways<number>
+  siteId: number
+  /**
+   * @kyselyType(PrismaJson.FooterJsonContent)
+   * [FooterJsonContent]
+   */
+  content: PrismaJson.FooterJsonContent
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface Navbar {
+  id: GeneratedAlways<number>
+  siteId: number
+  /**
+   * @kyselyType(PrismaJson.NavbarJsonContent)
+   * [NavbarJsonContent]
+   */
+  content: PrismaJson.NavbarJsonContent
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface RateLimiterFlexible {
+  key: string
+  points: number
+  expire: Timestamp | null
+}
+export interface Resource {
+  id: GeneratedAlways<string>
+  title: string
+  permalink: string
+  siteId: number
+  parentId: string | null
+  publishedVersionId: string | null
+  draftBlobId: string | null
+  state: Generated<ResourceState | null>
+  type: ResourceType
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface ResourcePermission {
+  id: GeneratedAlways<string>
+  userId: string
+  siteId: number
+  resourceId: string | null
+  role: RoleType
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+  deletedAt: Timestamp | null
+}
+export interface Site {
+  id: GeneratedAlways<number>
+  name: string
+  /**
+   * @kyselyType(PrismaJson.SiteJsonConfig)
+   * [SiteJsonConfig]
+   */
+  config: PrismaJson.SiteJsonConfig
+  /**
+   * @kyselyType(PrismaJson.SiteThemeJson)
+   * [SiteThemeJson]
+   */
+  theme: PrismaJson.SiteThemeJson | null
+  codeBuildId: string | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface User {
+  id: string
+  name: string
+  email: string
+  phone: string
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+  deletedAt: Timestamp | null
+}
+export interface VerificationToken {
+  identifier: string
+  token: string
+  attempts: Generated<number>
+  expires: Timestamp
+}
+export interface Version {
+  id: GeneratedAlways<string>
+  versionNum: number
+  resourceId: string
+  blobId: string
+  publishedAt: Generated<Timestamp>
+  publishedBy: string
+  updatedAt: Generated<Timestamp>
+}
+export interface Whitelist {
+  id: GeneratedAlways<number>
+  email: string
+  expiry: Timestamp | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
+export interface DB {
+  Blob: Blob
+  Footer: Footer
+  Navbar: Navbar
+  RateLimiterFlexible: RateLimiterFlexible
+  Resource: Resource
+  ResourcePermission: ResourcePermission
+  Site: Site
+  User: User
+  VerificationToken: VerificationToken
+  Version: Version
+  Whitelist: Whitelist
+}

--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1418,6 +1418,10 @@ video {
   -webkit-line-clamp: 3;
 }
 
+.\!block {
+  display: block !important;
+}
+
 .block {
   display: block;
 }
@@ -3196,6 +3200,11 @@ video {
 .text-link {
   --tw-text-opacity: 1;
   color: rgb(26 86 229 / var(--tw-text-opacity));
+}
+
+.text-link-hover {
+  --tw-text-opacity: 1;
+  color: rgb(21 71 190 / var(--tw-text-opacity));
 }
 
 .text-site-secondary {
@@ -5499,6 +5508,12 @@ video {
 
 .\[\&\:not\(\:first-child\)\]\:mt-9:not(:first-child) {
   margin-top: 2.25rem;
+}
+
+.\[\&\:not\(\:first-child\)\]\:first-of-type\:mt-7:first-of-type:not(
+    :first-child
+  ) {
+  margin-top: 1.75rem;
 }
 
 .\[\&\:not\(\:last-child\)\]\:mb-0:not(:last-child) {

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -44,6 +44,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
     onSuccess: async () => {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
+      await utils.page.getCategories.invalidate({ pageId, siteId })
     },
   })
 

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -36,6 +36,7 @@ const SuspendablePublishButton = ({
         ...BRIEF_TOAST_SETTINGS,
       })
       await utils.page.readPage.invalidate({ pageId, siteId })
+      await utils.page.getCategories.invalidate({ pageId, siteId })
     },
     onError: async (error) => {
       console.error(`Error occurred when publishing page: ${error.message}`)

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -17,6 +17,8 @@ import {
   jsonFormsArrayControlTester,
   JsonFormsBooleanControl,
   jsonFormsBooleanControlTester,
+  JsonFormsCategoryControl,
+  jsonFormsCategoryControlTester,
   JsonFormsConstControl,
   jsonFormsConstControlTester,
   JsonFormsDateControl,
@@ -89,6 +91,10 @@ const renderers: JsonFormsRendererRegistryEntry[] = [
     // we render null so that the users don't get visual noise
     tester: rankWith(JSON_FORMS_RANKING.Catchall, () => true),
     renderer: () => null,
+  },
+  {
+    tester: jsonFormsCategoryControlTester,
+    renderer: JsonFormsCategoryControl,
   },
 ]
 const ajv = new Ajv({

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -15,12 +15,15 @@ export const jsonFormsCategoryControlTester: RankedTester = rankWith(
   and(schemaMatches((schema) => schema.format === "category")),
 )
 
+interface JsonFormsCategoryControlProps extends ControlProps {
+  data: string
+}
 function SuspendableJsonFormsCategoryControl({
   data,
   handleChange,
   path,
   label,
-}: ControlProps) {
+}: JsonFormsCategoryControlProps) {
   const { siteId, pageId } = useQueryParse(editPageSchema)
 
   const [{ categories }] = trpc.page.getCategories.useSuspenseQuery({

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -1,0 +1,60 @@
+import type { ControlProps, RankedTester } from "@jsonforms/core"
+import { FormControl, Skeleton } from "@chakra-ui/react"
+import { and, rankWith, schemaMatches } from "@jsonforms/core"
+import { withJsonFormsControlProps } from "@jsonforms/react"
+import { FormLabel, SingleSelect } from "@opengovsg/design-system-react"
+
+import Suspense from "~/components/Suspense"
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { editPageSchema } from "~/features/editing-experience/schema"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { trpc } from "~/utils/trpc"
+
+export const jsonFormsCategoryControlTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.RefControl,
+  and(schemaMatches((schema) => schema.format === "category")),
+)
+
+function SuspendableJsonFormsCategoryControl({
+  data,
+  handleChange,
+  path,
+  label,
+}: ControlProps) {
+  const { siteId, pageId } = useQueryParse(editPageSchema)
+
+  const [{ categories }] = trpc.page.getCategories.useSuspenseQuery({
+    siteId,
+    pageId,
+  })
+
+  return (
+    <SingleSelect
+      value={data}
+      name={label}
+      items={categories.map((category) => {
+        return { label: category, value: category }
+      })}
+      isClearable={false}
+      onChange={(value) => handleChange(path, value)}
+    />
+  )
+}
+
+export function JsonFormsCategoryControl({
+  description,
+  required,
+  label,
+  ...props
+}: ControlProps) {
+  return (
+    <FormControl isRequired={required} gap="0.5rem">
+      <FormLabel description={description}>{label}</FormLabel>
+      <Suspense fallback={<Skeleton />}>
+        <SuspendableJsonFormsCategoryControl {...props} label={label} />
+      </Suspense>
+    </FormControl>
+  )
+}
+
+export default withJsonFormsControlProps(JsonFormsCategoryControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -6,7 +6,7 @@ import { FormLabel, SingleSelect } from "@opengovsg/design-system-react"
 
 import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
-import { editPageSchema } from "~/features/editing-experience/schema"
+import { collectionItemSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 
@@ -24,11 +24,15 @@ function SuspendableJsonFormsCategoryControl({
   path,
   label,
 }: JsonFormsCategoryControlProps) {
-  const { siteId, pageId } = useQueryParse(editPageSchema)
+  const { siteId, pageId, linkId } = useQueryParse(collectionItemSchema)
 
   const [{ categories }] = trpc.page.getCategories.useSuspenseQuery({
     siteId,
-    pageId,
+    // NOTE: This control should only be rendered inside
+    // a collection - because of this,
+    // there is either a `pageId` or a `linkId`
+    // and if there isn't, we give a dummy value
+    pageId: pageId || linkId || -1,
   })
 
   return (

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -66,3 +66,7 @@ export {
   default as JsonFormsUnionRootControl,
   jsonFormsUnionRootControlTester,
 } from "./JsonFormsUnionRootControl"
+export {
+  default as JsonFormsCategoryControl,
+  jsonFormsCategoryControlTester,
+} from "./JsonFormsCategoryControl"

--- a/apps/studio/src/features/editing-experience/schema.ts
+++ b/apps/studio/src/features/editing-experience/schema.ts
@@ -4,3 +4,9 @@ export const editPageSchema = z.object({
   pageId: z.coerce.number(),
   siteId: z.coerce.number(),
 })
+
+export const collectionItemSchema = editPageSchema
+  .extend({
+    linkId: z.coerce.number(),
+  })
+  .partial({ pageId: true, linkId: true })

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -127,6 +127,7 @@ export const pageRouter = router({
           ResourceType.CollectionPage,
           ResourceType.CollectionLink,
         ])
+        .where("r.parentId", "=", String(parentId))
         .select((eb) => {
           return eb.fn
             .coalesce(
@@ -136,7 +137,6 @@ export const pageRouter = router({
             .as("category")
         })
         .distinct()
-        .where("r.parentId", "=", String(parentId))
         .execute()
 
       const categories = blobs

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -163,6 +163,7 @@ export const pageRouter = router({
         })
         .selectFrom("coalescedBlobs")
         .select("coalescedBlobs.category")
+        .distinct()
         .where("coalescedBlobs.category", "is not", null)
         .execute()
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -166,7 +166,9 @@ export const pageRouter = router({
         .where("coalescedBlobs.category", "is not", null)
         .execute()
 
-      const categories = blobs.map((blob) => blob.category).filter(Boolean)
+      const categories = blobs
+        .map((blob) => blob.category)
+        .filter((c) => c !== null)
 
       return {
         categories,

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -141,7 +141,7 @@ export const pageRouter = router({
 
       const categories = blobs
         .map((blob) => blob.category)
-        .filter((c) => c !== null && !!c.trim())
+        .filter((c) => !!c && !!c.trim())
 
       return {
         categories,

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -111,7 +111,10 @@ export const pageRouter = router({
       const { parentId } = await db
         .selectFrom("Resource")
         .where("id", "=", String(pageId))
-        .where("type", "=", ResourceType.CollectionPage)
+        .where("type", "in", [
+          ResourceType.CollectionPage,
+          ResourceType.CollectionLink,
+        ])
         .select("parentId")
         .executeTakeFirstOrThrow()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33932,6 +33932,21 @@
     "tooling/typescript": {
       "name": "@isomer/tsconfig",
       "version": "0.0.0"
+    },
+    "tooling/template/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.13",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.13.tgz",
+      "integrity": "sha512-V26ezyjPqQpDBV4lcWIh8B/QICQ4v+M5Bo9ykLN+sqeKKBxJVDpEc6biDVyluTXTC40f5IqCU0ttth7Es2ZuMw==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -13,6 +13,7 @@ import { REF_HREF_PATTERN } from "~/utils/validation"
 const categorySchemaObject = Type.Object({
   category: Type.String({
     title: "Article category",
+    format: "category",
     description:
       "The category is used for filtering in the parent collection page",
   }),


### PR DESCRIPTION
## Problem
Add dropdown for collections, see ticket for deets

## Solution
1. use a db query to get all the category values - this takes the draft blob if it is there, otherwise it orders by the publishedAt and takes the latest one 
2. render this on the frontend as a dropdown of the values
3. Add a `Suspense` + `Skeleton` so there's a nice loading state


## Screenshots
<img width="502" alt="image" src="https://github.com/user-attachments/assets/ebbd6a0e-def5-42a4-ba06-53baa003ab46" />

## Tests 
- [ ] Go to site 7 on `staging`
- [ ] Create a collection 
- [ ] Create a collection page 
    - [ ] edit the db so that this page's category is updated
- [ ] Create another collection page 
- [ ] Check the dropdown 
- [ ] it should have `Feature Articles` (default value) + the previous pag e
- [ ] Publish this page 
- [ ] The dropdown should still have the same values
- [ ] Make some change so that there's a draft blob id 
- [ ] update the category for this draft blob to some other value (now, published blob + draft blob has diff values)
- [ ] Click on dropdown again 
- [ ] it should have the new values 