### PR TITLE
fix: correct grammar in CollaboratorsDescription component text

### DIFF
--- a/apps/studio/src/features/users/components/CollaboratorsDescription.tsx
+++ b/apps/studio/src/features/users/components/CollaboratorsDescription.tsx
@@ -9,7 +9,7 @@ export const CollaboratorsDescription = () => {
   if (ability.can("manage", "UserManagement")) {
     return (
       <Text textStyle="body-2">
-        View and manage people that collaborate with you on this site,
+        View and manage people that collaborate with you on this site.
       </Text>
     )
   }
@@ -17,7 +17,7 @@ export const CollaboratorsDescription = () => {
   if (ability.can("read", "UserManagement")) {
     return (
       <Text textStyle="body-2">
-        View people that you collaborate with you on this site
+        View people that you collaborate with you on this site.
       </Text>
     )
   }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Missing/incorrect punctuation

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- fix fullstops

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to User Management feature and check that the text ends with `.`