### PR TITLE
chore: generate random permalink for collection links since they will…

### DIFF
--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -76,6 +76,10 @@ export const CreateCollectionPageDetailsScreen = () => {
     if (!permalinkFieldState.isDirty) {
       setValue(
         "permalink",
+        // NOTE: We generate a random `uuid` for `CollectionLink.permalink`
+        // because this field is never used and discarded at publishing.
+        // This is because the `CollectionLink` will point to the actual resource
+        // at compile time rather than the permalink given here.
         type === ResourceType.CollectionPage
           ? generatePageUrl(title)
           : crypto.randomUUID(),


### PR DESCRIPTION
## Problem
- right now, the `title` and `permalink` field for `CollectionLink` shows `optional` when it is not
- we generate the `permalink` from the `titel` for the collection link, but it is never used -> we should instead generate a uuid for it to avoid collision

## Solution
- set `isRequired` for the above 2 fields
- set `permalink` to be a `uuid` if the `type = CollectionLink`
 
## Tests
- [ ] create a collection link
- [ ] set a random title for the collection link
- [ ] the title field should **not** hav ethe `optional` text
- [ ] note down the `id` ofthe generated link
- [ ] go to our db
- [ ] verify that the permalink of this collection link is a random uuid
- [ ] create a collection page
- [ ] verify that the `titel` and `permalink` are both required
- [ ] verify that the `permalink` is generated based oiff the title