### PR TITLE
chore: add eslint rule

### DIFF
--- a/apps/studio/eslint.config.mjs
+++ b/apps/studio/eslint.config.mjs
@@ -18,6 +18,25 @@ export default [
         "error",
         { ignorePrimitives: true },
       ],
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@chakra-ui/react",
+              importNames: ["useToast"],
+              message:
+                "Please use useToast from @opengovsg/design-system-react instead.",
+            },
+            {
+              name: "@chakra-ui/react",
+              importNames: ["FormLabel", "FormErrorMessage", "FormHelperText"],
+              message:
+                "Please use FormLabel, FormErrorMessage, and FormHelperText from @opengovsg/design-system-react instead.",
+            },
+          ],
+        },
+      ],
     },
   },
 ]

--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -2,7 +2,6 @@ import type { Editor } from "@tiptap/react"
 import { useEffect } from "react"
 import {
   FormControl,
-  FormHelperText,
   HStack,
   Modal,
   ModalBody,
@@ -14,6 +13,7 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
   FormLabel,
   ModalCloseButton,
   Textarea,

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -3,8 +3,6 @@ import {
   Box,
   chakra,
   FormControl,
-  FormHelperText,
-  FormLabel,
   Icon,
   Input,
   Modal,
@@ -21,6 +19,8 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
+  FormLabel,
   useToast,
 } from "@opengovsg/design-system-react"
 import { useAtomValue, useSetAtom } from "jotai"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -4,8 +4,6 @@ import { useEffect } from "react"
 import {
   Box,
   FormControl,
-  FormHelperText,
-  FormLabel,
   Icon,
   Input,
   Modal,
@@ -19,6 +17,8 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
+  FormLabel,
   ModalCloseButton,
   useToast,
 } from "@opengovsg/design-system-react"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -3,8 +3,6 @@ import {
   chakra,
   Flex,
   FormControl,
-  FormHelperText,
-  FormLabel,
   Input,
   ListItem,
   ModalBody,
@@ -17,6 +15,8 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
+  FormLabel,
   Infobox,
 } from "@opengovsg/design-system-react"
 import { ResourceType } from "~prisma/generated/generatedEnums"

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -4,8 +4,6 @@ import { useEffect } from "react"
 import {
   Box,
   FormControl,
-  FormHelperText,
-  FormLabel,
   Icon,
   Input,
   Modal,
@@ -19,6 +17,8 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
+  FormLabel,
   ModalCloseButton,
   useToast,
 } from "@opengovsg/design-system-react"

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -3,8 +3,6 @@ import {
   chakra,
   Flex,
   FormControl,
-  FormHelperText,
-  FormLabel,
   Input,
   ModalBody,
   ModalHeader,
@@ -15,6 +13,8 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
+  FormLabel,
   Infobox,
 } from "@opengovsg/design-system-react"
 import { Controller } from "react-hook-form"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
@@ -1,9 +1,10 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import { Box, FormControl, FormHelperText } from "@chakra-ui/react"
+import { Box, FormControl } from "@chakra-ui/react"
 import { and, isStringControl, rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import {
   FormErrorMessage,
+  FormHelperText,
   FormLabel,
   Textarea,
 } from "@opengovsg/design-system-react"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
@@ -1,9 +1,10 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import { Box, FormControl, FormHelperText } from "@chakra-ui/react"
+import { Box, FormControl } from "@chakra-ui/react"
 import { isStringControl, rankWith } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import {
   FormErrorMessage,
+  FormHelperText,
   FormLabel,
   Input,
 } from "@opengovsg/design-system-react"

--- a/apps/studio/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
+++ b/apps/studio/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
@@ -2,7 +2,6 @@ import { useState } from "react"
 import { useRouter } from "next/router"
 import {
   FormControl,
-  FormLabel,
   InputGroup,
   InputLeftAddon,
   Stack,
@@ -10,6 +9,7 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormLabel,
   Infobox,
   Input,
 } from "@opengovsg/design-system-react"

--- a/packages/components/eslint.config.mjs
+++ b/packages/components/eslint.config.mjs
@@ -40,6 +40,10 @@ export default [
               message:
                 "Please use export from ~/lib/twMerge instead of the node module",
             },
+            {
+              name: "next/navigation",
+              message: "Please use export from next instead of next/navigation",
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Problem
we have a few imports that should be banned - this adds eslint rules to prevent them

## Solution
1. add eslint rule to ban chakra imports that have duplicates in ogpds
2. add eslint rule to ban `next/navigation` in components