### PR TITLE
isom-1740 backend user management service (tracking last login)

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -93,6 +93,7 @@ export interface User {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
   deletedAt: Timestamp | null
+  lastLoginAt: Timestamp | null
 }
 export interface VerificationToken {
   identifier: string

--- a/apps/studio/prisma/migrations/20250218133951_add_user_last_login_at/migration.sql
+++ b/apps/studio/prisma/migrations/20250218133951_add_user_last_login_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "lastLoginAt" TIMESTAMP(3);

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -122,6 +122,7 @@ model User {
   createdAt DateTime  @default(now())
   updatedAt DateTime  @default(now()) @updatedAt
   deletedAt DateTime?
+  lastLoginAt DateTime?
 
   ResourcePermission ResourcePermission[]
   versions           Version[]

--- a/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
+++ b/apps/studio/src/components/ErrorBoundary/DefaultTrpcError.tsx
@@ -1,6 +1,6 @@
+import type { FallbackProps } from "react-error-boundary"
 import { useRouter } from "next/router"
 import { type TRPC_ERROR_CODE_KEY } from "@trpc/server/rpc"
-import { FallbackProps } from "react-error-boundary"
 
 import { trpc } from "~/utils/trpc"
 import { FullscreenSpinner } from "../FullscreenSpinner"

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -1,7 +1,7 @@
+import type { ButtonProps } from "@opengovsg/design-system-react"
 import { Skeleton } from "@chakra-ui/react"
 import {
   Button,
-  ButtonProps,
   TouchableTooltip,
   useToast,
 } from "@opengovsg/design-system-react"

--- a/apps/studio/src/features/editing-experience/components/form-builder/components/LinkErrorBoundary.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/LinkErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react"
+import type { PropsWithChildren } from "react"
 import { IconButton, Stack, Text } from "@chakra-ui/react"
 import { Infobox } from "@opengovsg/design-system-react"
 import { ErrorBoundary } from "react-error-boundary"

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -99,7 +99,9 @@ export const emailSessionRouter = router({
 
       const user = await ctx.prisma.user.upsert({
         where: { email },
-        update: {},
+        update: {
+          lastLoginAt: new Date(),
+        },
         create: {
           email,
           // TODO: add the phone in later, this is a wip

--- a/apps/studio/src/server/modules/auth/sgid/__tests__/sgid.service.test.ts
+++ b/apps/studio/src/server/modules/auth/sgid/__tests__/sgid.service.test.ts
@@ -1,0 +1,63 @@
+import { resetTables } from "tests/integration/helpers/db"
+import { describe, expect, it } from "vitest"
+
+import { prisma } from "~/server/prisma"
+import { upsertSgidAccountAndUser } from "../sgid.service"
+
+describe("sgid.service", () => {
+  const TEST_EMAIL = "test@open.gov.sg"
+  const TEST_NAME = "Test User"
+  const TEST_SUB = "test-sub-123"
+
+  beforeEach(async () => {
+    await resetTables("User")
+  })
+
+  describe("upsertSgidAccountAndUser", () => {
+    it("should set lastLoginAt to null when creating a new user", async () => {
+      // Act
+      await upsertSgidAccountAndUser({
+        prisma,
+        pocdexEmail: TEST_EMAIL,
+        name: TEST_NAME,
+        sub: TEST_SUB,
+      })
+
+      // Assert
+      const user = await prisma.user.findUnique({
+        where: { email: TEST_EMAIL },
+      })
+      expect(user?.lastLoginAt).toBe(null)
+    })
+
+    it("should update lastLoginAt when user logs in", async () => {
+      // Arrange
+      const beforeLogin = new Date()
+      await prisma.user.create({
+        data: {
+          email: TEST_EMAIL,
+          name: TEST_NAME,
+          phone: "",
+          lastLoginAt: null,
+        },
+      })
+
+      // Act
+      await upsertSgidAccountAndUser({
+        prisma,
+        pocdexEmail: TEST_EMAIL,
+        name: TEST_NAME,
+        sub: TEST_SUB,
+      })
+
+      // Assert
+      const user = await prisma.user.findUnique({
+        where: { email: TEST_EMAIL },
+      })
+      expect(user?.lastLoginAt).toBeInstanceOf(Date)
+      expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
+        beforeLogin.getTime(),
+      )
+    })
+  })
+})

--- a/apps/studio/src/server/modules/auth/sgid/sgid.service.ts
+++ b/apps/studio/src/server/modules/auth/sgid/sgid.service.ts
@@ -20,7 +20,9 @@ export const upsertSgidAccountAndUser = async ({
       where: {
         email: pocdexEmail,
       },
-      update: {},
+      update: {
+        lastLoginAt: new Date(),
+      },
       create: {
         email: pocdexEmail,
         name,

--- a/apps/studio/tests/integration/helpers/iron-session.ts
+++ b/apps/studio/tests/integration/helpers/iron-session.ts
@@ -103,6 +103,7 @@ export const createTestUser = () => ({
   updatedAt: MOCK_STORY_DATE,
   phone: "123456789",
   deletedAt: null,
+  lastLoginAt: null,
 })
 
 // NOTE: The argument to this function was changed from

--- a/apps/studio/tests/msw/handlers/me.ts
+++ b/apps/studio/tests/msw/handlers/me.ts
@@ -12,6 +12,7 @@ export const defaultUser: User = {
   createdAt: MOCK_STORY_DATE,
   updatedAt: MOCK_STORY_DATE,
   deletedAt: null,
+  lastLoginAt: null,
 }
 
 const defaultMeGetQuery = () => {


### PR DESCRIPTION
## Problem

Track user login timestamps by adding a `lastLoginAt` field to the User model.

This change is essential for improving user authentication tracking and analytics.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Added `lastLoginAt` field to the User model.
- Updated authentication logic to set `lastLoginAt` during user login.

## Tests

The following tests have been added to confirm functionality:

- Tests for setting `lastLoginAt` to null when creating a new user.
- Tests for updating `lastLoginAt` when a user logs in.

### Manual tests

1. Login into studio with a new email -> `lastLoginAt` should be current timestamp
2. Log out and login again -> `lastLoginAt` should be a new timestamp 