### PR TITLE
fix: storybook rendering changes (out of nowhere 😔)

### DIFF
--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -43,13 +43,10 @@ initialize({
 const trpc = createTRPCReact<AppRouter>()
 
 const StorybookEnvDecorator: Decorator = (story) => {
-  const mockEnv: EnvContextReturn["env"] = merge(
-    {
-      NEXT_PUBLIC_APP_NAME: "Isomer Studio",
-      NEXT_PUBLIC_APP_VERSION: "Storybook",
-    },
-    env,
-  )
+  const mockEnv: EnvContextReturn["env"] = merge(env, {
+    NEXT_PUBLIC_APP_NAME: "Isomer Studio",
+    NEXT_PUBLIC_APP_VERSION: "Storybook",
+  })
   return <EnvProvider env={mockEnv}>{story()}</EnvProvider>
 }
 

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -46,6 +46,9 @@ const StorybookEnvDecorator: Decorator = (story) => {
   const mockEnv: EnvContextReturn["env"] = merge(env, {
     NEXT_PUBLIC_APP_NAME: "Isomer Studio",
     NEXT_PUBLIC_APP_VERSION: "Storybook",
+    // Required to be be empty string for storybook
+    // so it will fallback to storybook static assets mock
+    NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME: "",
   })
   return <EnvProvider env={mockEnv}>{story()}</EnvProvider>
 }

--- a/apps/studio/src/features/editing-experience/components/PreviewWithoutSitemap.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewWithoutSitemap.tsx
@@ -12,7 +12,7 @@ import { RenderEngine } from "@opengovsg/isomer-components"
 import { merge } from "lodash"
 
 import { withSuspense } from "~/hocs/withSuspense"
-import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
+import { ASSETS_BASE_URL } from "~/utils/generateAssetUrl"
 import { trpc } from "~/utils/trpc"
 
 export type PreviewProps = IsomerSchema & {
@@ -66,7 +66,7 @@ function SuspendablePreview({
         ...siteConfig,
         navBarItems: navbar,
         footerItems: footer,
-        assetsBaseUrl: generateAssetBaseUrl(),
+        assetsBaseUrl: ASSETS_BASE_URL,
       }}
       LinkComponent={FakeLink}
       ScriptComponent={Script}

--- a/apps/studio/src/features/editing-experience/components/PreviewWithoutSitemap.tsx
+++ b/apps/studio/src/features/editing-experience/components/PreviewWithoutSitemap.tsx
@@ -12,7 +12,7 @@ import { RenderEngine } from "@opengovsg/isomer-components"
 import { merge } from "lodash"
 
 import { withSuspense } from "~/hocs/withSuspense"
-import { useEnv } from "~/hooks/useEnv"
+import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
 import { trpc } from "~/utils/trpc"
 
 export type PreviewProps = IsomerSchema & {
@@ -40,7 +40,6 @@ function SuspendablePreview({
   siteMap,
   ...props
 }: PreviewProps) {
-  const { env } = useEnv()
   const [siteConfig] = trpc.site.getConfig.useSuspenseQuery({ id: siteId })
   const [{ content: footer }] = trpc.site.getFooter.useSuspenseQuery({
     id: siteId,
@@ -67,7 +66,7 @@ function SuspendablePreview({
         ...siteConfig,
         navBarItems: navbar,
         footerItems: footer,
-        assetsBaseUrl: `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`,
+        assetsBaseUrl: generateAssetBaseUrl(),
       }}
       LinkComponent={FakeLink}
       ScriptComponent={Script}

--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useImage.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useImage.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-import { env } from "~/env.mjs"
+import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
 
 const waitFor = (baseTimeoutMs = 500) => {
   return new Promise((resolve) => setTimeout(resolve, baseTimeoutMs))
@@ -41,14 +41,13 @@ export const useImageUpload = ({
   retries = 3,
   baseTimeoutMs = 500,
 }: UseImageProps) => {
-  const assetsBaseUrl = `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`
   const [isLoading, setIsLoading] = useState(false)
   const handleImageUpload = async (src: string) => {
     setIsLoading(true)
     try {
       const res = await retry(
         async () => {
-          const response = await fetch(`${assetsBaseUrl}${src}`)
+          const response = await fetch(`${generateAssetBaseUrl()}${src}`)
           if (!response.ok) {
             throw new Error(`Unable to read from ${src}`)
           }

--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useImage.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useImage.ts
@@ -1,6 +1,6 @@
 import { useState } from "react"
 
-import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
+import { ASSETS_BASE_URL } from "~/utils/generateAssetUrl"
 
 const waitFor = (baseTimeoutMs = 500) => {
   return new Promise((resolve) => setTimeout(resolve, baseTimeoutMs))
@@ -47,7 +47,7 @@ export const useImageUpload = ({
     try {
       const res = await retry(
         async () => {
-          const response = await fetch(`${generateAssetBaseUrl()}${src}`)
+          const response = await fetch(`${ASSETS_BASE_URL}${src}`)
           if (!response.ok) {
             throw new Error(`Unable to read from ${src}`)
           }

--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useS3Image.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useS3Image.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 
-import { env } from "~/env.mjs"
+import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
 
 const getImageAsFile = async (imageUrl: string): Promise<File> => {
   const resp = await fetch(imageUrl)
@@ -11,7 +11,6 @@ const getImageAsFile = async (imageUrl: string): Promise<File> => {
   })
 }
 
-const assetsBaseUrl = `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`
 export const useS3Image = (imagePath: string) => {
   const [image, setImage] = useState<File | undefined>()
 
@@ -20,7 +19,7 @@ export const useS3Image = (imagePath: string) => {
       setImage(undefined)
       return
     }
-    getImageAsFile(`${assetsBaseUrl}${imagePath}`)
+    getImageAsFile(`${generateAssetBaseUrl()}${imagePath}`)
       .then((image) => {
         setImage(image)
       })

--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useS3Image.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useS3Image.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 
-import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
+import { ASSETS_BASE_URL } from "~/utils/generateAssetUrl"
 
 const getImageAsFile = async (imageUrl: string): Promise<File> => {
   const resp = await fetch(imageUrl)
@@ -19,7 +19,7 @@ export const useS3Image = (imagePath: string) => {
       setImage(undefined)
       return
     }
-    getImageAsFile(`${generateAssetBaseUrl()}${imagePath}`)
+    getImageAsFile(`${ASSETS_BASE_URL}${imagePath}`)
       .then((image) => {
         setImage(image)
       })

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -6,11 +6,9 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 
-import { env } from "~/env.mjs"
 import PageSettings from "~/pages/sites/[siteId]/pages/[pageId]/settings"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
-
-const assetsBaseUrl = `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`
+import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
 
 const uploadHandler = {
   default: () =>
@@ -22,7 +20,7 @@ const uploadHandler = {
 
 const imageHandler = {
   default: (delayMs?: number | "infinite") =>
-    http.get(`${assetsBaseUrl}/MOCK_STORYBOOK_ASSET`, async () => {
+    http.get(`${generateAssetBaseUrl()}/MOCK_STORYBOOK_ASSET`, async () => {
       await delay(delayMs)
       return fetch(
         "https://i.natgeofe.com/n/548467d8-c5f1-4551-9f58-6817a8d2c45e/NationalGeographic_2572187_3x2.jpg",

--- a/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditPageSettings.stories.tsx
@@ -8,7 +8,7 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 
 import PageSettings from "~/pages/sites/[siteId]/pages/[pageId]/settings"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
-import { generateAssetBaseUrl } from "~/utils/generateAssetUrl"
+import { ASSETS_BASE_URL } from "~/utils/generateAssetUrl"
 
 const uploadHandler = {
   default: () =>
@@ -20,7 +20,7 @@ const uploadHandler = {
 
 const imageHandler = {
   default: (delayMs?: number | "infinite") =>
-    http.get(`${generateAssetBaseUrl()}/MOCK_STORYBOOK_ASSET`, async () => {
+    http.get(`${ASSETS_BASE_URL}/MOCK_STORYBOOK_ASSET`, async () => {
       await delay(delayMs)
       return fetch(
         "https://i.natgeofe.com/n/548467d8-c5f1-4551-9f58-6817a8d2c45e/NationalGeographic_2572187_3x2.jpg",

--- a/apps/studio/src/utils/generateAssetUrl.ts
+++ b/apps/studio/src/utils/generateAssetUrl.ts
@@ -1,7 +1,11 @@
 import { env } from "~/env.mjs"
 
+export const generateAssetBaseUrl = (): string => {
+  return env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME
+    ? `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`
+    : ""
+}
+
 export const generateAssetUrl = (url: string): string => {
-  return url.startsWith("/")
-    ? `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}${url}`
-    : url
+  return url.startsWith("/") ? `${generateAssetBaseUrl()}${url}` : url
 }

--- a/apps/studio/src/utils/generateAssetUrl.ts
+++ b/apps/studio/src/utils/generateAssetUrl.ts
@@ -1,11 +1,9 @@
 import { env } from "~/env.mjs"
 
-export const generateAssetBaseUrl = (): string => {
-  return env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME
-    ? `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`
-    : ""
-}
+export const ASSETS_BASE_URL = env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME
+  ? `https://${env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME}`
+  : ""
 
 export const generateAssetUrl = (url: string): string => {
-  return url.startsWith("/") ? `${generateAssetBaseUrl()}${url}` : url
+  return url.startsWith("/") ? `${ASSETS_BASE_URL}${url}` : url
 }

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
@@ -27,7 +27,6 @@ const meta: Meta<typeof Hero> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",
@@ -93,9 +92,7 @@ export const ColourBlock: Story = {
       isGovernment: true,
       logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
-
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",
         termsOfUseLink: "https://www.isomer.gov.sg/terms",
@@ -144,7 +141,6 @@ export const ColourBlockInverse: Story = {
       isGovernment: true,
       logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
 
       footerItems: {

--- a/packages/components/src/templates/next/components/complex/Image/Image.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<ImageProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta<InfoCardsProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<InfoColsProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<InfobarProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.stories.tsx
@@ -44,7 +44,6 @@ const meta: Meta<InfopicProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<KeyStatisticsProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<ContentPageHeaderProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx
@@ -28,7 +28,6 @@ const meta: Meta<FooterProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.stories.tsx
@@ -172,7 +172,6 @@ const meta: Meta<NavbarProps> = {
       isGovernment: true,
       logoUrl: "/isomer-logo.svg",
       lastUpdated: "2021-10-01",
-      assetsBaseUrl: "https://cms.isomer.gov.sg",
       navBarItems: [],
       footerItems: {
         privacyStatementLink: "https://www.isomer.gov.sg/privacy",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Storybook starts failing after https://github.com/opengovsg/isomer/pull/1199 e.g. https://www.chromatic.com/build?appId=66543928751c844d159a31ef&number=3059&captureStack=capture-v7

suspect its due to the infrastracture upgrade from chromatic since issue started after that

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/e0b424db-5e70-4392-b716-b97a61c2ada2" />

## Solution

**Bug Fixes**:

- switch the order of env and manual overiding to not have it be overwritten e.g. https://www.chromatic.com/test?appId=66543928751c844d159a31ef&id=67ffce99c6d2e77ecc58d6d7
- create `generateAssetBaseUrl` so that we can set storybook's `NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME` as empty string for storybook so that it can fallback to use its static asset handling

**Improvements**:

- remove the need to reference `assetsBaseUrl` since we already set up static assets in storybook in https://github.com/opengovsg/isomer/pull/1222/files
- have `generateAssetBaseUrl()` as a single source of truth for asset base url

