### PR TITLE
fix: add invalidation after publish

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -187,3 +187,4 @@ echo "ETag: $ETag"
 jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
 jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
 aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag
+aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
## Problem
We had have an issue where users fetch stale data.

## Solution
Add invalidation after publish - refer to the cloudfront [docs](https://docs.aws.amazon.com/cli/latest/reference/cloudfront/create-invalidation.html) for this
