### PR TITLE
isom-1904 support infobar styling dark selective display 2

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Block/DraggableBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/DraggableBlock.tsx
@@ -31,7 +31,7 @@ export const DraggableBlock = ({
     // this gets a `$Ref` only and not the concrete values
     return block.type === "prose"
       ? PROSE_COMPONENT_NAME
-      : (getComponentSchema(block.type).title ?? "Unknown")
+      : (getComponentSchema({ component: block.type }).title ?? "Unknown")
   }, [block.type])
 
   const previewText: string = renderComponentPreviewText({

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -252,7 +252,10 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
     return <></>
   }
 
-  const subSchema = getComponentSchema(component.type)
+  const subSchema = getComponentSchema({
+    component: component.type,
+    layout: previewPageState.layout,
+  })
   const { title } = subSchema
   const validateFn = ajv.compile<IsomerComponent>(subSchema)
   const componentName = title || "component"

--- a/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditPageDrawer.tsx
@@ -12,7 +12,7 @@ import RawJsonEditorModeStateDrawer from "./RawJsonEditorModeStateDrawer"
 import RootStateDrawer from "./RootStateDrawer"
 import TipTapProseComponent from "./TipTapProseComponent"
 
-const proseSchema = getComponentSchema("prose")
+const proseSchema = getComponentSchema({ component: "prose" })
 const ajv = new Ajv({ allErrors: true, strict: false, logger: false })
 const validate = ajv.compile<ProseProps>(proseSchema)
 

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -45,7 +45,7 @@ export default function HeroEditorDrawer(): JSX.Element {
   } = useEditorDrawerContext()
   const toast = useToast()
 
-  const subSchema = getComponentSchema("hero")
+  const subSchema = getComponentSchema({ component: "hero" })
   const validateFn = ajv.compile<IsomerComponent>(subSchema)
 
   const { pageId, siteId } = useQueryParse(editPageSchema)
@@ -206,7 +206,7 @@ export default function HeroEditorDrawer(): JSX.Element {
         <ErrorProvider>
           <Box px="1.5rem" py="1rem" flex={1} overflow="auto">
             <FormBuilder<IsomerComponent>
-              schema={getComponentSchema("hero")}
+              schema={subSchema}
               validateFn={validateFn}
               data={previewPageState.content[0]}
               handleChange={handleChange}

--- a/packages/components/src/interfaces/complex/Infobar.ts
+++ b/packages/components/src/interfaces/complex/Infobar.ts
@@ -7,6 +7,7 @@ import type {
   LinkComponentType,
 } from "~/types"
 import { LINK_HREF_PATTERN } from "~/utils/validation"
+import { ARRAY_RADIO_FORMAT } from "../format"
 
 const INFOBAR_VARIANT = {
   light: "light",
@@ -15,86 +16,104 @@ const INFOBAR_VARIANT = {
 
 export const DEFAULT_INFOBAR_VARIANT = INFOBAR_VARIANT.light
 
-export const InfobarSchema = Type.Object(
-  {
-    type: Type.Literal("infobar", { default: "infobar" }),
-    title: Type.String({
-      title: "Title",
-      maxLength: 100,
-    }),
-    description: Type.Optional(
-      Type.String({
-        title: "Description",
+const generateInfobarSchema = ({
+  includeDarkVariant,
+}: {
+  includeDarkVariant: boolean
+}) => {
+  return Type.Object(
+    {
+      type: Type.Literal("infobar", { default: "infobar" }),
+      title: Type.String({
+        title: "Title",
         maxLength: 100,
       }),
-    ),
-    variant: Type.Optional(
-      Type.Union(
-        [
-          Type.Literal(INFOBAR_VARIANT.light, {
-            title: "Light (Default)",
-          }),
-          Type.Literal(INFOBAR_VARIANT.dark, {
-            title: "Dark",
-          }),
-        ],
-        {
-          default: DEFAULT_INFOBAR_VARIANT,
-          title: "Call-to-Action style",
-          format: "hidden",
-          type: "string",
-        },
+      description: Type.Optional(
+        Type.String({
+          title: "Description",
+          maxLength: 100,
+        }),
       ),
-    ),
-    buttonLabel: Type.Optional(
-      Type.String({
-        title: "Button text",
-        description:
-          "A descriptive text. Avoid generic text such as “Click here” or “Learn more”",
-        maxLength: 50,
-      }),
-    ),
-    buttonUrl: Type.Optional(
-      Type.String({
-        title: "Button destination",
-        description: "When this is clicked, open:",
-        format: "link",
-        pattern: LINK_HREF_PATTERN,
-      }),
-    ),
-    secondaryButtonLabel: Type.Optional(
-      Type.String({
-        title: "Secondary button text",
-        maxLength: 50,
-        description:
-          "A descriptive text. Avoid generic text such as “Click here” or “Learn more”",
-      }),
-    ),
-    secondaryButtonUrl: Type.Optional(
-      Type.String({
-        title: "Secondary button destination",
-        description: "When this is clicked, open:",
-        format: "link",
-        pattern: LINK_HREF_PATTERN,
-      }),
-    ),
-  },
-  {
-    groups: [
-      {
-        label: "Primary call-to-action",
-        fields: ["buttonLabel", "buttonUrl"],
-      },
-      {
-        label: "Secondary call-to-action",
-        fields: ["secondaryButtonLabel", "secondaryButtonUrl"],
-      },
-    ],
-    title: "Infobar component",
-  },
-)
+      variant: Type.Optional(
+        Type.Union(
+          [
+            Type.Literal(INFOBAR_VARIANT.light, {
+              title: "Light (Default)",
+            }),
+            ...(includeDarkVariant
+              ? [
+                  Type.Literal(INFOBAR_VARIANT.dark, {
+                    title: "Dark",
+                  }),
+                ]
+              : []),
+          ],
+          {
+            default: DEFAULT_INFOBAR_VARIANT,
+            title: "Call-to-Action style",
+            format: includeDarkVariant ? ARRAY_RADIO_FORMAT : "hidden",
+            type: "string",
+          },
+        ),
+      ),
+      buttonLabel: Type.Optional(
+        Type.String({
+          title: "Button text",
+          description:
+            "A descriptive text. Avoid generic text such as “Click here” or “Learn more”",
+          maxLength: 50,
+        }),
+      ),
+      buttonUrl: Type.Optional(
+        Type.String({
+          title: "Button destination",
+          description: "When this is clicked, open:",
+          format: "link",
+          pattern: LINK_HREF_PATTERN,
+        }),
+      ),
+      secondaryButtonLabel: Type.Optional(
+        Type.String({
+          title: "Secondary button text",
+          maxLength: 50,
+          description:
+            "A descriptive text. Avoid generic text such as “Click here” or “Learn more”",
+        }),
+      ),
+      secondaryButtonUrl: Type.Optional(
+        Type.String({
+          title: "Secondary button destination",
+          description: "When this is clicked, open:",
+          format: "link",
+          pattern: LINK_HREF_PATTERN,
+        }),
+      ),
+    },
+    {
+      groups: [
+        {
+          label: "Primary call-to-action",
+          fields: ["buttonLabel", "buttonUrl"],
+        },
+        {
+          label: "Secondary call-to-action",
+          fields: ["secondaryButtonLabel", "secondaryButtonUrl"],
+        },
+      ],
+      title: "Infobar component",
+    },
+  )
+}
 
-export type InfobarProps = Static<typeof InfobarSchema> & {
+export const InfobarHomepageSchema = generateInfobarSchema({
+  includeDarkVariant: true,
+})
+
+export const InfobarDefaultSchema = generateInfobarSchema({
+  includeDarkVariant: false,
+})
+
+export type InfobarProps = Static<typeof InfobarHomepageSchema> & {
   sectionIdx?: number // TODO: Remove this property, only used in classic theme
   subtitle?: string // Subtitle that is only used in the classic theme
   layout: IsomerPageLayoutType

--- a/packages/components/src/interfaces/complex/index.ts
+++ b/packages/components/src/interfaces/complex/index.ts
@@ -21,7 +21,8 @@ export {
 } from "./InfoCards"
 export { InfoColsSchema, type InfoColsProps } from "./InfoCols"
 export {
-  InfobarSchema,
+  InfobarDefaultSchema,
+  InfobarHomepageSchema,
   type InfobarProps,
   DEFAULT_INFOBAR_VARIANT,
 } from "./Infobar"

--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -1,7 +1,7 @@
 import type { TSchema } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerComponentTypes } from "~/types"
+import type { IsomerComponentTypes, IsomerPageLayoutType } from "~/types"
 import {
   AccordionSchema,
   BlockquoteSchema,
@@ -15,7 +15,8 @@ import {
   HeroSchema,
   IframeSchema,
   ImageSchema,
-  InfobarSchema,
+  InfobarDefaultSchema,
+  InfobarHomepageSchema,
   InfoCardsSchema,
   InfoColsSchema,
   InfopicSchema,
@@ -37,7 +38,7 @@ export const IsomerComplexComponentsMap = {
   hero: HeroSchema,
   iframe: IframeSchema,
   image: ImageSchema,
-  infobar: InfobarSchema,
+  infobar: InfobarDefaultSchema,
   infocards: InfoCardsSchema,
   infocols: InfoColsSchema,
   infopic: InfopicSchema,
@@ -67,16 +68,29 @@ export const componentSchemaDefinitions = {
   },
 }
 
-export const getComponentSchema = (
-  component: IsomerComponentTypes,
-): TSchema => {
-  const componentSchema =
-    component === "prose"
-      ? Type.Ref(IsomerNativeComponentsMap.prose)
-      : IsomerComplexComponentsMap[component]
+interface ComponentSchema {
+  component: IsomerComponentTypes
+  layout?: IsomerPageLayoutType
+}
 
+const generateComponentSchema = ({ component, layout }: ComponentSchema) => {
+  if (component === "prose") {
+    return Type.Ref(IsomerNativeComponentsMap.prose)
+  }
+
+  if (component === "infobar") {
+    return layout === "homepage" ? InfobarHomepageSchema : InfobarDefaultSchema
+  }
+
+  return IsomerComplexComponentsMap[component]
+}
+
+export const getComponentSchema = ({
+  component,
+  layout,
+}: ComponentSchema): TSchema => {
   return {
-    ...componentSchema,
+    ...generateComponentSchema({ component, layout }),
     ...componentSchemaDefinitions,
   }
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

A follow-up to https://github.com/opengovsg/isomer/pull/1293 based on what was discussed

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- make `variant` be dynamic for layouts based on whats generated
- pass in that props from studio
