### PR TITLE
fix: set page state only after return to root

### DIFF
--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -81,8 +81,6 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
       ...previewPageState,
       content: updatedBlocks,
     }
-    setSavedPageState(newPageState)
-    setPreviewPageState(newPageState)
     onDeleteBlockModalClose()
     setDrawerState({ state: "root" })
     setAddedBlockIndex(null)
@@ -91,6 +89,15 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
       siteId,
       content: JSON.stringify(newPageState),
     })
+    // NOTE: This chunk needs to be AFTER `setDrawerState`.
+    // This is because we set the state of the drawer and then
+    // use `flushSync` to force a re-render.
+    // As this state is also read by `FormBuilder`,
+    // setting the state here will lead to a crash
+    // as the component will then re-render with an invalid
+    // state being fed to `FormBuilder`.
+    setSavedPageState(newPageState)
+    setPreviewPageState(newPageState)
   }, [
     currActiveIdx,
     onDeleteBlockModalClose,


### PR DESCRIPTION
## Problem
At present, deleting any block above a `Text` block causes a crash. This is because (**note**: i'm guessing here as i'm not 100% confident) the blocks re-rendered and the new state is immediately fed to `JSONForms` via `FormBuilder` prior to the update loop being complete.

Closes [insert issue #]

## Solution
Shift the update for block state **below** the state update for drawer, so that `FormBuilder` doesn't see the new state whilst its internal state hasn't been updated.

## Videos

https://github.com/user-attachments/assets/8c59bdf0-3c1f-4c08-bdbc-7390ffbd16f4

