### PR TITLE
fix: get datadog api key from ssm secretes

### DIFF
--- a/.aws/deploy/task-definition.json
+++ b/.aws/deploy/task-definition.json
@@ -113,10 +113,6 @@
         {
           "name": "DD_TRACE_STARTUP_LOGS",
           "value": "true"
-        },
-        {
-          "name": "DD_API_KEY",
-          "value": "<DD_API_KEY>"
         }
       ],
       "dockerLabels": {
@@ -128,7 +124,12 @@
       },
       "mountPoints": [],
       "volumesFrom": [],
-      "secrets": [],
+      "secrets": [
+        {
+          "name": "DD_API_KEY",
+          "valueFrom": "/datadog/api-key"
+        }
+      ],
       "logConfiguration": {
         "logDriver": "awslogs",
         "options": {


### PR DESCRIPTION
## Problem
1. we should not use secrets in github actions.

Closes ISOM-1855 

## Solution
1. remove the key from our ci (still need to remove from GHA)
2. add the key in an associated PR in infra
 
## Release steps
1. [Run](https://github.com/opengovsg/isomer-next-infra/pull/144) the `pulumi up` to add the api key to our `production` + `uat` + `vapt` environment (already done for `staging`)
2. release this PR to `production`
3. force push to `vapt` (for `uat`, we have a workflow that'll deploy post release)=