### PR TITLE
feat: add audit logging to site router with tests

### DIFF
--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -61,8 +61,8 @@ interface FooterUpdateDelta {
 }
 
 interface NavbarUpdateDelta {
-  before: Footer
-  after: Footer
+  before: Navbar
+  after: Navbar
 }
 
 type ConfigEventLogProps =
@@ -102,6 +102,7 @@ export const logConfigEvent: AuditLogger<ConfigEventLogProps> = async (
       delta,
       userId: by.id,
       ipAddress: ip,
+      metadata: {},
     })
     .execute()
 }

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -7,10 +7,12 @@ import {
 } from "tests/integration/helpers/iron-session"
 import {
   setupAdminPermissions,
+  setupEditorPermissions,
   setupSite,
 } from "tests/integration/helpers/seed"
 
 import { createCallerFactory } from "~/server/trpc"
+import { AuditLogEvent, db, jsonb } from "../../database"
 import { siteRouter } from "../site.router"
 
 const createCaller = createCallerFactory(siteRouter)
@@ -158,6 +160,310 @@ describe("site.router", async () => {
       expect(result).toEqual({ name: site.name })
     })
 
-    it.skip("should throw 403 if user does not have read access to the site", async () => {})
+    it("should throw 403 if user does not have read access to the site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+
+      // Act
+      const result = caller.getSiteName({ siteId: site.id })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+  })
+
+  describe("setNotification", () => {
+    beforeEach(async () => {
+      await resetTables("AuditLog", "Site")
+    })
+
+    it("should throw 401 if user is not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.setNotification({
+        siteId: 1,
+        notification: "foo",
+        notificationEnabled: true,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+      await expect(db.selectFrom("AuditLog").execute()).resolves.toEqual([])
+    })
+
+    it("should throw 403 if user does not have write access to the site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.setNotification({
+        siteId: site.id,
+        notification: "foo",
+        notificationEnabled: true,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      await expect(db.selectFrom("AuditLog").execute()).resolves.toEqual([])
+    })
+
+    it("should save changes to the site notification successfully if one exists", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await db
+        .updateTable("Site")
+        .set((eb) => ({
+          config: eb(
+            "Site.config",
+            "||",
+            // @ts-expect-error JSON concat operator replaces the entire notification object if it exists, but Kysely does not have types for this.
+            jsonb({
+              notification: { content: [{ type: "text", text: "bar" }] },
+            }),
+          ),
+        }))
+        .where("id", "=", site.id)
+        .execute()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.setNotification({
+        siteId: site.id,
+        notification: "foo",
+        notificationEnabled: true,
+      })
+
+      // Assert
+      const newSite = await db
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .select("Site.config")
+        .executeTakeFirstOrThrow()
+      expect(newSite.config.notification).toEqual({
+        content: [{ type: "text", text: "foo" }],
+      })
+      const auditLog = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLog).toBeDefined()
+      expect(auditLog?.eventType).toEqual(AuditLogEvent.SiteConfigUpdate)
+      expect(auditLog?.userId).toEqual(session.userId)
+    })
+
+    it("should add the site notification successfully if one did exist before", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.setNotification({
+        siteId: site.id,
+        notification: "foo",
+        notificationEnabled: true,
+      })
+
+      // Assert
+      const newSite = await db
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .select("Site.config")
+        .executeTakeFirstOrThrow()
+      expect(newSite.config.notification).toEqual({
+        content: [{ type: "text", text: "foo" }],
+      })
+      const auditLog = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLog).toBeDefined()
+      expect(auditLog?.eventType).toEqual(AuditLogEvent.SiteConfigUpdate)
+      expect(auditLog?.userId).toEqual(session.userId)
+    })
+
+    it("should remove the site notification successfully if notification is disabled", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await db
+        .updateTable("Site")
+        .set((eb) => ({
+          config: eb(
+            "Site.config",
+            "||",
+            // @ts-expect-error JSON concat operator replaces the entire notification object if it exists, but Kysely does not have types for this.
+            jsonb({
+              notification: { content: [{ type: "text", text: "bar" }] },
+            }),
+          ),
+        }))
+        .where("id", "=", site.id)
+        .execute()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.setNotification({
+        siteId: site.id,
+        notification: "foo",
+        notificationEnabled: false,
+      })
+
+      // Assert
+      const newSite = await db
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .select("Site.config")
+        .executeTakeFirstOrThrow()
+      expect(newSite.config.notification).toBeUndefined()
+      const auditLog = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirst()
+      expect(auditLog).toBeDefined()
+      expect(auditLog?.eventType).toEqual(AuditLogEvent.SiteConfigUpdate)
+      expect(auditLog?.userId).toEqual(session.userId)
+    })
+  })
+
+  describe("setSiteConfigByAdmin", () => {
+    beforeEach(async () => {
+      await resetTables("AuditLog", "Site", "Navbar", "Footer")
+    })
+
+    it("should throw 401 if user is not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.setSiteConfigByAdmin({
+        siteId: 1,
+        config: "config",
+        theme: "theme",
+        navbar: "navbar",
+        footer: "footer",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+      await expect(db.selectFrom("AuditLog").execute()).resolves.toEqual([])
+    })
+
+    it("should throw 403 if user does not have write access to the site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.setSiteConfigByAdmin({
+        siteId: site.id,
+        config: "config",
+        theme: "theme",
+        navbar: "navbar",
+        footer: "footer",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      await expect(db.selectFrom("AuditLog").execute()).resolves.toEqual([])
+    })
+
+    it("should save changes to the site config, navbar and footer successfully", async () => {
+      // Arrange
+      const NEW_CONFIG = `"config"`
+      const NEW_THEME = `"theme"`
+      const NEW_NAVBAR = `"navbar"`
+      const NEW_FOOTER = `"footer"`
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.setSiteConfigByAdmin({
+        siteId: site.id,
+        config: NEW_CONFIG,
+        theme: NEW_THEME,
+        navbar: NEW_NAVBAR,
+        footer: NEW_FOOTER,
+      })
+
+      // Assert
+      const newSite = await db
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      const newNavbar = await db
+        .selectFrom("Navbar")
+        .where("siteId", "=", site.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      const newFooter = await db
+        .selectFrom("Footer")
+        .where("siteId", "=", site.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+
+      expect(newSite.config).toEqual(NEW_CONFIG.replaceAll(`"`, ""))
+      expect(newSite.theme).toEqual(NEW_THEME.replaceAll(`"`, ""))
+      expect(newNavbar.content).toEqual(NEW_NAVBAR.replaceAll(`"`, ""))
+      expect(newFooter.content).toEqual(NEW_FOOTER.replaceAll(`"`, ""))
+      expect(auditLogs).toHaveLength(3)
+      expect(
+        auditLogs.some(
+          (log) => log.eventType === AuditLogEvent.SiteConfigUpdate,
+        ),
+      ).toBe(true)
+      expect(
+        auditLogs.some((log) => log.eventType === AuditLogEvent.NavbarUpdate),
+      ).toBe(true)
+      expect(
+        auditLogs.some((log) => log.eventType === AuditLogEvent.FooterUpdate),
+      ).toBe(true)
+      expect(auditLogs.every((log) => log.userId === session.userId)).toBe(true)
+    })
   })
 })

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -180,7 +180,7 @@ describe("site.router", async () => {
 
   describe("setNotification", () => {
     beforeEach(async () => {
-      await resetTables("AuditLog", "Site")
+      await resetTables("AuditLog")
     })
 
     it("should throw 401 if user is not logged in", async () => {
@@ -356,7 +356,7 @@ describe("site.router", async () => {
 
   describe("setSiteConfigByAdmin", () => {
     beforeEach(async () => {
-      await resetTables("AuditLog", "Site", "Navbar", "Footer")
+      await resetTables("AuditLog", "Navbar", "Footer")
     })
 
     it("should throw 401 if user is not logged in", async () => {

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -3,6 +3,7 @@ import type {
   IsomerSiteThemeProps,
   IsomerSiteWideComponentsProps,
 } from "@opengovsg/isomer-components"
+import { TRPCError } from "@trpc/server"
 
 import {
   getConfigSchema,
@@ -174,14 +175,29 @@ export const siteRouter = router({
           .selectFrom("User")
           .where("id", "=", ctx.user.id)
           .selectAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!user) {
+          // NOTE: This shouldn't happen as the user is already logged in
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "The user could not be found.",
+          })
+        }
 
         // Update site-level configuration
         const oldSite = await tx
           .selectFrom("Site")
           .where("id", "=", siteId)
           .selectAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!oldSite) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "The site could not be found.",
+          })
+        }
 
         const newSite = await tx
           .updateTable("Site")
@@ -191,7 +207,14 @@ export const siteRouter = router({
           })
           .where("id", "=", siteId)
           .returningAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!newSite) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to update site configuration.",
+          })
+        }
 
         await logConfigEvent(tx, {
           eventType: AuditLogEvent.SiteConfigUpdate,
@@ -207,7 +230,14 @@ export const siteRouter = router({
           .selectFrom("Navbar")
           .where("siteId", "=", siteId)
           .selectAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!oldNavbar) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "The navbar for the site could not be found.",
+          })
+        }
 
         const newNavbar = await tx
           .updateTable("Navbar")
@@ -220,7 +250,14 @@ export const siteRouter = router({
           })
           .where("siteId", "=", siteId)
           .returningAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!newNavbar) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to update site navbar.",
+          })
+        }
 
         await logConfigEvent(tx, {
           eventType: AuditLogEvent.NavbarUpdate,
@@ -236,7 +273,14 @@ export const siteRouter = router({
           .selectFrom("Footer")
           .where("siteId", "=", siteId)
           .selectAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!oldFooter) {
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message: "The footer for the site could not be found.",
+          })
+        }
 
         const newFooter = await tx
           .updateTable("Footer")
@@ -249,7 +293,14 @@ export const siteRouter = router({
           })
           .where("siteId", "=", siteId)
           .returningAll()
-          .executeTakeFirstOrThrow()
+          .executeTakeFirst()
+
+        if (!newFooter) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to update site footer.",
+          })
+        }
 
         await logConfigEvent(tx, {
           eventType: AuditLogEvent.FooterUpdate,

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -98,13 +98,28 @@ export const setSiteNotification = async ({
     .selectFrom("User")
     .where("id", "=", userId)
     .selectAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!user) {
+    // NOTE: This shouldn't happen as the user is already logged in
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "The user could not be found",
+    })
+  }
 
   const oldSite = await tx
     .selectFrom("Site")
     .where("id", "=", siteId)
     .selectAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!oldSite) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "The site could not be found",
