### PR TITLE
fix - add custom error message for JsonFormsTextAreaControl

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
@@ -12,6 +12,7 @@ import {
   JSON_FORMS_RANKING,
   TEXTAREA_CHARACTERS_PER_ROW,
 } from "~/constants/formBuilder"
+import { getCustomErrorMessage } from "./utils"
 
 export const jsonFormsTextAreaControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.TextAreaControl,
@@ -77,7 +78,7 @@ export function JsonFormsTextAreaControl({
           </FormHelperText>
         )}
         <FormErrorMessage>
-          {label} {errors}
+          {label} {getCustomErrorMessage(errors)}
         </FormErrorMessage>
       </FormControl>
     </Box>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1504/page-editing-error-message-when-title-is-empty

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- wrap in custom error message wrapper

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to a content page (or create one)
2. click to edit "content page header"
3. remove the content of "content page summary". It should NOT say `Content page summary is a required property` but `Content page summary cannot be empty`