### PR TITLE
Enhancement/add collection in folders

### DIFF
--- a/apps/studio/src/features/dashboard/components/DashboardLayout.tsx
+++ b/apps/studio/src/features/dashboard/components/DashboardLayout.tsx
@@ -11,6 +11,51 @@ import {
 } from "@chakra-ui/react"
 import { Breadcrumb } from "@opengovsg/design-system-react"
 
+import type { RouterOutput } from "~/utils/trpc"
+import { getFolderHref } from "~/utils/resource"
+
+/**
+ * NOTE: This returns the path from root down to the parent of the element.
+ * The element at index 0 is always the root
+ * and the last element is always the parent of the current folder
+ */
+export const getBreadcrumbsFromRoot = (
+  resource: RouterOutput["resource"]["getParentOf"],
+  siteId: string,
+): { href: string; label: string }[] => {
+  // NOTE: We only consider the 3 cases below:
+  // Root -> Folder
+  // Root -> Parent -> Folder
+  // Root -> ... -> Parent -> Folder
+  const rootHref = `/sites/${siteId}`
+
+  if (resource.parent?.parentId) {
+    return [
+      { href: rootHref, label: "Home" },
+      {
+        href: getFolderHref(siteId, resource.parent.parentId),
+        label: "...",
+      },
+      {
+        href: getFolderHref(siteId, resource.parent.id),
+        label: resource.parent.title,
+      },
+    ]
+  }
+
+  if (resource.parent?.id) {
+    return [
+      { href: rootHref, label: "Home" },
+      {
+        href: getFolderHref(siteId, resource.parent.id),
+        label: resource.parent.title,
+      },
+    ]
+  }
+
+  return [{ href: rootHref, label: "Home" }]
+}
+
 export const DashboardLayout = ({
   breadcrumbs,
   icon,

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -41,12 +41,13 @@ type CreateCollectionModalProps = Pick<
   UseDisclosureReturn,
   "isOpen" | "onClose"
 > &
-  Pick<CreateCollectionProps, "siteId">
+  Pick<CreateCollectionProps, "siteId" | "parentFolderId">
 
 export const CreateCollectionModal = ({
   isOpen,
   onClose,
   siteId,
+  parentFolderId,
 }: CreateCollectionModalProps): JSX.Element => {
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -56,6 +57,7 @@ export const CreateCollectionModal = ({
         key={String(isOpen)}
         onClose={onClose}
         siteId={siteId}
+        parentFolderId={parentFolderId}
       />
     </Modal>
   )
@@ -64,6 +66,7 @@ export const CreateCollectionModal = ({
 const CreateCollectionModalContent = ({
   onClose,
   siteId,
+  parentFolderId,
 }: CreateCollectionModalProps) => {
   const {
     register,
@@ -80,6 +83,7 @@ const CreateCollectionModalContent = ({
     },
     schema: createCollectionSchema.omit({
       siteId: true,
+      parentFolderId: true,
     }),
   })
   const { errors, isValid } = formState
@@ -110,7 +114,7 @@ const CreateCollectionModalContent = ({
 
   const [collectionTitle, permalink] = watch(["collectionTitle", "permalink"])
   const onSubmit = handleSubmit((data) => {
-    mutate({ ...data, siteId })
+    mutate({ ...data, parentFolderId, siteId })
   })
 
   useEffect(() => {

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -2,7 +2,7 @@ import { Portal, useDisclosure } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { useSetAtom } from "jotai"
-import { BiFileBlank, BiFolder } from "react-icons/bi"
+import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
 import type { RouterOutput } from "~/utils/trpc"
@@ -13,6 +13,7 @@ import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResou
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { PageSettingsModal } from "~/features/dashboard/components/PageSettingsModal"
 import { ResourceTable } from "~/features/dashboard/components/ResourceTable"
+import { CreateCollectionModal } from "~/features/editing-experience/components/CreateCollectionModal"
 import { CreateFolderModal } from "~/features/editing-experience/components/CreateFolderModal"
 import { CreatePageModal } from "~/features/editing-experience/components/CreatePageModal"
 import { MoveResourceModal } from "~/features/editing-experience/components/MoveResourceModal"
@@ -83,6 +84,11 @@ const FolderPage: NextPageWithLayout = () => {
     onOpen: onFolderCreateModalOpen,
     onClose: onFolderCreateModalClose,
   } = useDisclosure()
+  const {
+    isOpen: isCollectionCreateModalOpen,
+    onOpen: onCollectionCreateModalOpen,
+    onClose: onCollectionCreateModalClose,
+  } = useDisclosure()
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
 
   const { folderId, siteId } = useQueryParse(folderPageSchema)
@@ -145,6 +151,12 @@ const FolderPage: NextPageWithLayout = () => {
                       >
                         Page
                       </Menu.Item>
+                      <Menu.Item
+                        onClick={onCollectionCreateModalOpen}
+                        icon={<BiData fontSize="1rem" />}
+                      >
+                        Collection
+                      </Menu.Item>
                     </Menu.List>
                   </Portal>
                 </>
@@ -167,6 +179,12 @@ const FolderPage: NextPageWithLayout = () => {
       <CreateFolderModal
         isOpen={isFolderCreateModalOpen}
         onClose={onFolderCreateModalClose}
+        siteId={parseInt(siteId)}
+        parentFolderId={parseInt(folderId)}
+      />
+      <CreateCollectionModal
+        isOpen={isCollectionCreateModalOpen}
+        onClose={onCollectionCreateModalClose}
         siteId={parseInt(siteId)}
         parentFolderId={parseInt(folderId)}
       />

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -20,16 +20,13 @@ import { MoveResourceModal } from "~/features/editing-experience/components/Move
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminCmsSearchableLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
+import { getFolderHref, getRootHref } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
 
 const folderPageSchema = z.object({
   siteId: z.string(),
   folderId: z.string(),
 })
-
-const getFolderHref = (siteId: string, folderId: string) => {
-  return `/sites/${siteId}/folders/${folderId}`
-}
 
 /**
  * NOTE: This returns the path from root down to the parent of the element.
@@ -44,7 +41,7 @@ const getBreadcrumbsFrom = (
   // Root -> Folder
   // Root -> Parent -> Folder
   // Root -> ... -> Parent -> Folder
-  const rootHref = `/sites/${siteId}`
+  const rootHref = getRootHref(siteId)
 
   if (resource.parent?.parentId) {
     return [
@@ -102,12 +99,10 @@ const FolderPage: NextPageWithLayout = () => {
     resourceId: parseInt(folderId),
   })
 
-  const breadcrumbs = getBreadcrumbsFrom(resource, siteId)
-
   return (
     <>
       <DashboardLayout
-        breadcrumbs={breadcrumbs.concat({
+        breadcrumbs={getBreadcrumbsFrom(resource, siteId).concat({
           href: getFolderHref(siteId, folderId),
           label: title,
         })}

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -5,10 +5,12 @@ import { useSetAtom } from "jotai"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 
-import type { RouterOutput } from "~/utils/trpc"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
 import { folderSettingsModalAtom } from "~/features/dashboard/atoms"
-import { DashboardLayout } from "~/features/dashboard/components/DashboardLayout"
+import {
+  DashboardLayout,
+  getBreadcrumbsFromRoot,
+} from "~/features/dashboard/components/DashboardLayout"
 import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal/DeleteResourceModal"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { PageSettingsModal } from "~/features/dashboard/components/PageSettingsModal"
@@ -20,55 +22,13 @@ import { MoveResourceModal } from "~/features/editing-experience/components/Move
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminCmsSearchableLayout } from "~/templates/layouts/AdminCmsSidebarLayout"
-import { getFolderHref, getRootHref } from "~/utils/resource"
+import { getFolderHref } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
 
 const folderPageSchema = z.object({
   siteId: z.string(),
   folderId: z.string(),
 })
-
-/**
- * NOTE: This returns the path from root down to the parent of the element.
- * The element at index 0 is always the root
- * and the last element is always the parent of the current folder
- */
-const getBreadcrumbsFrom = (
-  resource: RouterOutput["resource"]["getParentOf"],
-  siteId: string,
-): { href: string; label: string }[] => {
-  // NOTE: We only consider the 3 cases below:
-  // Root -> Folder
-  // Root -> Parent -> Folder
-  // Root -> ... -> Parent -> Folder
-  const rootHref = getRootHref(siteId)
-
-  if (resource.parent?.parentId) {
-    return [
-      { href: rootHref, label: "Home" },
-      {
-        href: getFolderHref(siteId, resource.parent.parentId),
-        label: "...",
-      },
-      {
-        href: getFolderHref(siteId, resource.parent.id),
-        label: resource.parent.title,
-      },
-    ]
-  }
-
-  if (resource.parent?.id) {
-    return [
-      { href: rootHref, label: "Home" },
-      {
-        href: getFolderHref(siteId, resource.parent.id),
-        label: resource.parent.title,
-      },
-    ]
-  }
-
-  return [{ href: rootHref, label: "Home" }]
-}
 
 const FolderPage: NextPageWithLayout = () => {
   const {
@@ -102,7 +62,7 @@ const FolderPage: NextPageWithLayout = () => {
   return (
     <>
       <DashboardLayout
-        breadcrumbs={getBreadcrumbsFrom(resource, siteId).concat({
+        breadcrumbs={getBreadcrumbsFromRoot(resource, siteId).concat({
           href: getFolderHref(siteId, folderId),
           label: title,
         })}

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -46,4 +46,6 @@ export const createCollectionSchema = z.object({
     }),
   permalink: permalinkSchema,
   siteId: z.number().min(1),
+  // Nullable for top level folder
+  parentFolderId: z.number().optional(),
 })

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -51,11 +51,15 @@ export const collectionRouter = router({
   create: protectedProcedure
     .input(createCollectionSchema)
     .mutation(
-      async ({ ctx, input: { collectionTitle, permalink, siteId } }) => {
+      async ({
+        ctx,
+        input: { collectionTitle, permalink, siteId, parentFolderId },
+      }) => {
         await validateUserPermissionsForResource({
           siteId,
           action: "create",
           userId: ctx.user.id,
+          resourceId: !!parentFolderId ? String(parentFolderId) : null,
         })
 
         const result = await db
@@ -65,6 +69,7 @@ export const collectionRouter = router({
             siteId,
             type: ResourceType.Collection,
             title: collectionTitle,
+            parentId: parentFolderId ? String(parentFolderId) : null,
             state: ResourceState.Published,
           })
           .returning(defaultCollectionSelect)

--- a/apps/studio/src/utils/resource.ts
+++ b/apps/studio/src/utils/resource.ts
@@ -35,3 +35,15 @@ export const getLinkToResource = ({
 }) => {
   return `/sites/${siteId}/${getResourceSubpath(type)}/${resourceId}`
 }
+
+export const getRootHref = (siteId: string) => {
+  return `/sites/${siteId}`
+}
+
+export const getFolderHref = (siteId: string, folderId: string) => {
+  return `/sites/${siteId}/folders/${folderId}`
+}
+
+export const getCollectionHref = (siteId: string, collectionId: string) => {
+  return `/sites/${siteId}/collections/${collectionId}`
+}

--- a/apps/studio/src/utils/resource.ts
+++ b/apps/studio/src/utils/resource.ts
@@ -36,10 +36,6 @@ export const getLinkToResource = ({
   return `/sites/${siteId}/${getResourceSubpath(type)}/${resourceId}`
 }
 
-export const getRootHref = (siteId: string) => {
-  return `/sites/${siteId}`
-}
-
 export const getFolderHref = (siteId: string, folderId: string) => {
   return `/sites/${siteId}/folders/${folderId}`
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

During [Isoranges workabouts sync](https://www.notion.so/opengov/Workarounds-in-Isomer-18277dbba7888070922ff637552ca467), it was identified that one of the limitations for studio is the inability to create non-root level collections.

This PR aims to enables that by replicating the logic for creating non-root level folders, to:
1) improve the information architecture of the sites _(for those that found workabouts)_
2) reduce support load from oncall isoengineers _(for those who reached out to isoengeers for help)_

**Note**: this PR was not set out to allow the moving of collection across folders - we can skip that for now IMO as it's not a commonly requested/used feature.
 
## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- replicating the logic for creating non-root level folders
- updating breadcrumbs for collections to remove previous assumption of hardcoding only the root page
- refactor to reduce code duplication amongst the two flows (creating non-root folders and non-root collections)

## Before & After Screenshots

https://github.com/user-attachments/assets/297d525a-5f7e-4c68-bf68-b1a29d688e76

## Tests

1. go to a folder
2. click on the dropdown button "Add new item" and select Collection
3. fill in the details and click "create" -> the collection should appear