### PR TITLE
feat: allow enabling of Singpass for selected users

### DIFF
--- a/apps/studio/src/features/me/api/useMe.ts
+++ b/apps/studio/src/features/me/api/useMe.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from "react"
 import { useRouter } from "next/router"
+import { useGrowthBook } from "@growthbook/growthbook-react"
 
 import { useLoginState } from "~/features/auth"
 import { trpc } from "~/utils/trpc"
@@ -8,6 +9,7 @@ import { isUserOnboarded } from "./isUserOnboarded"
 export const useMe = () => {
   const [me] = trpc.me.get.useSuspenseQuery()
   const router = useRouter()
+  const gb = useGrowthBook()
 
   const { removeLoginStateFlag } = useLoginState()
   const logoutMutation = trpc.auth.logout.useMutation()
@@ -16,6 +18,7 @@ export const useMe = () => {
     (redirectToSignIn = true) => {
       return logoutMutation.mutate(undefined, {
         onSuccess: () => {
+          void gb.setAttributes({})
           removeLoginStateFlag()
           if (redirectToSignIn) {
             void router.push("/sign-in")
@@ -23,7 +26,7 @@ export const useMe = () => {
         },
       })
     },
-    [logoutMutation, removeLoginStateFlag, router],
+    [gb, logoutMutation, removeLoginStateFlag, router],
   )
 
   const isOnboarded = useMemo(() => isUserOnboarded(me), [me])

--- a/apps/studio/src/features/sign-in/components/EmailLogin/EmailLoginForm.tsx
+++ b/apps/studio/src/features/sign-in/components/EmailLogin/EmailLoginForm.tsx
@@ -1,18 +1,27 @@
 import { useCallback } from "react"
+import { useGrowthBook } from "@growthbook/growthbook-react"
 
 import type { VfnStepData } from "../SignInContext"
+import type { GrowthbookAttributes } from "~/types/growthbook"
 import { useSignInContext } from "../SignInContext"
 import { EmailInput } from "./EmailInput"
 
 export const EmailLoginForm = () => {
   const { setVfnStepData, proceedToVerification } = useSignInContext()
+  const gb = useGrowthBook()
 
   const handleOnSuccessEmail = useCallback(
     ({ email, otpPrefix }: VfnStepData) => {
       setVfnStepData({ email, otpPrefix })
+
+      const newAttributes: Partial<GrowthbookAttributes> = {
+        email,
+      }
+
+      void gb.updateAttributes(newAttributes)
       proceedToVerification()
     },
-    [proceedToVerification, setVfnStepData],
+    [gb, proceedToVerification, setVfnStepData],
   )
 
   return <EmailInput onSuccess={handleOnSuccessEmail} />

--- a/apps/studio/src/features/sign-in/components/SignInContext.tsx
+++ b/apps/studio/src/features/sign-in/components/SignInContext.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import { createContext, useCallback, useContext, useState } from "react"
+import { useGrowthBook } from "@growthbook/growthbook-react"
 import { useInterval } from "usehooks-ts"
 
 type SignInStateType = "initial" | "verification"
@@ -53,6 +54,8 @@ export const SignInContextProvider = ({
   const [vfnStepData, setVfnStepData] = useState<VfnStepData>()
   const [timer, setTimer] = useState(delayForResendSeconds)
 
+  const gb = useGrowthBook()
+
   const resetTimer = useCallback(
     () => setTimer(delayForResendSeconds),
     [delayForResendSeconds],
@@ -67,7 +70,8 @@ export const SignInContextProvider = ({
     setState("initial")
     setVfnStepData(undefined)
     setErrorState(undefined)
-  }, [])
+    void gb.setAttributes({})
+  }, [gb])
 
   // Start the resend timer once in the vfn step.
   useInterval(

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -3,6 +3,7 @@ import pick from "lodash/pick"
 import set from "lodash/set"
 
 import type { SessionData } from "~/lib/types/session"
+import type { GrowthbookAttributes } from "~/types/growthbook"
 import { env } from "~/env.mjs"
 import { IS_SINGPASS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { sendMail } from "~/lib/mail"
@@ -135,6 +136,12 @@ export const emailSessionRouter = router({
         }
         throw e
       }
+
+      const newAttributes: Partial<GrowthbookAttributes> = {
+        email,
+      }
+
+      await ctx.gb.setAttributes(newAttributes)
 
       const isSingpassEnabled = ctx.gb.isOn(IS_SINGPASS_ENABLED_FEATURE_KEY)
 

--- a/apps/studio/src/types/growthbook.ts
+++ b/apps/studio/src/types/growthbook.ts
@@ -1,0 +1,3 @@
+export interface GrowthbookAttributes {
+  email: string
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1883.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Added email attribute to Growthbook to allow for selective enabling of Singpass using the email address.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Add your email address to Growthbook and force the value to be `false` for the `is-singpass-enabled` feature flag.
- [ ] Attempt to log in to Isomer Studio
- [ ] Verify that you did not need to authenticate with Singpass
- [ ] Use another email that is not in the list inside Growthbook to log in to Isomer Studio
- [ ] Verify that you had to authenticate with Singpass