### PR TITLE
Fix/truncated 100th item

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1462,6 +1462,10 @@ video {
   aspect-ratio: 2/1;
 }
 
+.aspect-\[3\/2\] {
+  aspect-ratio: 3/2;
+}
+
 .aspect-\[5\/6\] {
   aspect-ratio: 5/6;
 }
@@ -1509,10 +1513,6 @@ video {
 
 .h-\[0\.6rem\] {
   height: 0.6rem;
-}
-
-.h-\[11\.875rem\] {
-  height: 11.875rem;
 }
 
 .h-\[160px\] {
@@ -2815,8 +2815,8 @@ video {
   padding-right: 1rem;
 }
 
-.ps-8 {
-  padding-inline-start: 2rem;
+.ps-9 {
+  padding-inline-start: 2.25rem;
 }
 
 .pt-0 {
@@ -4898,14 +4898,6 @@ video {
     height: 1rem;
   }
 
-  .md\:h-52 {
-    height: 13rem;
-  }
-
-  .md\:h-60 {
-    height: 15rem;
-  }
-
   .md\:w-1\/2 {
     width: 50%;
   }
@@ -5144,8 +5136,16 @@ video {
     display: none;
   }
 
+  .lg\:aspect-\[2\/1\] {
+    aspect-ratio: 2/1;
+  }
+
   .lg\:aspect-\[3\/2\] {
     aspect-ratio: 3/2;
+  }
+
+  .lg\:aspect-square {
+    aspect-ratio: 1 / 1;
   }
 
   .lg\:h-16 {

--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
@@ -21,7 +21,7 @@ const OrderedList = ({
 }: OrderedListProps) => {
   return (
     <ol
-      className={`mt-6 ps-8 ${getOrderedListType(level)}`}
+      className={`mt-6 ps-9 ${getOrderedListType(level)}`}
       start={attrs?.start}
     >
       {content.map((item, index) => (

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
@@ -19,7 +19,7 @@ const UnorderedList = ({
   site,
 }: UnorderedListProps) => {
   return (
-    <ul className={`mt-6 ps-8 ${getUnorderedListType(level)}`}>
+    <ul className={`mt-6 ps-9 ${getUnorderedListType(level)}`}>
       {content.map((item, index) => (
         <ListItem
           key={index}

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -567,3 +567,30 @@ export const TaggedArticle: Story = {
     ],
   },
 }
+
+// Placing this story here as it's due to the overflow-x-auto class on the parent div
+export const OrderedList100Items: Story = {
+  name: "100th Ordered Marker Not Truncated",
+  args: {
+    ...generateArgs({ summary: "" }),
+    content: [
+      {
+        type: "prose",
+        content: [
+          {
+            type: "orderedList",
+            content: Array.from({ length: 100 }, (_, i) => ({
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: `Item ${i + 1}` }],
+                },
+              ],
+            })),
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

ordered list beyond 100th item in an article page are truncated off

![image](https://github.com/user-attachments/assets/0542d8d5-5068-4ec0-8b72-ee6716b419dd)

re: https://opengovproducts.slack.com/archives/C07CWUNUL68/p1745399835855599

## Solution

<!-- How did you solve the problem? -->

**Bug Fixes**:

- increase the padding slightly 

## Tests

<!-- What tests should be run to confirm functionality? -->

- refer to storybook