### PR TITLE
refactor: move `deploy_uat` job into correct workflow

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -44,37 +44,3 @@ jobs:
 
     secrets:
       DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
-
-  // NOTE: we should deploy to `uat` on every release so that the environment will stay up to date
-  deploy_uat:
-    name: Deploy app to uat
-    uses: ./.github/workflows/aws_deploy.yml
-    with:
-      aws-region: "ap-southeast-1"
-      aws-account-id: "343218177745"
-      cicd-role: "arn:aws:iam::343218177745:role/isomer-next-infra-github-oidc-role-d2e1bd3"
-      ecr-repository: "isomer-next-infra-uat-ecr"
-      ecs-cluster-name: "studio-uat-ecs"
-      ecs-service-name: "studio-uat-ecs-service"
-      ecs-container-name: "studio"
-      ecs-container-port: 3000
-      environment: "uat"
-      shortEnv: "uat"
-      codedeploy-appspec-path: .aws/deploy/appspec.json
-      ecs-task-definition-path: .aws/deploy/task-definition.json
-      codedeploy-application: "studio-uat-ecs-app"
-      codedeploy-deployment-group: "studio-uat-ecs-dg"
-      ecs-task-role: studio-uat-ecs-task-role
-      ecs-task-exec-role: studio-uat-ecs-task-exec-role
-      app-url: "https://uat-studio.isomer.gov.sg"
-      app-name: "Isomer Studio (UAT)"
-      app-version: ${{ github.sha }}
-      app-enable-sgid: false
-      app-s3-region: "ap-southeast-1"
-      app-s3-assets-bucket-name: "isomer-next-infra-uat-assets-private-e728930"
-      app-s3-assets-domain-name: "isomer-user-content-uat.by.gov.sg"
-      app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
-      app-intercom-app-id: "jv2tjc3g"
-
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - uat
+  release:
+    types:
+      - released # we should deploy to `uat` on every release so that the environment will stay up to date
 
 jobs:
   deploy_uat:


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

currently we put `deploy_uat` job in `deploy_production` workflow. this:
1. can be confusing (naming-wise)
2. duplicated code and no single source of truth

## Solution

<!-- How did you solve the problem? -->

**Improvements**:

- move it to use `on -> release` (similar to prod) instead
