### PR TITLE
wizgov widget add data topic props

### DIFF
--- a/packages/components/src/interfaces/internal/Wizgov.ts
+++ b/packages/components/src/interfaces/internal/Wizgov.ts
@@ -2,6 +2,7 @@ import type { IsomerSiteProps } from "~/types"
 
 export interface WizgovProps {
   "data-agency": string
+  "data-topic"?: string
 }
 
 export interface WizgovWidgetProps extends WizgovProps {

--- a/packages/components/src/templates/next/components/internal/Wizgov/WizgovWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Wizgov/WizgovWidget.tsx
@@ -46,13 +46,5 @@ export const WizgovWidget = ({
     }
   }, [])
 
-  return (
-    <div
-      id="wizgov-widget"
-      data-agency={wizgovProps["data-agency"]}
-      {...(!!wizgovProps["data-topic"] && {
-        "data-topic": wizgovProps["data-topic"],
-      })}
-    />
-  )
+  return <div id="wizgov-widget" {...wizgovProps} />
 }

--- a/packages/components/src/templates/next/components/internal/Wizgov/WizgovWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Wizgov/WizgovWidget.tsx
@@ -46,5 +46,13 @@ export const WizgovWidget = ({
     }
   }, [])
 
-  return <div id="wizgov-widget" data-agency={wizgovProps["data-agency"]} />
+  return (
+    <div
+      id="wizgov-widget"
+      data-agency={wizgovProps["data-agency"]}
+      {...(!!wizgovProps["data-topic"] && {
+        "data-topic": wizgovProps["data-topic"],
+      })}
+    />
+  )
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C07CWUNUL68/p1743496259124609

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- add support for `data-topic` for wizgov

## Tests

<!-- What tests should be run to confirm functionality? -->

1. add a `data-topic` into the wizgov config and it should filter the topics
