### PR TITLE
fix: treat empty date string as dateless variant

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -57,7 +57,9 @@ export const getCollectionItems = ({
     )
     .map((item) => {
       const date =
-        item.date !== undefined ? getParsedDate(item.date) : undefined
+        item.date !== undefined && item.date !== ""
+          ? getParsedDate(item.date)
+          : undefined
 
       const baseItem = {
         type: "collectionCard" as const,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Empty date strings are being treated as an article with a date.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make empty date strings be treated as dateless variant of an article.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new article inside a collection
- [ ] Ensure that the article does not have any date set on it
- [ ] Enter the raw JSON editor mode to ensure that the `date` key is set to an empty string
- [ ] Publish the article
- [ ] Verify on the built site that the article shows up as a dateless article, instead of today's date