### PR TITLE
chore: add error logging for Singpass auth

### DIFF
--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server"
 import { resetTables } from "tests/integration/helpers/db"
 import {
   applySession,
@@ -28,29 +29,24 @@ describe("auth.email", () => {
   })
 
   describe("login", () => {
-    it("should throw if email is not provided", async () => {
+    it("should throw 400 if email is not provided", async () => {
       // Act
       const result = caller.login({ email: "" })
 
       // Assert
-      await expect(result).rejects.toThrowError()
+      await expect(result).rejects.toThrowError(
+        "Please sign in with a valid email address.",
+      )
     })
 
-    it("should throw if email is invalid", async () => {
+    it("should throw 400 if email is invalid", async () => {
       // Act
       const result = caller.login({ email: "not-an-email" })
 
       // Assert
-      await expect(result).rejects.toThrowError()
-    })
-
-    // skipping as we need to allow vendor emails as well
-    it.skip("should throw if email is not a government email address", async () => {
-      // Act
-      const result = caller.login({ email: "validbutnotgovt@example.com" })
-
-      // Assert
-      await expect(result).rejects.toThrowError()
+      await expect(result).rejects.toThrowError(
+        "Please sign in with a valid email address.",
+      )
     })
 
     it("should return email and a prefix if OTP is sent successfully", async () => {
@@ -73,7 +69,7 @@ describe("auth.email", () => {
       expect(result).toEqual(expectedReturn)
     })
 
-    it("should throw if user is deleted", async () => {
+    it("should throw 401 if user is deleted", async () => {
       // Arrange
       await setupUser({
         name: "Deleted",
@@ -88,7 +84,10 @@ describe("auth.email", () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        "Email address is not whitelisted",
+        new TRPCError({
+          code: "UNAUTHORIZED",
+          message: "Email address is not whitelisted",
+        }),
       )
     })
   })
@@ -172,7 +171,7 @@ describe("auth.email", () => {
       expect(auditLogs[0]?.delta.before!.attempts).toBe(2)
     })
 
-    it("should throw if OTP is not found", async () => {
+    it("should throw 400 if OTP is not found", async () => {
       // Act
       const result = caller.verifyOtp({
         email: TEST_VALID_EMAIL,
@@ -182,14 +181,17 @@ describe("auth.email", () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        "Please request for another OTP",
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Please request for another OTP",
+        }),
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
       ).resolves.toHaveLength(0)
     })
 
-    it("should throw if OTP is invalid", async () => {
+    it("should throw 400 if OTP is invalid", async () => {
       // Arrange
       await prisma.verificationToken.create({
         data: {
@@ -208,14 +210,17 @@ describe("auth.email", () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        "Token is invalid or has expired",
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Token is invalid or has expired",
+        }),
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
       ).resolves.toHaveLength(0)
     })
 
-    it("should throw if OTP is expired", async () => {
+    it("should throw 400 if OTP is expired", async () => {
       // Arrange
       await prisma.verificationToken.create({
         data: {
@@ -233,14 +238,17 @@ describe("auth.email", () => {
 
       // Assert
       await expect(result).rejects.toThrowError(
-        "Token is invalid or has expired",
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Token is invalid or has expired",
+        }),
       )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
       ).resolves.toHaveLength(0)
     })
 
-    it("should throw if max verification attempts has been reached", async () => {
+    it("should throw 400 if max verification attempts has been reached", async () => {
       // Arrange
       await prisma.verificationToken.create({
         data: {
@@ -258,7 +266,12 @@ describe("auth.email", () => {
       })
 
       // Assert
-      await expect(result).rejects.toThrowError("Too many attempts")
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Too many attempts",
+        }),
+      )
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
       ).resolves.toHaveLength(0)

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -33,6 +33,11 @@ export const emailSessionRouter = router({
 
       // Assert that the user is both whitelisted and not deleted
       if (!isWhitelisted || isDeleted) {
+        ctx.logger.warn(
+          { email, isDeleted, isWhitelisted },
+          "User is not whitelisted or deleted",
+        )
+
         throw new TRPCError({
           code: "UNAUTHORIZED",
           message: "Email address is not whitelisted",
@@ -80,9 +85,10 @@ export const emailSessionRouter = router({
         ])
       } catch (e) {
         ctx.logger.error(
-          { error: e },
+          { error: e, email },
           "Failed to send OTP email for email sign in",
         )
+
         throw new TRPCError({
           code: "INTERNAL_SERVER_ERROR",
           message: "Failed to send OTP email",
@@ -116,6 +122,11 @@ export const emailSessionRouter = router({
         })
       } catch (e) {
         if (e instanceof VerificationError) {
+          ctx.logger.warn(
+            { error: e, email },
+            "Failed to verify OTP for email sign in",
+          )
+
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: e.message,

--- a/apps/studio/src/server/modules/auth/singpass/__tests__/singpass.router.test.ts
+++ b/apps/studio/src/server/modules/auth/singpass/__tests__/singpass.router.test.ts
@@ -1,0 +1,370 @@
+import { TRPCError } from "@trpc/server"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
+import { expect, vi } from "vitest"
+
+import type { SessionData } from "~/lib/types/session"
+import { env } from "~/env.mjs"
+import { AuditLogEvent, db } from "~/server/modules/database"
+import { createCallerFactory } from "~/server/trpc"
+import { SINGPASS_SIGN_IN_STATE } from "../singpass.constants"
+import { singpassRouter } from "../singpass.router"
+import * as SingpassService from "../singpass.service"
+
+const createCaller = createCallerFactory(singpassRouter)
+const TEST_VALID_EMAIL = "test@open.gov.sg"
+const MOCK_ORIGINAL_UUID = "2625dd66-2cbb-414b-a136-f62bb516653c"
+const MOCK_SINGPASS_UUID = "beef6054-985f-4073-ae91-cd61552e2a7d"
+
+describe("auth.singpass", () => {
+  let caller: ReturnType<typeof createCaller>
+  let session: ReturnType<typeof applySession>
+
+  beforeEach(async () => {
+    await resetTables("AuditLog", "User", "VerificationToken", "Whitelist")
+    await setUpWhitelist({ email: TEST_VALID_EMAIL })
+    await setupUser({ email: TEST_VALID_EMAIL })
+    session = applySession()
+    caller = createCaller(createMockRequest(session))
+    vi.clearAllMocks()
+  })
+
+  describe("login", () => {
+    it("should throw if email verification has not been completed", async () => {
+      // Act
+      const result = caller.login({ landingUrl: new URL("http://localhost") })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Email verification has not been completed",
+        }),
+      )
+    })
+
+    it("should return redirectUrl if login is successful", async () => {
+      // Arrange
+      const verificationToken = await db
+        .insertInto("VerificationToken")
+        .values({
+          expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+          identifier: "identifier",
+          token: "token",
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+
+      session.singpass = {
+        sessionState: {
+          userId: "test-user-id" as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      // Act
+      const result = await caller.login({
+        landingUrl: new URL("http://localhost"),
+      })
+
+      // Assert
+      expect(result).toHaveProperty("redirectUrl")
+    })
+  })
+
+  describe("getUserProps", () => {
+    it("should throw if no session state is found", async () => {
+      // Act
+      const result = caller.getUserProps()
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid login flow",
+        }),
+      )
+    })
+
+    it("should throw if user is not found", async () => {
+      // Arrange
+      session.singpass = {
+        sessionState: {
+          userId: "non-existent-user-id" as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      // Act
+      const result = caller.getUserProps()
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "NOT_FOUND", message: "User not found" }),
+      )
+    })
+
+    it("should return name and isNewUser if session state is found", async () => {
+      // Arrange
+      const user = await db
+        .selectFrom("User")
+        .where("email", "=", TEST_VALID_EMAIL)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      session.singpass = {
+        sessionState: {
+          userId: user.id as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      // Act
+      const result = await caller.getUserProps()
+
+      // Assert
+      expect(result).toEqual({
+        name: user.name || user.email,
+        isNewUser: !user.singpassUuid,
+      })
+    })
+  })
+
+  describe("callback", () => {
+    it("should throw if no session state is found", async () => {
+      // Act
+      const result = caller.callback({
+        state: "state",
+        code: "code",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid login flow",
+        }),
+      )
+    })
+
+    it("should throw if Singpass callback state is invalid", async () => {
+      // Arrange
+      session.singpass = {
+        sessionState: {
+          userId: "user-id" as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      // Assert
+      await expect(
+        caller.callback({
+          state: "invalid-state",
+          code: "code",
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Invalid Singpass callback state",
+        }),
+      )
+    })
+
+    it("should throw if the Singpass UUID cannot be extracted", async () => {
+      // Arrange
+      session.singpass = {
+        sessionState: {
+          userId: "user-id" as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      vi.spyOn(SingpassService, "login").mockResolvedValue({
+        uuid: undefined,
+      })
+
+      // Assert
+      await expect(
+        caller.callback({
+          state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+          code: "code",
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Singpass login failed",
+        }),
+      )
+    })
+
+    it("should throw an error if the user's UUID from Singpass does not match the one stored in the database", async () => {
+      // Arrange
+      const user = await db
+        .updateTable("User")
+        .set({ singpassUuid: MOCK_ORIGINAL_UUID })
+        .where("email", "=", TEST_VALID_EMAIL)
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      session.singpass = {
+        sessionState: {
+          userId: user.id as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      vi.spyOn(SingpassService, "login").mockResolvedValue({
+        uuid: MOCK_SINGPASS_UUID,
+      })
+
+      // Assert
+      await expect(
+        caller.callback({
+          state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+          code: "code",
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Singpass profile does not match user",
+        }),
+      )
+    })
+
+    it("should store the user's Singpass UUID in the database if it is the first-time login", async () => {
+      // Arrange
+      const user = await db
+        .updateTable("User")
+        .set({ singpassUuid: null })
+        .where("email", "=", TEST_VALID_EMAIL)
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      session.singpass = {
+        sessionState: {
+          userId: user.id as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      vi.spyOn(SingpassService, "login").mockResolvedValue({
+        uuid: MOCK_SINGPASS_UUID,
+      })
+
+      // Act
+      await caller.callback({
+        state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+        code: "code",
+      })
+
+      // Assert
+      const updatedUser = await db
+        .selectFrom("User")
+        .selectAll()
+        .where("email", "=", TEST_VALID_EMAIL)
+        .executeTakeFirstOrThrow()
+      expect(updatedUser.singpassUuid).toEqual(MOCK_SINGPASS_UUID)
+      // Audit log should have been created
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(2)
+      expect(auditLogs).toEqual([
+        expect.objectContaining({
+          eventType: AuditLogEvent.UserUpdate,
+          delta: {
+            before: expect.objectContaining({ singpassUuid: null }),
+            after: expect.objectContaining({
+              singpassUuid: MOCK_SINGPASS_UUID,
+            }),
+          },
+        }),
+        expect.objectContaining({
+          eventType: AuditLogEvent.Login,
+          delta: {
+            before: { attempts: null },
+            after: null,
+          },
+        }),
+      ])
+    })
+
+    it("should record the user's login audit log upon successful authentication", async () => {
+      // Arrange
+      const user = await db
+        .updateTable("User")
+        .set({ singpassUuid: MOCK_SINGPASS_UUID })
+        .where("email", "=", TEST_VALID_EMAIL)
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      session.singpass = {
+        sessionState: {
+          userId: user.id as NonNullable<
+            NonNullable<SessionData["singpass"]>["sessionState"]
+          >["userId"],
+          verificationToken: {} as never,
+          codeVerifier: "code-verifier",
+          nonce: "nonce",
+        },
+      }
+      await session.save()
+
+      vi.spyOn(SingpassService, "login").mockResolvedValue({
+        uuid: MOCK_SINGPASS_UUID,
+      })
+
+      // Act
+      await caller.callback({
+        state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+        code: "code",
+      })
+
+      // Assert
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs).toEqual([
+        expect.objectContaining({
+          eventType: AuditLogEvent.Login,
+          delta: {
+            before: { attempts: null },
+            after: null,
+          },
+        }),
+      ])
+    })
+  })
+})

--- a/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
@@ -130,6 +130,11 @@ export const singpassRouter = router({
       })
 
       if (!uuid) {
+        ctx.logger.error(
+          { code, codeVerifier, nonce, state: parsedState.data },
+          "Failed to login to Singpass",
+        )
+
         throw new TRPCError({
           // TODO: Change to SERVICE_UNAVAILABLE when TRPC is upgraded to 11.x
           code: "INTERNAL_SERVER_ERROR",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We need to add error logging and monitoring for the new 2FA flows, so we know and can respond to issues that users might face.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add logging with context to the authentication flows, so that they can be monitored via alarms on Datadog.
- Also add unit tests for the added/updated flows.