### PR TITLE
isom-1740 backend user management service (API endpoints)

### DIFF
--- a/apps/studio/src/schemas/user.ts
+++ b/apps/studio/src/schemas/user.ts
@@ -1,0 +1,52 @@
+import { RoleType } from "~prisma/generated/generatedEnums"
+import { z } from "zod"
+
+import { offsetPaginationSchema } from "./pagination"
+
+export const createInputSchema = z.object({
+  siteId: z.number().min(1),
+  users: z.array(
+    z.object({
+      email: z.string().email(),
+      role: z.nativeEnum(RoleType).optional().default(RoleType.Editor),
+    }),
+  ),
+})
+
+export const createOutputSchema = z.array(
+  z.object({
+    id: z.string(),
+    email: z.string().email(),
+    role: z.nativeEnum(RoleType),
+  }),
+)
+
+export const deleteInputSchema = z.object({
+  siteId: z.number().min(1),
+  userId: z.string(),
+})
+
+export const deleteOutputSchema = z.boolean()
+
+export const listInputSchema = z.object({
+  siteId: z.number().min(1),
+  ...offsetPaginationSchema.shape,
+})
+
+export const listOutputSchema = z.array(
+  z.object({
+    id: z.string(),
+    email: z.string().email(),
+    name: z.string().optional().nullable(),
+    lastLoginAt: z.date().nullable(),
+    role: z.nativeEnum(RoleType),
+  }),
+)
+
+export const updateInputSchema = z.object({
+  siteId: z.number().min(1),
+  userId: z.string(),
+  role: z.nativeEnum(RoleType),
+})
+
+export const updateOutputSchema = z.boolean()

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -7,6 +7,7 @@ import type {
   PermissionsProps,
   ResourceAbility,
   SiteAbility,
+  UserManagementAbility,
 } from "./permissions.type"
 import { db } from "../database"
 import { CRUD_ACTIONS } from "./permissions.type"
