### PR TITLE
Security - add missing permissions (assets + resources)

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -204,7 +204,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
           return acc
         }, [])
 
-      deleteAssets({ fileKeys: assetsToDelete })
+      deleteAssets({ siteId, fileKeys: assetsToDelete })
     }
 
     savePage(

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -124,7 +124,7 @@ export default function HeroEditorDrawer(): JSX.Element {
           return acc
         }, [])
 
-      deleteAssets({ fileKeys: assetsToDelete })
+      deleteAssets({ siteId, fileKeys: assetsToDelete })
     }
 
     mutate(

--- a/apps/studio/src/schemas/asset.ts
+++ b/apps/studio/src/schemas/asset.ts
@@ -19,6 +19,7 @@ export const getPresignedPutUrlSchema = z.object({
 })
 
 export const deleteAssetsSchema = z.object({
+  siteId: z.number().min(1),
   fileKeys: z.array(
     z.string({
       required_error: "Missing file keys",

--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -1,0 +1,190 @@
+import { TRPCError } from "@trpc/server"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupEditorPermissions,
+  setupSite,
+  setUpWhitelist,
+} from "tests/integration/helpers/seed"
+import { vi } from "vitest"
+
+import { createCallerFactory } from "~/server/trpc"
+import { assetRouter } from "../asset.router"
+import * as assetService from "../asset.service"
+
+const createCaller = createCallerFactory(assetRouter)
+
+describe("asset.router", async () => {
+  let caller: ReturnType<typeof createCaller>
+  const session = await applyAuthedSession()
+
+  const TEST_VALID_EMAIL = "test@open.gov.sg"
+
+  beforeAll(() => {
+    caller = createCaller(createMockRequest(session))
+  })
+
+  beforeEach(async () => {
+    await resetTables("Site", "ResourcePermission", "Resource")
+    await setUpWhitelist({ email: TEST_VALID_EMAIL })
+    // Reset any mocks after each test
+    vi.restoreAllMocks()
+  })
+
+  describe("getPresignedPutUrl", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.getPresignedPutUrl({
+        siteId: 1,
+        fileName: "test.png",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if site does not exist", async () => {
+      // Act
+      const result = caller.getPresignedPutUrl({
+        siteId: 99999,
+        fileName: "test.png",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw 403 if user does not have permission to read site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+
+      // Act
+      const result = caller.getPresignedPutUrl({
+        siteId: site.id,
+        fileName: "test.png",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should return success if user has permission to read site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.getPresignedPutUrl({
+        siteId: site.id,
+        fileName: "test.png",
+      })
+
+      // Assert
+      await expect(result).resolves.not.toThrow()
+    })
+  })
+
+  describe("deleteAssets", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.deleteAssets({
+        siteId: 1,
+        fileKeys: ["test.png"],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if site does not exist", async () => {
+      // Arrange
+      const result = caller.deleteAssets({
+        siteId: 99999,
+        fileKeys: ["test.png"],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw 403 if user does not have permission to read site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+
+      // Act
+      const result = caller.deleteAssets({
+        siteId: site.id,
+        fileKeys: ["test.png"],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should return success if user has permission to read site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Mock the markFileAsDeleted function to resolve successfully
+      // Workaround as we do not really want to set up a full integration test here with S3
+      vi.spyOn(assetService, "markFileAsDeleted").mockResolvedValue(undefined)
+
+      // Act
+      const result = caller.deleteAssets({
+        siteId: site.id,
+        fileKeys: ["test.png"],
+      })
+
+      // Assert
+      // The function doesn't return a value, so we just check that it resolves without error
+      await expect(result).resolves.not.toThrow()
+    })
+  })
+})

--- a/apps/studio/src/server/modules/asset/asset.router.ts
+++ b/apps/studio/src/server/modules/asset/asset.router.ts
@@ -6,12 +6,19 @@ import {
   getFileKey,
   getPresignedPutUrl,
   markFileAsDeleted,
+  validateUserPermissionsForAsset,
 } from "./asset.service"
 
 export const assetRouter = router({
   getPresignedPutUrl: protectedProcedure
     .input(getPresignedPutUrlSchema)
     .mutation(async ({ ctx, input: { siteId, fileName } }) => {
+      await validateUserPermissionsForAsset({
+        siteId,
+        action: "read",
+        userId: ctx.user.id,
+      })
+
       const fileKey = getFileKey({
         siteId,
         fileName,
@@ -39,8 +46,12 @@ export const assetRouter = router({
 
   deleteAssets: protectedProcedure
     .input(deleteAssetsSchema)
-    .mutation(async ({ ctx, input }) => {
-      const { fileKeys } = input
+    .mutation(async ({ ctx, input: { siteId, fileKeys } }) => {
+      await validateUserPermissionsForAsset({
+        siteId,
+        action: "read",
+        userId: ctx.user.id,
+      })
 
       await Promise.allSettled(
         fileKeys.map((fileKey) => markFileAsDeleted({ key: fileKey })),

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -1,11 +1,23 @@
 import { randomUUID } from "crypto"
 import type { z } from "zod"
 
+import type { SitePermissionsProps } from "../site/site.service"
 import type { getPresignedPutUrlSchema } from "~/schemas/asset"
 import { env } from "~/env.mjs"
 import { deleteFile, generateSignedPutUrl } from "~/lib/s3"
+import { validateUserPermissionsForSite } from "../site/site.service"
 
 const { NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME } = env
+
+// Reusing site permissions since all users can create assets
+// Creating a wrapper as a reminder to update if we will to introduce a READ-only role
+export const validateUserPermissionsForAsset = async ({
+  siteId,
+  action,
+  userId,
+}: SitePermissionsProps) => {
+  await validateUserPermissionsForSite({ siteId, action, userId })
+}
 
 export const getFileKey = ({
   siteId,

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -8,11 +8,16 @@ import type {
 import { db, jsonb, sql } from "../database"
 import { definePermissionsForSite } from "../permissions/permissions.service"
 
+export interface SitePermissionsProps
+  extends Omit<PermissionsProps, "resourceId"> {
+  action: CrudResourceActions
+}
+
 export const validateUserPermissionsForSite = async ({
   siteId,
   userId,
   action,
-}: Omit<PermissionsProps, "resourceId"> & { action: CrudResourceActions }) => {
+}: SitePermissionsProps) => {
   const perms = await definePermissionsForSite({
     siteId,
     userId,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1762/security-no-permissions-check-on-deleting-assets

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- safety checks for permissions for assets - we use a wrapper around SitePermission since all users can delete assets at this moment, but i think it's good because 1) it provides a basic SitePerms check , 2) having this wrapper make us be more conscious of any changes in the future

