### PR TITLE
fix: respect page ordering for GitHub sites

### DIFF
--- a/tooling/build/scripts/generate-sitemap.js
+++ b/tooling/build/scripts/generate-sitemap.js
@@ -244,10 +244,27 @@ const getSiteMapChildrenEntries = async (fullPath, relativePath) => {
 
   children.push(...danglingDirEntries)
 
-  // Ensure that the result is ordered in alphabetical order
-  children.sort((a, b) =>
-    a.title.localeCompare(b.title, undefined, { numeric: true }),
-  )
+  children.sort((a, b) => {
+    const aPermalink = a.permalink.split("/").pop()
+    const bPermalink = b.permalink.split("/").pop()
+
+    if (!pageOrderData) {
+      return a.title.localeCompare(b.title, undefined, { numeric: true })
+    }
+
+    if (pageOrderData.order.indexOf(aPermalink) === -1) {
+      return 1
+    }
+
+    if (pageOrderData.order.indexOf(bPermalink) === -1) {
+      return -1
+    }
+
+    return (
+      pageOrderData.order.indexOf(aPermalink) -
+      pageOrderData.order.indexOf(bPermalink)
+    )
+  })
 
   return children
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The page ordering functionality that we have for Studio is not available for GitHub sites.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Duplicate the page ordering functionality that Studio has to GitHub sites.