### PR TITLE
chore: add check for immediate children

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -17,7 +17,7 @@ import type {
 import type { SearchResultResource } from "./resource.types"
 import type { ResourceItemContent } from "~/schemas/resource"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
-import { getSitemapTree } from "~/utils/sitemap"
+import { getSitemapTree, PAGE_RESOURCE_TYPES } from "~/utils/sitemap"
 import { logPublishEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceType, sql } from "../database"
@@ -362,7 +362,7 @@ export const getLocalisedSitemap = async (
         .leftJoin("Blob as published", "Version.blobId", "published.id")
         .select(() => [headerSql, thumbnailSql, ...defaultResourceSelect]),
     )
-    .with("childCousinIndexPages", (eb) => {
+    .with("childCousinPages", (eb) => {
       return eb
         .selectFrom("Resource")
         .where("parentId", "in", (qb) =>
@@ -374,7 +374,7 @@ export const getLocalisedSitemap = async (
               ResourceType.Folder,
             ]),
         )
-        .where("type", "=", ResourceType.IndexPage)
+        .where("type", "in", PAGE_RESOURCE_TYPES)
         .where("state", "=", "Published")
         .leftJoin("Version", "Version.id", "publishedVersionId")
         .leftJoin("Blob as published", "Version.blobId", "published.id")
@@ -390,7 +390,7 @@ export const getLocalisedSitemap = async (
     )
     .union((eb) =>
       eb
-        .selectFrom("childCousinIndexPages as Resource")
+        .selectFrom("childCousinPages as Resource")
         .select(["summary", "thumbnail", ...defaultResourceSelect]),
     )
     .orderBy("title asc")

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -27,7 +27,8 @@ const getResourcesWithFullPermalink = (
   const children = resources
     .filter((resources) => {
       return parent.type === ResourceType.RootPage
-        ? resources.parentId === null
+        ? resources.parentId === null &&
+            resources.type !== ResourceType.RootPage
         : resources.parentId === parent.id
     })
     .map((child) => {
@@ -68,7 +69,10 @@ const getSitemapTreeFromArray = (
       )
     })
     .filter((resource) => {
-      return resource.parentId === parentId
+      return (
+        resource.parentId === parentId &&
+        resource.type !== ResourceType.IndexPage
+      )
     })
 
   // TODO: Sort the children by the page ordering if the FolderMeta resource exists

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -2,8 +2,14 @@ import type { IsomerSitemap } from "@opengovsg/isomer-components"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { Resource } from "~prisma/generated/selectableTypes"
-import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
 
+export const PAGE_RESOURCE_TYPES = [
+  ResourceType.Page,
+  ResourceType.CollectionPage,
+  ResourceType.CollectionLink,
+  ResourceType.IndexPage,
+  ResourceType.RootPage,
+] as const
 type ResourceDto = Omit<
   Resource,
   "id" | "parentId" | "publishedVersionId" | "draftBlobId"
@@ -14,35 +20,69 @@ type ResourceDto = Omit<
   thumbnail?: string
 }
 
+const getResourcesWithFullPermalink = (
+  resources: ResourceDto[],
+  parent: ResourceDto,
+): ResourceDto[] => {
+  const children = resources
+    .filter((resources) => {
+      return parent.type === ResourceType.RootPage
+        ? resources.parentId === null
+        : resources.parentId === parent.id
+    })
+    .map((child) => {
+      return {
+        ...child,
+        permalink: `${parent.type === ResourceType.RootPage ? "" : parent.permalink}/${child.permalink}`,
+      }
+    })
+
+  return [
+    ...children,
+    ...children.flatMap((child) =>
+      getResourcesWithFullPermalink(resources, child),
+    ),
+  ]
+}
+
 const getSitemapTreeFromArray = (
   resources: ResourceDto[],
   parentId: string | null,
-  path: string,
 ): IsomerSitemap[] | undefined => {
   if (resources.length === 0) {
     return undefined
   }
 
   // Get the immediate children of the resource with the given parent ID
-  const children = resources.filter((resource) => {
-    if (parentId === null) {
+  const children = resources
+    .filter((resource) => {
+      const hasPageChildren = resources.some((possibleChild) => {
+        return (
+          possibleChild.permalink.startsWith(resource.permalink) &&
+          PAGE_RESOURCE_TYPES.find((t) => t === possibleChild.type)
+        )
+      })
       return (
-        resource.parentId === null &&
-        resource.type !== ResourceType.RootPage &&
-        resource.type !== ResourceType.FolderMeta &&
-        resource.type !== ResourceType.CollectionMeta
+        PAGE_RESOURCE_TYPES.find((t) => t === resource.type) || hasPageChildren
       )
-    }
-    return (
-      resource.parentId === parentId &&
-      resource.permalink !== INDEX_PAGE_PERMALINK
-    )
-  })
+    })
+    .filter((resource) => {
+      if (parentId === null) {
+        return (
+          resource.parentId === null &&
+          resource.type !== ResourceType.RootPage &&
+          resource.type !== ResourceType.FolderMeta &&
+          resource.type !== ResourceType.CollectionMeta
+        )
+      }
+      return (
+        resource.parentId === parentId &&
+        resource.type !== ResourceType.IndexPage
+      )
+    })
 
   // TODO: Sort the children by the page ordering if the FolderMeta resource exists
   return children.map((resource) => {
-    const permalink = `${path}${resource.permalink}`
-
     if (
       resource.type === ResourceType.Page ||
       resource.type === ResourceType.CollectionPage
@@ -54,7 +94,7 @@ const getSitemapTreeFromArray = (
         summary: resource.summary ?? "",
         lastModified: new Date() // TODO: Update this to the updated_at field in DB
           .toISOString(),
-        permalink,
+        permalink: resource.permalink,
         image: {
           src: resource.thumbnail ?? "",
           alt: "",
@@ -65,30 +105,36 @@ const getSitemapTreeFromArray = (
     const indexPage = resources.find(
       (child) =>
         // NOTE: This child is the index page of this resource
-        child.permalink === INDEX_PAGE_PERMALINK &&
-        child.parentId === resource.id,
+        child.type === ResourceType.IndexPage && child.parentId === resource.id,
     )
 
-    const titleOfPage = indexPage?.title
-    const summaryOfPage = indexPage?.summary
+    if (!!indexPage) {
+      return {
+        id: String(resource.id),
+        layout: "content", // Note: We are not using the layout field in our previews
+        title: indexPage.title,
+        summary: indexPage.summary ?? `Pages in ${resource.title}`,
+        lastModified: new Date() // TODO: Update this to the updated_at field in DB
+          .toISOString(),
+        // NOTE: This permalink is unused in the preview
+        permalink: resource.permalink,
+        image: !!indexPage.thumbnail
+          ? { src: indexPage.thumbnail, alt: "" }
+          : undefined,
+        children: getSitemapTreeFromArray(resources, resource.id),
+      }
+    }
 
     return {
       id: String(resource.id),
       layout: "content", // Note: We are not using the layout field in our previews
-      title: titleOfPage || resource.title,
-      summary: summaryOfPage ?? `Pages in ${resource.title}`,
+      title: resource.title,
+      summary: `Pages in ${resource.title}`,
       lastModified: new Date() // TODO: Update this to the updated_at field in DB
         .toISOString(),
       // NOTE: This permalink is unused in the preview
-      permalink,
-      image: !!indexPage?.thumbnail
-        ? { src: indexPage.thumbnail, alt: "" }
-        : undefined,
-      children: getSitemapTreeFromArray(
-        resources,
-        resource.id,
-        `${permalink}/`,
-      ),
+      permalink: resource.permalink,
+      children: getSitemapTreeFromArray(resources, resource.id),
     }
   })
 }
@@ -98,6 +144,11 @@ export const getSitemapTree = (
   rootResource: ResourceDto,
   resources: ResourceDto[],
 ): IsomerSitemap => {
+  const resourcesWithFullPermalink = getResourcesWithFullPermalink(
+    resources,
+    rootResource,
+  )
+
   return {
     id: String(rootResource.id),
     layout: "homepage", // Note: We are not using the layout field in our previews
@@ -107,6 +158,6 @@ export const getSitemapTree = (
       .toISOString(),
     // NOTE: This permalink is unused in the preview
     permalink: "/",
-    children: getSitemapTreeFromArray(resources, null, "/"),
+    children: getSitemapTreeFromArray(resourcesWithFullPermalink, null),
   }
 }

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -56,29 +56,19 @@ const getSitemapTreeFromArray = (
   // Get the immediate children of the resource with the given parent ID
   const children = resources
     .filter((resource) => {
-      const hasPageChildren = resources.some((possibleChild) => {
+      const hasPageDescendants = resources.some((possibleChild) => {
         return (
           possibleChild.permalink.startsWith(resource.permalink) &&
           PAGE_RESOURCE_TYPES.find((t) => t === possibleChild.type)
         )
       })
       return (
-        PAGE_RESOURCE_TYPES.find((t) => t === resource.type) || hasPageChildren
+        PAGE_RESOURCE_TYPES.find((t) => t === resource.type) ||
+        hasPageDescendants
       )
     })
     .filter((resource) => {
-      if (parentId === null) {
-        return (
-          resource.parentId === null &&
-          resource.type !== ResourceType.RootPage &&
-          resource.type !== ResourceType.FolderMeta &&
-          resource.type !== ResourceType.CollectionMeta
-        )
-      }
-      return (
-        resource.parentId === parentId &&
-        resource.type !== ResourceType.IndexPage
-      )
+      return resource.parentId === parentId
     })
 
   // TODO: Sort the children by the page ordering if the FolderMeta resource exists
@@ -92,8 +82,7 @@ const getSitemapTreeFromArray = (
         layout: "content", // Note: We are not using the layout field in our sitemap for preview
         title: resource.title,
         summary: resource.summary ?? "",
-        lastModified: new Date() // TODO: Update this to the updated_at field in DB
-          .toISOString(),
+        lastModified: resource.updatedAt.toISOString(),
         permalink: resource.permalink,
         image: {
           src: resource.thumbnail ?? "",


### PR DESCRIPTION
## Problem
[see slack thread](https://opengovproducts.slack.com/archives/C06R4DX966P/p1746684298741139)
  

## Solution
1. first, we pre-generate the list of full URLs 
2. we then generate the list of resources **that are actually going to be in our sitemap** - the source of truth for this shuold be based off publishing. 
3. based off `publishing/index`, we will only create index pages for **folders that have some children** (regardless of nesting depth).

## Caveats
1. because we only take `immediateChildren` + `childCousinIndexPages`, this isn't quite enough to get the full list of pages under a folder. this means that for folders with `draft` index pagse (or no index pages) but deeply nested children, there will be a difference in preview