### PR TITLE
hotfix to use InfobarHomepageSchema instead

### DIFF
--- a/packages/components/src/schemas/components.ts
+++ b/packages/components/src/schemas/components.ts
@@ -38,7 +38,7 @@ export const IsomerComplexComponentsMap = {
   hero: HeroSchema,
   iframe: IframeSchema,
   image: ImageSchema,
-  infobar: InfobarDefaultSchema,
+  infobar: InfobarHomepageSchema,
   infocards: InfoCardsSchema,
   infocols: InfoColsSchema,
   infopic: InfopicSchema,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C06R4DX966P/p1747214962495839?thread_ts=1747208642.036699&cid=C06R4DX966P

The issue is because our `validatedPageProcedure` for `updatePageBlob` relies on `IsomerSchema` for determining what's a correct schema

```ts
const schemaValidator = ajv.compile<IsomerSchema>(schema)
```

We were using Infobar's default-schema over homepage-schema, which causes an issue because default-schema have a tighter check against allowing `dark` option

## Solution

<!-- How did you solve the problem? -->

- replace `InfobarDefaultSchema` with `InfobarHomepageSchema`

> [!NOTE]
> With this change, it also means the one is able to overwrite infobar's schema in non-homepage layout as `dark` and it will still pass the validation. However, this shouldn't matter as 1) the "variant" field won't be show in studio, 2) even if set to `dark`, the component wouldn't render it. Nevertheless, we should deeper into how we generate the schema instead as right now it's a 1-1 relationship (one component type can only have one schema for ajv)