### PR TITLE
migration(index-page): add children page blocks to all existing folders

### DIFF
--- a/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.test.ts
@@ -74,7 +74,7 @@ const getCustomIndexPage = (title: string, layout: "content" | "index") => {
       },
     ],
     version: "0.1.0",
-  } satisfies PrismaJson.BlobJsonContent
+  } as any
 }
 
 const getEmptyIndexPage = (title: string) => {
@@ -92,7 +92,7 @@ const getEmptyIndexPage = (title: string) => {
       },
     },
     content: [],
-  } satisfies PrismaJson.BlobJsonContent
+  } as any
 }
 
 describe("addChildrenBlock", () => {

--- a/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.test.ts
@@ -1,0 +1,265 @@
+import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupCollection,
+  setupFolder,
+  setupPageResource,
+} from "tests/integration/helpers/seed"
+
+import { db, jsonb } from "~/server/modules/database"
+import {
+  createDefaultPage,
+  createFolderIndexPage,
+} from "~/server/modules/page/page.service"
+import {
+  getBlobOfResource,
+  getPageById,
+} from "~/server/modules/resource/resource.service"
+import { up as addChildrenBlock } from "./addChildrenBlock"
+
+const getCustomIndexPage = (title: string, layout: "content" | "index") => {
+  return {
+    page: {
+      title,
+      permalink: "/get-help",
+      lastModified: "2025-02-25T03:49:00.242Z",
+      contentPageHeader: {
+        summary: `Pages in ${title}`,
+      },
+    },
+    layout,
+    content: [
+      {
+        type: "infocards",
+        cards: [
+          {
+            url: "https://www.zakat.sg/how-to-apply-zakat/",
+            title: "Zakat assistance",
+            imageFit: "cover",
+            description: "Helping the poor and needy.",
+          },
+          {
+            url: "[resource:48:36774]",
+            title: "Islamic Legacy Planning",
+            imageFit: "cover",
+            description:
+              "Helping individuals plan and manage their assets in accordance with Islamic guidelines.",
+          },
+          {
+            url: "[resource:48:36785]",
+            title: "MUIS Special Needs Trust Scheme",
+            imageFit: "cover",
+            description:
+              "Supporting individuals with special needs within the Muslim community.",
+          },
+          {
+            url: "[resource:48:36784]",
+            title: "Appeal Board",
+            imageFit: "cover",
+            description:
+              "The board serves as an independent body to ensure fairness and justice in resolving disputes, offering a formal avenue for appeals.",
+          },
+          {
+            url: "https://ask.gov.sg/muis",
+            title: "FAQs",
+            imageFit: "cover",
+            description: "Frequently Asked Questions.",
+          },
+        ],
+        title: "",
+        variant: "cardsWithoutImages",
+        subtitle: "",
+        maxColumns: "1",
+      },
+    ],
+    version: "0.1.0",
+  } satisfies PrismaJson.BlobJsonContent
+}
+
+const getEmptyIndexPage = (title: string) => {
+  return {
+    version: "0.1.0",
+    layout: ISOMER_USABLE_PAGE_LAYOUTS.Index,
+    // NOTE: cannot use placeholder values here
+    // because this are used for generation of breadcrumbs
+    // and the page title
+    page: {
+      title,
+      lastModified: new Date().toISOString(),
+      contentPageHeader: {
+        summary: `Pages in ${title}`,
+      },
+    },
+    content: [],
+  } satisfies PrismaJson.BlobJsonContent
+}
+
+describe("addChildrenBlock", () => {
+  beforeEach(async () => {
+    await resetTables("Blob", "Resource")
+  })
+
+  it("should not affect IndexPages of collections", async () => {
+    // Arrange
+    const { site, collection } = await setupCollection()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: collection.id,
+    })
+    const expected = await getBlobOfResource({ db, resourceId: page.id })
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(expected.content)
+  })
+  it("should not affect IndexPages that have child blocks", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(createFolderIndexPage(folder.title)) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(blob.content)
+  })
+  it("should not add children pages block to index pages that have `layout: content`", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const customIndexPage = getCustomIndexPage(folder.title, "content")
+    const blob = await db
+      .insertInto("Blob")
+      .values({
+        content: jsonb(customIndexPage),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(customIndexPage)
+  })
+  it("should add children pages block at the last index of the content for index pages without content", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(getEmptyIndexPage(folder.title)) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content.content).toEqual(
+      createFolderIndexPage(folder.title).content,
+    )
+  })
+  it("should add children pages block at the last index of the content for index pages with content", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(createFolderIndexPage(folder.title)) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(blob.content)
+  })
+  it("should not publish the change", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(createFolderIndexPage(folder.title)) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+    expect(page.state).toBe("Draft")
+    expect(page.publishedVersionId).toBeNull()
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(blob.content)
+    const newPage = await getPageById(db, {
+      resourceId: Number(page.id),
+      siteId: site.id,
+    })
+    expect(newPage?.state).toBe("Draft")
+    expect(newPage?.publishedVersionId).toBe(null)
+  })
+  it("should not affect non-index pages", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(createDefaultPage({ layout: "content" })) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.Page,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addChildrenBlock()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(blob.content)
+  })
+})

--- a/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.ts
+++ b/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.ts
@@ -28,7 +28,7 @@ export const up = async () => {
           "type" = 'IndexPage'
       ) AS "indexContent"
     WHERE
