### PR TITLE
Fix collectionblock preview

### DIFF
--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -911,20 +911,10 @@ describe("folder.router", async () => {
 
       // Assert
       expect(result.childPages).toHaveLength(7)
-      const indexPagesOfFolders = await db
-        .selectFrom("Resource")
-        .where(
-          "parentId",
-          "in",
-          folders.map(({ id }) => id),
-        )
-        .where("type", "=", "IndexPage")
-        .select("id")
-        .execute()
-      const indexPagesId = indexPagesOfFolders.map(({ id }) => id)
+      const folderPagesId = folders.map(({ id }) => id)
       const pagesId = pages.map(({ id }) => id)
       expect(result.childPages.map(({ id }) => id).toSorted()).toStrictEqual(
-        [...pagesId, ...indexPagesId].toSorted(),
+        [...pagesId, ...folderPagesId].toSorted(),
       )
     })
   })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -1033,9 +1033,9 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(indexPage.id)
+      expect(child?.id).toBe(collection.id) // should be from the collection regardless
       expect(child?.permalink).toBe(`/${collection.permalink}`)
-      expect(child?.title).toBe(collection.title) // should be from the folder
+      expect(child?.title).toBe(collection.title) // should be from the collection
       expect(child?.summary).toBe(`Pages in ${collection.title}`) // should not be from the index page
     })
 
@@ -1076,7 +1076,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(indexPage.id)
+      expect(child?.id).toBe(collection.id) // should be from the collection regardless
       expect(child?.permalink).toBe(`/${collection.permalink}`)
       expect(child?.title).toBe(indexPage.title) // should be from the index page
       expect(child?.summary).toBe("Hello im the index page") // should be from the index page
@@ -1284,7 +1284,7 @@ describe("resource.service", () => {
 
       // Assert: Find Child Collection (With Index Page) in the sitemap
       const collection2Node = childFolderChildren?.find(
-        (child) => child.id === collection2IndexPage.id,
+        (child) => child.id === collection2.id,
       )
       expect(collection2Node?.title).toBe("Collection 2 Index Page")
       expect(collection2Node?.summary).toBe("Hello im the index page")

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -946,7 +946,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(indexPage.id)
+      expect(child?.id).toBe(folder.id)
       expect(child?.permalink).toBe(`/${folder.permalink}`)
       expect(child?.title).toBe(folder.title) // should be from the folder
       expect(child?.summary).toBe(`Pages in ${folder.title}`) // should not be from the index page
@@ -989,7 +989,7 @@ describe("resource.service", () => {
 
       // Assert
       const child = result.children?.at(0)
-      expect(child?.id).toBe(indexPage.id)
+      expect(child?.id).toBe(folder.id)
       expect(child?.permalink).toBe(`/${folder.permalink}`)
       expect(child?.title).toBe(indexPage.title) // should be from the index page
       expect(child?.summary).toBe("Hello im the index page") // should be from the index page
@@ -1137,15 +1137,14 @@ describe("resource.service", () => {
         state: ResourceState.Published,
       })
 
-      const { blob: folderAIndexPageBlob, page: folderAIndexPage } =
-        await setupPageResource({
-          title: "Folder A",
-          resourceType: ResourceType.IndexPage,
-          siteId: site.id,
-          parentId: folder.id,
-          state: ResourceState.Published,
-          userId: (await setupUser({})).id,
-        })
+      const { blob: folderAIndexPageBlob } = await setupPageResource({
+        title: "Folder A",
+        resourceType: ResourceType.IndexPage,
+        siteId: site.id,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: (await setupUser({})).id,
+      })
       await db
         .updateTable("Blob")
         .where("id", "=", folderAIndexPageBlob.id)
@@ -1190,7 +1189,7 @@ describe("resource.service", () => {
       // Assert: Find Folder in the sitemap
       const folderNode = result.children
         ?.at(0)
-        ?.children?.find((child) => child.id === folderAIndexPage.id)
+        ?.children?.find((child) => child.id === folder.id)
       expect(folderNode?.title).toBe(folder.title)
       expect(folderNode?.summary).toBe("Hello im the index page")
       expect(folderNode?.image?.src).toBe("https://indexpageblob.com")
@@ -1243,15 +1242,14 @@ describe("resource.service", () => {
         parentId: childFolder.id,
         state: ResourceState.Published,
       })
-      const { blob: collection2IndexPageBlob, page: collection2IndexPage } =
-        await setupPageResource({
-          title: "Collection 2 Index Page",
-          resourceType: ResourceType.IndexPage,
-          siteId: site.id,
-          parentId: collection2.id,
-          state: ResourceState.Published,
-          userId: (await setupUser({})).id,
-        })
+      const { blob: collection2IndexPageBlob } = await setupPageResource({
+        title: "Collection 2 Index Page",
+        resourceType: ResourceType.IndexPage,
+        siteId: site.id,
+        parentId: collection2.id,
+        state: ResourceState.Published,
+        userId: (await setupUser({})).id,
+      })
       await db
         .updateTable("Blob")
         .where("id", "=", collection2IndexPageBlob.id)

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -75,16 +75,7 @@ const getSitemapTreeFromArray = (
     const summaryOfPage = indexPage?.summary
 
     return {
-      id:
-        resource.type === ResourceType.Collection
-          ? // Note: Current publishing script still use collection id
-            // as the id even if there is an index page
-            resource.id
-          : // NOTE: this is done for compat reasons as
-            // our publishing script uses the index page id
-            // if it can find one and if it cannot,
-            // then uses the base `resourceId`
-            (indexPage?.id ?? resource.id),
+      id: resource.id,
       layout:
         resource.type === ResourceType.Collection
           ? ISOMER_USABLE_PAGE_LAYOUTS.Collection // Needed for collectionblock component to fetch the correct collection

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -75,11 +75,16 @@ const getSitemapTreeFromArray = (
     const summaryOfPage = indexPage?.summary
 
     return {
-      // NOTE: this is done for compat reasons as
-      // our publishing script uses the index page id
-      // if it can find one and if it cannot,
-      // then uses the base `resourceId`
-      id: indexPage?.id ?? resource.id,
+      id:
+        resource.type === ResourceType.Collection
+          ? // Note: Current publishing script still use collection id
+            // as the id even if there is an index page
+            resource.id
+          : // NOTE: this is done for compat reasons as
+            // our publishing script uses the index page id
+            // if it can find one and if it cannot,
+            // then uses the base `resourceId`
+            (indexPage?.id ?? resource.id),
       layout:
         resource.type === ResourceType.Collection
           ? ISOMER_USABLE_PAGE_LAYOUTS.Collection // Needed for collectionblock component to fetch the correct collection


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C0924LBA0PR

## Solution

<!-- How did you solve the problem? -->

**Bug Fixes**:

- revert changes on how `id` is generated for collection that has index pages

## Tests

<!-- What tests should be run to confirm functionality? -->

1. Go to studio and create a collection with an index page
2. Go to root page and add a valid collectionblock to the homepage (linking to the collection ID as reference) - page should render
