### PR TITLE
fix: update all query params in one call

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/useCollection.ts
+++ b/packages/components/src/templates/next/layouts/Collection/useCollection.ts
@@ -75,9 +75,10 @@ export const useCollection = ({
   )
 
   const handleClearFilter = useCallback(() => {
-    handleSearchValueChange("")
-    setAppliedFilters([])
-  }, [handleSearchValueChange, setAppliedFilters])
+    updateQueryParams({
+      newParams: { search: "", filters: "[]", page: "1" },
+    })
+  }, [updateQueryParams])
 
   return {
     paginatedItems,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The clear all filters button calls `updateQueryParams` twice, which results in a race condition.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Directly set the query params when clearing all filters.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to a collection page.
- [ ] Type some search query that will give you 0 results.
- [ ] Click on "Clear search and filters".
- [ ] Verify that the button works.