### PR TITLE
feat(audit-logs): log publish events

### DIFF
--- a/apps/studio/prisma/types.ts
+++ b/apps/studio/prisma/types.ts
@@ -39,7 +39,7 @@ declare global {
       after: Record<string, unknown>
     }
     interface DeleteLogEvent {
-      before: Record<string, unknown>
+      before: Record<string, unknown> | null
       after: null
     }
     interface FullLogEvent {

--- a/apps/studio/prisma/types.ts
+++ b/apps/studio/prisma/types.ts
@@ -39,16 +39,21 @@ declare global {
       after: Record<string, unknown>
     }
     interface DeleteLogEvent {
-      before: Record<string, unknown> | null
+      before: Record<string, unknown>
       after: null
     }
     interface FullLogEvent {
       before: Record<string, unknown>
       after: Record<string, unknown>
     }
+    interface PublishLogEvent {
+      before: Record<string, unknown> | null
+      after: Record<string, unknown> | null
+    }
     type AuditLogDeltaJsonContent =
       | FullLogEvent
       | CreateLogEvent
       | DeleteLogEvent
+      | PublishLogEvent
   }
 }

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -10,6 +10,7 @@ import type {
   Transaction,
   User,
   VerificationToken,
+  Version,
 } from "../database"
 
 type WithoutMeta<T> = Omit<T, "createdAt" | "updatedAt">
@@ -145,7 +146,9 @@ export const logAuthEvent: AuditLogger<AuthEventLogProps> = async (
     .execute()
 }
 
-type BlobPublishEvent = WithoutMeta<Resource & Blob & { versionId: string }>
+type VersionPointer = { versionId: Version["id"] }
+
+type BlobPublishEvent = WithoutMeta<Resource & Blob & VersionPointer>
 type ResourcePublishEvent = WithoutMeta<Resource>
 type ConfigPublishEvent = WithoutMeta<Site | Navbar | Footer>
 
@@ -156,8 +159,8 @@ interface PublishEventLogProps<T> {
     // We don't want to store the `version` because it is a pointer
     // to the blob/resource
     // we will instead store the full data here so it is an accurate snapshot
-    before: T | null
-    after: T & { versionId: string }
+    before: WithoutMeta<VersionPointer> | null
+    after: T & { versionId?: string }
   }
   eventType: Extract<AuditLogEvent, "Publish">
   ip?: string

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -151,7 +151,12 @@ interface VersionPointer {
 }
 
 type BlobPublishEvent = Resource & Blob
-type ConfigPublishEvent = Site | Navbar | Footer
+// NOTE: Only 2 kinds of config changes atm
+// first, we allow users to set site notif
+// next, admins can wholesale update site + footer + navbar
+type ConfigPublishEvent = { site: Site } & { navbar?: Navbar } & {
+  footer?: Footer
+}
 
 interface PublishEventLogProps<
   Before,

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -166,6 +166,7 @@ interface PublishEventLogProps<T> {
   }
   eventType: Extract<AuditLogEvent, "Publish">
   ip?: string
+  metadata?: Record<string, unknown>
 }
 
 type BlobPublishEventLogProps = PublishEventLogProps<BlobPublishEvent>
@@ -176,7 +177,7 @@ export const logPublishEvent: AuditLogger<
   | BlobPublishEventLogProps
   | ResourcePublishEventLogProps
   | ConfigPublishEventLogProps
