### PR TITLE
fix - add explicit 5000ms timeout for growthbook

### DIFF
--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
-import { userEvent, within } from "@storybook/test"
+import { userEvent, waitFor, within } from "@storybook/test"
 import { ResourceState } from "~prisma/generated/generatedEnums"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
@@ -129,7 +129,11 @@ export const Dropdown: Story = {
   play: async ({ canvasElement, ...rest }) => {
     const canvas = within(canvasElement)
     await EditFixedBlockState.play?.({ canvasElement, ...rest })
-    const button = await canvas.findByRole("combobox")
+    // waitFor used as we can override the default timeout of findByRole (1000ms)
+    // this is needed as growthbook might take more than 1000ms to initialise
+    const button = await waitFor(() => canvas.findByRole("combobox"), {
+      timeout: 5000,
+    })
     await userEvent.click(button)
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react"
-import { userEvent, within } from "@storybook/test"
+import { userEvent, waitFor, within } from "@storybook/test"
 import { ResourceState } from "~prisma/generated/generatedEnums"
 import { collectionHandlers } from "tests/msw/handlers/collection"
 import { meHandlers } from "tests/msw/handlers/me"
@@ -62,14 +62,18 @@ export default meta
 type Story = StoryObj<typeof CollectionLinkPage>
 
 export const Default: Story = {}
+
 export const Dropdown: Story = {
   parameters: {
     growthbook: [createDropdownGbParameters("1")],
   },
-  play: async (context) => {
-    const { canvasElement } = context
+  play: async ({ canvasElement }) => {
     const screen = within(canvasElement)
-    const button = await screen.findByRole("combobox")
+    // waitFor used as we can override the default timeout of findByRole (1000ms)
+    // this is needed as growthbook might take more than 1000ms to initialise
+    const button = await waitFor(() => screen.findByRole("combobox"), {
+      timeout: 5000,
+    })
     await userEvent.click(button)
   },
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

storybook failing intermittently - suspected its due to growthbook initialization taking more than the default timeout of `findByRole` of 1000ms

e.g. https://www.chromatic.com/test?appId=66543928751c844d159a31ef&id=67a050ef4c2883649ed2a658

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- explicitly overwrite the timeout to be 5000ms instead
