### PR TITLE
isom-1874 refactor remove soft deletion for users and resourcepermission

### DIFF
--- a/apps/studio/prisma/custom/migration.sql
+++ b/apps/studio/prisma/custom/migration.sql
@@ -17,3 +17,7 @@ DROP INDEX "User_email_deletedAt_key";
 CREATE UNIQUE INDEX IF NOT EXISTS "User_email_deletedAt_key" ON "User"("email", "deletedAt") NULLS NOT DISTINCT;
 
 ---------------------------------
+
+DROP INDEX "ResourcePermission_userId_siteId_resourceId_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ResourcePermission_userId_siteId_resourceId_key" ON "ResourcePermission"("userId", "siteId", "resourceId") NULLS NOT DISTINCT;

--- a/apps/studio/prisma/generated/generatedEnums.ts
+++ b/apps/studio/prisma/generated/generatedEnums.ts
@@ -1,41 +1,41 @@
 export const ResourceState = {
-  Draft: "Draft",
-  Published: "Published",
-} as const
-export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
+    Draft: "Draft",
+    Published: "Published"
+} as const;
+export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState];
 export const ResourceType = {
-  RootPage: "RootPage",
-  Page: "Page",
-  Folder: "Folder",
-  Collection: "Collection",
-  CollectionMeta: "CollectionMeta",
-  CollectionLink: "CollectionLink",
-  CollectionPage: "CollectionPage",
-  IndexPage: "IndexPage",
-  FolderMeta: "FolderMeta",
-} as const
-export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType]
+    RootPage: "RootPage",
+    Page: "Page",
+    Folder: "Folder",
+    Collection: "Collection",
+    CollectionMeta: "CollectionMeta",
+    CollectionLink: "CollectionLink",
+    CollectionPage: "CollectionPage",
+    IndexPage: "IndexPage",
+    FolderMeta: "FolderMeta"
+} as const;
+export type ResourceType = (typeof ResourceType)[keyof typeof ResourceType];
 export const RoleType = {
-  Admin: "Admin",
-  Editor: "Editor",
-  Publisher: "Publisher",
-} as const
-export type RoleType = (typeof RoleType)[keyof typeof RoleType]
+    Admin: "Admin",
+    Editor: "Editor",
+    Publisher: "Publisher"
+} as const;
+export type RoleType = (typeof RoleType)[keyof typeof RoleType];
 export const AuditLogEvent = {
-  ResourceCreate: "ResourceCreate",
-  ResourceUpdate: "ResourceUpdate",
-  ResourceDelete: "ResourceDelete",
-  UserCreate: "UserCreate",
-  UserUpdate: "UserUpdate",
-  UserDelete: "UserDelete",
-  Publish: "Publish",
-  Login: "Login",
-  Logout: "Logout",
-  PermissionCreate: "PermissionCreate",
-  PermissionUpdate: "PermissionUpdate",
-  PermissionDelete: "PermissionDelete",
-  SiteConfigUpdate: "SiteConfigUpdate",
-  FooterUpdate: "FooterUpdate",
-  NavbarUpdate: "NavbarUpdate",
-} as const
-export type AuditLogEvent = (typeof AuditLogEvent)[keyof typeof AuditLogEvent]
+    ResourceCreate: "ResourceCreate",
+    ResourceUpdate: "ResourceUpdate",
+    ResourceDelete: "ResourceDelete",
+    UserCreate: "UserCreate",
+    UserUpdate: "UserUpdate",
+    UserDelete: "UserDelete",
+    Publish: "Publish",
+    Login: "Login",
+    Logout: "Logout",
+    PermissionCreate: "PermissionCreate",
+    PermissionUpdate: "PermissionUpdate",
+    PermissionDelete: "PermissionDelete",
+    SiteConfigUpdate: "SiteConfigUpdate",
+    FooterUpdate: "FooterUpdate",
+    NavbarUpdate: "NavbarUpdate"
+} as const;
+export type AuditLogEvent = (typeof AuditLogEvent)[keyof typeof AuditLogEvent];

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -1,152 +1,143 @@
-import type { ColumnType, GeneratedAlways } from "kysely"
+import type { ColumnType, GeneratedAlways } from "kysely";
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
+export type Timestamp = ColumnType<Date, Date | string, Date | string>;
 