+    })
+  }
 
   const newSite = await tx
     .updateTable("Site")
@@ -114,7 +129,14 @@ export const setSiteNotification = async ({
     }))
     .where("id", "=", siteId)
     .returningAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!newSite) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to update site configuration",
+    })
+  }
 
   await logConfigEvent(tx, {
     eventType: AuditLogEvent.SiteConfigUpdate,
@@ -141,20 +163,42 @@ export const clearSiteNotification = async ({
     .selectFrom("User")
     .where("id", "=", userId)
     .selectAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!user) {
+    // NOTE: This shouldn't happen as the user is already logged in
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "The user could not be found",
+    })
+  }
 
   const oldSite = await tx
     .selectFrom("Site")
     .where("id", "=", siteId)
     .selectAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!oldSite) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "The site could not be found",
+    })
+  }
 
   const newSite = await tx
     .updateTable("Site")
     .set({ config: sql`config - 'notification'` })
     .where("id", "=", siteId)
     .returningAll()
-    .executeTakeFirstOrThrow()
+    .executeTakeFirst()
+
+  if (!newSite) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Failed to update site configuration",
+    })
+  }
 
   await logConfigEvent(tx, {
     eventType: AuditLogEvent.SiteConfigUpdate,

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -1,11 +1,12 @@
-import { type IsomerSiteConfigProps } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 
+import type { DB, Transaction } from "../database"
 import type {
   CrudResourceActions,
   PermissionsProps,
 } from "../permissions/permissions.type"
-import { db, jsonb, sql } from "../database"
+import { logConfigEvent } from "../audit/audit.service"
+import { AuditLogEvent, db, jsonb, sql } from "../database"
 import { definePermissionsForSite } from "../permissions/permissions.service"
 
 export const validateUserPermissionsForSite = async ({
@@ -54,18 +55,6 @@ export const getSiteNameAndCodeBuildId = async (siteId: number) => {
     .executeTakeFirstOrThrow()
 }
 
-// Note: This overwrites the full site config
-// TODO: Should trigger immediate re-publish of site
-export const setSiteConfig = async (
-  siteId: number,
-  config: IsomerSiteConfigProps,
-) => {
-  return db
-    .updateTable("Site")
-    .set({ config: jsonb(config) })
-    .where("id", "=", siteId)
-    .executeTakeFirstOrThrow()
-}
 export const getNotification = async (siteId: number) => {
   const result = await db
     .selectFrom("Site")
@@ -85,11 +74,19 @@ export const getNotification = async (siteId: number) => {
   return result.content?.[0]?.text ?? ""
 }
 
-// TODO: Should trigger immediate re-publish of site
-export const setSiteNotification = async (
-  siteId: number,
-  notification: string,
-) => {
+interface SetSiteNotificationParams {
+  tx: Transaction<DB>
+  siteId: number
+  userId: string
+  notification: string // TODO: Replace this with Tiptap schema once frontend refactored
+}
+
+export const setSiteNotification = async ({
+  tx,
+  siteId,
+  userId,
+  notification,
+}: SetSiteNotificationParams): Promise<void> => {
   // TODO: Remove tiptap schema coercion when tiptap editor is used on the frontend.
   const notificationSchema = {
     notification: {
@@ -97,21 +94,74 @@ export const setSiteNotification = async (
     },
   }
 
-  return db
+  const user = await tx
+    .selectFrom("User")
+    .where("id", "=", userId)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  const oldSite = await tx
+    .selectFrom("Site")
+    .where("id", "=", siteId)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  const newSite = await tx
     .updateTable("Site")
     .set((eb) => ({
       // @ts-expect-error JSON concat operator replaces the entire notification object if it exists, but Kysely does not have types for this.
       config: eb("Site.config", "||", jsonb(notificationSchema)),
     }))
     .where("id", "=", siteId)
+    .returningAll()
     .executeTakeFirstOrThrow()
+
+  await logConfigEvent(tx, {
+    eventType: AuditLogEvent.SiteConfigUpdate,
+    delta: {
+      before: oldSite,
+      after: newSite,
+    },
+    by: user,
+  })
 }
 
-// TODO: Should trigger immediate re-publish of site
-export const clearSiteNotification = async (siteId: number) => {
-  return db
+interface ClearSiteNotificationParams {
+  tx: Transaction<DB>
+  siteId: number
+  userId: string
+}
+
+export const clearSiteNotification = async ({
+  tx,
+  siteId,
+  userId,
+}: ClearSiteNotificationParams) => {
+  const user = await tx
+    .selectFrom("User")
+    .where("id", "=", userId)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  const oldSite = await tx
+    .selectFrom("Site")
+    .where("id", "=", siteId)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  const newSite = await tx
     .updateTable("Site")
     .set({ config: sql`config - 'notification'` })
     .where("id", "=", siteId)
+    .returningAll()
     .executeTakeFirstOrThrow()
+
+  await logConfigEvent(tx, {
+    eventType: AuditLogEvent.SiteConfigUpdate,
+    delta: {
+      before: oldSite,
+      after: newSite,
+    },
+    by: user,
+  })
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1779.
Closes ISOM-1784.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Added audit logging capabilities to the site router.

**Improvements**:

- Removed unused `setSiteConfig` function inside site.service.ts.
- Added test that was previously skipped, to test for 403 when the user has no access to the site in calling `getSiteName`.


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Log in to Studio as an Isomer Admin.
- [ ] Navigate to a site and edit the site notification.
- [ ] Verify that an audit log entry is created when the site notification contents is changed.
- [ ] Go to the site config settings page.
- [ ] Make any changes to any of the config, navbar and footer.
- [ ] Verify that 3 audit log entries are created, with 1 log entry to represent changes in the config, navbar and footer each.