### PR TITLE
chore: make concurrency group more specific

### DIFF
--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,7 +1,7 @@
 name: Deploy to production
 
 concurrency:
-  group: ${{ github.ref }}
+  group: deploy-production-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -1,7 +1,7 @@
 name: Deploy to staging
 
 concurrency:
-  group: ${{ github.ref }}
+  group: deploy-staging-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -1,7 +1,7 @@
 name: Deploy to uat
 
 concurrency:
-  group: ${{ github.ref }}
+  group: deploy-uat-${{ github.ref }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/update_release_branch.yml
+++ b/.github/workflows/update_release_branch.yml
@@ -1,7 +1,7 @@
 name: Update release branch
 
 concurrency:
-  group: ${{ github.ref }}
+  group: update-release-branch-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

All CIs are using the same concurrency group, even though they are doing different things.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make the concurrency groups more specific using the name of the workflow file as prefix