### PR TITLE
Add growthbook for isomer core 

### DIFF
--- a/apps/studio/src/components/AppNavbar.tsx
+++ b/apps/studio/src/components/AppNavbar.tsx
@@ -6,10 +6,13 @@ import { BiLinkExternal } from "react-icons/bi"
 
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { AvatarMenu } from "./AvatarMenu"
 
 export function AppNavbar(): JSX.Element {
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE],
+  })
 
   return (
     <Flex flex="0 0 auto" gridColumn="1/-1" height={ADMIN_NAVBAR_HEIGHT}>

--- a/apps/studio/src/features/dashboard/components/AdminCreateIndexPageButton.tsx
+++ b/apps/studio/src/features/dashboard/components/AdminCreateIndexPageButton.tsx
@@ -4,6 +4,7 @@ import { BiLogoDevTo } from "react-icons/bi"
 
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { trpc } from "~/utils/trpc"
 
 interface AdminCreateIndexPageButtonProps {
@@ -16,7 +17,9 @@ export const AdminCreateIndexPageButton = ({
 }: AdminCreateIndexPageButtonProps) => {
   const toast = useToast()
   const utils = trpc.useUtils()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
+  })
 
   const { data: indexPage } = trpc.resource.getIndexPage.useQuery({
     siteId,

--- a/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/LinkEditorDrawer.tsx
@@ -13,6 +13,7 @@ import type { CollectionLinkProps } from "../atoms"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { safeJsonParse } from "~/utils/safeJsonParse"
 import { trpc } from "~/utils/trpc"
 import { linkAtom, linkRefAtom } from "../atoms"
@@ -48,7 +49,9 @@ const InnerDrawer = ({
   setDrawerState,
 }: LinkEditorDrawerStateProps) => {
   const { errors } = useBuilderErrors()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
+  })
 
   return (
     <Flex flexDir="column" position="relative" h="100%" w="100%">

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -10,6 +10,7 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { trpc } from "~/utils/trpc"
 import { TYPE_TO_ICON } from "../constants"
 import { editPageSchema } from "../schema"
@@ -44,7 +45,9 @@ export default function RootStateDrawer() {
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const utils = trpc.useUtils()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
+  })
   const toast = useToast({ status: "error" })
 
   const { mutate } = trpc.page.reorderBlock.useMutation({

--- a/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
+++ b/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
@@ -2,16 +2,29 @@ import { useFeatureValue } from "@growthbook/growthbook-react"
 
 import type { GrowthbookIsomerAdminFeature } from "~/lib/growthbook"
 import { useMe } from "~/features/me/api"
-import { ISOMER_ADMIN_FEATURE_KEY } from "~/lib/growthbook"
+import { ADMIN_ROLE, ISOMER_ADMIN_FEATURE_KEY } from "~/lib/growthbook"
 
-export const useIsUserIsomerAdmin = () => {
+interface UseIsUserIsomerAdminProps {
+  roles: (typeof ADMIN_ROLE)[keyof typeof ADMIN_ROLE][]
+}
+
+export const useIsUserIsomerAdmin = ({ roles }: UseIsUserIsomerAdminProps) => {
   const {
     me: { email },
   } = useMe()
-  const { users } = useFeatureValue<GrowthbookIsomerAdminFeature>(
+
+  const { core, migrators } = useFeatureValue<GrowthbookIsomerAdminFeature>(
     ISOMER_ADMIN_FEATURE_KEY,
-    { users: [] },
+    { core: [], migrators: [] },
   )
 
-  return users.includes(email)
+  if (roles.includes(ADMIN_ROLE.CORE)) {
+    return core.includes(email)
+  }
+
+  if (roles.includes(ADMIN_ROLE.MIGRATORS)) {
+    return migrators.includes(email)
+  }
+
+  return false
 }

--- a/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
+++ b/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
@@ -18,12 +18,12 @@ export const useIsUserIsomerAdmin = ({ roles }: UseIsUserIsomerAdminProps) => {
     { core: [], migrators: [] },
   )
 
-  if (roles.includes(ADMIN_ROLE.CORE)) {
-    return core.includes(email)
+  if (roles.includes(ADMIN_ROLE.CORE) && core.includes(email)) {
+    return true
   }
 
-  if (roles.includes(ADMIN_ROLE.MIGRATORS)) {
-    return migrators.includes(email)
+  if (roles.includes(ADMIN_ROLE.MIGRATORS) && migrators.includes(email)) {
+    return true
   }
 
   return false

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -8,5 +8,11 @@ export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 // that we want. Hence, we have to define it as a type instead of an interface.
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type GrowthbookIsomerAdminFeature = {
-  users: string[]
+  [ADMIN_ROLE.CORE]: string[]
+  [ADMIN_ROLE.MIGRATORS]: string[]
 }
+
+export const ADMIN_ROLE = {
+  CORE: "core",
+  MIGRATORS: "migrators",
+} as const

--- a/apps/studio/src/pages/godmode/create-site.tsx
+++ b/apps/studio/src/pages/godmode/create-site.tsx
@@ -23,6 +23,7 @@ import {
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useZodForm } from "~/lib/form"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { type NextPageWithLayout } from "~/lib/types"
 import { createSiteSchema } from "~/schemas/site"
 import { AdminLayout } from "~/templates/layouts/AdminLayout"
@@ -31,7 +32,9 @@ import { trpc } from "~/utils/trpc"
 const GodModeCreateSitePage: NextPageWithLayout = () => {
   const toast = useToast()
   const router = useRouter()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE],
+  })
 
   if (!isUserIsomerAdmin) {
     toast({

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -11,6 +11,7 @@ import { useToast } from "@opengovsg/design-system-react"
 
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminLayout } from "~/templates/layouts/AdminLayout"
 
@@ -28,7 +29,9 @@ const GODMODE_LINKS = [
 const GodModePage: NextPageWithLayout = () => {
   const toast = useToast()
   const router = useRouter()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE],
+  })
 
   if (!isUserIsomerAdmin) {
     toast({

--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -20,6 +20,7 @@ import { useToast } from "@opengovsg/design-system-react"
 
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AdminLayout } from "~/templates/layouts/AdminLayout"
 import { trpc } from "~/utils/trpc"
@@ -27,7 +28,9 @@ import { trpc } from "~/utils/trpc"
 const GodModePublishingPage: NextPageWithLayout = () => {
   const toast = useToast()
   const router = useRouter()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE],
+  })
 
   if (!isUserIsomerAdmin) {
     toast({

--- a/apps/studio/src/pages/sites/[siteId]/admin.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/admin.tsx
@@ -24,6 +24,7 @@ import { UnsavedSettingModal } from "~/features/editing-experience/components/Un
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useZodForm } from "~/lib/form"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { type NextPageWithLayout } from "~/lib/types"
 import { setSiteConfigByAdminSchema } from "~/schemas/site"
 import { AdminSidebarOnlyLayout } from "~/templates/layouts/AdminSidebarOnlyLayout"
@@ -45,7 +46,9 @@ const SiteAdminPage: NextPageWithLayout = () => {
   const router = useRouter()
   const trpcUtils = trpc.useUtils()
   const { siteId } = useQueryParse(siteAdminSchema)
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
+  })
 
   if (!isUserIsomerAdmin) {
     toast({

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -231,7 +231,7 @@ interface ValidateUserIsIsomerAdminProps {
   gb: GrowthBook
 }
 
-export const validateUserIsIsomerAdmin = async ({
+export const validateUserIsIsomerCoreAdmin = async ({
   userId,
   gb,
 }: ValidateUserIsIsomerAdminProps) => {
@@ -241,12 +241,12 @@ export const validateUserIsIsomerAdmin = async ({
     .select(["email"])
     .executeTakeFirstOrThrow()
 
-  const { users } = gb.getFeatureValue<GrowthbookIsomerAdminFeature>(
+  const { core } = gb.getFeatureValue<GrowthbookIsomerAdminFeature>(
     ISOMER_ADMIN_FEATURE_KEY,
-    { users: [] },
+    { core: [], migrators: [] },
   )
 
-  if (!users.includes(user.email)) {
+  if (!core.includes(user.email)) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "You do not have sufficient permissions to perform this action",

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -5,6 +5,7 @@ import type {
 } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import {
   createSiteSchema,
   getConfigSchema,
@@ -50,7 +51,11 @@ export const siteRouter = router({
       .execute()
   }),
   listAllSites: protectedProcedure.query(async ({ ctx }) => {
-    await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
+    await validateUserIsIsomerCoreAdmin({
+      userId: ctx.user.id,
+      gb: ctx.gb,
+      roles: [ADMIN_ROLE.CORE],
+    })
 
     return db
       .selectFrom("Site")
@@ -338,14 +343,22 @@ export const siteRouter = router({
   create: protectedProcedure
     .input(createSiteSchema)
     .mutation(async ({ ctx, input: { siteName } }) => {
-      await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
+      await validateUserIsIsomerCoreAdmin({
+        userId: ctx.user.id,
+        gb: ctx.gb,
+        roles: [ADMIN_ROLE.CORE],
+      })
 
       return createSite({ siteName })
     }),
   publish: protectedProcedure
     .input(publishSiteSchema)
     .mutation(async ({ ctx, input: { siteId } }) => {
-      await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
+      await validateUserIsIsomerCoreAdmin({
+        userId: ctx.user.id,
+        gb: ctx.gb,
+        roles: [ADMIN_ROLE.CORE],
+      })
 
       const byUser = await db
         .selectFrom("User")
@@ -371,7 +384,11 @@ export const siteRouter = router({
       })
     }),
   publishAll: protectedProcedure.mutation(async ({ ctx }) => {
-    await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
+    await validateUserIsIsomerCoreAdmin({
+      userId: ctx.user.id,
+      gb: ctx.gb,
+      roles: [ADMIN_ROLE.CORE],
+    })
 
     const byUser = await db
       .selectFrom("User")

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -20,7 +20,7 @@ import { safeJsonParse } from "~/utils/safeJsonParse"
 import { logConfigEvent, logPublishEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { AuditLogEvent, db, jsonb } from "../database"
-import { validateUserIsIsomerAdmin } from "../permissions/permissions.service"
+import { validateUserIsIsomerCoreAdmin } from "../permissions/permissions.service"
 import {
   getFooter,
   getLocalisedSitemap,
@@ -50,7 +50,7 @@ export const siteRouter = router({
       .execute()
   }),
   listAllSites: protectedProcedure.query(async ({ ctx }) => {
-    await validateUserIsIsomerAdmin({ userId: ctx.user.id, gb: ctx.gb })
+    await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
 
     return db
       .selectFrom("Site")
@@ -338,14 +338,14 @@ export const siteRouter = router({
   create: protectedProcedure
     .input(createSiteSchema)
     .mutation(async ({ ctx, input: { siteName } }) => {
-      await validateUserIsIsomerAdmin({ userId: ctx.user.id, gb: ctx.gb })
+      await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
 
       return createSite({ siteName })
     }),
   publish: protectedProcedure
     .input(publishSiteSchema)
     .mutation(async ({ ctx, input: { siteId } }) => {
-      await validateUserIsIsomerAdmin({ userId: ctx.user.id, gb: ctx.gb })
+      await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
 
       const byUser = await db
         .selectFrom("User")
@@ -371,7 +371,7 @@ export const siteRouter = router({
       })
     }),
   publishAll: protectedProcedure.mutation(async ({ ctx }) => {
-    await validateUserIsIsomerAdmin({ userId: ctx.user.id, gb: ctx.gb })
+    await validateUserIsIsomerCoreAdmin({ userId: ctx.user.id, gb: ctx.gb })
 
     const byUser = await db
       .selectFrom("User")

--- a/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminCmsSidebarLayout.tsx
@@ -14,6 +14,7 @@ import { DirectorySidebar } from "~/features/dashboard/components/DirectorySideb
 import { useMe } from "~/features/me/api"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { type GetLayout } from "~/lib/types"
 
 export const AdminCmsSearchableLayout: GetLayout = (page) => {
@@ -43,7 +44,9 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
   const { siteId } = useQueryParse(siteSchema)
 
   const { logout } = useMe()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
+  })
 
   const pageNavItems: CmsSidebarItem[] = [
     {

--- a/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
+++ b/apps/studio/src/templates/layouts/AdminSidebarOnlyLayout.tsx
@@ -13,6 +13,7 @@ import { SearchableHeader } from "~/components/SearchableHeader"
 import { useMe } from "~/features/me/api"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { ADMIN_ROLE } from "~/lib/growthbook"
 import { type GetLayout } from "~/lib/types"
 
 export const AdminSidebarOnlyLayout: GetLayout = (page) => {
@@ -42,7 +43,9 @@ const CmsSidebarWrapper = ({ children }: PropsWithChildren) => {
   const { siteId } = useQueryParse(siteSchema)
 
   const { logout } = useMe()
-  const isUserIsomerAdmin = useIsUserIsomerAdmin()
+  const isUserIsomerAdmin = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
+  })
 
   const pageNavItems: CmsSidebarItem[] = [
     {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some features should only be limited to core team e.g. god mode

previously: https://github.com/opengovsg/isomer/pull/1251

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- split `users` into `core` and `migrators` in growthbook
- TODO: clean-up and remove `users` key-value from `isomer_admins` after this is launched