### PR TITLE
fix: add 2 more retries cos we cool

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useAssetUpload.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useAssetUpload.ts
@@ -8,7 +8,7 @@ interface UseAssetUploadProps {
   baseTimeoutMs?: number
 }
 export const useAssetUpload = ({
-  numOfAttempts = 3,
+  numOfAttempts = 5,
   baseTimeoutMs = 500,
 }: UseAssetUploadProps) => {
   const [isLoading, setIsLoading] = useState(false)


### PR DESCRIPTION
## Problem
images over 3mb are dying cos too big to scan quickly. 

Closes [insert issue #]

## Solution
add 2 more retries for safety 