### PR TITLE
chore: add canonical URL for all pages for SEO

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -124,6 +124,9 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
     twitter: {
       card: "summary_large_image" as const,
     },
+    alternates: {
+      canonical: canonicalUrl,
+    },
   }
 
   return metadata


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some SEO agency has been complaining that we do not provide the `rel="canonical"` tag, which is bad for SEO.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Specify the canonical URL in the `<meta>` tag.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Build a site using the changes in this branch
- [ ] Verify in the HTML of the built site that the `rel="canonical"` `<meta>` tag exists for every page (can take a sample of a couple of pages).