### PR TITLE
chore: fix styling on infobox

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -238,6 +238,7 @@ export default function RootStateDrawer() {
         <VStack w="100%" h="100%" gap="1rem">
           {isCustomContentIndexPage && (
             <Infobox
+              width="100%"
               size="sm"
               border="1px solid"
               borderColor="utility.feedback.info"
@@ -449,7 +450,7 @@ export default function RootStateDrawer() {
           mt="auto"
         >
           <VStack spacing="1.25rem">
-            <Infobox size="sm" variant="warning">
+            <Infobox width="100%" size="sm" variant="warning">
               <Text textStyle="body-2">
                 All custom content that was previously on this page will be lost
                 once you press ‘Accept this change’.


### PR DESCRIPTION
## Problem
- our infobox isn't full width on bigger screens for the toggle 

## Solution
- add full width for infobox

## Screenshots
**old**
<img width="876" alt="image" src="https://github.com/user-attachments/assets/5a9ec948-3c18-403d-9292-cf0d592bfa9c" />
<img width="849" alt="image" src="https://github.com/user-attachments/assets/f572dabf-fa54-43e8-bd5d-1eb1191d3868" />

**new**
<img width="889" alt="image" src="https://github.com/user-attachments/assets/8c580291-0dd6-4452-9aa5-93ffd32f7433" />
<img width="855" alt="image" src="https://github.com/user-attachments/assets/6bd3c7fc-6b6f-4015-9508-e4cc233ec91b" />
