### PR TITLE
Singpass fallback - reduce TTL to 1 hour

### DIFF
--- a/apps/studio/src/hooks/useIsSingpassEnabled.ts
+++ b/apps/studio/src/hooks/useIsSingpassEnabled.ts
@@ -1,6 +1,12 @@
 import { useFeatureValue } from "@growthbook/growthbook-react"
 
-import { IS_SINGPASS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+import {
+  IS_SINGPASS_ENABLED_FEATURE_KEY,
+  IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+} from "~/lib/growthbook"
 
 export const useIsSingpassEnabled = () =>
-  useFeatureValue<boolean>(IS_SINGPASS_ENABLED_FEATURE_KEY, false)
+  useFeatureValue<boolean>(
+    IS_SINGPASS_ENABLED_FEATURE_KEY,
+    IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+  )

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -2,3 +2,4 @@ export const BANNER_FEATURE_KEY = "isomer-next-banner"
 export const ISOMER_ADMIN_FEATURE_KEY = "isomer_admins"
 export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
+export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = false

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -1,5 +1,17 @@
+import type { GrowthBook } from "@growthbook/growthbook"
+
 export const BANNER_FEATURE_KEY = "isomer-next-banner"
 export const ISOMER_ADMIN_FEATURE_KEY = "isomer_admins"
 export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = false
+
+interface IsSingpassEnabledProps {
+  gb: GrowthBook
+}
+export const isSingpassEnabled = ({ gb }: IsSingpassEnabledProps): boolean => {
+  return gb.getFeatureValue(
+    IS_SINGPASS_ENABLED_FEATURE_KEY,
+    IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+  )
+}

--- a/apps/studio/src/server/context.ts
+++ b/apps/studio/src/server/context.ts
@@ -5,10 +5,7 @@ import { type User } from "@prisma/client"
 import { getIronSession } from "iron-session"
 
 import { env } from "~/env.mjs"
-import {
-  IS_SINGPASS_ENABLED_FEATURE_KEY,
-  IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
-} from "~/lib/growthbook"
+import { isSingpassEnabled } from "~/lib/growthbook"
 import { type Session, type SessionData } from "~/lib/types/session"
 import { generateSessionOptions } from "./modules/auth/session"
 import { db } from "./modules/database"
@@ -45,13 +42,8 @@ export const createContext = async (opts: CreateNextContextOptions) => {
   })
   await growthbookContext.init({ timeout: 2000 })
 
-  const isSingpassEnabled = growthbookContext.getFeatureValue(
-    IS_SINGPASS_ENABLED_FEATURE_KEY,
-    IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
-  )
-
   // Added security measure to limit session TTL to 1 hour when Singpass is disabled
-  const sessionOptions = isSingpassEnabled
+  const sessionOptions = isSingpassEnabled({ gb: growthbookContext })
     ? generateSessionOptions({ ttlInHours: 12 })
     : generateSessionOptions({ ttlInHours: 1 })
 

--- a/apps/studio/src/server/modules/auth/session.ts
+++ b/apps/studio/src/server/modules/auth/session.ts
@@ -2,13 +2,21 @@ import { type SessionOptions } from "iron-session"
 
 import { env } from "~/env.mjs"
 
-export const sessionOptions: SessionOptions = {
-  password: {
-    "1": env.SESSION_SECRET,
-  },
-  cookieName: "auth.session-token",
-  ttl: 60 * 60 * 12, // 12 hours
-  cookieOptions: {
-    secure: env.NODE_ENV === "production",
-  },
+interface GenerateSessionOptionsProps {
+  ttlInHours?: number
+}
+export const generateSessionOptions = ({
+  ttlInHours = 12,
+}: GenerateSessionOptionsProps): SessionOptions => {
+  const ONE_HOUR = 60 * 60
+  return {
+    password: {
+      "1": env.SESSION_SECRET,
+    },
+    cookieName: "auth.session-token",
+    ttl: ONE_HOUR * ttlInHours,
+    cookieOptions: {
+      secure: env.NODE_ENV === "production",
+    },
+  }
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://www.notion.so/opengov/Isomer-Next-Decision-Matrix-for-Disabling-Singpass-as-2FA-1d177dbba78880289845fc20f53f8503#1d277dbba78880f1b071ef622311fac6

## Solution

<!-- How did you solve the problem? -->

**Improvements**:

- make TTL dynamic based on whether Singpass is enabled
- create const for fallback value for whether singpass is enabled or not, as single source of truth

