### PR TITLE
Remove margin-top for blockquote when it's used on homepage

### DIFF
--- a/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.tsx
+++ b/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.tsx
@@ -8,7 +8,7 @@ import { ImageClient } from "../Image"
 
 const createBlockquoteStyles = tv({
   slots: {
-    outerContainer: "mt-6 bg-base-canvas-alt first:mt-0",
+    outerContainer: "bg-base-canvas-alt",
     innerContainer: `${ComponentContent} flex`,
     quoteContainer: "flex w-full flex-col gap-3",
     openApostrophe: "text-brand-canvas-inverse",
@@ -30,7 +30,8 @@ const createBlockquoteStyles = tv({
         image: "h-60 min-h-60 w-60 min-w-60",
       },
       default: {
-        outerContainer: "border-l-4 border-brand-canvas-inverse",
+        outerContainer:
+          "mt-6 border-l-4 border-brand-canvas-inverse first:mt-0",
         innerContainer: "flex-col gap-6 px-5 py-4 sm:flex-row sm:gap-10",
         quoteContainer: "sm:flex-row",
         openApostrophe: "text-[32px]",

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -376,6 +376,14 @@ const generateArgs = ({
         buttonUrl: "[resource:1:1]",
       },
       {
+        type: "blockquote",
+        quote:
+          "I managed to experience new things: saw a dead fish in a plastic bag for the first time, which was an eye-opener because I never thought I would actually get to see something like this ever.",
+        source: "Hannah Teo, Greenies ambassador",
+        imageSrc: "https://placehold.co/600x600",
+        imageAlt: "This is the alt text",
+      },
+      {
         type: "infocols",
         title: "Highlights",
         subtitle: "Some of the things that we are working on",
@@ -435,14 +443,6 @@ const generateArgs = ({
           { label: "Total Merchandise Trade, Dec 2023 (YoY)", value: "-6.8%" },
           { label: "Industrial Production, Dec 2023 (YoY)", value: "-2.5%" },
         ],
-      },
-      {
-        type: "blockquote",
-        quote:
-          "I managed to experience new things: saw a dead fish in a plastic bag for the first time, which was an eye-opener because I never thought I would actually get to see something like this ever.",
-        source: "Hannah Teo, Greenies ambassador",
-        imageSrc: "https://placehold.co/600x600",
-        imageAlt: "This is the alt text",
       },
     ],
   }


### PR DESCRIPTION
## Problem

Blockquotes have a margin-top when it's used on homepage. 

Closes [ISOM-1948]

## Solution

- Removed margin-top for blockquote when it's used on homepage. Kept it when it's used on other layouts; no changes should be observed for these snapshots. 
- Added a story where the blockquote comes below a solid colour block to verify on Chromatic.

See Chromatic snapshots for before and after.