### PR TITLE
chore: reduce dependabot PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
     versioning-strategy: increase
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       aws-sdk:
         applies-to: version-updates


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Dependabot is opening too many PRs and we don't have the bandwidth to look into them.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Reduce the limit on the number of PRs open by dependabot from 10 to 5.