### PR TITLE
fix(bug): link editor throws an error when the referenced item has been deleted

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/components/LinkErrorBoundary.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/LinkErrorBoundary.tsx
@@ -1,0 +1,50 @@
+import { PropsWithChildren } from "react"
+import { IconButton, Stack, Text } from "@chakra-ui/react"
+import { Infobox } from "@opengovsg/design-system-react"
+import { ErrorBoundary } from "react-error-boundary"
+import { BiTrash } from "react-icons/bi"
+
+interface LinkErrorBoundaryProps {
+  resetLink: () => void
+}
+export const LinkErrorBoundary = ({
+  resetLink,
+  children,
+}: PropsWithChildren<LinkErrorBoundaryProps>) => {
+  return (
+    <ErrorBoundary
+      fallbackRender={({ resetErrorBoundary }) => (
+        <Infobox
+          variant="error"
+          borderRadius="4px"
+          borderColor="utility.feedback.critical"
+          border="1px solid"
+          bg="utility.feedback.critical"
+          w="100%"
+          size="sm"
+        >
+          <Stack direction="column" w="full">
+            <Text textStyle="subhead-2">
+              The page you linked no longer exists
+            </Text>
+            <Text> Pick a different destination</Text>
+          </Stack>
+          <IconButton
+            size="xs"
+            variant="clear"
+            alignSelf="center"
+            colorScheme="critical"
+            aria-label="Remove file"
+            icon={<BiTrash />}
+            onClick={() => {
+              resetLink()
+              resetErrorBoundary()
+            }}
+          />
+        </Infobox>
+      )}
+    >
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/components/LinkErrorBoundary.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/LinkErrorBoundary.tsx
@@ -16,7 +16,7 @@ export const LinkErrorBoundary = ({
       fallbackRender={({ resetErrorBoundary }) => (
         <Infobox
           variant="error"
-          borderRadius="4px"
+          borderRadius="0.25rem"
           borderColor="utility.feedback.critical"
           border="1px solid"
           bg="utility.feedback.critical"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
@@ -6,10 +6,12 @@ import {
   FormControl,
   IconButton,
   Skeleton,
+  Stack,
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
-import { Button, FormLabel } from "@opengovsg/design-system-react"
+import { Button, FormLabel, Infobox } from "@opengovsg/design-system-react"
+import { ErrorBoundary } from "react-error-boundary"
 import { BiTrash } from "react-icons/bi"
 
 import type { LinkTypesWithHrefFormat } from "../../../LinkEditor/constants"
@@ -71,50 +73,82 @@ export function BaseLinkControl({
     <>
       <Box as={FormControl} isRequired={required}>
         <FormLabel>{label}</FormLabel>
-        <Flex
-          px="1rem"
-          py="0.75rem"
-          flexDir="row"
-          background="brand.primary.100"
-          justifyContent="space-between"
-          alignItems="center"
-        >
-          {!!data ? (
-            <>
-              {pageType !== LINK_TYPES.Page && (
-                <Text overflow="auto">{displayedHref}</Text>
-              )}
-              {pageType === LINK_TYPES.Page && dataString.length > 0 && (
-                <Suspense fallback={<Skeleton w="100%" h="100%" />}>
-                  <SuspendableLabel
-                    resourceId={getResourceIdFromReferenceLink(dataString)}
-                  />
-                </Suspense>
-              )}
+        <ErrorBoundary
+          fallbackRender={({ resetErrorBoundary }) => (
+            <Infobox
+              variant="error"
+              borderRadius="4px"
+              borderColor="utility.feedback.critical"
+              border="1px solid"
+              bg="utility.feedback.critical"
+              w="100%"
+              size="sm"
+            >
+              <Stack direction="column" w="full">
+                <Text textStyle="subhead-2">
+                  The page you linked no longer exists
+                </Text>
+                <Text textStyle="body-2"> Pick a different destination</Text>
+              </Stack>
               <IconButton
                 size="xs"
                 variant="clear"
                 colorScheme="critical"
                 aria-label="Remove file"
                 icon={<BiTrash />}
-                onClick={() => handleChange(path, undefined)}
+                onClick={() => {
+                  handleChange(path, undefined)
+                  resetErrorBoundary()
+                }}
               />
-            </>
-          ) : (
-            <>
-              <Text>{description}</Text>
-              <Button
-                onClick={onOpen}
-                variant="link"
-                aria-labelledby="button-label"
-              >
-                <Text id="button-label" textStyle="subhead-2">
-                  Link something...
-                </Text>
-              </Button>
-            </>
+            </Infobox>
           )}
-        </Flex>
+        >
+          <Flex
+            px="1rem"
+            py="0.75rem"
+            flexDir="row"
+            background="brand.primary.100"
+            justifyContent="space-between"
+            alignItems="center"
+          >
+            {!!data ? (
+              <>
+                {pageType !== LINK_TYPES.Page && (
+                  <Text overflow="auto">{displayedHref}</Text>
+                )}
+                {pageType === LINK_TYPES.Page && dataString.length > 0 && (
+                  <Suspense fallback={<Skeleton w="100%" h="100%" />}>
+                    <SuspendableLabel
+                      resourceId={getResourceIdFromReferenceLink(dataString)}
+                    />
+                  </Suspense>
+                )}
+                <IconButton
+                  size="xs"
+                  variant="clear"
+                  colorScheme="critical"
+                  aria-label="Remove file"
+                  icon={<BiTrash />}
+                  onClick={() => handleChange(path, undefined)}
+                />
+              </>
+            ) : (
+              <>
+                <Text>{description}</Text>
+                <Button
+                  onClick={onOpen}
+                  variant="link"
+                  aria-labelledby="button-label"
+                >
+                  <Text id="button-label" textStyle="subhead-2">
+                    Link something...
+                  </Text>
+                </Button>
+              </>
+            )}
+          </Flex>
+        </ErrorBoundary>
       </Box>
       <LinkEditorModal
         linkTypes={linkTypes}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
@@ -6,12 +6,10 @@ import {
   FormControl,
   IconButton,
   Skeleton,
-  Stack,
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
-import { Button, FormLabel, Infobox } from "@opengovsg/design-system-react"
-import { ErrorBoundary } from "react-error-boundary"
+import { Button, FormLabel } from "@opengovsg/design-system-react"
 import { BiTrash } from "react-icons/bi"
 
 import type { LinkTypesWithHrefFormat } from "../../../LinkEditor/constants"
@@ -21,6 +19,7 @@ import { getResourceIdFromReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
 import { LINK_TYPES } from "../../../LinkEditor/constants"
 import { getLinkHrefType } from "../../../LinkEditor/utils"
+import { LinkErrorBoundary } from "../../components/LinkErrorBoundary"
 
 const parseHref = (href: string, pageType: LinkTypesWithHrefFormat) => {
   switch (pageType) {
@@ -73,37 +72,7 @@ export function BaseLinkControl({
     <>
       <Box as={FormControl} isRequired={required}>
         <FormLabel>{label}</FormLabel>
-        <ErrorBoundary
-          fallbackRender={({ resetErrorBoundary }) => (
-            <Infobox
-              variant="error"
-              borderRadius="4px"
-              borderColor="utility.feedback.critical"
-              border="1px solid"
-              bg="utility.feedback.critical"
-              w="100%"
-              size="sm"
-            >
-              <Stack direction="column" w="full">
-                <Text textStyle="subhead-2">
-                  The page you linked no longer exists
-                </Text>
-                <Text textStyle="body-2"> Pick a different destination</Text>
-              </Stack>
-              <IconButton
-                size="xs"
-                variant="clear"
-                colorScheme="critical"
-                aria-label="Remove file"
-                icon={<BiTrash />}
-                onClick={() => {
-                  handleChange(path, undefined)
-                  resetErrorBoundary()
-                }}
-              />
-            </Infobox>
-          )}
-        >
+        <LinkErrorBoundary resetLink={() => handleChange(path, undefined)}>
           <Flex
             px="1rem"
             py="0.75rem"
@@ -148,7 +117,7 @@ export function BaseLinkControl({
               </>
             )}
           </Flex>
-        </ErrorBoundary>
+        </LinkErrorBoundary>
       </Box>
       <LinkEditorModal
         linkTypes={linkTypes}


### PR DESCRIPTION
## Problem
Currently, when we delete a link and go back to an item that is referencing it, we will see an error page with no way for the user to self resolve; this isn't ideal

## Solution
1. add error boundary and use it in `BaseLinkControl`
2. the error stems from `getWithFullPermalink` - at present, only this method throws an error for the children of the error boundary, so we won't display this error boundary for an unrelated error
3. for other call sites of `getWithFullPermalink`, the precondition (at least on frontend) is that hte resource exists 
    - link editor modal, where we click on an item 
    - folder settings modal (for full permalink of folder) 
    - create page (full permalink of parent) 
    hence, i didn't add on those places

## Video

https://github.com/user-attachments/assets/d35f38b1-4e1b-4ad7-a82e-13351dbc3271

## Tests 
1. Go to any Studio site and edit the home page.
2. Use the raw JSON editor mode to change the primary CTA button link to a reference link pointing to a non-existent resource ID, then save.
3. Click on the button to edit the hero banner.
4. You should see the infobox on the button link 
5. Click the trash icon
6. Relink an existing page and save
7. reload the page
8. the page should not crash