### PR TITLE
isom-1760: internal links PR- state persisted after closing

### DIFF
--- a/apps/studio/src/components/ResourceSelector/useResourceStack.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceStack.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import type { ResourceItemContent } from "~/schemas/resource"
 import { trpc } from "~/utils/trpc"
@@ -27,6 +27,10 @@ export const useResourceStack = ({
   const [resourceStack, setResourceStack] = useState<ResourceItemContent[]>(
     pendingMovedItemAncestryStack ?? [],
   )
+
+  useEffect(() => {
+    return () => setResourceStack([])
+  }, [pendingMovedItemAncestryStack])
 
   const [isResourceHighlighted, setIsResourceHighlighted] =
     useState<boolean>(!!selectedResourceId)

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -106,7 +106,6 @@ const MoveResourceContent = withSuspense(
     })
 
     const movedItem = useAtomValue(moveResourceAtom)
-    console.log(11111, movedItem, movedItem?.permalink)
 
     return (
       <ModalContent>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1760/internal-links-pr-follow-up-state-is-persisted-after-closing-modla

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- remove console log lmao

**Bug Fixes**:

- cleanup state on dismount

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/fa674221-11b9-4cc3-8416-789bbff9af52

**AFTER**:

<!-- [insert screenshot here] -->

https://github.com/user-attachments/assets/645d146e-a78f-40ac-b6ad-a62a936ccba3

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
