### PR TITLE
fix: fix erroneous conditional for homepage

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -352,51 +352,51 @@ export default function RootStateDrawer() {
                           ref={provided.innerRef}
                         >
                           <Box w="100%">
-                            {((isHeroFixedBlock &&
-                              savedPageState.content.length === 1) ||
-                              (savedPageState.content.length === 0 &&
-                                pageLayout !==
-                                  ISOMER_USABLE_PAGE_LAYOUTS.Index) ||
-                              !isPreviewingIndexPage) && (
-                              <>
-                                <VStack
-                                  justifyContent="center"
-                                  spacing={0}
-                                  mt="2.75rem"
-                                  mb="1.5rem"
-                                >
-                                  <BlockEditingPlaceholder />
-                                  <Text
-                                    mt="0.75rem"
-                                    textStyle="subhead-1"
-                                    color="base.content.default"
+                            {!isPreviewingIndexPage &&
+                              ((isHeroFixedBlock &&
+                                savedPageState.content.length === 1) ||
+                                (savedPageState.content.length === 0 &&
+                                  pageLayout !==
+                                    ISOMER_USABLE_PAGE_LAYOUTS.Index)) && (
+                                <>
+                                  <VStack
+                                    justifyContent="center"
+                                    spacing={0}
+                                    mt="2.75rem"
+                                    mb="1.5rem"
                                   >
-                                    Blocks you add will appear here
-                                  </Text>
-                                  <Text
-                                    mt="0.25rem"
-                                    textStyle="caption-2"
-                                    color="base.content.medium"
-                                  >
-                                    Click the ‘Add block’ button above to add
-                                    blocks to this page
-                                  </Text>
-                                </VStack>
+                                    <BlockEditingPlaceholder />
+                                    <Text
+                                      mt="0.75rem"
+                                      textStyle="subhead-1"
+                                      color="base.content.default"
+                                    >
+                                      Blocks you add will appear here
+                                    </Text>
+                                    <Text
+                                      mt="0.25rem"
+                                      textStyle="caption-2"
+                                      color="base.content.medium"
+                                    >
+                                      Click the ‘Add block’ button above to add
+                                      blocks to this page
+                                    </Text>
+                                  </VStack>
 
-                                <Button
-                                  variant="outline"
-                                  w="100%"
-                                  onClick={() =>
-                                    setDrawerState({ state: "addBlock" })
-                                  }
-                                  leftIcon={
-                                    <Icon as={BiPlus} fontSize="1.25rem" />
-                                  }
-                                >
-                                  Add a new block
-                                </Button>
-                              </>
-                            )}
+                                  <Button
+                                    variant="outline"
+                                    w="100%"
+                                    onClick={() =>
+                                      setDrawerState({ state: "addBlock" })
+                                    }
+                                    leftIcon={
+                                      <Icon as={BiPlus} fontSize="1.25rem" />
+                                    }
+                                  >
+                                    Add a new block
+                                  </Button>
+                                </>
+                              )}
 
                             <Flex flexDirection="column" mt="-0.25rem">
                               {previewPageState.content.map((block, index) => {


### PR DESCRIPTION
## Problem
Previously, the code had an inner conditional for `!isPreviewingIndexPage` - this led to issues because the inner conditional evaluated to `true` (see below code) 

```ts
  (savedPageState.content.length === 0 &&
    pageLayout !==
    ISOMER_USABLE_PAGE_LAYOUTS.Index) ||
  // default value for this is `false` -> this becomes `true` here 
  !isPreviewingIndexPage)
```

## Solution
Shift the `!isPreviewingIndexPage` conditional out - we should always check that the index page is not being shown on the outermost layer because it has the highest priority


## Screenshots
**Before**
<img width="483" alt="image" src="https://github.com/user-attachments/assets/f37cb261-aa25-4ae8-a411-01de3653729e" />

**After**

https://github.com/user-attachments/assets/f8dee592-aad7-4b8a-882e-2b9bedd63579
