### PR TITLE
fix(filenames): sanitise filenames so that special characters are stripped 

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -126,6 +126,7 @@
     "date-fns-tz": "^3.1.3",
     "dd-trace": "^5.24.0",
     "exponential-backoff": "^3.1.2",
+    "filenamify": "^6.0.0",
     "flat": "^6.0.1",
     "fuzzysort": "^3.1.0",
     "inter-ui": "^4.1.0",

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -76,6 +76,19 @@ describe("asset.service", () => {
       expect(result).toMatch(/^303\/[0-9a-f-]{36}\/ملف\.pdf$/)
     })
 
+    it("should handle all special characters that might need sanitization even when the characters are not consecutive", () => {
+      // Arrange
+      const siteId = 404
+      const fileName = '<fi:l|e<>:"|?*.txt'
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      // NOTE: Special characters in consecutive runs are compressed to single character
+      expect(result).toMatch(/^404\/[0-9a-f-]{36}\/-fi-l-e-\.txt$/)
+    })
+
     it("should handle special characters that might need sanitization", () => {
       // Arrange
       const siteId = 404

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -79,13 +79,14 @@ describe("asset.service", () => {
     it("should handle special characters that might need sanitization", () => {
       // Arrange
       const siteId = 404
-      const fileName = "file<>:\"|?*.txt"
+      const fileName = 'file<>:"|?*.txt'
 
       // Act
       const result = getFileKey({ siteId, fileName })
 
       // Assert
-      expect(result).toMatch(/^404\/[0-9a-f-]{36}\/file---------\.txt$/)
+      // NOTE: Special characters in consecutive runs are compressed to single character
+      expect(result).toMatch(/^404\/[0-9a-f-]{36}\/file-\.txt$/)
     })
 
     it("should handle very long unicode filename", () => {
@@ -114,30 +115,6 @@ describe("asset.service", () => {
       expect(result1).not.toEqual(result2)
       expect(result1).toMatch(/同一个文件\.pdf$/)
       expect(result2).toMatch(/同一个文件\.pdf$/)
-    })
-
-    it("should handle filename with only unicode characters", () => {
-      // Arrange
-      const siteId = 707
-      const fileName = "한글파일명.hwp"
-
-      // Act
-      const result = getFileKey({ siteId, fileName })
-
-      // Assert
-      expect(result).toMatch(/^707\/[0-9a-f-]{36}\/한글파일명\.hwp$/)
-    })
-
-    it("should preserve file extension with unicode base name", () => {
-      // Arrange
-      const siteId = 808
-      const fileName = "файл.расширение"
-
-      // Act
-      const result = getFileKey({ siteId, fileName })
-
-      // Assert
-      expect(result).toMatch(/^808\/[0-9a-f-]{36}\/файл\.расширение$/)
     })
 
     it("should handle mixed scripts in filename", () => {

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest"
+
+import { getFileKey } from "../asset.service"
+
+describe("asset.service", () => {
+  describe("getFileKey", () => {
+    it("should generate a file key with basic ASCII filename", () => {
+      // Arrange
+      const siteId = 123
+      const fileName = "test-file.jpg"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^123\/[0-9a-f-]{36}\/test-file\.jpg$/)
+    })
+
+    it("should handle unicode characters in filename", () => {
+      // Arrange
+      const siteId = 456
+      const fileName = "测试文件.pdf"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^456\/[0-9a-f-]{36}\/测试文件\.pdf$/)
+    })
+
+    it("should handle emoji in filename", () => {
+      // Arrange
+      const siteId = 789
+      const fileName = "🎉celebration🎊.png"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^789\/[0-9a-f-]{36}\/🎉celebration🎊\.png$/)
+    })
+
+    it("should handle mixed unicode and ASCII characters", () => {
+      // Arrange
+      const siteId = 101
+      const fileName = "report-2024年度.docx"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^101\/[0-9a-f-]{36}\/report-2024年度\.docx$/)
+    })
+
+    it("should handle cyrillic characters", () => {
+      // Arrange
+      const siteId = 202
+      const fileName = "документ.txt"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^202\/[0-9a-f-]{36}\/документ\.txt$/)
+    })
+
+    it("should handle arabic characters", () => {
+      // Arrange
+      const siteId = 303
+      const fileName = "ملف.pdf"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^303\/[0-9a-f-]{36}\/ملف\.pdf$/)
+    })
+
+    it("should handle special characters that might need sanitization", () => {
+      // Arrange
+      const siteId = 404
+      const fileName = "file<>:\"|?*.txt"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^404\/[0-9a-f-]{36}\/file---------\.txt$/)
+    })
+
+    it("should handle very long unicode filename", () => {
+      // Arrange
+      const siteId = 505
+      const longUnicodeName = "很长的文件名".repeat(20) + ".jpg"
+
+      // Act
+      const result = getFileKey({ siteId, fileName: longUnicodeName })
+
+      // Assert
+      expect(result).toMatch(/^505\/[0-9a-f-]{36}\/很长的文件名/)
+      expect(result).toContain(".jpg")
+    })
+
+    it("should generate unique folder names for same filename", () => {
+      // Arrange
+      const siteId = 606
+      const fileName = "同一个文件.pdf"
+
+      // Act
+      const result1 = getFileKey({ siteId, fileName })
+      const result2 = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result1).not.toEqual(result2)
+      expect(result1).toMatch(/同一个文件\.pdf$/)
+      expect(result2).toMatch(/同一个文件\.pdf$/)
+    })
+
+    it("should handle filename with only unicode characters", () => {
+      // Arrange
+      const siteId = 707
+      const fileName = "한글파일명.hwp"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^707\/[0-9a-f-]{36}\/한글파일명\.hwp$/)
+    })
+
+    it("should preserve file extension with unicode base name", () => {
+      // Arrange
+      const siteId = 808
+      const fileName = "файл.расширение"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^808\/[0-9a-f-]{36}\/файл\.расширение$/)
+    })
+
+    it("should handle mixed scripts in filename", () => {
+      // Arrange
+      const siteId = 909
+      const fileName = "English中文العربية.txt"
+
+      // Act
+      const result = getFileKey({ siteId, fileName })
+
+      // Assert
+      expect(result).toMatch(/^909\/[0-9a-f-]{36}\/English中文العربية\.txt$/)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto"
 import type { z } from "zod"
+import filenamify from "filenamify"
 
 import type { getPresignedPutUrlSchema } from "~/schemas/asset"
 import { env } from "~/env.mjs"
@@ -13,8 +14,9 @@ export const getFileKey = ({
 }: z.infer<typeof getPresignedPutUrlSchema>) => {
   // NOTE: We're using a random folder name to prevent collisions
   const folderName = randomUUID()
+  const sanitizedFileName = filenamify(fileName, { replacement: "-" })
 
-  return `${siteId}/${folderName}/${fileName}`
+  return `${siteId}/${folderName}/${sanitizedFileName}`
 }
 
 export const getPresignedPutUrl = async ({ key }: { key: string }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "date-fns-tz": "^3.1.3",
         "dd-trace": "^5.24.0",
         "exponential-backoff": "^3.1.2",
+        "filenamify": "^6.0.0",
         "flat": "^6.0.1",
         "fuzzysort": "^3.1.0",
         "inter-ui": "^4.1.0",
@@ -20264,6 +20265,33 @@
         "node": ">= 10"
       }
     },
+    "node_modules/filename-reserved-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
+      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
+      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "filename-reserved-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -34143,7 +34171,7 @@
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.36.1",
-        "eslint-plugin-react-hooks": "*",
+        "eslint-plugin-react-hooks": "beta",
         "prettier": "^3.3.3",
         "typescript": "5.6.2",
         "typescript-eslint": "^8.33.1"


### PR DESCRIPTION
## Problem
see attached issue (sensitive as security and this is open repo)

## Solution
1. use `filenamify` to strip special characters
2. write tests (thx claude) to ensure that unicode/other languages are preserved

## Tests
- [ ] upload a jpeg or pdf file onto studio **without any speical characters**
- [ ] ensure that the filename is fully preserved
- [ ] upload a jpeg or pdf file onto studio with chinese/tamil characters (`English中文வணக்கம்` if you need) but **without special characters**
- [ ] ensure that the filename is preserved 
- [ ] upload a jpeg or pdf file with special characters (`[<>:"/\|?*]` from filenamify docs) and ensure that all characters are replaced to `-`. take note that runs of special characters will be replaced by a **single replacement `-`**