### PR TITLE
feat: add audit logging to folder router with tests

### DIFF
--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -12,7 +12,16 @@ import type {
   VerificationToken,
 } from "../database"
 
-type FullResource = Resource & (Blob | undefined)
+type WithoutMeta<T> = Omit<T, "createdAt" | "updatedAt">
+
+// NOTE: Either a folder/collection that doesn't have a blob
+// or a page w/ blob
+type FullResource =
+  | WithoutMeta<Resource>
+  | {
+      blob: WithoutMeta<Blob>
+      resource: WithoutMeta<Resource>
+    }
 
 interface ResourceCreateDelta {
   before: null
@@ -46,7 +55,7 @@ export const logResourceEvent: AuditLogger<ResourceEventLogProps> = async (
 ) => {
   await tx
     .insertInto("AuditLog")
-    .values({ eventType, delta, userId: by.id, ipAddress: ip })
+    .values({ eventType, delta, userId: by.id, ipAddress: ip, metadata: {} })
     .execute()
 }
 

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -10,6 +10,7 @@ import type {
   Transaction,
   User,
   VerificationToken,
+  Version,
 } from "../database"
 
 type WithoutMeta<T> = Omit<T, "createdAt" | "updatedAt">
@@ -144,11 +145,7 @@ export const logAuthEvent: AuditLogger<AuthEventLogProps> = async (
     .execute()
 }
 
-type PublishEvents =
-  | (FullResource & { versionNumber: number })
-  | Site
-  | Navbar
-  | Footer
+type PublishEvent = WithoutMeta<Version>
 
 interface PublishEventLogProps {
   by: User
@@ -157,8 +154,8 @@ interface PublishEventLogProps {
     // We don't want to store the `version` because it is a pointer
     // to the blob/resource
     // we will instead store the full data here so it is an accurate snapshot
-    before: PublishEvents | null
-    after: PublishEvents
+    before: PublishEvent | null
+    after: PublishEvent
   }
   eventType: Extract<AuditLogEvent, "Publish">
   ip?: string

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -16,7 +16,7 @@ import {
 } from "tests/integration/helpers/seed"
 
 import { createCallerFactory } from "~/server/trpc"
-import { db, ResourceType } from "../../database"
+import { AuditLogEvent, db, ResourceType } from "../../database"
 import { folderRouter } from "../folder.router"
 
 const createCaller = createCallerFactory(folderRouter)
@@ -28,6 +28,7 @@ describe("folder.router", async () => {
 
   beforeEach(async () => {
     await resetTables(
+      "AuditLog",
       "Blob",
       "Resource",
       "Site",
@@ -59,6 +60,9 @@ describe("folder.router", async () => {
       await expect(result).rejects.toThrowError(
         new TRPCError({ code: "UNAUTHORIZED" }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should throw 409 if permalink already exists", async () => {
@@ -84,6 +88,9 @@ describe("folder.router", async () => {
           message: "A resource with the same permalink already exists",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should throw 404 if `siteId` does not exist", async () => {
@@ -136,6 +143,9 @@ describe("folder.router", async () => {
           message: "Parent folder does not exist",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should throw 400 if `parentFolderId` is not a folder", async () => {
@@ -163,6 +173,9 @@ describe("folder.router", async () => {
           message: "Resource ID does not point to a folder",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should create a folder even with duplicate permalink if `siteId` is different", async () => {
@@ -190,6 +203,13 @@ describe("folder.router", async () => {
         permalink: duplicatePermalink,
       })
       expect(result).toEqual({ folderId: actualFolder.id })
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceCreate)
     })
 
     it("should create a folder", async () => {
@@ -214,6 +234,13 @@ describe("folder.router", async () => {
         siteId: site.id,
       })
       expect(result).toEqual({ folderId: actualFolder.id })
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceCreate)
     })
 
     it("should create a nested folder if `parentFolderId` is provided", async () => {
@@ -240,6 +267,13 @@ describe("folder.router", async () => {
       })
       expect(actualFolder.parentId).toEqual(parentFolder.id)
       expect(result).toEqual({ folderId: actualFolder.id })
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceCreate)
     })
 
     it("should throw 403 if user does not have admin access to the site and tries to create a root level folder", async () => {
@@ -263,6 +297,9 @@ describe("folder.router", async () => {
             "You do not have sufficient permissions to perform this action",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should throw 403 if user does not have access to the site", async () => {
@@ -286,6 +323,9 @@ describe("folder.router", async () => {
             "You do not have sufficient permissions to perform this action",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it.skip("should throw 403 if user does not have write access to the parent folder", async () => {})
@@ -374,7 +414,7 @@ describe("folder.router", async () => {
       )
     })
 
-    it("should return 200 ", async () => {
+    it("should return 200 if the folder exists", async () => {
       // Arrange
       const { folder, site } = await setupFolder()
       await setupAdminPermissions({ userId: session.userId, siteId: site.id })
@@ -410,6 +450,9 @@ describe("folder.router", async () => {
       await expect(result).rejects.toThrowError(
         new TRPCError({ code: "UNAUTHORIZED" }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should throw 409 if permalink already exists", async () => {
@@ -439,6 +482,9 @@ describe("folder.router", async () => {
           message: "A resource with the same permalink already exists",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should allow duplicate permalinks if the site is different", async () => {
@@ -464,6 +510,13 @@ describe("folder.router", async () => {
 
       // Assert
       expect(result).toMatchObject(expected)
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
 
     it("should throw 404 if `siteId` does not exist", async () => {
@@ -492,6 +545,9 @@ describe("folder.router", async () => {
             "You do not have sufficient permissions to perform this action",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should allow edits onto a folder regardless of the parent", async () => {
@@ -527,6 +583,13 @@ describe("folder.router", async () => {
         permalink: expected.permalink,
         parentId: page.id,
       })
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
 
     it("should throw 403 if user does not have access to the site", async () => {
@@ -550,6 +613,9 @@ describe("folder.router", async () => {
             "You do not have sufficient permissions to perform this action",
         }),
       )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should return undefined if the resourceId is not a folder", async () => {
@@ -568,6 +634,9 @@ describe("folder.router", async () => {
 
       // Assert
       expect(result).toEqual(undefined)
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toEqual([])
     })
 
     it("should allow edits on a root level folder regardless of the role", async () => {
@@ -593,6 +662,13 @@ describe("folder.router", async () => {
         permalink: expected.permalink,
         id: expected.id,
       })
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
 
     it("should allow edits on a nested folder regardless of the role", async () => {
@@ -622,6 +698,13 @@ describe("folder.router", async () => {
         permalink: expected.permalink,
         id: expected.id,
       })
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs?.userId).toEqual(session.userId)
+      expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
   })
 })

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -62,7 +62,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 409 if permalink already exists", async () => {
@@ -90,7 +90,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 404 if `siteId` does not exist", async () => {
@@ -145,7 +145,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 400 if `parentFolderId` is not a folder", async () => {
@@ -175,7 +175,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should create a folder even with duplicate permalink if `siteId` is different", async () => {
@@ -299,7 +299,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 403 if user does not have access to the site", async () => {
@@ -325,7 +325,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it.skip("should throw 403 if user does not have write access to the parent folder", async () => {})
@@ -452,7 +452,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 409 if permalink already exists", async () => {
@@ -484,7 +484,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should allow duplicate permalinks if the site is different", async () => {
@@ -547,7 +547,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should allow edits onto a folder regardless of the parent", async () => {
@@ -615,7 +615,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 404 if the resourceId is not a folder", async () => {
@@ -641,7 +641,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should throw 404 if the resourceId does not exist", async () => {
@@ -666,7 +666,7 @@ describe("folder.router", async () => {
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
-      ).resolves.toEqual([])
+      ).resolves.toHaveLength(0)
     })
 
     it("should allow edits on a root level folder regardless of the role", async () => {

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -30,6 +30,13 @@ export const folderRouter = router({
           resourceId: !!parentFolderId ? String(parentFolderId) : null,
         })
 
+        // Get user information
+        const user = await db
+          .selectFrom("User")
+          .where("id", "=", ctx.user.id)
+          .selectAll()
+          .executeTakeFirstOrThrow(() => new TRPCError({ code: "NOT_FOUND" }))
+
         // Validate site is valid
         const site = await db
           .selectFrom("Site")
@@ -68,12 +75,6 @@ export const folderRouter = router({
         }
 
         const folder = await db.transaction().execute(async (tx) => {
-          const user = await tx
-            .selectFrom("User")
-            .where("id", "=", ctx.user.id)
-            .selectAll()
-            .executeTakeFirstOrThrow(() => new TRPCError({ code: "NOT_FOUND" }))
-
           const folder = await tx
             .insertInto("Resource")
             .values({
@@ -151,13 +152,13 @@ export const folderRouter = router({
           userId: ctx.user.id,
         })
 
-        const result = await db.transaction().execute(async (tx) => {
-          const user = await tx
-            .selectFrom("User")
-            .where("id", "=", ctx.user.id)
-            .selectAll()
-            .executeTakeFirstOrThrow(() => new TRPCError({ code: "NOT_FOUND" }))
+        const user = await db
+          .selectFrom("User")
+          .where("id", "=", ctx.user.id)
+          .selectAll()
+          .executeTakeFirstOrThrow(() => new TRPCError({ code: "NOT_FOUND" }))
 
+        const result = await db.transaction().execute(async (tx) => {
           const oldResource = await db
             .selectFrom("Resource")
             .selectAll()
@@ -178,8 +179,8 @@ export const folderRouter = router({
 
           const newResource = await db
             .updateTable("Resource")
-            .where("Resource.id", "=", resourceId)
-            .where("Resource.siteId", "=", Number(siteId))
+            .where("Resource.id", "=", oldResource.id)
+            .where("Resource.siteId", "=", oldResource.siteId)
             .where("Resource.type", "in", [
               ResourceType.Folder,
               ResourceType.Collection,

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -170,7 +170,10 @@ export const folderRouter = router({
             .executeTakeFirst()
 
           if (!oldResource) {
-            return undefined
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Resource does not exist",
+            })
           }
 
           const newResource = await db
@@ -208,10 +211,6 @@ export const folderRouter = router({
 
           return newResource
         })
-
-        if (!result) {
-          return undefined
-        }
 
         await publishSite(ctx.logger, Number(siteId))
 

--- a/apps/studio/src/server/modules/folder/folder.select.ts
+++ b/apps/studio/src/server/modules/folder/folder.select.ts
@@ -3,12 +3,12 @@ import type { SelectExpression } from "kysely"
 import type { DB } from "~prisma/generated/generatedTypes"
 
 export const defaultFolderSelect = [
-  "Resource.id",
-  "Resource.parentId",
-  "Resource.permalink",
-  "Resource.title",
-  "Resource.siteId",
-  "Resource.state",
-  "Resource.type",
-  "Resource.draftBlobId",
+  "id",
+  "parentId",
+  "permalink",
+  "title",
+  "siteId",
+  "state",
+  "type",
+  "draftBlobId",
 ] satisfies SelectExpression<DB, "Resource">[]


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1777.
Closes ISOM-1786.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Added audit logging capabilities to the folder router.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Log in to Isomer Studio.
- [ ] Create a new folder in any site.
- [ ] Verify that an additional audit log entry has been created in the AuditLog table which is of ResourceCreate type.
- [ ] Edit the folder's name.
- [ ] Verify that an additional audit log entry has been created in the AuditLog table which is of ResourceUpdate type.