### PR TITLE
add configurable title for image schema

### DIFF
--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -5,12 +5,14 @@ import type { IsomerSiteProps } from "~/types"
 import { ARRAY_RADIO_FORMAT } from "../format"
 
 export const generateImageSrcSchema = ({
+  title = "Image",
   description,
 }: {
+  title?: string
   description?: string
 }) => {
   return Type.String({
-    title: "Image",
+    title,
     format: "image",
     description,
   })

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -31,7 +31,7 @@ const imageSchemaObject = Type.Object({
     Type.Object({
       src: generateImageSrcSchema({
         description:
-          "Displayed at the top of the page and as a thumbnail in the collection view",
+          "Displayed as a thumbnail in the collection view",
       }),
       alt: AltTextSchema,
     }),

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -30,8 +30,9 @@ const imageSchemaObject = Type.Object({
   image: Type.Optional(
     Type.Object({
       src: generateImageSrcSchema({
+        title: "Thumbnail",
         description:
-          "Displayed as a thumbnail in the collection view",
+          "Upload an image if you want to have a custom thumbnail for this item",
       }),
       alt: AltTextSchema,
     }),


### PR DESCRIPTION
Allow custom thumbnail title and improve description copy

Updates the image schema to support custom titles and clarifies the thumbnail description text to be more user-friendly.