### PR TITLE
chore: disable crawling of search page

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -122,6 +122,7 @@ export const getRobotsTxt = (props: IsomerPageSchemaType) => {
     {
       userAgent: "*",
       allow: "/",
+      disallow: ["/search"],
     },
   ]
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Search page got noindex but got feedback that we should put inside robots.txt instead.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add `/search` to disallow in robots.txt