### PR TITLE
chore: add gb

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -51,7 +51,7 @@ import {
   jsonFormsVerticalLayoutTester,
 } from "./renderers"
 
-const renderers: JsonFormsRendererRegistryEntry[] = [
+export const renderers: JsonFormsRendererRegistryEntry[] = [
   {
     tester: jsonFormsProseControlTester,
     renderer: JsonFormsProseControl,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -67,7 +67,7 @@ export function JsonFormsCategoryControl({
     CATEGORY_DROPDOWN_FEATURE_KEY,
     { enabledSites: [] },
   )
-  const handleChange: ControlProps["handleChange"] = (path, value) => {
+  const handleChange: ControlProps["handleChange"] = (path, value: string) => {
     props.handleChange(path, value)
     setLink((prev) => ({ ...prev, category: value }))
   }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -1,5 +1,6 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
 import { FormControl, Skeleton } from "@chakra-ui/react"
+import { useFeatureValue } from "@growthbook/growthbook-react"
 import { and, rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import { FormLabel, SingleSelect } from "@opengovsg/design-system-react"
@@ -8,7 +9,9 @@ import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { collectionItemSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { CATEGORY_DROPDOWN_FEATURE_KEY } from "~/lib/growthbook"
 import { trpc } from "~/utils/trpc"
+import { JsonFormsTextControl } from "./JsonFormsTextControl"
 
 export const jsonFormsCategoryControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.RefControl,
@@ -54,13 +57,27 @@ export function JsonFormsCategoryControl({
   label,
   ...props
 }: ControlProps) {
-  return (
+  const { siteId } = useQueryParse(editPageSchema)
+  const { enabledSites } = useFeatureValue<{ enabledSites: string[] }>(
+    CATEGORY_DROPDOWN_FEATURE_KEY,
+    { enabledSites: [] },
+  )
+
+  const isDropdownEnabled = enabledSites.includes(siteId.toString())
+  return isDropdownEnabled ? (
     <FormControl isRequired={required} gap="0.5rem">
       <FormLabel description={description}>{label}</FormLabel>
       <Suspense fallback={<Skeleton />}>
         <SuspendableJsonFormsCategoryControl {...props} label={label} />
       </Suspense>
     </FormControl>
+  ) : (
+    <JsonFormsTextControl
+      {...props}
+      description={description}
+      required={required}
+      label={label}
+    />
   )
 }
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -4,9 +4,11 @@ import { useFeatureValue } from "@growthbook/growthbook-react"
 import { and, rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import { FormLabel, SingleSelect } from "@opengovsg/design-system-react"
+import { useSetAtom } from "jotai"
 
 import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { linkAtom } from "~/features/editing-experience/atoms"
 import { collectionItemSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { CATEGORY_DROPDOWN_FEATURE_KEY } from "~/lib/growthbook"
@@ -46,7 +48,9 @@ function SuspendableJsonFormsCategoryControl({
         return { label: category, value: category }
       })}
       isClearable={false}
-      onChange={(value) => handleChange(path, value)}
+      onChange={(value) => {
+        handleChange(path, value)
+      }}
     />
   )
 }
@@ -57,18 +61,27 @@ export function JsonFormsCategoryControl({
   label,
   ...props
 }: ControlProps) {
-  const { siteId } = useQueryParse(editPageSchema)
+  const { siteId } = useQueryParse(collectionItemSchema)
+  const setLink = useSetAtom(linkAtom)
   const { enabledSites } = useFeatureValue<{ enabledSites: string[] }>(
     CATEGORY_DROPDOWN_FEATURE_KEY,
     { enabledSites: [] },
   )
+  const handleChange: ControlProps["handleChange"] = (path, value) => {
+    props.handleChange(path, value)
+    setLink((prev) => ({ ...prev, category: value }))
+  }
 
   const isDropdownEnabled = enabledSites.includes(siteId.toString())
   return isDropdownEnabled ? (
     <FormControl isRequired={required} gap="0.5rem">
       <FormLabel description={description}>{label}</FormLabel>
       <Suspense fallback={<Skeleton />}>
-        <SuspendableJsonFormsCategoryControl {...props} label={label} />
+        <SuspendableJsonFormsCategoryControl
+          {...props}
+          label={label}
+          handleChange={handleChange}
+        />
       </Suspense>
     </FormControl>
   ) : (
@@ -77,6 +90,7 @@ export function JsonFormsCategoryControl({
       description={description}
       required={required}
       label={label}
+      handleChange={handleChange}
     />
   )
 }

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -1,2 +1,3 @@
 export const BANNER_FEATURE_KEY = "isomer-next-banner"
 export const ISOMER_ADMIN_FEATURE_KEY = "isomer_admins"
+export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -7,10 +7,14 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
-import { createBannerGbParameters } from "~/stories/utils/growthbook"
+import {
+  createBannerGbParameters,
+  createDropdownGbParameters,
+} from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),
+  pageHandlers.getCategories.default(),
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
   pageHandlers.countWithoutRoot.default(),
@@ -115,5 +119,17 @@ export const LinkModal: Story = {
     await AddTextBlock.play?.(context)
 
     await userEvent.click(canvas.getByRole("button", { name: /link/i }))
+  },
+}
+
+export const Dropdown: Story = {
+  parameters: {
+    growthbook: [createDropdownGbParameters("1")],
+  },
+  play: async ({ canvasElement, ...rest }) => {
+    const canvas = within(canvasElement)
+    await EditFixedBlockState.play?.({ canvasElement, ...rest })
+    const button = await canvas.findByRole("combobox")
+    await userEvent.click(button)
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
@@ -14,6 +14,7 @@ const COMMON_HANDLERS = [
   meHandlers.me(),
   pageHandlers.listWithoutRoot.default(),
   pageHandlers.getRootPage.default(),
+  pageHandlers.getCategories.default(),
   pageHandlers.countWithoutRoot.default(),
   sitesHandlers.getLocalisedSitemap.default(),
   sitesHandlers.getTheme.default(),

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
@@ -8,7 +8,10 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 
 import CollectionLinkPage from "~/pages/sites/[siteId]/links/[linkId]"
-import { createBannerGbParameters } from "~/stories/utils/growthbook"
+import {
+  createBannerGbParameters,
+  createDropdownGbParameters,
+} from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),
@@ -59,6 +62,17 @@ export default meta
 type Story = StoryObj<typeof CollectionLinkPage>
 
 export const Default: Story = {}
+export const Dropdown: Story = {
+  parameters: {
+    growthbook: [createDropdownGbParameters("1")],
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    const screen = within(canvasElement)
+    const button = await screen.findByRole("combobox")
+    await userEvent.click(button)
+  },
+}
 
 export const PublishedState: Story = {
   parameters: {

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsCategoryControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsCategoryControl.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react"
+import { Type } from "@sinclair/typebox"
+import { pageHandlers } from "tests/msw/handlers/page"
+
+import {
+  JsonFormsCategoryControl,
+  jsonFormsCategoryControlTester,
+} from "~/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl"
+import { createDropdownGbParameters } from "~/stories/utils/growthbook"
+import { FormBuilder } from "./formBuilder"
+
+const meta: Meta<typeof FormBuilder> = {
+  title: "Pages/Edit Page/components/JsonFormsCategoryControl",
+  component: FormBuilder,
+  parameters: {
+    msw: {
+      handlers: [pageHandlers.getCategories.default()],
+    },
+    nextjs: {
+      router: {
+        query: {
+          siteId: "1",
+          pageId: "1",
+        },
+        pathname: "/sites/[siteId]/pages/[pageId]",
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof JsonFormsCategoryControl>
+
+const schema = Type.Object({
+  category: Type.String({
+    title: "Article category",
+    format: "category",
+    description:
+      "The category is used for filtering in the parent collection page",
+  }),
+})
+
+export const Default: Story = {
+  args: {
+    schema,
+    renderers: [
+      {
+        tester: jsonFormsCategoryControlTester,
+        renderer: JsonFormsCategoryControl,
+      },
+    ],
+  },
+}
+
+export const Dropdown: Story = {
+  parameters: {
+    growthbook: [createDropdownGbParameters("1")],
+    msw: {
+      handlers: [pageHandlers.getCategories.default()],
+    },
+  },
+  args: {
+    schema,
+    renderers: [
+      {
+        tester: jsonFormsCategoryControlTester,
+        renderer: JsonFormsCategoryControl,
+      },
+    ],
+  },
+}

--- a/apps/studio/src/stories/Page/EditPage/components/formBuilder.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/formBuilder.tsx
@@ -1,0 +1,23 @@
+import { JsonForms } from "@jsonforms/react"
+import { type TSchema } from "@sinclair/typebox"
+import Ajv from "ajv"
+
+import { renderers } from "~/features/editing-experience/components/form-builder/FormBuilder"
+
+const ajv = new Ajv({
+  useDefaults: true,
+  allErrors: true,
+  strict: false,
+  logger: false,
+})
+
+interface FormBuilderProps {
+  schema: TSchema
+  data: unknown
+}
+
+export function FormBuilder({ schema, data }: FormBuilderProps): JSX.Element {
+  return (
+    <JsonForms schema={schema} data={data} renderers={renderers} ajv={ajv} />
+  )
+}

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -1,6 +1,9 @@
 import type { BannerProps } from "@opengovsg/design-system-react"
 
-import { BANNER_FEATURE_KEY } from "~/lib/growthbook"
+import {
+  BANNER_FEATURE_KEY,
+  CATEGORY_DROPDOWN_FEATURE_KEY,
+} from "~/lib/growthbook"
 
 export const createBannerGbParameters = ({
   variant,
@@ -10,4 +13,7 @@ export const createBannerGbParameters = ({
   message: string
 }) => {
   return [BANNER_FEATURE_KEY, { variant, message }]
+}
+export const createDropdownGbParameters = (siteId: string) => {
+  return [CATEGORY_DROPDOWN_FEATURE_KEY, { enabledSites: [siteId] }]
 }

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -67,6 +67,15 @@ const pageListQuery = (wait?: DelayMode | number) => {
 }
 
 export const pageHandlers = {
+  getCategories: {
+    default: () => {
+      return trpcMsw.page.getCategories.query(() => {
+        return {
+          categories: ["Category 1", "Category 2", "Category 3"],
+        }
+      })
+    },
+  },
   updateSettings: {
     collection: () => {
       trpcMsw.page.updateSettings.mutation(() => {


### PR DESCRIPTION
## Problem
We want to gate the dropdown for collections to hfpg only (siteId = 29) 

## Solution
1. add growthbook feature key
2. retrieve key at runtime 
3. depending on feature key, render either text control (old) or the dropdown (new) 

## Tests
### For staging 
1. go to site id = 7 
2. create a collection
3. create a page in the collection
4. the article category should be a dropdown
5. go to any other site id 
6. repeat steps 2-3 
7. the article category should be a free text field 