### PR TITLE
chore: prevent users from updating index page wrongly

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -56,7 +56,7 @@ export const ResourceTableMenu = ({
       <Portal>
         <MenuList>
           {/* TODO: Open edit modal depending on resource  */}
-          {type === ResourceType.Page ? (
+          {type === ResourceType.Page && (
             <>
               <MenuItem
                 onClick={() =>
@@ -77,7 +77,8 @@ export const ResourceTableMenu = ({
                 </MenuItem>
               </Can>
             </>
-          ) : (
+          )}
+          {type === ResourceType.Folder && (
             <MenuItem
               onClick={() =>
                 setFolderSettingsModalState({


### PR DESCRIPTION
## Problem
index pages should not need to be updated - currently, isomer admins can update either name/permalink but the index page should have a fixed permalink and use the name of the containing directory (folder/collection), so this is wrong too

## Solution
1. remove capability for isomer admins to update title/permalink

## Tests
1. sign in as isomer admi
2. go to a collection
3. create index page
4. click the menu button
5. should not see an option to update the settings
6. repeat setps 2-5 but for folders