### PR TITLE
fix: add back missing check on children pages block

### DIFF
--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -911,20 +911,10 @@ describe("folder.router", async () => {
 
       // Assert
       expect(result.childPages).toHaveLength(7)
-      const indexPagesOfFolders = await db
-        .selectFrom("Resource")
-        .where(
-          "parentId",
-          "in",
-          folders.map(({ id }) => id),
-        )
-        .where("type", "=", "IndexPage")
-        .select("id")
-        .execute()
-      const indexPagesId = indexPagesOfFolders.map(({ id }) => id)
+      const folderPagesId = folders.map(({ id }) => id)
       const pagesId = pages.map(({ id }) => id)
       expect(result.childPages.map(({ id }) => id).toSorted()).toStrictEqual(
-        [...pagesId, ...indexPagesId].toSorted(),
+        [...pagesId, ...folderPagesId].toSorted(),
       )
     })
   })

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -392,7 +392,7 @@ export const folderRouter = router({
         // we will only select published index pages here
         .where("state", "=", ResourceState.Published)
         .where("type", "=", ResourceType.IndexPage)
-        .select(["Resource.id", "title"])
+        .select(["Resource.parentId as id", "title"])
         .unionAll((qb) => {
           return qb
             .selectFrom("directChildren")

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -16,7 +16,6 @@ import {
   AuditLogEvent,
   db,
   jsonb,
-  Resource,
   ResourceState,
   ResourceType,
 } from "../database"
@@ -382,6 +381,11 @@ export const folderRouter = router({
             ])
             .select(["Resource.id", "title", "type"])
         })
+        // NOTE: we need to select the `Folder/Collection`.`id`
+        // rather than the `IndexPage` as our publishing script
+        // uses the actual `id` of the containing `Folder/Collection`.
+        // However, we will use the `IndexPage` as a filter as we should only
+        // show the preview for published `IndexPages` (draft pages won't show on end site)
         .with("publishedCousinIndexPages", (eb) => {
           return (
             eb


### PR DESCRIPTION
## Problem

Index pages were not correctly displaying the children pages block when one wasn't explicitly present in the content. The check to auto-inject the default children pages block was missing.

Closes #1471

## Solution

Added back the missing logic to check if a `childrenpages` block exists in the index page content. If no children pages block is present, the default `DEFAULT_CHILDREN_PAGES_BLOCK` is automatically appended to the page content before rendering.

**Changes:**
- Import `DEFAULT_CHILDREN_PAGES_BLOCK` constant
- Check if content already has a `childrenpages` block using `content.some()`
- If not present, append the default children pages block to the content
- Pass the updated `pageContent` to `getTransformedPageContent()` instead of raw `content`

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Index pages now correctly display the children pages block even when one isn't explicitly defined in the page content

## Before & After Screenshots

**BEFORE**:
Index pages without an explicit children pages block would not show child pages.

**AFTER**:
Index pages automatically include the default children pages block if one isn't present.

## Tests

- [ ] Create a folder with child pages/folders/collections
- [ ] Ensure the index page of the folder does NOT have an explicit children pages block in its content
- [ ] View the index page - it should now display the children pages automatically
- [ ] Verify that index pages WITH an explicit children pages block still work correctly

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A