### PR TITLE
fix: make blockquote image alt optional

### DIFF
--- a/packages/components/src/interfaces/complex/Blockquote.ts
+++ b/packages/components/src/interfaces/complex/Blockquote.ts
@@ -21,7 +21,10 @@ export const BlockquoteSchema = Type.Object(
     // because the schema does not support having dependent properties. If no
     // image is provided, the alt text will be ignored
     imageSrc: Type.Optional(ImageSrcSchema),
-    imageAlt: AltTextSchema,
+    // Setting as optional because the image is optional.
+    // If no image is provided and this is required, the schema will throw an error,
+    // making it impossible to create a blockquote without an image on Studio
+    imageAlt: Type.Optional(AltTextSchema),
   },
   {
     title: "Blockquote component",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Users cannot create block quotes without image as alt text is required

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- make image alt text optional

> [!NOTE]
> this is not ideal as users will be able to create an image without an alt text, but this is a workabout 

### Tests

- try to create a block quote component with NO image. you should be able to do so