### PR TITLE
[A11y] Increase touch target of list items nested in tables

### DIFF
--- a/packages/components/src/templates/next/components/native/Table/Table.stories.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.stories.tsx
@@ -2025,3 +2025,125 @@ export const NestedColumns: Story = {
     ],
   },
 }
+
+export const ListInTable: Story = {
+  args: {
+    attrs: {
+      caption: "Resources for the scheme",
+    },
+    content: [
+      {
+        type: "tableRow",
+        content: [
+          {
+            type: "tableHeader",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Category" }],
+              },
+            ],
+          },
+          {
+            type: "tableHeader",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Files for download" }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "tableRow",
+        content: [
+          {
+            type: "tableCell",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: "Files for everyone" }],
+              },
+            ],
+          },
+          {
+            type: "tableCell",
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  {
+                    type: "text",
+                    text: "Here are some files you can download:",
+                  },
+                ],
+              },
+              {
+                type: "unorderedList",
+                content: [
+                  {
+                    type: "listItem",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [
+                          {
+                            type: "text",
+                            text: "<a href='https://google.com'>A long file name that's available for download [PDF, 2MB]</a>",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "listItem",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [
+                          {
+                            type: "text",
+                            text: "<a href='https://google.com'>An even longer file name that's available for download [PDF, 2MB]</a>",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "listItem",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [
+                          {
+                            type: "text",
+                            text: "<a href='https://google.com'>A long file name that's available for download [PDF, 2MB]</a>",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    type: "listItem",
+                    content: [
+                      {
+                        type: "paragraph",
+                        content: [
+                          {
+                            type: "text",
+                            text: "<a href='https://google.com'>A very very very long file name that's available for download [PDF, 2MB]</a>",
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -9,7 +9,7 @@ import Paragraph from "../Paragraph"
 import UnorderedList from "../UnorderedList"
 
 const tableCellStyles = tv({
-  base: "max-w-40 break-words border border-base-divider-medium px-4 py-3 align-top [&_li]:my-0 [&_li]:pl-1 [&_ol]:mt-0 [&_ol]:ps-5 [&_ul]:mt-0 [&_ul]:ps-5",
+  base: "max-w-40 break-words border border-base-divider-medium px-4 py-3 align-top [&_li]:mb-4 [&_li]:mt-0 [&_li]:pl-1 [&_ol]:mt-0 [&_ol]:ps-5 [&_ul]:mt-0 [&_ul]:ps-5",
   variants: {
     isHeader: {
       true: "bg-base-canvas-backdrop [&_ol]:prose-label-md-medium [&_p]:prose-label-md-medium",


### PR DESCRIPTION
## Problem

Hyperlinks on a list nested inside a table had small touch targets because the list-spacing wasn't being applied.

This fails WCAG 2.5.8

Slack discussion: https://opengovproducts.slack.com/archives/C082M357BAA/p1741683515905209

## Solution

The problem is not the line height of the list items itself, but more of the distance between each item in a list.

As a solution, adding mb-[15px] and mt-0. 

## Before

<img width="760" alt="image" src="https://github.com/user-attachments/assets/85dcb547-30b2-4251-aae6-ab13c95dedc3" />

## After

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/62216b5f-9b08-4517-b138-2eb21e314fb6" />
