### PR TITLE
Infopic (text on left) alignment is off when title and description are short

### DIFF
--- a/packages/components/src/templates/next/components/complex/Infopic/common.ts
+++ b/packages/components/src/templates/next/components/complex/Infopic/common.ts
@@ -24,7 +24,7 @@ export const infopicStyles = tv({
       },
       false: {
         container: "lg:[grid-template-areas:'content_img']",
-        content: "lg:justify-self-end lg:pr-24",
+        content: "lg:justify-self-start lg:pr-24",
       },
     },
     colorScheme: {

--- a/packages/components/src/templates/next/components/complex/Infopic/components/BlockInfopic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/components/BlockInfopic.stories.tsx
@@ -111,3 +111,12 @@ export const LongTitleAndDesc: Story = {
       "https://images.unsplash.com/photo-1713098372674-cbf10e8c2bba?q=80&w=3869&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
   },
 }
+
+export const ShortTitleAndDesc: Story = {
+  args: {
+    title: "Short title",
+    description: "Very short",
+    imageSrc:
+      "https://images.unsplash.com/photo-1713098372674-cbf10e8c2bba?q=80&w=3869&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+  },
+}


### PR DESCRIPTION
## Problem

Infopic alignment is off when title and description are short. Only happens to text on left.

Closes [ISOM-1966]

## Solution

Change text justification to right

**BEFORE**:

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/e9a6aa90-5013-4549-8ded-448c6b23247e" />

**AFTER**:

<img width="1232" alt="image" src="https://github.com/user-attachments/assets/8b13aca8-969e-4128-9bce-c809eaadaae3" />
