### PR TITLE
isom-1723 - fix studio table buttons disappear on smaller screen

### DIFF
--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -113,7 +113,6 @@ export const CollectionTable = ({
       instance={tableInstance}
       sx={{
         tableLayout: "auto",
-        minWidth: "1000px",
         overflowX: "auto",
       }}
       totalRowCount={totalRowCount}

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -119,7 +119,6 @@ export const ResourceTable = ({
       instance={tableInstance}
       sx={{
         tableLayout: "auto",
-        minWidth: "1000px",
         overflowX: "auto",
       }}
       totalRowCount={totalCount}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1723/table-on-studio-overflows-horizontally-so-buttons-disappear-on-smaller

there's a minwidth 1000px

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- remove minwidth

## Before & After Screenshots

| before | after |
| - | - |
| <img width="1038" alt="image" src="https://github.com/user-attachments/assets/7d24e9d9-b632-4a7c-abcd-ce181cbb37ce" /> | <img width="1038" alt="image" src="https://github.com/user-attachments/assets/234deb4c-8583-436d-a52f-6f98ea3ca300" /> |

## Tests

1. adjust screen size viewport to be smaller horizontally - the buttons should always be reasonably there