### PR TITLE
chore: deploy to `uat` on every release

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -44,3 +44,37 @@ jobs:
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
+
+  // NOTE: we should deploy to `uat` on every release so that the environment will stay up to date
+  deploy_uat:
+    name: Deploy app to uat
+    uses: ./.github/workflows/aws_deploy.yml
+    with:
+      aws-region: "ap-southeast-1"
+      aws-account-id: "343218177745"
+      cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-github-oidc-role-d2e1bd3"
+      ecr-repository: "isomer-next-infra-uat-ecr"
+      ecs-cluster-name: "studio-uat-ecs"
+      ecs-service-name: "studio-uat-ecs-service"
+      ecs-container-name: "studio"
+      ecs-container-port: 3000
+      environment: "uat"
+      shortEnv: "uat"
+      codedeploy-appspec-path: .aws/deploy/appspec.json
+      ecs-task-definition-path: .aws/deploy/task-definition.json
+      codedeploy-application: "studio-uat-ecs-app"
+      codedeploy-deployment-group: "studio-uat-ecs-dg"
+      ecs-task-role: studio-uat-ecs-task-role
+      ecs-task-exec-role: studio-uat-ecs-task-exec-role
+      app-url: "https://uat-studio.isomer.gov.sg"
+      app-name: "Isomer Studio (UAT)"
+      app-version: ${{ github.sha }}
+      app-enable-sgid: false
+      app-s3-region: "ap-southeast-1"
+      app-s3-assets-bucket-name: "isomer-next-infra-uat-assets-private-e728930"
+      app-s3-assets-domain-name: "isomer-user-content-uat.by.gov.sg"
+      app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
+      app-intercom-app-id: "jv2tjc3g"
+
+    secrets:
+      DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -9,12 +9,10 @@ on:
     branches:
       - uat
 
-# NOTE: This is actually using our federated isomer-staging account
 jobs:
-  deploy_staging:
+  deploy_uat:
     name: Deploy app to uat
     uses: ./.github/workflows/aws_deploy.yml
-    # NOTE: deploy in `staging` env to set env specific secrets
     with:
       aws-region: "ap-southeast-1"
       aws-account-id: "343218177745"


### PR DESCRIPTION
## Problem
we shuold deploy to `uat` on every release so that the environment stays up to date with `production` and `uat` users can enjoy latest featureset

## Solution
copy deployment workflow for `uat` over to production deploy workflow.

concretely, this means we will deploy to `uat` on every release and testing of new features (via pushing to `uat`) will have to be off `main` or it will reset the state of the environment