### PR TITLE
chore: fix publishing for empty links

### DIFF
--- a/apps/studio/src/features/editing-experience/atoms.ts
+++ b/apps/studio/src/features/editing-experience/atoms.ts
@@ -19,3 +19,9 @@ export const linkAtom = atom<CollectionLinkProps>({
   category: "",
   title: "",
 })
+
+// NOTE: We need this because this atom takes in the value
+// for the ref when the link itself is saved.
+// This is strictly used for validation to see
+// if we should allow the `Publish`
+export const linkRefAtom = atom("")

--- a/apps/studio/src/features/editing-experience/components/LinkEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditNavbar.tsx
@@ -7,12 +7,14 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { Breadcrumb } from "@opengovsg/design-system-react"
+import { useAtomValue } from "jotai"
 
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { editLinkSchema } from "~/pages/sites/[siteId]/links/[linkId]"
 import { getResourceSubpath } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
+import { linkRefAtom } from "../atoms"
 import PublishButton from "./PublishButton"
 
 interface NavigationBreadcrumbsProps {
@@ -92,6 +94,7 @@ const NavigationBreadcrumbs = ({
 
 export const LinkEditNavbar = (): JSX.Element => {
   const { linkId, siteId } = useQueryParse(editLinkSchema)
+  const ref = useAtomValue(linkRefAtom)
 
   return (
     <Flex
@@ -112,7 +115,7 @@ export const LinkEditNavbar = (): JSX.Element => {
 
       {linkId && siteId && (
         <Flex justifyContent={"end"} alignItems={"center"} flex={1}>
-          <PublishButton pageId={linkId} siteId={siteId} />
+          <PublishButton pageId={linkId} siteId={siteId} isDisabled={!ref} />
         </Flex>
       )}
     </Flex>

--- a/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, Text, VStack } from "@chakra-ui/react"
 import { Button, useToast } from "@opengovsg/design-system-react"
 import { LAYOUT_PAGE_MAP } from "@opengovsg/isomer-components"
 import Ajv from "ajv"
-import { useAtom } from "jotai"
+import { useAtom, useSetAtom } from "jotai"
 import isEmpty from "lodash/isEmpty"
 import isEqual from "lodash/isEqual"
 import { z } from "zod"
@@ -15,7 +15,7 @@ import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { safeJsonParse } from "~/utils/safeJsonParse"
 import { trpc } from "~/utils/trpc"
-import { linkAtom } from "../atoms"
+import { linkAtom, linkRefAtom } from "../atoms"
 import { ActivateRawJsonEditorMode } from "./ActivateRawJsonEditorMode"
 import { ErrorProvider, useBuilderErrors } from "./form-builder/ErrorProvider"
 import FormBuilder from "./form-builder/FormBuilder"
@@ -165,6 +165,7 @@ export const LinkEditorDrawer = () => {
   const [data, setLinkAtom] = useAtom(linkAtom)
   const utils = trpc.useUtils()
   const toast = useToast()
+  const setLinkRef = useSetAtom(linkRefAtom)
 
   const [{ content, title }] =
     trpc.collection.readCollectionLink.useSuspenseQuery(
@@ -178,6 +179,7 @@ export const LinkEditorDrawer = () => {
             ...(data.content.page as CollectionLinkProps),
             title: data.title,
           })
+          setLinkRef((data.content.page as CollectionLinkProps).ref)
         },
         refetchOnWindowFocus: false,
       },

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -20,6 +20,7 @@ const SuspendablePublishButton = ({
   pageId,
   siteId,
   isDisabled,
+  onClick,
   ...rest
 }: PublishButtonProps): JSX.Element => {
   const toast = useToast()
@@ -73,7 +74,10 @@ const SuspendablePublishButton = ({
               isDisabled={!isChangesPendingPublish || isDisabled}
               variant="solid"
               size="sm"
-              onClick={handlePublish}
+              onClick={(e) => {
+                handlePublish()
+                onClick?.(e)
+              }}
               isLoading={isLoading}
               {...rest}
             >

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from "@chakra-ui/react"
 import {
   Button,
+  ButtonProps,
   TouchableTooltip,
   useToast,
 } from "@opengovsg/design-system-react"
@@ -10,7 +11,7 @@ import { Can } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
 
-interface PublishButtonProps {
+interface PublishButtonProps extends ButtonProps {
   pageId: number
   siteId: number
 }
@@ -18,6 +19,8 @@ interface PublishButtonProps {
 const SuspendablePublishButton = ({
   pageId,
   siteId,
+  isDisabled,
+  ...rest
 }: PublishButtonProps): JSX.Element => {
   const toast = useToast()
   const utils = trpc.useUtils()
@@ -67,11 +70,12 @@ const SuspendablePublishButton = ({
         >
           {allowed && (
             <Button
-              isDisabled={!isChangesPendingPublish}
+              isDisabled={!isChangesPendingPublish || isDisabled}
               variant="solid"
               size="sm"
               onClick={handlePublish}
               isLoading={isLoading}
+              {...rest}
             >
               Publish
             </Button>


### PR DESCRIPTION
## Problem
1. users can publish empty links 

## Solution
1. add a `ref` atom that we use **ONLY** to validate to see if a user can publish
2. this is only updated `onSave` - so we know it's accurate
3. we cannot use the other `linkAtom` as that's required for updating our UI

## Videos
https://github.com/user-attachments/assets/6554f0fb-49da-47c3-8e05-27179477410d

## Tests
1. create a new collection link 
2. ensure that publishing is blocked
3. add a ref
4. publishing shuold still be blocked
5. click save
6. publishing should be allowed
7. go back to the collection
8. repeat steps 1-2 