### PR TITLE
chore: add watch command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:template": "dotenv -- turbo build:template",
     "clean": "turbo clean",
     "dev": "dotenv -- turbo run dev",
+    "watch:packages": "dotenv -- turbo watch build --filter='./packages/*'",
     "dev:e2e": "dotenv -- turbo run dev:e2e",
     "test:e2e": "dotenv -- turbo run test:e2e",
     "setup:test": "turbo setup:test",


### PR DESCRIPTION
## Problem
don't want to have ot manually run `watch` every time a thing change on components

## Solution
add `npm run watch:packages` command that watches our `build` whenever there are code changes so that it'll reflect on studio automatically 