### PR TITLE
feat: add query params to collection filters

### DIFF
--- a/packages/components/src/hooks/useQueryParams.ts
+++ b/packages/components/src/hooks/useQueryParams.ts
@@ -1,5 +1,10 @@
 import { useEffect, useState } from "react"
 
+const getQueryParams = (params: URLSearchParams) => {
+  const entries = Array.from(params.entries())
+  return Object.fromEntries(entries)
+}
+
 interface UpdateQueryParams {
   oldParams: Record<string, string>
   newParams: Record<string, string | undefined>
@@ -16,8 +21,7 @@ export const useQueryParams = (): [
   // Parse initial query params from the URL when component mounts
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    const entries = Array.from(params.entries())
-    setQueryParams(Object.fromEntries(entries))
+    setQueryParams(getQueryParams(params))
   }, [])
 
   const updateQueryParams = ({ oldParams, newParams }: UpdateQueryParams) => {
@@ -30,11 +34,13 @@ export const useQueryParams = (): [
       }
     }
 
-    const newUrl = window.location.pathname + "?" + params.toString()
+    const url = new URL(window.location.pathname, window.location.origin)
+    url.search = params.toString()
+    const newUrl = url.toString()
+
     // NOTE: We do not want to add a new entry to the history stack
     window.history.replaceState({}, "", newUrl)
-
-    setQueryParams(Object.fromEntries(Array.from(params.entries())))
+    setQueryParams(getQueryParams(params))
   }
 
   return [queryParams, updateQueryParams]

--- a/packages/components/src/hooks/useQueryParams.ts
+++ b/packages/components/src/hooks/useQueryParams.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react"
+
+interface UpdateQueryParams {
+  oldParams: Record<string, string>
+  newParams: Record<string, string | undefined>
+}
+
+// A hook to manage a page's query params without adding new entries to the
+// history stack
+export const useQueryParams = (): [
+  Record<string, string>,
+  (params: UpdateQueryParams) => void,
+] => {
+  const [queryParams, setQueryParams] = useState({})
+
+  // Parse initial query params from the URL when component mounts
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const entries = Array.from(params.entries())
+    setQueryParams(Object.fromEntries(entries))
+  }, [])
+
+  const updateQueryParams = ({ oldParams, newParams }: UpdateQueryParams) => {
+    const params = new URLSearchParams(oldParams)
+    for (const key in newParams) {
+      if (newParams[key] == undefined || newParams[key] === "") {
+        params.delete(key)
+      } else {
+        params.set(key, newParams[key])
+      }
+    }
+
+    const newUrl = window.location.pathname + "?" + params.toString()
+    // NOTE: We do not want to add a new entry to the history stack
+    window.history.replaceState({}, "", newUrl)
+
+    setQueryParams(Object.fromEntries(Array.from(params.entries())))
+  }
+
+  return [queryParams, updateQueryParams]
+}

--- a/packages/components/src/hooks/useQueryParams.ts
+++ b/packages/components/src/hooks/useQueryParams.ts
@@ -6,7 +6,6 @@ const getQueryParams = (params: URLSearchParams) => {
 }
 
 interface UpdateQueryParams {
-  oldParams: Record<string, string>
   newParams: Record<string, string | undefined>
 }
 
@@ -24,8 +23,8 @@ export const useQueryParams = (): [
     setQueryParams(getQueryParams(params))
   }, [])
 
