### PR TITLE
[component] enhance infocards to use fixed aspect ratio across all breakpoints

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -169,13 +169,14 @@ export type SingleCardNoImageProps = Static<typeof SingleCardNoImageSchema> & {
 }
 export type SingleCardWithImageProps = Static<
   typeof SingleCardWithImageSchema
-> & {
-  site: IsomerSiteProps
-  layout: IsomerPageLayoutType
-  isExternalLink?: boolean
-  LinkComponent?: LinkComponentType
-  shouldLazyLoad?: boolean
-}
+> &
+  Pick<Static<typeof InfoCardsBaseSchema>, "maxColumns"> & {
+    site: IsomerSiteProps
+    layout: IsomerPageLayoutType
+    isExternalLink?: boolean
+    LinkComponent?: LinkComponentType
+    shouldLazyLoad?: boolean
+  }
 export type InfoCardsProps = Static<typeof InfoCardsSchema> & {
   layout: IsomerPageLayoutType
   site: IsomerSiteProps

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -87,6 +87,7 @@ const InfoCardsBaseSchema = Type.Object({
   maxColumns: Type.Optional(
     Type.Union(
       [
+        Type.Literal("1", { title: "1 column" }),
         Type.Literal("2", { title: "2 columns" }),
         Type.Literal("3", { title: "3 columns" }),
       ],

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -87,7 +87,6 @@ const InfoCardsBaseSchema = Type.Object({
   maxColumns: Type.Optional(
     Type.Union(
       [
-        Type.Literal("1", { title: "1 column" }),
         Type.Literal("2", { title: "2 columns" }),
         Type.Literal("3", { title: "3 columns" }),
       ],

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -149,6 +149,16 @@ export const WithImage2ColumnsHomepage: Story = {
   args: generateArgs({ maxColumns: "2", layout: "homepage" }),
 }
 
+export const WithImage1Columns: Story = {
+  name: "With Image (1 Col)",
+  args: generateArgs({ maxColumns: "1" }),
+}
+
+export const WithImage1ColumnsHomepage: Story = {
+  name: "With Image (1 Col) Homepage",
+  args: generateArgs({ maxColumns: "1", layout: "homepage" }),
+}
+
 export const NoImage: Story = {
   args: generateArgs({ maxColumns: "3", withoutImage: true }),
 }

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -149,16 +149,6 @@ export const WithImage2ColumnsHomepage: Story = {
   args: generateArgs({ maxColumns: "2", layout: "homepage" }),
 }
 
-export const WithImage1Columns: Story = {
-  name: "With Image (1 Col)",
-  args: generateArgs({ maxColumns: "1" }),
-}
-
-export const WithImage1ColumnsHomepage: Story = {
-  name: "With Image (1 Col) Homepage",
-  args: generateArgs({ maxColumns: "1", layout: "homepage" }),
-}
-
 export const NoImage: Story = {
   args: generateArgs({ maxColumns: "3", withoutImage: true }),
 }

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -41,7 +41,7 @@ const createInfoCardsStyles = tv({
     grid: "grid grid-cols-1 gap-10 md:gap-7 lg:gap-x-16 lg:gap-y-12",
     cardContainer: "group flex flex-col gap-5 outline-0",
     cardImageContainer:
-      "w-full overflow-hidden rounded-lg border border-base-divider-subtle bg-base-canvas drop-shadow-none transition ease-in",
+      "aspect-[3/2] w-full overflow-hidden rounded-lg border border-base-divider-subtle bg-base-canvas drop-shadow-none transition ease-in",
     cardImage: "h-full w-full object-center",
     cardTextContainer: "flex flex-col gap-2.5 sm:gap-3",
     cardTitleArrow:
@@ -55,13 +55,11 @@ const createInfoCardsStyles = tv({
         container: "py-12 first:pt-0 md:py-16",
         headingContainer: "gap-2.5 lg:max-w-3xl",
         headingSubtitle: "prose-headline-lg-regular",
-        cardImageContainer: "h-[11.875rem] md:h-60",
       },
       default: {
         container: "mt-14 first:mt-0",
         headingContainer: "gap-6",
         headingSubtitle: "prose-body-base",
-        cardImageContainer: "h-[11.875rem] md:h-52",
       },
     },
     isClickableCard: {
@@ -78,9 +76,6 @@ const createInfoCardsStyles = tv({
       },
     },
     maxColumns: {
-      "1": {
-        grid: "",
-      },
       "2": {
         grid: "md:grid-cols-2",
       },
@@ -94,6 +89,15 @@ const createInfoCardsStyles = tv({
       },
     },
   },
+  compoundVariants: [
+    {
+      layout: "default",
+      maxColumns: "3",
+      class: {
+        cardImageContainer: "aspect-square",
+      },
+    },
+  ],
   defaultVariants: {
     layout: "default",
     maxColumns: "3",

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -91,10 +91,31 @@ const createInfoCardsStyles = tv({
   },
   compoundVariants: [
     {
+      layout: "homepage",
+      maxColumns: "3",
+      class: {
+        cardImageContainer: "aspect-[3/2]",
+      },
+    },
+    {
+      layout: "homepage",
+      maxColumns: "2",
+      class: {
+        cardImageContainer: "aspect-[2/1]",
+      },
+    },
+    {
       layout: "default",
       maxColumns: "3",
       class: {
         cardImageContainer: "aspect-square",
+      },
+    },
+    {
+      layout: "default",
+      maxColumns: "2",
+      class: {
+        cardImageContainer: "aspect-[3/2]",
       },
     },
   ],
@@ -137,6 +158,7 @@ const InfoCardImage = ({
   imageUrl,
   imageAlt,
   imageFit,
+  maxColumns,
   url,
   layout,
   site,
@@ -145,6 +167,7 @@ const InfoCardImage = ({
   SingleCardWithImageProps,
   | "imageUrl"
   | "imageAlt"
+  | "maxColumns"
   | "url"
   | "imageFit"
   | "layout"
@@ -160,6 +183,7 @@ const InfoCardImage = ({
     <div
       className={compoundStyles.cardImageContainer({
         layout: getTailwindVariantLayout(layout),
+        maxColumns,
         isClickableCard: !!url,
       })}
     >
@@ -235,6 +259,7 @@ const InfoCardWithImage = ({
   imageAlt,
   imageFit,
   url,
+  maxColumns,
   layout,
   site,
   LinkComponent,
@@ -253,6 +278,7 @@ const InfoCardWithImage = ({
         imageUrl={imageUrl}
         imageAlt={imageAlt}
         url={url}
+        maxColumns={maxColumns}
         site={site}
         layout={layout}
         shouldLazyLoad={shouldLazyLoad}
@@ -292,6 +318,7 @@ const InfoCards = ({
               <InfoCardWithImage
                 key={idx}
                 {...card}
+                maxColumns={maxColumns}
                 layout={layout}
                 site={site}
                 LinkComponent={LinkComponent}

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -76,6 +76,9 @@ const createInfoCardsStyles = tv({
       },
     },
     maxColumns: {
+      "1": {
+        grid: "",
+      },
       "2": {
         grid: "md:grid-cols-2",
       },
@@ -101,14 +104,14 @@ const createInfoCardsStyles = tv({
       layout: "homepage",
       maxColumns: "2",
       class: {
-        cardImageContainer: "aspect-[2/1]",
+        cardImageContainer: "aspect-[3/2] lg:aspect-[2/1]",
       },
     },
     {
       layout: "default",
       maxColumns: "3",
       class: {
-        cardImageContainer: "aspect-square",
+        cardImageContainer: "aspect-[3/2] lg:aspect-square",
       },
     },
     {

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1314,6 +1314,7 @@ export const Default: Story = {
       },
       {
         type: "infocards",
+        maxColumns: "3",
         title:
           "Explore your great neighbourhood with us can’t stretch all the way so this needs a max width",
         subtitle:

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -293,6 +293,7 @@ export const Default: Story = {
       },
       {
         type: "infocards",
+        maxColumns: "3",
         title: "Section title ministry highlights",
         subtitle:
           "Section subtitle, maximum 150 chars. These are some of the things we are working on. As a ministry, we focus on delivering value to the members of public.",


### PR DESCRIPTION
## Problem

Infocards were using variant aspect ratios, so it was difficult for site editors to prepare images that display nicely across all breakpoints.

Closes [ISOM-1831]

## Solution

Applied fixed aspect ratios based on document shared with team in Feb:

<img width="976" alt="image" src="https://github.com/user-attachments/assets/bbb62082-3688-45f2-921b-d6df3bb00738" />

Thank you Zhong Jun for helping with this PR!
