### PR TITLE
fix unique constraint on user and resourcepermission

### DIFF
--- a/apps/studio/prisma/migrations/20250305210834_fix_unique_indexes_on_user_and_resourcepermission/migration.sql
+++ b/apps/studio/prisma/migrations/20250305210834_fix_unique_indexes_on_user_and_resourcepermission/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId,siteId,resourceId,deletedAt]` on the table `ResourcePermission` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[email,deletedAt]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "ResourcePermission_userId_siteId_resourceId_role_key";
+
+-- DropIndex
+DROP INDEX "User_email_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ResourcePermission_userId_siteId_resourceId_deletedAt_key" ON "ResourcePermission"("userId", "siteId", "resourceId", "deletedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_deletedAt_key" ON "User"("email", "deletedAt");

--- a/apps/studio/prisma/migrations/20250305210937_custom_migration/migration.sql
+++ b/apps/studio/prisma/migrations/20250305210937_custom_migration/migration.sql
@@ -1,9 +1,3 @@
--- Override Prisma's unique index with unique NOT DISTINCT index
-DROP INDEX IF EXISTS "Resource_siteId_parentId_permalink_key";
-
-CREATE UNIQUE INDEX IF NOT EXISTS "Resource_siteId_parentId_permalink_key" ON "Resource"("siteId", "parentId", "permalink") NULLS NOT DISTINCT;
-
-
 ---------------------------------
 -- This migration fixes uniqueness constraints for User and ResourcePermission.
 -- Reference: https://github.com/opengovsg/isomer/pull/1155
@@ -16,4 +10,5 @@ DROP INDEX "User_email_deletedAt_key";
 
 CREATE UNIQUE INDEX IF NOT EXISTS "User_email_deletedAt_key" ON "User"("email", "deletedAt") NULLS NOT DISTINCT;
 
----------------------------------
+---------------------------------;
+

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -116,7 +116,7 @@ enum ResourceType {
 model User {
   id    String @id @default(cuid())
   name  String
-  email String @unique
+  email String
   phone String
 
   createdAt DateTime  @default(now())
@@ -125,6 +125,11 @@ model User {
 
   ResourcePermission ResourcePermission[]
   versions           Version[]
+
+  // This unique index is subsequently replaced with a custom index that
+  // treats nulls as not distinct.
+  // This is required so prisma does not attempt to drop the custom index.
+  @@unique([email, deletedAt])
 }
 
 model Site {
@@ -189,7 +194,10 @@ model ResourcePermission {
   updatedAt  DateTime  @default(now()) @updatedAt
   deletedAt  DateTime?
 
-  @@unique([userId, siteId, resourceId, role])
+  // This unique index is subsequently replaced with a custom index that
+  // treats nulls as not distinct.
+  // This is required so prisma does not attempt to drop the custom index.
+  @@unique([userId, siteId, resourceId, deletedAt])
 }
 
 enum RoleType {

--- a/apps/studio/prisma/scripts/addUsersToSite.ts
+++ b/apps/studio/prisma/scripts/addUsersToSite.ts
@@ -35,7 +35,7 @@ export const addUsersToSite = async ({
           })
           .onConflict((oc) =>
             oc
-              .column("email")
+              .columns(["email", "deletedAt"])
               .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
           )
           .returning(["id", "name", "email"])

--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -39,7 +39,7 @@ async function main() {
         })
         .onConflict((oc) =>
           oc
-            .column("email")
+            .columns(["email", "deletedAt"])
             .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
         )
         .returning(["id", "name"])


### PR DESCRIPTION
# Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The current unique index for ResourcePermission in Prisma, defined as `@@unique([userId, siteId, resourceId, role])`, has three key issues:

## 1. Standard Unique Constraints Treat NULL as Distinct, Allowing Duplicate Permissions

Unique constraints in SQL consider each `NULL` value as distinct, which allows multiple records with `NULL` values in the same indexed columns.

For example, both of these records can exist together:
```sql
{ "siteId": 1, "userId": 1, "role": "Admin", "resourceId": NULL }
{ "siteId": 1, "userId": 1, "role": "Editor", "resourceId": NULL }
```

This creates ambiguity in determining the correct permission (Admin or Editor). While we might assume that the highest permission should apply (Admin > Editor), this assumption may not always hold true.

It also complicates database queries since we would always need to check for and resolve this edge case.

### Solution: Use `NULLS NOT DISTINCT` to treat `NULL` values as equal.

Note: This feature is only available in PostgreSQL 15 and later.

This is also unsupported in Prisma, thus we have to insert a custom migration. This is referencing how https://github.com/opengovsg/isomer/pull/642 did it

## 2. Including "role" in the Unique Index Allows Multiple Role Entries

Since `role` is part of the unique index, multiple records with different roles can exist for the same `(siteId, userId, resourceId)`.

Example:
```sql
{ "siteId": 1, "userId": 1, "resourceId": 1, "role": "Admin" }
{ "siteId": 1, "userId": 1, "resourceId": 1, "role": "Editor" }
```

This results in the same issue as above: ambiguity in determining the correct role for a user.

### Solution: Remove `role` from the unique index.

This ensures that for a given `(siteId, userId, resourceId)`, only one entry exists.

## 3. Lack of a Unique Constraint on `deletedAt` Prevents Record Recreation

The system uses soft deletion by setting a timestamp in the deletedAt field. However, the current unique constraint does not include deletedAt, preventing previously deleted records from being reinserted.

Example:
```sql
-- When this exists
{ "siteId": 1, "userId": 1, "resourceId": 1, "role": "Editor", "deletedAt": "some_timestamp" }

-- This new record cannot be created:
{ "siteId": 1, "userId": 1, "resourceId": 1, "role": "Editor", "deletedAt": NULL }
```

### Solution: Add `deletedAt` to the unique index

This allows re-creation of soft-deleted records.

# Breaking Changes

There are no breaking changes, but a database audit is required to ensure compatibility.

This can be verified by running the following queries and confirming that both return 0 results.

## Check for Duplicate ResourcePermissions
```sql
SELECT "siteId", "userId", "resourceId", "deletedAt", COUNT(*)
FROM "ResourcePermission"
GROUP BY "siteId", "userId", "resourceId", "deletedAt"
HAVING COUNT(*) > 1;
```

## Check for Duplicate Users
```sql
SELECT "email", "deletedAt", COUNT(*)
FROM "User"
GROUP BY "email", "deletedAt"
HAVING COUNT(*) > 1;
```