### PR TITLE
feat: make container root filesystem readonly

### DIFF
--- a/.aws/deploy/task-definition.json
+++ b/.aws/deploy/task-definition.json
@@ -42,7 +42,8 @@
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }
-      }
+      },
+      "readonlyRootFilesystem": true
     },
     {
       "name": "dd-agent",
@@ -122,7 +123,8 @@
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }
-      }
+      },
+      "readonlyRootFilesystem": true
     }
   ],
   "family": "isomer-infra",

--- a/.aws/deploy/task-definition.json
+++ b/.aws/deploy/task-definition.json
@@ -123,8 +123,7 @@
           "awslogs-region": "ap-southeast-1",
           "awslogs-stream-prefix": "ecs"
         }
-      },
-      "readonlyRootFilesystem": true
+      }
     }
   ],
   "family": "isomer-infra",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

It is a recommended security practice to make the container root filesystem readonly.

Fulfils cs-6 of SSP requirements.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Set `readonlyRootFilesystem` to be true for all containers that Isomer Studio uses.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Deploy to staging
- [ ] Verify that you are able to access the staging Studio
- [ ] Perform CRUD functions (including uploading of assets) on Studio to verify that everything still works as expected