### PR TITLE
chore: remove unused variables

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -114,9 +114,6 @@ on:
       DD_API_KEY:
         description: "Datadog API key for uploading sourcemaps"
         required: false
-      RDS_READER_ENDPOINT:
-        description: "RDS reader endpoint for database connection"
-        required: false
 
 permissions:
   id-token: write
@@ -213,8 +210,6 @@ jobs:
           sed -i 's/<SHORT_ENV>/${{ inputs.shortEnv }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<CPU>/${{ inputs.environment == 'production' && 1024 || 512 }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<MEMORY>/${{ inputs.environment == 'production' && 2048 || 1024 }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<RDS_READER_ENDPOINT>/${{ secrets.RDS_READER_ENDPOINT }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<RDS_DATADOG_PASSWORD>/${{ secrets.RDS_DATADOG_PASSWORD}}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<DD_COMMIT_SHA>/${{ github.sha }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<ECS_TASK_ROLE>/${{ inputs.ecs-task-role }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<ECS_TASK_EXEC_ROLE>/${{ inputs.ecs-task-exec-role }}/g' ${{ inputs.ecs-task-definition-path }}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -44,4 +44,3 @@ jobs:
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
-      RDS_READER_ENDPOINT: ${{ secrets.RDS_READER_ENDPOINT }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -44,4 +44,3 @@ jobs:
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
-      RDS_READER_ENDPOINT: ${{ secrets.RDS_READER_ENDPOINT }}

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -44,4 +44,3 @@ jobs:
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
-      RDS_READER_ENDPOINT: ${{ secrets.RDS_READER_ENDPOINT }}


### PR DESCRIPTION
## Problem
- we have 2 unused variables for datadog, which are both removed here

## Solution
- removed the variables, cross checked against `task-def` to make sure we weren't using them