### PR TITLE
fix: remove optional for email OTP login

### DIFF
--- a/apps/studio/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
+++ b/apps/studio/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
@@ -116,6 +116,7 @@ export const VerificationInput = (): JSX.Element | null => {
           id="email"
           isInvalid={!!errors.token}
           isReadOnly={verifyOtpMutation.isLoading}
+          isRequired
         >
           <FormLabel htmlFor="email">
             Enter the OTP sent to {vfnStepData.email}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

So weird, suddenly our form fields are showing optional.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make email verification OTP form field required.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="913" alt="image" src="https://github.com/user-attachments/assets/62c838a8-0ab8-48ef-a135-eeb6be2543e6" />

**AFTER**:

<!-- [insert screenshot here] -->
<img width="923" alt="image" src="https://github.com/user-attachments/assets/07559a32-16ff-4242-a992-efd804320729" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Enter your email address when you log in to Studio.
- [ ] Verify that the "(optional)" text does not appear when at the input verification OTP stage.