### PR TITLE
Singpass fallback - Disabling singpass send notification

### DIFF
--- a/apps/studio/src/constants/misc.ts
+++ b/apps/studio/src/constants/misc.ts
@@ -1,1 +1,2 @@
-export const ISOMER_SUPPORT_LINK = "mailto:support@isomer.gov.sg"
+export const ISOMER_SUPPORT_EMAIL = "support@isomer.gov.sg"
+export const ISOMER_SUPPORT_LINK = `mailto:${ISOMER_SUPPORT_EMAIL}`

--- a/apps/studio/src/features/mail/service.ts
+++ b/apps/studio/src/features/mail/service.ts
@@ -1,4 +1,8 @@
-import type { InvitationEmailTemplateData } from "./templates"
+import type {
+  InvitationEmailTemplateData,
+  PublishAlertContentPublisherEmailTemplateData,
+  PublishAlertSiteAdminEmailTemplateData,
+} from "./templates"
 import { createBaseLogger } from "~/lib/logger"
 import { isValidEmail } from "~/utils/email"
 import { sendMail } from "../../lib/mail"
@@ -28,6 +32,64 @@ export async function sendInvitation(
   } catch (error) {
     logger.error({
       error: "Failed to send invitation email",
+      email: data.recipientEmail,
+      originalError: error,
+    })
+    throw error
+  }
+}
+
+export async function sendPublishAlertContentPublisherEmail(
+  data: PublishAlertContentPublisherEmailTemplateData,
+): Promise<void> {
+  if (!isValidEmail(data.recipientEmail)) {
+    logger.error({
+      error: "Invalid email format",
+      email: data.recipientEmail,
+    })
+    throw new Error("Invalid email format")
+  }
+
+  const template = templates.publishAlertContentPublisher(data)
+
+  try {
+    await sendMail({
+      recipient: data.recipientEmail,
+      subject: template.subject,
+      body: template.body,
+    })
+  } catch (error) {
+    logger.error({
+      error: "Failed to send publish alert content publisher email",
+      email: data.recipientEmail,
+      originalError: error,
+    })
+    throw error
+  }
+}
+
+export async function sendPublishAlertSiteAdminEmail(
+  data: PublishAlertSiteAdminEmailTemplateData,
+): Promise<void> {
+  if (!isValidEmail(data.recipientEmail)) {
+    logger.error({
+      error: "Invalid email format",
+      email: data.recipientEmail,
+    })
+    throw new Error("Invalid email format")
+  }
+
+  const template = templates.publishAlertSiteAdmin(data)
+
+  try {
+    await sendMail({
+      recipient: data.recipientEmail,
+      subject: template.subject,
+      body: template.body,
+    })
+  } catch (error) {
+    logger.error({
+      error: "Failed to send publish alert site admin email",
       email: data.recipientEmail,
       originalError: error,
     })

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -4,8 +4,12 @@ import type {
   BaseEmailTemplateData,
   EmailTemplate,
   InvitationEmailTemplateData,
+  PublishAlertContentPublisherEmailTemplateData,
+  PublishAlertSiteAdminEmailTemplateData,
 } from "./types"
+import { ISOMER_SUPPORT_EMAIL, ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { env } from "~/env.mjs"
+import { getResourceStudioUrl } from "~/utils/resources"
 
 export const invitationTemplate = (
   data: InvitationEmailTemplateData,
@@ -50,6 +54,38 @@ export const invitationTemplate = (
   }
 }
 
+export const publishAlertContentPublisherTemplate = (
+  data: PublishAlertContentPublisherEmailTemplateData,
+): EmailTemplate => {
+  const { recipientEmail, siteName, resource } = data
+  const resourceStudioUrl = getResourceStudioUrl(resource)
+
+  return {
+    subject: `[Isomer Studio] ${resource.title} has been published`,
+    body: `<p>Hi ${recipientEmail},</p>
+<p>You have successfully published "${resource.title}" on ${siteName}. You can access your published content on Isomer Studio at <a href="${resourceStudioUrl}">${resourceStudioUrl}</a>.</p>
+<p><strong>Note:</strong> You're receiving this notification because content was published during a Singpass authentication outage. If you didn't authorize this publication, please contact <a href="${ISOMER_SUPPORT_LINK}">${ISOMER_SUPPORT_EMAIL}</a> immediately.</p>
+<p>Best,</p>
+<p>Isomer team</p>`,
+  }
+}
+
+export const publishAlertSiteAdminTemplate = (
+  data: PublishAlertSiteAdminEmailTemplateData,
+): EmailTemplate => {
+  const { recipientEmail, publisherEmail, siteName, resource } = data
+  const resourceStudioUrl = getResourceStudioUrl(resource)
+
+  return {
+    subject: `[Isomer Studio] ${resource.title} has been published`,
+    body: `<p>Hi ${recipientEmail},</p>
+<p>${publisherEmail} has published "${resource.title}" on ${siteName}. You can view the published content on Isomer Studio at <a href="${resourceStudioUrl}">${resourceStudioUrl}</a>.</p>
+<p><strong>Note:</strong> You're receiving this notification because content was published during a Singpass authentication outage. As a site admin, we want to keep you informed of all publishing activities. If you have any concerns, please contact <a href="${ISOMER_SUPPORT_LINK}">${ISOMER_SUPPORT_EMAIL}</a> immediately.</p>
+<p>Best,</p>
+<p>Isomer team</p>`,
+  }
+}
+
 type EmailTemplateFunction<
   T extends BaseEmailTemplateData = BaseEmailTemplateData,
 > = (data: T) => EmailTemplate
@@ -57,4 +93,8 @@ type EmailTemplateFunction<
 export const templates = {
   invitation:
     invitationTemplate satisfies EmailTemplateFunction<InvitationEmailTemplateData>,
+  publishAlertContentPublisher:
+    publishAlertContentPublisherTemplate satisfies EmailTemplateFunction<PublishAlertContentPublisherEmailTemplateData>,
+  publishAlertSiteAdmin:
+    publishAlertSiteAdminTemplate satisfies EmailTemplateFunction<PublishAlertSiteAdminEmailTemplateData>,
 } as const

--- a/apps/studio/src/features/mail/templates/types.ts
+++ b/apps/studio/src/features/mail/templates/types.ts
@@ -1,4 +1,5 @@
 import type { RoleType } from "~prisma/generated/generatedEnums"
+import type { Resource } from "~prisma/generated/generatedTypes"
 
 export interface BaseEmailTemplateData {
   recipientEmail: string
@@ -9,6 +10,19 @@ export interface InvitationEmailTemplateData extends BaseEmailTemplateData {
   siteName: string
   role: RoleType
   isSingpassEnabled?: boolean
+}
+
+export interface PublishAlertContentPublisherEmailTemplateData
+  extends BaseEmailTemplateData {
+  siteName: string
+  resource: Resource
+}
+
+export interface PublishAlertSiteAdminEmailTemplateData
+  extends BaseEmailTemplateData {
+  publisherEmail: string
+  siteName: string
+  resource: Resource
 }
 
 export interface EmailTemplate {

--- a/apps/studio/src/features/mail/templates/types.ts
+++ b/apps/studio/src/features/mail/templates/types.ts
@@ -1,5 +1,5 @@
+import type { Resource } from "~/server/modules/database"
 import type { RoleType } from "~prisma/generated/generatedEnums"
-import type { Resource } from "~prisma/generated/generatedTypes"
 
 export interface BaseEmailTemplateData {
   recipientEmail: string
@@ -11,7 +11,6 @@ export interface InvitationEmailTemplateData extends BaseEmailTemplateData {
   role: RoleType
   isSingpassEnabled?: boolean
 }
-
 export interface PublishAlertContentPublisherEmailTemplateData
   extends BaseEmailTemplateData {
   siteName: string

--- a/apps/studio/src/features/sign-in/components/EmailLogin/EmailInput.tsx
+++ b/apps/studio/src/features/sign-in/components/EmailLogin/EmailInput.tsx
@@ -11,6 +11,7 @@ import {
 } from "@opengovsg/design-system-react"
 
 import type { VfnStepData } from "../SignInContext"
+import { ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { useZodForm } from "~/lib/form"
 import { emailSignInSchema } from "~/schemas/auth/email/sign-in"
 import { trpc } from "~/utils/trpc"
@@ -23,7 +24,7 @@ const EmailInputErrorMessage = ({ type, message }: Partial<FieldError>) => {
         <Text>
           We are having trouble sending an OTP to this email address.{" "}
           <Link
-            href="mailto:support@isomer.gov.sg?subject=I can't receive OTP on Isomer Studio"
+            href={`${ISOMER_SUPPORT_LINK}?subject=I can't receive OTP on Isomer Studio`}
             color="utility.feedback.critical"
             _hover={{
               color: "unset",

--- a/apps/studio/src/pages/sites/[siteId]/admin.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/admin.tsx
@@ -19,6 +19,7 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 import { z } from "zod"
 
 import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { ISOMER_SUPPORT_EMAIL } from "~/constants/misc"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { UnsavedSettingModal } from "~/features/editing-experience/components/UnsavedSettingModal"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
@@ -124,8 +125,7 @@ const SiteAdminPage: NextPageWithLayout = () => {
     onError: () => {
       toast({
         title: "Error saving site config!",
-        description:
-          "If this persists, please report this issue at support@isomer.gov.sg",
+        description: `If this persists, please report this issue at ${ISOMER_SUPPORT_EMAIL}`,
         status: "error",
         ...BRIEF_TOAST_SETTINGS,
       })

--- a/apps/studio/src/pages/sites/[siteId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings.tsx
@@ -20,6 +20,7 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 import { z } from "zod"
 
 import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { ISOMER_SUPPORT_EMAIL } from "~/constants/misc"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { UnsavedSettingModal } from "~/features/editing-experience/components/UnsavedSettingModal"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -53,8 +54,7 @@ const SiteSettingsPage: NextPageWithLayout = () => {
     onError: () => {
       toast({
         title: "Error saving site settings!",
-        description:
-          "If this persists, please report this issue at support@isomer.gov.sg",
+        description: `If this persists, please report this issue at ${ISOMER_SUPPORT_EMAIL}`,
         status: "error",
         ...BRIEF_TOAST_SETTINGS,
       })

--- a/apps/studio/src/server/modules/auth/email/email.service.ts
+++ b/apps/studio/src/server/modules/auth/email/email.service.ts
@@ -101,18 +101,19 @@ export const alertPublishWhenSingpassDisabled = async ({
     .select("User.email")
     .execute()
 
-  await sendPublishAlertContentPublisherEmail({
-    recipientEmail: publisherEmail,
-    siteName: site.name,
-    resource,
-  })
-
-  for (const admin of allSiteAdminsMinusCurrentUser) {
-    await sendPublishAlertSiteAdminEmail({
-      recipientEmail: admin.email,
-      publisherEmail,
+  await Promise.all([
+    sendPublishAlertContentPublisherEmail({
+      recipientEmail: publisherEmail,
       siteName: site.name,
       resource,
-    })
-  }
+    }),
+    ...allSiteAdminsMinusCurrentUser.map((admin) =>
+      sendPublishAlertSiteAdminEmail({
+        recipientEmail: admin.email,
+        publisherEmail,
+        siteName: site.name,
+        resource,
+      }),
+    ),
+  ])
 }

--- a/apps/studio/src/server/modules/auth/email/email.service.ts
+++ b/apps/studio/src/server/modules/auth/email/email.service.ts
@@ -1,7 +1,7 @@
 import cuid2 from "@paralleldrive/cuid2"
 import { TRPCError } from "@trpc/server"
 
-import type { DB, Resource, Transaction, User } from "../../database"
+import type { DB, Transaction, User } from "../../database"
 import {
   sendPublishAlertContentPublisherEmail,
   sendPublishAlertSiteAdminEmail,

--- a/apps/studio/src/server/modules/auth/email/email.service.ts
+++ b/apps/studio/src/server/modules/auth/email/email.service.ts
@@ -1,9 +1,13 @@
 import cuid2 from "@paralleldrive/cuid2"
 import { TRPCError } from "@trpc/server"
 
-import type { DB, Transaction, User } from "../../database"
+import type { DB, Resource, Transaction, User } from "../../database"
+import {
+  sendPublishAlertContentPublisherEmail,
+  sendPublishAlertSiteAdminEmail,
+} from "~/features/mail/service"
 import { logUserEvent } from "../../audit/audit.service"
-import { AuditLogEvent } from "../../database"
+import { AuditLogEvent, db, RoleType } from "../../database"
 
 interface UpsertUserParams {
   tx: Transaction<DB>
@@ -58,4 +62,57 @@ export const upsertUser = async ({
   })
 
   return newUser
+}
+
+interface AlertPublishWhenSingpassDisabledParams {
+  siteId: number
+  resourceId: string
+  publisherId: User["id"]
+  publisherEmail: User["email"]
+}
+
+export const alertPublishWhenSingpassDisabled = async ({
+  siteId,
+  resourceId,
+  publisherId,
+  publisherEmail,
+}: AlertPublishWhenSingpassDisabledParams) => {
+  const site = await db
+    .selectFrom("Site")
+    .where("id", "=", siteId)
+    .select("Site.name")
+    .executeTakeFirstOrThrow()
+
+  const resource = await db
+    .selectFrom("Resource")
+    .where("id", "=", resourceId)
+    .where("siteId", "=", siteId)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+
+  const allSiteAdminsMinusCurrentUser = await db
+    .selectFrom("User")
+    .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
+    .where("User.deletedAt", "is", null)
+    .where("ResourcePermission.siteId", "=", siteId)
+    .where("ResourcePermission.role", "=", RoleType.Admin)
+    .where("ResourcePermission.userId", "!=", publisherId)
+    .where("ResourcePermission.deletedAt", "is", null)
+    .select("User.email")
+    .execute()
+
+  await sendPublishAlertContentPublisherEmail({
+    recipientEmail: publisherEmail,
+    siteName: site.name,
+    resource,
+  })
+
+  for (const admin of allSiteAdminsMinusCurrentUser) {
+    await sendPublishAlertSiteAdminEmail({
+      recipientEmail: admin.email,
+      publisherEmail,
+      siteName: site.name,
+      resource,
+    })
+  }
 }

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -542,6 +542,7 @@ export const pageRouter = router({
       })
       return publishPageResource(
         ctx.logger,
+        ctx.gb,
         siteId,
         String(pageId),
         ctx.user.id,

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -10,6 +10,9 @@ import {
   BiSort,
 } from "react-icons/bi"
 
+import type { Resource } from "~prisma/generated/generatedTypes"
+import { env } from "~/env.mjs"
+
 export const isAllowedToHaveChildren = (
   resourceType: ResourceType,
 ): boolean => {
@@ -63,4 +66,29 @@ export const getUserViewableResourceTypes = (): ResourceType[] => {
     ResourceType.CollectionLink,
     ResourceType.CollectionPage,
   ]
+}
+
+export const getResourceStudioUrl = (resource: Resource): string => {
+  const siteUrlPrefix = `${env.NEXT_PUBLIC_APP_URL}/sites/${resource.siteId}`
+
+  switch (resource.type) {
+    case ResourceType.RootPage:
+      return siteUrlPrefix
+    case ResourceType.Page:
+    case ResourceType.IndexPage:
+    case ResourceType.CollectionPage:
+      return `${siteUrlPrefix}/pages/${String(resource.id)}`
+    case ResourceType.CollectionLink:
+      return `${siteUrlPrefix}/links/${String(resource.id)}`
+    case ResourceType.Folder:
+      return `${siteUrlPrefix}/folders/${String(resource.id)}`
+    case ResourceType.Collection:
+      return `${siteUrlPrefix}/collections/${String(resource.id)}`
+    case ResourceType.FolderMeta:
+    case ResourceType.CollectionMeta:
+      return "" // they aren't accessible by users
+    default:
+      const exhaustiveCheck: never = resource.type
+      return exhaustiveCheck
+  }
 }

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -10,7 +10,7 @@ import {
   BiSort,
 } from "react-icons/bi"
 
-import type { Resource } from "~prisma/generated/generatedTypes"
+import type { Resource } from "~/server/modules/database"
 import { env } from "~/env.mjs"
 
 export const isAllowedToHaveChildren = (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://www.notion.so/opengov/Isomer-Next-Decision-Matrix-for-Disabling-Singpass-as-2FA-1d177dbba78880289845fc20f53f8503#1d277dbba78880f1b071ef622311fac6

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- on `publishPageResource` when singpass is down, send an email to publisher and all site admins

**Improvements**:

- refactor `ISOMER_SUPPORT_EMAIL` and `ISOMER_SUPPORT_LINK`