@@ -103,6 +104,53 @@ export const validateUserPermissionsForResource = async ({
 
   // TODO: create should check against the current resource id
   if (perms.cannot(action, resource)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have sufficient permissions to perform this action",
+    })
+  }
+}
+
+const definePermissionsForManagingUsers = async ({
+  userId,
+  siteId,
+}: Omit<PermissionsProps, "resourceId">) => {
+  const builder = new AbilityBuilder<UserManagementAbility>(createMongoAbility)
+  const roles = await db
+    .selectFrom("ResourcePermission")
+    .where("userId", "=", userId)
+    .where("siteId", "=", siteId)
+    .where("resourceId", "is", null)
+    .where("deletedAt", "is", null)
+    .select("role")
+    .execute()
+
+  // NOTE: Any role should be able to read the list of user permissions
+  if (roles.length > 0) {
+    builder.can("read", "UserManagement")
+  }
+
+  // Only Admin role can manage permissions
+  if (roles.some(({ role }) => role === RoleType.Admin)) {
+    CRUD_ACTIONS.map((action) => {
+      builder.can(action, "UserManagement")
+    })
+  }
+
+  return builder.build({ detectSubjectType: () => "UserManagement" })
+}
+
+export const validatePermissionsForManagingUsers = async ({
+  siteId,
+  userId,
+  action,
+}: Omit<PermissionsProps, "resourceId"> & { action: CrudResourceActions }) => {
+  const perms = await definePermissionsForManagingUsers({
+    siteId,
+    userId,
+  })
+
+  if (perms.cannot(action, "UserManagement")) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "You do not have sufficient permissions to perform this action",

--- a/apps/studio/src/server/modules/permissions/permissions.type.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.type.ts
@@ -16,6 +16,9 @@ export type ResourceAbility = PureAbility<ResourcePermissionTuple>
 export type SitePermissionTuple = [CrudResourceActions, "Site"]
 export type SiteAbility = PureAbility<SitePermissionTuple>
 
+export type UserManagementTuple = [CrudResourceActions, "UserManagement"]
+export type UserManagementAbility = PureAbility<UserManagementTuple>
+
 export interface PermissionsProps {
   userId: string
   siteId: number

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -1,0 +1,701 @@
+import { TRPCError } from "@trpc/server"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupAdminPermissions,
+  setUpEditorPermissions,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { MOCK_TEST_USER_NAME } from "tests/msw/constants"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { db, RoleType } from "~/server/modules/database"
+import { createCallerFactory } from "~/server/trpc"
+import { userRouter } from "../user.router"
+
+const createCaller = createCallerFactory(userRouter)
+
+describe("user.router", () => {
+  const TEST_EMAIL = "test@open.gov.sg"
+
+  let caller: ReturnType<typeof createCaller>
+  let session: Awaited<ReturnType<typeof applyAuthedSession>>
+  let siteId: number
+
+  beforeEach(async () => {
+    await resetTables("User", "Site", "ResourcePermission")
+
+    const { site } = await setupSite()
+    siteId = site.id
+    session = await applyAuthedSession()
+    caller = createCaller(createMockRequest(session))
+  })
+
+  describe("create", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.create({
+        siteId,
+        users: [{ email: TEST_EMAIL }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user is not admin of the site", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const { site: newSite } = await setupSite()
+
+      // Act
+      const result = caller.create({
+        siteId: newSite.id,
+        users: [{ email: TEST_EMAIL }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw error if email is empty string", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        users: [{ email: "" }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError()
+    })
+
+    it("should throw error if email is invalid", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        users: [{ email: "not-an-email" }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError()
+    })
+
+    it("should throw 409 if user already exists but has non-null deletedAt", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: true })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        users: [{ email: user.email }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "User was deleted before. Contact support to restore.",
+        }),
+      )
+    })
+
+    it("should throw 409 if both user and permissions already exists", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: false })
+      await setupAdminPermissions({ userId: user.id, siteId })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        users: [{ email: TEST_EMAIL }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "User and permissions already exists",
+        }),
+      )
+    })
+
+    it("should create user permissions successfully if user already exists but permissions do not exist", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: false })
+
+      // Act
+      const result = await caller.create({
+        siteId,
+        users: [{ email: TEST_EMAIL }],
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result).toEqual([
+        expect.objectContaining({
+          email: TEST_EMAIL,
+          id: expect.any(String),
+        }),
+      ])
+
+      // Assert: No new user was created
+      const dbUserResult = await db
+        .selectFrom("User")
+        .where("email", "=", TEST_EMAIL)
+        .selectAll()
+        .execute()
+      expect(dbUserResult).toHaveLength(1)
+
+      // Assert: Verify permissions in database
+      const resourcePermissions = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", user.id)
+        .where("siteId", "=", siteId)
+        .selectAll()
+        .execute()
+      expect(resourcePermissions).toHaveLength(1)
+      expect(resourcePermissions).toEqual([
+        expect.objectContaining({
+          userId: user.id,
+          siteId,
+          role: RoleType.Editor,
+        }),
+      ])
+    })
+
+    it("should create both user and permissions successfully if user is admin", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const createdUsers = await caller.create({
+        siteId,
+        users: [{ email: TEST_EMAIL }],
+      })
+
+      // Assert
+      expect(createdUsers).toHaveLength(1)
+      expect(createdUsers).toEqual([
+        expect.objectContaining({
+          email: TEST_EMAIL,
+          id: expect.any(String),
+        }),
+      ])
+
+      // Assert: Verify user in database
+      const user = await db
+        .selectFrom("User")
+        .where("email", "=", TEST_EMAIL)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(user).toMatchObject({
+        email: TEST_EMAIL,
+        id: createdUsers[0]?.id,
+        deletedAt: null,
+      })
+
+      // Assert: Verify permissions in database
+      const resourcePermissions = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", user.id)
+        .where("siteId", "=", siteId)
+        .selectAll()
+        .execute()
+      expect(resourcePermissions).toHaveLength(1)
+      expect(resourcePermissions).toEqual([
+        expect.objectContaining({
+          userId: user.id,
+          siteId,
+        }),
+      ])
+    })
+
+    // Skip for now as we aren't working on multiple users creation yet
+    it.skip("should create multiple users successfully if user is admin", async () => {})
+    it.skip("should not create any users if one of the emails is invalid", async () => {})
+  })
+
+  describe("delete", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.delete({
+        siteId,
+        userId: "test-user-id",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user is not admin of the site", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const { site: newSite } = await setupSite()
+      const newUser = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+
+      // Act
+      const result = caller.delete({
+        siteId: newSite.id,
+        userId: newUser.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw 404 if user does not exist", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = caller.delete({
+        siteId,
+        userId: "non-existent-id",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        }),
+      )
+    })
+
+    it("should throw 404 if user exist but the permissions do not exist", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: false })
+
+      // Act
+      const result = caller.delete({ siteId, userId: user.id })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        }),
+      )
+    })
+
+    it("should throw 404 if user to delete is not from the same site", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const { site: newSite } = await setupSite()
+      const newUser = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+      await setupAdminPermissions({ userId: newUser.id, siteId: newSite.id })
+
+      // Act
+      const result = caller.delete({
+        siteId,
+        userId: newUser.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        }),
+      )
+    })
+
+    it("should throw 403 if user tries to delete their own account", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = caller.delete({
+        siteId,
+        userId: session.userId!,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message: "You cannot delete your own account",
+        }),
+      )
+    })
+
+    it("should soft delete an existing user's permissions successfully", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const userToDelete = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+      await setUpEditorPermissions({ userId: userToDelete.id, siteId })
+
+      // Act
+      const result = await caller.delete({
+        siteId,
+        userId: userToDelete.id,
+      })
+
+      // Assert
+      expect(result).toBe(true)
+
+      // Verify in database
+      const deletedUserPermissions = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", userToDelete.id)
+        .where("siteId", "=", siteId)
+        .select("deletedAt")
+        .execute()
+      expect(deletedUserPermissions).toHaveLength(1) // ensure it's not hard deleted
+      expect(deletedUserPermissions[0]?.deletedAt).not.toBeNull()
+    })
+
+    // User might have permissions to multiple sites
+    // We should only soft delete the permissions for the site that the user is being deleted from
+    it("should soft delete a user's permissions and not their account", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const userToDelete = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+      await setUpEditorPermissions({ userId: userToDelete.id, siteId })
+
+      // Act
+      const result = await caller.delete({
+        siteId,
+        userId: userToDelete.id,
+      })
+
+      // Assert
+      expect(result).toBe(true)
+
+      // Verify in database
+      const dbUsers = await db
+        .selectFrom("User")
+        .where("id", "=", userToDelete.id)
+        .select("deletedAt")
+        .execute()
+      expect(dbUsers).toHaveLength(1)
+      expect(dbUsers[0]?.deletedAt).toBeNull()
+    })
+  })
+
+  describe("list", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.list({ siteId })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user does not have any permissions to the site", async () => {
+      // Act
+      const result = caller.list({ siteId })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should return array with self when no other users exist", async () => {
+      // Arrange
+      await setUpEditorPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = await caller.list({ siteId })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: session.userId,
+          name: MOCK_TEST_USER_NAME,
+          lastLoginAt: null,
+        }),
+      ])
+    })
+
+    it("should return paginated results (10 users per page)", async () => {
+      // Arrange
+      await setUpEditorPermissions({ userId: session.userId, siteId })
+
+      for (let i = 0; i < 15; i++) {
+        const editorUser = await setupUser({
+          email: `editor.user.${i}@open.gov.sg`,
+          isDeleted: false,
+        })
+        await setUpEditorPermissions({ userId: editorUser.id, siteId })
+      }
+
+      // Act
+      const result = await caller.list({ siteId })
+
+      // Assert
+      expect(result).toHaveLength(10)
+    })
+
+    it("should return paginated results (10 users per page) with offset", async () => {
+      // Arrange
+      await setUpEditorPermissions({ userId: session.userId, siteId })
+
+      for (let i = 0; i < 15; i++) {
+        const editorUser = await setupUser({
+          email: `editor.user.${i}@open.gov.sg`,
+          isDeleted: false,
+        })
+        await setUpEditorPermissions({ userId: editorUser.id, siteId })
+      }
+
+      // Act
+      const result = await caller.list({ siteId, offset: 10 })
+
+      // Assert
+      expect(result).toHaveLength(6)
+    })
+  })
+
+  describe("update", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.update({
+        siteId,
+        userId: "test-user-id",
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user is not admin of the site", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const { site: newSite } = await setupSite()
+
+      // Act
+      const result = caller.update({
+        siteId: newSite.id,
+        userId: "test-user-id",
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw 404 if user does not exist", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = caller.update({
+        siteId,
+        userId: "non-existent-id",
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "User not found",
+        }),
+      )
+    })
+
+    it("should throw 404 if user exist but the permissions do not exist", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: false })
+
+      // Act
+      const result = caller.update({
+        siteId,
+        userId: user.id,
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        }),
+      )
+    })
+
+    it("should throw 404 if user to update is not from the same site", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const { site: newSite } = await setupSite()
+      const newUser = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+      await setupAdminPermissions({ userId: newUser.id, siteId: newSite.id })
+
+      // Act
+      const result = caller.update({
+        siteId,
+        userId: newUser.id,
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        }),
+      )
+    })
+
+    it("should throw 409 if user exists but has non-null deletedAt", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: true })
+
+      // Act
+      const result = caller.update({
+        siteId,
+        userId: user.id,
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "User was deleted before. Contact support to restore.",
+        }),
+      )
+    })
+    it("should throw 403 if user tries to update their own role", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      // Act
+      const result = caller.update({
+        siteId,
+        userId: session.userId!,
+        role: RoleType.Editor,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message: "You cannot update your own role",
+        }),
+      )
+    })
+
+    it("should update a user's role successfully", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const userToUpdate = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+
+      await setUpEditorPermissions({ userId: userToUpdate.id, siteId })
+
+      // Act
+      const result = await caller.update({
+        siteId,
+        userId: userToUpdate.id,
+        role: RoleType.Admin,
+      })
+
+      // Assert
+      expect(result).toBe(true)
+
+      // Verify in database
+      const updatedUser = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", userToUpdate.id)
+        .where("siteId", "=", siteId)
+        .select("role")
+        .executeTakeFirst()
+      expect(updatedUser?.role).toBe(RoleType.Admin)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -75,20 +75,6 @@ describe("user.router", () => {
       )
     })
 
