### PR TITLE
fix: set required form fields for create folder modal

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -134,7 +134,7 @@ const CreateFolderModalContent = ({
         <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
-            <FormControl isInvalid={!!errors.folderTitle}>
+            <FormControl isRequired isInvalid={!!errors.folderTitle}>
               <FormLabel color="base.content.strong">
                 Folder name
                 <FormHelperText color="base.content.default">
@@ -157,7 +157,7 @@ const CreateFolderModalContent = ({
                 </FormHelperText>
               )}
             </FormControl>
-            <FormControl isInvalid={!!errors.permalink}>
+            <FormControl isRequired isInvalid={!!errors.permalink}>
               <FormLabel color="base.content.strong">
                 Folder URL
                 <FormHelperText color="base.content.default">

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -118,7 +118,7 @@ export const CreatePageDetailsScreen = () => {
               </Stack>
               <Stack gap="1.5rem">
                 {/* Section 1: Page Title */}
-                <FormControl isInvalid={!!errors.title}>
+                <FormControl isRequired isInvalid={!!errors.title}>
                   <FormLabel color="base.content.strong">
                     Page title
                     <FormHelperText color="base.content.default">
@@ -141,7 +141,7 @@ export const CreatePageDetailsScreen = () => {
                 </FormControl>
 
                 {/* Section 2: Page URL */}
-                <FormControl isInvalid={!!errors.permalink}>
+                <FormControl isRequired isInvalid={!!errors.permalink}>
                   <FormLabel>
                     Page URL
                     <FormHelperText>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

For some reason, we are now showing `(optional)` beside the form fields when creating new folders, but all the fields should be required.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Set the form fields in the create folder modal to all be required.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="704" alt="image" src="https://github.com/user-attachments/assets/88b6875e-20c9-4b87-a141-4837acc13195" />

**AFTER**:

<!-- [insert screenshot here] -->
<img width="713" alt="image" src="https://github.com/user-attachments/assets/1fc18fc4-b2a0-4d81-aaf7-0af5a5455462" />

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Go to Studio and create a folder.
2. Verify that the create folder form has all the fields shown to be required (no optional text).
3. Verify that you are not able to create the folder if any of the fields are not filled in.
4. Verify that you can still proceed to create the folder with all the fields filled in.