### PR TITLE
feat: add toggle to switch to new index page

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1422,10 +1422,6 @@ video {
   -webkit-line-clamp: 3;
 }
 
-.\!block {
-  display: block !important;
-}
-
 .block {
   display: block;
 }
@@ -1533,10 +1529,6 @@ video {
 
 .h-\[0\.6rem\] {
   height: 0.6rem;
-}
-
-.h-\[11\.875rem\] {
-  height: 11.875rem;
 }
 
 .h-\[160px\] {
@@ -2884,10 +2876,6 @@ video {
   padding-right: 0.25rem;
 }
 
-.pr-10 {
-  padding-right: 2.5rem;
-}
-
 .pr-14 {
   padding-right: 3.5rem;
 }
@@ -2902,10 +2890,6 @@ video {
 
 .pr-4 {
   padding-right: 1rem;
-}
-
-.ps-8 {
-  padding-inline-start: 2rem;
 }
 
 .ps-9 {
@@ -3292,11 +3276,6 @@ video {
   color: rgb(55 65 81 / var(--tw-text-opacity));
 }
 
-.text-gray-800 {
-  --tw-text-opacity: 1;
-  color: rgb(31 41 55 / var(--tw-text-opacity));
-}
-
 .text-gray-900 {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
@@ -3320,11 +3299,6 @@ video {
 .text-link {
   --tw-text-opacity: 1;
   color: rgb(26 86 229 / var(--tw-text-opacity));
-}
-
-.text-link-hover {
-  --tw-text-opacity: 1;
-  color: rgb(21 71 190 / var(--tw-text-opacity));
 }
 
 .text-site-secondary {
@@ -5121,28 +5095,8 @@ video {
     height: 1rem;
   }
 
-  .md\:h-52 {
-    height: 13rem;
-  }
-
-  .md\:h-60 {
-    height: 15rem;
-  }
-
-  .md\:h-\[240px\] {
-    height: 240px;
-  }
-
-  .md\:max-h-full {
-    max-height: 100%;
-  }
-
   .md\:w-1\/2 {
     width: 50%;
-  }
-
-  .md\:w-\[200px\] {
-    width: 200px;
   }
 
   .md\:min-w-\[67\%\] {
@@ -5292,11 +5246,6 @@ video {
     text-align: center;
   }
 
-  .md\:text-2xl {
-    font-size: 1.5rem;
-    line-height: 2rem;
-  }
-
   .md\:text-5xl {
     font-size: 3rem;
     line-height: 1;
@@ -5380,24 +5329,12 @@ video {
     margin-left: 6rem;
   }
 
-  .lg\:ml-4 {
-    margin-left: 1rem;
-  }
-
   .lg\:mr-24 {
     margin-right: 6rem;
   }
 
   .lg\:mr-3 {
     margin-right: 0.75rem;
-  }
-
-  .lg\:mt-0 {
-    margin-top: 0px;
-  }
-
-  .lg\:mt-2 {
-    margin-top: 0.5rem;
   }
 
   .lg\:mt-\[0\.2rem\] {
@@ -5458,10 +5395,6 @@ video {
 
   .lg\:w-1\/2 {
     width: 50%;
-  }
-
-  .lg\:w-1\/4 {
-    width: 25%;
   }
 
   .lg\:w-4 {
@@ -5644,6 +5577,10 @@ video {
     padding-left: 6rem;
   }
 
+  .lg\:pr-10 {
+    padding-right: 2.5rem;
+  }
+
   .lg\:pr-12 {
     padding-right: 3rem;
   }
@@ -5654,11 +5591,6 @@ video {
 
   .lg\:pt-10 {
     padding-top: 2.5rem;
-  }
-
-  .lg\:text-4xl {
-    font-size: 2.25rem;
-    line-height: 2.5rem;
   }
 
   .lg\:text-\[0\.875rem\] {
@@ -5846,12 +5778,6 @@ video {
 
 .\[\&\:not\(\:first-child\)\]\:mt-9:not(:first-child) {
   margin-top: 2.25rem;
-}
-
-.\[\&\:not\(\:first-child\)\]\:first-of-type\:mt-7:first-of-type:not(
-    :first-child
-  ) {
-  margin-top: 1.75rem;
 }
 
 .\[\&\:not\(\:last-child\)\]\:mb-0:not(:last-child) {

--- a/apps/studio/src/components/Disable.tsx
+++ b/apps/studio/src/components/Disable.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from "react"
+import { Box } from "@chakra-ui/react"
+
+interface DisableProps {
+  when?: boolean
+}
+
+export const Disable = ({
+  when,
+  children,
+}: PropsWithChildren<DisableProps>): JSX.Element => {
+  return when ? (
+    // NOTE: This is done so that the cursor has the disabled icon
+    // while not permitting any `onClick` events.
+    // Combining them into the same element leads to
+    // the cursor icon being active.
+    <Box cursor="not-allowed" w="full" h="full">
+      <Box pointerEvents="none" w="full" h="full">
+        {children}
+      </Box>
+    </Box>
+  ) : (
+    <>{children}</>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/ConfirmConvertIndexPageModal/ConfirmConvertIndexPageModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/ConfirmConvertIndexPageModal/ConfirmConvertIndexPageModal.tsx
@@ -1,0 +1,51 @@
+import {
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+} from "@chakra-ui/react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
+
+interface ConfirmConvertIndexPageModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onProceed: () => void
+}
+
+export const ConfirmConvertIndexPageModal = ({
+  isOpen,
+  onClose,
+  onProceed,
+}: ConfirmConvertIndexPageModalProps): JSX.Element => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader pr="4.5rem">
+          Are you sure you want to accept these changes?
+        </ModalHeader>
+
+        <ModalCloseButton size="lg" />
+
+        <ModalBody>
+          <Text textStyle="body-2">All your custom content will be lost.</Text>
+        </ModalBody>
+
+        <ModalFooter>
+          <HStack spacing="1rem">
+            <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+              No, cancel
+            </Button>
+            <Button variant="solid" onClick={onProceed}>
+              Accept changes
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/ConfirmConvertIndexPageModal/ConfirmConvertIndexPageModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/ConfirmConvertIndexPageModal/ConfirmConvertIndexPageModal.tsx
@@ -32,7 +32,7 @@ export const ConfirmConvertIndexPageModal = ({
         <ModalCloseButton size="lg" />
 
         <ModalBody>
-          <Text textStyle="body-2">All your custom content will be lost.</Text>
+          <Text textStyle="body-2">This cannot be undone.</Text>
         </ModalBody>
 
         <ModalFooter>

--- a/apps/studio/src/features/editing-experience/components/ConfirmConvertIndexPageModal/index.ts
+++ b/apps/studio/src/features/editing-experience/components/ConfirmConvertIndexPageModal/index.ts
@@ -1,0 +1,1 @@
+export * from "./ConfirmConvertIndexPageModal"

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -159,7 +159,7 @@ export default function RootStateDrawer() {
     // NOTE: This is defined but we just do the assertion here
     // because the type for `DEFAULT_BLOCKS` is possibly undefined
     // so `ts` cannot infer
-    if (!DEFAULT_BLOCKS.childpage) return
+    if (!DEFAULT_BLOCKS.childrenpages) return
 
     const newPageState = {
       ...savedPageState,
@@ -167,7 +167,10 @@ export default function RootStateDrawer() {
     // NOTE: This layout needs to be outside, otherwise it is treated as a
     // string type rather than the array of layout consts
     newPageState.layout = "index"
-    newPageState.content = [...savedPageState.content, DEFAULT_BLOCKS.childpage]
+    newPageState.content = [
+      ...savedPageState.content,
+      DEFAULT_BLOCKS.childrenpages,
+    ]
     setPreviewPageState(newPageState)
     setIsPreviewingIndexPage(true)
   }, [savedPageState, setPreviewPageState])

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -167,7 +167,7 @@ export default function RootStateDrawer() {
     // NOTE: This layout needs to be outside, otherwise it is treated as a
     // string type rather than the array of layout consts
     newPageState.layout = "index"
-    newPageState.content = [DEFAULT_BLOCKS.childpage]
+    newPageState.content = [...savedPageState.content, DEFAULT_BLOCKS.childpage]
     setPreviewPageState(newPageState)
     setIsPreviewingIndexPage(true)
   }, [savedPageState, setPreviewPageState])

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -1,11 +1,22 @@
 import type { DropResult } from "@hello-pangea/dnd"
-import { useCallback } from "react"
-import { Box, Button, Flex, Icon, Text, VStack } from "@chakra-ui/react"
+import { useCallback, useState } from "react"
+import {
+  Box,
+  Button,
+  Flex,
+  Icon,
+  Text,
+  useDisclosure,
+  VStack,
+} from "@chakra-ui/react"
 import { DragDropContext, Droppable } from "@hello-pangea/dnd"
-import { useToast } from "@opengovsg/design-system-react"
+import { Infobox, useToast } from "@opengovsg/design-system-react"
 import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 import { BiPin, BiPlus, BiPlusCircle } from "react-icons/bi"
 
+import { Disable } from "~/components/Disable"
+import { DEFAULT_BLOCKS } from "~/components/PageEditor/constants"
 import { BlockEditingPlaceholder } from "~/components/Svg"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -18,6 +29,8 @@ import { editPageSchema } from "../schema"
 import { ActivateRawJsonEditorMode } from "./ActivateRawJsonEditorMode"
 import { BaseBlock } from "./Block/BaseBlock"
 import { DraggableBlock } from "./Block/DraggableBlock"
+import { ConfirmConvertIndexPageModal } from "./ConfirmConvertIndexPageModal"
+import { CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE } from "./constants"
 
 interface FixedBlockContent {
   label: string
@@ -41,19 +54,26 @@ const FIXED_BLOCK_CONTENT: Record<string, FixedBlockContent> = {
 
 export default function RootStateDrawer() {
   const {
+    type,
     setDrawerState,
     setCurrActiveIdx,
     savedPageState,
     setSavedPageState,
+    previewPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
-
+  const [isPreviewingIndexPage, setIsPreviewingIndexPage] = useState(false)
+  const {
+    isOpen: isConfirmConvertIndexPageModalOpen,
+    onOpen: onConfirmConvertIndexPageModalOpen,
+    onClose: onConfirmConvertIndexPageModalClose,
+  } = useDisclosure()
   const { pageId, siteId } = useQueryParse(editPageSchema)
   const utils = trpc.useUtils()
   const isUserIsomerAdmin = useIsUserIsomerAdmin({
     roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
   })
-  const toast = useToast({ status: "error" })
+  const toast = useToast()
 
   const { mutate } = trpc.page.reorderBlock.useMutation({
     onSuccess: async () => {
@@ -77,10 +97,23 @@ export default function RootStateDrawer() {
       toast({
         title: "Failed to update blocks",
         description: error.message,
+        status: "error",
         ...BRIEF_TOAST_SETTINGS,
       })
     },
   })
+
+  const { mutate: savePage, isLoading: isSavingPage } =
+    trpc.page.updatePageBlob.useMutation({
+      onSuccess: async () => {
+        await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
+        await utils.page.readPage.invalidate({ pageId, siteId })
+        toast({
+          title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
+          ...BRIEF_TOAST_SETTINGS,
+        })
+      },
+    })
 
   const onDragEnd = useCallback(
     (result: DropResult) => {
@@ -122,7 +155,55 @@ export default function RootStateDrawer() {
     ],
   )
 
-  const pageLayout: string = savedPageState.layout
+  const handleConversionToIndexPage = useCallback(() => {
+    // NOTE: This is defined but we just do the assertion here
+    // because the type for `DEFAULT_BLOCKS` is possibly undefined
+    // so `ts` cannot infer
+    if (!DEFAULT_BLOCKS.childpage) return
+
+    const newPageState = {
+      ...savedPageState,
+    }
+    // NOTE: This layout needs to be outside, otherwise it is treated as a
+    // string type rather than the array of layout consts
+    newPageState.layout = "index"
+    newPageState.content = [DEFAULT_BLOCKS.childpage]
+    setPreviewPageState(newPageState)
+    setIsPreviewingIndexPage(true)
+  }, [savedPageState, setPreviewPageState])
+
+  const handleCancelConversionToIndexPage = useCallback(() => {
+    setIsPreviewingIndexPage(false)
+    setPreviewPageState(savedPageState)
+  }, [savedPageState, setPreviewPageState])
+
+  const handleSaveConversionToIndexPage = useCallback(() => {
+    savePage(
+      {
+        pageId,
+        siteId,
+        content: JSON.stringify(previewPageState),
+      },
+      {
+        onSuccess: () => {
+          setIsPreviewingIndexPage(false)
+          setSavedPageState(previewPageState)
+          onConfirmConvertIndexPageModalClose()
+          setDrawerState({ state: "root" })
+        },
+      },
+    )
+  }, [
+    onConfirmConvertIndexPageModalClose,
+    pageId,
+    previewPageState,
+    savePage,
+    setDrawerState,
+    setSavedPageState,
+    siteId,
+  ])
+
+  const pageLayout = previewPageState.layout
 
   // NOTE: because we migrate from github -> studio
   // and also becuase our underlying is just json,
@@ -133,152 +214,265 @@ export default function RootStateDrawer() {
     savedPageState.content.length > 0 &&
     savedPageState.content[0]?.type === "hero"
 
+  const isCustomContentIndexPage =
+    type === ResourceType.IndexPage && pageLayout !== "index"
+
   return (
-    <VStack gap="1.5rem" p="1.5rem">
-      {isUserIsomerAdmin && (
-        <ActivateRawJsonEditorMode
-          onActivate={() => setDrawerState({ state: "rawJsonEditor" })}
-        />
-      )}
-      {/* Fixed Blocks Section */}
-      <VStack gap="1rem" w="100%" align="start">
-        <VStack gap="0.25rem" align="start">
-          <Text textStyle="subhead-1">Fixed blocks</Text>
-          <Text textStyle="caption-2" color="base.content.medium">
-            These components are fixed for the layout and cannot be deleted
-          </Text>
-        </VStack>
-        {isHeroFixedBlock ? (
-          <BaseBlock
-            onClick={() => {
-              setCurrActiveIdx(0)
-              setDrawerState({ state: "heroEditor" })
-            }}
-            label="Hero banner"
-            description="Title, subtitle, and Call-to-Action"
-            icon={TYPE_TO_ICON.hero}
-          />
-        ) : (
-          <BaseBlock
-            onClick={() => {
-              setDrawerState({ state: "metadataEditor" })
-            }}
-            label={
-              FIXED_BLOCK_CONTENT[pageLayout]?.label ||
-              "Page description and summary"
-            }
-            description={
-              FIXED_BLOCK_CONTENT[pageLayout]?.description || "Click to edit"
-            }
-            icon={BiPin}
+    <Flex direction="column" h="full">
+      <ConfirmConvertIndexPageModal
+        isOpen={isConfirmConvertIndexPageModalOpen}
+        onClose={onConfirmConvertIndexPageModalClose}
+        onProceed={handleSaveConversionToIndexPage}
+      />
+
+      <VStack gap="1.5rem" p="1.5rem" flex={1}>
+        {isUserIsomerAdmin && (
+          <ActivateRawJsonEditorMode
+            onActivate={() => setDrawerState({ state: "rawJsonEditor" })}
           />
         )}
-      </VStack>
 
-      <VStack w="100%" h="100%" gap="1rem">
-        {/* Custom Blocks Section */}
-        <Flex flexDirection="row" w="100%">
-          <VStack gap="0.25rem" align="start" flex={1}>
-            <Text textStyle="subhead-1">Custom blocks</Text>
-            <Text textStyle="caption-2" color="base.content.medium">
-              Use blocks to display your content in various ways
-            </Text>
-          </VStack>
-          {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Index && (
-            <Button
-              size="xs"
-              flexShrink={0}
-              leftIcon={<BiPlusCircle fontSize="1.25rem" />}
-              variant="clear"
-              onClick={() => setDrawerState({ state: "addBlock" })}
+        <VStack w="100%" h="100%" gap="1rem">
+          {isCustomContentIndexPage && (
+            <Infobox
+              size="sm"
+              border="1px solid"
+              borderColor="utility.feedback.info"
+              borderRadius="0.25rem"
             >
-              Add block
-            </Button>
-          )}
-        </Flex>
-        <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="blocks">
-            {(provided) => (
-              <VStack
-                {...provided.droppableProps}
-                w="100%"
-                ref={provided.innerRef}
-              >
-                <Box w="100%">
-                  {((isHeroFixedBlock && savedPageState.content.length === 1) ||
-                    (savedPageState.content.length === 0 &&
-                      pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Index)) && (
-                    <>
-                      <VStack
-                        justifyContent="center"
-                        spacing={0}
-                        mt="2.75rem"
-                        mb="1.5rem"
-                      >
-                        <BlockEditingPlaceholder />
-                        <Text
-                          mt="0.75rem"
-                          textStyle="subhead-1"
-                          color="base.content.default"
-                        >
-                          Blocks you add will appear here
-                        </Text>
-                        <Text
-                          mt="0.25rem"
-                          textStyle="caption-2"
-                          color="base.content.medium"
-                        >
-                          Click the ‘Add block’ button above to add blocks to
-                          this page
-                        </Text>
-                      </VStack>
+              <VStack spacing="0.75rem" alignItems="start">
+                <VStack spacing="0.25rem" alignItems="start">
+                  <Text textStyle="body-2">
+                    You’re using a custom layout for this page.
+                  </Text>
+                  <Text textStyle="body-2">
+                    You can choose to use the new index page layout, but you
+                    will lose all custom content you’ve added.
+                  </Text>
+                </VStack>
 
-                      <Button
-                        variant="outline"
-                        w="100%"
-                        onClick={() => setDrawerState({ state: "addBlock" })}
-                        leftIcon={<Icon as={BiPlus} fontSize="1.25rem" />}
-                      >
-                        Add a new block
-                      </Button>
-                    </>
-                  )}
-
-                  <Flex flexDirection="column" mt="-0.25rem">
-                    {savedPageState.content.map((block, index) => {
-                      if (isHeroFixedBlock && index === 0) {
-                        return <></>
-                      }
-
-                      return (
-                        <DraggableBlock
-                          block={block}
-                          // TODO: Generate a block ID instead of index
-                          key={`${block.type}-${index}`}
-                          // TODO: Use block ID when instead of index for uniquely identifying blocks
-                          draggableId={`${block.type}-${index}`}
-                          index={index}
-                          onClick={() => {
-                            setCurrActiveIdx(index)
-                            // TODO: we should automatically do this probably?
-                            const nextState =
-                              savedPageState.content[index]?.type === "prose"
-                                ? "nativeEditor"
-                                : "complexEditor"
-                            // NOTE: SNAPSHOT
-                            setDrawerState({ state: nextState })
-                          }}
-                        />
-                      )
-                    })}
-                  </Flex>
-                </Box>
-                {provided.placeholder}
+                <Button
+                  textStyle="body-2"
+                  variant="link"
+                  fontSize="0.875rem"
+                  onClick={() => handleConversionToIndexPage()}
+                >
+                  Preview what this looks like
+                </Button>
               </VStack>
-            )}
-          </Droppable>
-        </DragDropContext>
+            </Infobox>
+          )}
+
+          {isPreviewingIndexPage && (
+            <Infobox
+              size="sm"
+              border="1px solid"
+              borderColor="utility.feedback.info"
+              borderRadius="0.25rem"
+              w="full"
+            >
+              <Text textStyle="body-2">
+                You’re previewing what you’ll see once you accept the change.
+              </Text>
+            </Infobox>
+          )}
+
+          {/* Fixed Blocks Section */}
+          <Disable when={isPreviewingIndexPage}>
+            <VStack gap="1.5rem" flex={1} w="full">
+              <VStack gap="1rem" w="100%" align="start">
+                <VStack gap="0.25rem" align="start">
+                  <Text textStyle="subhead-1">Fixed blocks</Text>
+                  <Text textStyle="caption-2" color="base.content.medium">
+                    These components are fixed for the layout and cannot be
+                    deleted
+                  </Text>
+                </VStack>
+
+                {isHeroFixedBlock ? (
+                  <BaseBlock
+                    onClick={() => {
+                      setCurrActiveIdx(0)
+                      setDrawerState({ state: "heroEditor" })
+                    }}
+                    label="Hero banner"
+                    description="Title, subtitle, and Call-to-Action"
+                    icon={TYPE_TO_ICON.hero}
+                  />
+                ) : (
+                  <BaseBlock
+                    onClick={() => {
+                      setDrawerState({ state: "metadataEditor" })
+                    }}
+                    label={
+                      FIXED_BLOCK_CONTENT[pageLayout]?.label ||
+                      "Page description and summary"
+                    }
+                    description={
+                      FIXED_BLOCK_CONTENT[pageLayout]?.description ||
+                      "Click to edit"
+                    }
+                    icon={BiPin}
+                  />
+                )}
+              </VStack>
+
+              <VStack gap="1.5rem" w="100%">
+                <VStack w="100%" h="100%" gap="1rem">
+                  {/* Custom Blocks Section */}
+                  {/* Custom Blocks Section */}
+                  <Flex flexDirection="row" w="100%">
+                    <VStack gap="0.25rem" align="start" flex={1}>
+                      <Text textStyle="subhead-1">Custom blocks</Text>
+                      <Text textStyle="caption-2" color="base.content.medium">
+                        Use blocks to display your content in various ways
+                      </Text>
+                    </VStack>
+                    {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Index && (
+                      <Button
+                        size="xs"
+                        flexShrink={0}
+                        leftIcon={<BiPlusCircle fontSize="1.25rem" />}
+                        variant="clear"
+                        onClick={() => setDrawerState({ state: "addBlock" })}
+                      >
+                        Add block
+                      </Button>
+                    )}
+                  </Flex>
+                  <DragDropContext onDragEnd={onDragEnd}>
+                    <Droppable droppableId="blocks">
+                      {(provided) => (
+                        <VStack
+                          {...provided.droppableProps}
+                          w="100%"
+                          ref={provided.innerRef}
+                        >
+                          <Box w="100%">
+                            {((isHeroFixedBlock &&
+                              savedPageState.content.length === 1) ||
+                              (savedPageState.content.length === 0 &&
+                                pageLayout !==
+                                  ISOMER_USABLE_PAGE_LAYOUTS.Index) ||
+                              !isPreviewingIndexPage) && (
+                              <>
+                                <VStack
+                                  justifyContent="center"
+                                  spacing={0}
+                                  mt="2.75rem"
+                                  mb="1.5rem"
+                                >
+                                  <BlockEditingPlaceholder />
+                                  <Text
+                                    mt="0.75rem"
+                                    textStyle="subhead-1"
+                                    color="base.content.default"
+                                  >
+                                    Blocks you add will appear here
+                                  </Text>
+                                  <Text
+                                    mt="0.25rem"
+                                    textStyle="caption-2"
+                                    color="base.content.medium"
+                                  >
+                                    Click the ‘Add block’ button above to add
+                                    blocks to this page
+                                  </Text>
+                                </VStack>
+
+                                <Button
+                                  variant="outline"
+                                  w="100%"
+                                  onClick={() =>
+                                    setDrawerState({ state: "addBlock" })
+                                  }
+                                  leftIcon={
+                                    <Icon as={BiPlus} fontSize="1.25rem" />
+                                  }
+                                >
+                                  Add a new block
+                                </Button>
+                              </>
+                            )}
+
+                            <Flex flexDirection="column" mt="-0.25rem">
+                              {previewPageState.content.map((block, index) => {
+                                if (isHeroFixedBlock && index === 0) {
+                                  return <></>
+                                }
+
+                                return (
+                                  <DraggableBlock
+                                    block={block}
+                                    // TODO: Generate a block ID instead of index
+                                    key={`${block.type}-${index}`}
+                                    // TODO: Use block ID when instead of index for uniquely identifying blocks
+                                    draggableId={`${block.type}-${index}`}
+                                    index={index}
+                                    onClick={() => {
+                                      setCurrActiveIdx(index)
+                                      // TODO: we should automatically do this probably?
+                                      const nextState =
+                                        savedPageState.content[index]?.type ===
+                                        "prose"
+                                          ? "nativeEditor"
+                                          : "complexEditor"
+                                      // NOTE: SNAPSHOT
+                                      setDrawerState({ state: nextState })
+                                    }}
+                                  />
+                                )
+                              })}
+                            </Flex>
+                          </Box>
+                          {provided.placeholder}
+                        </VStack>
+                      )}
+                    </Droppable>
+                  </DragDropContext>
+                </VStack>
+              </VStack>
+            </VStack>
+          </Disable>
+        </VStack>
       </VStack>
-    </VStack>
+
+      {isPreviewingIndexPage && (
+        <Box
+          bgColor="base.canvas.default"
+          boxShadow="md"
+          py="1.5rem"
+          px="2rem"
+          mt="auto"
+        >
+          <VStack spacing="1.25rem">
+            <Infobox size="sm" variant="warning">
+              <Text textStyle="body-2">
+                All custom content that was previously on this page will be lost
+                once you press ‘Accept this change’.
+              </Text>
+            </Infobox>
+
+            <VStack gap="1rem" w="full">
+              <Button
+                w="100%"
+                isLoading={isSavingPage}
+                onClick={onConfirmConvertIndexPageModalOpen}
+              >
+                Accept this change
+              </Button>
+
+              <Button
+                w="100%"
+                variant="outline"
+                onClick={handleCancelConversionToIndexPage}
+              >
+                Keep old version
+              </Button>
+            </VStack>
+          </VStack>
+        </Box>
+      )}
+    </Flex>
   )
 }

--- a/apps/studio/src/stories/Page/EditPage/EditIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditIndexPage.stories.tsx
@@ -117,3 +117,14 @@ export const EditChildBlockState: Story = {
     await userEvent.click(button)
   },
 }
+
+export const CustomIndexPage: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.readPageAndBlob.customIndex(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+}

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -752,6 +752,104 @@ export const pageHandlers = {
         }
       })
     },
+    customIndex: () => {
+      // @ts-expect-error incomplete types
+      return trpcMsw.page.readPageAndBlob.query(() => {
+        return {
+          title: "Index page",
+          updatedAt: new Date("2024-09-12T07:00:00.000Z"),
+          permalink: "_index",
+          navbar: {
+            id: 1,
+            siteId: 1,
+            content: [
+              {
+                url: "/item-one",
+                name: "Expandable nav item",
+                items: [
+                  {
+                    url: "/item-one/pa-network-one",
+                    name: "PA's network one",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                  {
+                    url: "/item-one/pa-network-two",
+                    name: "PA's network two",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                  {
+                    url: "/item-one/pa-network-three",
+                    name: "PA's network three",
+                  },
+                  {
+                    url: "/item-one/pa-network-four",
+                    name: "PA's network four",
+                    description:
+                      "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+                  },
+                  {
+                    url: "/item-one/pa-network-five",
+                    name: "PA's network five",
+                    description:
+                      "Click here and brace yourself for mild disappointment. This one has a pretty long one",
+                  },
+                  {
+                    url: "/item-one/pa-network-six",
+                    name: "PA's network six",
+                    description:
+                      "Click here and brace yourself for mild disappointment.",
+                  },
+                ],
+              },
+            ],
+          },
+          footer: {
+            id: 1,
+            siteId: 1,
+            content: {
+              siteNavItems: [
+                { url: "/about", title: "About us" },
+                { url: "/partners", title: "Our partners" },
+                {
+                  url: "/grants-and-programmes",
+                  title: "Grants and programmes",
+                },
+                { url: "/contact-us", title: "Contact us" },
+                { url: "/something-else", title: "Something else" },
+                { url: "/resources", title: "Resources" },
+              ],
+              contactUsLink: "/contact-us",
+              termsOfUseLink: "/terms-of-use",
+              feedbackFormLink: "https://www.form.gov.sg",
+              privacyStatementLink: "/privacy",
+            },
+          },
+          content: {
+            page: {
+              date: "11-09-2024",
+              title: "article layout",
+              category: "Feature Articles",
+              articlePageHeader: { summary: "" },
+            },
+            childpages: {
+              layout: "boxes",
+              summary: false,
+              thumbnail: false,
+            },
+            layout: "content",
+            content: [],
+            version: "0.1.0",
+          },
+          type: "IndexPage",
+          theme: "isomer-next",
+          logoUrl: "",
+          siteName: "MTI",
+          isGovernment: true,
+        }
+      })
+    },
   },
   readPage: {
     homepage: (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1897.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add a new toggle for converting custom index pages into the new index page.

## Screenshots

![image](https://github.com/user-attachments/assets/bd11a6d1-1ec2-4f86-9560-2b9e15ac8aa1)
![image](https://github.com/user-attachments/assets/5c9f2772-e84f-4145-af1b-71c62d7aa063)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Create a new index page
- [ ] Use the raw JSON editor mode to convert the `layout` of the page from `index` to `content` and remove the `childpages` key. Save the changes.
- [ ] Verify that the infobox appears at the top.
- [ ] Click on preview changes, verify that you should be able to see a preview of the index page and you are not able to click into anything inside the editor.
- [ ] Verify that the "Keep old version" button brings you correctly back to the original page state.
- [ ] Verify that the "Accept this change" opens up a confirm changes modal
- [ ] Verify that the "Accept changes" button causes the index page changes to be persisted.
- [ ] Use the raw JSON editor mode to verify that the `layout` of the page is now changed back to `index` and that there is a `childpages` key.