### PR TITLE
Loosen character limits on image (+ image gallery) and infobar

### DIFF
--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -46,7 +46,7 @@ export const ImageSchema = Type.Object(
     caption: Type.Optional(
       Type.String({
         title: "Caption",
-        maxLength: 100,
+        maxLength: 250,
         format: "textarea",
       }),
     ),

--- a/packages/components/src/interfaces/complex/Infobar.ts
+++ b/packages/components/src/interfaces/complex/Infobar.ts
@@ -31,7 +31,7 @@ const generateInfobarSchema = ({
       description: Type.Optional(
         Type.String({
           title: "Description",
-          maxLength: 100,
+          maxLength: 200,
         }),
       ),
       variant: Type.Optional(

--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -7,7 +7,7 @@ const createImageStyles = tv({
   slots: {
     container: "mt-0 [&:not(:first-child)]:mt-7",
     caption:
-      "overflow-wrap break-word prose-label-sm-medium mt-2 max-w-[100ch] text-base-content-subtle md:mx-auto md:text-center",
+      "overflow-wrap break-word prose-label-sm-medium mt-2 max-w-[70ch] text-base-content-subtle md:mx-auto md:text-center",
     image: "mx-auto h-auto max-w-full rounded",
   },
   variants: {

--- a/packages/components/src/templates/next/components/complex/ImageGallery/ImageGalleryClient.tsx
+++ b/packages/components/src/templates/next/components/complex/ImageGallery/ImageGalleryClient.tsx
@@ -21,7 +21,7 @@ const createImagePreviewStyles = tv({
           "border-base-content outline outline-[0.25rem] outline-offset-[-0.25rem] outline-base-content",
       },
       false: {
-        container: "border-base-divider-subtle hover:opacity-80",
+        container: "border-base-divider-medium hover:opacity-80",
       },
     },
     numberOfImages: {
@@ -207,7 +207,7 @@ export const ImageGalleryClient = ({
                     />
                     {image.caption && (
                       <div className="prose-label-sm-medium absolute bottom-0 left-0 right-0 bg-base-canvas-inverse-overlay/90 p-3 text-white">
-                        {image.caption}
+                        <div className="line-clamp-3">{image.caption}</div>
                       </div>
                     )}
                   </div>


### PR DESCRIPTION
## Problem

We impose character limits on Isomer Next conservatively. To minimise ways to abuse a component, we take the minimum number of characters that make sense. This is usually 50 for very short text (button), 100 for short text (titles), 150-200 for longer text (description) and so on. 

These conservative limits make sure that the component looks balanced when the limits are maxed. However, as we migrate more sites we start seeing more sites with content that they cannot afford to shorten. These two components -- image and infobar -- are recent examples.

Closes [ISOM-1967]

## Solution

- Increase infobar description limit from 100 -> 200
- Increase image caption limit from 100 -> 250
- Increase image gallery's image caption limit from 100 -> 250
- Image's caption has a smaller 
- In Image Gallery, captions will be truncated to 3 lines on mobile to avoid obstructing the image too much. Front-load your captions with important details.

However, Isomer Next's principles on concise and easy-to-scan content still stand. 