### PR TITLE
fix(deploy): add github ref to image tag 

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -150,7 +150,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
           ENV: ${{ inputs.environment }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{github.ref}}/${{ github.sha }}
         with:
           context: .
           file: "./apps/studio/Dockerfile"

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -150,7 +150,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
           ENV: ${{ inputs.environment }}
-          IMAGE_TAG: ${{github.ref}}/${{ github.sha }}
+          IMAGE_TAG: ${{ github.ref_name }}_${{ github.sha }}
         with:
           context: .
           file: "./apps/studio/Dockerfile"
@@ -223,7 +223,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
           ENV: ${{ inputs.environment }}
-          IMAGE_TAG: ${{ github.sha }}
+          IMAGE_TAG: ${{ github.ref_name }}_${{ github.sha }}
         with:
           task-definition: ${{ inputs.ecs-task-definition-path }}
           container-name: ${{ inputs.ecs-container-name }}


### PR DESCRIPTION
## Problem
right now, our docker images are uniquely identified by the github sha. most of the itme, this is ok. however, when we want to rollback a commit, what happens is that we will attach a tag to the old version. this results in deploys failing as our tags are immutable on production

Closes [insert issue #]

## Solution 
- add `github.ref` to be part fo the image tag. when this is from a push, this will be a branch name. however, on release, this will be the `release_tag`; this means we can have 2 release tags that are differently only ihn the release version but having the same commit hash
