### PR TITLE
Fix UI janks in bold components

### DIFF
--- a/packages/components/src/templates/next/components/complex/Hero/HeroFloating.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroFloating.tsx
@@ -56,7 +56,7 @@ export const HeroFloating = ({
           src={backgroundSrc}
           alt={title}
           width="100%"
-          className="aspect-[3/2] w-full object-center lg:w-[66.67%]"
+          className="aspect-[3/2] w-full object-cover object-center lg:w-[66.67%]"
           lazyLoading={false}
         />
       </div>

--- a/packages/components/src/templates/next/components/complex/Infopic/components/FullInfopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/components/FullInfopic.tsx
@@ -27,6 +27,7 @@ export const FullInfopic = ({
       style={{
         backgroundImage: `url('${imageSrc}')`,
         backgroundSize: "cover",
+        backgroundPosition: "center",
       }}
       id={id}
     >


### PR DESCRIPTION
## Problem

Some minor UI bugs on bold components:
- The infocards full variant's background image was aligned to the top. Have to set to `background-position: center` explicitly.
- The floating hero banner's image wasn't set to `image-fit: cover`, so some images were getting squished. Migrators reported. 

Closes [ISOM-1953]

## Before & After

### Infopic full
(look closely where the rhino's legs are!!)
Before:
<img width="1168" alt="image" src="https://github.com/user-attachments/assets/3d3dccdf-4030-4728-9fd3-d30241ce227f" />

After:
<img width="1225" alt="image" src="https://github.com/user-attachments/assets/539f4f0b-ab30-478f-9547-c478a05c9db2" />

### Floating hero
Before:
<img width="1152" alt="image" src="https://github.com/user-attachments/assets/0879627d-c534-4210-8949-132c74066279" />

After: 
<img width="1210" alt="image" src="https://github.com/user-attachments/assets/1c8b3a72-2e35-496e-8a7e-941649b12e8a" />
