### PR TITLE
chore: remove extra rootpage resource fetched from db

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -17,7 +17,7 @@ import type {
 import type { SearchResultResource } from "./resource.types"
 import type { ResourceItemContent } from "~/schemas/resource"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
-import { getSitemapTree, PAGE_RESOURCE_TYPES } from "~/utils/sitemap"
+import { CHILD_PAGE_RESOURCE_TYPES, getSitemapTree } from "~/utils/sitemap"
 import { logPublishEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceType, sql } from "../database"
@@ -374,7 +374,7 @@ export const getLocalisedSitemap = async (
               ResourceType.Folder,
             ]),
         )
-        .where("type", "in", PAGE_RESOURCE_TYPES)
+        .where("type", "in", CHILD_PAGE_RESOURCE_TYPES)
         .where("state", "=", "Published")
         .leftJoin("Version", "Version.id", "publishedVersionId")
         .leftJoin("Blob as published", "Version.blobId", "published.id")

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -3,12 +3,11 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { Resource } from "~prisma/generated/selectableTypes"
 
-export const PAGE_RESOURCE_TYPES = [
+export const CHILD_PAGE_RESOURCE_TYPES = [
   ResourceType.Page,
   ResourceType.CollectionPage,
   ResourceType.CollectionLink,
   ResourceType.IndexPage,
-  ResourceType.RootPage,
 ] as const
 type ResourceDto = Omit<
   Resource,
@@ -60,11 +59,11 @@ const getSitemapTreeFromArray = (
       const hasPageDescendants = resources.some((possibleChild) => {
         return (
           possibleChild.permalink.startsWith(resource.permalink) &&
-          PAGE_RESOURCE_TYPES.find((t) => t === possibleChild.type)
+          CHILD_PAGE_RESOURCE_TYPES.find((t) => t === possibleChild.type)
         )
       })
       return (
-        PAGE_RESOURCE_TYPES.find((t) => t === resource.type) ||
+        CHILD_PAGE_RESOURCE_TYPES.find((t) => t === resource.type) ||
         hasPageDescendants
       )
     })


### PR DESCRIPTION
## Problem
- we fetch the `RootPage` as part of the `immediateSibilngs` because on root page, the `parentId` is also `null`. this leads to alot of sub children if the tree is wide. later on, this blows the stack due to excessive processing in `getSitemapTreeFromArray` 

## Solution
we never need teh `RootPage`, so it's removed from filter + we update the name to maek it clearer
