### PR TITLE
chore: add back to top for article

### DIFF
--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -1,5 +1,6 @@
 import { type ArticlePageSchemaType } from "~/engine"
 import { getBreadcrumbFromSiteMap } from "~/utils"
+import { BackToTopLink } from "../../components/internal"
 import ArticlePageHeader from "../../components/internal/ArticlePageHeader"
 import { renderPageContent } from "../../render"
 import { Skeleton } from "../Skeleton"
@@ -46,6 +47,7 @@ const ArticleLayout = ({
               LinkComponent,
             })}
           </div>
+          <BackToTopLink />
         </div>
       </div>
     </Skeleton>


### PR DESCRIPTION
## Problem
collection pages don't have back to top button

## Solution
add back to top button below the content 

## Videos

https://github.com/user-attachments/assets/eb75df60-b2dc-4d60-83db-b4b49ccc8ba0

## Tests
1. open up a article page in a folder
2. scroll to bottom
3. click back to top
4. it should work
5. repeat steps 1-4 but for an article page inside a collection

