### PR TITLE
fix: Dynamically display accepted file types in FileAttachment

### DIFF
--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -4,10 +4,7 @@ import { FormControl, Skeleton, Text } from "@chakra-ui/react"
 import { Attachment } from "@opengovsg/design-system-react"
 
 import { useImageUpload } from "~/features/editing-experience/components/form-builder/hooks/useImage"
-import {
-  ACCEPTED_FILE_TYPES_MESSAGE,
-  ONE_MB_IN_BYTES,
-} from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
+import { ONE_MB_IN_BYTES } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
 import { getPresignedPutUrlSchema } from "~/schemas/asset"
 
@@ -83,7 +80,7 @@ export const FileAttachment = ({
       <Text textStyle="body-2" textColor="base.content.medium" pt="0.5rem">
         {`Maximum file size: ${maxSizeInBytes / ONE_MB_IN_BYTES} MB`}
         <br />
-        {`Accepted file types: ${ACCEPTED_FILE_TYPES_MESSAGE}`}
+        {`Accepted file types: ${Object.keys(acceptedFileTypes).join(", ")}`}
       </Text>
     </FormControl>
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

wrong file tyep description

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- use correct variables

## Before & After Screenshots

**BEFORE**:

<img width="468" alt="image" src="https://github.com/user-attachments/assets/b920c6a9-913a-49c0-b22e-55cc0858ba74" />

**AFTER**:

<!-- [insert screenshot here] -->

<img width="570" alt="image" src="https://github.com/user-attachments/assets/c676ef7c-a650-425d-8c36-ba40857d3303" />
