### PR TITLE
Fix collection sorting schema display

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -3,7 +3,7 @@ export const JSON_FORMS_RANKING = {
   ArrayControl: 4,
   BooleanControl: 2,
   ConstControl: 2,
-  HiddenControl: 2,
+  HiddenControl: 99999999999, // Always rendered first
   ImageControl: 2,
   IntegerControl: 4,
   TextAreaControl: 1,

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -92,7 +92,11 @@ export const CollectionPagePageSchema = Type.Intersect([
   Type.Object({
     defaultSortBy: Type.Optional(
       Type.Union(
-        [Type.Literal("date"), Type.Literal("title"), Type.Literal("category")],
+        [
+          Type.Literal("date", { title: "Date" }),
+          Type.Literal("title", { title: "Title" }),
+          Type.Literal("category", { title: "Category" }),
+        ],
         {
           title: "Default sort by",
           description: "The default sort order of the collection",
@@ -103,13 +107,19 @@ export const CollectionPagePageSchema = Type.Intersect([
       ),
     ),
     defaultSortDirection: Type.Optional(
-      Type.Union([Type.Literal("asc"), Type.Literal("desc")], {
-        title: "Default sort direction",
-        description: "The default sort direction of the collection",
-        format: "hidden",
-        type: "string",
-        default: "desc",
-      }),
+      Type.Union(
+        [
+          Type.Literal("asc", { title: "Ascending" }),
+          Type.Literal("desc", { title: "Descending" }),
+        ],
+        {
+          title: "Default sort direction",
+          description: "The default sort direction of the collection",
+          format: "hidden",
+          type: "string",
+          default: "desc",
+        },
+      ),
     ),
   }),
 ])


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes sorting option being shown with wrong value

<img width="576" alt="image" src="https://github.com/user-attachments/assets/33335b16-21d4-4d85-81c6-aec4c7d46489" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- set "hidden" rendering priority to 99999999999
- Add descriptive name to option (even if they won't be seen now, since its actually hidden)

## Before & After Screenshots

**AFTER**:

no longer being rendered at all

<img width="589" alt="image" src="https://github.com/user-attachments/assets/1a83fa5a-e85b-483b-842e-6a8aec901589" />

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Create a collection
2. Add a custom index page
3. Click on editing header
4. Check -> sorting options should not be displayed under the tags option