### PR TITLE
fix: refine regex used to identify asset links

### DIFF
--- a/packages/components/src/utils/__tests__/getReferenceLinkHref.test.ts
+++ b/packages/components/src/utils/__tests__/getReferenceLinkHref.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest"
+
+import type { IsomerSitemap } from "~/types"
+import { getReferenceLinkHref } from "../getReferenceLinkHref"
+
+const EXAMPLE_SITEMAP: IsomerSitemap = {
+  id: "1",
+  title: "Home",
+  summary: "",
+  lastModified: "",
+  permalink: "/",
+  layout: "homepage",
+  children: [
+    {
+      id: "2",
+      title: "Page 1",
+      summary: "",
+      lastModified: "",
+      permalink: "/page-1",
+      layout: "content",
+    },
+  ],
+}
+
+describe("getReferenceLinkHref", () => {
+  it("should return undefined if referenceLink is undefined", () => {
+    const result = getReferenceLinkHref(
+      undefined,
+      EXAMPLE_SITEMAP,
+      "https://assets.example.com",
+    )
+    expect(result).toBeUndefined()
+  })
+
+  it("should return original link if referenceLink is not a reference link", () => {
+    const testCases = [
+      "https://example.com",
+      "https://example.com/page",
+      "/page",
+      "/page#section",
+      "/page?query=string",
+      "/2012/looks-like-asset-link",
+    ]
+
+    testCases.forEach((testCase) => {
+      const result = getReferenceLinkHref(
+        testCase,
+        EXAMPLE_SITEMAP,
+        "https://assets.example.com",
+      )
+      expect(result).toBe(testCase)
+    })
+  })
+
+  it("should return permalink if referenceLink is a reference link", () => {
+    const result = getReferenceLinkHref(
+      "[resource:1:2]",
+      EXAMPLE_SITEMAP,
+      "https://assets.example.com",
+    )
+    expect(result).toBe("/page-1")
+  })
+
+  it("should return original link if reference page is not found", () => {
+    const result = getReferenceLinkHref(
+      "[resource:1:999]",
+      EXAMPLE_SITEMAP,
+      "https://assets.example.com",
+    )
+    expect(result).toBe("[resource:1:999]")
+  })
+
+  it("should return asset link if referenceLink is an asset link", () => {
+    const result = getReferenceLinkHref(
+      "/1/dc2b609a-355e-406c-af6c-003683731e7e/RFP%20Template.docx",
+      EXAMPLE_SITEMAP,
+      "https://assets.example.com",
+    )
+    expect(result).toBe(
+      "https://assets.example.com/1/dc2b609a-355e-406c-af6c-003683731e7e/RFP%20Template.docx",
+    )
+  })
+})

--- a/packages/components/src/utils/getReferenceLinkHref.ts
+++ b/packages/components/src/utils/getReferenceLinkHref.ts
@@ -58,7 +58,10 @@ const convertAssetLinks = (
     return originalLink
   }
 
-  const match = /^\/(\d+)\//.exec(originalLink)
+  const match =
+    /^\/(\d+)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\//.exec(
+      originalLink,
+    )
 
   if (!match) {
     return originalLink

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -6,8 +6,9 @@ export const ALLOWED_URL_REGEXES = {
   // and should remain in sync.
   // Unfortunately, typebox requires a string and hence, doubly escaped characters
   // but `re.source` only gives us the actual string
-  // regex for asset links: /^\/(\d+)\//
-  files: "^\\/(\\d+)\\/",
+  // regex for asset links: /^\/(\d+)\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+  files:
+    "^\\/(\\d+)\\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\\/",
   // These are the standard internal links that are used by sites on GitHub.
   // We can drop them once all sites have fully migrated to Studio.
   legacy: "^\\/",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The regex used to identify asset links is too general, which can give false positives when the root folder's permalink is just numbers.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Properly detect asset links by including the UUID v4 portion as part of the asset links regex.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and create a root level folder with just numbers in the permalink (e.g. `2024`)
- [ ] Create a page within this new folder using any name/permalink and save.
- [ ] Inside a separate page, create a link to this newly created page and publish.
- [ ] Verify that the link is indeed pointing to the newly created page from the second page that you edited.