### PR TITLE
feat(collection-links): alllow users to add thumbnails to items

### DIFF
--- a/apps/studio/src/features/editing-experience/atoms.ts
+++ b/apps/studio/src/features/editing-experience/atoms.ts
@@ -1,3 +1,5 @@
+import type { LinkRefPageSchema } from "@opengovsg/isomer-components"
+import type { Static } from "@sinclair/typebox"
 import { format } from "date-fns"
 import { atom } from "jotai"
 
@@ -5,13 +7,10 @@ import type { ResourceItemContent } from "~/schemas/resource"
 
 export const moveResourceAtom = atom<null | ResourceItemContent>(null)
 
-export interface CollectionLinkProps {
-  ref: string
-  description?: string
-  date: string
-  category: string
+export type CollectionLinkProps = Static<typeof LinkRefPageSchema> & {
   title: string
 }
+
 export const linkAtom = atom<CollectionLinkProps>({
   ref: "",
   description: "",

--- a/apps/studio/src/features/editing-experience/components/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditLinkPreview.tsx
@@ -16,6 +16,7 @@ export const EditCollectionLinkPreview = (): JSX.Element => {
     title,
     category,
     ref,
+    image,
   } = useAtomValue(linkAtom)
   const { linkId, siteId } = useQueryParse(editLinkSchema)
   const [permalink] = trpc.page.getFullPermalink.useSuspenseQuery(
@@ -53,6 +54,7 @@ export const EditCollectionLinkPreview = (): JSX.Element => {
           {
             id: "9999999",
             title,
+            image,
             date,
             ref,
             summary: summary ?? "",

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -34,6 +34,12 @@ export const editLinkSchema = z.object({
   siteId: z.number().min(1),
   description: z.string().optional(),
   ref: z.string().min(1),
+  image: z
+    .object({
+      src: z.string(),
+      alt: z.string().max(120),
+    })
+    .optional(),
 })
 
 export const readLinkSchema = z.object({

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -285,7 +285,7 @@ export const collectionRouter = router({
     .input(editLinkSchema)
     .mutation(
       async ({
-        input: { date, category, linkId, siteId, description, ref },
+        input: { date, category, linkId, siteId, description, ref, image },
         ctx,
       }) => {
         // Things that aren't working yet:
@@ -330,7 +330,7 @@ export const collectionRouter = router({
           const blob = await updateBlobById(tx, {
             content: {
               ...content,
-              page: { description, ref, date, category },
+              page: { description, ref, date, category, image },
             },
             pageId: linkId,
             siteId,

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -148,7 +148,7 @@ export const NotFoundPagePageSchema = Type.Object({})
 export const SearchPagePageSchema = Type.Object({})
 
 export const FileRefPageSchema = BaseRefPageSchema
-export const LinkRefPageSchema = Type.Omit(BaseRefPageSchema, ["image"])
+export const LinkRefPageSchema = BaseRefPageSchema
 
 // These are props that are required by the render engine, but not enforced by
 // the JSON schema (as the data is being stored outside of the page JSON)


### PR DESCRIPTION
## Problem
see ticket

## Solution
1. add the `item` to the `LinkProps` in components
2. on studio, add this to the atom and to the backend where we send it to save. we also update the data being sent to teh preview iwth the image.

## Video

https://github.com/user-attachments/assets/5163b902-8fc5-4056-a974-68aa1b822f63



## Notes
- this PR isn't quite ideal because this change requires alot of manual work, whereas our ideal state is that we're hooked into json forms and the update is automatic (+ now our validation is out of sync on our backend). i can't quite remember why i needed to use the `atom`, but i'll try using the same `ajv` validator and see how it goes 