### PR TITLE
feat: allow users to edit link title

### DIFF
--- a/apps/studio/src/features/dashboard/atoms.ts
+++ b/apps/studio/src/features/dashboard/atoms.ts
@@ -25,6 +25,9 @@ export const folderSettingsModalAtom = atom<FolderSettingsModalState>(
 
 export interface PageSettingsState {
   pageId: string
-  type: typeof ResourceType.Page | typeof ResourceType.CollectionPage
+  type:
+    | typeof ResourceType.Page
+    | typeof ResourceType.CollectionPage
+    | typeof ResourceType.CollectionLink
 }
 export const pageSettingsModalAtom = atom<null | PageSettingsState>(null)

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -53,7 +53,8 @@ export const CollectionTableMenu = ({
       />
       <Portal>
         <MenuList>
-          {resourceType === ResourceType.CollectionPage && (
+          {(resourceType === ResourceType.CollectionPage ||
+            resourceType === ResourceType.CollectionLink) && (
             <MenuItem
               icon={<BiCog fontSize="1rem" />}
               onClick={() =>
@@ -63,7 +64,7 @@ export const CollectionTableMenu = ({
                 })
               }
             >
-              Edit page settings
+              Edit settings
             </MenuItem>
           )}
           <MenuItem

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -22,6 +22,7 @@ import {
   ModalCloseButton,
   useToast,
 } from "@opengovsg/design-system-react"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 import { useAtom } from "jotai"
 import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
@@ -121,14 +122,14 @@ const PageSettingsModalContent = ({
       await utils.collection.invalidate()
 
       toast({
-        title: "Saved and published page settings",
+        title: "Saved and published settings",
         description: "Check your site in 5-10 minutes to view it live.",
         status: "success",
       })
     },
     onError: (error) => {
       toast({
-        title: "Failed to save page settings",
+        title: "Failed to save settings",
         description: error.message,
         status: "error",
       })
@@ -155,14 +156,14 @@ const PageSettingsModalContent = ({
 
   return (
     <ModalContent key={pageId}>
-      <ModalHeader>Page settings</ModalHeader>
+      <ModalHeader>Settings</ModalHeader>
       <ModalCloseButton />
       <ModalBody>
         {/* NOTE: doing this because typescript doesn't infer that the property has to exist from the assertion on modal */}
         <VStack w="100%" gap="1rem" alignItems="flex-start">
           <FormControl isRequired isInvalid={!!errors.title}>
             <FormLabel description="Title should be descriptive">
-              Page title
+              Title
             </FormLabel>
             <Input
               w="100%"
@@ -177,51 +178,53 @@ const PageSettingsModalContent = ({
             <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
           </FormControl>
 
-          <FormControl isRequired isInvalid={!!errors.permalink}>
-            <FormLabel>Page URL</FormLabel>
-            <Controller
-              control={control}
-              name="permalink"
-              render={({ field: { onChange, ...field } }) => (
-                <Input
-                  placeholder={"URL will be autopopulated if left untouched"}
-                  noOfLines={1}
-                  mt="0.5rem"
-                  w="100%"
-                  {...field}
-                  onChange={(e) => {
-                    onChange(
-                      generateResourceUrl(e.target.value).slice(
-                        0,
-                        MAX_PAGE_URL_LENGTH,
-                      ),
-                    )
-                  }}
-                />
-              )}
-            />
-            <Infobox
-              my="0.5rem"
-              icon={<BiLink />}
-              variant="info-secondary"
-              size="sm"
-            >
-              <Text textStyle="subhead-2" overflow="hidden">
-                <chakra.span color="base.content.medium">
-                  {permalinksToRender.parentPermalinks}
-                </chakra.span>
-                {permalinksToRender.permalink}
-              </Text>
-            </Infobox>
-            <FormHelperText>
-              {MAX_PAGE_URL_LENGTH - permalink.length} characters left
-            </FormHelperText>
-            <FormErrorMessage>{errors.permalink?.message}</FormErrorMessage>
-          </FormControl>
+          {type !== ResourceType.CollectionLink && (
+            <FormControl isRequired isInvalid={!!errors.permalink}>
+              <FormLabel>URL</FormLabel>
+              <Controller
+                control={control}
+                name="permalink"
+                render={({ field: { onChange, ...field } }) => (
+                  <Input
+                    placeholder={"URL will be autopopulated if left untouched"}
+                    noOfLines={1}
+                    mt="0.5rem"
+                    w="100%"
+                    {...field}
+                    onChange={(e) => {
+                      onChange(
+                        generateResourceUrl(e.target.value).slice(
+                          0,
+                          MAX_PAGE_URL_LENGTH,
+                        ),
+                      )
+                    }}
+                  />
+                )}
+              />
+              <Infobox
+                my="0.5rem"
+                icon={<BiLink />}
+                variant="info-secondary"
+                size="sm"
+              >
+                <Text textStyle="subhead-2" overflow="hidden">
+                  <chakra.span color="base.content.medium">
+                    {permalinksToRender.parentPermalinks}
+                  </chakra.span>
+                  {permalinksToRender.permalink}
+                </Text>
+              </Infobox>
+              <FormHelperText>
+                {MAX_PAGE_URL_LENGTH - permalink.length} characters left
+              </FormHelperText>
+              <FormErrorMessage>{errors.permalink?.message}</FormErrorMessage>
+            </FormControl>
+          )}
 
           <Infobox variant="warning">
-            Changes to your page title and URL will get published immediately.
-            If you don't want to publish them, make this change later.
+            Changes to your title and URL will get published immediately. If you
+            don't want to publish them, make this change later.
           </Infobox>
         </VStack>
       </ModalBody>

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -67,7 +67,7 @@ export const ResourceTableMenu = ({
                 }
                 icon={<BiCog fontSize="1rem" />}
               >
-                Edit page settings
+                Edit settings
               </MenuItem>
 
               {/* TODO(ISOM-1552): Add back duplicate page functionality when implemented */}

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -134,6 +134,9 @@ export const pageSettingsSchema = z.discriminatedUnion("type", [
   basePageSettingsSchema.extend({
     type: z.literal(ResourceType.IndexPage),
   }),
+  basePageSettingsSchema.extend({
+    type: z.literal(ResourceType.CollectionLink),
+  }),
   rootPageSettingsSchema,
 ])
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -696,6 +696,7 @@ export const pageRouter = router({
               .where("Resource.type", "in", [
                 ResourceType.Page,
                 ResourceType.CollectionPage,
+                ResourceType.CollectionLink,
                 ResourceType.RootPage,
               ])
               .set({ title, ...settings })

--- a/apps/studio/src/stories/Page/FolderPage.stories.tsx
+++ b/apps/studio/src/stories/Page/FolderPage.stories.tsx
@@ -87,7 +87,7 @@ export const PageSettings: Story = {
     const { canvasElement } = context
     await PageResourceMenu.play?.(context)
     const screen = within(canvasElement.ownerDocument.body)
-    const pageSettingsButton = screen.getByText("Edit page settings")
+    const pageSettingsButton = screen.getByText("Edit settings")
 
     await userEvent.click(pageSettingsButton, {
       pointerEventsCheck: 0,

--- a/apps/studio/src/stories/Page/SitePage.stories.tsx
+++ b/apps/studio/src/stories/Page/SitePage.stories.tsx
@@ -82,7 +82,7 @@ export const PageSettings: Story = {
     const { canvasElement } = context
     await PageResourceMenu.play?.(context)
     const screen = within(canvasElement.ownerDocument.body)
-    const pageSettingsButton = screen.getByText("Edit page settings")
+    const pageSettingsButton = screen.getByText("Edit settings")
 
     await userEvent.click(pageSettingsButton, {
       pointerEventsCheck: 0,


### PR DESCRIPTION
## Problem
we want to allow users to edit their link title and self service

## Solution
1. reuse the existing page settings modal and remove the restriction that it needs to be a `Page` 
2. update wording of the modal and associated toasts to remove `page` (cleared by design alr)
3. hide the url when it's a link

## Videos

https://github.com/user-attachments/assets/346046d4-eca3-4164-9c13-382613319d08

## Tests
1. click into a collection
2. create a collection link
3. try to update the title
4. it should work
5. repeat steps 2-4 but for a collection page
6. click into a foldre
7. create a folder page
8. try to update the title
9. it should work