-    it("should throw error if email is empty string", async () => {
-      // Arrange
-      await setupAdminPermissions({ userId: session.userId, siteId })
-
-      // Act
-      const result = caller.create({
-        siteId,
-        users: [{ email: "" }],
-      })
-
-      // Assert
-      await expect(result).rejects.toThrowError()
-    })
-
     it("should throw error if email is invalid", async () => {
       // Arrange
       await setupAdminPermissions({ userId: session.userId, siteId })

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -7,7 +7,7 @@ import {
 } from "tests/integration/helpers/iron-session"
 import {
   setupAdminPermissions,
-  setUpEditorPermissions,
+  setupEditorPermissions,
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
@@ -377,7 +377,7 @@ describe("user.router", () => {
         email: TEST_EMAIL,
         isDeleted: false,
       })
-      await setUpEditorPermissions({ userId: userToDelete.id, siteId })
+      await setupEditorPermissions({ userId: userToDelete.id, siteId })
 
       // Act
       const result = await caller.delete({
@@ -409,7 +409,7 @@ describe("user.router", () => {
         email: TEST_EMAIL,
         isDeleted: false,
       })
-      await setUpEditorPermissions({ userId: userToDelete.id, siteId })
+      await setupEditorPermissions({ userId: userToDelete.id, siteId })
 
       // Act
       const result = await caller.delete({
@@ -461,7 +461,7 @@ describe("user.router", () => {
 
     it("should return array with self when no other users exist", async () => {
       // Arrange
-      await setUpEditorPermissions({ userId: session.userId, siteId })
+      await setupEditorPermissions({ userId: session.userId, siteId })
 
       // Act
       const result = await caller.list({ siteId })
@@ -479,14 +479,14 @@ describe("user.router", () => {
 
     it("should return paginated results (10 users per page)", async () => {
       // Arrange
-      await setUpEditorPermissions({ userId: session.userId, siteId })
+      await setupEditorPermissions({ userId: session.userId, siteId })
 
       for (let i = 0; i < 15; i++) {
         const editorUser = await setupUser({
           email: `editor.user.${i}@open.gov.sg`,
           isDeleted: false,
         })
-        await setUpEditorPermissions({ userId: editorUser.id, siteId })
+        await setupEditorPermissions({ userId: editorUser.id, siteId })
       }
 
       // Act
@@ -498,14 +498,14 @@ describe("user.router", () => {
 
     it("should return paginated results (10 users per page) with offset", async () => {
       // Arrange
-      await setUpEditorPermissions({ userId: session.userId, siteId })
+      await setupEditorPermissions({ userId: session.userId, siteId })
 
       for (let i = 0; i < 15; i++) {
         const editorUser = await setupUser({
           email: `editor.user.${i}@open.gov.sg`,
           isDeleted: false,
         })
-        await setUpEditorPermissions({ userId: editorUser.id, siteId })
+        await setupEditorPermissions({ userId: editorUser.id, siteId })
       }
 
       // Act
@@ -676,7 +676,7 @@ describe("user.router", () => {
         isDeleted: false,
       })
 
-      await setUpEditorPermissions({ userId: userToUpdate.id, siteId })
+      await setupEditorPermissions({ userId: userToUpdate.id, siteId })
 
       // Act
       const result = await caller.update({

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -1,40 +1,225 @@
+import { TRPCError } from "@trpc/server"
+import { RoleType } from "~prisma/generated/generatedEnums"
 import { resetTables } from "tests/integration/helpers/db"
-import { setupUser } from "tests/integration/helpers/seed"
+import { setupSite, setupUser } from "tests/integration/helpers/seed"
 
-import { isUserDeleted } from "../user.service"
+import { db } from "~/server/modules/database"
+import { createUser, isUserDeleted } from "../user.service"
 
 describe("user.service", () => {
-  beforeAll(async () => {
-    await resetTables("User")
-  })
-
-  it("should return false if user is not deleted", async () => {
-    // Arrange
-    const email = "active@example.com"
-    // Setup active user
-    await setupUser({
-      email: email,
-      isDeleted: false,
+  describe("isUserDeleted", () => {
+    beforeAll(async () => {
+      await resetTables("User")
     })
 
-    // Act
-    const result = await isUserDeleted(email)
-    // Assert
-    expect(result).toBe(false)
-  })
+    it("should return false if user is not deleted", async () => {
+      // Arrange
+      const email = "active@example.com"
+      // Setup active user
+      await setupUser({
+        email: email,
+        isDeleted: false,
+      })
 
-  it("should return true if user is deleted", async () => {
-    // Arrange
-    const email = "deleted@example.com"
-    // Setup deleted user
-    await setupUser({
-      email: email,
-      isDeleted: true,
+      // Act
+      const result = await isUserDeleted(email)
+      // Assert
+      expect(result).toBe(false)
     })
 
-    // Act
-    const result = await isUserDeleted(email)
-    // Assert
-    expect(result).toBe(true)
+    it("should return true if user is deleted", async () => {
+      // Arrange
+      const email = "deleted@example.com"
+      // Setup deleted user
+      await setupUser({
+        email: email,
+        isDeleted: true,
+      })
+
+      // Act
+      const result = await isUserDeleted(email)
+      // Assert
+      expect(result).toBe(true)
+    })
+  })
+
+  describe("createUser", () => {
+    const TEST_EMAIL = "test@example.com"
+    let siteId: number
+
+    beforeEach(async () => {
+      await resetTables("User", "ResourcePermission", "Site")
+      const { site } = await setupSite()
+      siteId = site.id
+    })
+
+    it("should throw error if email is invalid", async () => {
+      // Act
+      const result = createUser({
+        email: "invalid-email",
+        role: RoleType.Editor,
+        siteId,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid email",
+        }),
+      )
+    })
+
+    it("should throw error if site does not exist", async () => {
+      // Act
+      const result = createUser({
+        email: TEST_EMAIL,
+        role: RoleType.Editor,
+        siteId: 9999,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError()
+    })
+
+    it("should create a new user with default values", async () => {
+      // Act
+      const { user } = await createUser({
+        email: TEST_EMAIL,
+        name: "",
+        phone: "",
+        role: RoleType.Editor,
+        siteId,
+      })
+
+      // Assert: Verify user in database
+      const dbUserResult = await db
+        .selectFrom("User")
+        .where("id", "=", user.id)
+        .selectAll()
+        .execute()
+
+      expect(dbUserResult).toHaveLength(1)
+      expect(dbUserResult[0]).toMatchObject({
+        id: user.id,
+        email: TEST_EMAIL,
+        name: "",
+        phone: "",
+      })
+
+      // Assert: Verify resource permission in database
+      const dbResourcePermissionResult = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", user.id)
+        .where("siteId", "=", siteId)
+        .selectAll()
+        .execute()
+
+      expect(dbResourcePermissionResult).toHaveLength(1)
+      expect(dbResourcePermissionResult[0]).toMatchObject({
+        userId: user.id,
+        siteId,
+        role: RoleType.Editor,
+      })
+    })
+
+    it("should create a new user with provided values", async () => {
+      // Arrange
+      const name = "Test User"
+      const phone = "12345678"
+      const role = RoleType.Admin
+
+      // Act
+      const { user } = await createUser({
+        email: TEST_EMAIL,
+        name,
+        phone,
+        role,
+        siteId,
+      })
+
+      // Assert: Verify user in database
+      const dbUserResult = await db
+        .selectFrom("User")
+        .where("id", "=", user.id)
+        .selectAll()
+        .execute()
+
+      expect(dbUserResult).toHaveLength(1)
+      expect(dbUserResult[0]).toMatchObject({
+        id: user.id,
+        email: TEST_EMAIL,
+        name,
+        phone,
+      })
+
+      // Assert: Verify resource permission in database
+      const dbResourcePermissionResult = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", user.id)
+        .where("siteId", "=", siteId)
+        .selectAll()
+        .execute()
+
+      expect(dbResourcePermissionResult).toHaveLength(1)
+      expect(dbResourcePermissionResult[0]).toMatchObject({
+        userId: user.id,
+        siteId,
+        role,
+      })
+    })
+
+    it("should update existing user's email if there's a conflict", async () => {
+      // Arrange
+      await setupUser({ email: TEST_EMAIL, isDeleted: false })
+
+      // Act
+      await createUser({
+        email: TEST_EMAIL,
+        name: "",
+        phone: "",
+        role: RoleType.Editor,
+        siteId,
+      })
+
+      // Assert: Verify user in database
+      const dbUserResult = await db
+        .selectFrom("User")
+        .where("email", "=", TEST_EMAIL)
+        .selectAll()
+        .execute()
+
+      // Should only have one user with this email
+      expect(dbUserResult).toHaveLength(1)
+      expect(dbUserResult[0]).toMatchObject({
+        email: TEST_EMAIL,
+      })
+    })
+
+    it("should create resource permission for the user if user already exists", async () => {
+      // Arrange
+      const existingUser = await setupUser({
+        email: TEST_EMAIL,
+        isDeleted: false,
+      })
+
+      // Act
+      await createUser({ email: TEST_EMAIL, role: RoleType.Admin, siteId })
+
+      // Assert: Verify resource permission in database
+      const dbResourcePermissionResult = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", existingUser.id)
+        .where("siteId", "=", siteId)
+        .selectAll()
+        .execute()
+
+      expect(dbResourcePermissionResult).toHaveLength(1)
+      expect(dbResourcePermissionResult[0]).toMatchObject({
+        userId: existingUser.id,
+        siteId,
+        role: RoleType.Admin,
+      })
+    })
   })
 })

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -107,6 +107,27 @@ describe("user.service", () => {
       )
     })
 
+    it("should throw 409 if user already exists but has non-null deletedAt", async () => {
+      // Arrange
+      const user = await setupUser({ email: TEST_EMAIL, isDeleted: true })
+      await setupAdminPermissions({ userId: user.id, siteId })
+
+      // Act
+      const result = createUser({
+        email: TEST_EMAIL,
+        role: RoleType.Editor,
+        siteId,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "User was deleted before. Contact support to restore.",
+        }),
+      )
+    })
+
     it("should create a new user with default values", async () => {
       // Act
       const { user } = await createUser({

--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -1,0 +1,174 @@
+import { TRPCError } from "@trpc/server"
+
+import {
+  createInputSchema,
+  createOutputSchema,
+  deleteInputSchema,
+  deleteOutputSchema,
+  listInputSchema,
+  listOutputSchema,
+  updateInputSchema,
+  updateOutputSchema,
+} from "~/schemas/user"
+import { protectedProcedure, router } from "../../trpc"
+import { db, sql } from "../database"
+import { validatePermissionsForManagingUsers } from "../permissions/permissions.service"
+import { createUser } from "./user.service"
+
+export const userRouter = router({
+  create: protectedProcedure
+    .input(createInputSchema)
+    .output(createOutputSchema)
+    .mutation(async ({ ctx, input: { siteId, users } }) => {
+      await validatePermissionsForManagingUsers({
+        siteId,
+        userId: ctx.user.id,
+        action: "create",
+      })
+
+      const createdUsers = await db.transaction().execute(async (trx) => {
+        return await Promise.all(
+          users.map(async (user) => {
+            const { user: createdUser, resourcePermission } = await createUser({
+              ...user,
+              email: user.email.toLowerCase(),
+              siteId,
+              trx,
+            })
+            return {
+              id: createdUser.id,
+              email: createdUser.email,
+              role: resourcePermission.role,
+            }
+          }),
+        )
+      })
+
+      // TODO: Send welcome email to users
+      // Email service is not ready yet
+
+      return createdUsers
+    }),
+
+  delete: protectedProcedure
+    .input(deleteInputSchema)
+    .output(deleteOutputSchema)
+    .mutation(async ({ ctx, input: { siteId, userId } }) => {
+      await validatePermissionsForManagingUsers({
+        siteId,
+        userId: ctx.user.id,
+        action: "delete",
+      })
+
+      if (userId === ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You cannot delete your own account",
+        })
+      }
+
+      const deletedUserPermissions = await db
+        .updateTable("ResourcePermission")
+        .where("userId", "=", userId)
+        .where("siteId", "=", siteId)
+        .where("deletedAt", "is", null)
+        .set({ deletedAt: new Date() })
+        .returningAll()
+        .executeTakeFirst()
+
+      if (!deletedUserPermissions) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        })
+      }
+
+      return true
+    }),
+
+  list: protectedProcedure
+    .input(listInputSchema)
+    .output(listOutputSchema)
+    .query(async ({ ctx, input: { siteId, offset, limit } }) => {
+      await validatePermissionsForManagingUsers({
+        siteId,
+        userId: ctx.user.id,
+        action: "read",
+      })
+
+      return db
+        .selectFrom("User")
+        .innerJoin("ResourcePermission", "User.id", "ResourcePermission.userId")
+        .where("ResourcePermission.siteId", "=", siteId)
+        .orderBy("User.lastLoginAt", sql.raw(`DESC NULLS LAST`))
+        .select([
+          "User.id",
+          "User.email",
+          "User.name",
+          "User.lastLoginAt",
+          "ResourcePermission.role",
+        ])
+        .limit(limit)
+        .offset(offset)
+        .execute()
+    }),
+
+  update: protectedProcedure
+    .input(updateInputSchema)
+    .output(updateOutputSchema)
+    .mutation(async ({ ctx, input: { siteId, userId, role } }) => {
+      await validatePermissionsForManagingUsers({
+        siteId,
+        userId: ctx.user.id,
+        action: "update",
+      })
+
+      if (userId === ctx.user.id) {
+        throw new TRPCError({
+          code: "FORBIDDEN",
+          message: "You cannot update your own role",
+        })
+      }
+
+      const user = await db
+        .selectFrom("User")
+        .where("id", "=", userId)
+        .selectAll()
+        .executeTakeFirst()
+
+      if (!user) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User not found",
+        })
+      }
+
+      // Temporary test to ensure that we don't allow creating a user that was deleted before
+      // We prevent this as there's no complete audit trail of what happened to the user
+      // TODO: Remove this after audit logging is implemented
+      if (user.deletedAt) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "User was deleted before. Contact support to restore.",
+        })
+      }
+
+      const updatedUserPermissions = await db
+        .updateTable("ResourcePermission")
+        .where("userId", "=", userId)
+        .where("siteId", "=", siteId)
+        .where("resourceId", "is", null) // because we are updating site-wide permissions
+        .set({ role })
+        .returningAll()
+        .executeTakeFirst()
+
+      if (!updatedUserPermissions) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "User permissions not found",
+        })
+      }
+
+      return true
+    }),
+})

--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -13,7 +13,7 @@ import {
 import { protectedProcedure, router } from "../../trpc"
 import { db, sql } from "../database"
 import { validatePermissionsForManagingUsers } from "../permissions/permissions.service"
-import { createUser } from "./user.service"
+import { createUser, validateEmailRoleCombination } from "./user.service"
 
 export const userRouter = router({
   create: protectedProcedure
@@ -152,6 +152,8 @@ export const userRouter = router({
           message: "User was deleted before. Contact support to restore.",
         })
       }
+
+      validateEmailRoleCombination({ email: user.email, role })
 
       const updatedUserPermissions = await db
         .updateTable("ResourcePermission")

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -1,4 +1,9 @@
-import { db } from "../database"
+import cuid2 from "@paralleldrive/cuid2"
+import { TRPCError } from "@trpc/server"
+import isEmail from "validator/lib/isEmail"
+
+import type { ResourcePermission, User } from "~prisma/generated/generatedTypes"
+import { db, RoleType } from "../database"
 
 export const isUserDeleted = async (email: string) => {
   const lowercaseEmail = email.toLowerCase()
@@ -10,4 +15,64 @@ export const isUserDeleted = async (email: string) => {
     .executeTakeFirst()
 
   return user?.deletedAt ? true : false
+}
+
+interface CreateUserProps {
+  email: User["email"]
+  name?: User["name"]
+  phone?: User["phone"]
+  role: ResourcePermission["role"]
+  siteId: ResourcePermission["siteId"]
+}
+
+export const createUser = async ({
+  email,
+  name = "",
+  phone = "",
+  role = RoleType.Editor,
+  siteId,
+}: CreateUserProps) => {
+  if (!isEmail(email)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid email",
+    })
+  }
+
+  const { user, resourcePermission } = await db
+    .transaction()
+    .execute(async (tx) => {
+      const user = await tx
+        .insertInto("User")
+        .values({
+          id: cuid2.createId(),
+          email,
+          name,
+          phone,
+        })
+        .onConflict((oc) =>
+          oc
+            .column("email")
+            .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
+        )
+        .returning(["id", "email", "name", "phone"])
+        .executeTakeFirstOrThrow()
+
+      const resourcePermission = await tx
+        .insertInto("ResourcePermission")
+        .values({
+          userId: user.id,
+          siteId,
+          role,
+        })
+        .returning(["userId", "siteId", "role"])
+        .executeTakeFirstOrThrow()
+
+      return {
+        user,
+        resourcePermission,
+      }
+    })
+
+  return { user, resourcePermission }
 }

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -2,6 +2,7 @@ import cuid2 from "@paralleldrive/cuid2"
 import { TRPCError } from "@trpc/server"
 import isEmail from "validator/lib/isEmail"
 
+import type { SafeKysely } from "../database"
 import type { ResourcePermission, User } from "~prisma/generated/generatedTypes"
 import { db, RoleType } from "../database"
 
@@ -23,6 +24,7 @@ interface CreateUserProps {
   phone?: User["phone"]
   role: ResourcePermission["role"]
   siteId: ResourcePermission["siteId"]
+  trx?: SafeKysely // allows for transaction to be passed in from parent transaction
 }
 
 export const createUser = async ({
@@ -31,6 +33,7 @@ export const createUser = async ({
   phone = "",
   role = RoleType.Editor,
   siteId,
+  trx,
 }: CreateUserProps) => {
   if (!isEmail(email)) {
     throw new TRPCError({
@@ -39,40 +42,42 @@ export const createUser = async ({
     })
   }
 
-  const { user, resourcePermission } = await db
-    .transaction()
-    .execute(async (tx) => {
-      const user = await tx
-        .insertInto("User")
-        .values({
-          id: cuid2.createId(),
-          email,
-          name,
-          phone,
-        })
-        .onConflict((oc) =>
-          oc
-            .column("email")
-            .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
-        )
-        .returning(["id", "email", "name", "phone"])
-        .executeTakeFirstOrThrow()
+  const executeInTransaction = async (tx: SafeKysely) => {
+    const user = await tx
+      .insertInto("User")
+      .values({
+        id: cuid2.createId(),
+        email,
+        name,
+        phone,
+      })
+      .onConflict((oc) =>
+        oc
+          .column("email")
+          .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
+      )
+      .returning(["id", "email", "name", "phone"])
+      .executeTakeFirstOrThrow()
 
-      const resourcePermission = await tx
-        .insertInto("ResourcePermission")
-        .values({
-          userId: user.id,
-          siteId,
-          role,
-        })
-        .returning(["userId", "siteId", "role"])
-        .executeTakeFirstOrThrow()
+    const resourcePermission = await tx
+      .insertInto("ResourcePermission")
+      .values({
+        userId: user.id,
+        siteId,
+        role,
+      })
+      .returning(["userId", "siteId", "role"])
+      .executeTakeFirstOrThrow()
 
-      return {
-        user,
-        resourcePermission,
-      }
-    })
+    return {
+      user,
+      resourcePermission,
+    }
+  }
 
-  return { user, resourcePermission }
+  if (trx) {
+    return await executeInTransaction(trx)
+  }
+
+  return await db.transaction().execute(executeInTransaction)
 }

--- a/apps/studio/src/utils/__tests__/email.test.ts
+++ b/apps/studio/src/utils/__tests__/email.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+
+import { isGovEmail } from "../email"
+
+describe("isGovEmail", () => {
+  it("should return true for valid .gov.sg email addresses", () => {
+    const validEmails = [
+      "test@open.gov.sg",
+      "user@agency.gov.sg",
+      "name@department.gov.sg",
+      "test.user@ministry.gov.sg",
+      "first.last@subdomain.agency.gov.sg",
+    ]
+
+    validEmails.forEach((email) => {
+      expect(isGovEmail(email)).toBe(true)
+    })
+  })
+
+  it("should return false for non-.gov.sg email addresses", () => {
+    const invalidEmails = [
+      "test@example.com",
+      "user@gmail.com",
+      "name@yahoo.com",
+      "test@govsg.com",
+      "user@gov.sg.com",
+      "test@agency.gov.com",
+    ]
+
+    invalidEmails.forEach((email) => {
+      expect(isGovEmail(email)).toBe(false)
+    })
+  })
+
+  it("should return false for invalid email formats", () => {
+    const invalidFormats = [
+      "not-an-email",
+      "@gov.sg",
+      "test@",
+      "test@.gov.sg",
+      ".gov.sg",
+      "",
+      null,
+      undefined,
+      123,
+      {},
+      [],
+    ]
+
+    invalidFormats.forEach((input) => {
+      expect(isGovEmail(input)).toBe(false)
+    })
+  })
+})

--- a/apps/studio/tests/integration/helpers/iron-session.ts
+++ b/apps/studio/tests/integration/helpers/iron-session.ts
@@ -2,7 +2,7 @@ import type { RequestOptions, ResponseOptions } from "node-mocks-http"
 import { type NextApiRequest, type NextApiResponse } from "next"
 import { nanoid } from "nanoid"
 import { createMocks } from "node-mocks-http"
-import { MOCK_STORY_DATE } from "tests/msw/constants"
+import { MOCK_STORY_DATE, MOCK_TEST_USER_NAME } from "tests/msw/constants"
 
 import type { Context } from "~/server/context"
 import type { User } from "~server/db"
@@ -98,7 +98,7 @@ export const applySession = () => {
 
 export const createTestUser = () => ({
   email: `test${nanoid()}@example.com`,
-  name: "Test User",
+  name: MOCK_TEST_USER_NAME,
   createdAt: MOCK_STORY_DATE,
   updatedAt: MOCK_STORY_DATE,
   phone: "123456789",

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -34,7 +34,7 @@ const setUpUserPermissions = async ({
     .execute()
 }
 
-export const setUpEditorPermissions = async ({
+export const setupEditorPermissions = async ({
   userId,
   siteId,
   isDeleted = false,

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -7,15 +7,19 @@ import { db, jsonb } from "~server/db"
 import { nanoid } from "nanoid"
 import { MOCK_STORY_DATE } from "tests/msw/constants"
 
-export const setupAdminPermissions = async ({
-  userId,
-  siteId,
-  isDeleted = false,
-}: {
+interface UserPermissionsProps {
   userId?: string
   siteId: number
   isDeleted?: boolean
-}) => {
+  role: RoleType
+}
+
+const setUpUserPermissions = async ({
+  userId,
+  siteId,
+  isDeleted = false,
+  role,
+}: UserPermissionsProps) => {
   if (!userId) throw new Error("userId is a required field")
 
   await db
@@ -23,11 +27,37 @@ export const setupAdminPermissions = async ({
     .values({
       userId: String(userId),
       siteId,
-      role: RoleType.Admin,
+      role,
       resourceId: null,
       deletedAt: isDeleted ? MOCK_STORY_DATE : null,
     })
     .execute()
+}
+
+export const setUpEditorPermissions = async ({
+  userId,
+  siteId,
+  isDeleted = false,
+}: Omit<UserPermissionsProps, "role">) => {
+  await setUpUserPermissions({
+    userId,
+    siteId,
+    isDeleted,
+    role: RoleType.Editor,
+  })
+}
+
+export const setupAdminPermissions = async ({
+  userId,
+  siteId,
+  isDeleted = false,
+}: Omit<UserPermissionsProps, "role">) => {
+  await setUpUserPermissions({
+    userId,
+    siteId,
+    isDeleted,
+    role: RoleType.Admin,
+  })
 }
 
 export const setupSite = async (siteId?: number, fetch?: boolean) => {

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -482,12 +482,14 @@ export const setupUser = async ({
   email,
   phone = "",
   isDeleted,
+  hasLoggedIn = false,
 }: {
   name?: string
   userId?: string
   email: string
   phone?: string
   isDeleted: boolean
+  hasLoggedIn?: boolean
 }) => {
   return db
     .insertInto("User")
@@ -497,6 +499,7 @@ export const setupUser = async ({
       email,
       phone: phone,
       deletedAt: isDeleted ? MOCK_STORY_DATE : null,
+      lastLoginAt: hasLoggedIn ? MOCK_STORY_DATE : null,
     })
     .returningAll()
     .executeTakeFirstOrThrow()

--- a/apps/studio/tests/msw/constants.ts
+++ b/apps/studio/tests/msw/constants.ts
@@ -1,1 +1,2 @@
+export const MOCK_TEST_USER_NAME = "Test User"
 export const MOCK_STORY_DATE = new Date("2024-09-12T07:00:00.000Z")


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Implement user management functionality with role-based access control and email domain restrictions.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Features**:

- Restrict admin role to whitelisted gov.sg emails
- Implement user management router with CRUD operations
- Prevent recreating deleted users (due to incomplete audit trail at the moment)
- Prevent duplicate site-wide user permissions
- Add user management permissions service

**Improvements**:

- Improve createUser service with optional transaction support
- Extract mock test user name to constant
- Create setUpUserPermissions for more versatile user permission

## Tests

<!-- What tests should be run to confirm functionality? -->

- Comprehensive tests for isGovEmail utility function
- User management router tests
- User service tests
- Email validation tests
