### PR TITLE
chore: update to use the org wide secret

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -105,10 +105,6 @@ on:
         description: "Intercom app ID"
         required: false
         type: string
-    secrets:
-      DD_API_KEY:
-        description: "Datadog API key for uploading sourcemaps"
-        required: false
 
 permissions:
   id-token: write
@@ -173,8 +169,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     environment: ${{ inputs.environment }}
-    env:
-      DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
     steps:
       - name: Set up QEMU
@@ -207,7 +201,6 @@ jobs:
           sed -i 's/<DD_COMMIT_SHA>/${{ github.sha }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<ECS_TASK_ROLE>/${{ inputs.ecs-task-role }}/g' ${{ inputs.ecs-task-definition-path }}
           sed -i 's/<ECS_TASK_EXEC_ROLE>/${{ inputs.ecs-task-exec-role }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<DD_API_KEY>/${{ secrets.DD_API_KEY }}/g' ${{ inputs.ecs-task-definition-path }}
 
       - name: Replace variables in appspec
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         with:
           languages: js
           service: isomer-studio
-          api_key: ${{ secrets.DD_API_KEY }}
+          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
         run: turbo test-ci:unit --filter=isomer-studio --env-mode=loose
@@ -138,7 +138,7 @@ jobs:
         with:
           languages: js
           service: isomer-studio
-          api_key: ${{ secrets.DD_API_KEY }}
+          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Seed testing db
         run: turbo db:seed
       - name: Run Playwright tests

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -40,6 +40,3 @@ jobs:
       app-s3-assets-domain-name: "isomer-user-content.by.gov.sg"
       app-growthbook-client-key: "sdk-r07MHTLLgfdVDThi"
       app-intercom-app-id: "jv2tjc3g"
-
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -40,6 +40,3 @@ jobs:
       app-s3-assets-domain-name: "isomer-user-content-stg.by.gov.sg"
       app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
       app-intercom-app-id: "jv2tjc3g"
-
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -41,6 +41,3 @@ jobs:
       app-s3-assets-domain-name: "isomer-user-content-uat.by.gov.sg"
       app-growthbook-client-key: "sdk-JCHWTUKA5qK7GAZA"
       app-intercom-app-id: "jv2tjc3g"
-
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}

--- a/.github/workflows/deploy_vapt.yml
+++ b/.github/workflows/deploy_vapt.yml
@@ -38,6 +38,3 @@ jobs:
       app-s3-assets-domain-name: "isomer-user-content-vapt.by.gov.sg"
       app-growthbook-client-key: "sdk-JT4m6jtYc9TXrUp"
       app-intercom-app-id: "jv2tjc3g"
-
-    secrets:
-      DD_API_KEY: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}


### PR DESCRIPTION
## Problem
- still have 2 usages of our own `DD_API_KEY` for GHA to configure test visibility; this has been replaced with our org wide secret


## Solution
- use org wide secret
- reusable workflow for `aws_deploy` passes in `DD_API_KEY_GITHUB_ACTIONS` as the `secrets.DD_API_KEY`

## Notes 
will proceed to delete our own secret after this has been merged