### PR TITLE
feat: add audit logging to email router with tests

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -13,7 +13,7 @@ export type Generated<T> =
     : ColumnType<T, T | undefined, T>
 export type Timestamp = ColumnType<Date, Date | string, Date | string>
 
-export type AuditLog = {
+export interface AuditLog {
   id: GeneratedAlways<string>
   userId: string
   eventType: AuditLogEvent
@@ -27,7 +27,7 @@ export type AuditLog = {
   delta: PrismaJson.AuditLogDeltaJsonContent
   ipAddress: string | null
 }
-export type Blob = {
+export interface Blob {
   id: GeneratedAlways<string>
   /**
    * @kyselyType(PrismaJson.BlobJsonContent)
@@ -37,7 +37,7 @@ export type Blob = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Footer = {
+export interface Footer {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -48,7 +48,7 @@ export type Footer = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Navbar = {
+export interface Navbar {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -59,12 +59,12 @@ export type Navbar = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type RateLimiterFlexible = {
+export interface RateLimiterFlexible {
   key: string
   points: number
   expire: Timestamp | null
 }
-export type Resource = {
+export interface Resource {
   id: GeneratedAlways<string>
   title: string
   permalink: string
@@ -77,7 +77,7 @@ export type Resource = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type ResourcePermission = {
+export interface ResourcePermission {
   id: GeneratedAlways<string>
   userId: string
   siteId: number
@@ -87,7 +87,7 @@ export type ResourcePermission = {
   updatedAt: Generated<Timestamp>
   deletedAt: Timestamp | null
 }
-export type Site = {
+export interface Site {
   id: GeneratedAlways<number>
   name: string
   /**
@@ -104,7 +104,7 @@ export type Site = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type User = {
+export interface User {
   id: string
   name: string
   email: string
@@ -114,13 +114,13 @@ export type User = {
   deletedAt: Timestamp | null
   lastLoginAt: Timestamp | null
 }
-export type VerificationToken = {
+export interface VerificationToken {
   identifier: string
   token: string
   attempts: Generated<number>
   expires: Timestamp
 }
-export type Version = {
+export interface Version {
   id: GeneratedAlways<string>
   versionNum: number
   resourceId: string
@@ -129,14 +129,14 @@ export type Version = {
   publishedBy: string
   updatedAt: Generated<Timestamp>
 }
-export type Whitelist = {
+export interface Whitelist {
   id: GeneratedAlways<number>
   email: string
   expiry: Timestamp | null
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type DB = {
+export interface DB {
   AuditLog: AuditLog
   Blob: Blob
   Footer: Footer

--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1515,6 +1515,10 @@ video {
   height: 11.875rem;
 }
 
+.h-\[160px\] {
+  height: 160px;
+}
+
 .h-\[1px\] {
   height: 1px;
 }
@@ -1666,6 +1670,10 @@ video {
 
 .w-\[1px\] {
   width: 1px;
+}
+
+.w-\[200px\] {
+  width: 200px;
 }
 
 .w-auto {
@@ -2401,6 +2409,10 @@ video {
 
 .bg-brand-canvas {
   background-color: var(--color-brand-canvas-default);
+}
+
+.bg-brand-canvas-alt {
+  background-color: var(--color-brand-canvas-alt);
 }
 
 .bg-brand-canvas-inverse {
@@ -4731,12 +4743,20 @@ video {
     aspect-ratio: 2/1;
   }
 
+  .sm\:h-\[240px\] {
+    height: 240px;
+  }
+
   .sm\:min-h-\[22\.5rem\] {
     min-height: 22.5rem;
   }
 
   .sm\:w-3\/5 {
     width: 60%;
+  }
+
+  .sm\:w-\[200px\] {
+    width: 200px;
   }
 
   .sm\:flex-row {
@@ -4842,8 +4862,16 @@ video {
     margin-top: -1px;
   }
 
+  .md\:ml-4 {
+    margin-left: 1rem;
+  }
+
   .md\:mt-0 {
     margin-top: 0px;
+  }
+
+  .md\:mt-2 {
+    margin-top: 0.5rem;
   }
 
   .md\:mt-6 {
@@ -4878,16 +4906,8 @@ video {
     height: 15rem;
   }
 
-  .md\:h-\[240px\] {
-    height: 240px;
-  }
-
   .md\:w-1\/2 {
     width: 50%;
-  }
-
-  .md\:w-\[200px\] {
-    width: 200px;
   }
 
   .md\:min-w-\[67\%\] {
@@ -4952,6 +4972,10 @@ video {
 
   .md\:gap-3 {
     gap: 0.75rem;
+  }
+
+  .md\:gap-6 {
+    gap: 1.5rem;
   }
 
   .md\:gap-7 {
@@ -5088,24 +5112,12 @@ video {
     margin-left: 6rem;
   }
 
-  .lg\:ml-4 {
-    margin-left: 1rem;
-  }
-
   .lg\:mr-24 {
     margin-right: 6rem;
   }
 
   .lg\:mr-3 {
     margin-right: 0.75rem;
-  }
-
-  .lg\:mt-0 {
-    margin-top: 0px;
-  }
-
-  .lg\:mt-2 {
-    margin-top: 0.5rem;
   }
 
   .lg\:mt-\[0\.2rem\] {
@@ -5158,10 +5170,6 @@ video {
 
   .lg\:w-1\/2 {
     width: 50%;
-  }
-
-  .lg\:w-1\/4 {
-    width: 25%;
   }
 
   .lg\:w-4 {
@@ -5674,6 +5682,14 @@ video {
 .\[\&_li\]\:my-0 li {
   margin-top: 0px;
   margin-bottom: 0px;
+}
+
+.\[\&_li\]\:mb-4 li {
+  margin-bottom: 1rem;
+}
+
+.\[\&_li\]\:mt-0 li {
+  margin-top: 0px;
 }
 
 .\[\&_li\]\:pl-1 li {

--- a/apps/studio/src/server/context.ts
+++ b/apps/studio/src/server/context.ts
@@ -8,12 +8,12 @@ import { env } from "~/env.mjs"
 import { type Session, type SessionData } from "~/lib/types/session"
 import { sessionOptions } from "./modules/auth/session"
 import { db } from "./modules/database"
-import { type defaultMeSelect } from "./modules/me/me.select"
+import { type defaultUserSelect } from "./modules/me/me.select"
 import { prisma } from "./prisma"
 
 interface CreateContextOptions {
   session?: Session
-  user?: Pick<User, keyof typeof defaultMeSelect>
+  user?: Pick<User, (typeof defaultUserSelect)[number]>
 }
 
 /**

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -107,8 +107,8 @@ export const logConfigEvent: AuditLogger<ConfigEventLogProps> = async (
 }
 
 interface LoginDelta {
-  before: { token: VerificationToken }
-  after: { token: VerificationToken; user: User }
+  before: VerificationToken
+  after: null
 }
 
 // NOTE: logout just calls `session.destroy` and we only have

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -201,6 +201,7 @@ export const logUserEvent: AuditLogger<UserEventLogProps> = async (
       delta,
       userId: by.id,
       ipAddress: ip,
+      metadata: {},
     })
     .execute()
 }

--- a/apps/studio/src/server/modules/auth/__tests__/auth.router.test.ts
+++ b/apps/studio/src/server/modules/auth/__tests__/auth.router.test.ts
@@ -1,8 +1,8 @@
+import type { applySession } from "tests/integration/helpers/iron-session"
 import { TRPCError } from "@trpc/server"
 import { resetTables } from "tests/integration/helpers/db"
 import {
   applyAuthedSession,
-  applySession,
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
 import { setUpWhitelist } from "tests/integration/helpers/seed"

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -144,14 +144,13 @@ describe("auth.email", () => {
       })
 
       // Act
-      try {
-        await caller.verifyOtp({
+      await expect(
+        caller.verifyOtp({
           email: TEST_VALID_EMAIL,
           token: INVALID_OTP,
-        })
-      } catch (e) {
-        // Discard error since it is expected
-      }
+        }),
+      ).rejects.toThrowError()
+
       const result = caller.verifyOtp({
         email: TEST_VALID_EMAIL,
         token: VALID_OTP,

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.service.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.service.test.ts
@@ -1,0 +1,53 @@
+import { AuditLogEvent } from "@prisma/client"
+import { resetTables } from "tests/integration/helpers/db"
+import { setupUser } from "tests/integration/helpers/seed"
+
+import { db } from "~/server/modules/database"
+import { upsertUser } from "../email.service"
+
+describe("email.service", () => {
+  const TEST_EMAIL = "test@example.com"
+
+  beforeEach(async () => {
+    await resetTables("AuditLog", "User")
+  })
+
+  describe("upsertUser", () => {
+    it("should return an existing user if it already exists in the database", async () => {
+      // Arrange
+      await setupUser({ email: TEST_EMAIL })
+
+      // Act
+      const user = await db.transaction().execute(async (tx) => {
+        return upsertUser({ tx, email: TEST_EMAIL })
+      })
+
+      // Assert
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(user).toBeDefined()
+      expect(user.email).toBe(TEST_EMAIL)
+      expect(auditLogs).toHaveLength(0)
+    })
+
+    it("should create a new user if it does not exist in the database", async () => {
+      // Arrange
+      await setupUser({ email: "someone-else@example.com" })
+
+      // Act
+      const user = await db.transaction().execute(async (tx) => {
+        return upsertUser({ tx, email: TEST_EMAIL })
+      })
+
+      // Assert
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(user).toBeDefined()
+      expect(user.email).toBe(TEST_EMAIL)
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toBe(user.id)
+      expect(auditLogs?.eventType).toBe(AuditLogEvent.UserCreate)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.service.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.service.test.ts
@@ -23,10 +23,11 @@ describe("email.service", () => {
       })
 
       // Assert
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
       expect(user).toBeDefined()
       expect(user.email).toBe(TEST_EMAIL)
-      expect(auditLogs).toHaveLength(0)
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toHaveLength(0)
     })
 
     it("should create a new user if it does not exist in the database", async () => {
@@ -39,15 +40,12 @@ describe("email.service", () => {
       })
 
       // Assert
-      const auditLogs = await db
-        .selectFrom("AuditLog")
-        .selectAll()
-        .executeTakeFirst()
       expect(user).toBeDefined()
       expect(user.email).toBe(TEST_EMAIL)
-      expect(auditLogs).toBeDefined()
-      expect(auditLogs?.userId).toBe(user.id)
-      expect(auditLogs?.eventType).toBe(AuditLogEvent.UserCreate)
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs[0]?.userId).toBe(user.id)
+      expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.UserCreate)
     })
   })
 })

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -97,7 +97,7 @@ export const emailSessionRouter = router({
       if (!oldVerificationToken) {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: "Invalid login email",
+          message: "Please request for another OTP",
         })
       }
 
@@ -127,15 +127,10 @@ export const emailSessionRouter = router({
           by: user,
           delta: {
             before: {
-              token: oldVerificationToken,
+              ...oldVerificationToken,
+              attempts: oldVerificationToken.attempts + 1,
             },
-            after: {
-              token: {
-                ...oldVerificationToken,
-                attempts: oldVerificationToken.attempts + 1,
-              },
-              user,
-            },
+            after: null,
           },
           eventType: AuditLogEvent.Login,
         })

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -1,5 +1,7 @@
 import { TRPCError } from "@trpc/server"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import { formatInTimeZone } from "date-fns-tz"
+import pick from "lodash/pick"
 
 import { env } from "~/env.mjs"
 import { sendMail } from "~/lib/mail"
@@ -9,12 +11,15 @@ import {
 } from "~/schemas/auth/email/sign-in"
 import { publicProcedure, router } from "~/server/trpc"
 import { getBaseUrl } from "~/utils/getBaseUrl"
-import { defaultMeSelect } from "../../me/me.select"
+import { logAuthEvent } from "../../audit/audit.service"
+import { db } from "../../database"
+import { defaultUserSelect } from "../../me/me.select"
 import { isUserDeleted } from "../../user/user.service"
 import { isEmailWhitelisted } from "../../whitelist/whitelist.service"
 import { VerificationError } from "../auth.error"
 import { verifyToken } from "../auth.service"
 import { createTokenHash, createVfnPrefix, createVfnToken } from "../auth.util"
+import { upsertUser } from "./email.service"
 import { getOtpFingerPrint } from "./utils"
 
 export const emailSessionRouter = router({
@@ -42,6 +47,8 @@ export const emailSessionRouter = router({
       const hashedToken = createTokenHash(token, email)
 
       const url = new URL(getBaseUrl())
+
+      ctx.logger.info({ email, expires }, "Generated OTP for email sign in")
 
       // May have one of them fail,
       // so users may get an email but not have the token saved, but that should be fine.
@@ -79,6 +86,21 @@ export const emailSessionRouter = router({
     .input(emailVerifyOtpSchema)
     .meta({ rateLimitOptions: {} })
     .mutation(async ({ ctx, input: { email, token } }) => {
+      const oldVerificationToken = await ctx.prisma.verificationToken.findFirst(
+        {
+          where: {
+            identifier: getOtpFingerPrint(email, ctx.req),
+          },
+        },
+      )
+
+      if (!oldVerificationToken) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid login email",
+        })
+      }
+
       try {
         await verifyToken(ctx.prisma, ctx.req, {
           token,
@@ -95,34 +117,32 @@ export const emailSessionRouter = router({
         throw e
       }
 
-      const emailName = email.split("@")[0] ?? "unknown"
-
-      // Not using Prisma's `upsert` because Prisma's unique constraint with nullable fields
-      // like `deletedAt` causes type issues. Prisma expects `deletedAt` to be `string|Date`
-      // even when `null` is valid in the database schema.
-      const existingUser = await ctx.prisma.user.findFirst({
-        where: {
+      return db.transaction().execute(async (tx) => {
+        const user = await upsertUser({
+          tx,
           email,
-          deletedAt: null,
-        },
-      })
-      const user = existingUser
-        ? await ctx.prisma.user.update({
-            where: { id: existingUser.id },
-            data: { lastLoginAt: new Date() },
-            select: defaultMeSelect,
-          })
-        : await ctx.prisma.user.create({
-            data: {
-              email,
-              phone: "", // TODO: add the phone in later, this is a wip
-              name: emailName,
-            },
-            select: defaultMeSelect,
-          })
+        })
 
-      ctx.session.userId = user.id
-      await ctx.session.save()
-      return user
+        await logAuthEvent(tx, {
+          by: user,
+          delta: {
+            before: {
+              token: oldVerificationToken,
+            },
+            after: {
+              token: {
+                ...oldVerificationToken,
+                attempts: oldVerificationToken.attempts + 1,
+              },
+              user,
+            },
+          },
+          eventType: AuditLogEvent.Login,
+        })
+
+        ctx.session.userId = user.id
+        await ctx.session.save()
+        return pick(user, defaultUserSelect)
+      })
     }),
 })

--- a/apps/studio/src/server/modules/auth/email/email.service.ts
+++ b/apps/studio/src/server/modules/auth/email/email.service.ts
@@ -1,4 +1,5 @@
 import cuid2 from "@paralleldrive/cuid2"
+import { TRPCError } from "@trpc/server"
 
 import type { DB, Transaction, User } from "../../database"
 import { logUserEvent } from "../../audit/audit.service"
@@ -46,7 +47,14 @@ export const upsertUser = async ({
       lastLoginAt: new Date(),
     })
     .returningAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!newUser) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to create user",
+    })
+  }
 
   await logUserEvent(tx, {
     by: newUser,

--- a/apps/studio/src/server/modules/auth/email/email.service.ts
+++ b/apps/studio/src/server/modules/auth/email/email.service.ts
@@ -1,0 +1,61 @@
+import cuid2 from "@paralleldrive/cuid2"
+
+import type { DB, Transaction, User } from "../../database"
+import { logUserEvent } from "../../audit/audit.service"
+import { AuditLogEvent } from "../../database"
+
+interface GetOrCreateUserParams {
+  tx: Transaction<DB>
+  email: string
+}
+
+export const upsertUser = async ({
+  tx,
+  email,
+}: GetOrCreateUserParams): Promise<User> => {
+  const emailName = email.split("@")[0] ?? "unknown"
+
+  const possibleUser = await tx
+    .selectFrom("User")
+    .selectAll()
+    .where("email", "=", email)
+    .where("deletedAt", "is", null)
+    .executeTakeFirst()
+
+  if (possibleUser) {
+    // NOTE: We are not logging the UserUpdate event here, as that is already
+    // captured under the UserLogin event
+    await tx
+      .updateTable("User")
+      .set({
+        lastLoginAt: new Date(),
+      })
+      .where("id", "=", possibleUser.id)
+      .execute()
+
+    return possibleUser
+  }
+
+  const newUser = await tx
+    .insertInto("User")
+    .values({
+      id: cuid2.createId(),
+      email,
+      phone: "", // NOTE: The phone number is added in a later step by the user
+      name: emailName,
+      lastLoginAt: new Date(),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+  await logUserEvent(tx, {
+    by: newUser,
+    delta: {
+      before: null,
+      after: newUser,
+    },
+    eventType: AuditLogEvent.UserCreate,
+  })
+
+  return newUser
+}

--- a/apps/studio/src/server/modules/me/me.router.ts
+++ b/apps/studio/src/server/modules/me/me.router.ts
@@ -1,11 +1,13 @@
 import { protectedProcedure, router } from "~/server/trpc"
-import { defaultMeSelect } from "./me.select"
+import { db } from "../database"
+import { defaultUserSelect } from "./me.select"
 
 export const meRouter = router({
   get: protectedProcedure.query(async ({ ctx }) => {
-    return ctx.prisma.user.findUniqueOrThrow({
-      where: { id: ctx.user.id },
-      select: defaultMeSelect,
-    })
+    return db
+      .selectFrom("User")
+      .select(defaultUserSelect)
+      .where("id", "=", ctx.user.id)
+      .executeTakeFirstOrThrow()
   }),
 })

--- a/apps/studio/src/server/modules/me/me.select.ts
+++ b/apps/studio/src/server/modules/me/me.select.ts
@@ -1,14 +1,16 @@
-import { Prisma } from "@prisma/client"
+import type { SelectExpression } from "kysely"
+
+import type { DB } from "../database"
 
 /**
  * Default selector for when retrieving logged in user.
  * It's important to always explicitly say which fields you want to return in order to not leak extra information
  * @see https://github.com/prisma/prisma/issues/9353
  */
-export const defaultMeSelect = Prisma.validator<Prisma.UserSelect>()({
-  id: true,
-  email: true,
-  name: true,
-  phone: true,
-  createdAt: true,
-})
+export const defaultUserSelect = [
+  "id",
+  "email",
+  "name",
+  "phone",
+  "createdAt",
+] satisfies SelectExpression<DB, "User">[]

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -486,7 +486,7 @@ export const setupUser = async ({
   userId?: string
   email: string
   phone?: string
-  isDeleted: boolean
+  isDeleted?: boolean
   hasLoggedIn?: boolean
 }) => {
   return db


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1773.
Closes ISOM-1790.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Added audit logging capabilities to the email router.

**Improvements**:

- Changed the DB queries on me.router.ts to use via Kysely instead of Prisma directly.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] View the AuditLogs table using TablePlus on staging.
- [ ] Perform a successful login to Isomer Studio using an email address that has not logged in before.
- [ ] Verify that the AuditLogs has 2 new entries - UserCreate and Login events