-import type {
-  AuditLogEvent,
-  ResourceState,
-  ResourceType,
-  RoleType,
-} from "./generatedEnums"
+import type { ResourceState, ResourceType, RoleType, AuditLogEvent } from "./generatedEnums";
 
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>
-export type Timestamp = ColumnType<Date, Date | string, Date | string>
-
-export interface AuditLog {
-  id: GeneratedAlways<string>
-  userId: string
-  eventType: AuditLogEvent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  metadata: unknown
-  /**
-   * @kyselyType(PrismaJson.AuditLogDeltaJsonContent)
-   * [AuditLogDeltaJsonContent]
-   */
-  delta: PrismaJson.AuditLogDeltaJsonContent
-  ipAddress: string | null
-}
-export interface Blob {
-  id: GeneratedAlways<string>
-  /**
-   * @kyselyType(PrismaJson.BlobJsonContent)
-   * [BlobJsonContent]
-   */
-  content: PrismaJson.BlobJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Footer {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.FooterJsonContent)
-   * [FooterJsonContent]
-   */
-  content: PrismaJson.FooterJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface Navbar {
-  id: GeneratedAlways<number>
-  siteId: number
-  /**
-   * @kyselyType(PrismaJson.NavbarJsonContent)
-   * [NavbarJsonContent]
-   */
-  content: PrismaJson.NavbarJsonContent
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface RateLimiterFlexible {
-  key: string
-  points: number
-  expire: Timestamp | null
-}
-export interface Resource {
-  id: GeneratedAlways<string>
-  title: string
-  permalink: string
-  siteId: number
-  parentId: string | null
-  publishedVersionId: string | null
-  draftBlobId: string | null
-  state: Generated<ResourceState | null>
-  type: ResourceType
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface ResourcePermission {
-  id: GeneratedAlways<string>
-  userId: string
-  siteId: number
-  resourceId: string | null
-  role: RoleType
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  deletedAt: Timestamp | null
-}
-export interface Site {
-  id: GeneratedAlways<number>
-  name: string
-  /**
-   * @kyselyType(PrismaJson.SiteJsonConfig)
-   * [SiteJsonConfig]
-   */
-  config: PrismaJson.SiteJsonConfig
-  /**
-   * @kyselyType(PrismaJson.SiteThemeJson)
-   * [SiteThemeJson]
-   */
-  theme: PrismaJson.SiteThemeJson | null
-  codeBuildId: string | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface User {
-  id: string
-  name: string
-  email: string
-  phone: string
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-  deletedAt: Timestamp | null
-  lastLoginAt: Timestamp | null
-}
-export interface VerificationToken {
-  identifier: string
-  token: string
-  attempts: Generated<number>
-  expires: Timestamp
-}
-export interface Version {
-  id: GeneratedAlways<string>
-  versionNum: number
-  resourceId: string
-  blobId: string
-  publishedAt: Generated<Timestamp>
-  publishedBy: string
-  updatedAt: Generated<Timestamp>
-}
-export interface Whitelist {
-  id: GeneratedAlways<number>
-  email: string
-  expiry: Timestamp | null
-  createdAt: Generated<Timestamp>
-  updatedAt: Generated<Timestamp>
-}
-export interface DB {
-  AuditLog: AuditLog
-  Blob: Blob
-  Footer: Footer
-  Navbar: Navbar
-  RateLimiterFlexible: RateLimiterFlexible
-  Resource: Resource
-  ResourcePermission: ResourcePermission
-  Site: Site
-  User: User
-  VerificationToken: VerificationToken
-  Version: Version
-  Whitelist: Whitelist
-}
+export type AuditLog = {
+    id: GeneratedAlways<string>;
+    userId: string;
+    eventType: AuditLogEvent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+    metadata: unknown;
+    /**
+     * @kyselyType(PrismaJson.AuditLogDeltaJsonContent)
+     * [AuditLogDeltaJsonContent]
+     */
+    delta: PrismaJson.AuditLogDeltaJsonContent;
+    ipAddress: string | null;
+};
+export type Blob = {
+    id: GeneratedAlways<string>;
+    /**
+     * @kyselyType(PrismaJson.BlobJsonContent)
+     * [BlobJsonContent]
+     */
+    content: PrismaJson.BlobJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Footer = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.FooterJsonContent)
+     * [FooterJsonContent]
+     */
+    content: PrismaJson.FooterJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Navbar = {
+    id: GeneratedAlways<number>;
+    siteId: number;
+    /**
+     * @kyselyType(PrismaJson.NavbarJsonContent)
+     * [NavbarJsonContent]
+     */
+    content: PrismaJson.NavbarJsonContent;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type RateLimiterFlexible = {
+    key: string;
+    points: number;
+    expire: Timestamp | null;
+};
+export type Resource = {
+    id: GeneratedAlways<string>;
+    title: string;
+    permalink: string;
+    siteId: number;
+    parentId: string | null;
+    publishedVersionId: string | null;
+    draftBlobId: string | null;
+    state: Generated<ResourceState | null>;
+    type: ResourceType;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type ResourcePermission = {
+    id: GeneratedAlways<string>;
+    userId: string;
+    siteId: number;
+    resourceId: string | null;
+    role: RoleType;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type Site = {
+    id: GeneratedAlways<number>;
+    name: string;
+    /**
+     * @kyselyType(PrismaJson.SiteJsonConfig)
+     * [SiteJsonConfig]
+     */
+    config: PrismaJson.SiteJsonConfig;
+    /**
+     * @kyselyType(PrismaJson.SiteThemeJson)
+     * [SiteThemeJson]
+     */
+    theme: PrismaJson.SiteThemeJson | null;
+    codeBuildId: string | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type User = {
+    id: string;
+    name: string;
+    email: string;
+    phone: string;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+    lastLoginAt: Timestamp | null;
+};
+export type VerificationToken = {
+    identifier: string;
+    token: string;
+    attempts: Generated<number>;
+    expires: Timestamp;
+};
+export type Version = {
+    id: GeneratedAlways<string>;
+    versionNum: number;
+    resourceId: string;
+    blobId: string;
+    publishedAt: Generated<Timestamp>;
+    publishedBy: string;
+    updatedAt: Generated<Timestamp>;
+};
+export type Whitelist = {
+    id: GeneratedAlways<number>;
+    email: string;
+    expiry: Timestamp | null;
+    createdAt: Generated<Timestamp>;
+    updatedAt: Generated<Timestamp>;
+};
+export type DB = {
+    AuditLog: AuditLog;
+    Blob: Blob;
+    Footer: Footer;
+    Navbar: Navbar;
+    RateLimiterFlexible: RateLimiterFlexible;
+    Resource: Resource;
+    ResourcePermission: ResourcePermission;
+    Site: Site;
+    User: User;
+    VerificationToken: VerificationToken;
+    Version: Version;
+    Whitelist: Whitelist;
+};

--- a/apps/studio/prisma/migrations/20250408082157_/migration.sql
+++ b/apps/studio/prisma/migrations/20250408082157_/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `deletedAt` on the `ResourcePermission` table. All the data in the column will be lost.
+  - You are about to drop the column `deletedAt` on the `User` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[userId,siteId,resourceId]` on the table `ResourcePermission` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[email]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "ResourcePermission_userId_siteId_resourceId_deletedAt_key";
+
+-- DropIndex
+DROP INDEX "User_email_deletedAt_key";
+
+-- AlterTable
+ALTER TABLE "ResourcePermission" DROP COLUMN "deletedAt";
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "deletedAt";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ResourcePermission_userId_siteId_resourceId_key" ON "ResourcePermission"("userId", "siteId", "resourceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");

--- a/apps/studio/prisma/migrations/20250408092900_custom_migration/migration.sql
+++ b/apps/studio/prisma/migrations/20250408092900_custom_migration/migration.sql
@@ -1,0 +1,6 @@
+---------------------------------
+
+DROP INDEX "ResourcePermission_userId_siteId_resourceId_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ResourcePermission_userId_siteId_resourceId_key" ON "ResourcePermission"("userId", "siteId", "resourceId") NULLS NOT DISTINCT;
+

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -116,22 +116,17 @@ enum ResourceType {
 model User {
   id    String @id @default(cuid())
   name  String
-  email String
+  email String @unique
   phone String
 
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @default(now()) @updatedAt
-  deletedAt   DateTime?
   lastLoginAt DateTime?
 
   ResourcePermission ResourcePermission[]
   versions           Version[]
   AuditLog           AuditLog[]
 
-  // This unique index is subsequently replaced with a custom index that
-  // treats nulls as not distinct.
-  // This is required so prisma does not attempt to drop the custom index.
-  @@unique([email, deletedAt])
   @@index([lastLoginAt])
 }
 
@@ -195,12 +190,11 @@ model ResourcePermission {
   role       RoleType
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @default(now()) @updatedAt
-  deletedAt  DateTime?
 
   // This unique index is subsequently replaced with a custom index that
   // treats nulls as not distinct.
   // This is required so prisma does not attempt to drop the custom index.
-  @@unique([userId, siteId, resourceId, deletedAt])
+  @@unique([userId, siteId, resourceId])
 }
 
 enum RoleType {

--- a/apps/studio/prisma/scripts/addUsersToSite.ts
+++ b/apps/studio/prisma/scripts/addUsersToSite.ts
@@ -35,7 +35,7 @@ export const addUsersToSite = async ({
           })
           .onConflict((oc) =>
             oc
-              .columns(["email", "deletedAt"])
+              .columns(["email"])
               .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
           )
           .returning(["id", "name", "email"])

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -251,11 +251,9 @@ interface CreatePermissionDelta {
   after: ResourcePermission
 }
 
-// There's ResourcePermission for "before" and "after"
-// as we are only soft-deleting the record
 interface DeletePermissionDelta {
   before: ResourcePermission
-  after: ResourcePermission
+  after: null
 }
 
 // Note: This is not used anywhere at the moment as we only soft-delete

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -256,8 +256,6 @@ interface DeletePermissionDelta {
   after: null
 }
 
-// Note: This is not used anywhere at the moment as we only soft-delete
-// the ResourcePermission record, nevertheless, we keep it here for future use (if any)
 interface UpdatePermissionDelta {
   before: ResourcePermission
   after: ResourcePermission

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -72,25 +72,6 @@ describe("auth.email", () => {
       })
       expect(result).toEqual(expectedReturn)
     })
-
-    it("should throw if user is deleted", async () => {
-      // Arrange
-      await setupUser({
-        name: "Deleted",
-        userId: "deleted123",
-        email: TEST_VALID_EMAIL,
-        phone: "123",
-        isDeleted: true,
-      })
-
-      // Act
-      const result = caller.login({ email: TEST_VALID_EMAIL })
-
-      // Assert
-      await expect(result).rejects.toThrowError(
-        "Unauthorized. Contact Isomer support.",
-      )
-    })
   })
 
   describe("verifyOtp", () => {

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -3,9 +3,9 @@ import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import { formatInTimeZone } from "date-fns-tz"
 import pick from "lodash/pick"
 
+import type { SessionData } from "~/lib/types/session"
 import { env } from "~/env.mjs"
 import { sendMail } from "~/lib/mail"
-import { SessionData } from "~/lib/types/session"
 import {
   emailSignInSchema,
   emailVerifyOtpSchema,
@@ -15,7 +15,6 @@ import { getBaseUrl } from "~/utils/getBaseUrl"
 import { logAuthEvent } from "../../audit/audit.service"
 import { db } from "../../database"
 import { defaultUserSelect } from "../../me/me.select"
-import { isUserDeleted } from "../../user/user.service"
 import { isEmailWhitelisted } from "../../whitelist/whitelist.service"
 import { VerificationError } from "../auth.error"
 import { verifyToken } from "../auth.service"
@@ -30,10 +29,7 @@ export const emailSessionRouter = router({
     .meta({ rateLimitOptions: {} })
     .mutation(async ({ ctx, input: { email } }) => {
       const isWhitelisted = await isEmailWhitelisted(email)
-      const isDeleted = await isUserDeleted(email)
-
-      // Assert that the user is both whitelisted and not deleted
-      if (!isWhitelisted || isDeleted) {
+      if (!isWhitelisted) {
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Unauthorized. Contact Isomer support.",

--- a/apps/studio/src/server/modules/auth/email/email.service.ts
+++ b/apps/studio/src/server/modules/auth/email/email.service.ts
@@ -20,7 +20,6 @@ export const upsertUser = async ({
     .selectFrom("User")
     .selectAll()
     .where("email", "=", email)
-    .where("deletedAt", "is", null)
     .executeTakeFirst()
 
   if (possibleUser) {

--- a/apps/studio/src/server/modules/auth/sgid/__tests__/sgid.service.test.ts
+++ b/apps/studio/src/server/modules/auth/sgid/__tests__/sgid.service.test.ts
@@ -32,30 +32,6 @@ describe("sgid.service", () => {
       expect(user?.lastLoginAt).toBe(null)
     })
 
-    it("should throw if email is deleted", async () => {
-      // Arrange
-      await setupUser({
-        name: "Deleted",
-        userId: "deleted123",
-        email: TEST_EMAIL,
-        phone: "123",
-        isDeleted: true,
-      })
-
-      // Act
-      const result = upsertSgidAccountAndUser({
-        prisma,
-        pocdexEmail: TEST_EMAIL,
-        name: TEST_NAME,
-        sub: TEST_SUB,
-      })
-
-      // Assert
-      await expect(result).rejects.toThrowError(
-        "Unauthorized. Contact Isomer support.",
-      )
-    })
-
     it("should update lastLoginAt when user logs in", async () => {
       // Arrange
       const beforeLogin = new Date()

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -55,7 +55,6 @@ describe("collection.router", async () => {
     const user = await setupUser({
       userId: session.userId,
       email: "test@mock.com",
-      isDeleted: false,
     })
     await auth(user)
     auditSpy = vitest.spyOn(auditService, "logResourceEvent")

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -42,7 +42,6 @@ describe("folder.router", async () => {
     const user = await setupUser({
       userId: session.userId,
       email: "test@mock.com",
-      isDeleted: false,
     })
     await auth(user)
   })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -50,7 +50,6 @@ describe("resource.router", async () => {
     const user = await setupUser({
       userId: session.userId,
       email: "test@mock.com",
-      isDeleted: false,
     })
     await auth(user)
   })

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -632,7 +632,6 @@ export const resourceRouter = router({
         .selectFrom("ResourcePermission")
         .where("userId", "=", ctx.user.id)
         .where("siteId", "=", siteId)
-        .where("deletedAt", "is", null)
 
       if (!resourceId) {
         query.where("resourceId", "is", null)

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -103,31 +103,6 @@ describe("site.router", async () => {
       // Assert
       expect(result).toEqual([])
     })
-
-    it("should only return sites if the permissions are not deleted for the site", async () => {
-      const { site: site1 } = await setupSite()
-      const { site: site2 } = await setupSite()
-      await setupAdminPermissions({
-        userId: session.userId,
-        siteId: site1.id,
-        isDeleted: true,
-      })
-      await setupAdminPermissions({
-        userId: session.userId,
-        siteId: site2.id,
-      })
-
-      // Act
-      const result = await caller.list()
-
-      // Assert
-      expect(result).toEqual([
-        {
-          id: site2.id,
-          config: site2.config,
-        },
-      ])
-    })
   })
 
   describe("getSiteName", () => {

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -38,7 +38,6 @@ export const siteRouter = router({
     return db
       .selectFrom("Site")
       .innerJoin("ResourcePermission", "Site.id", "ResourcePermission.siteId")
-      .where("ResourcePermission.deletedAt", "is", null)
       .where("ResourcePermission.userId", "=", ctx.user.id)
       .select(["Site.id", "Site.config"])
       .groupBy(["Site.id", "Site.config"])

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -1303,43 +1303,30 @@ describe("user.router", () => {
         .executeTakeFirst()
       expect(updatedUser).not.toBeNull()
 
-      // Assert DB - audit logs (deleted permission)
-      const deletedPermissionAuditLogs = await db
+      // Assert DB - audit logs (count)
+      const updatedPermissionAuditLogs = await db
         .selectFrom("AuditLog")
-        .where("eventType", "=", "PermissionDelete")
+        .where("eventType", "=", "PermissionUpdate")
         .selectAll()
         .execute()
-      expect(deletedPermissionAuditLogs).toHaveLength(1)
-      expect(deletedPermissionAuditLogs[0]).toMatchObject({
-        eventType: "PermissionDelete",
-        delta: expect.objectContaining({
-          before: expect.objectContaining({
-            ..._.omit(currentPermission, ["createdAt", "updatedAt"]),
-          }),
-          after: null,
-        }),
-      })
+      expect(updatedPermissionAuditLogs).toHaveLength(1)
 
-      // Assert DB - audit logs (new permission)
-      const newPermission = await db
+      // Assert DB - audit logs (content)
+      const updatedPermission = await db
         .selectFrom("ResourcePermission")
         .where("userId", "=", userToUpdate.id)
         .where("siteId", "=", siteId)
         .where("role", "=", newRole)
         .selectAll()
         .executeTakeFirst()
-      const newPermissionAuditLogs = await db
-        .selectFrom("AuditLog")
-        .where("eventType", "=", "PermissionCreate")
-        .selectAll()
-        .execute()
-      expect(newPermissionAuditLogs).toHaveLength(1)
-      expect(newPermissionAuditLogs[0]).toMatchObject({
-        eventType: "PermissionCreate",
+      expect(updatedPermissionAuditLogs[0]).toMatchObject({
+        eventType: "PermissionUpdate",
         delta: expect.objectContaining({
-          before: null,
+          before: expect.objectContaining({
+            ..._.omit(currentPermission, ["createdAt", "updatedAt"]),
+          }),
           after: expect.objectContaining({
-            ..._.omit(newPermission, ["createdAt", "updatedAt"]),
+            ..._.omit(updatedPermission, ["createdAt", "updatedAt"]),
           }),
         }),
       })
@@ -1382,43 +1369,30 @@ describe("user.router", () => {
         .executeTakeFirst()
       expect(updatedUser?.role).toBe(newRole)
 
-      // Assert DB - audit logs (deleted permission)
-      const deletedPermissionAuditLogs = await db
+      // Assert DB - audit logs (count)
+      const updatedPermissionAuditLogs = await db
         .selectFrom("AuditLog")
-        .where("eventType", "=", "PermissionDelete")
+        .where("eventType", "=", "PermissionUpdate")
         .selectAll()
         .execute()
-      expect(deletedPermissionAuditLogs).toHaveLength(1)
-      expect(deletedPermissionAuditLogs[0]).toMatchObject({
-        eventType: "PermissionDelete",
-        delta: expect.objectContaining({
-          before: expect.objectContaining({
-            ..._.omit(currentPermission, ["createdAt", "updatedAt"]),
-          }),
-          after: null,
-        }),
-      })
+      expect(updatedPermissionAuditLogs).toHaveLength(1)
 
-      // Assert DB - audit logs (new permission)
-      const newPermission = await db
+      // Assert DB - audit logs (content)
+      const updatedPermission = await db
         .selectFrom("ResourcePermission")
         .where("userId", "=", userToUpdate.id)
         .where("siteId", "=", siteId)
         .where("role", "=", newRole)
         .selectAll()
         .executeTakeFirst()
-      const newPermissionAuditLogs = await db
-        .selectFrom("AuditLog")
-        .where("eventType", "=", "PermissionCreate")
-        .selectAll()
-        .execute()
-      expect(newPermissionAuditLogs).toHaveLength(1)
-      expect(newPermissionAuditLogs[0]).toMatchObject({
-        eventType: "PermissionCreate",
+      expect(updatedPermissionAuditLogs[0]).toMatchObject({
+        eventType: "PermissionUpdate",
         delta: expect.objectContaining({
-          before: null,
+          before: expect.objectContaining({
+            ..._.omit(currentPermission, ["createdAt", "updatedAt"]),
+          }),
           after: expect.objectContaining({
-            ..._.omit(newPermission, ["createdAt", "updatedAt"]),
+            ..._.omit(updatedPermission, ["createdAt", "updatedAt"]),
           }),
         }),
       })

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -11,44 +11,17 @@ import {
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { db } from "~/server/modules/database"
-import { createUserWithPermission, isUserDeleted } from "../user.service"
+import { createUserWithPermission } from "../user.service"
 
 describe("user.service", () => {
-  describe("isUserDeleted", () => {
-    beforeAll(async () => {
-      await resetTables("User")
-    })
-
-    it("should return false if user is not deleted", async () => {
-      // Arrange
-      const email = "active@example.com"
-      // Setup active user
-      await setupUser({
-        email: email,
-        isDeleted: false,
-      })
-
-      // Act
-      const result = await isUserDeleted(email)
-      // Assert
-      expect(result).toBe(false)
-    })
-
-    it("should return true if user is deleted", async () => {
-      // Arrange
-      const email = "deleted@example.com"
-      // Setup deleted user
-      await setupUser({
-        email: email,
-        isDeleted: true,
-      })
-
-      // Act
-      const result = await isUserDeleted(email)
-      // Assert
-      expect(result).toBe(true)
-    })
-  })
+  const assertUserCreateAuditLogNotCreated = async () => {
+    const auditLogs = await db
+      .selectFrom("AuditLog")
+      .where("eventType", "=", "UserCreate")
+      .selectAll()
+      .execute()
+    expect(auditLogs).toHaveLength(0)
+  }
 
   describe("createUserWithPermission", () => {
     const TEST_EMAIL = "test@open.gov.sg"
@@ -67,7 +40,6 @@ describe("user.service", () => {
       const creator = await setupUser({
         name: "creator",
         email: "creator@open.gov.sg",
-        isDeleted: false,
       })
       creatorUserId = creator.id
     })
@@ -92,8 +64,7 @@ describe("user.service", () => {
       )
 
       // Assert DB - audit logs
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(0)
+      void assertUserCreateAuditLogNotCreated()
     })
 
     it("should throw error if site does not exist", async () => {
@@ -112,17 +83,15 @@ describe("user.service", () => {
       await expect(result).rejects.toThrowError()
 
       // Assert DB - audit logs
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(0)
+      void assertUserCreateAuditLogNotCreated()
     })
 
     it("should throw error if both user and permission already exists", async () => {
       // Arrange
-      const user = await setupUser({ email: TEST_EMAIL, isDeleted: false })
+      const user = await setupUser({ email: TEST_EMAIL })
       await setupAdminPermissions({ userId: user.id, siteId })
 
       // Act
-
       const result = db.transaction().execute((tx) => {
         return createUserWithPermission({
           byUserId: creatorUserId,
@@ -132,6 +101,7 @@ describe("user.service", () => {
           tx,
         })
       })
+
       // Assert
       await expect(result).rejects.toThrowError(
         new TRPCError({
@@ -141,99 +111,7 @@ describe("user.service", () => {
       )
 
       // Assert DB - audit logs
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(0)
-    })
-
-    it("should create user if user already exists but has non-null deletedAt", async () => {
-      // Arrange
-      const user = await setupUser({ email: TEST_EMAIL, isDeleted: true })
-      await setupAdminPermissions({ userId: user.id, siteId })
-
-      // Act
-      const roleToCreate = RoleType.Editor
-      const { user: createdUser, resourcePermission } = await db
-        .transaction()
-        .execute((tx) => {
-          return createUserWithPermission({
-            byUserId: creatorUserId,
-            email: TEST_EMAIL,
-            role: roleToCreate,
-            siteId,
-            tx,
-          })
-        })
-
-      // Assert: Verify user in database
-      const dbUserResult = await db
-        .selectFrom("User")
-        .where("email", "=", TEST_EMAIL)
-        .selectAll()
-        .execute()
-      expect(dbUserResult).toHaveLength(2) // original + newly created record
-      expect(dbUserResult).toEqual([
-        expect.objectContaining({
-          email: TEST_EMAIL,
-          id: user.id, // original record
-          deletedAt: expect.any(Date),
-        }),
-        expect.objectContaining({
-          email: TEST_EMAIL,
-          id: expect.any(String),
-          deletedAt: null,
-        }),
-      ])
-
-      // Assert: Verify resource permission in database
-      const dbResourcePermissionResult = await db
-        .selectFrom("ResourcePermission")
-        .where("userId", "=", createdUser.id)
-        .where("siteId", "=", siteId)
-        .selectAll()
-        .execute()
-      expect(dbResourcePermissionResult).toHaveLength(1)
-      expect(dbResourcePermissionResult).toEqual([
-        expect.objectContaining({
-          userId: expect.any(String),
-          siteId,
-          role: roleToCreate,
-        }),
-      ])
-
-      // Assert DB - audit logs (user)
-      const userAuditLogs = await db
-        .selectFrom("AuditLog")
-        .where("eventType", "=", "UserCreate")
-        .selectAll()
-        .execute()
-      expect(userAuditLogs).toHaveLength(1)
-      expect(userAuditLogs[0]).toMatchObject({
-        eventType: "UserCreate",
-        delta: expect.objectContaining({
-          before: null,
-          after: expect.objectContaining({
-            id: createdUser.id,
-            email: TEST_EMAIL,
-          }),
-        }),
-      })
-
-      // Assert DB - audit logs (permission)
-      const permissionAuditLogs = await db
-        .selectFrom("AuditLog")
-        .where("eventType", "=", "PermissionCreate")
-        .selectAll()
-        .execute()
-      expect(permissionAuditLogs).toHaveLength(1)
-      expect(permissionAuditLogs[0]).toMatchObject({
-        eventType: "PermissionCreate",
-        delta: expect.objectContaining({
-          before: null,
-          after: expect.objectContaining(
-            _.omit(resourcePermission, ["createdAt", "updatedAt"]),
-          ),
-        }),
-      })
+      void assertUserCreateAuditLogNotCreated()
     })
 
     it("should throw 403 if creating a non-whitelisted non-gov.sg email with any role", async () => {
@@ -259,8 +137,7 @@ describe("user.service", () => {
       )
 
       // Assert DB - audit logs
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(0)
+      void assertUserCreateAuditLogNotCreated()
     })
 
     it("should throw 403 if assigning a non-gov.sg email with admin role", async () => {
@@ -289,8 +166,7 @@ describe("user.service", () => {
       )
 
       // Assert DB - audit logs
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(0)
+      void assertUserCreateAuditLogNotCreated()
     })
 
     it("should create a non-gov.sg email with non-admin role", async () => {
@@ -513,10 +389,7 @@ describe("user.service", () => {
 
     it("should create resource permission for the user if user already exists", async () => {
       // Arrange
-      const existingUser = await setupUser({
-        email: TEST_EMAIL,
-        isDeleted: false,
-      })
+      const existingUser = await setupUser({ email: TEST_EMAIL })
 
       // Act
       const { resourcePermission } = await db.transaction().execute((tx) => {

--- a/apps/studio/src/server/modules/user/__tests__/utils.ts
+++ b/apps/studio/src/server/modules/user/__tests__/utils.ts
@@ -17,7 +17,7 @@ export const setupIsomerAdmins = async ({
   hasLoggedIn?: boolean
 }) => {
   for (const email of ISOMER_ADMINS_AND_MIGRATORS_EMAILS) {
-    const user = await setupUser({ email, isDeleted: false, hasLoggedIn })
+    const user = await setupUser({ email, hasLoggedIn })
     await setupAdminPermissions({ userId: user.id, siteId })
   }
 }

--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -111,7 +111,6 @@ export const userRouter = router({
       const userToDeletePermissionsFrom = await db
         .selectFrom("User")
         .where("id", "=", userId)
-        .where("deletedAt", "is", null)
         .selectAll()
         .executeTakeFirst()
 
@@ -257,7 +256,6 @@ export const userRouter = router({
       const user = await db
         .selectFrom("User")
         .where("id", "=", userId)
-        .where("deletedAt", "is", null)
         .selectAll()
         .executeTakeFirst()
 

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -136,13 +136,11 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
     throw new TRPCError({ code: "UNAUTHORIZED" })
   }
 
-  // with addition of soft deletes, we need to now check for deletedAt
   // this check is required in case of an already ongoing session to logout the user
   const user = await db
     .selectFrom("User")
     .select(defaultUserSelect)
     .where("id", "=", ctx.session.userId)
-    .where("deletedAt", "is", null)
     .executeTakeFirst()
 
   if (!user) {

--- a/apps/studio/tests/integration/helpers/iron-session.ts
+++ b/apps/studio/tests/integration/helpers/iron-session.ts
@@ -106,7 +106,6 @@ export const createTestUser = () => ({
   createdAt: MOCK_STORY_DATE,
   updatedAt: MOCK_STORY_DATE,
   phone: MOCK_TEST_PHONE,
-  deletedAt: null,
   lastLoginAt: null,
 })
 

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -10,7 +10,6 @@ import { MOCK_STORY_DATE } from "tests/msw/constants"
 interface SetupPermissionsProps {
   userId?: string
   siteId: number
-  isDeleted?: boolean
   role: (typeof RoleType)[keyof typeof RoleType]
   useCurrentTime?: boolean
 }
@@ -19,7 +18,6 @@ const setupPermissions = async ({
   userId,
   siteId,
   role,
-  isDeleted = false,
   useCurrentTime = false,
 }: SetupPermissionsProps) => {
   if (!userId) throw new Error("userId is a required field")
@@ -32,7 +30,6 @@ const setupPermissions = async ({
       siteId,
       role,
       resourceId: null,
-      deletedAt: isDeleted ? time : null,
       createdAt: time,
       updatedAt: time,
     })
@@ -485,24 +482,21 @@ export const setupUser = async ({
   userId = nanoid(),
   email,
   phone = "",
-  isDeleted,
   hasLoggedIn = false,
 }: {
   name?: string
   userId?: string
   email: string
   phone?: string
-  isDeleted?: boolean
   hasLoggedIn?: boolean
 }) => {
-  return db
+  return await db
     .insertInto("User")
     .values({
       id: userId,
       name,
       email,
       phone: phone,
-      deletedAt: isDeleted ? MOCK_STORY_DATE : null,
       lastLoginAt: hasLoggedIn ? MOCK_STORY_DATE : null,
     })
     .returningAll()

--- a/apps/studio/tests/msw/handlers/me.ts
+++ b/apps/studio/tests/msw/handlers/me.ts
@@ -15,7 +15,6 @@ export const defaultUser: User = {
   phone: MOCK_TEST_PHONE,
   createdAt: MOCK_STORY_DATE,
   updatedAt: MOCK_STORY_DATE,
-  deletedAt: null,
   lastLoginAt: null,
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://linear.app/ogp/issue/ISOM-1874/refactor-remove-soft-deletion-for-users-and-resourcepermission

Previously we soft delete users in order to have audit trail. However, since audit log has been created, there's no longer a need to soft delete users since we can always retrieve that information from the AuditLog table

Doing so will also simplify implementation and testing by checking for less things

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- migration to remove `deletedAt` (and respective unique constraints) from `User` and `ResourcePermission` table
- remove `isDeleted` from `setupUser` and `setupPermission`
- update tests to not have to check for deleted users and permissions
- simplify implementation of `updateUserSitewidePermission` in https://github.com/opengovsg/isomer/commit/90eefe815e0006e5d45521adb74fe6f2395a193e as we update the record instead of deleting existing one and recreating a new one

## NOTE: IMPORTANT BEFORE DEPLOYING

We need to back-patch deleted user and resourcepermissions into AuditLog table before merging this and running migration, as the `deletedAt` column content will be wiped out