### PR TITLE
singpass: reduce iron session TTL from 7 days to 12 hours

### DIFF
--- a/apps/studio/src/server/modules/auth/session.ts
+++ b/apps/studio/src/server/modules/auth/session.ts
@@ -7,7 +7,7 @@ export const sessionOptions: SessionOptions = {
     "1": env.SESSION_SECRET,
   },
   cookieName: "auth.session-token",
-  ttl: 60 * 60 * 24 * 7, // 7 days
+  ttl: 60 * 60 * 12, // 12 hours
   cookieOptions: {
     secure: env.NODE_ENV === "production",
   },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1811/[misc]-reduce-session-duration-from-7-days-to-12-hours

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- update iron session duration to 12 hours
