### PR TITLE
chore: Singpass - set default to true + mock feature flags

### DIFF
--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -2,7 +2,7 @@ export const BANNER_FEATURE_KEY = "isomer-next-banner"
 export const ISOMER_ADMIN_FEATURE_KEY = "isomer_admins"
 export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
-export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = false
+export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 
 // Growthbook has a constraint in the typings that requires the index signature
 // of the object to be defined as a string instead of being specific to the keys

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -103,21 +103,20 @@ describe("auth.email", () => {
     const TEST_OTP_FINGERPRINT = getIpFingerprint(TEST_VALID_EMAIL, LOCALHOST)
 
     describe("when singpass is not enabled", () => {
-      beforeAll(() => {
+      beforeEach(() => {
         // Mock the GrowthBook isOn method to return false for the singpass feature
         const ctx = createMockRequest(session)
+        const originalIsOn = ctx.gb.isOn.bind(ctx.gb)
         vi.spyOn(ctx.gb, "isOn").mockImplementation((featureKey: string) => {
           return featureKey === IS_SINGPASS_ENABLED_FEATURE_KEY
             ? false
-            : ctx.gb.isOn(featureKey) // call original for other features
+            : originalIsOn(featureKey) // call original for other features
         })
         caller = createCaller(ctx)
       })
 
-      afterAll(() => {
+      afterEach(() => {
         vi.restoreAllMocks()
-        const ctx = createMockRequest(session)
-        caller = createCaller(ctx)
       })
 
       it("should successfully set session on first valid OTP", async () => {
@@ -260,6 +259,22 @@ describe("auth.email", () => {
     })
 
     describe("when singpass is enabled", () => {
+      beforeEach(() => {
+        // Mock the GrowthBook isOn method to return true for the singpass feature
+        const ctx = createMockRequest(session)
+        const originalIsOn = ctx.gb.isOn.bind(ctx.gb)
+        vi.spyOn(ctx.gb, "isOn").mockImplementation((featureKey: string) => {
+          return featureKey === IS_SINGPASS_ENABLED_FEATURE_KEY
+            ? true
+            : originalIsOn(featureKey) // call original for other features
+        })
+        caller = createCaller(ctx)
+      })
+
+      afterEach(() => {
+        vi.restoreAllMocks()
+      })
+
       it("should successfully set session on first valid OTP", async () => {
         // Arrange
         await setupUser({ email: TEST_VALID_EMAIL })

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -8,15 +8,19 @@ import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
 import { describe, expect, it } from "vitest"
 
 import { env } from "~/env.mjs"
+import { IS_SINGPASS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import * as mailLib from "~/lib/mail"
 import { AuditLogEvent, db } from "~/server/modules/database"
 import { prisma } from "~/server/prisma"
+import { createCallerFactory } from "~/server/trpc"
 import { createTokenHash } from "../../auth.util"
 import { emailSessionRouter } from "../email.router"
 import { getIpFingerprint, LOCALHOST } from "../utils"
 
+const createCaller = createCallerFactory(emailSessionRouter)
+
 describe("auth.email", () => {
-  let caller: Awaited<ReturnType<typeof emailSessionRouter.createCaller>>
+  let caller: ReturnType<typeof createCaller>
   let session: ReturnType<typeof applySession>
   const TEST_VALID_EMAIL = "test@open.gov.sg"
 
@@ -25,7 +29,7 @@ describe("auth.email", () => {
     await setUpWhitelist({ email: TEST_VALID_EMAIL })
     session = applySession()
     const ctx = createMockRequest(session)
-    caller = emailSessionRouter.createCaller(ctx)
+    caller = createCaller(ctx)
   })
 
   describe("login", () => {
@@ -98,77 +102,297 @@ describe("auth.email", () => {
     const INVALID_OTP = "987643"
     const TEST_OTP_FINGERPRINT = getIpFingerprint(TEST_VALID_EMAIL, LOCALHOST)
 
-    it("should successfully set session on first valid OTP", async () => {
-      // Arrange
-      await setupUser({ email: TEST_VALID_EMAIL })
-      await prisma.verificationToken.create({
-        data: {
-          expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_OTP_FINGERPRINT,
-          token: VALID_TOKEN_HASH,
-        },
+    describe("when singpass is not enabled", () => {
+      beforeAll(() => {
+        // Mock the GrowthBook isOn method to return false for the singpass feature
+        const ctx = createMockRequest(session)
+        vi.spyOn(ctx.gb, "isOn").mockImplementation((featureKey: string) => {
+          return featureKey === IS_SINGPASS_ENABLED_FEATURE_KEY
+            ? false
+            : ctx.gb.isOn(featureKey) // call original for other features
+        })
+        caller = createCaller(ctx)
       })
 
-      // Act
-      const result = caller.verifyOtp({
-        email: TEST_VALID_EMAIL,
-        token: VALID_OTP,
+      afterAll(() => {
+        vi.restoreAllMocks()
+        const ctx = createMockRequest(session)
+        caller = createCaller(ctx)
       })
 
-      // Assert
-      const expectedUser = {
-        id: expect.any(String),
-        email: TEST_VALID_EMAIL,
-      }
-      // Should return logged in user.
-      await expect(result).resolves.toMatchObject(expectedUser)
-      // Session should have been set with logged in user.
-      expect(session.userId).toEqual(expectedUser.id)
-      // Audit log should have been created.
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(1)
-      expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.Login)
-      expect(auditLogs[0]?.delta.before!.attempts).toBe(1)
+      it("should successfully set session on first valid OTP", async () => {
+        // Arrange
+        await setupUser({ email: TEST_VALID_EMAIL })
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+
+        // Act
+        const result = caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const expectedUser = {
+          id: expect.any(String),
+          email: TEST_VALID_EMAIL,
+        }
+        // Should return logged in user.
+        await expect(result).resolves.toMatchObject(expectedUser)
+        // Session should have been set with logged in user.
+        expect(session.userId).toEqual(expectedUser.id)
+        // Audit log should have been created.
+        const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+        expect(auditLogs).toHaveLength(1)
+        expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.Login)
+        expect(auditLogs[0]?.delta.before!.attempts).toBe(1)
+      })
+
+      it("should successfully set session on a subsequent valid OTP", async () => {
+        // Arrange
+        await setupUser({ email: TEST_VALID_EMAIL })
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+
+        // Act
+        await expect(
+          caller.verifyOtp({
+            email: TEST_VALID_EMAIL,
+            token: INVALID_OTP,
+          }),
+        ).rejects.toThrowError()
+
+        const result = caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const expectedUser = {
+          id: expect.any(String),
+          email: TEST_VALID_EMAIL,
+        }
+        // Should return logged in user.
+        await expect(result).resolves.toMatchObject(expectedUser)
+        // Session should have been set with logged in user.
+        expect(session.userId).toEqual(expectedUser.id)
+        // Audit log should have been created.
+        const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+        expect(auditLogs).toHaveLength(1)
+        expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.Login)
+        expect(auditLogs[0]?.delta.before!.attempts).toBe(2)
+      })
+
+      it("should set lastLoginAt when creating a new user", async () => {
+        // Arrange
+        const beforeLogin = new Date()
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+
+        // Act
+        await caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const user = await prisma.user.findFirst({
+          where: { email: TEST_VALID_EMAIL },
+        })
+        expect(user?.lastLoginAt).toBeInstanceOf(Date)
+        expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
+          beforeLogin.getTime(),
+        )
+      })
+
+      it("should update lastLoginAt when user logs in", async () => {
+        // Arrange
+        const beforeLogin = new Date()
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+        // Create user first
+        await prisma.user.create({
+          data: {
+            email: TEST_VALID_EMAIL,
+            name: "Test User",
+            phone: "",
+            lastLoginAt: null,
+          },
+        })
+
+        // Act
+        await caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const user = await prisma.user.findFirst({
+          where: { email: TEST_VALID_EMAIL },
+        })
+        expect(user?.lastLoginAt).toBeInstanceOf(Date)
+        expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
+          beforeLogin.getTime(),
+        )
+      })
     })
 
-    it("should successfully set session on a subsequent valid OTP", async () => {
-      // Arrange
-      await setupUser({ email: TEST_VALID_EMAIL })
-      await prisma.verificationToken.create({
-        data: {
-          expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_OTP_FINGERPRINT,
-          token: VALID_TOKEN_HASH,
-        },
-      })
+    describe("when singpass is enabled", () => {
+      it("should successfully set session on first valid OTP", async () => {
+        // Arrange
+        await setupUser({ email: TEST_VALID_EMAIL })
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
 
-      // Act
-      await expect(
-        caller.verifyOtp({
+        // Act
+        const result = caller.verifyOtp({
           email: TEST_VALID_EMAIL,
-          token: INVALID_OTP,
-        }),
-      ).rejects.toThrowError()
+          token: VALID_OTP,
+        })
 
-      const result = caller.verifyOtp({
-        email: TEST_VALID_EMAIL,
-        token: VALID_OTP,
+        // Assert
+        const expectedUser = {
+          id: expect.any(String),
+          email: TEST_VALID_EMAIL,
+        }
+        // Should return logged in user.
+        await expect(result).resolves.toMatchObject(expectedUser)
+        // Session should have been set with logged in user.
+        expect(session.userId).toEqual(expectedUser.id)
+        // Audit log should have been created.
+        const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+        expect(auditLogs).toHaveLength(1)
+        expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.Login)
+        expect(auditLogs[0]?.delta.before!.attempts).toBe(1)
       })
 
-      // Assert
-      const expectedUser = {
-        id: expect.any(String),
-        email: TEST_VALID_EMAIL,
-      }
-      // Should return logged in user.
-      await expect(result).resolves.toMatchObject(expectedUser)
-      // Session should have been set with logged in user.
-      expect(session.userId).toEqual(expectedUser.id)
-      // Audit log should have been created.
-      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(1)
-      expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.Login)
-      expect(auditLogs[0]?.delta.before!.attempts).toBe(2)
+      it("should successfully set session on a subsequent valid OTP", async () => {
+        // Arrange
+        await setupUser({ email: TEST_VALID_EMAIL })
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+
+        // Act
+        await expect(
+          caller.verifyOtp({
+            email: TEST_VALID_EMAIL,
+            token: INVALID_OTP,
+          }),
+        ).rejects.toThrowError()
+
+        const result = caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const expectedUser = {
+          id: expect.any(String),
+          email: TEST_VALID_EMAIL,
+        }
+        // Should return logged in user.
+        await expect(result).resolves.toMatchObject(expectedUser)
+        // Session should have been set with logged in user.
+        expect(session.userId).toEqual(expectedUser.id)
+        // Audit log should have been created.
+        const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+        expect(auditLogs).toHaveLength(1)
+        expect(auditLogs[0]?.eventType).toBe(AuditLogEvent.Login)
+        expect(auditLogs[0]?.delta.before!.attempts).toBe(2)
+      })
+
+      it("should set lastLoginAt when creating a new user", async () => {
+        // Arrange
+        const beforeLogin = new Date()
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+
+        // Act
+        await caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const user = await prisma.user.findFirst({
+          where: { email: TEST_VALID_EMAIL },
+        })
+        expect(user?.lastLoginAt).toBeInstanceOf(Date)
+        expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
+          beforeLogin.getTime(),
+        )
+      })
+
+      it("should update lastLoginAt when user logs in", async () => {
+        // Arrange
+        const beforeLogin = new Date()
+        await prisma.verificationToken.create({
+          data: {
+            expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
+            identifier: TEST_OTP_FINGERPRINT,
+            token: VALID_TOKEN_HASH,
+          },
+        })
+        // Create user first
+        await prisma.user.create({
+          data: {
+            email: TEST_VALID_EMAIL,
+            name: "Test User",
+            phone: "",
+            lastLoginAt: null,
+          },
+        })
+
+        // Act
+        await caller.verifyOtp({
+          email: TEST_VALID_EMAIL,
+          token: VALID_OTP,
+        })
+
+        // Assert
+        const user = await prisma.user.findFirst({
+          where: { email: TEST_VALID_EMAIL },
+        })
+        expect(user?.lastLoginAt).toBeInstanceOf(Date)
+        expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
+          beforeLogin.getTime(),
+        )
+      })
     })
 
     it("should throw 400 if OTP is not found", async () => {
@@ -275,69 +499,6 @@ describe("auth.email", () => {
       await expect(
         db.selectFrom("AuditLog").selectAll().execute(),
       ).resolves.toHaveLength(0)
-    })
-
-    it("should set lastLoginAt when creating a new user", async () => {
-      // Arrange
-      const beforeLogin = new Date()
-      await prisma.verificationToken.create({
-        data: {
-          expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_OTP_FINGERPRINT,
-          token: VALID_TOKEN_HASH,
-        },
-      })
-
-      // Act
-      await caller.verifyOtp({
-        email: TEST_VALID_EMAIL,
-        token: VALID_OTP,
-      })
-
-      // Assert
-      const user = await prisma.user.findFirst({
-        where: { email: TEST_VALID_EMAIL },
-      })
-      expect(user?.lastLoginAt).toBeInstanceOf(Date)
-      expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
-        beforeLogin.getTime(),
-      )
-    })
-
-    it("should update lastLoginAt when user logs in", async () => {
-      // Arrange
-      const beforeLogin = new Date()
-      await prisma.verificationToken.create({
-        data: {
-          expires: new Date(Date.now() + env.OTP_EXPIRY * 1000),
-          identifier: TEST_OTP_FINGERPRINT,
-          token: VALID_TOKEN_HASH,
-        },
-      })
-      // Create user first
-      await prisma.user.create({
-        data: {
-          email: TEST_VALID_EMAIL,
-          name: "Test User",
-          phone: "",
-          lastLoginAt: null,
-        },
-      })
-
-      // Act
-      await caller.verifyOtp({
-        email: TEST_VALID_EMAIL,
-        token: VALID_OTP,
-      })
-
-      // Assert
-      const user = await prisma.user.findFirst({
-        where: { email: TEST_VALID_EMAIL },
-      })
-      expect(user?.lastLoginAt).toBeInstanceOf(Date)
-      expect(user?.lastLoginAt!.getTime()).toBeGreaterThan(
-        beforeLogin.getTime(),
-      )
     })
   })
 })

--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -106,11 +106,11 @@ describe("auth.email", () => {
       beforeEach(() => {
         // Mock the GrowthBook isOn method to return false for the singpass feature
         const ctx = createMockRequest(session)
-        const originalIsOn = ctx.gb.isOn.bind(ctx.gb)
+        const originalIsOn = ctx.gb.isOn
         vi.spyOn(ctx.gb, "isOn").mockImplementation((featureKey: string) => {
           return featureKey === IS_SINGPASS_ENABLED_FEATURE_KEY
             ? false
-            : originalIsOn(featureKey) // call original for other features
+            : originalIsOn.call(ctx.gb, featureKey) // call original for other features
         })
         caller = createCaller(ctx)
       })
@@ -262,11 +262,11 @@ describe("auth.email", () => {
       beforeEach(() => {
         // Mock the GrowthBook isOn method to return true for the singpass feature
         const ctx = createMockRequest(session)
-        const originalIsOn = ctx.gb.isOn.bind(ctx.gb)
+        const originalIsOn = ctx.gb.isOn
         vi.spyOn(ctx.gb, "isOn").mockImplementation((featureKey: string) => {
           return featureKey === IS_SINGPASS_ENABLED_FEATURE_KEY
             ? true
-            : originalIsOn(featureKey) // call original for other features
+            : originalIsOn.call(ctx.gb, featureKey) // call original for other features
         })
         caller = createCaller(ctx)
       })

--- a/apps/studio/tests/integration/helpers/growthbook/mockFeatureFlags.ts
+++ b/apps/studio/tests/integration/helpers/growthbook/mockFeatureFlags.ts
@@ -1,3 +1,13 @@
-const mockFeatureFlags = new Map<string, unknown>()
+import {
+  IS_SINGPASS_ENABLED_FEATURE_KEY,
+  IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+} from "~/lib/growthbook"
+
+const mockFeatureFlags = new Map<string, unknown>([
+  [
+    IS_SINGPASS_ENABLED_FEATURE_KEY,
+    IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+  ],
+])
 
 export { mockFeatureFlags }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

- singpass currently defaults to false despite it being rolled out
- tests will fail if growthbook not being mocked correctly 

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- set default growthbook value for singpass as true
- add feature flags mocking
- split test for `verifyOtp` for email router to handle both scenarios of singpass enabled/disabled

