### PR TITLE
fix: set collection item dates to be optional

### DIFF
--- a/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
@@ -200,7 +200,7 @@ export const LinkEditorDrawer = () => {
     title,
   }
   const handleChange = (data: IsomerLinkSchema) =>
-    setLinkAtom((oldData) => ({ ...oldData, ...data }))
+    setLinkAtom(data as CollectionLinkProps)
 
   return (
     <ErrorProvider>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDateControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDateControl.tsx
@@ -33,7 +33,7 @@ export function JsonFormsDateControl({
         <FormLabel description={description}>{label}</FormLabel>
         <DatePicker
           inputValue={!!data ? String(data) : undefined}
-          allowManualInput={false}
+          allowManualInput={true}
           onInputValueChange={(date) => handleChange(path, date.toString())}
         />
         <FormErrorMessage>

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -7,18 +7,28 @@ import { MAX_FOLDER_PERMALINK_LENGTH, MAX_FOLDER_TITLE_LENGTH } from "./folder"
 // NOTE: zod's internal date schema uses `YYYY-MM-DD` but our format is
 // dd/mm/yyyy. Hence, we will run a 2 way conversion from
 // our format -> zod then zod -> our format
+// If the date is nullish, then we will return as undefined
 const slashDateSchema = z
   .string()
+  .nullish()
   .transform((d) => {
+    if (!d) {
+      return undefined
+    }
+
     return parse(d, "dd/mm/yyyy", new Date())
   })
-  .pipe(z.date())
+  .pipe(z.date().nullish())
   .transform((d) => {
+    if (!d) {
+      return undefined
+    }
+
     return format(d, "dd/mm/yyyy")
   })
 
 export const editLinkSchema = z.object({
-  date: slashDateSchema,
+  date: slashDateSchema.optional(),
   category: z.string(),
   linkId: z.number().min(1),
   siteId: z.number().min(1),

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -20,10 +20,12 @@ const categorySchemaObject = Type.Object({
 })
 
 const dateSchemaObject = Type.Object({
-  date: Type.String({
-    title: "Article date",
-    format: "date",
-  }),
+  date: Type.Optional(
+    Type.String({
+      title: "Article date",
+      format: "date",
+    }),
+  ),
 })
 
 const imageSchemaObject = Type.Object({


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The collection item dates are currently required, but they should be optional because we already support the dateless variant for collections.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Set the date field to be optional for collection items (links and articles).

## Screenshots

<img width="832" alt="image" src="https://github.com/user-attachments/assets/75bd3129-757c-4b27-874b-57c118da97a8" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- Go to Studio and enter any collection.
- Edit any article page in the collection, remove the article date and save the page. Verify that the page can be saved.
- Edit any collection link in the collection, remove the item date and save the item. Verify that the page can be saved.