### PR TITLE
chore: add rachel as Isomer admin user

### DIFF
--- a/apps/studio/prisma/constants.ts
+++ b/apps/studio/prisma/constants.ts
@@ -8,6 +8,7 @@ export const ISOMER_ADMINS = [
   "adriangoh",
   "shazli",
   "jinhui",
+  "rachellin",
 ]
 
 export const ISOMER_MIGRATORS = [


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Rachel is not part of the Isomer admins when creating new sites.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add Rachel as Isomer admin, so she's automatically added as an admin for new sites.