### PR TITLE
fix - remove conditional check for resoucetype

### DIFF
--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -118,10 +118,6 @@ export const pageRouter = router({
       const { parentId } = await db
         .selectFrom("Resource")
         .where("id", "=", String(pageId))
-        .where("type", "in", [
-          ResourceType.CollectionPage,
-          ResourceType.CollectionLink,
-        ])
         .select("parentId")
         .executeTakeFirstOrThrow()
 
@@ -130,10 +126,6 @@ export const pageRouter = router({
         .leftJoin("Blob as b", "r.draftBlobId", "b.id")
         .leftJoin("Version as v", "r.publishedVersionId", "v.id")
         .leftJoin("Blob as vb", "v.blobId", "vb.id")
-        .where("r.type", "in", [
-          ResourceType.CollectionPage,
-          ResourceType.CollectionLink,
-        ])
         .where("r.parentId", "=", String(parentId))
         .select((eb) => {
           return eb.fn


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

hotfix for https://github.com/opengovsg/isomer/pull/1048 - `getCategories` are used by folders too instead of only collections, and this query throw an error as it assumes theres only collections

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- remove conditional check for resource types

