### PR TITLE
chore: break word and resolve overflow

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -59,7 +59,7 @@ export const BaseBlock = ({
           <Icon as={icon} fontSize="0.75rem" color="base.content.default" />
         </Flex>
       )}
-      <Stack align="start" gap="0.25rem">
+      <Stack align="start" gap="0.25rem" overflow="auto">
         <Text textStyle="subhead-2" noOfLines={1}>
           {label}
         </Text>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
@@ -30,7 +30,7 @@ export const EditorContainer = ({
 
   return (
     <Box
-      wordBreak="break-all"
+      wordBreak="break-word"
       h="100%"
       transitionProperty="common"
       transitionDuration="normal"

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -59,6 +59,21 @@ export default meta
 type Story = StoryObj<typeof EditPage>
 
 export const Default: Story = {}
+export const Wordbreak: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const button = await canvas.findByRole("button", {
+      name: /This is a prose block/i,
+    })
+    await userEvent.click(button)
+
+    const textbox = await canvas.findByRole("textbox")
+    await userEvent.type(
+      textbox,
+      "long words should be preserved: supercalifragilisticexpialidocious",
+    )
+  },
+}
 
 export const EditFixedBlockState: Story = {
   play: async ({ canvasElement }) => {

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -55,6 +55,21 @@ export default meta
 type Story = StoryObj<typeof EditPage>
 
 export const Default: Story = {}
+export const Wordbreak: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const button = await canvas.findByRole("button", {
+      name: /This is a prose block/i,
+    })
+    await userEvent.click(button)
+
+    const textbox = await canvas.findByRole("textbox")
+    await userEvent.type(
+      textbox,
+      "long words should be preserved: supercalifragilisticexpialidocious",
+    )
+  },
+}
 
 export const EditFixedBlockState: Story = {
   play: async ({ canvasElement }) => {

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -384,6 +384,20 @@ export const pageHandlers = {
                 content: [
                   {
                     type: "paragraph",
+                    content: [
+                      {
+                        text: "Thisisaproseblockthathasnospacesandshouldautomaticallytruncatetopreventoverflow",
+                        type: "text",
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                type: "prose",
+                content: [
+                  {
+                    type: "paragraph",
                     content: [],
                   },
                 ],
@@ -579,6 +593,20 @@ export const pageHandlers = {
                   {
                     type: "paragraph",
                     content: [],
+                  },
+                ],
+              },
+              {
+                type: "prose",
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        text: "Thisisaproseblockthathasnospacesandshouldautomaticallytruncatetopreventoverflow",
+                        type: "text",
+                      },
+                    ],
                   },
                 ],
               },


### PR DESCRIPTION
## Problem
1. right now we are using `break-all` in tiptap, which causes wordbreak to be annoying.

## Solution
1. update to `break-word` - however, the preview text can now overflow (very long word, no space) so i had to add `overflow: auto` 

## Video

https://github.com/user-attachments/assets/5db726c1-987a-4f73-bba1-b8a5555b6a14

## Tests
1. create a new page
2. add a new text block
3. go into the text block
4. type out a sentence with a long word (like: supercalifragilisticexplalidicious) at the end
5. the long word should not be randomly truncated in the middle but reflow to the next time
6. type out a huge chunk of words without space (eg: testtesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttesttest) 
7. click save
8. the preview text should be automatically hidden rather than overflowing