### PR TITLE
fix: use sitename for meta title on homepage

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -2,6 +2,13 @@ import type { IsomerPageSchemaType, IsomerSitemap } from "~/types"
 import { ISOMER_PAGE_LAYOUTS } from "~/types"
 import { getSitemapAsArray } from "~/utils"
 
+const getMetaTitle = (props: IsomerPageSchemaType) => {
+  // NOTE: We show the site name as the title for the homepage, as places like
+  // WhatsApp do not use the site_name property of the OpenGraph metadata when
+  // displaying the page preview, which can be confusing for users
+  return props.page.permalink === "/" ? props.site.siteName : props.page.title
+}
+
 const getMetaDescription = (props: IsomerPageSchemaType) => {
   if (props.meta?.description) {
     return props.meta.description
@@ -85,6 +92,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
 
   const metadata = {
     metadataBase: props.site.url ? new URL(props.site.url) : undefined,
+    title: getMetaTitle(props),
     description: getMetaDescription(props),
     robots: {
       index:
@@ -99,7 +107,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
       shortcut: faviconUrl,
     },
     openGraph: {
-      title: props.page.title,
+      title: getMetaTitle(props),
       description: getMetaDescription(props),
       url: canonicalUrl,
       siteName: props.site.siteName,
@@ -118,14 +126,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
     },
   }
 
-  if (props.page.permalink === "/") {
-    return metadata
-  }
-
-  return {
-    ...metadata,
-    title: props.page.title,
-  }
+  return metadata
 }
 
 export const shouldBlockIndexing = (


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The meta title for homepage is shown as "Home", which can be confusing for users when sharing on WhatsApp.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Use the sitename in the meta title when sharing the homepage link on social media platforms.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

![image](https://github.com/user-attachments/assets/8d6c3c74-792b-447d-95f9-7bcbde6292ef)

**AFTER**:

<!-- [insert screenshot here] -->

_(imagine "Home" becomes the site name in the previous screenshot)_

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Build a site on staging using the changes in this PR
- [ ] Share the homepage of the built site on WhatsApp
- [ ] Verify that the title of the link preview is the site name and not "Home"