### PR TITLE
Refactor Navbar interfaces + streamline handling of external links

### DIFF
--- a/packages/components/src/interfaces/internal/Navbar.ts
+++ b/packages/components/src/interfaces/internal/Navbar.ts
@@ -1,3 +1,4 @@
+import type { LinkProps } from "./Link"
 import type { LocalSearchProps } from "./LocalSearchInputBox"
 import type { SearchSGInputBoxProps } from "./SearchSGInputBox"
 import type { ImageClientProps } from "~/templates/next/components/complex/Image"
@@ -8,28 +9,37 @@ import type {
   ScriptComponentType,
 } from "~/types"
 
-export interface NavbarItem {
+interface BaseNavbarItem {
   name: string
-  url: string
   description?: string
-  items?: Omit<NavbarItem, "items">[]
-  referenceLinkHref?: string
 }
 
-export interface BaseNavbarProps {
+export interface NavbarItem extends BaseNavbarItem {
+  url: string
+  items?: NavbarItem[]
+}
+
+export interface ProcessedNavbarItem extends BaseNavbarItem {
+  referenceLinkHref: LinkProps["href"]
+  isExternal: LinkProps["isExternal"]
+  items?: ProcessedNavbarItem[]
+}
+
+interface BaseNavbarProps {
   layout: IsomerPageLayoutType
   search?: LocalSearchProps | SearchSGInputBoxProps
-  items: NavbarItem[]
   LinkComponent?: LinkComponentType
   ScriptComponent?: ScriptComponentType
 }
 
 export interface NavbarProps extends BaseNavbarProps {
-  logoUrl: string
-  logoAlt: string
+  logoUrl: ImageClientProps["src"]
+  logoAlt: ImageClientProps["alt"]
   site: IsomerSiteProps
+  items: NavbarItem[]
 }
 
 export interface NavbarClientProps extends BaseNavbarProps {
   imageClientProps: ImageClientProps
+  items: ProcessedNavbarItem[]
 }

--- a/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavItemAccordion.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavItemAccordion.tsx
@@ -1,13 +1,16 @@
 import { BiChevronDown } from "react-icons/bi"
 
-import type { NavbarItem, NavbarProps } from "~/interfaces/internal/Navbar"
+import type {
+  NavbarClientProps,
+  ProcessedNavbarItem,
+} from "~/interfaces/internal/Navbar"
 import { tv } from "~/lib/tv"
-import { focusVisibleHighlight, isExternalUrl } from "~/utils"
+import { focusVisibleHighlight } from "~/utils"
 import { Link } from "../../Link"
 
 interface NavItemAccordionProps
-  extends NavbarItem,
-    Pick<NavbarProps, "LinkComponent"> {
+  extends ProcessedNavbarItem,
+    Pick<NavbarClientProps, "LinkComponent"> {
   isOpen: boolean
   onClick: () => void
   index: number
@@ -36,8 +39,8 @@ const { item, chevron, container, nestedItem, sublist } = mobileItemStyles()
 
 export const MobileNavItemAccordion = ({
   name,
-  url,
   referenceLinkHref,
+  isExternal,
   items,
   isOpen,
   onClick,
@@ -48,7 +51,7 @@ export const MobileNavItemAccordion = ({
     return (
       <div className={container()}>
         <Link
-          isExternal={isExternalUrl(url)}
+          isExternal={isExternal}
           LinkComponent={LinkComponent}
           className={item({
             className: focusVisibleHighlight(),
@@ -87,7 +90,6 @@ export const MobileNavItemAccordion = ({
       >
         <ul className={sublist()}>
           {items.map((subItem) => {
-            const isExternal = isExternalUrl(subItem.url)
             return (
               <li key={subItem.name}>
                 <div
@@ -98,7 +100,7 @@ export const MobileNavItemAccordion = ({
                   <Link
                     LinkComponent={LinkComponent}
                     href={subItem.referenceLinkHref}
-                    isExternal={isExternal}
+                    isExternal={subItem.isExternal}
                     className={nestedItem({
                       className: focusVisibleHighlight(),
                     })}

--- a/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavbarMenu.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavbarMenu.tsx
@@ -6,12 +6,12 @@ import { FocusScope } from "react-aria"
 import { Button } from "react-aria-components"
 import { useScrollLock } from "usehooks-ts"
 
-import type { NavbarProps } from "~/interfaces"
+import type { NavbarClientProps } from "~/interfaces"
 import { focusVisibleHighlight } from "~/utils"
 import { MobileNavItemAccordion } from "./MobileNavItemAccordion"
 
 interface MobileNavMenuProps
-  extends Pick<NavbarProps, "items" | "LinkComponent"> {
+  extends Pick<NavbarClientProps, "items" | "LinkComponent"> {
   top: number | undefined
   openNavItemIdx: number
   setOpenNavItemIdx: Dispatch<SetStateAction<number>>

--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -7,6 +7,7 @@ import { useScrollLock } from "usehooks-ts"
 
 import type {
   NavbarItem as BaseNavbarItemProps,
+  NavbarItem,
   NavbarProps,
 } from "~/interfaces/internal/Navbar"
 import { tv } from "~/lib/tv"
@@ -86,6 +87,7 @@ export const NavItem = forwardRef<HTMLButtonElement, NavbarItemProps>(
           <Megamenu
             name={name}
             description={description}
+            referenceLinkHref={referenceLinkHref}
             items={items}
             LinkComponent={LinkComponent}
             onCloseMegamenu={onCloseMegamenu}
@@ -99,17 +101,38 @@ export const NavItem = forwardRef<HTMLButtonElement, NavbarItemProps>(
 const Megamenu = ({
   name,
   description,
+  referenceLinkHref,
   onCloseMegamenu,
   items,
   LinkComponent,
-}: {
-  name: string
-  description?: string
-  items: BaseNavbarItemProps[]
+}: Pick<NavbarItem, "name" | "description" | "referenceLinkHref" | "items"> & {
   LinkComponent: NavbarProps["LinkComponent"]
   onCloseMegamenu: () => void
 }) => {
   useScrollLock()
+
+  const renderTitleContent = () => {
+    if (!referenceLinkHref) {
+      return name
+    }
+
+    const isExternal = isExternalUrl(referenceLinkHref)
+    return (
+      <Link
+        LinkComponent={LinkComponent}
+        isExternal={isExternal}
+        showExternalIcon={isExternal}
+        isWithFocusVisibleHighlight
+        href={referenceLinkHref}
+        className="group inline-flex w-fit items-center gap-1 hover:text-brand-interaction-hover hover:no-underline"
+      >
+        {name}
+        {!isExternal && (
+          <BiRightArrowAlt className="text-[1.5rem] transition ease-in group-hover:translate-x-1" />
+        )}
+      </Link>
+    )
+  }
 
   return (
     <div className="absolute left-0 right-0 top-full z-50">
@@ -122,7 +145,9 @@ const Megamenu = ({
           <div className="mx-auto flex w-full max-w-screen-xl flex-col gap-8 px-10 pb-16 pt-12">
             <div className="flex w-full flex-row items-start">
               <div className="flex flex-col gap-1">
-                <h2 className="prose-display-sm text-base-content">{name}</h2>
+                <h2 className="prose-display-sm text-base-content">
+                  {renderTitleContent()}
+                </h2>
                 {description && (
                   <p className="prose-label-sm-regular text-base-content-subtle">
                     {description}

--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -168,7 +168,7 @@ const Megamenu = ({
             </div>
 
             <ul className="grid grid-cols-3 gap-x-16 gap-y-8">
-              {items.map((subItem) => {
+              {items?.map((subItem) => {
                 const isExternal = isExternalUrl(subItem.url)
                 return (
                   <li key={subItem.name}>

--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -7,7 +7,6 @@ import { useScrollLock } from "usehooks-ts"
 
 import type {
   NavbarItem as BaseNavbarItemProps,
-  NavbarItem,
   NavbarProps,
 } from "~/interfaces/internal/Navbar"
 import { tv } from "~/lib/tv"
@@ -105,7 +104,10 @@ const Megamenu = ({
   onCloseMegamenu,
   items,
   LinkComponent,
-}: Pick<NavbarItem, "name" | "description" | "referenceLinkHref" | "items"> & {
+}: Pick<
+  BaseNavbarItemProps,
+  "name" | "description" | "referenceLinkHref" | "items"
+> & {
   LinkComponent: NavbarProps["LinkComponent"]
   onCloseMegamenu: () => void
 }) => {

--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -6,21 +6,17 @@ import { BiChevronDown, BiRightArrowAlt, BiX } from "react-icons/bi"
 import { useScrollLock } from "usehooks-ts"
 
 import type {
-  NavbarItem as BaseNavbarItemProps,
-  NavbarProps,
+  NavbarClientProps,
+  ProcessedNavbarItem as ProcessedNavbarItemProps,
 } from "~/interfaces/internal/Navbar"
 import { tv } from "~/lib/tv"
-import {
-  focusVisibleHighlight,
-  groupFocusVisibleHighlight,
-  isExternalUrl,
-} from "~/utils"
+import { focusVisibleHighlight, groupFocusVisibleHighlight } from "~/utils"
 import { IconButton } from "../IconButton"
 import { Link } from "../Link"
 
 interface NavbarItemProps
-  extends BaseNavbarItemProps,
-    Pick<NavbarProps, "LinkComponent"> {
+  extends ProcessedNavbarItemProps,
+    Pick<NavbarClientProps, "LinkComponent"> {
   isOpen: boolean
   onClick: () => void
   onCloseMegamenu: () => void
@@ -51,8 +47,8 @@ export const NavItem = forwardRef<HTMLButtonElement, NavbarItemProps>(
       items,
       LinkComponent,
       name,
-      url,
       referenceLinkHref,
+      isExternal,
       description,
       isOpen,
       onClick,
@@ -65,8 +61,8 @@ export const NavItem = forwardRef<HTMLButtonElement, NavbarItemProps>(
         <li className={item({ isOpen })}>
           <Link
             LinkComponent={LinkComponent}
-            isExternal={isExternalUrl(url)}
-            showExternalIcon={isExternalUrl(url)}
+            isExternal={isExternal}
+            showExternalIcon={isExternal}
             href={referenceLinkHref}
             className={focusVisibleHighlight()}
           >
@@ -87,6 +83,7 @@ export const NavItem = forwardRef<HTMLButtonElement, NavbarItemProps>(
             name={name}
             description={description}
             referenceLinkHref={referenceLinkHref}
+            isExternal={isExternal}
             items={items}
             LinkComponent={LinkComponent}
             onCloseMegamenu={onCloseMegamenu}
@@ -101,16 +98,11 @@ const Megamenu = ({
   name,
   description,
   referenceLinkHref,
-  onCloseMegamenu,
+  isExternal,
   items,
   LinkComponent,
-}: Pick<
-  BaseNavbarItemProps,
-  "name" | "description" | "referenceLinkHref" | "items"
-> & {
-  LinkComponent: NavbarProps["LinkComponent"]
-  onCloseMegamenu: () => void
-}) => {
+  onCloseMegamenu,
+}: Omit<NavbarItemProps, "isOpen" | "onClick">) => {
   useScrollLock()
 
   const renderTitleContent = () => {
@@ -118,7 +110,6 @@ const Megamenu = ({
       return name
     }
 
-    const isExternal = isExternalUrl(referenceLinkHref)
     return (
       <Link
         LinkComponent={LinkComponent}
@@ -169,14 +160,13 @@ const Megamenu = ({
 
             <ul className="grid grid-cols-3 gap-x-16 gap-y-8">
               {items?.map((subItem) => {
-                const isExternal = isExternalUrl(subItem.url)
                 return (
                   <li key={subItem.name}>
                     <div className="flex flex-col gap-1.5">
                       <Link
                         LinkComponent={LinkComponent}
-                        isExternal={isExternal}
-                        showExternalIcon={isExternal}
+                        isExternal={subItem.isExternal}
+                        showExternalIcon={subItem.isExternal}
                         isWithFocusVisibleHighlight
                         href={subItem.referenceLinkHref}
                         className="group prose-label-md-medium inline-flex w-fit items-center gap-1 text-base-content hover:text-brand-interaction-hover hover:no-underline"

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.stories.tsx
@@ -37,7 +37,7 @@ const meta: Meta<NavbarProps> = {
       {
         name: "Max 70 chars",
         description: "This is a description of the item.",
-        url: "/item-one",
+        url: "",
         items: [
           {
             name: "Join us",
@@ -80,7 +80,7 @@ const meta: Meta<NavbarProps> = {
       {
         name: "On navbar",
         url: "/item-two",
-        description: "This is a description of the item.",
+        description: "This navbar item has a reference link",
         items: [
           {
             name: "A sub item",
@@ -216,6 +216,19 @@ export const ExpandFirstItem: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await userEvent.click(canvas.getByRole("button", { name: /max 70 chars/i }))
+  },
+}
+
+export const ExpandNavbarItemWithLink: Story = {
+  parameters: {
+    viewport: {
+      defaultViewport: getViewportByMode("desktop"),
+    },
+    chromatic: withChromaticModes(["desktop"]),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole("button", { name: /on navbar/i }))
   },
 }
 

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -1,5 +1,10 @@
+import { omit } from "lodash"
+
 import type { NavbarProps } from "~/interfaces"
-import type { NavbarItem } from "~/interfaces/internal/Navbar"
+import type {
+  NavbarItem,
+  ProcessedNavbarItem,
+} from "~/interfaces/internal/Navbar"
 import { getReferenceLinkHref, isExternalUrl } from "~/utils"
 import NavbarClient from "./NavbarClient"
 
@@ -16,13 +21,14 @@ export const Navbar = ({
   LinkComponent,
 }: Omit<NavbarProps, "type">) => {
   // recursive function to process each navbar item
-  const processNavItem = (item: NavbarItem): NavbarItem => ({
-    ...item,
+  const processNavItem = (item: NavbarItem): ProcessedNavbarItem => ({
+    ...omit(item, "url"),
     referenceLinkHref: getReferenceLinkHref(
       item.url,
       site.siteMap,
       site.assetsBaseUrl,
     ),
+    isExternal: isExternalUrl(item.url),
     items: item.items?.map(processNavItem),
   })
 


### PR DESCRIPTION
> [!NOTE]
> Done but keeping as draft first as underlying base branch not ready yet. Decided to keep separate since this is an engineering improvement + reduce scope of PR 

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

- room for improvement for how we handle interfaces as distinction between server and client props aren't quite clear
- computing `isExternalUrl` on client side (`use client`) when it can be done beforehand - there's room for improvement to reduce file size of page generated, esp. since navbar is found in all pages

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- remove the need for `url` props and `isExternalUrl` utils - this reduces the file size and egress of the each pages served
- simplify interfaces and make the distinction between server/client more explicit