### PR TITLE
chore: fix index page swapping text appearing on collection index page

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -218,7 +218,9 @@ export default function RootStateDrawer() {
     savedPageState.content[0]?.type === "hero"
 
   const isCustomContentIndexPage =
-    type === ResourceType.IndexPage && pageLayout !== "index"
+    type === ResourceType.IndexPage &&
+    pageLayout !== "index" &&
+    pageLayout !== "collection"
 
   return (
     <Flex direction="column" h="full">


### PR DESCRIPTION
## Problem
See [thread](https://opengovproducts.slack.com/archives/C07CWUNUL68/p1750751430853799) - collection index page shouldn't have this. 

the check isn't stringent enough - we need to also check that the `pageLayout !== collection` so that this doens't display for collection index pages 

## Solution
update check for `isCustomContentIndexPage`

## Tests
- [ ] Create a collection
- [ ] create an index page inside teh collectoin (with the button)
- [ ] click the index page
- [ ] the message to swap to our index page should not be present