### PR TITLE
fix: break words for overflow preview and content

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -60,7 +60,7 @@ export const BaseBlock = ({
         </Flex>
       )}
       <Stack align="start" gap="0.25rem" overflow="auto">
-        <Text textStyle="subhead-2" noOfLines={1}>
+        <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
           {label}
         </Text>
         {description && (

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -39,7 +39,7 @@ const ArticleLayout = ({
         />
 
         <div className="mx-auto w-full gap-10 pb-20">
-          <div className="w-full overflow-x-auto lg:max-w-[660px]">
+          <div className="w-full overflow-x-auto break-words lg:max-w-[660px]">
             {renderPageContent({
               site,
               layout,

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -20,7 +20,7 @@ const createContentLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 flex flex-col gap-16",
+    content: "col-span-12 flex flex-col gap-16 break-words",
   },
   variants: {
     isSideRailPresent: {

--- a/packages/components/src/templates/next/layouts/Database/Database.tsx
+++ b/packages/components/src/templates/next/layouts/Database/Database.tsx
@@ -17,7 +17,7 @@ const createDatabaseLayoutStyles = tv({
   slots: {
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
-    content: "col-span-12 flex max-w-[54rem] flex-col gap-16",
+    content: "col-span-12 flex max-w-[54rem] flex-col gap-16 break-words",
     table: "col-span-12 [&:not(:first-child)]:mt-14",
   },
 })

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -21,7 +21,7 @@ const HomepageLayout = ({
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,
         // but cannot be used here as tailwind does not support dynamic class names
-        className={`[&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
+        className={`break-words [&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
       >
         {renderPageContent({
           content,

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -10,7 +10,7 @@ const createIndexPageLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 max-w-[54rem]",
+    content: "col-span-12 max-w-[54rem] break-words",
   },
 })
 

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -88,7 +88,7 @@ export const Skeleton = ({
       <main
         id={SKIP_TO_CONTENT_ANCHOR_ID}
         tabIndex={-1}
-        className="focus-visible:outline-none"
+        className="break-words focus-visible:outline-none"
       >
         {children}
       </main>

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -88,7 +88,7 @@ export const Skeleton = ({
       <main
         id={SKIP_TO_CONTENT_ANCHOR_ID}
         tabIndex={-1}
-        className="break-words focus-visible:outline-none"
+        className="focus-visible:outline-none"
       >
         {children}
       </main>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When users have a very long URL, it causes a scrollbar to appear for the content.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add break words to the component preview to remove the scrollbar.
- Also add break words to the Skeleton layout (which all layouts use) so the scrollbar doesn't appear.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

<img width="829" alt="image" src="https://github.com/user-attachments/assets/659ddf38-6175-4e0c-b922-5a183db5bc71" />
<img width="856" alt="image" src="https://github.com/user-attachments/assets/927a8e4d-181e-4c23-9ed6-4afbae4212a8" />


**AFTER**:

<!-- [insert screenshot here] -->
<img width="834" alt="image" src="https://github.com/user-attachments/assets/d216c5b4-67a6-4072-93d9-dc615c9cef9d" />
<img width="755" alt="image" src="https://github.com/user-attachments/assets/f94199cf-1ecd-4eb0-926e-24fc3adb3440" />


## Tests

<!-- What tests should be run to confirm functionality? -->

1. Copy and paste the JSON content [from this page](https://staging-studio.isomer.gov.sg/sites/1/pages/16893) into a new page.
2. Verify that there isn't a scrollbar in the component content preview on the left.
3. Verify that there isn't a scrollbar in the page preview itself on the right.