### PR TITLE
feat: take sort order from index pages

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -304,6 +304,8 @@ function generateSitemapTree(
   const children = [...existingChildren, ...danglingDirectories]
 
   // Get the page sorting order from the FolderMeta resource
+  // TODO: delete this once `FolderMeta` is removed
+  /** @deprecated use `pageOrderFromIndex` instead; we should remove this once `FolderMeta` is removed from db */
   const pageOrderFromMeta = resources.find(
     (resource) =>
       resource.type === "FolderMeta" &&

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -324,7 +324,9 @@ function generateSitemapTree(
             ? INDEX_PAGE_PERMALINK
             : `${pathPrefixWithoutLeadingSlash}/${INDEX_PAGE_PERMALINK}`),
     )
-    ?.content?.content?.at(-1)
+    ?.content?.content?.find(
+      ({ type }: { type: string }) => type === "childrenpages",
+    )
     ?.childrenPagesOrdering.map((id: string) => {
       const child = children.find(({ id: childId }) => {
         return id === childId

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -304,7 +304,7 @@ function generateSitemapTree(
   const children = [...existingChildren, ...danglingDirectories]
 
   // Get the page sorting order from the FolderMeta resource
-  const pageOrder = resources.find(
+  const pageOrderFromMeta = resources.find(
     (resource) =>
       resource.type === "FolderMeta" &&
       resource.fullPermalink ===
@@ -312,6 +312,27 @@ function generateSitemapTree(
           ? META_PERMALINK
           : `${pathPrefixWithoutLeadingSlash}/${META_PERMALINK}`),
   )?.content?.order
+
+  const pageOrderFromIndex = resources
+    .find(
+      (resource) =>
+        resource.type === "IndexPage" &&
+        resource.fullPermalink ===
+          (pathPrefixWithoutLeadingSlash.length === 0
+            ? INDEX_PAGE_PERMALINK
+            : `${pathPrefixWithoutLeadingSlash}/${INDEX_PAGE_PERMALINK}`),
+    )
+    ?.content?.content?.at(-1)
+    ?.childrenPagesOrdering.map((id: string) => {
+      const child = children.find(({ id: childId }) => {
+        return id === childId
+      })
+
+      return child?.permalink
+    })
+    .filter((permalink: string | undefined) => !!permalink)
+
+  const pageOrder = pageOrderFromIndex ?? pageOrderFromMeta
 
   children.sort((a, b) => {
     const aPermalink = a.permalink.split("/").pop()


### PR DESCRIPTION
**NOTE: THIS PR IS PENDING A TEST ON STAGING**

## Problem
we want the siderail to be sorted via the index page's sorting order also 

## Solution
1. sort the index page at the publishing level 
2. we take the index page order preferentially then fallback to folder meta if found. 
3. not removing the existing sort order on `ChildrenPages` -> this sort in publishing is kidna magical and i'd prefer to keep the extra sort in components just for guarantees