### PR TITLE
feat(aws): scan images with inspector and fail deploy if threshold exceeded

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -173,11 +173,27 @@ jobs:
         with:
           artifact_type: "container"
           artifact_path: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}"
-          critical_threshold: 1
-          high_threshold: 1
-          medium_threshold: 1
-          low_threshold: 1
-          other_threshold: 1
+          critical_threshold: 5
+          high_threshold: 10
+
+      # Display Inspector results in the GitHub Actions terminal
+      - name: Display CycloneDX SBOM (JSON)
+        run: cat ${{ steps.inspector.outputs.artifact_sbom }}
+
+      - name: Display Inspector vulnerability scan results (JSON)
+        run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
+
+      # Upload Inspector outputs as a .zip that can be downloaded
+      # from the GitHub actions job summary page.
+      - name: Upload Scan Results
+        id: upload-scan-results
+        uses: actions/upload-artifact@v4
+        with:
+          path: |
+            ${{ steps.inspector.outputs.inspector_scan_results }}
+            ${{ steps.inspector.outputs.inspector_scan_results_csv }}
+            ${{ steps.inspector.outputs.inspector_scan_results_markdown }}
+            ${{ steps.inspector.outputs.artifact_sbom }}
 
       - name: Fail job if vulnerability threshold is exceeded
         run: exit ${{ steps.inspector.outputs.vulnerability_threshold_exceeded }}

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -140,17 +140,16 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Build and push image to ECR
+      - name: Build and load image to Docker
         uses: docker/build-push-action@v4
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
-          ENV: ${{ inputs.environment }}
           IMAGE_TAG: ${{ github.ref_name }}_${{ github.sha }}
         with:
           context: .
           file: "./apps/studio/Dockerfile"
-          push: true
+          load: true
           tags: |
             ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
           build-args: |
@@ -163,6 +162,33 @@ jobs:
             NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME=${{ inputs.app-s3-assets-bucket-name }}
             NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY=${{ inputs.app-growthbook-client-key }}
             NEXT_PUBLIC_INTERCOM_APP_ID=${{ inputs.app-intercom-app-id }}
+
+      - name: Scan built image with Inspector
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
+        id: inspector
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+          IMAGE_TAG: ${{ github.ref_name }}_${{ github.sha }}
+        with:
+          artifact_type: "container"
+          artifact_path: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}"
+          critical_threshold: 1
+          high_threshold: 1
+          medium_threshold: 1
+          low_threshold: 1
+          other_threshold: 1
+
+      - name: Fail job if vulnerability threshold is exceeded
+        run: exit ${{ steps.inspector.outputs.vulnerability_threshold_exceeded }}
+
+      - name: Push image to ECR after scan passes
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+          IMAGE_TAG: ${{ github.ref_name }}_${{ github.sha }}
+        run: |
+          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
 
   deploy:
     name: Deploy image to ECS


### PR DESCRIPTION
## Problem
see corresponding ticket 

## Solution
1. add aws inpsector on infra side (corresponding `pulumi up` has been performed on `staging`)
2. scan the buiilt docker image iwth `aws inspector` then check if it's over thereshold (we have 2 critical vulnerability - 1 in nextjs, 1 in golang but no known exploits...)
3. fail the deploy if over threshold + upload assets 

## TODOs
- [ ] `pulumi up` on `production/uat` once environment is up to date
