### PR TITLE
chore: update Growthbook for UAT environment

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -40,7 +40,7 @@ jobs:
       app-s3-region: "ap-southeast-1"
       app-s3-assets-bucket-name: "isomer-next-infra-uat-assets-private-e728930"
       app-s3-assets-domain-name: "isomer-user-content-uat.by.gov.sg"
-      app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
+      app-growthbook-client-key: "sdk-JCHWTUKA5qK7GAZA"
       app-intercom-app-id: "jv2tjc3g"
 
     secrets:


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our Growthbook for the UAT environment is using staging, but it should have its own separate environment.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Update Growthbook client key to use the UAT client key SDK instead.