### PR TITLE
fix: prevent folder items from moving into collection

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -294,6 +294,17 @@ export const resourceRouter = router({
               })
             }
 
+            if (
+              parent.type === ResourceType.Collection &&
+              toMove.type !== ResourceType.CollectionPage &&
+              toMove.type !== ResourceType.CollectionLink
+            ) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Folder items can only be moved to another folder",
+              })
+            }
+
             if (movedResourceId === destinationResourceId) {
               throw new TRPCError({ code: "BAD_REQUEST" })
             }


### PR DESCRIPTION
## Problem
folder items shouldn't be movable into collection

## Solution
add another check to prevent folder items from being moved into a non folder

## Steps
1. create a folder
2. create a page inside the folder
3. create a collection
4. try to move the page into the collection
5. this should fail
6. try to move the folder itself into the collection
7. this should fail
8. create another collection
9. repeat steps 1-7 but with the move destination as the new folder
10. they should all succeed

## Video

https://github.com/user-attachments/assets/f216528f-f055-4e95-ac19-bcd999134791

