### PR TITLE
Article layout is not using Isomer Next colour and type tokens

### DIFF
--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -37,11 +37,11 @@ const ArticlePageHeader = ({
         <Breadcrumb links={breadcrumb.links} LinkComponent={LinkComponent} />
       </div>
 
-      <div className="mb-3 text-base font-medium text-gray-600">{category}</div>
+      <div className="prose-body-base mb-3 text-base-content">{category}</div>
 
       <div className="flex flex-col gap-5">
         <div className="flex flex-col gap-4">
-          <h1 className="break-words text-3xl font-semibold tracking-tight text-content-strong lg:text-4xl">
+          <h1 className="prose-display-md break-words text-base-content-strong">
             {title}
           </h1>
           {tags.length > 0 &&
@@ -57,10 +57,12 @@ const ArticlePageHeader = ({
         </div>
 
         {date && (
-          <p className="text-sm text-gray-800">{getFormattedDate(date)}</p>
+          <p className="prose-label-sm-medium text-base-content">
+            {getFormattedDate(date)}
+          </p>
         )}
 
-        <div className="text-xl tracking-tight text-gray-500 md:text-2xl">
+        <div className="prose-title-lg text-base-content-light">
           <ArticleSummaryContent
             summary={summary}
             site={site}

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -382,6 +382,19 @@ export const NoSummary: Story = {
             ],
           },
           {
+            type: "heading",
+            attrs: {
+              id: "section2",
+              level: 2,
+            },
+            content: [
+              {
+                type: "text",
+                text: "It does look a bit odd but we can't fix until the typography scale is rejigged",
+              },
+            ],
+          },
+          {
             type: "paragraph",
             content: [
               {


### PR DESCRIPTION
## Problem

- The article layout wasn't using the right tokens, it was using the old tailwind tokens. So the typography was a little off from other layouts.
- The title in the article layout is smaller than the Section Title.

Closes [ISO-161]

<img width="1595" alt="image" src="https://github.com/user-attachments/assets/f8867501-77b6-4372-84dc-e39b0984c8c4" />

This is with the section title:
<img width="1477" alt="image" src="https://github.com/user-attachments/assets/eb6db4a9-025d-4831-91d0-803ac8227118" />

## Solution

- Use the right tokens to match designs here https://www.figma.com/design/rsKQdmtyoOWawyAv1LkJJK/Isomer-Next-Component-Library?node-id=584-18886&t=mOp7e01PcMxtGaj3-1
- [Caveat] Using display-md for the title. This means that the article title and Section Title are the same size, but we can't fix it without rejigging the entire typographic scale.