### PR TITLE
chore: fix image showing errors when empty

### DIFF
--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -50,7 +50,7 @@ export const FileAttachment = ({
           onRejection={setRejections}
           onChange={(file) => {
             if (!file) {
-              setHref()
+              setHref(undefined)
               return
             }
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
@@ -90,11 +90,15 @@ const withContextToControlWithDetailProps = (
     ctx,
     props,
   }: JsonFormsStateContext & ControlWithDetailProps) {
-    // NOTE: provides `handleChange`
+    // NOTE: provides `handleChange` for our method.
+    // Unfortunately, the `ctx` is typed as `any` here
+    // and requires suprresion.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
     const dispatchProps = ctxDispatchToControlProps(ctx.dispatch)
     // NOTE: provides `uischemas, renderers, cells`
     // The previous implementation of using `withJsonFormsDetailProps`
     // only provided this.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const detailProps = ctxToControlWithDetailProps(ctx, props)
     return <Component {...props} {...dispatchProps} {...detailProps} />
   }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
@@ -92,7 +92,7 @@ const withContextToControlWithDetailProps = (
   }: JsonFormsStateContext & ControlWithDetailProps) {
     // NOTE: provides `handleChange` for our method.
     // Unfortunately, the `ctx` is typed as `any` here
-    // and requires suprresion.
+    // and requires suppression.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
     const dispatchProps = ctxDispatchToControlProps(ctx.dispatch)
     // NOTE: provides `uischemas, renderers, cells`

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
@@ -1,4 +1,5 @@
 import type {
+  ControlWithDetailProps,
   RankedTester,
   StatePropsOfControlWithDetail,
 } from "@jsonforms/core"
@@ -9,7 +10,12 @@ import {
   isObjectControl,
   rankWith,
 } from "@jsonforms/core"
-import { JsonFormsDispatch, withJsonFormsDetailProps } from "@jsonforms/react"
+import {
+  JsonFormsDispatch,
+  withJsonFormsControlProps,
+  withJsonFormsDetailProps,
+} from "@jsonforms/react"
+import isEmpty from "lodash/isEmpty"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 
@@ -19,6 +25,7 @@ export const jsonFormsObjectControlTester: RankedTester = rankWith(
 )
 
 export function JsonFormsObjectControl({
+  data,
   path,
   visible,
   renderers,
@@ -28,7 +35,8 @@ export function JsonFormsObjectControl({
   uischema,
   uischemas,
   rootSchema,
-}: StatePropsOfControlWithDetail) {
+  handleChange,
+}: ControlWithDetailProps) {
   const detailUiSchema = useMemo(
     () =>
       findUISchema(
@@ -43,6 +51,10 @@ export function JsonFormsObjectControl({
       ),
     [uischemas, schema, uischema, path, rootSchema],
   )
+
+  if (isEmpty(data)) {
+    handleChange(path, undefined)
+  }
 
   if (!visible) {
     return null
@@ -61,4 +73,4 @@ export function JsonFormsObjectControl({
   )
 }
 
-export default withJsonFormsDetailProps(JsonFormsObjectControl)
+export default withJsonFormsControlProps(JsonFormsObjectControl)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
@@ -1,8 +1,4 @@
-import type {
-  ControlWithDetailProps,
-  RankedTester,
-  StatePropsOfControlWithDetail,
-} from "@jsonforms/core"
+import type { ControlWithDetailProps, RankedTester } from "@jsonforms/core"
 import { useMemo } from "react"
 import {
   findUISchema,
@@ -10,11 +6,7 @@ import {
   isObjectControl,
   rankWith,
 } from "@jsonforms/core"
-import {
-  JsonFormsDispatch,
-  withJsonFormsControlProps,
-  withJsonFormsDetailProps,
-} from "@jsonforms/react"
+import { JsonFormsDispatch, withJsonFormsControlProps } from "@jsonforms/react"
 import isEmpty from "lodash/isEmpty"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"


### PR DESCRIPTION
## Problem
- right now, when a user adds image/alt text and then deletes both of them (ie, both image/alt are empty), we still show an error and prevent them from saving
- this is because the object containing both properties (`image` and `alt`) still exists as an empty object but our schema specifies that the object has to be either `undefined | { image, alt }` 

## Solution
- update props to our object control
- `handleChange` so that when `isEmpty(object)`, we set `object` itself to `undefined` 

 ## Videos

https://github.com/user-attachments/assets/d8214ecf-809a-47ae-823c-2365af1c6018

## Tests
- [ ] create an article
- [ ] click into the article's header
- [ ] upload an image
- [ ] the bottom save button should be grayed out
- [ ] delete teh image the button shuold be allowed
- [ ] add alt text (without an image)
- [ ] the button should still be grayed out
- [ ] when both are there, the button shuold be allowed

(basically is opposite of XOR for imgae/alt)