### PR TITLE
Potential fix for code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
@@ -8,24 +8,24 @@ export const getTagFilters = (
   // associated set of values as well as the selected value.
   // Hence, we store a map here of the category (eg: Body parts)
   // to the number of occurences of each value (eg: { Brain: 3, Leg: 2})
-  const tagCategories: Map<string, Map<string, number>> = new Map();
+  const tagCategories = new Map<string, Map<string, number>>()
 
   items.forEach(({ tags }) => {
     if (tags) {
       tags.forEach(({ selected: selectedLabels, category }) => {
         if (!tagCategories.has(category)) {
-          tagCategories.set(category, new Map());
+          tagCategories.set(category, new Map())
         }
-        const categoryMap = tagCategories.get(category)!;
+        const categoryMap = tagCategories.get(category) ?? new Map()
         selectedLabels.forEach((label) => {
           if (!categoryMap.has(label)) {
-            categoryMap.set(label, 0);
+            categoryMap.set(label, 0)
           }
-          categoryMap.set(label, categoryMap.get(label)! + 1);
-        });
-      });
+          categoryMap.set(label, (categoryMap.get(label) ?? 0) + 1)
+        })
+      })
     }
-  });
+  })
 
   return Array.from(tagCategories.entries())
     .reduce((acc: Filter[], [category, values]) => {
@@ -37,7 +37,7 @@ export const getTagFilters = (
         }))
         .sort((a, b) =>
           a.label.localeCompare(b.label, undefined, { numeric: true }),
-        );
+        )
 
       const filters: Filter[] = [
         ...acc,
@@ -46,11 +46,11 @@ export const getTagFilters = (
           id: category,
           label: category,
         },
-      ];
+      ]
 
-      return filters;
+      return filters
     }, [])
     .sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { numeric: true }),
-    );
+    )
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
@@ -8,29 +8,28 @@ export const getTagFilters = (
   // associated set of values as well as the selected value.
   // Hence, we store a map here of the category (eg: Body parts)
   // to the number of occurences of each value (eg: { Brain: 3, Leg: 2})
-  const tagCategories: Record<string, Record<string, number>> = {}
+  const tagCategories: Map<string, Map<string, number>> = new Map();
 
   items.forEach(({ tags }) => {
     if (tags) {
       tags.forEach(({ selected: selectedLabels, category }) => {
+        if (!tagCategories.has(category)) {
+          tagCategories.set(category, new Map());
+        }
+        const categoryMap = tagCategories.get(category)!;
         selectedLabels.forEach((label) => {
-          if (!tagCategories[category]) {
-            tagCategories[category] = {}
+          if (!categoryMap.has(label)) {
+            categoryMap.set(label, 0);
           }
-          if (!tagCategories[category][label]) {
-            tagCategories[category][label] = 0
-          }
-
-          tagCategories[category][label] += 1
-        })
-      })
+          categoryMap.set(label, categoryMap.get(label)! + 1);
+        });
+      });
     }
-  })
+  });
 
-  return Object.entries(tagCategories)
-    .reduce((acc: Filter[], curValue) => {
-      const [category, values] = curValue
-      const items: FilterItem[] = Object.entries(values)
+  return Array.from(tagCategories.entries())
+    .reduce((acc: Filter[], [category, values]) => {
+      const items: FilterItem[] = Array.from(values.entries())
         .map(([label, count]) => ({
           label,
           count,
@@ -38,7 +37,7 @@ export const getTagFilters = (
         }))
         .sort((a, b) =>
           a.label.localeCompare(b.label, undefined, { numeric: true }),
-        )
+        );
 
       const filters: Filter[] = [
         ...acc,
@@ -47,11 +46,11 @@ export const getTagFilters = (
           id: category,
           label: category,
         },
-      ]
+      ];
 
-      return filters
+      return filters;
     }, [])
     .sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { numeric: true }),
-    )
+    );
 }


### PR DESCRIPTION
Potential fix for [https://github.com/opengovsg/isomer/security/code-scanning/9](https://github.com/opengovsg/isomer/security/code-scanning/9)

To fix the issue, we need to prevent prototype pollution by ensuring that untrusted input cannot be used to modify `Object.prototype`. The best approach here is to replace the plain object `tagCategories` with a `Map`, which does not inherit from `Object.prototype` and is immune to prototype pollution. Alternatively, we could validate the `category` key to reject unsafe values like `__proto__`, but using a `Map` is a more robust and future-proof solution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
