### PR TITLE
test(e2e): skip initial login tests with Singpass

### DIFF
--- a/apps/studio/tests/e2e/singpass.test.ts
+++ b/apps/studio/tests/e2e/singpass.test.ts
@@ -31,7 +31,7 @@ const test = base.extend<LoginPageFixture>({
   },
 })
 
-test("first login with singpass should succeed", async ({
+test.skip("first login with singpass should succeed", async ({
   page,
   loginPage,
 }) => {
@@ -61,7 +61,7 @@ test("first login with singpass should succeed", async ({
   await expect(modal).toBeVisible()
 })
 
-test("logins should not succeed when the uuid is different", async ({
+test.skip("logins should not succeed when the uuid is different", async ({
   page,
   loginPage,
 }) => {
@@ -93,7 +93,7 @@ test("logins should not succeed when the uuid is different", async ({
   await expect(loginPage.singpassButton).toBeVisible()
 })
 
-test("subsequent login should succeed when the uuid matches", async ({
+test.skip("subsequent login should succeed when the uuid matches", async ({
   page,
   loginPage,
 }) => {
@@ -129,7 +129,7 @@ test("subsequent login should succeed when the uuid matches", async ({
   await expect(header).toBeVisible()
 })
 
-test("user should still be allowed to login even when there are no sites tied to them", async ({
+test.skip("user should still be allowed to login even when there are no sites tied to them", async ({
   page,
   loginPage,
 }) => {


### PR DESCRIPTION
the E2E test for singpass seems quite flakey - wondering if we should temp. disable it until its fixed?
- it is flakey test doesn't give us clear indication of whether something is really working
- its a blocker for the "Required" step in CI which means we have to keep retrying the failed tests in order to deploy.
- Might be an issue during VAPT if we have fixes for vulnerabilities but cannot merge and deploy