### PR TITLE
[component] update site notification styling

### DIFF
--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -18,10 +18,14 @@ const NotificationClient = ({
   return (
     isShown && (
       <div className="bg-utility-feedback-info-faint">
-        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
+        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-4 text-base-content md:px-10 md:py-4">
           <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
-          <div className="flex flex-1 flex-col gap-1">
-            {!!title && <h2 className="prose-headline-lg-medium">{title}</h2>}
+          <div className="flex flex-1 flex-col gap-0.5">
+            {!!title && (
+              <h2 className="prose-headline-base-medium text-base-content-strong">
+                {title}
+              </h2>
+            )}
             {baseParagraph}
           </div>
           <div aria-hidden className="flex h-6 w-6 shrink-0" />

--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -18,7 +18,7 @@ const NotificationClient = ({
   return (
     isShown && (
       <div className="bg-utility-feedback-info-faint">
-        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-4 text-base-content md:px-10 md:py-4">
+        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
           <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
           <div className="flex flex-1 flex-col gap-0.5">
             {!!title && (

--- a/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
@@ -36,10 +36,10 @@ export const UnsupportedBrowserBanner = ({
 
   return (
     <div className="bg-utility-feedback-warning">
-      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
+      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-4 text-base-content md:px-10 md:py-4">
         <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
-        <div className="flex flex-1 flex-col gap-1">
-          <div className="base-content-default prose-headline-lg-medium [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <div className="prose-headline-base-medium text-base-content-strong [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">
             This browser is not supported
           </div>
           <div className="prose-body-base [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">

--- a/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
@@ -36,7 +36,7 @@ export const UnsupportedBrowserBanner = ({
 
   return (
     <div className="bg-utility-feedback-warning">
-      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-4 text-base-content md:px-10 md:py-4">
+      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
         <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
         <div className="flex flex-1 flex-col gap-0.5">
           <div className="prose-headline-base-medium text-base-content-strong [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">


### PR DESCRIPTION
# Problem
Site notification takes up too much vertical space

# Solution
Adjust typography and spacing on site notification to match [new designs](https://www.figma.com/design/rsKQdmtyoOWawyAv1LkJJK/Isomer-Next-Component-Library?node-id=2817-48413&t=SvmWm2tSoxZ1XcCl-1)


<img width="654" alt="image" src="https://github.com/user-attachments/assets/f5572a56-aae5-4129-90c5-662da3be4ff3" />

Also modified the unsupported browser banner