### PR TITLE
feat(audit-logs): add initial service + methods to log various events

### DIFF
--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -34,5 +34,8 @@ export const AuditLogEvent = {
   PermissionCreate: "PermissionCreate",
   PermissionUpdate: "PermissionUpdate",
   PermissionDelete: "PermissionDelete",
+  SiteConfigUpdate: "SiteConfigUpdate",
+  FooterUpdate: "FooterUpdate",
+  NavbarUpdate: "NavbarUpdate",
 } as const
 export type AuditLogEvent = (typeof AuditLogEvent)[keyof typeof AuditLogEvent]

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -13,7 +13,7 @@ export type Generated<T> =
     : ColumnType<T, T | undefined, T>
 export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
-export interface AuditLog {
+export type AuditLog = {
   id: GeneratedAlways<string>
   userId: string
   eventType: AuditLogEvent
@@ -27,7 +27,7 @@ export interface AuditLog {
   delta: PrismaJson.AuditLogDeltaJsonContent
   ipAddress: string | null
 }
-export interface Blob {
+export type Blob = {
   id: GeneratedAlways<string>
   /**
    * @kyselyType(PrismaJson.BlobJsonContent)
@@ -37,7 +37,7 @@ export interface Blob {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface Footer {
+export type Footer = {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -48,7 +48,7 @@ export interface Footer {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface Navbar {
+export type Navbar = {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -59,12 +59,12 @@ export interface Navbar {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface RateLimiterFlexible {
+export type RateLimiterFlexible = {
   key: string
   points: number
   expire: Timestamp | null
 }
-export interface Resource {
+export type Resource = {
   id: GeneratedAlways<string>
   title: string
   permalink: string
@@ -77,7 +77,7 @@ export interface Resource {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface ResourcePermission {
+export type ResourcePermission = {
   id: GeneratedAlways<string>
   userId: string
   siteId: number
@@ -87,7 +87,7 @@ export interface ResourcePermission {
   updatedAt: Generated<Timestamp>
   deletedAt: Timestamp | null
 }
-export interface Site {
+export type Site = {
   id: GeneratedAlways<number>
   name: string
   /**
@@ -104,7 +104,7 @@ export interface Site {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface User {
+export type User = {
   id: string
   name: string
   email: string
@@ -114,13 +114,13 @@ export interface User {
   deletedAt: Timestamp | null
   lastLoginAt: Timestamp | null
 }
-export interface VerificationToken {
+export type VerificationToken = {
   identifier: string
   token: string
   attempts: Generated<number>
   expires: Timestamp
 }
-export interface Version {
+export type Version = {
   id: GeneratedAlways<string>
   versionNum: number
   resourceId: string
@@ -129,14 +129,14 @@ export interface Version {
   publishedBy: string
   updatedAt: Generated<Timestamp>
 }
-export interface Whitelist {
+export type Whitelist = {
   id: GeneratedAlways<number>
   email: string
   expiry: Timestamp | null
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export interface DB {
+export type DB = {
   AuditLog: AuditLog
   Blob: Blob
   Footer: Footer

--- a/apps/studio/prisma/migrations/20250318080632_add_audit_logs/migration.sql
+++ b/apps/studio/prisma/migrations/20250318080632_add_audit_logs/migration.sql
@@ -1,5 +1,5 @@
 -- CreateEnum
-CREATE TYPE "AuditLogEvent" AS ENUM ('ResourceCreate', 'ResourceUpdate', 'ResourceDelete', 'UserCreate', 'UserUpdate', 'UserDelete', 'Publish', 'Login', 'Logout', 'PermissionCreate', 'PermissionUpdate', 'PermissionDelete');
+CREATE TYPE "AuditLogEvent" AS ENUM ('ResourceCreate', 'ResourceUpdate', 'ResourceDelete', 'UserCreate', 'UserUpdate', 'UserDelete', 'Publish', 'Login', 'Logout', 'PermissionCreate', 'PermissionUpdate', 'PermissionDelete', 'SiteConfigUpdate', 'FooterUpdate', 'NavbarUpdate');
 
 -- CreateTable
 CREATE TABLE "AuditLog" (

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -119,21 +119,20 @@ model User {
   email String
   phone String
 
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @default(now()) @updatedAt
-  deletedAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @default(now()) @updatedAt
+  deletedAt   DateTime?
   lastLoginAt DateTime?
 
   ResourcePermission ResourcePermission[]
   versions           Version[]
   AuditLog           AuditLog[]
 
-  @@index([lastLoginAt])
-
   // This unique index is subsequently replaced with a custom index that
   // treats nulls as not distinct.
   // This is required so prisma does not attempt to drop the custom index.
   @@unique([email, deletedAt])
+  @@index([lastLoginAt])
 }
 
 model Site {
@@ -239,6 +238,9 @@ enum AuditLogEvent {
   PermissionCreate
   PermissionUpdate
   PermissionDelete
+  SiteConfigUpdate
+  FooterUpdate
+  NavbarUpdate
 }
 
 model AuditLog {

--- a/apps/studio/prisma/types.ts
+++ b/apps/studio/prisma/types.ts
@@ -34,9 +34,18 @@ declare global {
       _IsomerSiteWideComponentsProps["footerItems"],
       "JSONB"
     >
-    interface AuditLogDeltaJsonContent {
-      before: Record<string, unknown> | null
-      after: Record<string, unknown> | null
+    interface NewLogEvent {
+      before: null
+      after: Record<string, unknown>
     }
+    interface DeleteLogEvent {
+      before: Record<string, unknown>
+      after: null
+    }
+    interface FullLogEvent {
+      before: Record<string, unknown>
+      after: Record<string, unknown>
+    }
+    type AuditLogDeltaJsonContent = FullLogEvent | NewLogEvent | DeleteLogEvent
   }
 }

--- a/apps/studio/prisma/types.ts
+++ b/apps/studio/prisma/types.ts
@@ -34,9 +34,9 @@ declare global {
       _IsomerSiteWideComponentsProps["footerItems"],
       "JSONB"
     >
-    type AuditLogDeltaJsonContent = Tagged<
-      { before: Record<string, unknown>; after: Record<string, unknown> },
-      "JSONB"
-    >
+    interface AuditLogDeltaJsonContent {
+      before: Record<string, unknown> | null
+      after: Record<string, unknown> | null
+    }
   }
 }

--- a/apps/studio/prisma/types.ts
+++ b/apps/studio/prisma/types.ts
@@ -34,7 +34,7 @@ declare global {
       _IsomerSiteWideComponentsProps["footerItems"],
       "JSONB"
     >
-    interface NewLogEvent {
+    interface CreateLogEvent {
       before: null
       after: Record<string, unknown>
     }
@@ -46,6 +46,9 @@ declare global {
       before: Record<string, unknown>
       after: Record<string, unknown>
     }
-    type AuditLogDeltaJsonContent = FullLogEvent | NewLogEvent | DeleteLogEvent
+    type AuditLogDeltaJsonContent =
+      | FullLogEvent
+      | CreateLogEvent
+      | DeleteLogEvent
   }
 }

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -1,0 +1,37 @@
+import type {
+  AuditLogEvent,
+  Blob,
+  DB,
+  Resource,
+  Transaction,
+  User,
+} from "../database"
+
+interface ResourceEventLogProps {
+  eventType: Extract<
+    AuditLogEvent,
+    "ResourceCreate" | "ResourceUpdate" | "ResourceDelete" | "ResourceMove"
+  >
+  delta: {
+    // NOTE: Can be undefined because folders/collections don't have blobs
+    before: Resource & (Blob | undefined)
+    after: Resource & (Blob | undefined)
+  }
+  by: User
+  ip?: string
+  metadata: {
+    sessionId?: string
+  }
+}
+
+export const logResourceEvent = async (
+  tx: Transaction<DB>,
+  { eventType, delta, by, metadata, ip }: ResourceEventLogProps,
+) => {
+  await tx
+    .insertInto("AuditLog")
+    .values({ eventType, delta, userId: by.id, ipAddress: ip, metadata })
+    .execute()
+}
+
+export const logAuthEvent = async () => {}

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -3,6 +3,7 @@ import type {
   Blob,
   DB,
   Footer,
+  Navbar,
   Resource,
   ResourcePermission,
   Site,
@@ -133,6 +134,12 @@ export const logAuthEvent: AuditLogger<AuthEventLogProps> = async (
     .execute()
 }
 
+type PublishEvents =
+  | (FullResource & { versionNumber: number })
+  | Site
+  | Navbar
+  | Footer
+
 interface PublishEventLogProps {
   by: User
   delta: {
@@ -140,8 +147,8 @@ interface PublishEventLogProps {
     // We don't want to store the `version` because it is a pointer
     // to the blob/resource
     // we will instead store the full data here so it is an accurate snapshot
-    before: (FullResource & { versionNumber: number }) | null
-    after: FullResource & { versionNumber: number }
+    before: PublishEvents | null
+    after: PublishEvents
   }
   eventType: Extract<AuditLogEvent, "Publish">
   ip?: string

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -1,15 +1,12 @@
-import {
-  ResourcePermission,
-  VerificationToken,
-} from "~prisma/generated/generatedTypes"
-
 import type {
   AuditLogEvent,
   Blob,
   DB,
   Resource,
+  ResourcePermission,
   Transaction,
   User,
+  VerificationToken,
 } from "../database"
 
 type FullResource = Resource & (Blob | undefined)
@@ -59,7 +56,7 @@ interface LoginDelta {
 // `userId` or sgid info in session.
 interface LogoutDelta {
   before: User
-  after: {}
+  after: null
 }
 
 interface AuthEventLogProps {

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -103,3 +103,40 @@ export const logPublishEvent: AuditLogger<PublishEventLogProps> = async (
     })
     .execute()
 }
+
+interface CreateUserDelta {
+  before: null
+  after: User
+}
+
+interface DeleteUserDelta {
+  before: User
+  after: null
+}
+
+interface UpdateUserDelta {
+  before: User
+  after: User
+}
+
+interface UserEventLogProps {
+  by: User
+  delta: CreateUserDelta | DeleteUserDelta | UpdateUserDelta
+  eventType: Extract<AuditLogEvent, "UserCreate" | "UserUpdate" | "UserDelete">
+  ip?: string
+}
+
+export const logUserEvent: AuditLogger<UserEventLogProps> = async (
+  tx,
+  { by, delta, eventType, ip },
+) => {
+  await tx
+    .insertInto("AuditLog")
+    .values({
+      eventType,
+      delta,
+      userId: by.id,
+      ipAddress: ip,
+    })
+    .execute()
+}

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -80,6 +80,9 @@ interface PublishEventLogProps {
   by: User
   delta: {
     // NOTE: `null` if this is the first publish
+    // We don't want to store the `version` because it is a pointer
+    // to the blob/resource
+    // we will instead store the full data here so it is an accurate snapshot
     before: (FullResource & { versionNumber: number }) | null
     after: FullResource & { versionNumber: number }
   }

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -1,3 +1,5 @@
+import { VerificationToken } from "~prisma/generated/generatedTypes"
+
 import type {
   AuditLogEvent,
   Blob,
@@ -19,19 +21,45 @@ interface ResourceEventLogProps {
   }
   by: User
   ip?: string
-  metadata: {
-    sessionId?: string
-  }
 }
 
-export const logResourceEvent = async (
-  tx: Transaction<DB>,
-  { eventType, delta, by, metadata, ip }: ResourceEventLogProps,
+// NOTE: Type to force every logger method to have a tx
+type AuditLogger<T> = (tx: Transaction<DB>, props: T) => Promise<void>
+
+export const logResourceEvent: AuditLogger<ResourceEventLogProps> = async (
+  tx,
+  { eventType, delta, by, ip },
 ) => {
   await tx
     .insertInto("AuditLog")
-    .values({ eventType, delta, userId: by.id, ipAddress: ip, metadata })
+    .values({ eventType, delta, userId: by.id, ipAddress: ip })
     .execute()
 }
 
-export const logAuthEvent = async () => {}
+interface LoginDelta {
+  before: VerificationToken
+  after: VerificationToken
+}
+
+// NOTE: logout just calls `session.destroy` and we only have
+// `userId` or sgid info in session.
+interface LogoutDelta {
+  before: User
+  after: {}
+}
+
+interface AuthEventLogProps {
+  eventType: Extract<AuditLogEvent, "Login" | "Logout">
+  delta: LoginDelta | LogoutDelta
+  by: User
+  ip?: string
+}
+export const logAuthEvent: AuditLogger<AuthEventLogProps> = async (
+  tx,
+  { eventType, delta, by, ip },
+) => {
+  await tx
+    .insertInto("AuditLog")
+    .values({ eventType, delta, userId: by.id, ipAddress: ip })
+    .execute()
+}

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -733,12 +733,6 @@ describe("user.router", () => {
       await setupEditorPermissions({ userId: session.userId, siteId })
 
       const user = await setupUser({ email: TEST_EMAIL, isDeleted: false })
-      await setupEditorPermissions({
-        userId: user.id,
-        siteId,
-        isDeleted: true,
-        useCurrentTime: true,
-      })
       await setupAdminPermissions({
         userId: user.id,
         siteId,


### PR DESCRIPTION
## Problem
see related issue

## Solution
1. add various service methods to log different events
    - i didn't add `metadata` because i'm unsure what qualifies but feel free to extend the methods to add them yourself