### PR TITLE
Fix godmode publishall

### DIFF
--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -64,9 +64,9 @@ const GodModePublishingPage: NextPageWithLayout = () => {
 
   const { mutate: publishAllSite, isLoading: isPublishingAllSite } =
     trpc.site.publishAll.useMutation({
-      onSuccess: () => {
+      onSuccess: ({ siteCount }) => {
         toast({
-          title: "All sites published successfully",
+          title: `Starting to publish ${siteCount} sites in the background...`,
           status: "success",
           ...BRIEF_TOAST_SETTINGS,
         })

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -406,19 +406,31 @@ export const siteRouter = router({
       .where("codeBuildId", "is not", null)
       .execute()
 
-    await Promise.all(
-      sites.map((site) =>
-        db.transaction().execute(async (tx) => {
-          await logPublishEvent(tx, {
-            by: byUser,
-            eventType: AuditLogEvent.Publish,
-            delta: { before: null, after: null },
-            metadata: {},
-            siteId: site.id,
+    // Start background processing to not block the main thread and avoid timeouts
+    void (async () => {
+      // Looping intsead of Promise.all to avoid maxing out Prisma's connection pool
+      for (const site of sites) {
+        try {
+          await db.transaction().execute(async (tx) => {
+            await logPublishEvent(tx, {
+              by: byUser,
+              eventType: AuditLogEvent.Publish,
+              delta: { before: null, after: null },
+              metadata: {},
+              siteId: site.id,
+            })
+            await publishSite(ctx.logger, site.id)
           })
-          await publishSite(ctx.logger, site.id)
-        }),
-      ),
-    )
+        } catch (error) {
+          ctx.logger.error({
+            msg: "Failed to publish site",
+            siteId: site.id,
+            error,
+          })
+        }
+      }
+    })()
+
+    return { siteCount: sites.length }
   }),
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

app crashes due to spike in connection pool opening and exceeding Prisma's default connection pool of 10

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- do a loop instead of Promise.all
- process these in the background insstead of holding onto the thread -> also give more immediate feedback to the user