-  const updateQueryParams = ({ oldParams, newParams }: UpdateQueryParams) => {
-    const params = new URLSearchParams(oldParams)
+  const updateQueryParams = ({ newParams }: UpdateQueryParams) => {
+    const params = new URLSearchParams(queryParams)
     for (const key in newParams) {
       if (newParams[key] == undefined || newParams[key] === "") {
         params.delete(key)

--- a/packages/components/src/hooks/useQueryParams.ts
+++ b/packages/components/src/hooks/useQueryParams.ts
@@ -15,7 +15,7 @@ export const useQueryParams = (): [
   Record<string, string>,
   (params: UpdateQueryParams) => void,
 ] => {
-  const [queryParams, setQueryParams] = useState({})
+  const [queryParams, setQueryParams] = useState<Record<string, string>>({})
 
   // Parse initial query params from the URL when component mounts
   useEffect(() => {

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -12,6 +12,7 @@ export interface FileDetails {
 }
 interface BaseCardProps {
   tags?: Tag[]
+  id: string
   lastUpdated?: string
   category: string
   title: string
@@ -42,7 +43,7 @@ export type AllCardProps = ArticleCardProps | FileCardProps | LinkCardProps
 // Thus, only the necessary props are passed to this component.
 export type CollectionCardProps = Pick<
   AllCardProps,
-  "lastUpdated" | "category" | "title" | "description" | "image" | "tags"
+  "id" | "lastUpdated" | "category" | "title" | "description" | "image" | "tags"
 > & {
   referenceLinkHref: string | undefined
   imageSrc: string | undefined

--- a/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
+++ b/packages/components/src/templates/next/components/internal/PaginationControls/PaginationControls.tsx
@@ -46,7 +46,7 @@ export function PaginationControls({
             isDisabled={currPage === 1}
             onPress={() => {
               onPageChange?.()
-              setCurrPage((p) => Math.max(1, p - 1))
+              setCurrPage(Math.max(1, currPage - 1))
             }}
           />
         </PaginationItem>
@@ -72,7 +72,7 @@ export function PaginationControls({
             isDisabled={currPage >= totalPageCount}
             onPress={() => {
               onPageChange?.()
-              setCurrPage((p) => Math.min(totalPageCount, p + 1))
+              setCurrPage(Math.min(totalPageCount, currPage + 1))
             }}
           />
         </PaginationItem>

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -20,6 +20,7 @@ const processedCollectionItems = (
 ): ProcessedCollectionCardProps[] => {
   return items.map((item) => {
     const {
+      id,
       site,
       variant,
       lastUpdated,
@@ -32,6 +33,7 @@ const processedCollectionItems = (
     } = item
     const file = variant === "file" ? item.fileDetails : null
     return {
+      id,
       lastUpdated,
       category,
       title,

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -86,7 +86,7 @@ export const CollectionResults = ({
           {paginatedItems.map((item) =>
             variant === "collection" ? (
               <CollectionCard
-                key={`${item.title}-${item.category}`}
+                key={item.id}
                 {...item}
                 shouldShowDate={shouldShowDate}
                 siteAssetsBaseUrl={siteAssetsBaseUrl}
@@ -94,7 +94,7 @@ export const CollectionResults = ({
               />
             ) : (
               <BlogCard
-                key={`${item.title}-${item.category}`}
+                key={item.id}
                 {...item}
                 shouldShowDate={shouldShowDate}
                 siteAssetsBaseUrl={siteAssetsBaseUrl}

--- a/packages/components/src/templates/next/layouts/Collection/useCollection.ts
+++ b/packages/components/src/templates/next/layouts/Collection/useCollection.ts
@@ -26,11 +26,10 @@ export const useCollection = ({
   const setCurrPage = useCallback(
     (page: number) => {
       updateQueryParams({
-        oldParams: queryParams,
         newParams: { page: page.toString() },
       })
     },
-    [queryParams, updateQueryParams],
+    [updateQueryParams],
   )
 
   const appliedFilters = useMemo(() => {
@@ -43,11 +42,10 @@ export const useCollection = ({
   const setAppliedFilters = useCallback(
     (filters: AppliedFilter[]) => {
       updateQueryParams({
-        oldParams: queryParams,
         newParams: { filters: JSON.stringify(filters), page: "1" },
       })
     },
-    [queryParams, updateQueryParams],
+    [updateQueryParams],
   )
 
   const searchValue = useMemo(
@@ -57,11 +55,10 @@ export const useCollection = ({
   const handleSearchValueChange = useCallback(
     (value: string) => {
       updateQueryParams({
-        oldParams: queryParams,
         newParams: { search: value, page: "1" },
       })
     },
-    [queryParams, updateQueryParams],
+    [updateQueryParams],
   )
 
   const handleFilterToggle = useCallback(

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -21,7 +21,9 @@ export const getCategoryFilter = (
       label: label.charAt(0).toUpperCase() + label.slice(1),
       count,
     }))
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) =>
+      a.label.localeCompare(b.label, undefined, { numeric: true }),
+    )
 
   return {
     id: FILTER_ID_CATEGORY,

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -87,12 +87,12 @@ export const getCollectionItems = (
     if (a.rawDate && b.rawDate && a.rawDate.getTime() === b.rawDate.getTime()) {
       // localeCompare better than > operator as
       // it properly handles international and special characters
-      return a.title.localeCompare(b.title)
+      return a.title.localeCompare(b.title, undefined, { numeric: true })
     }
 
     // If both items have no dates, sort by title
     if (a.rawDate === undefined && b.rawDate === undefined) {
-      return a.title.localeCompare(b.title)
+      return a.title.localeCompare(b.title, undefined, { numeric: true })
     }
 
     // Rank items with no dates last

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -50,6 +50,7 @@ export const getCollectionItems = (
 
       const baseItem = {
         type: "collectionCard" as const,
+        id: item.permalink,
         rawDate: date,
         lastUpdated: date?.toISOString(),
         category: item.category || CATEGORY_OTHERS,
@@ -105,5 +106,5 @@ export const getCollectionItems = (
     }
 
     return a.rawDate.getTime() < b.rawDate.getTime() ? 1 : -1
-  }) as AllCardProps[]
+  }) satisfies AllCardProps[]
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
@@ -36,7 +36,9 @@ export const getTagFilters = (
           count,
           id: label,
         }))
-        .sort((a, b) => a.label.localeCompare(b.label))
+        .sort((a, b) =>
+          a.label.localeCompare(b.label, undefined, { numeric: true }),
+        )
 
       const filters: Filter[] = [
         ...acc,
@@ -49,5 +51,7 @@ export const getTagFilters = (
 
       return filters
     }, [])
-    .sort((a, b) => a.label.localeCompare(b.label))
+    .sort((a, b) =>
+      a.label.localeCompare(b.label, undefined, { numeric: true }),
+    )
 }

--- a/packages/components/src/templates/next/types/Pagination.ts
+++ b/packages/components/src/templates/next/types/Pagination.ts
@@ -1,10 +1,8 @@
-import type { Dispatch, SetStateAction } from "react"
-
 export interface PaginationProps {
   totalItems: number
   itemsPerPage: number
   currPage: number
-  setCurrPage: Dispatch<SetStateAction<number>>
+  setCurrPage: (previousState: number) => void
 }
 
 export default PaginationProps


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Agencies have been asking for enhancements about the collection filters:
- Having a permanent URL to share a particular set of active filters with other people
- Clicking on an article, then pressing back should retain the active filters
- Ordering of filters is not intuitive when it comes to numbers

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Revamped the way the collection filters are calculated and stored by using the query params as the source of truth, then deriving the other states from it.
- Enhanced the ordering of filters to take into account numbers (1 -> 2 -> 3 -> 22 rather than 1 -> 2 -> 22 -> 3).

**Bug fixes**:

- Fixed issue with phantom collection cards appearing when applying collection filters.

## Before & After Screenshots

- Live demo is available on the NNA staging site: https://staging.d2112ghehokgef.amplifyapp.com/available-courses/

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to a collection
- [ ] Activate any combination of filters, search and pagination
- [ ] Copy and paste the page's URL into another tab/window
- [ ] Verify that the same filters are being applied
- [ ] Verify that you can continue to interact with the collection filters
- [ ] Click on any one of the articles
- [ ] Press the browser back button
- [ ] Verify that the previous filters are still being applied