### PR TITLE
update Vica component interfaces and props handling + add staging link

### DIFF
--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -3,7 +3,7 @@ import type { IsomerSiteProps } from "~/types"
 // NOTE: not all props will be used even if we passed them in
 // as we will override some of them with Isomer's configuration e.g. font-family
 // Nevertheless, keeping them here for reference
-export interface VicaWidgetProps {
+export interface VicaProps {
   // UI Theme
   "app-id": string
   "app-name": string
@@ -46,6 +46,14 @@ export interface VicaWidgetProps {
   "app-enable-hide-translation"?: boolean
 }
 
-export interface VicaProps extends VicaWidgetProps {
+export interface VicaWidgetClientProps extends VicaProps {
+  environment: IsomerSiteProps["environment"]
+}
+
+export interface VicaWidgetProps extends VicaProps {
   site: IsomerSiteProps
+}
+
+export interface VicaStylesheetProps {
+  environment: IsomerSiteProps["environment"]
 }

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -34,7 +34,12 @@ export type { SiderailProps } from "./Siderail"
 export type { SkipToContentProps } from "./SkipToContent"
 export type { TableOfContentsProps } from "./TableOfContents"
 export type { WogaaProps } from "./Wogaa"
-export type { VicaWidgetProps, VicaProps } from "./Vica"
+export type {
+  VicaWidgetClientProps,
+  VicaWidgetProps,
+  VicaProps,
+  VicaStylesheetProps,
+} from "./Vica"
 export type {
   GoogleTagManagerHeaderScriptProps,
   GoogleTagManagerHeaderProps,

--- a/packages/components/src/templates/next/components/internal/Vica/VicaStylesheet.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaStylesheet.tsx
@@ -1,11 +1,14 @@
-export const VicaStylesheet = () => {
+import type { VicaStylesheetProps } from "~/interfaces"
+
+export const VicaStylesheet = ({ environment }: VicaStylesheetProps) => {
+  const stylesheetUrl =
+    environment === "production"
+      ? "https://webchat.vica.gov.sg/static/css/chat.css"
+      : "https://webchat.mol-vica.com/static/css/chat.css"
+
   return (
     <>
-      <link
-        href="https://webchat.vica.gov.sg/static/css/chat.css"
-        referrerPolicy="origin"
-        rel="stylesheet"
-      />
+      <link href={stylesheetUrl} referrerPolicy="origin" rel="stylesheet" />
     </>
   )
 }

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -1,11 +1,12 @@
-import type { VicaProps } from "~/interfaces"
+import type { VicaWidgetProps } from "~/interfaces"
 import { getReferenceLinkHref } from "~/utils"
 import { VicaWidgetClient } from "./VicaWidgetClient"
 
-export const VicaWidget = (props: VicaProps) => {
+export const VicaWidget = (props: VicaWidgetProps) => {
   const { site, "app-icon": appIcon, ...rest } = props
   return (
     <VicaWidgetClient
+      environment={site.environment}
       app-icon={
         appIcon
           ? getReferenceLinkHref(appIcon, site.siteMap, site.assetsBaseUrl)

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -2,28 +2,36 @@
 
 import { useEffect } from "react"
 
-import type { VicaWidgetProps } from "~/interfaces"
+import type { VicaWidgetClientProps } from "~/interfaces"
 
-// Next.js pre-fetching caused widget to disappear on page navigation
-// Doing this forces the widget to load in between page navigation
-const reloadVicaScript = () => {
-  const scriptId = "isomer-vica-script"
+export const VicaWidgetClient = ({
+  environment,
+  ...vicaProps
+}: VicaWidgetClientProps) => {
+  const scriptUrl =
+    environment === "production"
+      ? "https://webchat.vica.gov.sg/static/js/chat.js"
+      : "https://webchat.mol-vica.com/static/js/chat.js"
 
-  const existingScriptTag = document.getElementById(scriptId)
-  if (existingScriptTag) {
-    existingScriptTag.remove()
+  // Next.js pre-fetching caused widget to disappear on page navigation
+  // Doing this forces the widget to load in between page navigation
+  const reloadVicaScript = () => {
+    const scriptId = "isomer-vica-script"
+
+    const existingScriptTag = document.getElementById(scriptId)
+    if (existingScriptTag) {
+      existingScriptTag.remove()
+    }
+
+    const scriptTag = document.createElement("script")
+    scriptTag.id = scriptId
+    scriptTag.async = true
+    scriptTag.type = "text/javascript"
+    scriptTag.src = scriptUrl
+    scriptTag.referrerPolicy = "origin"
+    document.body.appendChild(scriptTag)
   }
 
-  const scriptTag = document.createElement("script")
-  scriptTag.id = scriptId
-  scriptTag.async = true
-  scriptTag.type = "text/javascript"
-  scriptTag.src = "https://webchat.vica.gov.sg/static/js/chat.js"
-  scriptTag.referrerPolicy = "origin"
-  document.body.appendChild(scriptTag)
-}
-
-export const VicaWidgetClient = (vica: VicaWidgetProps) => {
   useEffect(() => {
     // to not render during static site generation on the server
     if (typeof window === "undefined") return
@@ -41,7 +49,7 @@ export const VicaWidgetClient = (vica: VicaWidgetProps) => {
   return (
     <div
       id="webchat"
-      {...vica}
+      {...vicaProps}
       // We ignore config passed in from DB and manually overwrite
       // the following attributes to ensure consistency and best brand appearance
       app-font-family="Inter, system-ui, sans-serif"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -56,7 +56,7 @@ export const Skeleton = ({
 
       {!isStaging && <DatadogRum />}
 
-      {site.vica && <VicaStylesheet />}
+      {site.vica && <VicaStylesheet environment={site.environment} />}
 
       <ScrollToTop />
 

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -2,7 +2,7 @@ import type { IsomerSitemap } from "./sitemap"
 import type {
   NavbarProps,
   NotificationProps,
-  VicaWidgetProps,
+  VicaProps,
   WizgovProps,
 } from "~/interfaces"
 import type { SiteConfigFooterProps } from "~/interfaces/internal/Footer"
@@ -31,7 +31,7 @@ export interface IsomerSiteConfigProps {
   search: NavbarProps["search"]
   notification?: Omit<NotificationProps, "LinkComponent" | "site">
   siteGtmId?: string
-  vica?: VicaWidgetProps
+  vica?: VicaProps
   wizgov?: WizgovProps
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

VICA team wants to test how their stylesheet interacts with Isomer Next CSS

## Solution

<!-- How did you solve the problem? -->

**Improvements**:

- allow passing in of `environment`
- update props naming to be more similar and consistent with wizgov implementation
- move `reloadVicaScript` into client widget directly to reduce props passing
- **NOTE: will update CSP in separate PR**
