### PR TITLE
chore: fix infinite login spinner

### DIFF
--- a/apps/studio/src/components/ErrorBoundary/DefaultFallback.tsx
+++ b/apps/studio/src/components/ErrorBoundary/DefaultFallback.tsx
@@ -7,7 +7,7 @@ import { UnexpectedErrorCard } from "./UnexpectedErrorCard"
 
 export const DefaultFallback: ComponentType<FallbackProps> = ({
   error,
-  // resetErrorBoundary,
+  resetErrorBoundary,
 }) => {
   // Call resetErrorBoundary() to reset the error boundary and retry the render.
 
@@ -15,5 +15,7 @@ export const DefaultFallback: ComponentType<FallbackProps> = ({
 
   if (!res.success) return <UnexpectedErrorCard />
 
-  return <DefaultTrpcError code={res.data} />
+  return (
+    <DefaultTrpcError code={res.data} resetErrorBoundary={resetErrorBoundary} />
+  )
 }

--- a/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
+++ b/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
@@ -3,12 +3,11 @@ import { useRouter } from "next/router"
 import { type TRPC_ERROR_CODE_KEY } from "@trpc/server/rpc"
 
 import { trpc } from "~/utils/trpc"
-import { FullscreenSpinner } from "../FullscreenSpinner"
 import { DefaultNotFound } from "./DefaultNotFound"
 import { DefaultServerError } from "./DefaultServerError"
 import { UnexpectedErrorCard } from "./UnexpectedErrorCard"
 
-function UnauthorizedError() {
+export const UnauthorizedError = () => {
   const utils = trpc.useUtils()
   const router = useRouter()
   useEffect(() => {
@@ -16,7 +15,7 @@ function UnauthorizedError() {
     void router.push("/")
   }, [utils, router])
 
-  return <FullscreenSpinner />
+  return null
 }
 
 // TODO: Make custom components for these

--- a/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
+++ b/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
@@ -8,7 +8,7 @@ import { DefaultNotFound } from "./DefaultNotFound"
 import { DefaultServerError } from "./DefaultServerError"
 import { UnexpectedErrorCard } from "./UnexpectedErrorCard"
 
-export const UnauthorizedError = ({
+const UnauthorizedError = ({
   resetErrorBoundary,
 }: Pick<FallbackProps, "resetErrorBoundary">) => {
   const utils = trpc.useUtils()

--- a/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
+++ b/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
@@ -1,32 +1,37 @@
-import { useEffect } from "react"
 import { useRouter } from "next/router"
 import { type TRPC_ERROR_CODE_KEY } from "@trpc/server/rpc"
+import { FallbackProps } from "react-error-boundary"
 
 import { trpc } from "~/utils/trpc"
+import { FullscreenSpinner } from "../FullscreenSpinner"
 import { DefaultNotFound } from "./DefaultNotFound"
 import { DefaultServerError } from "./DefaultServerError"
 import { UnexpectedErrorCard } from "./UnexpectedErrorCard"
 
-export const UnauthorizedError = () => {
+export const UnauthorizedError = ({
+  resetErrorBoundary,
+}: Pick<FallbackProps, "resetErrorBoundary">) => {
   const utils = trpc.useUtils()
   const router = useRouter()
-  useEffect(() => {
-    void utils.invalidate()
-    void router.push("/")
-  }, [utils, router])
+  void utils.invalidate()
+  void router.push("/")
+  void resetErrorBoundary()
 
-  return null
+  return <FullscreenSpinner />
 }
 
 // TODO: Make custom components for these
-export function DefaultTrpcError({ code }: { code: TRPC_ERROR_CODE_KEY }) {
+export function DefaultTrpcError({
+  code,
+  resetErrorBoundary,
+}: { code: TRPC_ERROR_CODE_KEY } & Pick<FallbackProps, "resetErrorBoundary">) {
   switch (code) {
     case "NOT_FOUND":
       return <DefaultNotFound />
 
     case "UNAUTHORIZED":
       // TODO: add the default error boundary for perms here
-      return <UnauthorizedError />
+      return <UnauthorizedError resetErrorBoundary={resetErrorBoundary} />
 
     case "TIMEOUT":
     case "INTERNAL_SERVER_ERROR":


### PR DESCRIPTION
## Problem
See ticket

Closes ISOM-1716 (hopefully)

## Solution
- removed the full screen spinner and instead, return null since we're redirected out to `/` 

## Notes
- i tested this via setting the redirect in `/:page/settings`; previously, it showed teh spinner **even after** redirection but now, it displays only the expected content
- i think this happens because we wrap our app in a default error boundary, so this spinner displays **even after** redirection out to the new page

## Tests
1. give yourself access to some site 
2. go to that site 
3. now, delete your access to the site
4. refresh teh page
5. you should get redirected out to `/`
6. there shuold not be a loading spinner