### PR TITLE
fix: studio file/image upload acceptable file extension copywriting

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsMetaImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsMetaImageControl.tsx
@@ -16,7 +16,7 @@ import { getPresignedPutUrlSchema } from "~/schemas/asset"
 import { useImageUpload } from "../../hooks/useImage"
 import { useS3Image } from "../../hooks/useS3Image"
 import {
-  ACCEPTED_FILE_TYPES_MESSAGE,
+  ACCEPTED_IMAGE_TYPES_MESSAGE,
   IMAGE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
   MAX_IMG_FILE_SIZE_BYTES,
   ONE_MB_IN_BYTES,
@@ -96,7 +96,7 @@ export function JsonFormsMetaImageControl(
       <Text textStyle="body-2" textColor="base.content.medium" pt="0.5rem">
         {`Maximum file size: ${MAX_IMG_FILE_SIZE_BYTES / ONE_MB_IN_BYTES} MB`}
         <br />
-        {`Accepted file types: ${ACCEPTED_FILE_TYPES_MESSAGE}`}
+        {`Accepted file types: ${ACCEPTED_IMAGE_TYPES_MESSAGE}`}
       </Text>
       {!!errors && (
         <FormErrorMessage>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
@@ -9,6 +9,10 @@ export const IMAGE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING: Record<string, string> = {
   ".webp": "image/webp",
 }
 
+export const ACCEPTED_IMAGE_TYPES_MESSAGE = Object.keys(
+  IMAGE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
+).join(", ")
+
 export const MAX_FILE_SIZE_BYTES = 20000000
 export const FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING: Record<string, string> = {
   ".pdf": "application/pdf",
@@ -19,7 +23,7 @@ export const FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING: Record<string, string> = {
 }
 
 export const ACCEPTED_FILE_TYPES_MESSAGE = Object.keys(
-  IMAGE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
+  FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
 ).join(", ")
 
 export const ONE_MB_IN_BYTES = 1000000


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

RE: https://opengovproducts.slack.com/archives/C07CWUNUL68/p1740639058162289

Wrong copywriting for file upload

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- use the correct constants

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to a page -> create a text block -> click on "hyperlink" icon in tiptap -> click on "File" option -> It should show `Accepted file types: .pdf, .xls, .xlsx, .csv, .tsv`
2. go to a page -> click on "META SETTINGS" -> it should show `Accepted file types: .jpeg, .png, .gif, .svg, .tiff, .bmp, .webp`