### PR TITLE
feat: allow Google MyMaps and OneMap advanced minimap

### DIFF
--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -110,6 +110,17 @@ describe("validation", () => {
       })
     })
 
+    it("should allow Google My Maps embed URLs", () => {
+      const testCases = [
+        "https://www.google.com/maps/d/embed?mid=1Mgnp3R1e7rYXGY2Vn1efD-AWXlfZa8o&ehbc=2E312F",
+      ]
+
+      testCases.forEach((testCase) => {
+        const result = new RegExp(MAPS_EMBED_URL_PATTERN).test(testCase)
+        expect(result).toBe(true)
+      })
+    })
+
     it("should allow OneMap embed URLs", () => {
       const testCases = [
         "https://www.onemap.gov.sg/minimap/minimap.html?mapStyle=Default&zoomLevel=15&latLng=1.29793747849037,103.850182257356&ewt=JTNDcCUzRSUzQ3N0cm9uZyUzRU9wZW4lMjBHb3Zlcm5tZW50JTIwUHJvZHVjdHMlMjBvZmZpY2UlM0MlMkZzdHJvbmclM0UlM0MlMkZwJTNF&popupWidth=200&showPopup=true",

--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -124,6 +124,7 @@ describe("validation", () => {
     it("should allow OneMap embed URLs", () => {
       const testCases = [
         "https://www.onemap.gov.sg/minimap/minimap.html?mapStyle=Default&zoomLevel=15&latLng=1.29793747849037,103.850182257356&ewt=JTNDcCUzRSUzQ3N0cm9uZyUzRU9wZW4lMjBHb3Zlcm5tZW50JTIwUHJvZHVjdHMlMjBvZmZpY2UlM0MlMkZzdHJvbmclM0UlM0MlMkZwJTNF&popupWidth=200&showPopup=true",
+        "https://www.onemap.gov.sg/amm/amm.html?mapStyle=Default&zoomLevel=15&marker=postalcode:189554!colour:darkblue&marker=postalcode:068877!colour:red&marker=postalcode:179097!colour:red&popupWidth=200",
       ]
 
       testCases.forEach((testCase) => {
@@ -136,7 +137,9 @@ describe("validation", () => {
       const testCases = [
         "https://www.example.com/maps/embed?pb=!1m18!1m12!1m3!1d3961.473373876674!2d103.8486973142665!3d1.3035969990313745!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19b8b4c6e1e1%3A0x2f1f6b8f0a1b2a7d!2sMinistry%20of%20Communications%20and%20Information!5e0!3m2!1sen!2ssg!4v1632291134655!5m2!1en!2sg",
         "https://www.google.com/maps?pb=!1m18!1m12!1m3!1d3961.473373876674!2d103.8486973142665!3d1.3035969990313745!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19b8b4c6e1e1%3A0x2f1f6b8f0a1b2a7d!2sMinistry%20of%20Communications%20and%20Information!5e0!3m2!1en!2sg!4v1632291134655!5m2!1en!2sg",
+        "https://www.google.com/maps/eee/embed?mid=1Mgnp3R1e7rYXGY2Vn1efD-AWXlfZa8o&ehbc=2E312F",
         "https://www.google.fakesite.com/maps/embed?pb=!1m18!1m12!1m3!1d3961.473373876674!2d103.8486973142665!3d1.3035969990313745!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19b8b4c6e1e1%3A0x2f1f6b8f0a1b2a7d!2sMinistry%20of%20Communications%20and%20Information!5e0!3m2!1sen!2ssg!4v1632291134655!5m2!1en!2sg",
+        "https://www.onemap.gov.sg/minimap/amm.html?mapStyle=Default&zoomLevel=15&marker=postalcode:189554!colour:darkblue&marker=postalcode:068877!colour:red&marker=postalcode:179097!colour:red&popupWidth=200",
       ]
 
       testCases.forEach((testCase) => {

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -56,7 +56,7 @@ export const isValidMapEmbedUrl = (url: string) => {
 // that is supported inside the JSON schema. Components rely on the URL object
 // validation for better security.
 export const MAPS_EMBED_URL_REGEXES = {
-  googlemaps: "^https://www\\.google\\.com/maps/embed?.*$",
+  googlemaps: "^https://www\\.google\\.com/maps(?:/d)?/embed?.*$",
   onemap: "^https://www\\.onemap\\.gov\\.sg/minimap/minimap\\.html.*$",
 } as const
 

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -23,14 +23,16 @@ export const REF_HREF_PATTERN =
 const isValidGoogleMapsEmbedUrl = (urlObject: URL) => {
   return (
     urlObject.hostname === "www.google.com" &&
-    urlObject.pathname === "/maps/embed"
+    (urlObject.pathname === "/maps/embed" ||
+      urlObject.pathname === "/maps/d/embed")
   )
 }
 
 const isValidOneMapEmbedUrl = (urlObject: URL) => {
   return (
     urlObject.hostname === "www.onemap.gov.sg" &&
-    urlObject.pathname === "/minimap/minimap.html"
+    (urlObject.pathname === "/minimap/minimap.html" ||
+      urlObject.pathname === "/amm/amm.html")
   )
 }
 

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -57,7 +57,8 @@ export const isValidMapEmbedUrl = (url: string) => {
 // validation for better security.
 export const MAPS_EMBED_URL_REGEXES = {
   googlemaps: "^https://www\\.google\\.com/maps(?:/d)?/embed?.*$",
-  onemap: "^https://www\\.onemap\\.gov\\.sg/minimap/minimap\\.html.*$",
+  onemap:
+    "^https://www\\.onemap\\.gov\\.sg(/minimap/minimap\\.html|/amm/amm\\.html).*$",
 } as const
 
 export const MAPS_EMBED_URL_PATTERN = Object.values(MAPS_EMBED_URL_REGEXES)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We currently do not allow Google MyMaps and OneMap advanced minimap embeds.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Expand the validation functions to allow Google MyMaps and OneMap advanced minimap embeds.

## Screenshots

<img width="912" alt="image" src="https://github.com/user-attachments/assets/707a40b6-554f-435c-832c-3dd2704b7af8" />
<img width="887" alt="image" src="https://github.com/user-attachments/assets/2cf57a57-60a5-44f3-ad37-5b91fa7f9f0e" />


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit any page.
- [ ] Add a new Map component and paste in a Google MyMaps embed code (can [use this example](https://www.google.com/maps/d/viewer?mid=1Mgnp3R1e7rYXGY2Vn1efD-AWXlfZa8o&femb=1&ll=1.417905635974897%2C103.8045931392578&z=12)).
- [ ] Verify that the Map component can be created and the preview loads.
- [ ] Add a new Map component and paste in a OneMap advanced minimap embed ([create one here](https://www.onemap.gov.sg/tools/amm/#)).
- [ ] Verify that the Map component can be created and the preview loads.