-      ("content"->'content')::text NOT ILIKE '%"type": "childrenpages"%';
+      ("content"->'content')::text NOT ILIKE '%"type": "childrenpages"%' and "content" ->> 'layout' = 'index';
 `
 
   const result = await sqlQuery.execute(db)

--- a/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.ts
+++ b/apps/studio/prisma/scripts/migrations/addChildrenBlock/addChildrenBlock.ts
@@ -1,0 +1,58 @@
+import { DEFAULT_CHILDREN_PAGES_BLOCK } from "@opengovsg/isomer-components"
+
+import { db, sql } from "~/server/modules/database"
+import { updateBlobById } from "~/server/modules/resource/resource.service"
+
+export const up = async () => {
+  // Step 1: select all index pages and their blobs where
+  // the text `"type": "childrenpages"` isn't found
+  const sqlQuery = sql<{
+    id: string
+    siteId: string
+    content: PrismaJson.BlobJsonContent
+  }>`
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          COALESCE("db"."content", "pb"."content") AS "content",
+          "Resource"."id", 
+          "Resource"."siteId"
+        FROM
+          "Resource"
+          LEFT JOIN "Version" ON "Version"."id" = "Resource"."publishedVersionId"
+          LEFT JOIN "Blob" AS "pb" ON "pb"."id" = "Version"."blobId"
+          LEFT JOIN "Blob" AS "db" ON "db"."id" = "Resource"."draftBlobId"
+        WHERE
+          "type" = 'IndexPage'
+      ) AS "indexContent"
+    WHERE
+      ("content"->'content')::text NOT ILIKE '%"type": "childrenpages"%';
+`
+
+  const result = await sqlQuery.execute(db)
+
+  for (const r of result.rows) {
+    const existing = r.content.content
+    const updated = [...existing, DEFAULT_CHILDREN_PAGES_BLOCK]
+    const newContent = {
+      ...r.content,
+      content: updated,
+    }
+
+    await db.transaction().execute((tx) =>
+      updateBlobById(tx, {
+        pageId: Number(r.id),
+        content: newContent,
+        siteId: Number(r.siteId),
+      }),
+    )
+  }
+}
+
+// NOTE: Uncomment the below to run the migration
+// await up()
+
+// NOTE: Clean up folderMeta after successful by running this query:
+// delete from "Resource" where "type" = 'FolderMeta';

--- a/apps/studio/prisma/scripts/migrations/addChildrenBlock/index.ts
+++ b/apps/studio/prisma/scripts/migrations/addChildrenBlock/index.ts
@@ -1,0 +1,1 @@
+export * from "./addChildrenBlock"

--- a/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.test.ts
@@ -1,0 +1,170 @@
+import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupCollection,
+  setupFolder,
+  setupPageResource,
+  setupSite,
+} from "tests/integration/helpers/seed"
+
+import { db, jsonb } from "~/server/modules/database"
+import {
+  createDefaultPage,
+  createFolderIndexPage,
+} from "~/server/modules/page/page.service"
+import {
+  getBlobOfResource,
+  getPageById,
+} from "~/server/modules/resource/resource.service"
+import { up as addOrdering } from "./addOrdering"
+
+const getCustomIndexPage = (title: string, layout: "content" | "index") => {
+  return {
+    page: {
+      title,
+      permalink: "/get-help",
+      lastModified: "2025-02-25T03:49:00.242Z",
+      contentPageHeader: {
+        summary: `Pages in ${title}`,
+      },
+    },
+    layout,
+    content: [
+      {
+        type: "infocards",
+        cards: [
+          {
+            url: "https://www.zakat.sg/how-to-apply-zakat/",
+            title: "Zakat assistance",
+            imageFit: "cover",
+            description: "Helping the poor and needy.",
+          },
+          {
+            url: "[resource:48:36774]",
+            title: "Islamic Legacy Planning",
+            imageFit: "cover",
+            description:
+              "Helping individuals plan and manage their assets in accordance with Islamic guidelines.",
+          },
+          {
+            url: "[resource:48:36785]",
+            title: "MUIS Special Needs Trust Scheme",
+            imageFit: "cover",
+            description:
+              "Supporting individuals with special needs within the Muslim community.",
+          },
+          {
+            url: "[resource:48:36784]",
+            title: "Appeal Board",
+            imageFit: "cover",
+            description:
+              "The board serves as an independent body to ensure fairness and justice in resolving disputes, offering a formal avenue for appeals.",
+          },
+          {
+            url: "https://ask.gov.sg/muis",
+            title: "FAQs",
+            imageFit: "cover",
+            description: "Frequently Asked Questions.",
+          },
+        ],
+        title: "",
+        variant: "cardsWithoutImages",
+        subtitle: "",
+        maxColumns: "1",
+      },
+    ],
+    version: "0.1.0",
+  } as any
+}
+
+const getEmptyIndexPage = (title: string) => {
+  return {
+    version: "0.1.0",
+    layout: ISOMER_USABLE_PAGE_LAYOUTS.Index,
+    // NOTE: cannot use placeholder values here
+    // because this are used for generation of breadcrumbs
+    // and the page title
+    page: {
+      title,
+      lastModified: new Date().toISOString(),
+      contentPageHeader: {
+        summary: `Pages in ${title}`,
+      },
+    },
+    content: [],
+  } as any
+}
+
+describe("addOrdering", () => {
+  beforeEach(async () => {
+    await resetTables("Blob", "Resource")
+  })
+
+  it("should not affect any index pages with ordering", async () => {
+    // Arrange
+    const { site, folder } = await setupFolder()
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(createFolderIndexPage(folder.title)) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addOrdering()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual.content).toEqual(blob.content)
+  })
+  it("should not affect non index pages", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+    })
+    const expected = await getBlobOfResource({ db, resourceId: page.id })
+
+    // Act
+    await addOrdering()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual).toEqual(expected)
+  })
+  it("should not update other properties in the `childrenpages` block", async () => {
+    // Arrange
+    const { folder, site } = await setupFolder()
+    const blobContent = createFolderIndexPage(folder.title)
+    blobContent.version = "1.2.3"
+
+    const blob = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(blobContent) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { page } = await setupPageResource({
+      siteId: site.id,
+      resourceType: ResourceType.IndexPage,
+      parentId: folder.id,
+      blobId: blob.id,
+    })
+
+    // Act
+    await addOrdering()
+
+    // Assert
+    const actual = await getBlobOfResource({ db, resourceId: page.id })
+    expect(actual).toEqual(blob)
+  })
+
+  it("should not publish the page")
+})

--- a/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.test.ts
+++ b/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.test.ts
@@ -1,100 +1,18 @@
-import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 import { resetTables } from "tests/integration/helpers/db"
 import {
-  setupCollection,
   setupFolder,
   setupPageResource,
   setupSite,
 } from "tests/integration/helpers/seed"
 
 import { db, jsonb } from "~/server/modules/database"
-import {
-  createDefaultPage,
-  createFolderIndexPage,
-} from "~/server/modules/page/page.service"
+import { createFolderIndexPage } from "~/server/modules/page/page.service"
 import {
   getBlobOfResource,
   getPageById,
 } from "~/server/modules/resource/resource.service"
 import { up as addOrdering } from "./addOrdering"
-
-const getCustomIndexPage = (title: string, layout: "content" | "index") => {
-  return {
-    page: {
-      title,
-      permalink: "/get-help",
-      lastModified: "2025-02-25T03:49:00.242Z",
-      contentPageHeader: {
-        summary: `Pages in ${title}`,
-      },
-    },
-    layout,
-    content: [
-      {
-        type: "infocards",
-        cards: [
-          {
-            url: "https://www.zakat.sg/how-to-apply-zakat/",
-            title: "Zakat assistance",
-            imageFit: "cover",
-            description: "Helping the poor and needy.",
-          },
-          {
-            url: "[resource:48:36774]",
-            title: "Islamic Legacy Planning",
-            imageFit: "cover",
-            description:
-              "Helping individuals plan and manage their assets in accordance with Islamic guidelines.",
-          },
-          {
-            url: "[resource:48:36785]",
-            title: "MUIS Special Needs Trust Scheme",
-            imageFit: "cover",
-            description:
-              "Supporting individuals with special needs within the Muslim community.",
-          },
-          {
-            url: "[resource:48:36784]",
-            title: "Appeal Board",
-            imageFit: "cover",
-            description:
-              "The board serves as an independent body to ensure fairness and justice in resolving disputes, offering a formal avenue for appeals.",
-          },
-          {
-            url: "https://ask.gov.sg/muis",
-            title: "FAQs",
-            imageFit: "cover",
-            description: "Frequently Asked Questions.",
-          },
-        ],
-        title: "",
-        variant: "cardsWithoutImages",
-        subtitle: "",
-        maxColumns: "1",
-      },
-    ],
-    version: "0.1.0",
-  } as any
-}
-
-const getEmptyIndexPage = (title: string) => {
-  return {
-    version: "0.1.0",
-    layout: ISOMER_USABLE_PAGE_LAYOUTS.Index,
-    // NOTE: cannot use placeholder values here
-    // because this are used for generation of breadcrumbs
-    // and the page title
-    page: {
-      title,
-      lastModified: new Date().toISOString(),
-      contentPageHeader: {
-        summary: `Pages in ${title}`,
-      },
-    },
-    content: [],
-  } as any
-}
 
 describe("addOrdering", () => {
   beforeEach(async () => {
@@ -181,7 +99,7 @@ describe("addOrdering", () => {
       .values({ content: jsonb(blobContent) })
       .returningAll()
       .executeTakeFirstOrThrow()
-    
+
     const { page } = await setupPageResource({
       siteId: site.id,
       resourceType: ResourceType.IndexPage,
@@ -189,15 +107,20 @@ describe("addOrdering", () => {
       blobId: blob.id,
     })
 
-    const pageBeforeMigration = await getPageById({ db, pageId: page.id })
+    const actual = await getPageById(db, {
+      resourceId: Number(page.id),
+      siteId: site.id,
+    })
 
     // Act
     await addOrdering()
 
     // Assert
-    const pageAfterMigration = await getPageById({ db, pageId: page.id })
-    expect(pageAfterMigration.publishedVersionId).toEqual(
-      pageBeforeMigration.publishedVersionId
-    )
+    const expected = await getPageById(db, {
+      resourceId: Number(page.id),
+      siteId: site.id,
+    })
+    // NOTE: the state should still be `draft`
+    expect(actual).toEqual(expected)
   })
 })

--- a/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.ts
+++ b/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_CHILDREN_PAGES_BLOCK } from "@opengovsg/isomer-components"
+
+import { db, sql } from "~/server/modules/database"
+import { updateBlobById } from "~/server/modules/resource/resource.service"
+
+export const up = async () => {
+  // Step 1: select all index pages and their blobs where
+  // the text `"type": "childrenpages"` isn't found
+  const sqlQuery = sql<{
+    id: string
+    siteId: string
+    content: PrismaJson.BlobJsonContent
+  }>`
+    SELECT
+      *
+    FROM
+      (
+        SELECT
+          COALESCE("db"."content", "pb"."content") AS "content",
+          "Resource"."id", 
+          "Resource"."siteId"
+        FROM
+          "Resource"
+          LEFT JOIN "Version" ON "Version"."id" = "Resource"."publishedVersionId"
+          LEFT JOIN "Blob" AS "pb" ON "pb"."id" = "Version"."blobId"
+          LEFT JOIN "Blob" AS "db" ON "db"."id" = "Resource"."draftBlobId"
+        WHERE
+          "type" = 'IndexPage'
+      ) AS "indexContent"
+    WHERE
+      ("content"->'content')::text ILIKE '%"type": "childrenpages"%' and "content" ->> 'layout' = 'index' and ("content" -> 'content')::text NOT ILIKE '%"childrenPagesOrdering"%';
+`
+
+  const result = await sqlQuery.execute(db)
+
+  for (const r of result.rows) {
+    const last = r.content.content.at(-1)
+    // NOTE: We only care if it is `undefined`,
+    // empty array is acceptable
+    if (last?.type !== "childrenpages" || !last.childrenPagesOrdering) {
+      console.log(
+        `Found block that did not have type: childrenpages on Resource: ${r.id}`,
+      )
+
+      return
+    }
+
+    const updated = [
+      ...r.content.content.slice(0, -1),
+      { ...last, childrenPagesOrdering: [] },
+    ]
+    const newContent = {
+      ...r.content,
+      content: updated,
+    }
+
+    await db.transaction().execute((tx) =>
+      updateBlobById(tx, {
+        pageId: Number(r.id),
+        content: newContent as any,
+        siteId: Number(r.siteId),
+      }),
+    )
+  }
+}
+
+// NOTE: Uncomment the below to run the migration
+// await up()
+
+// NOTE: Clean up folderMeta after successful by running this query:
+// delete from "Resource" where "type" = 'FolderMeta';

--- a/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.ts
+++ b/apps/studio/prisma/scripts/migrations/addOrdering/addOrdering.ts
@@ -1,5 +1,3 @@
-import { DEFAULT_CHILDREN_PAGES_BLOCK } from "@opengovsg/isomer-components"
-
 import { db, sql } from "~/server/modules/database"
 import { updateBlobById } from "~/server/modules/resource/resource.service"
 

--- a/apps/studio/prisma/scripts/migrations/addOrdering/index.ts
+++ b/apps/studio/prisma/scripts/migrations/addOrdering/index.ts
@@ -1,0 +1,1 @@
+export * from "./addOrdering"

--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -11,6 +11,7 @@ export const JSON_FORMS_RANKING = {
   ObjectControl: 2,
   // NOTE: needs to have higher priority than anyof
   ChildrenPagesControl: 4,
+  ChildrenPagesOrderingControl: 2,
   AllOfControl: 3,
   AnyOfControl: 3,
   ProseControl: 3,

--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -11,7 +11,8 @@ export const JSON_FORMS_RANKING = {
   ObjectControl: 2,
   // NOTE: needs to have higher priority than anyof
   ChildrenPagesControl: 4,
-  ChildrenPagesOrderingControl: 2,
+  // NOTE: needs to have higher priority than array
+  ChildrenPagesOrderingControl: 5,
   AllOfControl: 3,
   AnyOfControl: 3,
   ProseControl: 3,

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -1,6 +1,7 @@
 import type { ButtonProps, StackProps } from "@chakra-ui/react"
 import type { IconType } from "react-icons"
 import { chakra, Flex, HStack, Icon, Stack, Text } from "@chakra-ui/react"
+import { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd"
 import { BiGridVertical } from "react-icons/bi"
 
 interface BaseBlockProps {
@@ -10,6 +11,7 @@ interface BaseBlockProps {
   description?: string
   containerProps?: StackProps
   onClick?: () => void
+  draggableProps?: DraggableProvidedDragHandleProps | null
 }
 
 export const BaseBlock = ({
@@ -17,9 +19,12 @@ export const BaseBlock = ({
   dragHandle,
   label,
   description,
+  draggableProps,
   containerProps,
   onClick,
 }: BaseBlockProps): JSX.Element => {
+  const actualDraggableProps = draggableProps ?? {}
+
   return (
     <HStack
       as="button"
@@ -46,6 +51,7 @@ export const BaseBlock = ({
       align="center"
       textAlign="start"
       onClick={onClick}
+      {...actualDraggableProps}
       {...containerProps}
     >
       {dragHandle}

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -21,6 +21,8 @@ import {
   jsonFormsCategoryControlTester,
   JsonFormsChildrenPagesLayoutControl,
   jsonFormsChildrenPagesLayoutControlTester,
+  JsonFormsChildrenPagesOrderingControl,
+  jsonFormsChildrenPagesOrderingControlTester,
   JsonFormsConstControl,
   jsonFormsConstControlTester,
   JsonFormsDateControl,
@@ -56,6 +58,10 @@ import {
 } from "./renderers"
 
 export const renderers: JsonFormsRendererRegistryEntry[] = [
+  {
+    renderer: JsonFormsChildrenPagesOrderingControl,
+    tester: jsonFormsChildrenPagesOrderingControlTester,
+  },
   {
     tester: jsonFormsProseControlTester,
     renderer: JsonFormsProseControl,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
@@ -23,7 +23,11 @@ export const jsonFormsChildrenPagesOrderingControlTester: RankedTester =
     schemaMatches((schema) => schema.format === "childrenPagesOrdering"),
   )
 
-const merge = (base: string[], all: string[]): string[] => {
+const merge = (
+  base: string[],
+  all: string[],
+  mappings: Map<string, string>,
+): string[] => {
   const baseSet = new Set(base)
   const allSet = new Set(all)
 
@@ -37,7 +41,16 @@ const merge = (base: string[], all: string[]): string[] => {
 
   return base
     .filter((resourceId) => !toRemoveFromBase.has(resourceId))
-    .concat(Array.from(toAdd))
+    .concat(
+      // NOTE: We have to assume default sort order (alphabetical)
+      // when we shift in new items
+      Array.from(toAdd).toSorted((a, b) => {
+        const aTitle = mappings.get(a) ?? ""
+        const bTitle = mappings.get(b) ?? ""
+
+        return aTitle.localeCompare(bTitle, undefined)
+      }),
+    )
 }
 
 type ReorderingControlProps<T = string> = Omit<ControlProps, "data"> & {
@@ -138,6 +151,7 @@ const SuspendableBlocks = ({
   const resources = merge(
     data,
     childPages.map(({ id }) => id),
+    mappings,
   ).map((resourceId) => {
     return {
       title: mappings.get(resourceId) ?? "Unknown page",

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
@@ -114,12 +114,10 @@ const DraggableBlocks = ({
                       >
                         <BaseBlock
                           dragHandle={
-                            <BaseBlockDragHandle
-                              isDragging={isDragging}
-                              {...provided.dragHandleProps}
-                            />
+                            <BaseBlockDragHandle isDragging={isDragging} />
                           }
                           label={resource.title}
+                          draggableProps={provided.dragHandleProps}
                         />
                       </VStack>
                     )

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
@@ -1,5 +1,5 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import { Box, FormControl, VStack } from "@chakra-ui/react"
+import { Box, FormControl, Skeleton, VStack } from "@chakra-ui/react"
 import {
   DragDropContext,
   Draggable,
@@ -10,6 +10,7 @@ import { rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
 import { FormLabel } from "@opengovsg/design-system-react"
 
+import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { editPageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -22,20 +23,32 @@ export const jsonFormsChildrenPagesOrderingControlTester: RankedTester =
     schemaMatches((schema) => schema.format === "childrenPagesOrdering"),
   )
 
-export function JsonFormsChildrenPagesLayoutControl({
+const merge = (base: string[], all: string[]): string[] => {
+  const baseSet = new Set(base)
+  const allSet = new Set(all)
+
+  // NOTE: values that are in the user given ordering but not in
+  // the list of child pages returned from db implies
+  // that they have been removed from the current folder
+  const toRemoveFromBase = baseSet.difference(allSet)
+  // NOTE: values that are returned as concrete pages by the db
+  // and can be moved around by the user
+  const toAdd = allSet.difference(baseSet).values()
+
+  return base
+    .filter((resourceId) => !toRemoveFromBase.has(resourceId))
+    .concat(Array.from(toAdd))
+}
+
+type ReorderingControlProps<T = string> = Omit<ControlProps, "data"> & {
+  data: T[]
+}
+
+const DraggableBlocks = ({
   data,
-  label,
-  description,
   handleChange,
   path,
-}: Omit<ControlProps, "data"> & { data: string[] }): JSX.Element {
-  const { pageId: indexPageId, siteId } = useQueryParse(editPageSchema)
-
-  const [{ childPages }] = trpc.folder.listChildPages.useSuspenseQuery({
-    siteId: String(siteId),
-    indexPageId: String(indexPageId),
-  })
-
+}: ReorderingControlProps<{ title: string; id: string }>) => {
   const onDragEnd = ({ source, destination }: DropResult) => {
     if (!destination) return
 
@@ -51,8 +64,97 @@ export function JsonFormsChildrenPagesLayoutControl({
 
     updatedBlocks.splice(to, 0, movedBlock)
 
-    handleChange(path, updatedBlocks)
+    handleChange(
+      path,
+      updatedBlocks.map(({ id }) => id),
+    )
   }
+
+  return (
+    <DragDropContext onDragEnd={onDragEnd}>
+      <Droppable droppableId="blocks">
+        {(provided) => {
+          return (
+            <VStack
+              spacing="0.75rem"
+              {...provided.droppableProps}
+              w="100%"
+              ref={provided.innerRef}
+              h="full"
+            >
+              {data.map((resource, index) => (
+                <Draggable
+                  key={resource.id}
+                  disableInteractiveElementBlocking
+                  draggableId={resource.id}
+                  index={index}
+                >
+                  {(provided, snapshot) => {
+                    const isDragging =
+                      snapshot.isDragging || snapshot.isDropAnimating
+                    return (
+                      <VStack
+                        my="0.25rem"
+                        w="100%"
+                        ref={provided.innerRef}
+                        {...provided.draggableProps}
+                      >
+                        <BaseBlock
+                          dragHandle={
+                            <BaseBlockDragHandle
+                              isDragging={isDragging}
+                              {...provided.dragHandleProps}
+                            />
+                          }
+                          label={resource.title}
+                        />
+                      </VStack>
+                    )
+                  }}
+                </Draggable>
+              ))}
+
+              {provided.placeholder}
+            </VStack>
+          )
+        }}
+      </Droppable>
+    </DragDropContext>
+  )
+}
+
+const SuspendableBlocks = ({
+  data,
+  siteId,
+  indexPageId,
+  ...rest
+}: ReorderingControlProps & { siteId: string; indexPageId: string }) => {
+  const [{ childPages }] = trpc.folder.listChildPages.useSuspenseQuery({
+    siteId: String(siteId),
+    indexPageId: String(indexPageId),
+  })
+
+  const mappings = new Map(childPages.map(({ title, id }) => [id, title]))
+  const resources = merge(
+    data,
+    childPages.map(({ id }) => id),
+  ).map((resourceId) => {
+    return {
+      title: mappings.get(resourceId) ?? "Unknown page",
+      id: resourceId,
+    }
+  })
+
+  return <DraggableBlocks data={resources} {...rest} />
+}
+
+export function JsonFormsChildrenPagesLayoutControl({
+  data,
+  label,
+  description,
+  ...rest
+}: ReorderingControlProps): JSX.Element {
+  const { pageId: indexPageId, siteId } = useQueryParse(editPageSchema)
 
   return (
     <Box h="full">
@@ -60,59 +162,16 @@ export function JsonFormsChildrenPagesLayoutControl({
         <FormLabel mb="1rem" description={description}>
           {label || "Variant"}
         </FormLabel>
-        <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="blocks">
-            {(provided) => {
-              return (
-                <VStack
-                  spacing="0.75rem"
-                  {...provided.droppableProps}
-                  w="100%"
-                  ref={provided.innerRef}
-                  h="full"
-                >
-                  {data.map((resourceId: string, index) => {
-                    return (
-                      <Draggable
-                        key={resourceId}
-                        disableInteractiveElementBlocking
-                        draggableId={resourceId}
-                        index={index}
-                      >
-                        {(provided, snapshot) => {
-                          const isDragging =
-                            snapshot.isDragging || snapshot.isDropAnimating
-                          return (
-                            <VStack
-                              my="0.25rem"
-                              w="100%"
-                              ref={provided.innerRef}
-                              {...provided.draggableProps}
-                            >
-                              <BaseBlock
-                                dragHandle={
-                                  <BaseBlockDragHandle
-                                    isDragging={isDragging}
-                                    {...provided.dragHandleProps}
-                                  />
-                                }
-                                label={
-                                  childPages.find(({ id }) => id === resourceId)
-                                    ?.title ?? ""
-                                }
-                              />
-                            </VStack>
-                          )
-                        }}
-                      </Draggable>
-                    )
-                  })}
-                  {provided.placeholder}
-                </VStack>
-              )
-            }}
-          </Droppable>
-        </DragDropContext>
+        <Suspense fallback={<Skeleton h="2rem" w="100%" />}>
+          <SuspendableBlocks
+            indexPageId={String(indexPageId)}
+            siteId={String(siteId)}
+            data={data}
+            label={label}
+            description={description}
+            {...rest}
+          />
+        </Suspense>
       </FormControl>
     </Box>
   )

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsChildrenPagesOrderingControl.tsx
@@ -16,42 +16,13 @@ import { editPageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 import { BaseBlock, BaseBlockDragHandle } from "../../../Block/BaseBlock"
+import { merge } from "./utils/merge"
 
 export const jsonFormsChildrenPagesOrderingControlTester: RankedTester =
   rankWith(
     JSON_FORMS_RANKING.ChildrenPagesOrderingControl,
     schemaMatches((schema) => schema.format === "childrenPagesOrdering"),
   )
-
-const merge = (
-  base: string[],
-  all: string[],
-  mappings: Map<string, string>,
-): string[] => {
-  const baseSet = new Set(base)
-  const allSet = new Set(all)
-
-  // NOTE: values that are in the user given ordering but not in
-  // the list of child pages returned from db implies
-  // that they have been removed from the current folder
-  const toRemoveFromBase = baseSet.difference(allSet)
-  // NOTE: values that are returned as concrete pages by the db
-  // and can be moved around by the user
-  const toAdd = allSet.difference(baseSet).values()
-
-  return base
-    .filter((resourceId) => !toRemoveFromBase.has(resourceId))
-    .concat(
-      // NOTE: We have to assume default sort order (alphabetical)
-      // when we shift in new items
-      Array.from(toAdd).toSorted((a, b) => {
-        const aTitle = mappings.get(a) ?? ""
-        const bTitle = mappings.get(b) ?? ""
-
-        return aTitle.localeCompare(bTitle, undefined)
-      }),
-    )
-}
 
 type ReorderingControlProps<T = string> = Omit<ControlProps, "data"> & {
   data: T[]

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -78,3 +78,7 @@ export {
   default as JsonFormsChildrenPagesLayoutControl,
   jsonFormsChildrenPagesLayoutControlTester,
 } from "./JsonFormsChildPageLayoutControl"
+export {
+  default as JsonFormsChildrenPagesOrderingControl,
+  jsonFormsChildrenPagesOrderingControlTester,
+} from "./JsonFormsChildrenPagesOrderingControl"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/utils/__tests__/merge.test.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/utils/__tests__/merge.test.ts
@@ -1,0 +1,63 @@
+import { merge } from "../merge"
+
+describe("merge", () => {
+  it("should put strings that are not in base at the back and sorted by title", () => {
+    // Arrange
+    const base = ["2", "1", "53"]
+    const all = ["12", "4", "5", "2", "53", "1"]
+    const mappings = new Map([
+      ["12", "abc"],
+      ["4", "cde"],
+      ["5", "aaaaaa"],
+      ["2", "b"],
+      ["53", "ab"],
+      ["1", "aaaaa"],
+    ])
+
+    // Act
+    const expected = ["2", "1", "53", "5", "12", "4"]
+
+    // Assert
+    const actual = merge(base, all, mappings)
+    expect(actual).toStrictEqual(expected)
+  })
+
+  it("should remove strings that are in base but not in all", () => {
+    // Arrange
+    const base = ["2", "1", "53"]
+    const all = ["12", "4", "5"]
+    const mappings = new Map([
+      ["12", "abc"],
+      ["4", "cde"],
+      ["5", "aaaaaa"],
+    ])
+
+    // Act
+    const expected = ["5", "12", "4"]
+
+    // Assert
+    const actual = merge(base, all, mappings)
+    expect(actual).toStrictEqual(expected)
+  })
+
+  it("should respect the casing of the title", () => {
+    // Arrange
+    const base = ["2", "1", "53"]
+    const all = ["12", "4", "5", "2", "53", "1"]
+    const mappings = new Map([
+      ["12", "AAA"],
+      ["4", "aaa"],
+      ["5", "AAAA"],
+      ["2", "b"],
+      ["53", "ab"],
+      ["1", "aaaaa"],
+    ])
+
+    // Act
+    const expected = ["2", "1", "53", "4", "12", "5"]
+
+    // Assert
+    const actual = merge(base, all, mappings)
+    expect(actual).toStrictEqual(expected)
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/utils/merge.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/utils/merge.ts
@@ -1,0 +1,29 @@
+export const merge = (
+  base: string[],
+  all: string[],
+  mappings: Map<string, string>,
+): string[] => {
+  const baseSet = new Set(base)
+  const allSet = new Set(all)
+
+  // NOTE: values that are in the user given ordering but not in
+  // the list of child pages returned from db implies
+  // that they have been removed from the current folder
+  const toRemoveFromBase = baseSet.difference(allSet)
+  // NOTE: values that are returned as concrete pages by the db
+  // and can be moved around by the user
+  const toAdd = allSet.difference(baseSet).values()
+
+  return base
+    .filter((resourceId) => !toRemoveFromBase.has(resourceId))
+    .concat(
+      // NOTE: We have to assume default sort order (alphabetical)
+      // when we shift in new items
+      Array.from(toAdd).toSorted((a, b) => {
+        const aTitle = mappings.get(a) ?? ""
+        const bTitle = mappings.get(b) ?? ""
+
+        return aTitle.localeCompare(bTitle, undefined)
+      }),
+    )
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/layouts/JsonFormsVerticalLayout.tsx
@@ -105,7 +105,7 @@ export function JsonFormsVerticalLayoutRenderer({
   const newElements = getUiSchemaWithGroup(schema, elements)
 
   return (
-    <Box w="100%" display="flex" flexDirection="column" gap="1.25rem">
+    <Box w="100%" display="flex" flexDirection="column" gap="1.25rem" h="full">
       {newElements.map((element, index) => (
         <JsonFormsDispatch
           key={`${path}-${index}`}

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -33,11 +33,14 @@ export const readFolderSchema = z
   })
   .merge(offsetPaginationSchema)
 
-export const baseEditFolderSchema = z.object({
+const baseFolderSchema = z.object({
   resourceId: z.string(),
+  siteId: z.string(),
+})
+
+export const baseEditFolderSchema = baseFolderSchema.extend({
   permalink: permalinkSchema,
   title: z.string().min(1, { message: "Enter a title for this folder" }),
-  siteId: z.string(),
 })
 
 export const editFolderSchema = baseEditFolderSchema.superRefine(
@@ -68,3 +71,7 @@ export const insertChildpageblockSchema = baseIndexPageSchema.extend({
       .passthrough(),
   ),
 })
+
+export const listSchema = baseFolderSchema
+  .omit({ resourceId: true })
+  .extend({ indexPageId: z.string() })

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -72,6 +72,6 @@ export const insertChildpageblockSchema = baseIndexPageSchema.extend({
   ),
 })
 
-export const listSchema = baseFolderSchema
+export const listChildPagesSchema = baseFolderSchema
   .omit({ resourceId: true })
   .extend({ indexPageId: z.string() })

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1009,7 +1009,7 @@ describe("collection.router", async () => {
       // Act
       const originalBlob = await db
         .transaction()
-        .execute((tx) => getBlobOfResource({ tx, resourceId: page.id }))
+        .execute((tx) => getBlobOfResource({ db: tx, resourceId: page.id }))
 
       // Assert
       const expected = await caller.updateCollectionLink({
@@ -1046,7 +1046,7 @@ describe("collection.router", async () => {
       })
       const originalBlob = await db
         .transaction()
-        .execute((tx) => getBlobOfResource({ tx, resourceId: page.id }))
+        .execute((tx) => getBlobOfResource({ db: tx, resourceId: page.id }))
       await setupAdminPermissions({ userId: session.userId, siteId: site.id })
 
       // Act

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -323,7 +323,7 @@ export const collectionRouter = router({
             )
 
           const oldBlob = await getBlobOfResource({
-            tx,
+            db: tx,
             resourceId: resource.id,
           })
 

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -363,9 +363,7 @@ export const folderRouter = router({
         })
         .execute()
 
-      // TODO: there are a few things we need to do:
-      // 1. Think about how to handle cases where 2 people are editing the order
-      // 2. map the collections and folders into their respective index pages
+      // TODO: Think about how to handle cases where 2 people are editing the order
       return { childPages }
     }),
 })

--- a/apps/studio/src/server/modules/folder/folder.service.ts
+++ b/apps/studio/src/server/modules/folder/folder.service.ts
@@ -1,0 +1,69 @@
+import { db, Resource, sql } from "../database"
+
+export const retrieveFolderOrder = async (
+  folderId: string | null,
+): Promise<string[] | undefined> => {
+  // NOTE: this can only happen if we are asking
+  // for the folder order of the root page
+  // which should never happen
+  // as the root page does
+  // not have the `ChildPages` component
+  if (folderId === null) return undefined
+
+  let order: Resource["id"][] | undefined
+
+  const meta = await db
+    .selectFrom("Resource as r")
+    .leftJoin("Version as v", "v.resourceId", "r.id")
+    .leftJoin("Blob as pb", "v.blobId", "pb.id")
+    // NOTE: this is a left join because
+    // the resource might not have a a draft blob
+    // if it is newly published
+    .leftJoin("Blob as db", "r.draftBlobId", "db.id")
+    .where("type", "=", "FolderMeta")
+    .where("r.parentId", "=", folderId)
+    .select((eb) =>
+      eb.fn
+        // NOTE: if the user has updated the ordering since the last publish,
+        // use that ordering rather than the previously published one
+        .coalesce(
+          sql<string[]>`db.content->'meta'->>'order'`,
+          sql<string[]>`pb.content->'meta'->>'order'`,
+        )
+        .as("order"),
+    )
+    .executeTakeFirst()
+
+  if (meta) {
+    order = meta.order
+  }
+
+  return order
+}
+
+export const orderPagesBy = <T extends Pick<Resource, "id" | "title">>(
+  pages: T[],
+  order?: string[],
+) => {
+  return pages.toSorted((a, b) => {
+    if (order === undefined) {
+      return a.title.localeCompare(b.title, undefined, { numeric: true })
+    }
+
+    const [aIndex, bIndex] = [order.indexOf(a.id), order.indexOf(b.id)]
+
+    if (aIndex === bIndex) {
+      return a.title.localeCompare(b.title, undefined, { numeric: true })
+    }
+
+    if (aIndex === -1) {
+      return 1
+    }
+
+    if (bIndex === -1) {
+      return -1
+    }
+
+    return aIndex - bIndex
+  })
+}

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -682,7 +682,9 @@ describe("page.router", async () => {
       })
       const oldBlob = await db
         .transaction()
-        .execute((tx) => getBlobOfResource({ tx, resourceId: pageToUpdate.id }))
+        .execute((tx) =>
+          getBlobOfResource({ db: tx, resourceId: pageToUpdate.id }),
+        )
 
       // Act
       const result = await caller.updatePageBlob(pageUpdateArgs)
@@ -728,7 +730,7 @@ describe("page.router", async () => {
       const oldBlob = await db
         .transaction()
         .execute((tx) =>
-          getBlobOfResource({ tx, resourceId: publishedPageToUpdate.id }),
+          getBlobOfResource({ db: tx, resourceId: publishedPageToUpdate.id }),
         )
 
       // Act

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -314,7 +314,7 @@ export const pageRouter = router({
         actualBlocks.splice(to, 0, movedBlock)
 
         const oldBlob = await getBlobOfResource({
-          tx,
+          db: tx,
           resourceId: String(pageId),
         })
         const updatedBlob = await updateBlobById(tx, {
@@ -382,7 +382,7 @@ export const pageRouter = router({
 
       await db.transaction().execute(async (tx) => {
         const oldBlob = await getBlobOfResource({
-          tx,
+          db: tx,
           resourceId: String(input.pageId),
         })
         const updatedBlob = await updateBlobById(tx, input)
@@ -621,7 +621,7 @@ export const pageRouter = router({
           ? rest
           : ({ ...rest, meta: newMeta } as PrismaJson.BlobJsonContent)
 
-        const oldBlob = await getBlobOfResource({ tx, resourceId })
+        const oldBlob = await getBlobOfResource({ db: tx, resourceId })
         const newBlob = await updateBlobById(tx, {
           pageId: Number(resourceId),
           content: newContent,

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -946,7 +946,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(folder.id)
+      expect(child?.id).toBe(indexPage.id)
       expect(child?.permalink).toBe(`/${folder.permalink}`)
       expect(child?.title).toBe(folder.title) // should be from the folder
       expect(child?.summary).toBe(`Pages in ${folder.title}`) // should not be from the index page
@@ -989,7 +989,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(folder.id)
+      expect(child?.id).toBe(indexPage.id)
       expect(child?.permalink).toBe(`/${folder.permalink}`)
       expect(child?.title).toBe(indexPage.title) // should be from the index page
       expect(child?.summary).toBe("Hello im the index page") // should be from the index page
@@ -1033,7 +1033,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(collection.id)
+      expect(child?.id).toBe(indexPage.id)
       expect(child?.permalink).toBe(`/${collection.permalink}`)
       expect(child?.title).toBe(collection.title) // should be from the folder
       expect(child?.summary).toBe(`Pages in ${collection.title}`) // should not be from the index page
@@ -1076,7 +1076,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(collection.id)
+      expect(child?.id).toBe(indexPage.id)
       expect(child?.permalink).toBe(`/${collection.permalink}`)
       expect(child?.title).toBe(indexPage.title) // should be from the index page
       expect(child?.summary).toBe("Hello im the index page") // should be from the index page
@@ -1137,14 +1137,15 @@ describe("resource.service", () => {
         state: ResourceState.Published,
       })
 
-      const { blob: folderAIndexPageBlob } = await setupPageResource({
-        title: "Folder A",
-        resourceType: ResourceType.IndexPage,
-        siteId: site.id,
-        parentId: folder.id,
-        state: ResourceState.Published,
-        userId: (await setupUser({})).id,
-      })
+      const { blob: folderAIndexPageBlob, page: folderAIndexPage } =
+        await setupPageResource({
+          title: "Folder A",
+          resourceType: ResourceType.IndexPage,
+          siteId: site.id,
+          parentId: folder.id,
+          state: ResourceState.Published,
+          userId: (await setupUser({})).id,
+        })
       await db
         .updateTable("Blob")
         .where("id", "=", folderAIndexPageBlob.id)
@@ -1189,7 +1190,7 @@ describe("resource.service", () => {
       // Assert: Find Folder in the sitemap
       const folderNode = result.children
         ?.at(0)
-        ?.children?.find((child) => child.id === folder.id)
+        ?.children?.find((child) => child.id === folderAIndexPage.id)
       expect(folderNode?.title).toBe(folder.title)
       expect(folderNode?.summary).toBe("Hello im the index page")
       expect(folderNode?.image?.src).toBe("https://indexpageblob.com")
@@ -1242,14 +1243,15 @@ describe("resource.service", () => {
         parentId: childFolder.id,
         state: ResourceState.Published,
       })
-      const { blob: collection2IndexPageBlob } = await setupPageResource({
-        title: "Collection 2 Index Page",
-        resourceType: ResourceType.IndexPage,
-        siteId: site.id,
-        parentId: collection2.id,
-        state: ResourceState.Published,
-        userId: (await setupUser({})).id,
-      })
+      const { blob: collection2IndexPageBlob, page: collection2IndexPage } =
+        await setupPageResource({
+          title: "Collection 2 Index Page",
+          resourceType: ResourceType.IndexPage,
+          siteId: site.id,
+          parentId: collection2.id,
+          state: ResourceState.Published,
+          userId: (await setupUser({})).id,
+        })
       await db
         .updateTable("Blob")
         .where("id", "=", collection2IndexPageBlob.id)
@@ -1282,7 +1284,7 @@ describe("resource.service", () => {
 
       // Assert: Find Child Collection (With Index Page) in the sitemap
       const collection2Node = childFolderChildren?.find(
-        (child) => child.id === collection2.id,
+        (child) => child.id === collection2IndexPage.id,
       )
       expect(collection2Node?.title).toBe("Collection 2 Index Page")
       expect(collection2Node?.summary).toBe("Hello im the index page")

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -169,13 +169,13 @@ export const updatePageById = (
 }
 
 export const getBlobOfResource = async ({
-  tx,
+  db,
   resourceId,
 }: {
-  tx: Transaction<DB>
+  db: SafeKysely
   resourceId: string
 }) => {
-  const { draftBlobId, publishedVersionId } = await tx
+  const { draftBlobId, publishedVersionId } = await db
     .selectFrom("Resource")
     .where("id", "=", resourceId)
     .select(["draftBlobId", "publishedVersionId"])
@@ -189,7 +189,7 @@ export const getBlobOfResource = async ({
 
   if (draftBlobId) {
     return (
-      tx
+      db
         .selectFrom("Blob")
         .where("id", "=", draftBlobId)
         .selectAll()
@@ -198,7 +198,7 @@ export const getBlobOfResource = async ({
     )
   }
 
-  return tx
+  return db
     .selectFrom("Blob")
     .selectAll()
     .where("Blob.id", "=", (eb) =>

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -50,7 +50,7 @@ const getSitemapTreeFromArray = (
       resource.type === ResourceType.CollectionPage
     ) {
       return {
-        id: String(resource.id),
+        id: resource.id,
         layout: "content", // Note: We are not using the layout field in our sitemap for preview
         title: resource.title,
         summary: resource.summary ?? "",
@@ -75,7 +75,11 @@ const getSitemapTreeFromArray = (
     const summaryOfPage = indexPage?.summary
 
     return {
-      id: String(resource.id),
+      // NOTE: this is done for compat reasons as
+      // our publishing script uses the index page id
+      // if it can find one and if it cannot,
+      // then uses the base `resourceId`
+      id: indexPage?.id ?? resource.id,
       layout:
         resource.type === ResourceType.Collection
           ? ISOMER_USABLE_PAGE_LAYOUTS.Collection // Needed for collectionblock component to fetch the correct collection

--- a/packages/components/src/interfaces/complex/ChildrenPages.ts
+++ b/packages/components/src/interfaces/complex/ChildrenPages.ts
@@ -29,6 +29,12 @@ export const ChildrenPagesSchema = Type.Object(
         "We will use the child pages' feature images as their thumbnail.",
       default: false,
     }),
+    childrenPagesOrdering: Type.Literal("childrenPagesOrdering", {
+      default: "childrenPagesOrdering",
+      format: "childrenPagesOrdering",
+      title: "Ordering of Child pages",
+      description: "Drag and drop pages to reorder them",
+    }),
   },
   {
     title: "Child pages",

--- a/packages/components/src/interfaces/complex/ChildrenPages.ts
+++ b/packages/components/src/interfaces/complex/ChildrenPages.ts
@@ -29,8 +29,8 @@ export const ChildrenPagesSchema = Type.Object(
         "We will use the child pages' feature images as their thumbnail.",
       default: false,
     }),
-    childrenPagesOrdering: Type.Literal("childrenPagesOrdering", {
-      default: "childrenPagesOrdering",
+    childrenPagesOrdering: Type.Array(Type.String(), {
+      default: [],
       format: "childrenPagesOrdering",
       title: "Ordering of Child pages",
       description: "Drag and drop pages to reorder them",

--- a/packages/components/src/interfaces/complex/ChildrenPages.ts
+++ b/packages/components/src/interfaces/complex/ChildrenPages.ts
@@ -29,12 +29,17 @@ export const ChildrenPagesSchema = Type.Object(
         "We will use the child pages' feature images as their thumbnail.",
       default: false,
     }),
-    childrenPagesOrdering: Type.Array(Type.String(), {
-      default: [],
-      format: "childrenPagesOrdering",
-      title: "Ordering of Child pages",
-      description: "Drag and drop pages to reorder them",
-    }),
+    // NOTE: We set this to `Optional` for now due to backcompat
+    // TODO: Remove this chunk after we run the forward migration to
+    // add this property to all index pages
+    childrenPagesOrdering: Type.Optional(
+      Type.Array(Type.String(), {
+        default: [],
+        format: "childrenPagesOrdering",
+        title: "Ordering of Child pages",
+        description: "Drag and drop pages to reorder them",
+      }),
+    ),
   },
   {
     title: "Child pages",

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.stories.tsx
@@ -355,6 +355,7 @@ export const Default: Story = {
     permalink: "/parent",
     LinkComponent: "a",
     site,
+    childrenPagesOrdering: [],
   },
 }
 
@@ -364,6 +365,7 @@ export const BaseRows: Story = {
     site,
     permalink: "/parent",
     LinkComponent: "a",
+    childrenPagesOrdering: [],
   },
 }
 
@@ -374,6 +376,7 @@ export const RowsWithDescription: Story = {
     permalink: "/parent",
     LinkComponent: "a",
     showSummary: true,
+    childrenPagesOrdering: [],
   },
 }
 
@@ -384,6 +387,7 @@ export const RowsWithThumbnailOnly: Story = {
     permalink: "/parent",
     LinkComponent: "a",
     showThumbnail: true,
+    childrenPagesOrdering: [],
   },
 }
 
@@ -395,6 +399,7 @@ export const RowsWithThumbnailAndDescription: Story = {
     LinkComponent: "a",
     showSummary: true,
     showThumbnail: true,
+    childrenPagesOrdering: [],
   },
 }
 
@@ -404,6 +409,7 @@ export const Boxes: Story = {
     site,
     permalink: "/parent",
     LinkComponent: "a",
+    childrenPagesOrdering: [],
   },
 }
 
@@ -414,6 +420,7 @@ export const BoxesWithDescription: Story = {
     permalink: "/parent",
     LinkComponent: "a",
     showSummary: true,
+    childrenPagesOrdering: [],
   },
 }
 
@@ -424,6 +431,7 @@ export const BoxesWithThumbnailOnly: Story = {
     permalink: "/parent",
     LinkComponent: "a",
     showThumbnail: true,
+    childrenPagesOrdering: [],
   },
 }
 export const BoxesWithThumbnailAndDescription: Story = {
@@ -434,5 +442,6 @@ export const BoxesWithThumbnailAndDescription: Story = {
     LinkComponent: "a",
     showSummary: true,
     showThumbnail: true,
+    childrenPagesOrdering: [],
   },
 }

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
@@ -223,7 +223,7 @@ const RowLayout = ({
 }
 
 const ChildrenPages = ({
-  childrenPagesOrdering,
+  childrenPagesOrdering = [],
   permalink,
   site,
   LinkComponent,

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
@@ -223,6 +223,7 @@ const RowLayout = ({
 }
 
 const ChildrenPages = ({
+  childrenPagesOrdering,
   permalink,
   site,
   LinkComponent,
@@ -236,12 +237,34 @@ const ChildrenPages = ({
     return <></>
   }
 
-  const children = currentPageNode.children.map((child) => ({
-    title: child.title,
-    url: child.permalink,
-    description: child.summary,
-    image: child.image,
-  }))
+  const children = currentPageNode.children
+    .map((child) => ({
+      id: child.id,
+      title: child.title,
+      url: child.permalink,
+      description: child.summary,
+      image: child.image,
+    }))
+    .sort((a, b) => {
+      const [aIndex, bIndex] = [
+        childrenPagesOrdering.indexOf(a.id),
+        childrenPagesOrdering.indexOf(b.id),
+      ]
+
+      if (aIndex === bIndex) {
+        return a.title.localeCompare(b.title, undefined, { numeric: true })
+      }
+
+      if (aIndex === -1) {
+        return 1
+      }
+
+      if (bIndex === -1) {
+        return -1
+      }
+
+      return aIndex - bIndex
+    })
 
   if (variant === "boxes") {
     return (

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.stories.tsx
@@ -200,6 +200,7 @@ export const Rows: Story = {
         variant: "rows",
         showSummary: false,
         showThumbnail: false,
+        childrenPagesOrdering: [],
       },
     ],
   }),
@@ -209,6 +210,7 @@ export const RowsWithImageOnly: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "rows",
         showSummary: false,
@@ -222,6 +224,7 @@ export const RowsWithDescriptionOnly: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "rows",
         showSummary: true,
@@ -235,6 +238,7 @@ export const RowsWithImageAndDescription: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "rows",
         showSummary: true,
@@ -263,6 +267,7 @@ export const RowsWithImageAndDescriptionAndContent: Story = {
         ],
       },
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "rows",
         showSummary: true,
@@ -276,6 +281,7 @@ export const Boxes: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "boxes",
         showSummary: false,
@@ -289,6 +295,7 @@ export const BoxesWithImageOnly: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "boxes",
         showSummary: false,
@@ -302,6 +309,7 @@ export const BoxesWithDescriptionOnly: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "boxes",
         showSummary: true,
@@ -315,6 +323,7 @@ export const BoxesWithImageAndDescription: Story = {
   args: generateIndexPage(DEFAULT_INDEX_PAGE, {
     content: [
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "boxes",
         showSummary: true,
@@ -343,6 +352,7 @@ export const BoxesWithImageAndDescriptionAndContent: Story = {
         ],
       },
       {
+        childrenPagesOrdering: [],
         type: "childrenpages",
         variant: "boxes",
         showSummary: true,


### PR DESCRIPTION
## Problem
we want to add children pages block to any block that does not have it at present. 

Closes [insert issue #]

## Solution
- this PR adds a migration to do that and verifies the changes via tests
- this works via getting all index pages with `layout: index`, then filtering for those without an existing `childrenpages` block 
- when we get this list, we spread the existing content and add the default children page at the last index