### PR TITLE
add temporary workaround for VAPT testers in isGovEmail function

### DIFF
--- a/apps/studio/src/utils/email.ts
+++ b/apps/studio/src/utils/email.ts
@@ -1,9 +1,20 @@
 import isEmail from "validator/lib/isEmail"
 
+import { env } from "~/env.mjs"
+
 /**
  * Returns whether the passed value is a valid government email.
  */
 export const isGovEmail = (value: unknown) => {
+  // Temp. workaround to allow VAPT testers to be added as admins
+  if (
+    env.NEXT_PUBLIC_APP_ENV === "vapt" &&
+    typeof value === "string" &&
+    ["marta@cure53.de", "rupp@cure53.de", "dennis@cure53.de"].includes(value)
+  ) {
+    return true
+  }
+
   return (
     typeof value === "string" && isEmail(value) && value.endsWith(".gov.sg")
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We wanna do VAPT and grant testers ADMIN access but they cannot be added as their email doesn't end with `.gov.sg`

## Solution

Hardcoded to return true for `isGovEmail` for `vapt` environment and their emails