### PR TITLE
Improve lighthouse TBT (update GTM to use "src" instead of inline)

### DIFF
--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -10,13 +10,8 @@ const GoogleTagManagerHeaderScript = ({
   return (
     <ScriptComponent
       id={`_next-gtm-init-${gtmId}`}
-      dangerouslySetInnerHTML={{
-        __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-					new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-					j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-					'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','${gtmId}');`,
-      }}
+      strategy="afterInteractive" // next/script's default but just in case Vercel changes it in the future
+      src={`https://www.googletagmanager.com/gtm.js?id=${gtmId}`}
     />
   )
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Why `dangerouslySetInnerHTML` performs worse
- even if it eventually injects GTM asynchronously (j.async = true), the execution of that whole IIFE **runs immediately**, during the main thread’s execution window.
- That adds script evaluation time to your page load, which: 1) Shows up in "Long Tasks" in Chrome performance profiler, and 2) Contributes to TBT and INP in Lighthouse

## Solution

<!-- How did you solve the problem? -->

- using `src` and `afterinteractive` instead of inline

 ### pros (as compared to existing inline method)

improved performance and UX
- delaying the loading of GTM to reduce render-blocking resources
- ensures that critical content is available to users without delay. 

### pros (as compared to existing inline method)
_note, this is our tradeoff_

- Delayed tag firing: Tags that rely on GTM may fire later than expected, potentially missing early user interactions e.g. **missing tracking of users who bounced too early**
   - tested on Preview mode on GTM dashboard and its still firing events 

### Impact

**1. Performance**
- as a standalone, there's minimal improvement
- however, when coupled with https://github.com/opengovsg/isomer/pull/1460, it consistently scores >90 for a live site

**2. Best practices**
- i think its because clarity's loading is also delayed (until after page hydrates), it no longer shows up in "best practices"

![image](https://github.com/user-attachments/assets/82cf9932-dc9e-4583-ace4-5c848995cd72)

Note:
- this is based off one of the better sites
- even on sites with not-so-good-performance score 80+ for performance, as compared to their 70+ currently on WOGAA. 