-> = async (tx, { by, delta, eventType, ip }) => {
+> = async (tx, { by, delta, eventType, ip, metadata = {} }) => {
   await tx
     .insertInto("AuditLog")
     .values({
@@ -184,6 +185,7 @@ export const logPublishEvent: AuditLogger<
       delta,
       userId: by.id,
       ipAddress: ip,
+      metadata,
     })
     .execute()
 }

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -146,7 +146,9 @@ export const logAuthEvent: AuditLogger<AuthEventLogProps> = async (
     .execute()
 }
 
-type VersionPointer = { versionId: Version["id"] }
+interface VersionPointer {
+  versionId: Version["id"]
+}
 
 type BlobPublishEvent = WithoutMeta<Resource & Blob & VersionPointer>
 type ResourcePublishEvent = WithoutMeta<Resource>

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -161,7 +161,7 @@ type ConfigPublishEvent = { site: Site } & { navbar?: Navbar } & {
 interface PublishEventLogProps<
   Before,
   After,
-  Meta extends Record<string, unknown> = {},
+  Meta extends Record<string, unknown>,
 > {
   by: User
   delta: {

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1,3 +1,4 @@
+import type { MockInstance } from "vitest"
 import { TRPCError } from "@trpc/server"
 import _, { omit } from "lodash"
 import { auth } from "tests/integration/helpers/auth"
@@ -16,7 +17,6 @@ import {
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
-import type { MockInstance } from "vitest"
 
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -217,7 +217,7 @@ describe("collection.router", async () => {
       })
       expect(result).toMatchObject({ id: actualCollection.id })
       expect(auditSpy).toHaveBeenCalled()
-      await assertAuditLogRows(1)
+      await assertAuditLogRows(2)
       const auditEntry = await db
         .selectFrom("AuditLog")
         .where("eventType", "=", "ResourceCreate")
@@ -251,7 +251,7 @@ describe("collection.router", async () => {
       })
       expect(result).toMatchObject({ id: actualCollection.id })
       expect(auditSpy).toHaveBeenCalled()
-      await assertAuditLogRows(1)
+      await assertAuditLogRows(2)
       const auditEntry = await db
         .selectFrom("AuditLog")
         .where("eventType", "=", "ResourceCreate")
@@ -285,7 +285,7 @@ describe("collection.router", async () => {
       })
       expect(actualCollection.parentId).toEqual(parent.id)
       expect(result).toMatchObject({ id: actualCollection.id })
-      await assertAuditLogRows(1)
+      await assertAuditLogRows(2)
       expect(auditSpy).toHaveBeenCalled()
       const auditEntry = await db
         .selectFrom("AuditLog")
@@ -320,7 +320,7 @@ describe("collection.router", async () => {
       })
       expect(actualCollection.parentId).toEqual(parent.id)
       expect(result).toMatchObject({ id: actualCollection.id })
-      await assertAuditLogRows(1)
+      await assertAuditLogRows(2)
       expect(auditSpy).toHaveBeenCalled()
       const auditEntry = await db
         .selectFrom("AuditLog")

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -16,7 +16,7 @@ import {
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
-import { MockInstance } from "vitest"
+import type { MockInstance } from "vitest"
 
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -11,7 +11,6 @@ import { readFolderSchema } from "~/schemas/folder"
 import { createCollectionPageSchema } from "~/schemas/page"
 import { protectedProcedure, router } from "~/server/trpc"
 import { logResourceEvent } from "../audit/audit.service"
-import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceState, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { validateUserPermissionsForResource } from "../permissions/permissions.service"
@@ -19,6 +18,7 @@ import {
   defaultResourceSelect,
   getBlobOfResource,
   getSiteResourceById,
+  publishResource,
   updateBlobById,
 } from "../resource/resource.service"
 import { defaultCollectionSelect } from "./collection.select"
@@ -127,7 +127,7 @@ export const collectionRouter = router({
         })
 
         // TODO: Create the index page for the collection and publish it
-        await publishSite(ctx.logger, siteId)
+        await publishResource(user.id, result.id, ctx.logger)
 
         return pick(result, defaultCollectionSelect)
       },

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -127,7 +127,7 @@ export const collectionRouter = router({
         })
 
         // TODO: Create the index page for the collection and publish it
-        await publishResource(user.id, result.id, ctx.logger)
+        await publishResource(user.id, result, ctx.logger)
 
         return pick(result, defaultCollectionSelect)
       },

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -110,7 +110,7 @@ export const folderRouter = router({
         })
 
         // TODO: Create the index page for the folder and publish it
-        await publishResource(user.id, folder.id, ctx.logger)
+        await publishResource(user.id, folder, ctx.logger)
 
         return { folderId: folder.id }
       },
@@ -213,7 +213,7 @@ export const folderRouter = router({
           return newResource
         })
 
-        await publishResource(user.id, result.id, ctx.logger)
+        await publishResource(user.id, result, ctx.logger)
 
         return pick(result, defaultFolderSelect)
       },

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -9,10 +9,10 @@ import {
 } from "~/schemas/folder"
 import { protectedProcedure, router } from "~/server/trpc"
 import { logResourceEvent } from "../audit/audit.service"
-import { publishSite } from "../aws/codebuild.service"
 import { AuditLogEvent, db, ResourceState, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { validateUserPermissionsForResource } from "../permissions/permissions.service"
+import { publishResource } from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({
@@ -110,7 +110,7 @@ export const folderRouter = router({
         })
 
         // TODO: Create the index page for the folder and publish it
-        await publishSite(ctx.logger, siteId)
+        await publishResource(user.id, folder.id, ctx.logger)
 
         return { folderId: folder.id }
       },
@@ -213,7 +213,7 @@ export const folderRouter = router({
           return newResource
         })
 
-        await publishSite(ctx.logger, Number(siteId))
+        await publishResource(user.id, result.id, ctx.logger)
 
         return pick(result, defaultFolderSelect)
       },

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -25,7 +25,6 @@ import {
 import { protectedProcedure, router } from "~/server/trpc"
 import { ajv } from "~/utils/ajv"
 import { safeJsonParse } from "~/utils/safeJsonParse"
-import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { validateUserPermissionsForResource } from "../permissions/permissions.service"
@@ -37,6 +36,7 @@ import {
   getResourceFullPermalink,
   getResourcePermalinkTree,
   publishPageResource,
+  publishResource,
   updateBlobById,
 } from "../resource/resource.service"
 import { getSiteConfig } from "../site/site.service"
@@ -526,7 +526,7 @@ export const pageRouter = router({
 
             // We do an implicit publish so that we can make the changes to the
             // page settings immediately visible on the end site
-            await publishSite(ctx.logger, siteId)
+            await publishResource(ctx.user.id, updatedResource.id, ctx.logger)
 
             return updatedResource
           } catch (err) {

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -36,7 +36,7 @@ import {
   getPageById,
   getResourceFullPermalink,
   getResourcePermalinkTree,
-  publishResource,
+  publishPageResource,
   updateBlobById,
 } from "../resource/resource.service"
 import { getSiteConfig } from "../site/site.service"
@@ -416,7 +416,7 @@ export const pageRouter = router({
   publishPage: protectedProcedure
     .input(publishPageSchema)
     .mutation(async ({ ctx, input: { siteId, pageId } }) =>
-      publishResource(ctx.logger, siteId, String(pageId), ctx.user.id),
+      publishPageResource(ctx.logger, siteId, String(pageId), ctx.user.id),
     ),
 
   updateMeta: protectedProcedure

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1725,7 +1725,7 @@ describe("resource.router", async () => {
         .where("id", "=", page.id)
         .executeTakeFirst()
       expect(actual).toBeUndefined()
-      expect(result).toEqual(1)
+      expect(result).toEqual(page)
     })
 
     it("should delete a folder and all its children (recursively) successfully", async () => {
@@ -1790,7 +1790,7 @@ describe("resource.router", async () => {
         ])
         .execute()
       expect(actual).toHaveLength(0)
-      expect(result).toEqual(1)
+      expect(result).toEqual(folderToUse)
       expect(auditSpy).toHaveBeenCalledTimes(1)
       const auditEntry = await db
         .selectFrom("AuditLog")

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -29,7 +29,6 @@ import {
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
 import { logResourceEvent } from "../audit/audit.service"
-import { publishSite } from "../aws/codebuild.service"
 import { db, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
@@ -44,6 +43,7 @@ import {
   getSearchResults,
   getSearchWithResourceIds,
   getWithFullPermalink,
+  publishResource,
 } from "./resource.service"
 
 const fetchResource = async (resourceId: string | null) => {
@@ -450,7 +450,7 @@ export const resourceRouter = router({
             throw err
           })
 
-        await publishSite(ctx.logger, result.siteId)
+        await publishResource(user.id, result.id, ctx.logger)
         return result
       },
     ),
@@ -561,18 +561,19 @@ export const resourceRouter = router({
           .where("Resource.id", "=", String(resourceId))
           .where("Resource.siteId", "=", siteId)
           .where("Resource.type", "!=", ResourceType.RootPage)
+          .returningAll()
           .executeTakeFirst()
       })
 
-      if (Number(result.numDeletedRows) === 0) {
+      if (!result) {
         throw new TRPCError({ code: "BAD_REQUEST" })
       }
 
-      await publishSite(ctx.logger, siteId)
+      await publishResource(user.id, result.id, ctx.logger)
 
       // NOTE: We need to do this cast as the property is a `bigint`
       // and trpc cannot serialise it, which leads to errors
-      return Number(result.numDeletedRows)
+      return result
     }),
 
   getParentOf: protectedProcedure

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -28,8 +28,7 @@ import {
   searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
-import { logPublishEvent, logResourceEvent } from "../audit/audit.service"
-import { publishSite } from "../aws/codebuild.service"
+import { logResourceEvent } from "../audit/audit.service"
 import { db, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -28,7 +28,8 @@ import {
   searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
-import { logResourceEvent } from "../audit/audit.service"
+import { logPublishEvent, logResourceEvent } from "../audit/audit.service"
+import { publishSite } from "../aws/codebuild.service"
 import { db, ResourceType } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
@@ -450,7 +451,7 @@ export const resourceRouter = router({
             throw err
           })
 
-        await publishResource(user.id, result.id, ctx.logger)
+        await publishResource(user.id, result, ctx.logger)
         return result
       },
     ),
@@ -569,7 +570,7 @@ export const resourceRouter = router({
         throw new TRPCError({ code: "BAD_REQUEST" })
       }
 
-      await publishResource(user.id, result.id, ctx.logger)
+      await publishResource(user.id, result, ctx.logger)
 
       // NOTE: We need to do this cast as the property is a `bigint`
       // and trpc cannot serialise it, which leads to errors

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -12,6 +12,7 @@ import type {
   SafeKysely,
   Site,
   Transaction,
+  User,
 } from "../database"
 import type { SearchResultResource } from "./resource.types"
 import type { ResourceItemContent } from "~/schemas/resource"
@@ -525,7 +526,7 @@ export const publishPageResource = async (
 // this should be used for publishes that do not incur a change to `Blob.content`
 // and hence, don't incur a log to the `Version` table
 export const publishResource = async (
-  by: string,
+  by: User["id"],
   resource: Resource,
   logger: Logger<string>,
 ) => {

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -496,7 +496,7 @@ export const publishPageResource = async (
         by,
         delta: {
           before: previousVersion?.id
-            ? { versionId: previousVersion?.id }
+            ? { versionId: previousVersion.id }
             : null,
           after: { ...fullResource, ...version },
         },

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -495,7 +495,7 @@ export const publishPageResource = async (
 
       const previousVersion = await tx
         .selectFrom("Version")
-        .where("Version.versionNum", "=", Number(version.versionId) - 1)
+        .where("Version.versionNum", "=", Number(version.versionNum) - 1)
         .where("Version.resourceId", "=", resourceId)
         .select("Version.id")
         .executeTakeFirst()

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -269,17 +269,17 @@ describe("site.router", async () => {
       const auditLog = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLog).toHaveLength(2)
       expect(
-        auditLog?.some(({ eventType }) => {
+        auditLog.some(({ eventType }) => {
           return eventType === AuditLogEvent.SiteConfigUpdate
         }),
       ).toEqual(true)
       expect(
-        auditLog?.some(({ eventType }) => {
+        auditLog.some(({ eventType }) => {
           return eventType === AuditLogEvent.Publish
         }),
       ).toEqual(true)
       expect(
-        auditLog?.every(({ userId }) => {
+        auditLog.every(({ userId }) => {
           return userId === session.userId
         }),
       ).toEqual(true)

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -22,6 +22,7 @@ import {
   getFooter,
   getLocalisedSitemap,
   getNavBar,
+  publishSiteConfig,
 } from "../resource/resource.service"
 import {
   clearSiteNotification,
@@ -139,16 +140,16 @@ export const siteRouter = router({
         action: "update",
       })
 
-      await db.transaction().execute(async (tx) => {
+      const site = await db.transaction().execute(async (tx) => {
         if (notificationEnabled) {
-          await setSiteNotification({
+          return await setSiteNotification({
             tx,
             siteId,
             userId: ctx.user.id,
             notification,
           })
         } else {
-          await clearSiteNotification({
+          return await clearSiteNotification({
             tx,
             siteId,
             userId: ctx.user.id,
@@ -156,7 +157,7 @@ export const siteRouter = router({
         }
       })
 
-      await publishSite(ctx.logger, siteId)
+      await publishSiteConfig(ctx.user.id, { site }, ctx.logger)
 
       return input
     }),
@@ -310,8 +311,12 @@ export const siteRouter = router({
           },
           by: user,
         })
-      })
 
-      await publishSite(ctx.logger, siteId)
+        await publishSiteConfig(
+          ctx.user.id,
+          { site: newSite, navbar: newNavbar, footer: newFooter },
+          ctx.logger,
+        )
+      })
     }),
 })

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -16,7 +16,6 @@ import {
 import { protectedProcedure, router } from "~/server/trpc"
 import { safeJsonParse } from "~/utils/safeJsonParse"
 import { logConfigEvent } from "../audit/audit.service"
-import { publishSite } from "../aws/codebuild.service"
 import { AuditLogEvent, db, jsonb } from "../database"
 import {
   getFooter,

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -86,7 +86,7 @@ export const setSiteNotification = async ({
   siteId,
   userId,
   notification,
-}: SetSiteNotificationParams): Promise<void> => {
+}: SetSiteNotificationParams) => {
   // TODO: Remove tiptap schema coercion when tiptap editor is used on the frontend.
   const notificationSchema = {
     notification: {
@@ -146,6 +146,8 @@ export const setSiteNotification = async ({
     },
     by: user,
   })
+
+  return newSite
 }
 
 interface ClearSiteNotificationParams {
@@ -208,4 +210,6 @@ export const clearSiteNotification = async ({
     },
     by: user,
   })
+
+  return newSite
 }

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -41,10 +41,10 @@ const createVersion = async (
       publishedAt: new Date(),
       publishedBy: publisherId,
     })
-    .returning("Version.id")
+    .returning(["Version.id", "Version.versionNum"])
     .executeTakeFirstOrThrow()
 
-  return { versionId: addedVersion.id }
+  return { versionId: addedVersion.id, versionNum: addedVersion.versionNum }
 }
 
 export const incrementVersion = async ({

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server"
 import { ResourceState } from "~prisma/generated/generatedEnums"
 import { type DB } from "~prisma/generated/generatedTypes"
 
-import type { SafeKysely } from "../database"
+import type { SafeKysely, Transaction } from "../database"
 import { db } from "../database"
 import { getPageById, updatePageById } from "../resource/resource.service"
 
@@ -51,64 +51,59 @@ export const incrementVersion = async ({
   siteId,
   resourceId,
   userId,
+  tx,
 }: {
   siteId: number
+  tx: Transaction<DB>
   resourceId: string
   userId: string
 }) => {
-  return await db
-    .transaction()
-    // serialize to prevent discrepancies from
-    // concurrent publishes from other users
-    .setIsolationLevel("serializable")
-    .execute(async (tx) => {
-      const page = await getPageById(tx, {
-        siteId,
-        resourceId: Number(resourceId),
-      })
-      if (!page) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "Page not found",
-        })
-      }
-
-      if (!page.draftBlobId) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "No drafts to publish for this page",
-        })
-      }
-
-      let newVersionNum = 1
-      if (page.publishedVersionId) {
-        const currentVersion = await getVersionById({
-          versionId: page.publishedVersionId,
-        })
-        newVersionNum = Number(currentVersion.versionNum) + 1
-      }
-
-      // Create the new version
-      const newVersion = await createVersion(tx, {
-        versionNum: newVersionNum,
-        resourceId,
-        blobId: page.draftBlobId,
-        publisherId: userId,
-      })
-
-      // Update resource with new versionId and draft to be null
-      await updatePageById(
-        {
-          ...page,
-          id: parseInt(page.id),
-          publishedVersionId: newVersion.versionId,
-          draftBlobId: null,
-          state: ResourceState.Published,
-          siteId,
-          parentId: page.parentId ? parseInt(page.parentId) : undefined,
-        },
-        tx,
-      )
-      return { versionId: newVersion }
+  const page = await getPageById(tx, {
+    siteId,
+    resourceId: Number(resourceId),
+  })
+  if (!page) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Page not found",
     })
+  }
+
+  if (!page.draftBlobId) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "No drafts to publish for this page",
+    })
+  }
+
+  let newVersionNum = 1
+  if (page.publishedVersionId) {
+    const currentVersion = await getVersionById({
+      versionId: page.publishedVersionId,
+    })
+    newVersionNum = Number(currentVersion.versionNum) + 1
+  }
+
+  // Create the new version
+  const newVersion = await createVersion(tx, {
+    versionNum: newVersionNum,
+    resourceId,
+    blobId: page.draftBlobId,
+    publisherId: userId,
+  })
+
+  // Update resource with new versionId and draft to be null
+  await updatePageById(
+    {
+      ...page,
+      id: parseInt(page.id),
+      publishedVersionId: newVersion.versionId,
+      draftBlobId: null,
+      state: ResourceState.Published,
+      siteId,
+      parentId: page.parentId ? parseInt(page.parentId) : undefined,
+    },
+    tx,
+  )
+  return newVersion
 }


### PR DESCRIPTION
## Problem
see attached issue

Closes [insert issue #]

## Solution
1. log the delta of version for page publishes because this is the only write to db. we capture the resource at 2 points, first when it is being edited and secondly, when it is being published. when it is being edited, we capture the full delta (before/after) but at the point of pubilsh, we capture the resource **as-is**