### PR TITLE
feat: add trigger to block UPDATE and DELETE of audit logs

### DIFF
--- a/apps/studio/prisma/migrations/20250319072442_prevent_audit_logs_update_and_delete/migration.sql
+++ b/apps/studio/prisma/migrations/20250319072442_prevent_audit_logs_update_and_delete/migration.sql
@@ -1,0 +1,16 @@
+-- This is a custom migration to block any UPDATE and DELETE operations on the
+-- AuditLog table
+CREATE OR REPLACE FUNCTION prevent_audit_logs_update_and_delete()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'Cannot update or delete rows in table "AuditLog"';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_audit_logs_update_and_delete
+BEFORE UPDATE OR DELETE ON "AuditLog"
+FOR EACH ROW
+EXECUTE FUNCTION prevent_audit_logs_update_and_delete();

--- a/apps/studio/src/server/modules/audit/__tests__/audit.service.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/audit.service.test.ts
@@ -1,0 +1,72 @@
+import { resetTables } from "tests/integration/helpers/db"
+import { setupUser } from "tests/integration/helpers/seed"
+
+import { AuditLogEvent, db } from "../../database"
+import { logUserEvent } from "../audit.service"
+
+describe("audit.service", () => {
+  beforeEach(async () => {
+    await resetTables("AuditLog", "User")
+  })
+
+  describe("logUserEvent", () => {
+    it("should log a resource event successfully", async () => {
+      // Arrange
+      const user = await setupUser({
+        email: "test@example.com",
+      })
+
+      // Act
+      await db.transaction().execute(async (tx) => {
+        await logUserEvent(tx, {
+          eventType: AuditLogEvent.UserCreate,
+          delta: {
+            before: null,
+            after: user,
+          },
+          by: user,
+          ip: "1.2.3.4",
+        })
+      })
+
+      // Assert
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+
+      expect(auditLogs).toBeDefined()
+      expect(auditLogs.userId).toEqual(user.id)
+      expect(auditLogs.eventType).toEqual(AuditLogEvent.UserCreate)
+    })
+
+    // NOTE: This test pertains to the DB trigger function that is used to
+    // prevent the AuditLog table from getting UPDATE or DELETE
+    it("should prevent audit logs from being tampered with", async () => {
+      // Arrange
+      const user = await setupUser({
+        email: "test@example.com",
+      })
+      await db.transaction().execute(async (tx) => {
+        await logUserEvent(tx, {
+          eventType: AuditLogEvent.UserCreate,
+          delta: {
+            before: null,
+            after: user,
+          },
+          by: user,
+          ip: "1.2.3.4",
+        })
+      })
+
+      // Assert
+      await expect(
+        db
+          .updateTable("AuditLog")
+          .set({ eventType: AuditLogEvent.UserDelete })
+          .execute(),
+      ).rejects.toThrowError()
+      await expect(db.deleteFrom("AuditLog").execute()).rejects.toThrowError()
+    })
+  })
+})

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -201,6 +201,7 @@ export const logUserEvent: AuditLogger<UserEventLogProps> = async (
       delta,
       userId: by.id,
       ipAddress: ip,
+      metadata: {},
     })
     .execute()
 }

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -486,7 +486,7 @@ export const setupUser = async ({
   userId?: string
   email: string
   phone?: string
-  isDeleted: boolean
+  isDeleted?: boolean
   hasLoggedIn?: boolean
 }) => {
   return db


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1768.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add new database migration to prevent UPDATE and DELETE actions on the AuditLog table.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Make any changes that creates an AuditLog table.
- Use TablePlus to try and update any contents of any AuditLog row.
- Verify that you are blocked from performing the update.
- Attempt to delete any AuditLog row.
- Verify that you are blocked from performing the delete.