### PR TITLE
chore(tests): add tests for `listChildrenPage`

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -47,7 +47,8 @@
     "jump:vapt": "source .ssh/.env.vapt && ssh -L 5433:$DB_HOST:5432 $SSH_USER@$SSH_HOST -i .ssh/studio-vapt-bastion.pem",
     "migrate:staging": "source .ssh/.env.staging && npx prisma migrate deploy",
     "migrate:uat": "source .ssh/.env.uat && npx prisma migrate deploy",
-    "migrate:vapt": "source .ssh/.env.vapt && npx prisma migrate deploy"
+    "migrate:vapt": "source .ssh/.env.vapt && npx prisma migrate deploy",
+    "test:watch": "dotenv -e .env.test npx vitest watch"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -772,7 +772,7 @@ describe("folder.router", async () => {
       // Arrange
       const invalidSiteId = 999
       const { site, folder } = await setupFolder()
-      await setupAdminPermissions({
+      await setupEditorPermissions({
         userId: session.userId,
         siteId: site.id,
       })
@@ -830,14 +830,13 @@ describe("folder.router", async () => {
     it("should throw 404 if the page specified by `indexPageId` is not an `IndexPage`", async () => {
       // Arrange
       const { site, folder } = await setupFolder()
-      await setupAdminPermissions({ siteId: site.id, userId: session.userId })
+      await setupEditorPermissions({ siteId: site.id, userId: session.userId })
       const { page } = await setupPageResource({
         resourceType: "Page",
         parentId: folder.id,
       })
 
       // Act
-
       const result = caller.listChildPages({
         siteId: String(site.id),
         indexPageId: page.id,
@@ -858,7 +857,7 @@ describe("folder.router", async () => {
     it("should throw 404 if the `indexPageId` does not exist", async () => {
       // Arrange
       const { site } = await setupFolder()
-      await setupAdminPermissions({ siteId: site.id, userId: session.userId })
+      await setupEditorPermissions({ siteId: site.id, userId: session.userId })
 
       // Act
       const result = caller.listChildPages({
@@ -870,7 +869,7 @@ describe("folder.router", async () => {
       await expect(result).rejects.toThrowError(
         new TRPCError({
           code: "NOT_FOUND",
-          message: "No index page with the specified id could be found",
+          message: "Resource not found",
         }),
       )
       await expect(
@@ -881,7 +880,7 @@ describe("folder.router", async () => {
     it("should return only the published pages of the parent folder", async () => {
       // Arrange
       const { site, folder } = await setupFolder()
-      await setupAdminPermissions({ siteId: site.id, userId: session.userId })
+      await setupEditorPermissions({ siteId: site.id, userId: session.userId })
       const { page: indexPage } = await setupPageResource({
         parentId: folder.id,
         siteId: site.id,

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -16,7 +16,7 @@ import {
 } from "tests/integration/helpers/seed"
 
 import { createCallerFactory } from "~/server/trpc"
-import { AuditLogEvent, db, ResourceType } from "../../database"
+import { AuditLogEvent, db, ResourceState, ResourceType } from "../../database"
 import { folderRouter } from "../folder.router"
 
 const createCaller = createCallerFactory(folderRouter)
@@ -737,6 +737,198 @@ describe("folder.router", async () => {
       expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
   })
+  describe("listChildPages", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const { folder, site } = await setupFolder()
+      const { page: indexPage } = await setupPageResource({
+        parentId: folder.id,
+        siteId: site.id,
+        resourceType: "IndexPage",
+      })
+      await createChildPages({
+        parentId: folder.id,
+        siteId: site.id,
+        numPages: 3,
+        numFolders: 5,
+      })
+
+      // Act
+      const result = unauthedCaller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: indexPage.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toHaveLength(0)
+    })
+
+    it("should return an empty array if `siteId` does not exist", async () => {
+      // Arrange
+      const invalidSiteId = 999
+      const { site, folder } = await setupFolder()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      expect(site.id).not.toEqual(invalidSiteId)
+      const { page: indexPage } = await setupPageResource({
+        parentId: folder.id,
+        siteId: site.id,
+        resourceType: "IndexPage",
+      })
+      await createChildPages({
+        parentId: folder.id,
+        siteId: site.id,
+        numPages: 3,
+        numFolders: 5,
+      })
+
+      // Act
+      const result = await caller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: indexPage.id,
+      })
+
+      // Assert
+      expect(result.childPages).toEqual([])
+    })
+
+    it("should throw 403 if user does not have access to the site", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder()
+      const { page: indexPage } = await setupPageResource({
+        parentId: folder.id,
+        siteId: site.id,
+        resourceType: "IndexPage",
+      })
+
+      // Act
+      const result = caller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: indexPage.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toHaveLength(0)
+    })
+
+    it("should throw 404 if the page specified by `indexPageId` is not an `IndexPage`", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder()
+      await setupAdminPermissions({ siteId: site.id, userId: session.userId })
+      const { page } = await setupPageResource({
+        resourceType: "Page",
+        parentId: folder.id,
+      })
+
+      // Act
+
+      const result = caller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: page.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "No index page with the specified id could be found",
+        }),
+      )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toHaveLength(0)
+    })
+
+    it("should throw 404 if the `indexPageId` does not exist", async () => {
+      // Arrange
+      const { site } = await setupFolder()
+      await setupAdminPermissions({ siteId: site.id, userId: session.userId })
+
+      // Act
+      const result = caller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: "1234",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "No index page with the specified id could be found",
+        }),
+      )
+      await expect(
+        db.selectFrom("AuditLog").selectAll().execute(),
+      ).resolves.toHaveLength(0)
+    })
+
+    it("should return only the published pages of the parent folder", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder()
+      await setupAdminPermissions({ siteId: site.id, userId: session.userId })
+      const { page: indexPage } = await setupPageResource({
+        parentId: folder.id,
+        siteId: site.id,
+        resourceType: "IndexPage",
+      })
+      const { pages, folders } = await createChildPages({
+        parentId: folder.id,
+        siteId: site.id,
+        numPages: 3,
+        numFolders: 4,
+        state: "Published",
+        userId: session.userId,
+      })
+
+      // NOTE: Not `published`
+      await createChildPages({
+        parentId: folder.id,
+        siteId: site.id,
+        numPages: 3,
+        numFolders: 4,
+      })
+
+      // Act
+      const result = await caller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: indexPage.id,
+      })
+
+      // Assert
+      expect(result.childPages).toHaveLength(7)
+      const indexPagesOfFolders = await db
+        .selectFrom("Resource")
+        .where(
+          "parentId",
+          "in",
+          folders.map(({ id }) => id),
+        )
+        .where("type", "=", "IndexPage")
+        .select("id")
+        .execute()
+      const indexPagesId = indexPagesOfFolders.map(({ id }) => id)
+      const pagesId = pages.map(({ id }) => id)
+      expect(result.childPages.map(({ id }) => id).toSorted()).toStrictEqual(
+        [...pagesId, ...indexPagesId].toSorted(),
+      )
+    })
+  })
 })
 
 // Test util functions
@@ -754,4 +946,70 @@ const getFolderWithPermalink = ({
     .where("permalink", "=", permalink)
     .selectAll()
     .executeTakeFirstOrThrow()
+}
+
+const createChildPages = async ({
+  parentId,
+  siteId,
+  numPages,
+  numFolders,
+  state = ResourceState.Draft,
+  userId,
+}: {
+  parentId: string
+  siteId: number
+  numPages: number
+  numFolders: number
+  state?: ResourceState
+  userId?: string
+}) => {
+  if (state === ResourceState.Published && !userId) {
+    throw new Error(
+      "Precondition failed for `createChildPages`: a valid `userId` is required in order to publish a resource",
+    )
+  }
+
+  const pages = await Promise.all(
+    Array.from({ length: numPages })
+      .fill(null)
+      .map(async () => {
+        const permalink = crypto.randomUUID()
+        const { page } = await setupPageResource({
+          resourceType: "Page",
+          siteId,
+          parentId,
+          state,
+          permalink,
+          userId,
+        })
+        return page
+      }),
+  )
+
+  const folders = await Promise.all(
+    Array.from({ length: numFolders })
+      .fill(null)
+      .map(async () => {
+        const { folder } = await setupFolder({
+          siteId,
+          parentId,
+          permalink: crypto.randomUUID(),
+          state: ResourceState.Published,
+        })
+
+        const permalink = crypto.randomUUID()
+        await setupPageResource({
+          resourceType: "IndexPage",
+          siteId,
+          parentId: folder.id,
+          state,
+          permalink,
+          userId,
+        })
+
+        return folder
+      }),
+  )
+
+  return { pages, folders }
 }

--- a/apps/studio/turbo.json
+++ b/apps/studio/turbo.json
@@ -3,6 +3,7 @@
   "extends": ["//"],
   "tasks": {
     "db:seed": {},
+    "test:watch": {},
     "test:unit": {
       "dependsOn": ["generate"]
     },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -8,6 +8,7 @@
   "type": "module",
   "scripts": {
     "rollup": "rollup -c",
+    "test:watch": "npx vitest watch",
     "storybook": "storybook dev -p 6006",
     "dev": "tsc -w",
     "build-storybook": "storybook build",

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
@@ -10,6 +10,7 @@ import {
 } from "~/utils"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
+import { mergeChildrenPages } from "./utils"
 
 const ChildpageImage = ({
   src,
@@ -245,26 +246,7 @@ const ChildrenPages = ({
       description: child.summary,
       image: child.image,
     }))
-    .sort((a, b) => {
-      const [aIndex, bIndex] = [
-        childrenPagesOrdering.indexOf(a.id),
-        childrenPagesOrdering.indexOf(b.id),
-      ]
-
-      if (aIndex === bIndex) {
-        return a.title.localeCompare(b.title, undefined, { numeric: true })
-      }
-
-      if (aIndex === -1) {
-        return 1
-      }
-
-      if (bIndex === -1) {
-        return -1
-      }
-
-      return aIndex - bIndex
-    })
+    .sort((a, b) => mergeChildrenPages(a, b, childrenPagesOrdering))
 
   if (variant === "boxes") {
     return (

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/__tests__/utils.test.ts
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/__tests__/utils.test.ts
@@ -4,128 +4,130 @@ import { describe, expect, it } from "vitest"
 import { ChildPage } from "../types"
 import { mergeChildrenPages } from "../utils"
 
-const MOCK_CHILDREN_PAGES: ChildPage[] = [
-  {
-    id: "1",
-    title: "random title 1",
-    url: "random url 1",
-    description: "random desc 1",
-  },
-  {
-    id: "2",
-    title: "random title 2",
-    url: "random url 2",
-    description: "random desc 2",
-  },
-  {
-    id: "3",
-    title: "random title 3",
-    url: "random url 3",
-    description: "random desc 3",
-  },
-  {
-    id: "4",
-    title: "random title 4",
-    url: "random url 4",
-    description: "random desc 4",
-  },
-  {
-    id: "5",
-    title: "random title 5",
-    url: "random url 5",
-    description: "random desc 5",
-  },
-  {
-    id: "6",
-    title: "random title 6",
-    url: "random url 6",
-    description: "random desc 6",
-  },
-]
+const generateChildrenPages = (extraPages: ChildPage[] = []): ChildPage[] => {
+  return [
+    {
+      id: "1",
+      title: "random title 1",
+      url: "random url 1",
+      description: "random desc 1",
+    },
+    {
+      id: "2",
+      title: "random title 2",
+      url: "random url 2",
+      description: "random desc 2",
+    },
+    {
+      id: "3",
+      title: "random title 3",
+      url: "random url 3",
+      description: "random desc 3",
+    },
+    {
+      id: "4",
+      title: "random title 4",
+      url: "random url 4",
+      description: "random desc 4",
+    },
+    {
+      id: "5",
+      title: "random title 5",
+      url: "random url 5",
+      description: "random desc 5",
+    },
+    {
+      id: "6",
+      title: "random title 6",
+      url: "random url 6",
+      description: "random desc 6",
+    },
+    ...extraPages,
+  ]
+}
 
 describe("ChildrenPages.utils", () => {
-  it("should sort the children pages in the order specified", () => {
-    // Arrange
-    const ordering = ["3", "1", "4", "2", "5", "6"]
+  describe("mergeChildrenPages", () => {
+    it("should sort the children pages in the order specified", () => {
+      // Arrange
+      const ordering = ["3", "1", "4", "2", "5", "6"]
 
-    // Act
-    // NOTE: need to deep clone because `sort` is inplace
-    const actual = cloneDeep(MOCK_CHILDREN_PAGES).sort((a, b) =>
-      mergeChildrenPages(a, b, ordering),
-    )
+      // Act
+      // NOTE: need to deep clone because `sort` is inplace
+      const actual = cloneDeep(generateChildrenPages()).sort((a, b) =>
+        mergeChildrenPages(a, b, ordering),
+      )
 
-    // Assert
-    expect(actual.map(({ id }) => id)).toEqual(ordering)
-  })
+      // Assert
+      expect(actual.map(({ id }) => id)).toEqual(ordering)
+    })
 
-  it("should add children pages that are not in ordering at the back of the array", () => {
-    // Arrange
-    const ordering = ["3", "1", "4", "2", "5", "6"]
-    const arr = [
-      {
-        id: "22",
-        title: "random title 22",
-        url: "random url 22",
-        description: "random desc 22",
-      },
-      ...cloneDeep(MOCK_CHILDREN_PAGES),
-    ]
+    it("should add children pages that are not in ordering at the back of the array", () => {
+      // Arrange
+      const ordering = ["3", "1", "4", "2", "5", "6"]
+      const arr = [
+        {
+          id: "22",
+          title: "random title 0",
+          url: "random url 22",
+          description: "random desc 22",
+        },
+        ...generateChildrenPages(),
+      ]
 
-    // Act
-    // NOTE: need to deep clone because `sort` is inplace
-    const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
+      // Act
+      const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
 
-    // Assert
-    expect(actual.map(({ id }) => id)).toEqual([...ordering, "22"])
-  })
-  it("should respect numeric sorting for title when the pages are not specified in the order", () => {
-    // Arrange
-    const ordering: never[] = []
-    const arr = [
-      {
-        id: "1",
-        title: "random title 1",
-        url: "random url 1",
-        description: "random desc 1",
-      },
-      {
-        id: "10",
-        title: "random title 10",
-        url: "random url 10",
-        description: "random desc 10",
-      },
-    ]
+      // Assert
+      expect(actual.map(({ id }) => id)).toEqual([...ordering, "22"])
+    })
+    it("should respect numeric sorting for title when the pages are not specified in the order", () => {
+      // Arrange
+      const ordering: never[] = []
+      const arr = [
+        {
+          id: "1",
+          title: "random title 1",
+          url: "random url 1",
+          description: "random desc 1",
+        },
+        {
+          id: "10",
+          title: "random title 10",
+          url: "random url 10",
+          description: "random desc 10",
+        },
+      ]
 
-    // Act
-    // NOTE: need to deep clone because `sort` is inplace
-    const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
+      // Act
+      const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
 
-    // Assert
-    expect(actual.map(({ id }) => id)).toEqual(["1", "10"])
-  })
-  it("should be case sensitive for title sorting when the pages are not specified in the order", () => {
-    // Arrange
-    const ordering: never[] = []
-    const arr = [
-      {
-        id: "1",
-        title: "random title 1",
-        url: "random url 1",
-        description: "random desc 1",
-      },
-      {
-        id: "2",
-        title: "Random title 1",
-        url: "random url 1",
-        description: "random desc 1",
-      },
-    ]
+      // Assert
+      expect(actual.map(({ id }) => id)).toEqual(["1", "10"])
+    })
+    it("should be case sensitive for title sorting when the pages are not specified in the order", () => {
+      // Arrange
+      const ordering: never[] = []
+      const arr = [
+        {
+          id: "1",
+          title: "random title 1",
+          url: "random url 1",
+          description: "random desc 1",
+        },
+        {
+          id: "2",
+          title: "Random title 1",
+          url: "random url 1",
+          description: "random desc 1",
+        },
+      ]
 
-    // Act
-    // NOTE: need to deep clone because `sort` is inplace
-    const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
+      // Act
+      const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
 
-    // Assert
-    expect(actual.map(({ id }) => id)).toEqual(["1", "2"])
+      // Assert
+      expect(actual.map(({ id }) => id)).toEqual(["1", "2"])
+    })
   })
 })

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/__tests__/utils.test.ts
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/__tests__/utils.test.ts
@@ -1,0 +1,131 @@
+import { cloneDeep } from "lodash"
+import { describe, expect, it } from "vitest"
+
+import { ChildPage } from "../types"
+import { mergeChildrenPages } from "../utils"
+
+const MOCK_CHILDREN_PAGES: ChildPage[] = [
+  {
+    id: "1",
+    title: "random title 1",
+    url: "random url 1",
+    description: "random desc 1",
+  },
+  {
+    id: "2",
+    title: "random title 2",
+    url: "random url 2",
+    description: "random desc 2",
+  },
+  {
+    id: "3",
+    title: "random title 3",
+    url: "random url 3",
+    description: "random desc 3",
+  },
+  {
+    id: "4",
+    title: "random title 4",
+    url: "random url 4",
+    description: "random desc 4",
+  },
+  {
+    id: "5",
+    title: "random title 5",
+    url: "random url 5",
+    description: "random desc 5",
+  },
+  {
+    id: "6",
+    title: "random title 6",
+    url: "random url 6",
+    description: "random desc 6",
+  },
+]
+
+describe("ChildrenPages.utils", () => {
+  it("should sort the children pages in the order specified", () => {
+    // Arrange
+    const ordering = ["3", "1", "4", "2", "5", "6"]
+
+    // Act
+    // NOTE: need to deep clone because `sort` is inplace
+    const actual = cloneDeep(MOCK_CHILDREN_PAGES).sort((a, b) =>
+      mergeChildrenPages(a, b, ordering),
+    )
+
+    // Assert
+    expect(actual.map(({ id }) => id)).toEqual(ordering)
+  })
+
+  it("should add children pages that are not in ordering at the back of the array", () => {
+    // Arrange
+    const ordering = ["3", "1", "4", "2", "5", "6"]
+    const arr = [
+      {
+        id: "22",
+        title: "random title 22",
+        url: "random url 22",
+        description: "random desc 22",
+      },
+      ...cloneDeep(MOCK_CHILDREN_PAGES),
+    ]
+
+    // Act
+    // NOTE: need to deep clone because `sort` is inplace
+    const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
+
+    // Assert
+    expect(actual.map(({ id }) => id)).toEqual([...ordering, "22"])
+  })
+  it("should respect numeric sorting for title when the pages are not specified in the order", () => {
+    // Arrange
+    const ordering: never[] = []
+    const arr = [
+      {
+        id: "1",
+        title: "random title 1",
+        url: "random url 1",
+        description: "random desc 1",
+      },
+      {
+        id: "10",
+        title: "random title 10",
+        url: "random url 10",
+        description: "random desc 10",
+      },
+    ]
+
+    // Act
+    // NOTE: need to deep clone because `sort` is inplace
+    const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
+
+    // Assert
+    expect(actual.map(({ id }) => id)).toEqual(["1", "10"])
+  })
+  it("should be case sensitive for title sorting when the pages are not specified in the order", () => {
+    // Arrange
+    const ordering: never[] = []
+    const arr = [
+      {
+        id: "1",
+        title: "random title 1",
+        url: "random url 1",
+        description: "random desc 1",
+      },
+      {
+        id: "2",
+        title: "Random title 1",
+        url: "random url 1",
+        description: "random desc 1",
+      },
+    ]
+
+    // Act
+    // NOTE: need to deep clone because `sort` is inplace
+    const actual = arr.sort((a, b) => mergeChildrenPages(a, b, ordering))
+
+    // Assert
+    expect(actual.map(({ id }) => id)).toEqual(["1", "2"])
+  })
+})

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/types.ts
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/types.ts
@@ -1,0 +1,6 @@
+import { IsomerSitemap } from "~/types"
+
+export type ChildPage = Pick<IsomerSitemap, "id" | "title" | "image"> & {
+  url: IsomerSitemap["permalink"]
+  description: IsomerSitemap["summary"]
+}

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/utils.ts
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/utils.ts
@@ -1,0 +1,27 @@
+import type { ChildPage } from "./types"
+import type { ChildrenPagesProps } from "~/interfaces"
+
+export const mergeChildrenPages = (
+  a: ChildPage,
+  b: ChildPage,
+  childrenPagesOrdering: ChildrenPagesProps["childrenPagesOrdering"] = [],
+) => {
+  const [aIndex, bIndex] = [
+    childrenPagesOrdering.indexOf(a.id),
+    childrenPagesOrdering.indexOf(b.id),
+  ]
+
+  if (aIndex === bIndex) {
+    return a.title.localeCompare(b.title, undefined, { numeric: true })
+  }
+
+  if (aIndex === -1) {
+    return 1
+  }
+
+  if (bIndex === -1) {
+    return -1
+  }
+
+  return aIndex - bIndex
+}

--- a/packages/components/turbo.json
+++ b/packages/components/turbo.json
@@ -2,6 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
+    "test:watch": {},
     "build": {
       "outputs": ["dist/**"]
     },


### PR DESCRIPTION
## Problem
This PR adds tests as a follow up to the previous PR - mainly for sort + list behaviour

## Solution
1. reorg some files in `ChildrenPages` for testing
2. add tests 
3. add `test:watch` command to `turbo` so we can watch test executions
