### PR TITLE
feat: add migration for adding default index pages

### DIFF
--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage.ts
@@ -1,0 +1,70 @@
+// This migration is to update the Folders that currently
+// do not have an `IndexPage` to have a default one.
+// It is a one-time migration to update the existing Folder records
+// It is not reversible
+
+import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
+import { db, jsonb, ResourceType } from "~/server/modules/database"
+import { createFolderIndexPage } from "~/server/modules/page/page.service"
+
+export const createDefaultFolderIndexPage = async () => {
+  try {
+    const folderWithChildren = (
+      await db
+        .selectFrom("Resource as f")
+        .leftJoin("Resource as ip", "f.id", "ip.parentId")
+        .where("ip.type", "=", "IndexPage")
+        .where("f.type", "=", "Folder")
+        .select("f.id")
+        .execute()
+    ).map(({ id }) => id)
+
+    const danglingFolders = await db
+      .selectFrom("Resource as f")
+      .where("type", "=", "Folder")
+      .where("id", "not in", folderWithChildren)
+      .select(["id", "title", "siteId"])
+      .execute()
+
+    const defaultBlobs = danglingFolders.map((folder) => ({
+      content: jsonb(createFolderIndexPage(folder.title)),
+    }))
+
+    await db.transaction().execute(async (tx) => {
+      const blobs = await tx
+        .insertInto("Blob")
+        .values(defaultBlobs)
+        .returning("id")
+        .execute()
+
+      await tx
+        .insertInto("Resource")
+        .values(
+          danglingFolders.map((folder, index) => {
+            return {
+              parentId: folder.id,
+              title: folder.title,
+              type: ResourceType.IndexPage,
+              permalink: INDEX_PAGE_PERMALINK,
+              // NOTE: No difference here in `Blob.content`;
+              // we create the blobs based off `danglingFolders`
+              // and this is also generated off `danglingFolders`
+              // so the blob will always be defined
+              draftBlobId: blobs[index]!.id,
+              siteId: folder.siteId,
+            }
+          }),
+        )
+        .execute()
+
+      // NOTE: not creating `Version` here to mimic default behaviour for folder creation
+    })
+  } catch (error) {
+    console.error("Transaction failed:", error)
+    console.log("All changes have been rolled back.")
+    throw error
+  }
+}
+
+// Uncomment to run the migration
+// createDefaultFolderIndexPage()

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/__tests__/addDefaultIndexPage.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/__tests__/addDefaultIndexPage.test.ts
@@ -1,0 +1,191 @@
+// This migration is to update the Folders that currently
+// do not have an `IndexPage` to have a default one.
+// It is a one-time migration to update the existing Folder records
+// It is not reversible
+
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupAdminPermissions,
+  setupBlob,
+  setupCollection,
+  setupCollectionLink,
+  setupEditorPermissions,
+  setupFolder,
+  setupFolderMeta,
+  setupPageResource,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+
+import { db, jsonb } from "~/server/modules/database"
+import { createFolderIndexPage } from "~/server/modules/page/page.service"
+import { createDefaultFolderIndexPage } from "../addDefaultIndexPage"
+
+describe("createDefaultFolderIndexPage", async () => {
+  let site: Awaited<ReturnType<typeof setupSite>>["site"]
+
+  beforeEach(async () => {
+    await resetTables("Blob", "Resource")
+  })
+
+  beforeAll(async () => {
+    const { site: _site } = await setupSite()
+    site = _site
+  })
+
+  it("should not impact folders with existing index pages", async () => {
+    // Arrange
+    const { folder } = await setupFolder({ siteId: site.id })
+    const { page } = await setupPageResource({
+      parentId: folder.id,
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+    })
+
+    // Act
+    await createDefaultFolderIndexPage()
+
+    // Assert
+    const indexPage = await getIndexPageOf(folder.id)
+    expect(indexPage).toEqual(page)
+  })
+  it("should create index pages for folders at root that do not have index pages ", async () => {
+    // Arrange
+    await createFolderWithChildren(site.id)
+    const { folder } = await setupFolder({
+      siteId: site.id,
+      title: "Folder without index page",
+      permalink: "noIndex",
+    })
+    const indexPageBlobContent = createFolderIndexPage(folder.title)
+
+    // Act
+    await createDefaultFolderIndexPage()
+
+    // Assert
+    const indexPage = await getIndexPageOf(folder.id)
+    expect(indexPage?.draftBlobId).toBeDefined()
+    const draftBlob = await getBlob(indexPage?.draftBlobId ?? "")
+    // NOTE: For some reason, the date comparisons fail between the `page.lastModified` and the `Blob.content.page.lastModified`
+    // but the values are only off by 1 nanosecond
+    expect(draftBlob?.content.content).toEqual(indexPageBlobContent.content)
+  })
+  it("should create index pages for nested folders that do not have index pages", async () => {
+    // Arrange
+    const { folder: parent } = await createFolderWithChildren(site.id)
+    const { folder } = await setupFolder({
+      siteId: site.id,
+      title: "Folder without index page",
+      permalink: "noIndex",
+      parentId: parent.id,
+    })
+    const indexPageBlobContent = createFolderIndexPage(folder.title)
+
+    // Act
+    await createDefaultFolderIndexPage()
+
+    // Assert
+    const indexPage = await getIndexPageOf(folder.id)
+    expect(indexPage?.draftBlobId).toBeDefined()
+    const draftBlob = await getBlob(indexPage?.draftBlobId ?? "")
+    // NOTE: For some reason, the date comparisons fail between the `page.lastModified` and the `Blob.content.page.lastModified`
+    // but the values are only off by 1 nanosecond
+    expect(draftBlob?.content.content).toEqual(indexPageBlobContent.content)
+  })
+
+  it("should not create index pages for collections with index pages", async () => {
+    // Arrange
+    await createFolderWithChildren(site.id)
+    const { collection } = await setupCollection({ siteId: site.id })
+    const { page } = await setupPageResource({
+      parentId: collection.id,
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+    })
+    const blobContent = createFolderIndexPage(collection.title)
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(blobContent) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    await db
+      .updateTable("Resource")
+      .set({ draftBlobId: blob.id })
+      .where("id", "=", page.id)
+      .execute()
+
+    // Act
+    await createDefaultFolderIndexPage()
+
+    // Assert
+    const indexPage = await getIndexPageOf(collection.id)
+    expect(indexPage?.draftBlobId).toBeDefined()
+    const draftBlob = await getBlob(indexPage?.draftBlobId ?? "")
+    expect(draftBlob?.content.content).toEqual(blob?.content.content)
+    const possiblyUpdatedIndexPage = await db
+      .selectFrom("Resource")
+      .where("id", "=", page.id)
+      .select("draftBlobId")
+      .executeTakeFirstOrThrow()
+    // Expect that no changes occured as a result of this change -
+    // both the draft blob and the id are identical
+    expect(possiblyUpdatedIndexPage.draftBlobId).toEqual(blob.id)
+  })
+  it("should not create index pages for collections without index pages", async () => {
+    // Arrange
+    await createFolderWithChildren(site.id)
+    const { collection } = await setupCollection({ siteId: site.id })
+
+    // Act
+    await createDefaultFolderIndexPage()
+
+    // Assert
+    const indexPage = await getIndexPageOf(collection.id)
+    expect(indexPage).toBeUndefined()
+  })
+  it("should not create any versions for the newly created index pages", async () => {
+    // Arrange
+    const { folder } = await createFolderWithChildren(site.id)
+
+    // Act
+    await createDefaultFolderIndexPage()
+
+    // Assert
+    const indexPage = await getIndexPageOf(folder.id)
+    expect(indexPage).toBeDefined()
+    const versions = await db
+      .selectFrom("Version")
+      .where("Version.resourceId", "=", indexPage!.id)
+      .selectAll()
+      .execute()
+    expect(versions).toStrictEqual([])
+  })
+})
+
+const getIndexPageOf = (resourceId: string) => {
+  return db
+    .selectFrom("Resource")
+    .where("parentId", "=", resourceId)
+    .where("type", "=", ResourceType.IndexPage)
+    .selectAll()
+    .executeTakeFirst()
+}
+
+const getBlob = (blobId: string) =>
+  db
+    .selectFrom("Blob")
+    .where("id", "=", blobId)
+    .select("content")
+    .executeTakeFirst()
+
+const createFolderWithChildren = async (siteId: number, parentId?: string) => {
+  const { folder } = await setupFolder({ siteId, parentId })
+  const { page } = await setupPageResource({
+    parentId: folder.id,
+    siteId,
+    resourceType: ResourceType.IndexPage,
+  })
+
+  return { folder, page }
+}

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/__tests__/addDefaultIndexPage.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/__tests__/addDefaultIndexPage.test.ts
@@ -31,7 +31,7 @@ describe("createDefaultFolderIndexPage", () => {
   it("should not impact folders with existing index pages", async () => {
     // Arrange
     const { folder } = await setupFolder({ siteId: site.id })
-    const { page } = await setupPageResource({
+    await setupPageResource({
       parentId: folder.id,
       siteId: site.id,
       resourceType: ResourceType.IndexPage,
@@ -41,8 +41,14 @@ describe("createDefaultFolderIndexPage", () => {
     await createDefaultFolderIndexPage()
 
     // Assert
-    const indexPage = await getIndexPageOf(folder.id)
-    expect(indexPage).toEqual(page)
+    const indexPages = await db
+      .selectFrom("Resource")
+      .where("parentId", "=", folder.id)
+      .where("type", "=", ResourceType.IndexPage)
+      .selectAll()
+      .execute()
+
+    expect(indexPages.length).toEqual(1)
   })
   it("should create index pages for folders at root that do not have index pages ", async () => {
     // Arrange

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/__tests__/addDefaultIndexPage.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/__tests__/addDefaultIndexPage.test.ts
@@ -6,23 +6,17 @@
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { resetTables } from "tests/integration/helpers/db"
 import {
-  setupAdminPermissions,
-  setupBlob,
   setupCollection,
-  setupCollectionLink,
-  setupEditorPermissions,
   setupFolder,
-  setupFolderMeta,
   setupPageResource,
   setupSite,
-  setupUser,
 } from "tests/integration/helpers/seed"
 
 import { db, jsonb } from "~/server/modules/database"
 import { createFolderIndexPage } from "~/server/modules/page/page.service"
 import { createDefaultFolderIndexPage } from "../addDefaultIndexPage"
 
-describe("createDefaultFolderIndexPage", async () => {
+describe("createDefaultFolderIndexPage", () => {
   let site: Awaited<ReturnType<typeof setupSite>>["site"]
 
   beforeEach(async () => {
@@ -122,7 +116,7 @@ describe("createDefaultFolderIndexPage", async () => {
     const indexPage = await getIndexPageOf(collection.id)
     expect(indexPage?.draftBlobId).toBeDefined()
     const draftBlob = await getBlob(indexPage?.draftBlobId ?? "")
-    expect(draftBlob?.content.content).toEqual(blob?.content.content)
+    expect(draftBlob?.content.content).toEqual(blob.content.content)
     const possiblyUpdatedIndexPage = await db
       .selectFrom("Resource")
       .where("id", "=", page.id)

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/addDefaultIndexPage.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/addDefaultIndexPage.ts
@@ -8,66 +8,68 @@ import { db, jsonb, ResourceType } from "~/server/modules/database"
 import { createFolderIndexPage } from "~/server/modules/page/page.service"
 
 export const createDefaultFolderIndexPage = async () => {
-  try {
-    const folderWithChildren = (
-      await db
-        .selectFrom("Resource as f")
-        .leftJoin("Resource as ip", "f.id", "ip.parentId")
-        .where("ip.type", "=", "IndexPage")
-        .where("f.type", "=", "Folder")
-        .select("f.id")
-        .execute()
-    ).map(({ id }) => id)
-
-    const danglingFolders = await db
+  const folderWithChildren = (
+    await db
       .selectFrom("Resource as f")
-      .where("type", "=", "Folder")
-      .where("id", "not in", folderWithChildren)
-      .select(["id", "title", "siteId"])
+      .leftJoin("Resource as ip", "f.id", "ip.parentId")
+      .where("ip.type", "=", "IndexPage")
+      .where("f.type", "=", "Folder")
+      .select("f.id")
       .execute()
+  ).map(({ id }) => id)
 
-    if (danglingFolders.length === 0) {
-      return
+  const foldersWithoutIndex = await db
+    .selectFrom("Resource as f")
+    .where("type", "=", "Folder")
+    .where("id", "not in", folderWithChildren)
+    .select(["id", "title", "siteId"])
+    .execute()
+
+  if (foldersWithoutIndex.length === 0) {
+    return
+  }
+
+  const defaultBlobs = foldersWithoutIndex.map((folder) => {
+    const content = jsonb(createFolderIndexPage(folder.title))
+    return [
+      {
+        content,
+      },
+      folder,
+    ] satisfies [{ content: typeof content }, typeof folder]
+  })
+
+  for (const [defaultBlob, folder] of defaultBlobs) {
+    try {
+      await db.transaction().execute(async (tx) => {
+        const insertedBlob = await tx
+          .insertInto("Blob")
+          .values(defaultBlob)
+          .returning("id")
+          .executeTakeFirstOrThrow()
+
+        await tx
+          .insertInto("Resource")
+          .values({
+            parentId: folder.id,
+            title: folder.title,
+            type: ResourceType.IndexPage,
+            permalink: INDEX_PAGE_PERMALINK,
+            // NOTE: No difference here in `Blob.content`;
+            // we create the blobs based off `danglingFolders`
+            // and this is also generated off `danglingFolders`
+            // so the blob will always be defined
+            draftBlobId: insertedBlob.id,
+            siteId: folder.siteId,
+          })
+          .execute()
+
+        // NOTE: not creating `Version` here to mimic default behaviour for folder creation
+      })
+    } catch (e) {
+      console.error(
+        `[ERROR]: Unable to create index page for Folder: ${folder.title} with id: ${folder.id}.\n Error received: ${JSON.stringify(e, null, 2)}`,
+      )
     }
-
-    const defaultBlobs = danglingFolders.map((folder) => ({
-      content: jsonb(createFolderIndexPage(folder.title)),
-    }))
-
-    await db.transaction().execute(async (tx) => {
-      const blobs = await tx
-        .insertInto("Blob")
-        .values(defaultBlobs)
-        .returning("id")
-        // .compile().sql
-        // .explain()
-        .execute()
-
-      await tx
-        .insertInto("Resource")
-        .values(
-          danglingFolders.map((folder, index) => {
-            return {
-              parentId: folder.id,
-              title: folder.title,
-              type: ResourceType.IndexPage,
-              permalink: INDEX_PAGE_PERMALINK,
-              // NOTE: No difference here in `Blob.content`;
-              // we create the blobs based off `danglingFolders`
-              // and this is also generated off `danglingFolders`
-              // so the blob will always be defined
-              draftBlobId: blobs[index]?.id,
-              siteId: folder.siteId,
-            }
-          }),
-        )
-        .execute()
-
-      // NOTE: not creating `Version` here to mimic default behaviour for folder creation
-    })
-  } catch (error) {
-    console.error("Transaction failed:", error)
-    console.log("All changes have been rolled back.")
-    throw error
   }
 }

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/addDefaultIndexPage.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/addDefaultIndexPage.ts
@@ -26,6 +26,10 @@ export const createDefaultFolderIndexPage = async () => {
       .select(["id", "title", "siteId"])
       .execute()
 
+    if (danglingFolders.length === 0) {
+      return
+    }
+
     const defaultBlobs = danglingFolders.map((folder) => ({
       content: jsonb(createFolderIndexPage(folder.title)),
     }))
@@ -35,6 +39,8 @@ export const createDefaultFolderIndexPage = async () => {
         .insertInto("Blob")
         .values(defaultBlobs)
         .returning("id")
+        // .compile().sql
+        // .explain()
         .execute()
 
       await tx
@@ -65,6 +71,3 @@ export const createDefaultFolderIndexPage = async () => {
     throw error
   }
 }
-
-// Uncomment to run the migration
-// createDefaultFolderIndexPage()

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/addDefaultIndexPage.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/addDefaultIndexPage.ts
@@ -56,7 +56,7 @@ export const createDefaultFolderIndexPage = async () => {
               // we create the blobs based off `danglingFolders`
               // and this is also generated off `danglingFolders`
               // so the blob will always be defined
-              draftBlobId: blobs[index]!.id,
+              draftBlobId: blobs[index]?.id,
               siteId: folder.siteId,
             }
           }),

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/index.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/index.ts
@@ -1,0 +1,4 @@
+import { createDefaultFolderIndexPage } from "./addDefaultIndexPage"
+
+// Uncomment to run the migration
+// createDefaultFolderIndexPage()

--- a/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/index.ts
+++ b/apps/studio/prisma/scripts/migrations/addDefaultIndexPage/index.ts
@@ -1,4 +1,4 @@
 import { createDefaultFolderIndexPage } from "./addDefaultIndexPage"
 
-// Uncomment to run the migration
-// createDefaultFolderIndexPage()
+// NOTE: did this to stop lint errors...
+export const runMigration = createDefaultFolderIndexPage


### PR DESCRIPTION
## Problem
see attached issue

Closes [insert issue #]

## Solution
- add as a prisma script that we will invoke manually. this was chosen over writing raw sql due to ease of comprehension for kysely (sorry i pleb)
- this works via getting all the folders that have an index page then we take the inverse of that. i couldn't use `not in` here (on the `expression builder` as it didn't seem to exist on the builder, requiring 2 queries.
- for each dangling folder, i then create a **draft** index page (with blob); this was done to mimic the default behaviour we have now, where we also create a draft index page by default. 
