### PR TITLE
fix: reset the editor drawer state first before mutation

### DIFF
--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -77,10 +77,13 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
       ...previewPageState,
       content: updatedBlocks,
     }
+    // NOTE: We need to reset the drawer state before mutating the page state,
+    // as the mutation will cause the active index to point to an incorrect
+    // block, which causes the editor to crash
+    setDrawerState({ state: "root" })
     setSavedPageState(newPageState)
     setPreviewPageState(newPageState)
     onDeleteBlockModalClose()
-    setDrawerState({ state: "root" })
     setAddedBlockIndex(null)
     mutate({
       pageId,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1894.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Reset the editor drawer state before mutating the page state.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new content page.
- [ ] Create a new text component and insert any text, save the component.
- [ ] Create a contentpic component and save the component.
- [ ] Go back to the text component and delete it.
- [ ] Verify that the text component is deleted successfully without any errors.