### PR TITLE
chore: increase InfoCards limit from 12 to 30

### DIFF
--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -126,7 +126,7 @@ const InfoCardsWithImageSchema = Type.Object(
     variant: Type.Literal(CARDS_WITH_IMAGES, { default: CARDS_WITH_IMAGES }),
     cards: Type.Array(SingleCardWithImageSchema, {
       title: "Cards",
-      maxItems: 12,
+      maxItems: 30,
       default: [],
     }),
   },
@@ -142,7 +142,7 @@ const InfoCardsNoImageSchema = Type.Object(
     }),
     cards: Type.Array(SingleCardNoImageSchema, {
       title: "Cards",
-      maxItems: 12,
+      maxItems: 30,
       default: [],
     }),
   },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-1900.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Increased the limit on the number of InfoCards from 12 to 30.