### PR TITLE
vica: support asset URL + use site color + fix disappearing between navigation

### DIFF
--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -1,4 +1,4 @@
-import type { IsomerSiteProps, ScriptComponentType } from "~/types"
+import type { IsomerSiteProps } from "~/types"
 
 // NOTE: not all props will be used even if we passed them in
 // as we will override some of them with Isomer's configuration e.g. font-family
@@ -48,5 +48,4 @@ export interface VicaWidgetProps {
 
 export interface VicaProps extends VicaWidgetProps {
   site: IsomerSiteProps
-  ScriptComponent?: ScriptComponentType
 }

--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -1,9 +1,9 @@
-import type { ScriptComponentType } from "~/types"
+import type { IsomerSiteProps, ScriptComponentType } from "~/types"
 
 // NOTE: not all props will be used even if we passed them in
 // as we will override some of them with Isomer's configuration e.g. font-family
 // Nevertheless, keeping them here for reference
-interface VicaWidgetProps {
+export interface VicaWidgetProps {
   // UI Theme
   "app-id": string
   "app-name": string
@@ -47,5 +47,6 @@ interface VicaWidgetProps {
 }
 
 export interface VicaProps extends VicaWidgetProps {
+  site: IsomerSiteProps
   ScriptComponent?: ScriptComponentType
 }

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -34,7 +34,7 @@ export type { SiderailProps } from "./Siderail"
 export type { SkipToContentProps } from "./SkipToContent"
 export type { TableOfContentsProps } from "./TableOfContents"
 export type { WogaaProps } from "./Wogaa"
-export type { VicaProps } from "./Vica"
+export type { VicaWidgetProps, VicaProps } from "./Vica"
 export type {
   GoogleTagManagerHeaderScriptProps,
   GoogleTagManagerHeaderProps,

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -1,32 +1,17 @@
-"use client"
-
 import type { VicaProps } from "~/interfaces"
+import { getReferenceLinkHref } from "~/utils"
+import { VicaWidgetClient } from "./VicaWidgetClient"
 
-export const VicaWidget = ({
-  ScriptComponent = "script",
-  ...props
-}: VicaProps) => {
-  // to not render during static site generation on the server
-  if (typeof window === "undefined") return null
-
+export const VicaWidget = (props: VicaProps) => {
+  const { site, "app-icon": appIcon, ...rest } = props
   return (
-    <>
-      <ScriptComponent
-        async
-        type="text/javascript"
-        src="https://webchat.vica.gov.sg/static/js/chat.js"
-        referrerPolicy="origin"
-        // 'lazyOnload' is recommended by Next.js for chat widgets
-        // Reference: https://nextjs.org/docs/pages/api-reference/components/script#lazyonload
-        strategy="lazyOnload"
-      />
-      <div
-        id="webchat"
-        {...props}
-        app-font-family="Inter, system-ui, sans-serif"
-        // NOTE: Clarifying with VICA regarding color scheme
-        // Once confirmed, will override with site's color scheme for consistency
-      />
-    </>
+    <VicaWidgetClient
+      app-icon={
+        appIcon
+          ? getReferenceLinkHref(appIcon, site.siteMap, site.assetsBaseUrl)
+          : undefined
+      }
+      {...rest}
+    />
   )
 }

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import type { VicaProps } from "~/interfaces"
+
+export const VicaWidgetClient = ({
+  ScriptComponent = "script",
+  ...vica
+}: Omit<VicaProps, "site">) => {
+  // to not render during static site generation on the server
+  if (typeof window === "undefined") return null
+
+  return (
+    <>
+      <ScriptComponent
+        async
+        type="text/javascript"
+        src="https://webchat.vica.gov.sg/static/js/chat.js"
+        referrerPolicy="origin"
+        // 'lazyOnload' is recommended by Next.js for chat widgets
+        // Reference: https://nextjs.org/docs/pages/api-reference/components/script#lazyonload
+        strategy="lazyOnload"
+      />
+      <div
+        id="webchat"
+        {...vica}
+        app-font-family="Inter, system-ui, sans-serif"
+        // NOTE: Clarifying with VICA regarding color scheme
+        // Once confirmed, will override with site's color scheme for consistency
+      />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react"
 
-import type { VicaProps } from "~/interfaces"
+import type { VicaWidgetProps } from "~/interfaces"
 
 // Next.js pre-fetching caused widget to disappear on page navigation
 // Doing this forces the widget to load in between page navigation
@@ -15,7 +15,7 @@ const loadVicaScript = () => {
   document.body.appendChild(scriptTag)
 }
 
-export const VicaWidgetClient = (vica: Omit<VicaProps, "site">) => {
+export const VicaWidgetClient = (vica: VicaWidgetProps) => {
   useEffect(() => {
     // to not render during static site generation on the server
     if (typeof window === "undefined") return

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -6,8 +6,16 @@ import type { VicaWidgetProps } from "~/interfaces"
 
 // Next.js pre-fetching caused widget to disappear on page navigation
 // Doing this forces the widget to load in between page navigation
-const loadVicaScript = () => {
+const reloadVicaScript = () => {
+  const scriptId = "isomer-vica-script"
+
+  const existingScriptTag = document.getElementById(scriptId)
+  if (existingScriptTag) {
+    existingScriptTag.remove()
+  }
+
   const scriptTag = document.createElement("script")
+  scriptTag.id = scriptId
   scriptTag.async = true
   scriptTag.type = "text/javascript"
   scriptTag.src = "https://webchat.vica.gov.sg/static/js/chat.js"
@@ -23,10 +31,10 @@ export const VicaWidgetClient = (vica: VicaWidgetProps) => {
     // Only inject the script after everything else has finished loading
     // This is to replicate Next.js lazyOnload behaviour (as recommended for widgets)
     if (document.readyState === "complete") {
-      loadVicaScript()
+      reloadVicaScript()
     } else {
-      window.addEventListener("load", loadVicaScript)
-      return () => window.removeEventListener("load", loadVicaScript)
+      window.addEventListener("load", reloadVicaScript)
+      return () => window.removeEventListener("load", reloadVicaScript)
     }
   }, [])
 

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -34,9 +34,13 @@ export const VicaWidgetClient = (vica: Omit<VicaProps, "site">) => {
     <div
       id="webchat"
       {...vica}
+      // We ignore config passed in from DB and manually overwrite
+      // the following attributes to ensure consistency and best brand appearance
       app-font-family="Inter, system-ui, sans-serif"
-      // NOTE: Clarifying with VICA regarding color scheme
-      // Once confirmed, will override with site's color scheme for consistency
+      app-foreground-color="#FFFFFF" // hardcoded to be white for all agencies
+      app-color="var(--color-brand-canvas-inverse)"
+      app-button-border-color="var(--color-brand-canvas-inverse)"
+      app-canvas-background-color="var(--color-brand-canvas-default)"
     />
   )
 }

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -1,32 +1,42 @@
 "use client"
 
+import { useEffect } from "react"
+
 import type { VicaProps } from "~/interfaces"
 
-export const VicaWidgetClient = ({
-  ScriptComponent = "script",
-  ...vica
-}: Omit<VicaProps, "site">) => {
-  // to not render during static site generation on the server
-  if (typeof window === "undefined") return null
+// Next.js pre-fetching caused widget to disappear on page navigation
+// Doing this forces the widget to load in between page navigation
+const loadVicaScript = () => {
+  const scriptTag = document.createElement("script")
+  scriptTag.async = true
+  scriptTag.type = "text/javascript"
+  scriptTag.src = "https://webchat.vica.gov.sg/static/js/chat.js"
+  scriptTag.referrerPolicy = "origin"
+  document.body.appendChild(scriptTag)
+}
+
+export const VicaWidgetClient = (vica: Omit<VicaProps, "site">) => {
+  useEffect(() => {
+    // to not render during static site generation on the server
+    if (typeof window === "undefined") return
+
+    // Only inject the script after everything else has finished loading
+    // This is to replicate Next.js lazyOnload behaviour (as recommended for widgets)
+    if (document.readyState === "complete") {
+      loadVicaScript()
+    } else {
+      window.addEventListener("load", loadVicaScript)
+      return () => window.removeEventListener("load", loadVicaScript)
+    }
+  }, [])
 
   return (
-    <>
-      <ScriptComponent
-        async
-        type="text/javascript"
-        src="https://webchat.vica.gov.sg/static/js/chat.js"
-        referrerPolicy="origin"
-        // 'lazyOnload' is recommended by Next.js for chat widgets
-        // Reference: https://nextjs.org/docs/pages/api-reference/components/script#lazyonload
-        strategy="lazyOnload"
-      />
-      <div
-        id="webchat"
-        {...vica}
-        app-font-family="Inter, system-ui, sans-serif"
-        // NOTE: Clarifying with VICA regarding color scheme
-        // Once confirmed, will override with site's color scheme for consistency
-      />
-    </>
+    <div
+      id="webchat"
+      {...vica}
+      app-font-family="Inter, system-ui, sans-serif"
+      // NOTE: Clarifying with VICA regarding color scheme
+      // Once confirmed, will override with site's color scheme for consistency
+    />
   )
 }

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -111,7 +111,13 @@ export const Skeleton = ({
       )}
 
       {/* Ensures that the webchat widget only loads after the page has loaded */}
-      {site.vica && <VicaWidget {...site.vica} />}
+      {site.vica && (
+        <VicaWidget
+          site={site}
+          ScriptComponent={ScriptComponent}
+          {...site.vica}
+        />
+      )}
     </>
   )
 }

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -111,13 +111,7 @@ export const Skeleton = ({
       )}
 
       {/* Ensures that the webchat widget only loads after the page has loaded */}
-      {site.vica && (
-        <VicaWidget
-          site={site}
-          ScriptComponent={ScriptComponent}
-          {...site.vica}
-        />
-      )}
+      {site.vica && <VicaWidget site={site} {...site.vica} />}
     </>
   )
 }

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -1,5 +1,9 @@
 import type { IsomerSitemap } from "./sitemap"
-import type { NavbarProps, NotificationProps, VicaProps } from "~/interfaces"
+import type {
+  NavbarProps,
+  NotificationProps,
+  VicaWidgetProps,
+} from "~/interfaces"
 import type { SiteConfigFooterProps } from "~/interfaces/internal/Footer"
 
 export interface IsomerGeneratedSiteProps {
@@ -26,7 +30,7 @@ export interface IsomerSiteConfigProps {
   search: NavbarProps["search"]
   notification?: Omit<NotificationProps, "LinkComponent" | "site">
   siteGtmId?: string
-  vica?: VicaProps
+  vica?: VicaWidgetProps
 }
 
 export type IsomerSiteProps = IsomerGeneratedSiteProps &


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

currently
- we don't support image asset url from isomer assets bucket (unless we explicitly include the base url)
- colors are hardcoded (because VICA didn't get back to us)
- vica disappears in between navigation

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- preprocess image url during build time and then pass into a client widget component (to prevent passing entire site to client side)
- pass in colors based on site config directly

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
