### PR TITLE
isom-1794 bug unable to create links to nested folders and pages

### DIFF
--- a/apps/studio/src/components/ResourceSelector/useResourceStack.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceStack.tsx
@@ -30,7 +30,7 @@ export const useResourceStack = ({
 
   useEffect(() => {
     return () => setResourceStack([])
-  }, [pendingMovedItemAncestryStack])
+  }, [])
 
   const [isResourceHighlighted, setIsResourceHighlighted] =
     useState<boolean>(!!selectedResourceId)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Cannot link in modal due to state resetting on dependency changes

Closes https://linear.app/ogp/issue/ISOM-1794/bug-unable-to-create-links-to-nested-folders-and-pages

## Solution

<!-- How did you solve the problem? -->

**Bug Fixes**:

- remove depdency in useEffect

## Tests

<!-- What tests should be run to confirm functionality? -->

https://github.com/user-attachments/assets/8d248cb2-6abf-461a-ba5c-857cb4d0414c

1. Go to Studio and create a Text component.
2. Type some random words and select some of them to add a link.
3. Attempt to add a link to a nested page/folder.
4. You should be able to do it successfully without the page list selector jumping back to the root.