### PR TITLE
Fix/revert gtm inline

### DIFF
--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -12,11 +12,9 @@ const GoogleTagManagerHeaderScript = ({
       id={`_next-gtm-init-${gtmId}`}
       strategy="afterInteractive" // next/script's default but just in case Vercel changes it in the future
       dangerouslySetInnerHTML={{
-        // Note: we use j.defer instead of j.async to ensure the script is non-blocking
-        // However, this means potentially losing some data of users who bounced really quickly (1-5% based on online articles),
         __html: `(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 					new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-					j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.defer=true;j.src=
+					j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 					'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','${gtmId}');`,
       }}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Fixed missing GTM data caused by https://github.com/opengovsg/isomer/pull/1474

## Solution

<!-- How did you solve the problem? -->

- reverting changes 
- instead, will set GTM and Clarity to load on "Window Loaded" in GTM setting instead, as per these few resources:
   - https://www.wpspeedfix.com/how-to-reduce-total-blocking-time/#Move-JavaScript-to-Google-Tag-Manager-and-Use-the-Window-Loaded-Trigger
   - https://web.dev/articles/tag-best-practices#choose_an_appropriate_trigger_event 