### PR TITLE
chore: fix permalinks

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -332,7 +332,7 @@ function generateSitemapTree(
         return id === childId
       })
 
-      return child?.permalink
+      return child?.permalink.split("/").pop()
     })
     .filter((permalink: string | undefined) => !!permalink)
 


### PR DESCRIPTION
## Problem
- we weren't using the `IndexPage.ordering` even when it exists; this is because we do a comparison by permalink and in the first step of our publishing code, we update the `permalink` to be `/<permalink` (see below code chunk - this is line 130 of `publishing/index.ts`)
```ts
          permalink: `/${getConvertedPermalink(resource.fullPermalink)}`,
```

## Solution
- split by `/` and `pop` to extract solely the last portion of the permalink

## Tests
- create a folder with some pages 
- in the index page, set the ordering to what you desire 
- publish the idnex page
- create a folder meta for a given folder; this should be **different** from the ordering in the idnex page
- set the `FolderMeta` to be published via the db
- build teh site
- on the site, verify that:
- index page has the order specified
- on any contnet page in the folder, teh siderail uses the index page's ordering