### PR TITLE
fix: set name + url as required for collection creation

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -160,7 +160,7 @@ const SuspendableModalContent = ({
         <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
-            <FormControl isInvalid={!!errors.title}>
+            <FormControl isRequired isInvalid={!!errors.title}>
               <FormLabel color="base.content.strong">
                 Folder name
                 <FormHelperText color="base.content.default">
@@ -182,7 +182,7 @@ const SuspendableModalContent = ({
                 </FormHelperText>
               )}
             </FormControl>
-            <FormControl isInvalid={!!errors.permalink}>
+            <FormControl isRequired isInvalid={!!errors.permalink}>
               <FormLabel color="base.content.strong">
                 Folder URL
                 <FormHelperText color="base.content.default">

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -136,7 +136,7 @@ const CreateCollectionModalContent = ({
         <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
-            <FormControl isInvalid={!!errors.collectionTitle}>
+            <FormControl isRequired isInvalid={!!errors.collectionTitle}>
               <FormLabel color="base.content.strong">
                 Collection name
                 <FormHelperText color="base.content.default">
@@ -159,7 +159,7 @@ const CreateCollectionModalContent = ({
                 </FormHelperText>
               )}
             </FormControl>
-            <FormControl isInvalid={!!errors.permalink}>
+            <FormControl isRequired isInvalid={!!errors.permalink}>
               <FormLabel color="base.content.strong">
                 Collection URL
                 <FormHelperText color="base.content.default">


### PR DESCRIPTION
## Problem
right now, collections have `name/url` set as `optional` on initial creation; for folders/collections, these are optional when editing the settings too 

Closes [insert issue #]

## Solution
set them to required
