### PR TITLE
isom-1727 bug external link all should have new tab icon open in new

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -2887,6 +2887,10 @@ video {
   vertical-align: top;
 }
 
+.align-middle {
+  vertical-align: middle;
+}
+
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -5040,6 +5044,14 @@ video {
     margin-bottom: 0.5rem;
   }
 
+  .lg\:ml-1 {
+    margin-left: 0.25rem;
+  }
+
+  .lg\:ml-1\.5 {
+    margin-left: 0.375rem;
+  }
+
   .lg\:ml-24 {
     margin-left: 6rem;
   }
@@ -5122,6 +5134,10 @@ video {
 
   .lg\:w-4 {
     width: 1rem;
+  }
+
+  .lg\:w-5 {
+    width: 1.25rem;
   }
 
   .lg\:w-64 {

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -126,12 +126,7 @@ const generateArgs = ({
     maxColumns: maxColumns,
     variant: withoutImage ? "cardsWithoutImages" : "cardsWithImages",
     cards: cards,
-    ...(hasCTA
-      ? {
-          label: "This is a CTA",
-          url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-        }
-      : {}),
+    ...(hasCTA ? { label: "This is a CTA", url: "/" } : {}),
   } as InfoCardsProps
 }
 

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
@@ -52,9 +52,9 @@ export const Default: Story = {
     title: "This is a place where you can put nice content",
     description: "About a sentence worth of description here",
     buttonLabel: "Primary CTA",
-    buttonUrl: "https://google.com",
+    buttonUrl: "/",
     secondaryButtonLabel: "Secondary CTA",
-    secondaryButtonUrl: "https://google.com",
+    secondaryButtonUrl: "/",
   },
 }
 
@@ -64,7 +64,7 @@ export const OneButton: Story = {
     title: "This is a place where you can put nice content",
     description: "About a sentence worth of description here",
     buttonLabel: "Primary CTA",
-    buttonUrl: "https://google.com",
+    buttonUrl: "/",
   },
 }
 
@@ -76,9 +76,9 @@ export const LongText: Story = {
     description:
       "About a sentence worth of description here About a sentence worth of description here About a sentence worth of description here",
     buttonLabel: "Primary CTA",
-    buttonUrl: "https://google.com",
+    buttonUrl: "/",
     secondaryButtonLabel: "Secondary CTA",
-    secondaryButtonUrl: "https://google.com",
+    secondaryButtonUrl: "/",
   },
 }
 

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<InfopicProps> = {
     imageSrc:
       "https://images.unsplash.com/photo-1527436826045-8805c615a6df?w=1280",
     buttonLabel: "Sign up",
-    buttonUrl: "https://open.gov.sg",
+    buttonUrl: "/",
     site: {
       siteName: "Isomer Next",
       siteMap: {

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.stories.tsx
@@ -113,7 +113,7 @@ export const WithLink: Story = {
         value: "4.0",
       },
     ],
-    url: "https://www.google.com",
+    url: "/",
   },
 }
 
@@ -132,7 +132,7 @@ export const WithLinkAndLabel: Story = {
         value: "4.0",
       },
     ],
-    url: "https://www.google.com",
+    url: "/",
     label: "We have no achievements",
   },
 }

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
@@ -76,8 +76,16 @@ export const Hover: Story = {
 }
 
 export const ExternalLink: Story = {
-  args: generateArgs({ isExternalLink: true }),
+  args: generateArgs({
+    isExternalLink: true,
+    title: "This is a not-so-long title that will be truncated",
+  }),
 }
