### PR TITLE
feat: add audit logging to resource router

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -450,10 +450,6 @@ export const resourceRouter = router({
             throw err
           })
 
-        if (!result) {
-          throw new TRPCError({ code: "NOT_FOUND" })
-        }
-
         await publishSite(ctx.logger, result.siteId)
         return result
       },

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -28,6 +28,7 @@ import {
   searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
+import { logResourceEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { db, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
@@ -37,6 +38,7 @@ import {
 } from "../permissions/permissions.service"
 import { validateUserPermissionsForSite } from "../site/site.service"
 import {
+  defaultResourceSelect,
   getBatchAncestryWithSelfQuery,
   getSearchRecentlyEdited,
   getSearchResults,
@@ -305,13 +307,25 @@ export const resourceRouter = router({
           })
         }
 
+        const user = await db
+          .selectFrom("User")
+          .selectAll()
+          .where("id", "=", ctx.user.id)
+          .executeTakeFirstOrThrow(
+            () =>
+              new TRPCError({
+                code: "BAD_REQUEST",
+                message: "Please ensure that you are logged in",
+              }),
+          )
+
         const result = await db
           .transaction()
           .execute(async (tx) => {
             const toMove = await tx
               .selectFrom("Resource")
               .where("id", "=", movedResourceId)
-              .select(["id", "siteId", "type", "parentId"])
+              .selectAll()
               .executeTakeFirst()
 
             if (!toMove) {
@@ -402,18 +416,29 @@ export const resourceRouter = router({
               })
               .execute()
 
-            return tx
+            const moved = await tx
               .selectFrom("Resource")
-              .where("id", "=", String(movedResourceId))
-              .select([
-                "Resource.siteId",
-                "Resource.parentId",
-                "Resource.id",
-                "Resource.type",
-                "Resource.permalink",
-                "Resource.title",
-              ])
+              .where("id", "=", movedResourceId)
+              .select(defaultResourceSelect)
               .executeTakeFirst()
+
+            // NOTE: this is technically impossible because we're executing
+            // inside a tx and this is the same resource which was fetched earlier
+            if (!moved) {
+              throw new TRPCError({
+                code: "INTERNAL_SERVER_ERROR",
+                message:
+                  "Something went wrong while attempting to move your resource, please try again later",
+              })
+            }
+
+            await logResourceEvent(tx, {
+              eventType: "ResourceUpdate",
+              delta: { before: toMove, after: moved },
+              by: user,
+            })
+
+            return moved
           })
           .catch((err) => {
             if (get(err, "code") === PG_ERROR_CODES.uniqueViolation) {
@@ -501,12 +526,47 @@ export const resourceRouter = router({
         resourceId,
       })
 
-      const result = await db
-        .deleteFrom("Resource")
-        .where("Resource.id", "=", String(resourceId))
-        .where("Resource.siteId", "=", siteId)
-        .where("Resource.type", "!=", ResourceType.RootPage)
-        .executeTakeFirst()
+      const user = await db
+        .selectFrom("User")
+        .selectAll()
+        .executeTakeFirstOrThrow(
+          () =>
+            new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Please ensure that you are logged in",
+            }),
+        )
+
+      const result = await db.transaction().execute(async (tx) => {
+        const before = await tx
+          .selectFrom("Resource")
+          .where("id", "=", resourceId)
+          .select(defaultResourceSelect)
+          .executeTakeFirst()
+
+        if (!before) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message: "The resource to be deleted could not be found",
+          })
+        }
+
+        await logResourceEvent(tx, {
+          delta: {
+            after: null,
+            before,
+          },
+          by: user,
+          eventType: "ResourceDelete",
+        })
+
+        return tx
+          .deleteFrom("Resource")
+          .where("Resource.id", "=", String(resourceId))
+          .where("Resource.siteId", "=", siteId)
+          .where("Resource.type", "!=", ResourceType.RootPage)
+          .executeTakeFirst()
+      })
 
       if (Number(result.numDeletedRows) === 0) {
         throw new TRPCError({ code: "BAD_REQUEST" })


### PR DESCRIPTION
## Problem
see attached issue

Closes https://linear.app/ogp/issue/ISOM-1783/[misc]-add-integration-tests-for-resourcerouter

## Solution
- use the provided service method to log in `resourceRouter`
- instead of using the custom kysely statement which we were doing previously, we go through `getFullPage` to get the full resource to store in our audit logs