### PR TITLE
Infocols has tiny/misaligned arrows when text is very long

### DIFF
--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.stories.tsx
@@ -71,8 +71,9 @@ export const Default: Story = {
       {
         title: "Partnerships",
         description:
+          "Multilateral collaborations to strengthen regional cooperation and build capabilities. Multilateral collaborations to strengthen regional cooperation and build capabilities.",
+        buttonLabel:
           "Multilateral collaborations to strengthen regional cooperation and build capabilities.",
-        buttonLabel: "Read article",
         buttonUrl: "/faq",
         icon: "users",
       },

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -129,14 +129,14 @@ const InfoBoxes = ({
               )}
 
               {buttonLabel && hasLink && (
-                <h3 className={compoundStyles.infoBoxButton()}>
+                <div className={compoundStyles.infoBoxButton()}>
                   {buttonLabel}
                   <BiRightArrowAlt
                     className={compoundStyles.infoBoxButtonIcon({
                       isExternalLink,
                     })}
                   />
-                </h3>
+                </div>
               )}
             </Link>
           )

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -31,9 +31,9 @@ const createInfoColsStyles = tv({
     ],
     infoBoxDescription: "prose-body-base text-base-content",
     infoBoxButton:
-      "prose-headline-base-medium inline-flex items-center gap-1 text-base-content-strong",
+      "prose-headline-base-medium items-center gap-1 text-base-content-strong",
     infoBoxButtonIcon:
-      "text-[1.375rem] transition ease-in group-hover:translate-x-1",
+      "ml-1 inline text-[1.375rem] transition ease-in group-hover:translate-x-1",
   },
   variants: {
     layout: {
@@ -129,14 +129,14 @@ const InfoBoxes = ({
               )}
 
               {buttonLabel && hasLink && (
-                <div className={compoundStyles.infoBoxButton()}>
+                <h3 className={compoundStyles.infoBoxButton()}>
                   {buttonLabel}
                   <BiRightArrowAlt
                     className={compoundStyles.infoBoxButtonIcon({
                       isExternalLink,
                     })}
                   />
-                </div>
+                </h3>
               )}
             </Link>
           )

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -33,7 +33,7 @@ const createInfoColsStyles = tv({
     infoBoxButton:
       "prose-headline-base-medium items-center gap-1 text-base-content-strong",
     infoBoxButtonIcon:
-      "ml-1 inline text-[1.375rem] transition ease-in group-hover:translate-x-1",
+      "mb-0.5 ml-1 inline text-[1.375rem] transition ease-in group-hover:translate-x-1",
   },
   variants: {
     layout: {


### PR DESCRIPTION
## Problem

When an infocol has a CTA that spans across more than 1 line, the arrow is aligned differently or becomes very tiny.

This is because the CTA and arrow were aligned using a `flex`, instead of the arrow being `inline` with the CTA.

<img width="390" alt="image" src="https://github.com/user-attachments/assets/4299c325-8e71-4dfe-9756-3067812f8d0f" />

Closes [ISOM-1952]

## Solution

Use inline. 

Looks like this now:
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/0b8716e6-6343-4355-a15f-1f95aa56437d" />