+
+// TODO: fix the external link icon showing up when the text is long
+// export const ExternalLinkLongText: Story = {
+//   args: generateArgs({ isExternalLink: true }),
+// }
 
 export const UndefinedDate: Story = {
   args: generateArgs({ isLastUpdatedUndefined: true }),

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
@@ -22,6 +22,16 @@ const meta: Meta<typeof BlogCard> = {
 export default meta
 type Story = StoryObj<typeof BlogCard>
 
+interface GenerateArgsProps {
+  shouldShowDate?: boolean
+  isLastUpdatedUndefined?: boolean
+  withoutImage?: boolean
+  title?: string
+  description?: string
+  tags?: Tag[]
+  isExternalLink?: boolean
+}
+
 const generateArgs = ({
   shouldShowDate = true,
   isLastUpdatedUndefined = false,
@@ -29,14 +39,10 @@ const generateArgs = ({
   title = "A journal on microscopic plastic and their correlation to the number of staycations enjoyed per millennials between the ages of 30-42, substantiated by research from IDK university",
   description = "We've looked at how people's spending correlates with how much microscopic plastic they consumed over the year. We've looked at how people's spending correlates with how much microscopic plastic they consumed over the year.",
   tags = [],
-}: {
+  isExternalLink = false,
+}: GenerateArgsProps): Partial<CollectionCardProps> & {
   shouldShowDate?: boolean
-  isLastUpdatedUndefined?: boolean
-  withoutImage?: boolean
-  title?: string
-  description?: string
-  tags?: Tag[]
-}): Partial<CollectionCardProps> & { shouldShowDate?: boolean } => {
+} => {
   return {
     lastUpdated: isLastUpdatedUndefined ? undefined : "December 2, 2023",
     category: "Research",
@@ -48,7 +54,7 @@ const generateArgs = ({
           src: "https://placehold.co/500x500",
           alt: "placeholder",
         },
-    referenceLinkHref: "/",
+    referenceLinkHref: isExternalLink ? "https://www.google.com" : "/",
     imageSrc: "https://placehold.co/500x500",
     itemTitle: title,
     shouldShowDate,
@@ -67,6 +73,10 @@ export const Hover: Story = {
       hover: [".group", "img"],
     },
   },
+}
+
+export const ExternalLink: Story = {
+  args: generateArgs({ isExternalLink: true }),
 }
 
 export const UndefinedDate: Story = {

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
@@ -81,11 +81,11 @@ export const ExternalLink: Story = {
   }),
 }
 
-// TODO: fix external link icon not visible when the text is being truncated
-// because the icon is at the end of the text
-// export const ExternalLinkLongText: Story = {
-//   args: generateArgs({ isExternalLink: true }),
-// }
+// TODO: ideally when the text is being truncated,
+// the external link icon should be at the end of the text instead of the newline
+export const ExternalLinkLongText: Story = {
+  args: generateArgs({ isExternalLink: true }),
+}
 
 export const UndefinedDate: Story = {
   args: generateArgs({ isLastUpdatedUndefined: true }),

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react"
-import { expect, userEvent, within } from "@storybook/test"
 
 import { withChromaticModes } from "@isomer/storybook-config"
 
@@ -82,7 +81,8 @@ export const ExternalLink: Story = {
   }),
 }
 
-// TODO: fix the external link icon showing up when the text is long
+// TODO: fix external link icon not visible when the text is being truncated
+// because the icon is at the end of the text
 // export const ExternalLinkLongText: Story = {
 //   args: generateArgs({ isExternalLink: true }),
 // }

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -1,18 +1,10 @@
-import { useEffect, useRef, useState } from "react"
-import { BiLinkExternal } from "react-icons/bi"
-
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
-import { tv } from "~/lib/tv"
-import { focusVisibleHighlight, getFormattedDate, isExternalUrl } from "~/utils"
+import { getFormattedDate, isExternalUrl } from "~/utils"
 import { ImageClient } from "../../complex/Image"
+import { Title } from "../CollectionCard/Title" // Reusing since the logic is the same for both
 import { Link } from "../Link"
 import { Tag } from "../Tag"
-
-const collectionCardLinkStyle = tv({
-  extend: focusVisibleHighlight,
-  base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 group-hover:underline",
-})
 
 export const BlogCard = ({
   LinkComponent,
@@ -32,22 +24,6 @@ export const BlogCard = ({
   LinkComponent: CollectionPageSchemaType["LinkComponent"]
 }): JSX.Element => {
   const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
-
-  const textRef = useRef<HTMLSpanElement | null>(null)
-  const [isTruncated, setIsTruncated] = useState(false)
-  useEffect(() => {
-    const checkTruncation = () => {
-      const element = textRef.current
-      if (!element) return
-
-      setIsTruncated(element.scrollHeight > element.clientHeight)
-    }
-
-    checkTruncation()
-
-    window.addEventListener("resize", checkTruncation)
-    return () => window.removeEventListener("resize", checkTruncation)
-  }, [itemTitle])
 
   return (
     // NOTE: In smaller viewports, we render a border between items for easy distinguishing
@@ -77,21 +53,7 @@ export const BlogCard = ({
         </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content">
-        <h3 className={collectionCardLinkStyle()}>
-          <span ref={textRef} className="line-clamp-3" title={itemTitle}>
-            {itemTitle}
-            {isExternalLink && !isTruncated && (
-              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-4" />
-            )}
-          </span>
-
-          {/* Show icon below text if truncated */}
-          {isExternalLink && isTruncated && (
-            <div className="mt-1">
-              <BiLinkExternal className="h-auto w-3.5 text-base-content-subtle lg:w-4" />
-            </div>
-          )}
-        </h3>
+        <Title title={itemTitle} isExternalLink={isExternalLink} />
         {tags && tags.length > 0 && (
           <div className="-mt-1 flex flex-col gap-2">
             {tags.flatMap(({ category, selected: labels }) => {

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react"
 import { BiLinkExternal } from "react-icons/bi"
 
 import type { CollectionCardProps } from "~/interfaces"
@@ -32,6 +33,22 @@ export const BlogCard = ({
 }): JSX.Element => {
   const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
 
+  const textRef = useRef<HTMLSpanElement | null>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+  useEffect(() => {
+    const checkTruncation = () => {
+      const element = textRef.current
+      if (!element) return
+
+      setIsTruncated(element.scrollHeight > element.clientHeight)
+    }
+
+    checkTruncation()
+
+    window.addEventListener("resize", checkTruncation)
+    return () => window.removeEventListener("resize", checkTruncation)
+  }, [itemTitle])
+
   return (
     // NOTE: In smaller viewports, we render a border between items for easy distinguishing
     // and to do that, we add a padding on smaller viewports
@@ -61,12 +78,19 @@ export const BlogCard = ({
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content">
         <h3 className={collectionCardLinkStyle()}>
-          <span className="relative inline">
-            <span title={itemTitle}>{itemTitle}</span>
-            {isExternalLink && (
-              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:w-5" />
+          <span ref={textRef} className="line-clamp-3" title={itemTitle}>
+            {itemTitle}
+            {isExternalLink && !isTruncated && (
+              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-4" />
             )}
           </span>
+
+          {/* Show icon below text if truncated */}
+          {isExternalLink && isTruncated && (
+            <div className="mt-1">
+              <BiLinkExternal className="h-auto w-3.5 text-base-content-subtle lg:w-4" />
+            </div>
+          )}
         </h3>
         {tags && tags.length > 0 && (
           <div className="-mt-1 flex flex-col gap-2">

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -1,7 +1,7 @@
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
 import { tv } from "~/lib/tv"
-import { focusVisibleHighlight, getFormattedDate } from "~/utils"
+import { focusVisibleHighlight, getFormattedDate, isExternalUrl } from "~/utils"
 import { ImageClient } from "../../complex/Image"
 import { Link } from "../Link"
 import { Tag } from "../Tag"
@@ -9,6 +9,11 @@ import { Tag } from "../Tag"
 const collectionCardLinkStyle = tv({
   extend: focusVisibleHighlight,
   base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 group-hover:underline",
+  variants: {
+    isExternalLink: {
+      true: "after:content-['_↗']",
+    },
+  },
 })
 
 export const BlogCard = ({
@@ -28,6 +33,8 @@ export const BlogCard = ({
   siteAssetsBaseUrl: string | undefined
   LinkComponent: CollectionPageSchemaType["LinkComponent"]
 }): JSX.Element => {
+  const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
+
   return (
     // NOTE: In smaller viewports, we render a border between items for easy distinguishing
     // and to do that, we add a padding on smaller viewports
@@ -35,6 +42,7 @@ export const BlogCard = ({
       LinkComponent={LinkComponent}
       href={referenceLinkHref}
       className="group flex flex-1 flex-col gap-3 border-b pb-5 pt-5 md:pt-0"
+      isExternal={isExternalLink}
     >
       {image && (
         <div className="relative mb-3 aspect-[2/1] h-auto min-h-40 shrink-0">
@@ -56,7 +64,10 @@ export const BlogCard = ({
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content">
         <h3 className="inline-block">
-          <span className={collectionCardLinkStyle()} title={itemTitle}>
+          <span
+            className={collectionCardLinkStyle({ isExternalLink })}
+            title={itemTitle}
+          >
             {itemTitle}
           </span>
         </h3>

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -1,3 +1,5 @@
+import { BiLinkExternal } from "react-icons/bi"
+
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
 import { tv } from "~/lib/tv"
@@ -9,11 +11,6 @@ import { Tag } from "../Tag"
 const collectionCardLinkStyle = tv({
   extend: focusVisibleHighlight,
   base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 group-hover:underline",
-  variants: {
-    isExternalLink: {
-      true: "after:content-['_↗']",
-    },
-  },
 })
 
 export const BlogCard = ({
@@ -63,12 +60,12 @@ export const BlogCard = ({
         </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content">
-        <h3 className="inline-block">
-          <span
-            className={collectionCardLinkStyle({ isExternalLink })}
-            title={itemTitle}
-          >
-            {itemTitle}
+        <h3 className={collectionCardLinkStyle()}>
+          <span className="relative inline">
+            <span title={itemTitle}>{itemTitle}</span>
+            {isExternalLink && (
+              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:w-4" />
+            )}
           </span>
         </h3>
         {tags && tags.length > 0 && (

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -64,7 +64,7 @@ export const BlogCard = ({
           <span className="relative inline">
             <span title={itemTitle}>{itemTitle}</span>
             {isExternalLink && (
-              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:w-4" />
+              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:w-5" />
             )}
           </span>
         </h3>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -21,6 +21,15 @@ const meta: Meta<typeof CollectionCard> = {
 export default meta
 type Story = StoryObj<typeof CollectionCard>
 
+interface GenerateArgsProps {
+  shouldShowDate?: boolean
+  isLastUpdatedUndefined?: boolean
+  withoutImage?: boolean
+  title?: string
+  description?: string
+  tags?: Tag[]
+  isExternalLink?: boolean
+}
 const generateArgs = ({
   shouldShowDate = true,
   isLastUpdatedUndefined = false,
@@ -28,14 +37,10 @@ const generateArgs = ({
   title = "A journal on microscopic plastic and their correlation to the number of staycations enjoyed per millennials between the ages of 30-42, substantiated by research from IDK university",
   description = "We've looked at how people's spending correlates with how much microscopic plastic they consumed over the year. We've looked at how people's spending correlates with how much microscopic plastic they consumed over the year.",
   tags = [],
-}: {
+  isExternalLink = false,
+}: GenerateArgsProps): Partial<CollectionCardProps> & {
   shouldShowDate?: boolean
-  isLastUpdatedUndefined?: boolean
-  withoutImage?: boolean
-  title?: string
-  description?: string
-  tags?: Tag[]
-}): Partial<CollectionCardProps> & { shouldShowDate?: boolean } => {
+} => {
   return {
     lastUpdated: isLastUpdatedUndefined ? undefined : "December 2, 2023",
     category: "Research",
@@ -47,7 +52,7 @@ const generateArgs = ({
           src: "https://placehold.co/500x500",
           alt: "placeholder",
         },
-    referenceLinkHref: "/",
+    referenceLinkHref: isExternalLink ? "https://www.google.com" : "/",
     imageSrc: "https://placehold.co/500x500",
     itemTitle: title,
     shouldShowDate,
@@ -66,6 +71,10 @@ export const Hover: Story = {
       hover: [".group", "img"],
     },
   },
+}
+
+export const ExternalLink: Story = {
+  args: generateArgs({ isExternalLink: true }),
 }
 
 export const UndefinedDate: Story = {

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -74,8 +74,16 @@ export const Hover: Story = {
 }
 
 export const ExternalLink: Story = {
-  args: generateArgs({ isExternalLink: true }),
+  args: generateArgs({
+    isExternalLink: true,
+    title: "This is a not-so-long title that will be truncated",
+  }),
 }
+
+// TODO: fix the external link icon showing up when the text is long
+// export const ExternalLinkLongText: Story = {
+//   args: generateArgs({ isExternalLink: true }),
+// }
 
 export const UndefinedDate: Story = {
   args: generateArgs({ isLastUpdatedUndefined: true }),

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -80,11 +80,11 @@ export const ExternalLink: Story = {
   }),
 }
 
-// TODO: fix external link icon not visible when the text is being truncated
-// because the icon is at the end of the text
-// export const ExternalLinkLongText: Story = {
-//   args: generateArgs({ isExternalLink: true }),
-// }
+// TODO: ideally when the text is being truncated,
+// the external link icon should be at the end of the text instead of the newline
+export const ExternalLinkLongText: Story = {
+  args: generateArgs({ isExternalLink: true }),
+}
 
 export const UndefinedDate: Story = {
   args: generateArgs({ isLastUpdatedUndefined: true }),

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -80,7 +80,8 @@ export const ExternalLink: Story = {
   }),
 }
 
-// TODO: fix the external link icon showing up when the text is long
+// TODO: fix external link icon not visible when the text is being truncated
+// because the icon is at the end of the text
 // export const ExternalLinkLongText: Story = {
 //   args: generateArgs({ isExternalLink: true }),
 // }

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -1,3 +1,5 @@
+import { BiLinkExternal } from "react-icons/bi"
+
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
 import { tv } from "~/lib/tv"
@@ -9,11 +11,6 @@ import { Tag } from "../Tag"
 const collectionCardLinkStyle = tv({
   extend: focusVisibleHighlight,
   base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 group-hover:underline",
-  variants: {
-    isExternalLink: {
-      true: "after:content-['_↗']",
-    },
-  },
 })
 
 export const CollectionCard = ({
@@ -48,8 +45,13 @@ export const CollectionCard = ({
         </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content lg:gap-2">
-        <h3 className={collectionCardLinkStyle({ isExternalLink })}>
-          <span title={itemTitle}>{itemTitle}</span>
+        <h3 className={collectionCardLinkStyle()}>
+          <span className="relative inline">
+            <span title={itemTitle}>{itemTitle}</span>
+            {isExternalLink && (
+              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:w-4" />
+            )}
+          </span>
         </h3>
         {tags && tags.length > 0 && (
           <>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -1,18 +1,10 @@
-import { useEffect, useRef, useState } from "react"
-import { BiLinkExternal } from "react-icons/bi"
-
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
-import { tv } from "~/lib/tv"
-import { focusVisibleHighlight, getFormattedDate, isExternalUrl } from "~/utils"
+import { getFormattedDate, isExternalUrl } from "~/utils"
 import { ImageClient } from "../../complex/Image"
 import { Link } from "../Link"
 import { Tag } from "../Tag"
-
-const collectionCardLinkStyle = tv({
-  extend: focusVisibleHighlight,
-  base: "prose-title-md-semibold flex w-fit flex-col underline-offset-4 group-hover:underline",
-})
+import { Title } from "./Title"
 
 export const CollectionCard = ({
   LinkComponent,
@@ -33,22 +25,6 @@ export const CollectionCard = ({
 }): JSX.Element => {
   const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
 
-  const textRef = useRef<HTMLSpanElement | null>(null)
-  const [isTruncated, setIsTruncated] = useState(false)
-  useEffect(() => {
-    const checkTruncation = () => {
-      const element = textRef.current
-      if (!element) return
-
-      setIsTruncated(element.scrollHeight > element.clientHeight)
-    }
-
-    checkTruncation()
-
-    window.addEventListener("resize", checkTruncation)
-    return () => window.removeEventListener("resize", checkTruncation)
-  }, [itemTitle])
-
   return (
     <Link
       LinkComponent={LinkComponent}
@@ -62,21 +38,7 @@ export const CollectionCard = ({
         </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content lg:gap-2">
-        <h3 className={collectionCardLinkStyle()}>
-          <span ref={textRef} className="line-clamp-3" title={itemTitle}>
-            {itemTitle}
-            {isExternalLink && !isTruncated && (
-              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-4" />
-            )}
-          </span>
-
-          {/* Show icon below text if truncated */}
-          {isExternalLink && isTruncated && (
-            <div className="mt-1">
-              <BiLinkExternal className="h-auto w-3.5 text-base-content-subtle lg:w-4" />
-            </div>
-          )}
-        </h3>
+        <Title title={itemTitle} isExternalLink={isExternalLink} />
         {tags && tags.length > 0 && (
           <>
             {tags.flatMap(({ category, selected: labels }) => {

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -49,7 +49,7 @@ export const CollectionCard = ({
           <span className="relative inline">
             <span title={itemTitle}>{itemTitle}</span>
             {isExternalLink && (
-              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:w-4" />
+              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-5" />
             )}
           </span>
         </h3>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -1,7 +1,7 @@
 import type { CollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
 import { tv } from "~/lib/tv"
-import { focusVisibleHighlight, getFormattedDate } from "~/utils"
+import { focusVisibleHighlight, getFormattedDate, isExternalUrl } from "~/utils"
 import { ImageClient } from "../../complex/Image"
 import { Link } from "../Link"
 import { Tag } from "../Tag"
@@ -9,6 +9,11 @@ import { Tag } from "../Tag"
 const collectionCardLinkStyle = tv({
   extend: focusVisibleHighlight,
   base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 group-hover:underline",
+  variants: {
+    isExternalLink: {
+      true: "after:content-['_↗']",
+    },
+  },
 })
 
 export const CollectionCard = ({
@@ -28,11 +33,14 @@ export const CollectionCard = ({
   siteAssetsBaseUrl: string | undefined
   LinkComponent: CollectionPageSchemaType["LinkComponent"]
 }): JSX.Element => {
+  const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
+
   return (
     <Link
       LinkComponent={LinkComponent}
       href={referenceLinkHref}
       className="group flex border-collapse flex-col gap-3 border-b border-divider-medium py-5 first:border-t lg:flex-row lg:gap-6"
+      isExternal={isExternalLink}
     >
       {shouldShowDate && (
         <p className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
@@ -40,7 +48,7 @@ export const CollectionCard = ({
         </p>
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content lg:gap-2">
-        <h3 className={collectionCardLinkStyle()}>
+        <h3 className={collectionCardLinkStyle({ isExternalLink })}>
           <span title={itemTitle}>{itemTitle}</span>
         </h3>
         {tags && tags.length > 0 && (

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react"
 import { BiLinkExternal } from "react-icons/bi"
 
 import type { CollectionCardProps } from "~/interfaces"
@@ -10,7 +11,7 @@ import { Tag } from "../Tag"
 
 const collectionCardLinkStyle = tv({
   extend: focusVisibleHighlight,
-  base: "prose-title-md-semibold line-clamp-3 w-fit underline-offset-4 group-hover:underline",
+  base: "prose-title-md-semibold flex w-fit flex-col underline-offset-4 group-hover:underline",
 })
 
 export const CollectionCard = ({
@@ -32,6 +33,22 @@ export const CollectionCard = ({
 }): JSX.Element => {
   const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
 
+  const textRef = useRef<HTMLSpanElement | null>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+  useEffect(() => {
+    const checkTruncation = () => {
+      const element = textRef.current
+      if (!element) return
+
+      setIsTruncated(element.scrollHeight > element.clientHeight)
+    }
+
+    checkTruncation()
+
+    window.addEventListener("resize", checkTruncation)
+    return () => window.removeEventListener("resize", checkTruncation)
+  }, [itemTitle])
+
   return (
     <Link
       LinkComponent={LinkComponent}
@@ -46,12 +63,19 @@ export const CollectionCard = ({
       )}
       <div className="flex flex-grow flex-col gap-3 text-base-content lg:gap-2">
         <h3 className={collectionCardLinkStyle()}>
-          <span className="relative inline">
-            <span title={itemTitle}>{itemTitle}</span>
-            {isExternalLink && (
-              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-5" />
+          <span ref={textRef} className="line-clamp-3" title={itemTitle}>
+            {itemTitle}
+            {isExternalLink && !isTruncated && (
+              <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-4" />
             )}
           </span>
+
+          {/* Show icon below text if truncated */}
+          {isExternalLink && isTruncated && (
+            <div className="mt-1">
+              <BiLinkExternal className="h-auto w-3.5 text-base-content-subtle lg:w-4" />
+            </div>
+          )}
         </h3>
         {tags && tags.length > 0 && (
           <>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/Title/ExternalLinkTitle.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/Title/ExternalLinkTitle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { BiLinkExternal } from "react-icons/bi"
+
+import { collectionCardLinkStyle } from "./collectionCardLinkStyle"
+
+// This is needed because we want the external link icon to always be visible
+// When title is not truncated, we show the external link icon at the end of the title
+// When title is truncated, we show the external link icon below the title in a new line
+export const ExternalLinkTitle = ({ title }: { title: string }) => {
+  const textRef = useRef<HTMLSpanElement | null>(null)
+
+  const [isTruncated, setIsTruncated] = useState(false)
+
+  useEffect(() => {
+    const checkTruncation = () => {
+      const element = textRef.current
+      if (!element) return
+
+      setIsTruncated(element.scrollHeight > element.clientHeight)
+    }
+
+    checkTruncation()
+
+    window.addEventListener("resize", checkTruncation)
+    return () => window.removeEventListener("resize", checkTruncation)
+  }, [title])
+
+  return (
+    <h3 className={collectionCardLinkStyle()}>
+      <span ref={textRef} className="line-clamp-3" title={title}>
+        {title}
+        {!isTruncated && (
+          <BiLinkExternal className="ml-1 inline-block h-auto w-3.5 align-middle lg:ml-1.5 lg:w-4" />
+        )}
+      </span>
+
+      {/* Show icon below text if truncated */}
+      {isTruncated && (
+        <div className="mt-1">
+          <BiLinkExternal className="h-auto w-3.5 text-base-content-subtle lg:w-4" />
+        </div>
+      )}
+    </h3>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/CollectionCard/Title/InternalLinkTitle.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/Title/InternalLinkTitle.tsx
@@ -1,0 +1,11 @@
+import { collectionCardLinkStyle } from "./collectionCardLinkStyle"
+
+export const InternalLinkTitle = ({ title }: { title: string }) => {
+  return (
+    <h3 className={collectionCardLinkStyle()}>
+      <span className="line-clamp-3" title={title}>
+        {title}
+      </span>
+    </h3>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/CollectionCard/Title/Title.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/Title/Title.tsx
@@ -1,0 +1,16 @@
+import type { CollectionCardProps } from "~/interfaces"
+import { ExternalLinkTitle } from "./ExternalLinkTitle"
+import { InternalLinkTitle } from "./InternalLinkTitle"
+
+interface TitleProps {
+  title: CollectionCardProps["itemTitle"]
+  isExternalLink: boolean
+}
+
+export const Title = ({ title, isExternalLink }: TitleProps) => {
+  return isExternalLink ? (
+    <ExternalLinkTitle title={title} />
+  ) : (
+    <InternalLinkTitle title={title} />
+  )
+}

--- a/packages/components/src/templates/next/components/internal/CollectionCard/Title/collectionCardLinkStyle.ts
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/Title/collectionCardLinkStyle.ts
@@ -1,0 +1,7 @@
+import { tv } from "~/lib/tv"
+import { focusVisibleHighlight } from "~/utils"
+
+export const collectionCardLinkStyle = tv({
+  extend: focusVisibleHighlight,
+  base: "prose-title-md-semibold flex w-fit flex-col underline-offset-4 group-hover:underline",
+})

--- a/packages/components/src/templates/next/components/internal/CollectionCard/Title/index.ts
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/Title/index.ts
@@ -1,0 +1,1 @@
+export * from "./Title"

--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.stories.tsx
@@ -67,6 +67,6 @@ export const Default: Story = {
       ],
     },
     buttonLabel: "Submit a proposal",
-    buttonUrl: "https://www.google.com",
+    buttonUrl: "/",
   },
 }

--- a/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.stories.tsx
@@ -2,18 +2,29 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { LinkButton } from "./LinkButton"
 
-const BUTTON_SIZES = ["base", "lg"] as const
-
 const meta: Meta<typeof LinkButton> = {
   title: "Next/Internal Components/LinkButton",
   component: LinkButton,
-  render: (args) => (
-    <div className="flex flex-wrap gap-2">
-      {BUTTON_SIZES.map((size) => (
-        <LinkButton key={size} {...args} size={size} />
-      ))}
-    </div>
-  ),
+  render: (args) => {
+    // Define matrices for link types and sizes
+    const links = ["/", "https://www.google.com"] as const
+    const sizes = ["base", "lg"] as const
+
+    // Generate all combinations
+    const combinations = sizes.flatMap((size) =>
+      links.map((link) => ({ size, link })),
+    )
+
+    return (
+      <div className="flex flex-col gap-2">
+        {combinations.map((combo, index) => (
+          <div key={index}>
+            <LinkButton {...args} size={combo.size} href={combo.link} />
+          </div>
+        ))}
+      </div>
+    )
+  },
   argTypes: {
     colorScheme: {
       options: ["default", "inverse"],
@@ -47,13 +58,6 @@ export const Default: Story = {
 export const LongerButtonText: Story = {
   args: {
     children: "slightly longer (link) button text",
-  },
-}
-
-export const ExternalLink: Story = {
-  args: {
-    ...Default.args,
-    href: "https://www.google.com",
   },
 }
 

--- a/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.stories.tsx
@@ -50,6 +50,13 @@ export const LongerButtonText: Story = {
   },
 }
 
+export const ExternalLink: Story = {
+  args: {
+    ...Default.args,
+    href: "https://www.google.com",
+  },
+}
+
 export const OutlineVariant: Story = {
   args: {
     ...Default.args,

--- a/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.tsx
+++ b/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.tsx
@@ -5,6 +5,7 @@ import type { VariantProps } from "tailwind-variants"
 
 import type { LinkProps } from "~/interfaces"
 import { twMerge } from "~/lib/twMerge"
+import { isExternalUrl } from "~/utils"
 import { buttonStyles } from "../Button"
 import { Link } from "../Link"
 
@@ -24,6 +25,9 @@ export const LinkButton = ({
   colorScheme,
   ...props
 }: LinkButtonProps) => {
+  const href = props.href
+  const isExternalLink = !!href && isExternalUrl(props.href)
+
   return (
     <Link
       {...props}
@@ -31,6 +35,8 @@ export const LinkButton = ({
         buttonStyles({ variant, size, className, colorScheme }),
         className,
       )}
+      isExternal={isExternalLink}
+      showExternalIcon={isExternalLink}
     />
   )
 }

--- a/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.tsx
+++ b/packages/components/src/templates/next/components/internal/LinkButton/LinkButton.tsx
@@ -2,12 +2,38 @@
 
 import type { ElementType } from "react"
 import type { VariantProps } from "tailwind-variants"
+import { BiLinkExternal } from "react-icons/bi"
 
 import type { LinkProps } from "~/interfaces"
+import { tv } from "~/lib/tv"
 import { twMerge } from "~/lib/twMerge"
 import { isExternalUrl } from "~/utils"
 import { buttonStyles } from "../Button"
 import { Link } from "../Link"
+
+// External link icon styling
+const externalIconStyles = tv({
+  base: "h-auto flex-shrink-0",
+  variants: {
+    size: {
+      base: "w-3.5 lg:w-4",
+      lg: "w-4.5 lg:w-5",
+    },
+  },
+  defaultVariants: {
+    size: "base",
+  },
+})
+
+// Link button layout styling
+const linkButtonStyles = tv({
+  base: "",
+  variants: {
+    isExternal: {
+      true: "flex items-center gap-2",
+    },
+  },
+})
 
 export interface LinkButtonProps
   extends LinkProps,
@@ -28,6 +54,23 @@ export const LinkButton = ({
   const href = props.href
   const isExternalLink = !!href && isExternalUrl(props.href)
 
+  if (isExternalLink) {
+    return (
+      <Link
+        {...props}
+        className={twMerge(
+          buttonStyles({ variant, size, className, colorScheme }),
+          linkButtonStyles({ isExternal: true }),
+          className,
+        )}
+        isExternal={isExternalLink}
+      >
+        {props.children}
+        <BiLinkExternal className={externalIconStyles({ size })} />
+      </Link>
+    )
+  }
+
   return (
     <Link
       {...props}
@@ -35,8 +78,6 @@ export const LinkButton = ({
         buttonStyles({ variant, size, className, colorScheme }),
         className,
       )}
-      isExternal={isExternalLink}
-      showExternalIcon={isExternalLink}
     />
   )
 }

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1308,9 +1308,9 @@ export const Default: Story = {
         title: "This is a place where you can put nice content",
         description: "About a sentence worth of description here",
         buttonLabel: "Primary CTA",
-        buttonUrl: "https://google.com",
+        buttonUrl: "/",
         secondaryButtonLabel: "Secondary CTA",
-        secondaryButtonUrl: "https://google.com",
+        secondaryButtonUrl: "/",
       },
       {
         type: "infocards",

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -276,9 +276,9 @@ export const Default: Story = {
         title: "This is a place where you can put nice content",
         description: "About a sentence worth of description here",
         buttonLabel: "Primary CTA",
-        buttonUrl: "https://google.com",
+        buttonUrl: "/",
         secondaryButtonLabel: "Secondary CTA",
-        secondaryButtonUrl: "https://google.com",
+        secondaryButtonUrl: "/",
       },
       {
         type: "infopic",
@@ -289,7 +289,7 @@ export const Default: Story = {
         imageAlt: "alt",
         imageSrc: "https://placehold.co/200x200",
         buttonLabel: "Primary CTA",
-        buttonUrl: "https://www.google.com",
+        buttonUrl: "/",
       },
       {
         type: "infocards",
@@ -298,7 +298,7 @@ export const Default: Story = {
           "Section subtitle, maximum 150 chars. These are some of the things we are working on. As a ministry, we focus on delivering value to the members of public.",
         variant: "cardsWithImages",
         label: "This is a CTA",
-        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        url: "/",
         cards: [
           {
             title: "Card with short title",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

For buttons and collection/blog cards, external links 1) do not open in new tab and 2) show "new tab" icon at the end

<img width="524" alt="image" src="https://github.com/user-attachments/assets/4e561819-fc53-495f-bd5a-06daab41d92b" />

Closes https://linear.app/ogp/issue/ISOM-1727/bug-external-link-all-should-have-new-tab-icon-open-in-new-tab

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add a check in `LinkButton`
- add a check in the `CollectionCard` and `BlogCard` + add stories

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to a component with a button e.g. Hero. Add the link to an external link e.g. `https://google.com`.
    - [ ] It should show a "open in new link" icon
    - [ ] after building, when clicked on, it should open new link. (alternately: can inspect element on studio to check for `target: _blank`
2. go to a collection and create a collection link. Add the link to an external link e.g. `https://google.com`.
    - [ ] It should show a "open in new link" icon
    - [ ] after building, when clicked on, it should open new link. (alternately: can inspect element on studio to check for `target: _blank`