### PR TITLE
isom-1574 - fix: add hover color for datatable

### DIFF
--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -119,7 +119,7 @@ export const Datatable = <T extends object>({
                 <Tr
                   key={row.id}
                   borderBottomWidth="1px"
-                  _hover={{ bg: "interaction.muted.main.hover" }}
+                  _hover={{ bgColor: "interaction.muted.main.hover" }}
                 >
                   {row.getVisibleCells().map((cell) => {
                     return (

--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -116,7 +116,11 @@ export const Datatable = <T extends object>({
             {rows.length === 0 && emptyPlaceholder}
             {rows.map((row) => {
               return (
-                <Tr key={row.id} borderBottomWidth="1px">
+                <Tr
+                  key={row.id}
+                  borderBottomWidth="1px"
+                  _hover={{ bg: "interaction.muted.main.hover" }}
+                >
                   {row.getVisibleCells().map((cell) => {
                     return (
                       <Td key={cell.id} verticalAlign="center">


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1574/dashboard-each-row-should-have-hover

datatable missing hover colour as per figma design

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add hover color to row

## Before & After Screenshots

https://github.com/user-attachments/assets/60a6322e-9171-40e7-a0d7-b7cf84790cd5

## Tests

<!-- What tests should be run to confirm functionality? -->

- hover across the different rows - it should have colour. 
  - note: as per figma design, only the name should be clickable  