### PR TITLE
fix - sign in page not full width

### DIFF
--- a/apps/studio/src/pages/sign-in/index.tsx
+++ b/apps/studio/src/pages/sign-in/index.tsx
@@ -18,7 +18,7 @@ import { type NextPageWithLayout } from "~/lib/types"
 const SignIn: NextPageWithLayout = () => {
   return (
     <PublicPageWrapper strict>
-      <Flex flexDir="column" h="inherit" minH="$100vh">
+      <Flex w="100%" flexDir="column" h="inherit" minH="$100vh">
         <RestrictedGovtMasthead />
         <BaseGridLayout flex={1}>
           <NonMobileSidebarGridArea>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

<img width="478" alt="image" src="https://github.com/user-attachments/assets/4acfad23-6e08-4191-8936-d87b09c28a9e" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add width 100%

## Before & After Screenshots

| before | after |
| - | - |
| ![Screenshot 2025-02-05 at 1 37 37 AM](https://github.com/user-attachments/assets/df98c0b3-af5a-4cb0-a9e6-12e4e23cbd3a) | ![Screenshot 2025-02-05 at 1 38 14 AM](https://github.com/user-attachments/assets/150b1a99-25b8-4935-8b14-01c6d3de6a97) |

## Tests

1. go to login page on a wide screen - the page should be centralized (masthead should be entirety of the screen)