### PR TITLE
isom-1795 user mgmt role state does not reset

### DIFF
--- a/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
@@ -38,9 +38,12 @@ export const EditUserModal = () => {
 
   const { siteId, userId, email, role } = useAtomValue(updateUserModalAtom)
   const setUpdateUserModalState = useSetAtom(updateUserModalAtom)
-  const onClose = () => setUpdateUserModalState(DEFAULT_UPDATE_USER_MODAL_STATE)
+  const onClose = () => {
+    reset()
+    setUpdateUserModalState(DEFAULT_UPDATE_USER_MODAL_STATE)
+  }
 
-  const { watch, handleSubmit, setValue } = useZodForm({
+  const { watch, handleSubmit, setValue, reset } = useZodForm({
     schema: zod.object({
       role: updateUserInputSchema.shape.role,
     }),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1795/bug-user-management-role-state-does-not-reset

## Solution

<!-- How did you solve the problem? -->

**Bug Fixes**:

- do a `reset()` when closing the modal

## Tests

<!-- What tests should be run to confirm functionality? -->

https://github.com/user-attachments/assets/e918ab7b-abcd-4c58-9583-cf543a3810c8

1. Navigate to Studio and go to the User management page.
2. Attempt to change a user's role from Editor to Publisher, then save.
3. Edit another user that is not a Publisher.
4. The role of the user should show Editor instead of Publisher