### PR TITLE
Support/add searchpage to create new site

### DIFF
--- a/apps/studio/prisma/seed.ts
+++ b/apps/studio/prisma/seed.ts
@@ -4,6 +4,8 @@
  * @link https://www.prisma.io/docs/guides/database/seed-database
  */
 
+import cuid2 from "@paralleldrive/cuid2"
+
 import { db, RoleType } from "../src/server/modules/database"
 import { createSite } from "../src/server/modules/site/site.service"
 import { addUsersToSite } from "./scripts/addUsersToSite"
@@ -12,7 +14,31 @@ const EDITOR_USER = "editor"
 const PUBLISHER_USER = "publisher"
 
 async function main() {
-  const { siteId } = await createSite({ siteName: "Isomer" })
+  const users = await Promise.all(
+    [EDITOR_USER, PUBLISHER_USER].map(async (email) => {
+      return await db
+        .insertInto("User")
+        .values({
+          id: cuid2.createId(),
+          email: `${email}@open.gov.sg`,
+          name: "",
+          phone: "",
+        })
+        .onConflict((oc) =>
+          oc
+            .columns(["email", "deletedAt"])
+            .doUpdateSet((eb) => ({ email: eb.ref("excluded.email") })),
+        )
+        .returning(["id", "name", "email"])
+        .executeTakeFirstOrThrow()
+    }),
+  )
+
+  const { siteId } = await createSite({
+    siteName: "Isomer",
+    // @ts-expect-error - We know that the first user is always created
+    userId: users[0]?.id,
+  })
 
   await db
     .insertInto("Whitelist")

--- a/apps/studio/src/server/modules/site/constants.ts
+++ b/apps/studio/src/server/modules/site/constants.ts
@@ -55,6 +55,13 @@ export const PAGE_BLOB: IsomerSchema = {
   ],
 }
 
+export const SEARCH_PAGE_BLOB: IsomerSchema = {
+  page: { title: "Search", description: "Search results" },
+  layout: "search",
+  content: [],
+  version: "0.1.0",
+}
+
 export const NAV_BAR_ITEMS: Navbar["items"] = [
   {
     name: "Expandable nav item",

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -349,7 +349,7 @@ export const siteRouter = router({
         roles: [ADMIN_ROLE.CORE],
       })
 
-      return createSite({ siteName })
+      return createSite({ siteName, userId: ctx.user.id })
     }),
   publish: protectedProcedure
     .input(publishSiteSchema)

--- a/packages/components/src/types/schema.ts
+++ b/packages/components/src/types/schema.ts
@@ -25,6 +25,7 @@ import {
   FileRefMetaSchema,
   HomePageMetaSchema,
   LinkRefMetaSchema,
+  SearchPageMetaSchema,
 } from "./meta"
 import {
   ArticlePagePageSchema,
@@ -34,6 +35,7 @@ import {
   FileRefPageSchema,
   HomePagePageSchema,
   LinkRefPageSchema,
+  SearchPagePageSchema,
 } from "./page"
 
 export const ISOMER_USABLE_PAGE_LAYOUTS = {
@@ -135,6 +137,23 @@ export const HomePageSchema = Type.Object(
   },
 )
 
+export const SearchPageSchema = Type.Object(
+  {
+    layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Search, {
+      default: ISOMER_PAGE_LAYOUTS.Search,
+    }),
+    meta: Type.Optional(SearchPageMetaSchema),
+    page: SearchPagePageSchema,
+    content: Type.Array(IsomerComponentsSchemas, {
+      title: "Page content",
+    }),
+  },
+  {
+    title: "Search",
+    description: "This is the search page for your site.",
+  },
+)
+
 export const IndexPageSchema = Type.Object(
   {
     layout: Type.Literal(ISOMER_PAGE_LAYOUTS.Index, {
@@ -225,6 +244,7 @@ export const IsomerPageSchema = Type.Composite([
     ContentPageSchema,
     DatabasePageSchema,
     HomePageSchema,
+    SearchPageSchema,
     IndexPageSchema,
     FileRefSchema,
     LinkRefSchema,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently when we allow user to self migrate on studio, we don't create the Search page record. On-call engineer has to manually go to tableplus to create this

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- create Search page resource and blob as part of the process
- refactor `createSite` by modularizing functions to improve readability 
