### PR TITLE
feat(audit-logging): add audit logging to collection router + tests 

### DIFF
--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -37,7 +37,7 @@ interface ResourceUpdateDelta {
   after: FullResource
 }
 
-interface ResourceEventLogProps {
+export interface ResourceEventLogProps {
   eventType: Extract<
     AuditLogEvent,
     "ResourceCreate" | "ResourceUpdate" | "ResourceDelete" | "ResourceMove"
@@ -49,7 +49,7 @@ interface ResourceEventLogProps {
 }
 
 // NOTE: Type to force every logger method to have a tx
-type AuditLogger<T> = (tx: Transaction<DB>, props: T) => Promise<void>
+export type AuditLogger<T> = (tx: Transaction<DB>, props: T) => Promise<void>
 
 export const logResourceEvent: AuditLogger<ResourceEventLogProps> = async (
   tx,

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -45,6 +45,7 @@ interface ResourceEventLogProps {
   delta: ResourceCreateDelta | ResourceDeleteDelta | ResourceUpdateDelta
   by: User
   ip?: string
+  metadata?: Record<string, unknown>
 }
 
 // NOTE: Type to force every logger method to have a tx
@@ -52,11 +53,11 @@ type AuditLogger<T> = (tx: Transaction<DB>, props: T) => Promise<void>
 
 export const logResourceEvent: AuditLogger<ResourceEventLogProps> = async (
   tx,
-  { eventType, delta, by, ip },
+  { eventType, delta, by, ip, metadata = {} },
 ) => {
   await tx
     .insertInto("AuditLog")
-    .values({ eventType, delta, userId: by.id, ipAddress: ip, metadata: {} })
+    .values({ eventType, delta, userId: by.id, ipAddress: ip, metadata })
     .execute()
 }
 

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -792,6 +792,7 @@ describe("collection.router", async () => {
         }),
       )
       expect(auditSpy).not.toHaveBeenCalled()
+      await assertAuditLogRows()
     })
 
     it("should throw 404 if the resource type is not a `CollectionLink`", async () => {
@@ -815,6 +816,7 @@ describe("collection.router", async () => {
         }),
       )
       expect(auditSpy).not.toHaveBeenCalled()
+      await assertAuditLogRows()
     })
 
     it("should throw 403 if the site does not exist", async () => {
@@ -840,6 +842,7 @@ describe("collection.router", async () => {
         }),
       )
       expect(auditSpy).not.toHaveBeenCalled()
+      await assertAuditLogRows()
     })
 
     it("should throw 403 if the user does not have `update` permissions", async () => {
@@ -865,6 +868,7 @@ describe("collection.router", async () => {
         }),
       )
       expect(auditSpy).not.toHaveBeenCalled()
+      await assertAuditLogRows()
     })
 
     it("should create a new `draftBlob` if it is currently `null`", async () => {
@@ -891,6 +895,7 @@ describe("collection.router", async () => {
       })
 
       expect(auditSpy).toHaveBeenCalled()
+      await assertAuditLogRows(1)
       const auditEntry = await db
         .selectFrom("AuditLog")
         .where("eventType", "=", "ResourceUpdate")
@@ -929,6 +934,7 @@ describe("collection.router", async () => {
 
       // Assert
       expect(auditSpy).toHaveBeenCalled()
+      await assertAuditLogRows(1)
       const auditEntry = await db
         .selectFrom("AuditLog")
         .where("eventType", "=", "ResourceUpdate")

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1,0 +1,910 @@
+import { TRPCError } from "@trpc/server"
+import _ from "lodash"
+import { auth } from "tests/integration/helpers/auth"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupAdminPermissions,
+  setupCollection,
+  setupEditorPermissions,
+  setupFolder,
+  setupPageResource,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+
+import * as auditService from "~/server/modules/audit/audit.service"
+import { createCallerFactory } from "~/server/trpc"
+import { db, ResourceType } from "../../database"
+import { getBlobOfResource } from "../../resource/resource.service"
+import { collectionRouter } from "../collection.router"
+
+const createCaller = createCallerFactory(collectionRouter)
+
+describe("collection.router", async () => {
+  let caller: ReturnType<typeof createCaller>
+  let unauthedCaller: ReturnType<typeof createCaller>
+  const session = await applyAuthedSession()
+
+  beforeEach(async () => {
+    await resetTables(
+      "Blob",
+      "AuditLog",
+      "Resource",
+      "Site",
+      "Version",
+      "User",
+      "ResourcePermission",
+    )
+    caller = createCaller(createMockRequest(session))
+    const unauthedSession = applySession()
+    unauthedCaller = createCaller(createMockRequest(unauthedSession))
+    const user = await setupUser({
+      userId: session.userId,
+      email: "test@mock.com",
+      isDeleted: false,
+    })
+    await auth(user)
+  })
+
+  describe("create", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Act
+      const result = unauthedCaller.create({
+        collectionTitle: "test collection",
+        siteId: 1,
+        permalink: "test-collection",
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 409 if permalink already exists", async () => {
+      // Arrange
+      const duplicatePermalink = "duplicate-permalink"
+      const { site } = await setupCollection({ permalink: duplicatePermalink })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.create({
+        collectionTitle: "test folder",
+        siteId: site.id,
+        permalink: duplicatePermalink,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A resource with the same permalink already exists",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 404 if `siteId` does not exist", async () => {
+      // Arrange
+      const invalidSiteId = 999
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      expect(site.id).not.toEqual(invalidSiteId)
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.create({
+        collectionTitle: "test collection",
+        siteId: invalidSiteId,
+        permalink: "test-collection",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 404 if `parentFolderId` does not exist", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.create({
+        collectionTitle: "test collection",
+        siteId: site.id,
+        permalink: "test-collection",
+        parentFolderId: 999,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Parent folder does not exist",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 400 if `parentFolderId` is not a folder", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.create({
+        collectionTitle: "test collection",
+        siteId: site.id,
+        permalink: "test-collection",
+        parentFolderId: Number(page.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Collections can only be created inside other folders or at the root",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should create a collection even with duplicate permalink if `siteId` is different", async () => {
+      // Arrange
+      const duplicatePermalink = "duplicate-permalink"
+      const { site: _firstSite } = await setupCollection({
+        permalink: duplicatePermalink,
+      })
+      const { site: secondSite } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: secondSite.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = await caller.create({
+        collectionTitle: "test collection",
+        siteId: secondSite.id,
+        permalink: duplicatePermalink,
+      })
+
+      // Assert
+      const actualCollection = await getCollectionWithPermalink({
+        siteId: secondSite.id,
+        permalink: duplicatePermalink,
+      })
+      expect(result).toMatchObject({ id: actualCollection.id })
+      expect(auditSpy).toHaveBeenCalled()
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceCreate")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(auditEntry.delta.after!).toMatchObject({ id: result.id })
+      expect(auditEntry.userId).toBe(session.userId)
+    })
+
+    it("should create a collection", async () => {
+      // Arrange
+      const permalinkToUse = "test-collection-999"
+      const { site } = await setupSite()
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.create({
+        collectionTitle: "test collection 999",
+        siteId: site.id,
+        permalink: permalinkToUse,
+      })
+
+      // Assert
+      const actualCollection = await getCollectionWithPermalink({
+        permalink: permalinkToUse,
+        siteId: site.id,
+      })
+      expect(result).toMatchObject({ id: actualCollection.id })
+      expect(auditSpy).toHaveBeenCalled()
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceCreate")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(auditEntry.delta.after!).toMatchObject({ id: result.id })
+      expect(auditEntry.userId).toBe(session.userId)
+    })
+
+    it("should create a nested collection if `parentFolderId` is provided", async () => {
+      // Arrange
+      const permalinkToUse = "test-collection-777"
+      const { folder: parent, site } = await setupFolder()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = await caller.create({
+        collectionTitle: "test collection",
+        siteId: site.id,
+        permalink: permalinkToUse,
+        parentFolderId: Number(parent.id),
+      })
+
+      // Assert
+      const actualCollection = await getCollectionWithPermalink({
+        permalink: permalinkToUse,
+        siteId: site.id,
+      })
+      expect(actualCollection.parentId).toEqual(parent.id)
+      expect(result).toMatchObject({ id: actualCollection.id })
+      expect(auditSpy).toHaveBeenCalled()
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceCreate")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(auditEntry.delta.after!).toMatchObject({ id: result.id })
+      expect(auditEntry.userId).toBe(session.userId)
+    })
+
+    it("should throw 403 if user does not have admin access to the site and tries to create a root level folder", async () => {
+      // Arrange
+      const permalinkToUse = "test-collection-777"
+      const { site } = await setupSite()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+
+      // Act
+      const result = caller.create({
+        collectionTitle: "test collection",
+        siteId: site.id,
+        permalink: permalinkToUse,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw 403 if user does not have access to the site", async () => {
+      // Arrange
+      const permalinkToUse = "test-collection-777"
+      const { folder: parentFolder, site } = await setupFolder()
+
+      // Act
+      const result = caller.create({
+        collectionTitle: "test collection",
+        siteId: site.id,
+        permalink: permalinkToUse,
+        parentFolderId: Number(parentFolder.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it.skip("should throw 403 if user does not have write access to the parent folder", async () => {})
+  })
+
+  describe("createCollectionPage", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+
+      // Act
+      const result = unauthedCaller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        permalink: "test-collection",
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 409 if permalink already exists", async () => {
+      // Arrange
+      const duplicatePermalink = "duplicate-permalink"
+      const { collection, site } = await setupCollection({
+        permalink: "parent",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      // NOTE: first call, now there's an existing page with `duplicatePermalink`
+      await caller.createCollectionPage({
+        title: "test folder",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        permalink: duplicatePermalink,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.createCollectionPage({
+        title: "test folder",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        permalink: duplicatePermalink,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A resource with the same permalink already exists",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 404 if `siteId` does not exist", async () => {
+      // Arrange
+      const invalidSiteId = 999
+      const { collection, site } = await setupCollection()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      expect(site.id).not.toEqual(invalidSiteId)
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: 999,
+        collectionId: Number(collection.id),
+        permalink: "test-collection",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 404 if `collectionId` does not exist", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: 999,
+        permalink: "test-collection",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Parent collection does not exist",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should throw 404 if `collectionId` is not a collection", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      // Act
+      const result = caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(page.id),
+        permalink: "test-collection",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Parent collection does not exist",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+
+    it("should create a collection page even with duplicate permalink if `siteId` is different", async () => {
+      // Arrange
+      const duplicatePermalink = "duplicate-permalink"
+      const { site, collection } = await setupCollection({
+        permalink: duplicatePermalink,
+      })
+      // NOTE: order matters here - this spy must be setup before
+      // the first call out to `createCollectionPage`
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+      const { site: secondSite, collection: secondCollection } =
+        await setupCollection({ permalink: duplicatePermalink })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: secondSite.id,
+      })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      await caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: secondSite.id,
+        collectionId: Number(secondCollection.id),
+        permalink: "test-collection",
+      })
+
+      // Act
+      const result = await caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        permalink: "test-collection",
+      })
+
+      // Assert
+      const actualCollectionPage = await getCollectionItemByPermalink(
+        "test-collection",
+        collection.id,
+      )
+      expect(result).toMatchObject({ pageId: actualCollectionPage.id })
+      expect(auditSpy).toHaveBeenCalledTimes(2)
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceCreate")
+        .orderBy("AuditLog.createdAt desc")
+        .selectAll()
+        .execute()
+      // NOTE: 2 pages created via the router method - expect 2 entries in our audit logs
+      expect(auditEntry).toHaveLength(2)
+      expect(auditEntry[0]).toBeDefined()
+      expect(auditEntry[0]!.delta.after!).toMatchObject({
+        resource: { id: result.pageId },
+      })
+    })
+
+    it("should create a collection page", async () => {
+      // Arrange
+      const permalink = "test-collection-999"
+      const { collection, site } = await setupCollection()
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        permalink,
+      })
+
+      // Assert
+      const actualCollectionPage = await getCollectionItemByPermalink(
+        permalink,
+        collection.id,
+      )
+      expect(result).toMatchObject({ pageId: actualCollectionPage.id })
+      expect(auditSpy).toHaveBeenCalled()
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceCreate")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(auditEntry.delta.after!).toMatchObject({
+        resource: { id: result.pageId },
+      })
+      expect(auditEntry.userId).toBe(session.userId)
+    })
+
+    it("should throw 403 if user does not have access to the site", async () => {
+      // Arrange
+      const permalinkToUse = "test-collection-777"
+      const { collection, site } = await setupCollection()
+
+      // Act
+      const result = caller.createCollectionPage({
+        title: "test collection",
+        type: "CollectionPage",
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        permalink: permalinkToUse,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it.skip("should throw 403 if user does not have write access to the parent collection", async () => {})
+  })
+  describe("getMetadata", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Act
+      const result = unauthedCaller.getMetadata({
+        siteId: 1,
+        resourceId: -1,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 404 if `siteId` does not exist", async () => {
+      // Arrange
+      const invalidSiteId = 999
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      expect(site.id).not.toEqual(invalidSiteId)
+
+      // Act
+      const result = caller.getMetadata({
+        siteId: invalidSiteId,
+        resourceId: 1,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw 404 if `collectionId` does not exist", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.getMetadata({
+        siteId: site.id,
+        resourceId: 999,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Collection not found",
+        }),
+      )
+    })
+
+    it("should throw 403 if user does not have read access to the site", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+
+      // Act
+      const result = caller.getMetadata({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should return 200 ", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+
+      // Act
+      const result = await caller.getMetadata({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+      })
+
+      // Assert
+      const expected = await db
+        .selectFrom("Resource")
+        .select(["Resource.title", "Resource.permalink", "Resource.parentId"])
+        .where("id", "=", collection.id)
+        .executeTakeFirst()
+      expect(result).toMatchObject(expected!)
+    })
+  })
+
+  describe("updateCollectionLink", () => {
+    it("should fail to update a non-existent `linkId`", async () => {
+      const { site } = await setupCollection()
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      const expected = caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "1",
+        linkId: 999,
+      })
+
+      await expect(expected).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Unable to find the requested collection link",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+    it("should fail to update if the resource type is not a `CollectionLink`", async () => {
+      const { site, collection } = await setupCollection()
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      const expected = caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "1",
+        linkId: Number(collection.id),
+      })
+
+      await expect(expected).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Unable to find the requested collection link",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+    it("should fail to update if the site does not exist", async () => {
+      const { page } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      const expected = caller.updateCollectionLink({
+        siteId: 999,
+        category: "category",
+        ref: "1",
+        linkId: Number(page.id),
+      })
+
+      await expect(expected).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+    it("should fail to update if the user does not have `update` permissions", async () => {
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      const expected = caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "1",
+        linkId: Number(page.id),
+      })
+
+      await expect(expected).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      expect(auditSpy).not.toHaveBeenCalled()
+    })
+    it("should create a new `draftBlob` if it is currently `null`", async () => {
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+        state: "Published",
+        userId: session.userId,
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+      expect(page.draftBlobId).toBe(null)
+      const originalBlob = await db
+        .transaction()
+        .execute((tx) => getBlobOfResource(tx, page.id))
+
+      const expected = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "1",
+        linkId: Number(page.id),
+      })
+
+      expect(auditSpy).toHaveBeenCalled()
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceUpdate")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(auditEntry.delta.before!).toMatchObject({
+        blob: _.omit(originalBlob, ["createdAt", "updatedAt"]),
+        resource: _.omit(page, ["createdAt", "updatedAt"]),
+      })
+      expect(auditEntry.delta.after!).toMatchObject({
+        blob: _.omit(expected, ["createdAt", "updatedAt"]),
+        resource: _.omit(page, ["createdAt", "updatedAt"]),
+      })
+      expect(auditEntry.userId).toBe(session.userId)
+      const actual = getCollectionItemByPermalink(page.permalink, page.parentId)
+      expect(expected).toMatchObject(actual)
+    })
+    it("should update the collection link successfully", async () => {
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      const originalBlob = await db
+        .transaction()
+        .execute((tx) => getBlobOfResource(tx, page.id))
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+
+      const expected = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "1",
+        linkId: Number(page.id),
+      })
+
+      expect(auditSpy).toHaveBeenCalled()
+      const auditEntry = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "ResourceUpdate")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(auditEntry.delta.before!).toMatchObject({
+        blob: _.omit(originalBlob, ["createdAt", "updatedAt"]),
+        resource: _.omit(page, ["createdAt", "updatedAt"]),
+      })
+      expect(auditEntry.delta.after!).toMatchObject({
+        blob: _.omit(expected, ["createdAt", "updatedAt"]),
+        resource: _.omit(page, ["createdAt", "updatedAt"]),
+      })
+      expect(auditEntry.userId).toBe(session.userId)
+      const actual = getCollectionItemByPermalink(page.permalink, page.parentId)
+      expect(expected).toMatchObject(actual)
+    })
+    it.skip("should fail to update to a deleted `ref`")
+    it.skip("should fail to update to an invalid `ref`")
+  })
+})
+
+// Test util functions
+const getCollectionWithPermalink = ({
+  siteId,
+  permalink,
+}: {
+  siteId: number
+  permalink: string
+}) => {
+  return db
+    .selectFrom("Resource")
+    .where("type", "=", ResourceType.Collection)
+    .where("siteId", "=", siteId)
+    .where("permalink", "=", permalink)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+}
+
+const getCollectionItemByPermalink = (
+  permalink: string,
+  parentId?: string | null,
+) => {
+  if (parentId) {
+    return db
+      .selectFrom("Resource")
+      .where("parentId", "=", parentId)
+      .where("permalink", "=", permalink)
+      .selectAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  return db
+    .selectFrom("Resource")
+    .where("parentId", "is", null)
+    .where("permalink", "=", permalink)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+}

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -20,9 +20,14 @@ import { MockInstance } from "vitest"
 
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"
-import { db, ResourceType } from "../../database"
+import { db } from "../../database"
 import { getBlobOfResource } from "../../resource/resource.service"
 import { collectionRouter } from "../collection.router"
+import {
+  assertAuditLogRows,
+  getCollectionItemByPermalink,
+  getCollectionWithPermalink,
+} from "./utils"
 
 const createCaller = createCallerFactory(collectionRouter)
 
@@ -947,47 +952,3 @@ describe("collection.router", async () => {
     it.skip("should throw when trying to update to an invalid `ref`")
   })
 })
-
-// Test util functions
-const getCollectionWithPermalink = ({
-  siteId,
-  permalink,
-}: {
-  siteId: number
-  permalink: string
-}) => {
-  return db
-    .selectFrom("Resource")
-    .where("type", "=", ResourceType.Collection)
-    .where("siteId", "=", siteId)
-    .where("permalink", "=", permalink)
-    .selectAll()
-    .executeTakeFirstOrThrow()
-}
-
-const getCollectionItemByPermalink = (
-  permalink: string,
-  parentId?: string | null,
-) => {
-  if (parentId) {
-    return db
-      .selectFrom("Resource")
-      .where("parentId", "=", parentId)
-      .where("permalink", "=", permalink)
-      .selectAll()
-      .executeTakeFirstOrThrow()
-  }
-
-  return db
-    .selectFrom("Resource")
-    .where("parentId", "is", null)
-    .where("permalink", "=", permalink)
-    .selectAll()
-    .executeTakeFirstOrThrow()
-}
-
-const assertAuditLogRows = async (numRows = 0) => {
-  const actual = await db.selectFrom("AuditLog").selectAll().execute()
-
-  expect(actual).toHaveLength(numRows)
-}

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server"
-import _ from "lodash"
+import _, { omit } from "lodash"
 import { auth } from "tests/integration/helpers/auth"
 import { resetTables } from "tests/integration/helpers/db"
 import {
@@ -579,7 +579,7 @@ describe("collection.router", async () => {
         .executeTakeFirstOrThrow()
       expect(auditEntry).toBeDefined()
       expect(auditEntry!.delta.after!).toMatchObject({
-        resource: result,
+        resource: omit(actualCollectionPage, ["updatedAt", "createdAt"]),
       })
     })
 

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -880,7 +880,7 @@ describe("collection.router", async () => {
       // Act
       const originalBlob = await db
         .transaction()
-        .execute((tx) => getBlobOfResource(tx, page.id))
+        .execute((tx) => getBlobOfResource({ tx, resourceId: page.id }))
 
       // Assert
       const expected = await caller.updateCollectionLink({
@@ -916,7 +916,7 @@ describe("collection.router", async () => {
       })
       const originalBlob = await db
         .transaction()
-        .execute((tx) => getBlobOfResource(tx, page.id))
+        .execute((tx) => getBlobOfResource({ tx, resourceId: page.id }))
       await setupAdminPermissions({ userId: session.userId, siteId: site.id })
 
       // Act

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -578,7 +578,7 @@ describe("collection.router", async () => {
         .selectAll()
         .executeTakeFirstOrThrow()
       expect(auditEntry).toBeDefined()
-      expect(auditEntry!.delta.after!).toMatchObject({
+      expect(auditEntry.delta.after!).toMatchObject({
         resource: omit(actualCollectionPage, ["updatedAt", "createdAt"]),
       })
     })

--- a/apps/studio/src/server/modules/collection/__tests__/utils.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/utils.ts
@@ -41,49 +41,6 @@ export const getCollectionItemByPermalink = (
 }
 
 export const assertAuditLogRows = async (numRows = 0) => {
-  // Test util functions
-  const getCollectionWithPermalink = ({
-    siteId,
-    permalink,
-  }: {
-    siteId: number
-    permalink: string
-  }) => {
-    return db
-      .selectFrom("Resource")
-      .where("type", "=", ResourceType.Collection)
-      .where("siteId", "=", siteId)
-      .where("permalink", "=", permalink)
-      .selectAll()
-      .executeTakeFirstOrThrow()
-  }
-
-  const getCollectionItemByPermalink = (
-    permalink: string,
-    parentId?: string | null,
-  ) => {
-    if (parentId) {
-      return db
-        .selectFrom("Resource")
-        .where("parentId", "=", parentId)
-        .where("permalink", "=", permalink)
-        .selectAll()
-        .executeTakeFirstOrThrow()
-    }
-
-    return db
-      .selectFrom("Resource")
-      .where("parentId", "is", null)
-      .where("permalink", "=", permalink)
-      .selectAll()
-      .executeTakeFirstOrThrow()
-  }
-
-  const assertAuditLogRows = async (numRows = 0) => {
-    const actual = await db.selectFrom("AuditLog").selectAll().execute()
-
-    expect(actual).toHaveLength(numRows)
-  }
   const actual = await db.selectFrom("AuditLog").selectAll().execute()
 
   expect(actual).toHaveLength(numRows)

--- a/apps/studio/src/server/modules/collection/__tests__/utils.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/utils.ts
@@ -1,0 +1,90 @@
+import { ResourceType } from "@prisma/client"
+
+import { db } from "../../database"
+
+// Test util functions
+export const getCollectionWithPermalink = ({
+  siteId,
+  permalink,
+}: {
+  siteId: number
+  permalink: string
+}) => {
+  return db
+    .selectFrom("Resource")
+    .where("type", "=", ResourceType.Collection)
+    .where("siteId", "=", siteId)
+    .where("permalink", "=", permalink)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const getCollectionItemByPermalink = (
+  permalink: string,
+  parentId?: string | null,
+) => {
+  if (parentId) {
+    return db
+      .selectFrom("Resource")
+      .where("parentId", "=", parentId)
+      .where("permalink", "=", permalink)
+      .selectAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  return db
+    .selectFrom("Resource")
+    .where("parentId", "is", null)
+    .where("permalink", "=", permalink)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+}
+
+export const assertAuditLogRows = async (numRows = 0) => {
+  // Test util functions
+  const getCollectionWithPermalink = ({
+    siteId,
+    permalink,
+  }: {
+    siteId: number
+    permalink: string
+  }) => {
+    return db
+      .selectFrom("Resource")
+      .where("type", "=", ResourceType.Collection)
+      .where("siteId", "=", siteId)
+      .where("permalink", "=", permalink)
+      .selectAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  const getCollectionItemByPermalink = (
+    permalink: string,
+    parentId?: string | null,
+  ) => {
+    if (parentId) {
+      return db
+        .selectFrom("Resource")
+        .where("parentId", "=", parentId)
+        .where("permalink", "=", permalink)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+    }
+
+    return db
+      .selectFrom("Resource")
+      .where("parentId", "is", null)
+      .where("permalink", "=", permalink)
+      .selectAll()
+      .executeTakeFirstOrThrow()
+  }
+
+  const assertAuditLogRows = async (numRows = 0) => {
+    const actual = await db.selectFrom("AuditLog").selectAll().execute()
+
+    expect(actual).toHaveLength(numRows)
+  }
+  const actual = await db.selectFrom("AuditLog").selectAll().execute()
+
+  expect(actual).toHaveLength(numRows)
+}

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -123,13 +123,13 @@ export const collectionRouter = router({
             by: user,
           })
 
-          return pick(collection, defaultCollectionSelect)
+          return collection
         })
 
         // TODO: Create the index page for the collection and publish it
         await publishSite(ctx.logger, siteId)
 
-        return result
+        return pick(result, defaultCollectionSelect)
       },
     ),
   createCollectionPage: protectedProcedure

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -10,16 +10,17 @@ import {
 import { readFolderSchema } from "~/schemas/folder"
 import { createCollectionPageSchema } from "~/schemas/page"
 import { protectedProcedure, router } from "~/server/trpc"
+import { logResourceEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceState, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { validateUserPermissionsForResource } from "../permissions/permissions.service"
 import {
   defaultResourceSelect,
+  getBlobOfResource,
   getSiteResourceById,
   updateBlobById,
 } from "../resource/resource.service"
-import { defaultCollectionSelect } from "./collection.select"
 import {
   createCollectionLinkJson,
   createCollectionPageJson,
@@ -62,27 +63,69 @@ export const collectionRouter = router({
           resourceId: !!parentFolderId ? String(parentFolderId) : null,
         })
 
-        const result = await db
-          .insertInto("Resource")
-          .values({
-            permalink,
-            siteId,
-            type: ResourceType.Collection,
-            title: collectionTitle,
-            parentId: parentFolderId ? String(parentFolderId) : null,
-            state: ResourceState.Published,
-          })
-          .returning(defaultCollectionSelect)
-          .executeTakeFirstOrThrow()
-          .catch((err) => {
-            if (get(err, "code") === PG_ERROR_CODES.uniqueViolation) {
+        const result = await db.transaction().execute(async (tx) => {
+          const user = await db
+            .selectFrom("User")
+            .where("id", "=", ctx.user.id)
+            .selectAll()
+            .executeTakeFirstOrThrow(
+              () => new TRPCError({ code: "BAD_REQUEST" }),
+            )
+
+          if (parentFolderId) {
+            const parentFolder = await db
+              .selectFrom("Resource")
+              .where("Resource.id", "=", String(parentFolderId))
+              .where("Resource.siteId", "=", siteId)
+              .select(["Resource.type", "Resource.id"])
+              .executeTakeFirst()
+
+            if (!parentFolder) {
               throw new TRPCError({
-                code: "CONFLICT",
-                message: "A resource with the same permalink already exists",
+                code: "NOT_FOUND",
+                message: "Parent folder does not exist",
               })
             }
-            throw err
+
+            if (parentFolder.type !== "Folder") {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message:
+                  "Collections can only be created inside other folders or at the root",
+              })
+            }
+          }
+
+          const collection = await tx
+            .insertInto("Resource")
+            .values({
+              permalink,
+              siteId,
+              type: ResourceType.Collection,
+              title: collectionTitle,
+              parentId: parentFolderId ? String(parentFolderId) : null,
+              state: ResourceState.Published,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+            .catch((err) => {
+              if (get(err, "code") === PG_ERROR_CODES.uniqueViolation) {
+                throw new TRPCError({
+                  code: "CONFLICT",
+                  message: "A resource with the same permalink already exists",
+                })
+              }
+              throw err
+            })
+
+          await logResourceEvent(tx, {
+            eventType: "ResourceCreate",
+            delta: { before: null, after: collection },
+            by: user,
           })
+
+          return collection
+        })
 
         // TODO: Create the index page for the collection and publish it
         await publishSite(ctx.logger, siteId)
@@ -108,17 +151,35 @@ export const collectionRouter = router({
         newPage = createCollectionLinkJson({ type })
       }
 
-      // TODO: Validate whether folderId actually is a folder instead of a page
-      // TODO: Validate whether siteId is a valid site
-      // TODO: Validate user has write-access to the site
       const resource = await db.transaction().execute(async (tx) => {
+        const parentCollection = await db
+          .selectFrom("Resource")
+          .where("Resource.id", "=", String(collectionId))
+          .where("Resource.siteId", "=", siteId)
+          .where("Resource.type", "=", ResourceType.Collection)
+          .select(["Resource.type", "Resource.id"])
+          .executeTakeFirst()
+
+        if (!parentCollection) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "Parent collection does not exist",
+          })
+        }
+
         const blob = await tx
           .insertInto("Blob")
           .values({
             content: jsonb(newPage),
           })
-          .returning("Blob.id")
+          .returningAll()
           .executeTakeFirstOrThrow()
+
+        const user = await db
+          .selectFrom("User")
+          .where("id", "=", ctx.user.id)
+          .selectAll()
+          .executeTakeFirstOrThrow(() => new TRPCError({ code: "BAD_REQUEST" }))
 
         const addedResource = await tx
           .insertInto("Resource")
@@ -130,7 +191,7 @@ export const collectionRouter = router({
             draftBlobId: blob.id,
             type,
           })
-          .returning("Resource.id")
+          .returningAll()
           .executeTakeFirstOrThrow()
           .catch((err) => {
             if (get(err, "code") === PG_ERROR_CODES.uniqueViolation) {
@@ -141,6 +202,16 @@ export const collectionRouter = router({
             }
             throw err
           })
+
+        await logResourceEvent(tx, {
+          eventType: "ResourceCreate",
+          by: user,
+          delta: {
+            before: null,
+            after: { resource: addedResource, blob },
+          },
+        })
+
         return addedResource
       })
       return { pageId: resource.id }
@@ -263,8 +334,32 @@ export const collectionRouter = router({
           type: ResourceType.CollectionLink,
         })
 
-        await db.transaction().execute(async (tx) => {
-          return updateBlobById(tx, {
+        return await db.transaction().execute(async (tx) => {
+          const user = await tx
+            .selectFrom("User")
+            .where("id", "=", ctx.user.id)
+            .selectAll()
+            .executeTakeFirstOrThrow(
+              () => new TRPCError({ code: "BAD_REQUEST" }),
+            )
+
+          const resource = await tx
+            .selectFrom("Resource")
+            .where("Resource.id", "=", String(linkId))
+            .where("Resource.siteId", "=", siteId)
+            .where("Resource.type", "=", ResourceType.CollectionLink)
+            .selectAll()
+            .executeTakeFirstOrThrow(
+              () =>
+                new TRPCError({
+                  code: "NOT_FOUND",
+                  message: "Unable to find the requested collection link",
+                }),
+            )
+
+          const oldBlob = await getBlobOfResource(tx, resource.id)
+
+          const blob = await updateBlobById(tx, {
             content: {
               ...content,
               page: { description, ref, date, category },
@@ -272,32 +367,17 @@ export const collectionRouter = router({
             pageId: linkId,
             siteId,
           })
-        })
 
-        return await db.transaction().execute(async (tx) => {
-          const { draftBlobId } = await tx
-            .selectFrom("Resource")
-            .where("Resource.id", "=", String(linkId))
-            .where("Resource.siteId", "=", siteId)
-            .select("Resource.draftBlobId")
-            .executeTakeFirstOrThrow()
+          await logResourceEvent(tx, {
+            eventType: "ResourceUpdate",
+            delta: {
+              before: { blob: oldBlob, resource },
+              after: { blob, resource },
+            },
+            by: user,
+          })
 
-          const { content } = await tx
-            .selectFrom("Blob")
-            .where("Blob.id", "=", draftBlobId)
-            .select("Blob.content")
-            .executeTakeFirstOrThrow()
-
-          await tx
-            .updateTable("Blob")
-            .where("Blob.id", "=", draftBlobId)
-            .set({
-              content: {
-                ...content,
-                page: { description, ref, date, category },
-              },
-            })
-            .execute()
+          return blob
         })
       },
     ),

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -1,6 +1,6 @@
 import type { UnwrapTagged } from "type-fest"
 import { TRPCError } from "@trpc/server"
-import { get } from "lodash"
+import { get, pick } from "lodash"
 
 import {
   createCollectionSchema,
@@ -21,6 +21,7 @@ import {
   getSiteResourceById,
   updateBlobById,
 } from "../resource/resource.service"
+import { defaultCollectionSelect } from "./collection.select"
 import {
   createCollectionLinkJson,
   createCollectionPageJson,
@@ -122,7 +123,7 @@ export const collectionRouter = router({
             by: user,
           })
 
-          return collection
+          return pick(collection, defaultCollectionSelect)
         })
 
         // TODO: Create the index page for the collection and publish it
@@ -156,7 +157,7 @@ export const collectionRouter = router({
       }
 
       const resource = await db.transaction().execute(async (tx) => {
-        const parentCollection = await db
+        const parentCollection = await tx
           .selectFrom("Resource")
           .where("Resource.id", "=", String(collectionId))
           .where("Resource.siteId", "=", siteId)
@@ -332,7 +333,7 @@ export const collectionRouter = router({
           type: ResourceType.CollectionLink,
         })
 
-        const user = await tx
+        const user = await db
           .selectFrom("User")
           .where("id", "=", ctx.user.id)
           .selectAll()

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -63,15 +63,13 @@ export const collectionRouter = router({
           resourceId: !!parentFolderId ? String(parentFolderId) : null,
         })
 
-        const result = await db.transaction().execute(async (tx) => {
-          const user = await db
-            .selectFrom("User")
-            .where("id", "=", ctx.user.id)
-            .selectAll()
-            .executeTakeFirstOrThrow(
-              () => new TRPCError({ code: "BAD_REQUEST" }),
-            )
+        const user = await db
+          .selectFrom("User")
+          .where("id", "=", ctx.user.id)
+          .selectAll()
+          .executeTakeFirstOrThrow(() => new TRPCError({ code: "BAD_REQUEST" }))
 
+        const result = await db.transaction().execute(async (tx) => {
           if (parentFolderId) {
             const parentFolder = await db
               .selectFrom("Resource")
@@ -143,6 +141,12 @@ export const collectionRouter = router({
         resourceId: !!input.collectionId ? String(input.collectionId) : null,
       })
 
+      const user = await db
+        .selectFrom("User")
+        .where("id", "=", ctx.user.id)
+        .selectAll()
+        .executeTakeFirstOrThrow(() => new TRPCError({ code: "BAD_REQUEST" }))
+
       let newPage: UnwrapTagged<PrismaJson.BlobJsonContent>
       const { title, type, permalink, siteId, collectionId } = input
       if (type === ResourceType.CollectionPage) {
@@ -174,12 +178,6 @@ export const collectionRouter = router({
           })
           .returningAll()
           .executeTakeFirstOrThrow()
-
-        const user = await db
-          .selectFrom("User")
-          .where("id", "=", ctx.user.id)
-          .selectAll()
-          .executeTakeFirstOrThrow(() => new TRPCError({ code: "BAD_REQUEST" }))
 
         const addedResource = await tx
           .insertInto("Resource")
@@ -334,15 +332,13 @@ export const collectionRouter = router({
           type: ResourceType.CollectionLink,
         })
 
-        return await db.transaction().execute(async (tx) => {
-          const user = await tx
-            .selectFrom("User")
-            .where("id", "=", ctx.user.id)
-            .selectAll()
-            .executeTakeFirstOrThrow(
-              () => new TRPCError({ code: "BAD_REQUEST" }),
-            )
+        const user = await tx
+          .selectFrom("User")
+          .where("id", "=", ctx.user.id)
+          .selectAll()
+          .executeTakeFirstOrThrow(() => new TRPCError({ code: "BAD_REQUEST" }))
 
+        return await db.transaction().execute(async (tx) => {
           const resource = await tx
             .selectFrom("Resource")
             .where("Resource.id", "=", String(linkId))

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -86,7 +86,7 @@ export const collectionRouter = router({
               })
             }
 
-            if (parentFolder.type !== "Folder") {
+            if (parentFolder.type !== ResourceType.Folder) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
                 message:
@@ -354,7 +354,10 @@ export const collectionRouter = router({
                 }),
             )
 
-          const oldBlob = await getBlobOfResource(tx, resource.id)
+          const oldBlob = await getBlobOfResource({
+            tx,
+            resourceId: resource.id,
+          })
 
           const blob = await updateBlobById(tx, {
             content: {

--- a/apps/studio/src/server/modules/collection/collection.select.ts
+++ b/apps/studio/src/server/modules/collection/collection.select.ts
@@ -3,9 +3,9 @@ import type { SelectExpression } from "kysely"
 import type { DB } from "../database"
 
 export const defaultCollectionSelect = [
-  "Resource.id",
-  "Resource.siteId",
-  "Resource.title",
-  "Resource.type",
-  "Resource.permalink",
+  "id",
+  "siteId",
+  "title",
+  "type",
+  "permalink",
 ] satisfies SelectExpression<DB, "Resource">[]

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -172,10 +172,13 @@ export const updatePageById = (
     .executeTakeFirstOrThrow()
 }
 
-export const getBlobOfResource = async (
-  tx: Transaction<DB>,
-  resourceId: string,
-) => {
+export const getBlobOfResource = async ({
+  tx,
+  resourceId,
+}: {
+  tx: Transaction<DB>
+  resourceId: string
+}) => {
   const { draftBlobId, publishedVersionId } = await tx
     .selectFrom("Resource")
     .where("id", "=", resourceId)

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -286,6 +286,12 @@ export const setupPageResource = async ({
     .returningAll()
     .executeTakeFirstOrThrow()
 
+  if (state === ResourceState.Published && !userId) {
+    throw new Error(
+      "Precondition failed, we need a valid `userId` in order to publish",
+    )
+  }
+
   if (state === ResourceState.Published && userId) {
     const version = await db
       .insertInto("Version")
@@ -364,7 +370,7 @@ export const setupCollection = async ({
   permalink?: string
   parentId?: string | null
   title?: string
-}) => {
+} = {}) => {
   const { site, navbar, footer } = await setupSite(siteIdProp, !!siteIdProp)
 
   const collection = await db


### PR DESCRIPTION
## Problem
See the attached issue for the problem 

## Solution
- add audit logging to folder router 

## Bug-fixes
- constrain `collectionRouter.updateCollectionLink` to only update collection links
- fix incorrect handling for `updateBlobById` when the resource is published
    - we create a `draftBlob` correctly but we don't use the `draftBlobId` of the newly created blob but isntead, the stale value of `page.draftBlobId` (which is `null`)
    - previously, we returned a `UpdateResult`, which led to a silent failure. this has been updated to `returningAll` because we should always expect >= 1 result
- removed duplicate (and incorrect) updates of `updateCollectionLink`