### PR TITLE
storybook mockdate for Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33576,6 +33576,7 @@
         "browserslist-useragent-regexp": "^4.1.3",
         "chromatic": "^11.5.3",
         "eslint": "^9.10.0",
+        "mockdate": "^3.0.5",
         "msw": "^2.7.0",
         "msw-storybook-addon": "^2.0.4",
         "npm-run-all": "^4.1.5",
@@ -34010,7 +34011,7 @@
         "eslint-plugin-import": "^2.30.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.36.1",
-        "eslint-plugin-react-hooks": "*",
+        "eslint-plugin-react-hooks": "beta",
         "prettier": "^3.3.3",
         "typescript": "5.6.2",
         "typescript-eslint": "^8.6.0"

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -2,6 +2,7 @@
 import type { Decorator, Preview } from "@storybook/react"
 import { withThemeByDataAttribute } from "@storybook/addon-themes"
 import { MINIMAL_VIEWPORTS } from "@storybook/addon-viewport"
+import mockdate from "mockdate"
 import { initialize, mswLoader } from "msw-storybook-addon"
 
 import "bootstrap-icons/font/bootstrap-icons.css"
@@ -115,6 +116,14 @@ const LayoutDecorator: Decorator = (storyFn) => (
   <div className="antialiased">{storyFn()}</div>
 )
 
+const MockDateDecorator: Decorator = (storyFn) => {
+  mockdate.reset()
+  const defaultDate = "2025-08-09T12:00:00.000Z"
+  mockdate.set(defaultDate)
+
+  return storyFn()
+}
+
 export const decorators: Decorator[] = [
   withThemeByDataAttribute({
     themes: {
@@ -124,6 +133,7 @@ export const decorators: Decorator[] = [
     defaultTheme: "Isomer Next",
   }),
   LayoutDecorator,
+  MockDateDecorator,
 ]
 
 export default preview

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -54,6 +54,7 @@
     "browserslist-useragent-regexp": "^4.1.3",
     "chromatic": "^11.5.3",
     "eslint": "^9.10.0",
+    "mockdate": "^3.0.5",
     "msw": "^2.7.0",
     "msw-storybook-addon": "^2.0.4",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

tired of approving date-related changes for storybook

## Solution

<!-- How did you solve the problem? -->

**Improvements**:

- mock it using `mockdate` and a mockdate decorator for Component storybook