### PR TITLE
isom-1867 prune inactive users (service + email)

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -124,6 +124,7 @@
     "ajv-errors": "^3.0.0",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.1.3",
+    "dayjs": "^1.11.13",
     "dd-trace": "^5.24.0",
     "exponential-backoff": "^3.1.2",
     "filenamify": "^6.0.0",

--- a/apps/studio/src/constants/misc.ts
+++ b/apps/studio/src/constants/misc.ts
@@ -1,2 +1,3 @@
 export const ISOMER_SUPPORT_EMAIL = "support@isomer.gov.sg"
 export const ISOMER_SUPPORT_LINK = `mailto:${ISOMER_SUPPORT_EMAIL}`
+export const HOURS_IN_MS = 60 * 60 * 1000

--- a/apps/studio/src/features/mail/service.ts
+++ b/apps/studio/src/features/mail/service.ts
@@ -136,6 +136,7 @@ export async function sendAccountDeactivationEmail(
       error: "Invalid email format",
       email: data.recipientEmail,
     })
+    throw new Error("Invalid email format")
   }
 
   const template = templates.accountDeactivation(data)

--- a/apps/studio/src/features/mail/service.ts
+++ b/apps/studio/src/features/mail/service.ts
@@ -1,4 +1,5 @@
 import type {
+  AccountDeactivationEmailTemplateData,
   InvitationEmailTemplateData,
   LoginAlertEmailTemplateData,
   PublishAlertContentPublisherEmailTemplateData,
@@ -120,6 +121,34 @@ export async function sendPublishAlertSiteAdminEmail(
   } catch (error) {
     logger.error({
       error: "Failed to send publish alert site admin email",
+      email: data.recipientEmail,
+      originalError: error,
+    })
+    throw error
+  }
+}
+
+export async function sendAccountDeactivationEmail(
+  data: AccountDeactivationEmailTemplateData,
+): Promise<void> {
+  if (!isValidEmail(data.recipientEmail)) {
+    logger.error({
+      error: "Invalid email format",
+      email: data.recipientEmail,
+    })
+  }
+
+  const template = templates.accountDeactivation(data)
+
+  try {
+    await sendMail({
+      recipient: data.recipientEmail,
+      subject: template.subject,
+      body: template.body,
+    })
+  } catch (error) {
+    logger.error({
+      error: "Failed to send account deactivation email",
       email: data.recipientEmail,
       originalError: error,
     })

--- a/apps/studio/src/features/mail/templates/__tests__/templates.test.ts
+++ b/apps/studio/src/features/mail/templates/__tests__/templates.test.ts
@@ -1,7 +1,8 @@
 import { RoleType } from "~prisma/generated/generatedEnums"
 
+import { ISOMER_SUPPORT_EMAIL, ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { env } from "~/env.mjs"
-import { invitationTemplate } from "../templates"
+import { accountDeactivationTemplate, invitationTemplate } from "../templates"
 
 describe("invitationTemplate", () => {
   const mockData = {
@@ -54,5 +55,181 @@ describe("invitationTemplate", () => {
         role: "InvalidRole" as RoleType,
       }),
     ).toThrow("Unknown role. Please check the role type.")
+  })
+})
+
+describe("accountDeactivationTemplate", () => {
+  const mockData = {
+    recipientEmail: "test@example.com",
+    sitesAndAdmins: [],
+  }
+
+  it("should generate correct subject line", () => {
+    // Arrange
+    const template = accountDeactivationTemplate(mockData)
+
+    // Assert
+    expect(template.subject).toBe(
+      "[Isomer Studio] Your account has been deactivated due to inactivity",
+    )
+  })
+
+  it("should generate correct body content with recipient email", () => {
+    // Arrange
+    const template = accountDeactivationTemplate(mockData)
+
+    // Assert
+    expect(template.body).toContain("Hi test@example.com")
+  })
+
+  it("should include inactivity message with correct days", () => {
+    // Arrange
+    const template = accountDeactivationTemplate(mockData)
+
+    // Assert
+    expect(template.body).toContain(
+      "Your Isomer Studio account has been removed as you have not logged in for over 90 days.",
+    )
+  })
+
+  it("should include reason for deactivation", () => {
+    // Arrange
+    const template = accountDeactivationTemplate(mockData)
+
+    // Assert
+    expect(template.body).toContain(
+      "This is a standard security measure to protect your site data.",
+    )
+  })
+
+  it("should include content preservation and site accessibility reassurance message", () => {
+    // Arrange
+    const template = accountDeactivationTemplate(mockData)
+
+    // Assert
+    expect(template.body).toContain(
+      "Your content and previous contributions have been preserved",
+    )
+    expect(template.body).toContain(
+      "Your site(s) will continue to be accessible to visitors, and all your work remains intact.",
+    )
+  })
+
+  it("should include instructions for regaining access", () => {
+    // Arrange
+    const template = accountDeactivationTemplate(mockData)
+
+    // Assert
+    expect(template.body).toContain(
+      "To regain access to your site(s), please follow the instructions below",
+    )
+  })
+
+  it("should include site name and admin emails in instructions when admins exist", () => {
+    // Arrange
+    const template = accountDeactivationTemplate({
+      recipientEmail: "test@example.com",
+      sitesAndAdmins: [
+        {
+          siteName: "Test Site 1",
+          adminEmails: ["admin1@example.com", "admin2@example.com"],
+        },
+      ],
+    })
+
+    // Assert
+    const expectedSiteInstructions = `<p><b>Test Site 1</b></p>
+          <p>To regain access, please contact one of your site's administrators:</p>
+          <ul><li>admin1@example.com</li><li>admin2@example.com</li></ul>
+        `
+    expect(template.body).toContain(expectedSiteInstructions)
+  })
+
+  it("should show support email message when no admins exist", () => {
+    // Arrange
+    const template = accountDeactivationTemplate({
+      recipientEmail: "test@example.com",
+      sitesAndAdmins: [
+        {
+          siteName: "Test Site 1",
+          adminEmails: [],
+        },
+      ],
+    })
+
+    // Assert
+    const expectedSiteInstructions = `<p><b>Test Site 1</b></p>
+        <p>There are no administrators for this site. To be added back, please send an email to <a href="${ISOMER_SUPPORT_LINK}">${ISOMER_SUPPORT_EMAIL}</a> with your line manager in CC for approval.</p>
+      `
+    expect(template.body).toContain(expectedSiteInstructions)
+  })
+
+  it("should handle multiple sites with admins", () => {
+    // Arrange
+    const template = accountDeactivationTemplate({
+      recipientEmail: "test@example.com",
+      sitesAndAdmins: [
+        {
+          siteName: "Site A",
+          adminEmails: ["admin1@example.com"],
+        },
+        {
+          siteName: "Site B",
+          adminEmails: ["admin2@example.com", "admin3@example.com"],
+        },
+      ],
+    })
+
+    // Assert
+    const expectedSiteInstructionForSiteA = `<p><b>Site A</b></p>
+          <p>To regain access, please contact one of your site's administrators:</p>
+          <ul><li>admin1@example.com</li></ul>
+        `
+    expect(template.body).toContain(expectedSiteInstructionForSiteA)
+
+    const expectedSiteInstructionForSiteB = `<p><b>Site B</b></p>
+          <p>To regain access, please contact one of your site's administrators:</p>
+          <ul><li>admin2@example.com</li><li>admin3@example.com</li></ul>
+        `
+    expect(template.body).toContain(expectedSiteInstructionForSiteB)
+  })
+
+  it("should handle multiple sites with mixed admin scenarios", () => {
+    // Arrange
+    const template = accountDeactivationTemplate({
+      recipientEmail: "test@example.com",
+      sitesAndAdmins: [
+        {
+          siteName: "Site with one admin",
+          adminEmails: ["admin@example.com"],
+        },
+        {
+          siteName: "Site with two admins",
+          adminEmails: ["admin1@example.com", "admin2@example.com"],
+        },
+        {
+          siteName: "Site without Admins",
+          adminEmails: [],
+        },
+      ],
+    })
+
+    // Assert
+    const expectedSiteInstructionForSiteWithOneAdmin = `<p><b>Site with one admin</b></p>
+          <p>To regain access, please contact one of your site's administrators:</p>
+          <ul><li>admin@example.com</li></ul>
+        `
+    expect(template.body).toContain(expectedSiteInstructionForSiteWithOneAdmin)
+
+    const expectedSiteInstructionForSiteWithTwoAdmins = `<p><b>Site with two admins</b></p>
+          <p>To regain access, please contact one of your site's administrators:</p>
+          <ul><li>admin1@example.com</li><li>admin2@example.com</li></ul>
+        `
+    expect(template.body).toContain(expectedSiteInstructionForSiteWithTwoAdmins)
+
+    const expectedSiteInstructionForSiteWithoutAdmins = `<p><b>Site without Admins</b></p>
+        <p>There are no administrators for this site. To be added back, please send an email to <a href="${ISOMER_SUPPORT_LINK}">${ISOMER_SUPPORT_EMAIL}</a> with your line manager in CC for approval.</p>
+      `
+    expect(template.body).toContain(expectedSiteInstructionForSiteWithoutAdmins)
   })
 })

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -1,6 +1,7 @@
 import { RoleType } from "~prisma/generated/generatedEnums"
 
 import type {
+  AccountDeactivationEmailTemplateData,
   BaseEmailTemplateData,
   EmailTemplate,
   InvitationEmailTemplateData,
@@ -10,6 +11,7 @@ import type {
 } from "./types"
 import { ISOMER_SUPPORT_EMAIL, ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { env } from "~/env.mjs"
+import { DAYS_FROM_LAST_LOGIN } from "~/server/modules/user/inactiveUsers.service"
 import { getStudioResourceUrl } from "~/utils/resources"
 
 export const invitationTemplate = (
@@ -103,6 +105,43 @@ export const publishAlertSiteAdminTemplate = (
   }
 }
 
+export const accountDeactivationTemplate = (
+  data: AccountDeactivationEmailTemplateData,
+): EmailTemplate => {
+  const { recipientEmail, sitesAndAdmins } = data
+
+  const siteSpecificInstructions = sitesAndAdmins
+    .map(({ siteName, adminEmails }) => {
+      if (adminEmails.length > 0) {
+        return `
+          <p><b>${siteName}</b></p>
+          <p>To regain access, please contact one of your site's administrators:</p>
+          <ul>${adminEmails.map((email) => `<li>${email}</li>`).join("")}</ul>
+        `
+      }
+      return `
+        <p><b>${siteName}</b></p>
+        <p>There are no administrators for this site. To be added back, please send an email to <a href="${ISOMER_SUPPORT_LINK}">${ISOMER_SUPPORT_EMAIL}</a> with your line manager in CC for approval.</p>
+      `
+    })
+    .join("")
+
+  const emailBody = [
+    `<p>Hi ${recipientEmail},</p>`,
+    `<p>Your Isomer Studio account has been removed as you have not logged in for over ${DAYS_FROM_LAST_LOGIN} days. This is a standard security measure to protect your site data.</p>`,
+    `<p>Your content and previous contributions have been preserved. Your site(s) will continue to be accessible to visitors, and all your work remains intact.</p>`,
+    `<p>To regain access to your site(s), please follow the instructions below:</p>`,
+    siteSpecificInstructions,
+    `<p>Best,</p>`,
+    `<p>Isomer team</p>`,
+  ].join("")
+
+  return {
+    subject: `[Isomer Studio] Your account has been deactivated due to inactivity`,
+    body: emailBody,
+  }
+}
+
 type EmailTemplateFunction<
   T extends BaseEmailTemplateData = BaseEmailTemplateData,
 > = (data: T) => EmailTemplate
@@ -116,4 +155,6 @@ export const templates = {
     publishAlertContentPublisherTemplate satisfies EmailTemplateFunction<PublishAlertContentPublisherEmailTemplateData>,
   publishAlertSiteAdmin:
     publishAlertSiteAdminTemplate satisfies EmailTemplateFunction<PublishAlertSiteAdminEmailTemplateData>,
+  accountDeactivation:
+    accountDeactivationTemplate satisfies EmailTemplateFunction<AccountDeactivationEmailTemplateData>,
 } as const

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -11,7 +11,7 @@ import type {
 } from "./types"
 import { ISOMER_SUPPORT_EMAIL, ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { env } from "~/env.mjs"
-import { DAYS_FROM_LAST_LOGIN } from "~/server/modules/user/inactiveUsers.service"
+import { MAX_DAYS_FROM_LAST_LOGIN } from "~/server/modules/user/constants"
 import { getStudioResourceUrl } from "~/utils/resources"
 
 export const invitationTemplate = (
@@ -128,7 +128,7 @@ export const accountDeactivationTemplate = (
 
   const emailBody = [
     `<p>Hi ${recipientEmail},</p>`,
-    `<p>Your Isomer Studio account has been removed as you have not logged in for over ${DAYS_FROM_LAST_LOGIN} days. This is a standard security measure to protect your site data.</p>`,
+    `<p>Your Isomer Studio account has been removed as you have not logged in for over ${MAX_DAYS_FROM_LAST_LOGIN} days. This is a standard security measure to protect your site data.</p>`,
     `<p>Your content and previous contributions have been preserved. Your site(s) will continue to be accessible to visitors, and all your work remains intact.</p>`,
     `<p>To regain access to your site(s), please follow the instructions below:</p>`,
     siteSpecificInstructions,

--- a/apps/studio/src/features/mail/templates/types.ts
+++ b/apps/studio/src/features/mail/templates/types.ts
@@ -27,6 +27,14 @@ export interface PublishAlertSiteAdminEmailTemplateData
   resource: Resource
 }
 
+export interface AccountDeactivationEmailTemplateData
+  extends BaseEmailTemplateData {
+  sitesAndAdmins: {
+    siteName: string
+    adminEmails: string[]
+  }[]
+}
+
 export interface EmailTemplate {
   subject: string
   body: string

--- a/apps/studio/src/server/modules/database/constants.ts
+++ b/apps/studio/src/server/modules/database/constants.ts
@@ -2,4 +2,5 @@
 // https://github.com/postgres/postgres/blob/master/src/backend/utils/errcodes.txt
 export const PG_ERROR_CODES = {
   uniqueViolation: "23505",
+  serializationFailure: "40001",
 } as const

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, it } from "vitest"
 
 import type { Site, User } from "~/server/modules/database"
 import { db, RoleType } from "~/server/modules/database"
-import { DAYS_IN_MS, removeInactiveUsers } from "../inactiveUsers.service"
+import { DAYS_IN_MS, deactiveInactiveUsers } from "../inactiveUsers.service"
 
 interface SetupUserWrapperProps {
   siteId?: number
@@ -48,7 +48,7 @@ const setupUserWrapper = async ({
 }
 
 describe("inactiveUsers.service", () => {
-  describe("removeInactiveUsers", () => {
+  describe("deactiveInactiveUsers", () => {
     let site: Site
 
     beforeAll(async () => {
@@ -62,7 +62,7 @@ describe("inactiveUsers.service", () => {
 
     it("should return an empty array when there are no users", async () => {
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -87,7 +87,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -102,7 +102,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(1)
@@ -118,7 +118,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -133,7 +133,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(1)
@@ -149,7 +149,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -184,7 +184,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(2)
@@ -212,7 +212,7 @@ describe("inactiveUsers.service", () => {
       }
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -226,7 +226,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -248,7 +248,7 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(1)
@@ -269,7 +269,7 @@ describe("inactiveUsers.service", () => {
       )
 
       // Act
-      const inactiveUsers = await removeInactiveUsers()
+      const inactiveUsers = await deactiveInactiveUsers()
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -15,8 +15,8 @@ import { db } from "~/server/modules/database"
 import { RoleType } from "~/server/modules/database/types"
 import { MAX_DAYS_FROM_LAST_LOGIN } from "../constants"
 import {
-  DAYS_IN_MS,
   deactivateUser,
+  getDateOnlyInSG,
   getInactiveUsers,
 } from "../inactiveUsers.service"
 
@@ -38,9 +38,7 @@ const setupUserWrapper = async ({
 }: SetupUserWrapperProps): Promise<User> => {
   const user = await setupUser({
     email: email ?? crypto.randomUUID() + "@user.com",
-    lastLoginAt: lastLoginDaysAgo
-      ? new Date(Date.now() - lastLoginDaysAgo * DAYS_IN_MS)
-      : null,
+    lastLoginAt: lastLoginDaysAgo ? getDateOnlyInSG(lastLoginDaysAgo) : null,
     isDeleted,
   })
 
@@ -66,7 +64,7 @@ const setupUserWrapper = async ({
   return await db
     .updateTable("User")
     .where("id", "=", user.id)
-    .set({ createdAt: new Date(Date.now() - createdDaysAgo * DAYS_IN_MS) })
+    .set({ createdAt: getDateOnlyInSG(createdDaysAgo) })
     .returningAll()
     .executeTakeFirstOrThrow()
 }

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -1,0 +1,188 @@
+import { resetTables } from "tests/integration/helpers/db"
+import { setupUser } from "tests/integration/helpers/seed"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import type { User } from "~/server/modules/database"
+import { db } from "~/server/modules/database"
+import { DAYS_IN_MS, removeInactiveUsers } from "../inactiveUsers.service"
+
+interface SetupUserWrapperProps {
+  createdDaysAgo: number | null
+  lastLoginDaysAgo: number | null
+  isDeleted?: boolean
+}
+const setupUserWrapper = async ({
+  createdDaysAgo = null,
+  lastLoginDaysAgo = null,
+  isDeleted = false,
+}: SetupUserWrapperProps): Promise<User> => {
+  const user = await setupUser({
+    email: crypto.randomUUID() + "@user.com",
+    lastLoginAt: lastLoginDaysAgo
+      ? new Date(Date.now() - lastLoginDaysAgo * DAYS_IN_MS)
+      : null,
+    isDeleted,
+  })
+
+  if (!createdDaysAgo) return user
+
+  return await db
+    .updateTable("User")
+    .where("id", "=", user.id)
+    .set({ createdAt: new Date(Date.now() - createdDaysAgo * DAYS_IN_MS) })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+describe("inactiveUsers.service", () => {
+  describe("removeInactiveUsers", () => {
+    beforeEach(async () => {
+      await resetTables("User", "ResourcePermission")
+    })
+
+    it("should return an empty array when there are no users", async () => {
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
+
+    it("should return an empty array if all users are active", async () => {
+      // Arrange
+      const _userCreatedRecentlyNeverLoggedIn = await setupUserWrapper({
+        createdDaysAgo: 89,
+        lastLoginDaysAgo: null,
+      })
+      const _userCreatedRecentlyLoggedInRecently = await setupUserWrapper({
+        createdDaysAgo: 89,
+        lastLoginDaysAgo: 1,
+      })
+      const _userCreatedLongAgoLoggedInRecently = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: 89,
+      })
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
+
+    it("should select users created over 90 days ago who never logged in", async () => {
+      // Arrange
+      const userCreatedLongAgoNeverLoggedIn = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(1)
+      expect(inactiveUsers[0]?.id).toBe(userCreatedLongAgoNeverLoggedIn.id)
+    })
+
+    it("should NOT select users created under 90 days ago who never logged in", async () => {
+      // Arrange
+      const _userCreatedRecentlyNeverLoggedIn = await setupUserWrapper({
+        createdDaysAgo: 89,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
+
+    it("should select users whose last login was over 90 days ago", async () => {
+      // Arrange
+      const userCreatedLongAgoLoggedInLongAgo = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: 91,
+      })
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(1)
+      expect(inactiveUsers[0]?.id).toBe(userCreatedLongAgoLoggedInLongAgo.id)
+    })
+
+    it("should NOT select users whose last login was under 90 days ago", async () => {
+      // Arrange
+      const _userCreatedLongAgoLoggedInRecently = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: 89,
+      })
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
+
+    it("should only select inactive users from a mixed pool", async () => {
+      // Arrange
+      const _userCreatedRecentlyNeverLoggedIn = await setupUserWrapper({
+        createdDaysAgo: 89,
+        lastLoginDaysAgo: null,
+      })
+      const _userCreatedRecentlyLoggedInRecently = await setupUserWrapper({
+        createdDaysAgo: 89,
+        lastLoginDaysAgo: 1,
+      })
+      const _userCreatedLongAgoLoggedInRecently = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: 89,
+      })
+      const userCreatedLongAgoNeverLoggedIn = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+      const userCreatedLongAgoLoggedInLongAgo = await setupUserWrapper({
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: 91,
+      })
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(2)
+
+      const inactiveUserIds = inactiveUsers.map((u) => u.id)
+      expect(inactiveUserIds).toContain(userCreatedLongAgoNeverLoggedIn.id)
+      expect(inactiveUserIds).toContain(userCreatedLongAgoLoggedInLongAgo.id)
+    })
+
+    it("should NOT select soft-deleted users regardless of activity and creation date", async () => {
+      // Arrange
+      const options = [null, 89, 91]
+      const optionsMap = options.map((option) => ({
+        createdDaysAgo: option,
+        lastLoginDaysAgo: option,
+      }))
+
+      for (const { createdDaysAgo, lastLoginDaysAgo } of optionsMap) {
+        await setupUserWrapper({
+          createdDaysAgo,
+          lastLoginDaysAgo,
+          isDeleted: true,
+        })
+      }
+
+      // Act
+      const inactiveUsers = await removeInactiveUsers()
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -8,7 +8,7 @@ import {
 import { beforeEach, describe, expect, it } from "vitest"
 
 import type { Site, User } from "~/server/modules/database"
-import { db, RoleType } from "~/server/modules/database"
+import { db } from "~/server/modules/database"
 import { DAYS_IN_MS, deactiveInactiveUsers } from "../inactiveUsers.service"
 
 interface SetupUserWrapperProps {

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -892,5 +892,41 @@ describe("inactiveUsers.service", () => {
       expect(inactiveUsers).toHaveLength(1)
       expect(inactiveUsers[0]?.id).toBe(userCreatedVeryLongAgo.id)
     })
+
+    it("should return empty array when toDaysAgo is greater than fromDaysAgo", async () => {
+      // Arrange
+      await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 100,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      const inactiveUsers = await getInactiveUsers({
+        fromDaysAgo: 80,
+        toDaysAgo: 120,
+      })
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
+
+    // default days for inactive users is 90 days by IM8 standard
+    it("should return empty array when fromDaysAgo is less than 90", async () => {
+      // Arrange
+      await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 80,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      const inactiveUsers = await getInactiveUsers({
+        fromDaysAgo: 70,
+      })
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(0)
+    })
   })
 })

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -530,7 +530,7 @@ describe("inactiveUsers.service", () => {
     it("should return an empty array when there are no users", async () => {
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -557,7 +557,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -574,7 +574,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -592,7 +592,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -609,7 +609,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -627,7 +627,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -664,7 +664,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -694,7 +694,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -710,7 +710,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -734,7 +734,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -759,7 +759,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -782,11 +782,115 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
+    })
+
+    it("should filter users by fromDaysAgo when provided", async () => {
+      // Arrange
+      const userCreatedVeryLongAgo = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 120,
+        lastLoginDaysAgo: null,
+      })
+      const userCreatedLongAgo = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 100,
+        lastLoginDaysAgo: null,
+      })
+      const userCreatedRecently = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 80,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act + Assert (1)
+      const usersCreatedVeryLongAgo = await getInactiveUsers({
+        fromDaysAgo: 130,
+        toDaysAgo: 110,
+      })
+      expect(usersCreatedVeryLongAgo).toHaveLength(1)
+      expect(usersCreatedVeryLongAgo[0]?.id).toBe(userCreatedVeryLongAgo.id)
+
+      // Act + Assert (2)
+      const usersCreatedLongAgo = await getInactiveUsers({
+        fromDaysAgo: 110,
+        toDaysAgo: 90,
+      })
+      expect(usersCreatedLongAgo).toHaveLength(1)
+      expect(usersCreatedLongAgo[0]?.id).toBe(userCreatedLongAgo.id)
+
+      // Act + Assert (3)
+      const usersCreatedRecently = await getInactiveUsers({
+        fromDaysAgo: 90,
+        toDaysAgo: 70,
+      })
+      expect(usersCreatedRecently).toHaveLength(1)
+      expect(usersCreatedRecently[0]?.id).toBe(userCreatedRecently.id)
+
+      // Act + Assert (4)
+      const users = await getInactiveUsers({
+        fromDaysAgo: 110,
+        toDaysAgo: 0,
+      })
+      expect(users).toHaveLength(2)
+      expect(users.map((u) => u.id)).toContain(userCreatedLongAgo.id)
+      expect(users.map((u) => u.id)).toContain(userCreatedRecently.id)
+    })
+
+    it("should filter users by fromDaysAgo for users who have logged in", async () => {
+      // Arrange
+      const _userLoggedInVeryLongAgo = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 120,
+        lastLoginDaysAgo: 110,
+      })
+      const userLoggedInLongAgo = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 100,
+        lastLoginDaysAgo: 90,
+      })
+      const _userLoggedInRecently = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 80,
+        lastLoginDaysAgo: 70,
+      })
+
+      // Act
+      const users = await getInactiveUsers({
+        fromDaysAgo: 110,
+        toDaysAgo: MAX_DAYS_FROM_LAST_LOGIN,
+      })
+
+      // Assert
+      expect(users).toHaveLength(1)
+      expect(users.map((u) => u.id)).toContain(userLoggedInLongAgo.id)
+    })
+
+    it("should work with only fromDaysAgo parameter", async () => {
+      // Arrange
+      const userCreatedVeryLongAgo = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 110,
+        lastLoginDaysAgo: null,
+      })
+      const _userCreatedLongAgo = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 80,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      const inactiveUsers = await getInactiveUsers({
+        fromDaysAgo: 120,
+      })
+
+      // Assert
+      expect(inactiveUsers).toHaveLength(1)
+      expect(inactiveUsers[0]?.id).toBe(userCreatedVeryLongAgo.id)
     })
   })
 })

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -392,11 +392,8 @@ describe("inactiveUsers.service", () => {
 
     it("should return an empty array when there are no users", async () => {
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -422,11 +419,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -442,11 +436,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -463,11 +454,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -483,11 +471,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -504,11 +489,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -544,11 +526,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -577,11 +556,8 @@ describe("inactiveUsers.service", () => {
       }
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -596,11 +572,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -623,11 +596,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -651,11 +621,8 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -677,11 +644,8 @@ describe("inactiveUsers.service", () => {
       )
 
       // Act
-      const inactiveUsers = await db.transaction().execute(async (tx) => {
-        return getInactiveUsers({
-          tx,
-          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
-        })
+      const inactiveUsers = await getInactiveUsers({
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -398,6 +398,30 @@ describe("inactiveUsers.service", () => {
       })
     })
 
+    it("should not include themselves in the site admins list", async () => {
+      // Arrange
+      const user = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act
+      await bulkDeactivateInactiveUsers()
+
+      // Assert
+      expect(sendAccountDeactivationEmail).toHaveBeenCalledTimes(1)
+      expect(sendAccountDeactivationEmail).toHaveBeenCalledWith({
+        recipientEmail: user.email,
+        sitesAndAdmins: [
+          {
+            siteName: site.name,
+            adminEmails: [], // does not include themselves
+          },
+        ],
+      })
+    })
+
     it("should not include non-admins (publishers + editors) in the site admins list", async () => {
       // Arrange
       await setupUserWrapper({

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -9,7 +9,11 @@ import { beforeEach, describe, expect, it } from "vitest"
 
 import type { Site, User } from "~/server/modules/database"
 import { db } from "~/server/modules/database"
-import { DAYS_IN_MS, deactiveInactiveUsers } from "../inactiveUsers.service"
+import {
+  DAYS_FROM_LAST_LOGIN,
+  DAYS_IN_MS,
+  getInactiveUsers,
+} from "../inactiveUsers.service"
 
 interface SetupUserWrapperProps {
   siteId?: number
@@ -48,7 +52,7 @@ const setupUserWrapper = async ({
 }
 
 describe("inactiveUsers.service", () => {
-  describe("deactiveInactiveUsers", () => {
+  describe("getInactiveUsers", () => {
     let site: Site
 
     beforeAll(async () => {
@@ -62,7 +66,12 @@ describe("inactiveUsers.service", () => {
 
     it("should return an empty array when there are no users", async () => {
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -87,7 +96,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -102,7 +116,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(1)
@@ -118,7 +137,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -133,7 +157,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(1)
@@ -149,7 +178,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -184,7 +218,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(2)
@@ -212,7 +251,12 @@ describe("inactiveUsers.service", () => {
       }
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -226,7 +270,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)
@@ -248,7 +297,12 @@ describe("inactiveUsers.service", () => {
       })
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(1)
@@ -269,7 +323,12 @@ describe("inactiveUsers.service", () => {
       )
 
       // Act
-      const inactiveUsers = await deactiveInactiveUsers()
+      const inactiveUsers = await db.transaction().execute(async (tx) => {
+        return getInactiveUsers({
+          tx,
+          daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        })
+      })
 
       // Assert
       expect(inactiveUsers).toHaveLength(0)

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -141,7 +141,7 @@ describe("inactiveUsers.service", () => {
       expect(sendAccountDeactivationEmail).not.toHaveBeenCalled()
     })
 
-    it("should handle multiple calls to deactivate same user", async () => {
+    it("should handle multiple calls to deactivate same user without sending duplicate emails", async () => {
       // Arrange
       await setupUserWrapper({
         siteId: site.id,

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -13,8 +13,8 @@ import type { Site, User } from "~/server/modules/database"
 import { sendAccountDeactivationEmail } from "~/features/mail/service"
 import { db } from "~/server/modules/database"
 import { RoleType } from "~/server/modules/database/types"
+import { MAX_DAYS_FROM_LAST_LOGIN } from "../constants"
 import {
-  DAYS_FROM_LAST_LOGIN,
   DAYS_IN_MS,
   deactivateUser,
   getInactiveUsers,
@@ -530,7 +530,7 @@ describe("inactiveUsers.service", () => {
     it("should return an empty array when there are no users", async () => {
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -557,7 +557,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -574,7 +574,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -592,7 +592,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -609,7 +609,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -627,7 +627,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -664,7 +664,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -694,7 +694,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -710,7 +710,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -734,7 +734,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -759,7 +759,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert
@@ -782,7 +782,7 @@ describe("inactiveUsers.service", () => {
 
       // Act
       const inactiveUsers = await getInactiveUsers({
-        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+        daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
       })
 
       // Assert

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -426,6 +426,24 @@ describe("inactiveUsers.service", () => {
       // Assert
       expect(sendAccountDeactivationEmail).toHaveBeenCalledTimes(0)
     })
+
+    it("should not throw error when userIdsToDeactivate is empty array", async () => {
+      // Arrange
+      const user = await setupUserWrapper({
+        siteId: site.id,
+        createdDaysAgo: 91,
+        lastLoginDaysAgo: null,
+      })
+
+      // Act & Assert
+      const result = deactivateUser({
+        user,
+        userIdsToDeactivate: [],
+      })
+
+      // Assert
+      await expect(result).resolves.not.toThrow()
+    })
   })
 
   describe("getInactiveUsers", () => {

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -1327,7 +1327,7 @@ describe("user.router", () => {
         const user = await setupUser({
           email: TEST_EMAIL,
           isDeleted: false,
-          hasLoggedIn: true,
+          lastLoginAt: MOCK_STORY_DATE,
         })
         await setupEditorPermissions({ userId: user.id, siteId })
 
@@ -2231,7 +2231,7 @@ describe("user.router", () => {
       const user = await setupUser({
         email: TEST_EMAIL,
         isDeleted: false,
-        hasLoggedIn: true,
+        lastLoginAt: MOCK_STORY_DATE,
       })
       await setupEditorPermissions({ userId: user.id, siteId })
 
@@ -2254,7 +2254,7 @@ describe("user.router", () => {
       const user = await setupUser({
         email: TEST_EMAIL,
         isDeleted: false,
-        hasLoggedIn: false,
+        lastLoginAt: null,
       })
       await db
         .updateTable("User")
@@ -2282,7 +2282,7 @@ describe("user.router", () => {
       const user = await setupUser({
         email: TEST_EMAIL,
         isDeleted: false,
-        hasLoggedIn: false,
+        lastLoginAt: null,
       })
       await db
         .updateTable("User")
@@ -2309,7 +2309,7 @@ describe("user.router", () => {
       const user = await setupUser({
         email: TEST_EMAIL,
         isDeleted: false,
-        hasLoggedIn: false,
+        lastLoginAt: null,
       })
       await db
         .updateTable("User")

--- a/apps/studio/src/server/modules/user/__tests__/utils.ts
+++ b/apps/studio/src/server/modules/user/__tests__/utils.ts
@@ -9,15 +9,12 @@ import {
 
 export const isomerAdminsCount = ISOMER_ADMINS_AND_MIGRATORS.length
 
-export const setupIsomerAdmins = async ({
-  siteId,
-  hasLoggedIn = false,
-}: {
-  siteId: number
-  hasLoggedIn?: boolean
-}) => {
+export const setupIsomerAdmins = async ({ siteId }: { siteId: number }) => {
   for (const email of ISOMER_ADMINS_AND_MIGRATORS_EMAILS) {
-    const user = await setupUser({ email, isDeleted: false, hasLoggedIn })
+    const user = await setupUser({
+      email,
+      isDeleted: false,
+    })
     await setupAdminPermissions({ userId: user.id, siteId })
   }
 }

--- a/apps/studio/src/server/modules/user/constants.ts
+++ b/apps/studio/src/server/modules/user/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -2,6 +2,7 @@ import type { DB, Transaction, User } from "../database"
 import { db } from "../database"
 
 export const DAYS_IN_MS = 24 * 60 * 60 * 1000
+export const DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
 
 interface GetInactiveUsersProps {
   tx: Transaction<DB>
@@ -35,8 +36,6 @@ const getInactiveUsers = async ({
 }
 
 export const removeInactiveUsers = async (): Promise<User[]> => {
-  const DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
-
   const inactiveUsers = await db
     .transaction()
     .setIsolationLevel("serializable")

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -2,13 +2,12 @@ import { ISOMER_ADMINS_AND_MIGRATORS_EMAILS } from "~prisma/constants"
 
 import type { User } from "../database"
 import type { AccountDeactivationEmailTemplateData } from "~/features/mail/templates/types"
+import { HOURS_IN_MS } from "~/constants/misc"
 import { sendAccountDeactivationEmail } from "~/features/mail/service"
 import { createBaseLogger } from "~/lib/logger"
 import { db, RoleType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { MAX_DAYS_FROM_LAST_LOGIN } from "./constants"
-
-export const HOURS_IN_MS = 60 * 60 * 1000
 
 const logger = createBaseLogger({
   path: "server/modules/user/inactiveUsers.service",

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -4,7 +4,7 @@ import type { User } from "../database"
 import type { AccountDeactivationEmailTemplateData } from "~/features/mail/templates/types"
 import { sendAccountDeactivationEmail } from "~/features/mail/service"
 import { createBaseLogger } from "~/lib/logger"
-import { db, sql } from "../database"
+import { db, RoleType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 
 export const DAYS_IN_MS = 24 * 60 * 60 * 1000
@@ -99,6 +99,7 @@ export const deactivateUser = async ({
               .where("ResourcePermission.userId", "!=", user.id) // don't want to ask users to ask themselves for permissions
               .where("ResourcePermission.userId", "not in", userIdsToDeactivate)
               .where("ResourcePermission.deletedAt", "is", null)
+              .where("ResourcePermission.role", "=", RoleType.Admin) // should only give the admin emails to request reactivation permissions from
               .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators
               .select([
                 "Site.id as siteId",

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -3,7 +3,7 @@ import dayjs from "dayjs"
 import timezone from "dayjs/plugin/timezone"
 import utc from "dayjs/plugin/utc"
 
-import type { User } from "../database"
+import type { DB, Site, Transaction, User } from "../database"
 import type { AccountDeactivationEmailTemplateData } from "~/features/mail/templates/types"
 import { sendAccountDeactivationEmail } from "~/features/mail/service"
 import { createBaseLogger } from "~/lib/logger"
@@ -70,122 +70,112 @@ export const getInactiveUsers = async ({
     .execute()
 }
 
-interface DeactivateUserProps {
-  user: User
-  userIdsToDeactivate: User["id"][] // used for idempotency purposes
+interface DeactivateUsersProps {
+  tx: Transaction<DB>
+  userIds: User["id"][]
 }
-export const deactivateUser = async ({
-  user,
-  userIdsToDeactivate,
-}: DeactivateUserProps): Promise<void> => {
-  // This should not happen as this sub-function is only called when there are users to deactivate
-  // Nevertheless, needed to add this as a safety net to ensure valid Kysely query
-  if (userIdsToDeactivate.length === 0) return
+type DeactivateUsersOutput = {
+  user: User
+  siteIds: Site["id"][]
+}[]
 
-  // Note: we are just deleting their site permissions (by setting deletedAt)
-  // we are NOT deleting the user themselves because the intention is to
-  // remove their access to interact with their sites, not remove them from Isomer
-  let sitesAndAdmins: AccountDeactivationEmailTemplateData["sitesAndAdmins"] =
-    []
+export const deactivateUsers = async ({
+  tx,
+  userIds,
+}: DeactivateUsersProps): Promise<DeactivateUsersOutput> => {
+  // prevent empty array from being passed in
+  if (userIds.length === 0) return []
 
-  try {
-    sitesAndAdmins = await db
-      .transaction()
-      .setIsolationLevel("serializable")
-      .execute(async (tx) => {
-        const deletedPermissions = await tx
-          .updateTable("ResourcePermission")
-          .where("userId", "=", user.id)
-          .where("deletedAt", "is", null)
-          .set({ deletedAt: new Date() })
-          .returningAll()
-          .execute()
+  const deletedPermissions = await tx
+    .updateTable("ResourcePermission")
+    .where("userId", "in", userIds)
+    .where("deletedAt", "is", null)
+    .set({ deletedAt: new Date() })
+    .returningAll()
+    .execute()
 
-        // For idempotency purposes since multiple nodes may run this function at the same time
-        if (deletedPermissions.length === 0) return []
+  return tx
+    .selectFrom("User")
+    .where("id", "in", userIds)
+    .selectAll()
+    .execute()
+    .then((users) =>
+      users.map((user) => ({
+        user,
+        siteIds: deletedPermissions
+          .filter((permission) => permission.userId === user.id)
+          .map((permission) => permission.siteId),
+      })),
+    )
+}
 
-        const siteIdsUserHasPermissionsFor = deletedPermissions.map(
-          (p) => p.siteId,
-        )
+interface GetSiteAndAdminsProps {
+  tx: Transaction<DB>
+  userId: User["id"]
+  siteIds: Site["id"][]
+}
 
-        return (
-          tx
-            .with("siteAdmins", (eb) =>
-              eb
-                .selectFrom("Site")
-                .innerJoin(
-                  "ResourcePermission",
-                  "ResourcePermission.siteId",
-                  "Site.id",
-                )
-                .innerJoin("User", "User.id", "ResourcePermission.userId")
-                .where("Site.id", "in", siteIdsUserHasPermissionsFor)
-                .where("ResourcePermission.userId", "!=", user.id) // don't want to ask users to ask themselves for permissions
-                .where(
-                  "ResourcePermission.userId",
-                  "not in",
-                  userIdsToDeactivate,
-                )
-                .where("ResourcePermission.deletedAt", "is", null)
-                .where("ResourcePermission.role", "=", RoleType.Admin) // should only give the admin emails to request reactivation permissions from
-                .where(
-                  "User.email",
-                  "not in",
-                  ISOMER_ADMINS_AND_MIGRATORS_EMAILS,
-                ) // we don't want to send emails to admins and migrators
-                .select([
-                  "Site.id as siteId",
-                  db.fn
-                    .agg<string[]>("array_agg", ["User.email"])
-                    .as("adminEmails"),
-                ])
-                .groupBy("Site.id"),
-            )
-            // Needed as we still want the site records even if there are no other users with permissions for that site
-            .with("baseSites", (eb) =>
-              eb
-                .selectFrom("Site")
-                .where("Site.id", "in", siteIdsUserHasPermissionsFor)
-                .select(["Site.id as siteId", "Site.name as siteName"]),
-            )
-            .selectFrom("baseSites")
-            .leftJoin("siteAdmins", "siteAdmins.siteId", "baseSites.siteId")
-            .select([
-              "baseSites.siteName",
-              sql<
-                string[]
-              >`COALESCE("siteAdmins"."adminEmails", ARRAY[]::text[])`.as(
-                "adminEmails",
-              ),
-            ])
-            .execute()
-        )
-      })
-  } catch (error) {
-    if (
-      // Handle serializable transaction errors gracefully
-      error instanceof Error &&
-      "code" in error &&
-      error.code === PG_ERROR_CODES.serializationFailure
-    ) {
-      // Return early as the user may have already been deactivated by another concurrent transaction
-      return
+type GetSiteAndAdminsOutput =
+  AccountDeactivationEmailTemplateData["sitesAndAdmins"]
+
+const getSiteAndAdmins = async ({
+  tx,
+  userId,
+  siteIds,
+}: GetSiteAndAdminsProps): Promise<GetSiteAndAdminsOutput> => {
+  return (
+    tx
+      .with("siteAdmins", (eb) =>
+        eb
+          .selectFrom("Site")
+          .innerJoin(
+            "ResourcePermission",
+            "ResourcePermission.siteId",
+            "Site.id",
+          )
+          .innerJoin("User", "User.id", "ResourcePermission.userId")
+          .where("Site.id", "in", siteIds)
+          .where("ResourcePermission.userId", "!=", userId) // don't want to ask users to ask themselves for permissions
+          .where("ResourcePermission.deletedAt", "is", null)
+          .where("ResourcePermission.role", "=", RoleType.Admin) // should only give the admin emails to request reactivation permissions from
+          .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators
+          .select([
+            "Site.id as siteId",
+            db.fn.agg<string[]>("array_agg", ["User.email"]).as("adminEmails"),
+          ])
+          .groupBy("Site.id"),
+      )
+      // Needed as we still want the site records even if there are no other users with permissions for that site
+      .with("baseSites", (eb) =>
+        eb
+          .selectFrom("Site")
+          .where("Site.id", "in", siteIds)
+          .select(["Site.id as siteId", "Site.name as siteName"]),
+      )
+      .selectFrom("baseSites")
+      .leftJoin("siteAdmins", "siteAdmins.siteId", "baseSites.siteId")
+      .select([
+        "baseSites.siteName",
+        sql<string[]>`COALESCE("siteAdmins"."adminEmails", ARRAY[]::text[])`.as(
+          "adminEmails",
+        ),
+      ])
+      .execute()
+  )
+}
+
+type SendAccountDeactivationEmailsProps = AccountDeactivationEmailTemplateData[]
+const sendAccountDeactivationEmails = async (
+  deactivatedUsersAndSites: SendAccountDeactivationEmailsProps,
+): Promise<void> => {
+  for (const { recipientEmail, sitesAndAdmins } of deactivatedUsersAndSites) {
+    try {
+      await sendAccountDeactivationEmail({ recipientEmail, sitesAndAdmins })
+    } catch {
+      logger.error(
+        `Error sending account deactivation email for user ${recipientEmail}`,
+      )
     }
-    // Re-throw other errors
-    throw error
-  }
-
-  // If there are no sites and admins, we don't need to send an email
-  // Note: this is to ensure there's idempotency and not send duplicate emails
-  if (sitesAndAdmins.length === 0) return
-
-  try {
-    await sendAccountDeactivationEmail({
-      recipientEmail: user.email,
-      sitesAndAdmins,
-    })
-  } catch {
-    logger.error(`Error sending account deactivation email for user ${user.id}`)
   }
 }
 
@@ -196,9 +186,48 @@ export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
   // 2. users who weren't removed for whatever reason e.g. unintentional failed cron job that wasn't retried
   const inactiveUsers = await getInactiveUsers({})
 
-  const userIdsToDeactivate = inactiveUsers.map((user) => user.id)
+  const deactivatedUsersAndSites: SendAccountDeactivationEmailsProps = []
 
-  for (const user of inactiveUsers) {
-    await deactivateUser({ user, userIdsToDeactivate })
+  try {
+    await db
+      .transaction()
+      .setIsolationLevel("serializable")
+      .execute(async (tx) => {
+        const deactivatedUsersAndSiteIds = await deactivateUsers({
+          tx,
+          userIds: inactiveUsers.map((user) => user.id),
+        })
+
+        for (const { user, siteIds } of deactivatedUsersAndSiteIds) {
+          const sitesAndAdmins = await getSiteAndAdmins({
+            tx,
+            userId: user.id,
+            siteIds,
+          })
+
+          deactivatedUsersAndSites.push({
+            recipientEmail: user.email,
+            sitesAndAdmins,
+          })
+        }
+      })
+  } catch (error) {
+    if (
+      // Handle serializable transaction errors gracefully
+      error instanceof Error &&
+      "code" in error &&
+      error.code === PG_ERROR_CODES.serializationFailure
+    ) {
+      logger.info("Serialization failure, retrying...")
+    }
+    // Re-throw other errors
+    throw error
   }
+
+  if (deactivatedUsersAndSites.length === 0) {
+    logger.info("No deactivated users and sites found")
+    return
+  }
+
+  await sendAccountDeactivationEmails(deactivatedUsersAndSites)
 }

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -123,6 +123,9 @@ const getSiteAndAdmins = async ({
   userId,
   siteIds,
 }: GetSiteAndAdminsProps): Promise<GetSiteAndAdminsOutput> => {
+  // Prevent empty array from being passed in
+  if (siteIds.length === 0) return []
+
   return (
     tx
       .with("siteAdmins", (eb) =>
@@ -199,6 +202,8 @@ export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
         })
 
         for (const { user, siteIds } of deactivatedUsersAndSiteIds) {
+          if (siteIds.length === 0) continue
+
           const sitesAndAdmins = await getSiteAndAdmins({
             tx,
             userId: user.id,

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -1,3 +1,5 @@
+import { ISOMER_ADMINS_AND_MIGRATORS_EMAILS } from "~prisma/constants"
+
 import type { DB, Transaction, User } from "../database"
 import { db } from "../database"
 
@@ -17,6 +19,7 @@ const getInactiveUsers = async ({
   return tx
     .selectFrom("User")
     .where("deletedAt", "is", null)
+    .where("email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // needed to provide support for agencies
     .where((eb) =>
       eb.or([
         // Users who have never logged in

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -1,0 +1,53 @@
+import type { DB, Transaction, User } from "../database"
+import { db } from "../database"
+
+export const DAYS_IN_MS = 24 * 60 * 60 * 1000
+
+interface GetInactiveUsersProps {
+  tx: Transaction<DB>
+  daysFromLastLogin: number
+}
+const getInactiveUsers = async ({
+  tx,
+  daysFromLastLogin,
+}: GetInactiveUsersProps): Promise<User[]> => {
+  const dateThreshold = new Date(Date.now() - daysFromLastLogin * DAYS_IN_MS)
+
+  return tx
+    .selectFrom("User")
+    .where("deletedAt", "is", null)
+    .where((eb) =>
+      eb.or([
+        // Users who have never logged in
+        eb.and([
+          eb("lastLoginAt", "is", null),
+          eb("createdAt", "<", dateThreshold),
+        ]),
+        // Users who have logged in but haven't logged in for a while
+        eb.and([
+          eb("lastLoginAt", "is not", null),
+          eb("lastLoginAt", "<", dateThreshold),
+        ]),
+      ]),
+    )
+    .selectAll()
+    .execute()
+}
+
+export const removeInactiveUsers = async (): Promise<User[]> => {
+  const DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
+
+  const inactiveUsers = await db
+    .transaction()
+    .setIsolationLevel("serializable")
+    .execute(async (tx) => {
+      const inactiveUsers = await getInactiveUsers({
+        tx,
+        daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+      })
+
+      return inactiveUsers
+    })
+
+  return inactiveUsers
+}

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -113,7 +113,7 @@ export const deactivateUser = async ({
           .with("siteAdmins", (eb) =>
             eb
               .selectFrom("Site")
-              .leftJoin(
+              .innerJoin(
                 "ResourcePermission",
                 "ResourcePermission.siteId",
                 "Site.id",

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -41,7 +41,7 @@ export const getInactiveUsers = async ({
           eb("User.lastLoginAt", "is", null),
           eb("User.createdAt", "<=", toDateThreshold),
           ...(fromDateThreshold
-            ? [eb("User.createdAt", ">=", fromDateThreshold)]
+            ? [eb("User.createdAt", ">", fromDateThreshold)]
             : []),
         ]),
         // Users who have logged in but haven't logged in for a while
@@ -49,7 +49,7 @@ export const getInactiveUsers = async ({
           eb("User.lastLoginAt", "is not", null),
           eb("User.lastLoginAt", "<=", toDateThreshold),
           ...(fromDateThreshold
-            ? [eb("User.lastLoginAt", ">=", fromDateThreshold)]
+            ? [eb("User.lastLoginAt", ">", fromDateThreshold)]
             : []),
         ]),
       ]),

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -77,6 +77,10 @@ export const deactivateUser = async ({
         // For idempotency purposes since multiple nodes may run this function at the same time
         if (deletedPermissions.length === 0) return []
 
+        const siteIdsUserHasPermissionsFor = deletedPermissions.map(
+          (p) => p.siteId,
+        )
+
         return await tx
           .selectFrom("Site")
           .leftJoin(
@@ -85,6 +89,7 @@ export const deactivateUser = async ({
             "Site.id",
           )
           .innerJoin("User", "User.id", "ResourcePermission.userId")
+          .where("Site.id", "in", siteIdsUserHasPermissionsFor)
           .where("ResourcePermission.userId", "!=", user.id) // don't want to ask users to ask themselves for permissions
           .where("ResourcePermission.userId", "not in", userIdsToDeactivate)
           .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -77,7 +77,7 @@ export const deactivateUser = async ({
         // For idempotency purposes since multiple nodes may run this function at the same time
         if (deletedPermissions.length === 0) return []
 
-        return await db
+        return await tx
           .selectFrom("Site")
           .leftJoin(
             "ResourcePermission",

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -18,23 +18,25 @@ const getInactiveUsers = async ({
 
   return tx
     .selectFrom("User")
-    .where("deletedAt", "is", null)
-    .where("email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // needed to provide support for agencies
+    .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
+    .where("User.deletedAt", "is", null)
+    .where("ResourcePermission.deletedAt", "is", null)
+    .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // needed to provide support for agencies
     .where((eb) =>
       eb.or([
         // Users who have never logged in
         eb.and([
-          eb("lastLoginAt", "is", null),
-          eb("createdAt", "<", dateThreshold),
+          eb("User.lastLoginAt", "is", null),
+          eb("User.createdAt", "<", dateThreshold),
         ]),
         // Users who have logged in but haven't logged in for a while
         eb.and([
-          eb("lastLoginAt", "is not", null),
-          eb("lastLoginAt", "<", dateThreshold),
+          eb("User.lastLoginAt", "is not", null),
+          eb("User.lastLoginAt", "<", dateThreshold),
         ]),
       ]),
     )
-    .selectAll()
+    .selectAll(["User"])
     .execute()
 }
 

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -1,10 +1,18 @@
 import { ISOMER_ADMINS_AND_MIGRATORS_EMAILS } from "~prisma/constants"
 
 import type { DB, Transaction, User } from "../database"
+import type { AccountDeactivationEmailTemplateData } from "~/features/mail/templates/types"
+import { sendAccountDeactivationEmail } from "~/features/mail/service"
+import { createBaseLogger } from "~/lib/logger"
 import { db } from "../database"
+import { PG_ERROR_CODES } from "../database/constants"
 
 export const DAYS_IN_MS = 24 * 60 * 60 * 1000
 export const DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
+
+const logger = createBaseLogger({
+  path: "server/modules/user/inactiveUsers.service",
+})
 
 interface GetInactiveUsersProps {
   tx: Transaction<DB>
@@ -39,6 +47,82 @@ export const getInactiveUsers = async ({
     .selectAll(["User"])
     .distinct()
     .execute()
+}
+
+interface DeactivateUserProps {
+  user: User
+  userIdsToDeactivate: User["id"][] // used for idempotency purposes
+}
+export const deactivateUser = async ({
+  user,
+  userIdsToDeactivate,
+}: DeactivateUserProps): Promise<void> => {
+  // Note: we are just deleting their site permissions (by setting deletedAt)
+  // we are NOT deleting the user themselves because the intention is to
+  // remove their access to interact with their sites, not remove them from Isomer
+  let sitesAndAdmins: AccountDeactivationEmailTemplateData["sitesAndAdmins"] =
+    []
+
+  try {
+    sitesAndAdmins = await db
+      .transaction()
+      .setIsolationLevel("serializable")
+      .execute(async (tx) => {
+        const deletedPermissions = await tx
+          .updateTable("ResourcePermission")
+          .where("userId", "=", user.id)
+          .where("deletedAt", "is", null)
+          .set({ deletedAt: new Date() })
+          .returningAll()
+          .execute()
+
+        // For idempotency purposes since multiple nodes may run this function at the same time
+        if (deletedPermissions.length === 0) return []
+
+        return await db
+          .selectFrom("Site")
+          .leftJoin(
+            "ResourcePermission",
+            "ResourcePermission.siteId",
+            "Site.id",
+          )
+          .innerJoin("User", "User.id", "ResourcePermission.userId")
+          .where("ResourcePermission.userId", "!=", user.id) // don't want to ask users to ask themselves for permissions
+          .where("ResourcePermission.userId", "not in", userIdsToDeactivate)
+          .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators
+          .select([
+            "Site.name as siteName",
+            db.fn.agg<string[]>("array_agg", ["User.email"]).as("adminEmails"),
+          ])
+          .groupBy("Site.name")
+          .execute()
+      })
+  } catch (error) {
+    if (
+      // Handle serializable transaction errors gracefully
+      error instanceof Error &&
+      "code" in error &&
+      error.code === PG_ERROR_CODES.serializationFailure
+    ) {
+      // Return early as the user may have already been deactivated by another concurrent transaction
+      return
+    }
+    // Re-throw other errors
+    throw error
+  }
+
+  // If there are no sites and admins, we don't need to send an email
+  // Note: this is to ensure there's idempotency and not send duplicate emails
+  if (sitesAndAdmins.length === 0) return
+
+  try {
+    await sendAccountDeactivationEmail({
+      recipientEmail: user.email,
+      sitesAndAdmins,
+    })
+  } catch {
+    logger.error(`Error sending account deactivation email for user ${user.id}`)
+  }
 }
 
 export const deactiveInactiveUsers = async (): Promise<User[]> => {

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -128,7 +128,7 @@ export const deactivateUser = async ({
   }
 }
 
-export const deactiveInactiveUsers = async (): Promise<void> => {
+export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
   const inactiveUsers = await getInactiveUsers({
     daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
   })

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -213,12 +213,15 @@ export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
       })
   } catch (error) {
     if (
-      // Handle serializable transaction errors gracefully
+      // Handle serializable transaction errors gracefully - this is expected for idempotency
       error instanceof Error &&
       "code" in error &&
       error.code === PG_ERROR_CODES.serializationFailure
     ) {
-      logger.info("Serialization failure, retrying...")
+      logger.info(
+        "Serialization failure detected, skipping operation for idempotency",
+      )
+      return
     }
     // Re-throw other errors
     throw error

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -123,10 +123,14 @@ export const deactivateUser = async ({
   }
 }
 
-export const deactiveInactiveUsers = async (): Promise<User[]> => {
+export const deactiveInactiveUsers = async (): Promise<void> => {
   const inactiveUsers = await getInactiveUsers({
     daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
   })
 
-  return inactiveUsers
+  const userIdsToDeactivate = inactiveUsers.map((user) => user.id)
+
+  for (const user of inactiveUsers) {
+    await deactivateUser({ user, userIdsToDeactivate })
+  }
 }

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -171,13 +171,11 @@ export const deactivateUser = async ({
 }
 
 export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
-  const inactiveUsers = await getInactiveUsers({
-    // not setting fromDaysAgo to MAX_DAYS_FROM_LAST_LOGIN because we want to
-    // deactivate users beyond the MAX_DAYS_FROM_LAST_LOGIN (e.g. 91 days). This could be due to:
-    // 1. legacy users who wasn't covered by the MAX_DAYS_FROM_LAST_LOGIN before the feature was introduced
-    // 2. users who weren't removed for whatever reason e.g. unintentional failed cron job that wasn't retried
-    toDaysAgo: 0,
-  })
+  // not setting fromDaysAgo to MAX_DAYS_FROM_LAST_LOGIN because we want to
+  // deactivate users beyond the MAX_DAYS_FROM_LAST_LOGIN (e.g. 91 days). This could be due to:
+  // 1. legacy users who wasn't covered by the MAX_DAYS_FROM_LAST_LOGIN before the feature was introduced
+  // 2. users who weren't removed for whatever reason e.g. unintentional failed cron job that wasn't retried
+  const inactiveUsers = await getInactiveUsers({})
 
   const userIdsToDeactivate = inactiveUsers.map((user) => user.id)
 

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -94,19 +94,18 @@ export const deactivateUsers = async ({
     .returningAll()
     .execute()
 
-  return tx
+  const users = await tx
     .selectFrom("User")
     .where("id", "in", userIds)
     .selectAll()
     .execute()
-    .then((users) =>
-      users.map((user) => ({
-        user,
-        siteIds: deletedPermissions
-          .filter((permission) => permission.userId === user.id)
-          .map((permission) => permission.siteId),
-      })),
-    )
+
+  return users.map((user) => ({
+    user,
+    siteIds: deletedPermissions
+      .filter((permission) => permission.userId === user.id)
+      .map((permission) => permission.siteId),
+  }))
 }
 
 interface GetSiteAndAdminsProps {

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -144,15 +144,13 @@ export const deactivateUser = async ({
           .leftJoin("siteAdmins", "siteAdmins.siteId", "baseSites.siteId")
           .select([
             "baseSites.siteName",
-            sql`COALESCE("siteAdmins"."adminEmails", ARRAY[]::text[])`.as(
+            sql<
+              string[]
+            >`COALESCE("siteAdmins"."adminEmails", ARRAY[]::text[])`.as(
               "adminEmails",
             ),
           ])
           .execute()
-          .then(
-            (result) =>
-              result as AccountDeactivationEmailTemplateData["sitesAndAdmins"],
-          )
       })
   } catch (error) {
     if (

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -92,6 +92,7 @@ export const deactivateUser = async ({
           .where("Site.id", "in", siteIdsUserHasPermissionsFor)
           .where("ResourcePermission.userId", "!=", user.id) // don't want to ask users to ask themselves for permissions
           .where("ResourcePermission.userId", "not in", userIdsToDeactivate)
+          .where("ResourcePermission.deletedAt", "is", null)
           .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators
           .select([
             "Site.name as siteName",

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -8,11 +8,27 @@ import { db, RoleType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { MAX_DAYS_FROM_LAST_LOGIN } from "./constants"
 
-export const DAYS_IN_MS = 24 * 60 * 60 * 1000
+export const HOURS_IN_MS = 60 * 60 * 1000
 
 const logger = createBaseLogger({
   path: "server/modules/user/inactiveUsers.service",
 })
+
+export function getDateOnlyInSG(daysAgo: number): Date {
+  const now = new Date()
+
+  // Convert to SG time
+  const sgOffsetMs = 8 * HOURS_IN_MS
+  const sgNow = new Date(now.getTime() + sgOffsetMs)
+
+  // Subtract daysAgo and zero out time (SG midnight)
+  sgNow.setDate(sgNow.getDate() - daysAgo)
+  sgNow.setHours(0, 0, 0, 0)
+
+  // Convert back to UTC
+  const utcDate = new Date(sgNow.getTime() - sgOffsetMs)
+  return utcDate
+}
 
 interface GetInactiveUsersProps {
   fromDaysAgo?: number
@@ -22,11 +38,8 @@ export const getInactiveUsers = async ({
   fromDaysAgo,
   toDaysAgo = MAX_DAYS_FROM_LAST_LOGIN,
 }: GetInactiveUsersProps): Promise<User[]> => {
-  const fromDateThreshold = fromDaysAgo
-    ? new Date(Date.now() - fromDaysAgo * DAYS_IN_MS)
-    : null
-
-  const toDateThreshold = new Date(Date.now() - toDaysAgo * DAYS_IN_MS)
+  const fromDateThreshold = fromDaysAgo ? getDateOnlyInSG(fromDaysAgo) : null
+  const toDateThreshold = getDateOnlyInSG(toDaysAgo)
 
   return db
     .selectFrom("User")

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -39,7 +39,7 @@ export const getInactiveUsers = async ({
         // Users who have never logged in
         eb.and([
           eb("User.lastLoginAt", "is", null),
-          eb("User.createdAt", "<", toDateThreshold),
+          eb("User.createdAt", "<=", toDateThreshold),
           ...(fromDaysAgo
             ? [eb("User.createdAt", ">=", fromDateThreshold)]
             : []),
@@ -47,7 +47,7 @@ export const getInactiveUsers = async ({
         // Users who have logged in but haven't logged in for a while
         eb.and([
           eb("User.lastLoginAt", "is not", null),
-          eb("User.lastLoginAt", "<", toDateThreshold),
+          eb("User.lastLoginAt", "<=", toDateThreshold),
           ...(fromDaysAgo
             ? [eb("User.lastLoginAt", ">=", fromDateThreshold)]
             : []),

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -10,7 +10,7 @@ interface GetInactiveUsersProps {
   tx: Transaction<DB>
   daysFromLastLogin: number
 }
-const getInactiveUsers = async ({
+export const getInactiveUsers = async ({
   tx,
   daysFromLastLogin,
 }: GetInactiveUsersProps): Promise<User[]> => {

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -55,6 +55,10 @@ export const deactivateUser = async ({
   user,
   userIdsToDeactivate,
 }: DeactivateUserProps): Promise<void> => {
+  // This should not happen as this sub-function is only called when there are users to deactivate
+  // Nevertheless, needed to add this as a safety net to ensure valid Kysely query
+  if (userIdsToDeactivate.length === 0) return
+
   // Note: we are just deleting their site permissions (by setting deletedAt)
   // we are NOT deleting the user themselves because the intention is to
   // remove their access to interact with their sites, not remove them from Isomer

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -3,8 +3,7 @@ import dayjs from "dayjs"
 import timezone from "dayjs/plugin/timezone"
 import utc from "dayjs/plugin/utc"
 
-import type { DB, Site, Transaction, User } from "../database"
-import type { AccountDeactivationEmailTemplateData } from "~/features/mail/templates/types"
+import type { ResourcePermission, Site, User } from "../database"
 import { sendAccountDeactivationEmail } from "~/features/mail/service"
 import { createBaseLogger } from "~/lib/logger"
 import { db, RoleType, sql } from "../database"
@@ -71,30 +70,44 @@ export const getInactiveUsers = async ({
 }
 
 interface DeactivateUsersProps {
-  tx: Transaction<DB>
   userIds: User["id"][]
 }
-type DeactivateUsersOutput = {
-  user: User
-  siteIds: Site["id"][]
-}[]
-
-export const deactivateUsers = async ({
-  tx,
-  userIds,
-}: DeactivateUsersProps): Promise<DeactivateUsersOutput> => {
+export const deactivateUsers = async ({ userIds }: DeactivateUsersProps) => {
   // prevent empty array from being passed in
   if (userIds.length === 0) return []
 
-  const deletedPermissions = await tx
-    .updateTable("ResourcePermission")
-    .where("userId", "in", userIds)
-    .where("deletedAt", "is", null)
-    .set({ deletedAt: new Date() })
-    .returningAll()
-    .execute()
+  let deletedPermissions: ResourcePermission[] = []
 
-  const users = await tx
+  try {
+    deletedPermissions = await db
+      .transaction()
+      .setIsolationLevel("serializable") // for idempotency
+      .execute(async (tx) => {
+        return tx
+          .updateTable("ResourcePermission")
+          .where("userId", "in", userIds)
+          .where("deletedAt", "is", null)
+          .set({ deletedAt: new Date() })
+          .returningAll()
+          .execute()
+      })
+  } catch (error) {
+    if (
+      // Handle serializable transaction errors gracefully - this is expected for idempotency
+      error instanceof Error &&
+      "code" in error &&
+      error.code === PG_ERROR_CODES.serializationFailure
+    ) {
+      logger.info(
+        "Serialization failure detected, skipping operation for idempotency",
+      )
+      return []
+    }
+    // Re-throw other errors
+    throw error
+  }
+
+  const users = await db
     .selectFrom("User")
     .where("id", "in", userIds)
     .selectAll()
@@ -109,24 +122,15 @@ export const deactivateUsers = async ({
 }
 
 interface GetSiteAndAdminsProps {
-  tx: Transaction<DB>
   userId: User["id"]
   siteIds: Site["id"][]
 }
-
-type GetSiteAndAdminsOutput =
-  AccountDeactivationEmailTemplateData["sitesAndAdmins"]
-
-const getSiteAndAdmins = async ({
-  tx,
-  userId,
-  siteIds,
-}: GetSiteAndAdminsProps): Promise<GetSiteAndAdminsOutput> => {
+const getSiteAndAdmins = async ({ userId, siteIds }: GetSiteAndAdminsProps) => {
   // Prevent empty array from being passed in
   if (siteIds.length === 0) return []
 
   return (
-    tx
+    db
       .with("siteAdmins", (eb) =>
         eb
           .selectFrom("Site")
@@ -166,21 +170,6 @@ const getSiteAndAdmins = async ({
   )
 }
 
-type SendAccountDeactivationEmailsProps = AccountDeactivationEmailTemplateData[]
-const sendAccountDeactivationEmails = async (
-  deactivatedUsersAndSites: SendAccountDeactivationEmailsProps,
-): Promise<void> => {
-  for (const { recipientEmail, sitesAndAdmins } of deactivatedUsersAndSites) {
-    try {
-      await sendAccountDeactivationEmail({ recipientEmail, sitesAndAdmins })
-    } catch {
-      logger.error(
-        `Error sending account deactivation email for user ${recipientEmail}`,
-      )
-    }
-  }
-}
-
 export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
   // not setting fromDaysAgo to MAX_DAYS_FROM_LAST_LOGIN because we want to
   // deactivate users beyond the MAX_DAYS_FROM_LAST_LOGIN (e.g. 91 days). This could be due to:
@@ -188,53 +177,32 @@ export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
   // 2. users who weren't removed for whatever reason e.g. unintentional failed cron job that wasn't retried
   const inactiveUsers = await getInactiveUsers({})
 
-  const deactivatedUsersAndSites: SendAccountDeactivationEmailsProps = []
+  const deactivatedUsersAndSiteIds = await deactivateUsers({
+    userIds: inactiveUsers.map((user) => user.id),
+  })
 
-  try {
-    await db
-      .transaction()
-      .setIsolationLevel("serializable")
-      .execute(async (tx) => {
-        const deactivatedUsersAndSiteIds = await deactivateUsers({
-          tx,
-          userIds: inactiveUsers.map((user) => user.id),
-        })
-
-        for (const { user, siteIds } of deactivatedUsersAndSiteIds) {
-          if (siteIds.length === 0) continue
-
-          const sitesAndAdmins = await getSiteAndAdmins({
-            tx,
-            userId: user.id,
-            siteIds,
-          })
-
-          deactivatedUsersAndSites.push({
-            recipientEmail: user.email,
-            sitesAndAdmins,
-          })
-        }
-      })
-  } catch (error) {
-    if (
-      // Handle serializable transaction errors gracefully - this is expected for idempotency
-      error instanceof Error &&
-      "code" in error &&
-      error.code === PG_ERROR_CODES.serializationFailure
-    ) {
-      logger.info(
-        "Serialization failure detected, skipping operation for idempotency",
-      )
-      return
-    }
-    // Re-throw other errors
-    throw error
-  }
-
-  if (deactivatedUsersAndSites.length === 0) {
+  if (deactivatedUsersAndSiteIds.length === 0) {
     logger.info("No deactivated users and sites found")
     return
   }
 
-  await sendAccountDeactivationEmails(deactivatedUsersAndSites)
+  for (const { user, siteIds } of deactivatedUsersAndSiteIds) {
+    if (siteIds.length === 0) continue
+
+    const sitesAndAdmins = await getSiteAndAdmins({
+      userId: user.id,
+      siteIds,
+    })
+
+    try {
+      await sendAccountDeactivationEmail({
+        recipientEmail: user.email,
+        sitesAndAdmins,
+      })
+    } catch {
+      logger.error(
+        `Error sending account deactivation email for user ${user.email}`,
+      )
+    }
+  }
 }

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -40,7 +40,7 @@ const getInactiveUsers = async ({
     .execute()
 }
 
-export const removeInactiveUsers = async (): Promise<User[]> => {
+export const deactiveInactiveUsers = async (): Promise<User[]> => {
   const inactiveUsers = await db
     .transaction()
     .setIsolationLevel("serializable")

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -40,7 +40,7 @@ export const getInactiveUsers = async ({
         eb.and([
           eb("User.lastLoginAt", "is", null),
           eb("User.createdAt", "<=", toDateThreshold),
-          ...(fromDaysAgo
+          ...(fromDateThreshold
             ? [eb("User.createdAt", ">=", fromDateThreshold)]
             : []),
         ]),
@@ -48,7 +48,7 @@ export const getInactiveUsers = async ({
         eb.and([
           eb("User.lastLoginAt", "is not", null),
           eb("User.lastLoginAt", "<=", toDateThreshold),
-          ...(fromDaysAgo
+          ...(fromDateThreshold
             ? [eb("User.lastLoginAt", ">=", fromDateThreshold)]
             : []),
         ]),

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -37,6 +37,7 @@ export const getInactiveUsers = async ({
       ]),
     )
     .selectAll(["User"])
+    .distinct()
     .execute()
 }
 

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -6,9 +6,9 @@ import { sendAccountDeactivationEmail } from "~/features/mail/service"
 import { createBaseLogger } from "~/lib/logger"
 import { db, RoleType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
+import { MAX_DAYS_FROM_LAST_LOGIN } from "./constants"
 
 export const DAYS_IN_MS = 24 * 60 * 60 * 1000
-export const DAYS_FROM_LAST_LOGIN = 90 // hardcoded to 90 as per IM8 requirement
 
 const logger = createBaseLogger({
   path: "server/modules/user/inactiveUsers.service",
@@ -160,7 +160,7 @@ export const deactivateUser = async ({
 
 export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
   const inactiveUsers = await getInactiveUsers({
-    daysFromLastLogin: DAYS_FROM_LAST_LOGIN,
+    daysFromLastLogin: MAX_DAYS_FROM_LAST_LOGIN,
   })
 
   const userIdsToDeactivate = inactiveUsers.map((user) => user.id)

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -525,14 +525,14 @@ export const setupUser = async ({
   email,
   phone = "",
   isDeleted = false,
-  hasLoggedIn = false,
+  lastLoginAt = null,
 }: {
   name?: string
   userId?: string
   email?: string
   phone?: string
   isDeleted?: boolean
-  hasLoggedIn?: boolean
+  lastLoginAt?: Date | null
 }) => {
   return db
     .insertInto("User")
@@ -542,7 +542,7 @@ export const setupUser = async ({
       email: email ?? `${nanoid()}@test.com`,
       phone: phone,
       deletedAt: isDeleted ? MOCK_STORY_DATE : null,
-      lastLoginAt: hasLoggedIn ? MOCK_STORY_DATE : null,
+      lastLoginAt,
     })
     .returningAll()
     .executeTakeFirstOrThrow()

--- a/package-lock.json
+++ b/package-lock.json
@@ -90,6 +90,7 @@
         "ajv-errors": "^3.0.0",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.1.3",
+        "dayjs": "^1.11.13",
         "dd-trace": "^5.24.0",
         "exponential-backoff": "^3.1.2",
         "filenamify": "^6.0.0",
@@ -18213,7 +18214,8 @@
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/dayzed": {
       "version": "3.2.3",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Partially closes https://linear.app/ogp/issue/ISOM-1867/ac-3-create-script-to-automatically-prune-users-not-logged-in-90-days

> [!NOTE]
> this PR does not include the scheduler aspect of it - will do that in another branch and PR 

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- add service to remove inactive users from sites
- add email template for sending to them when deactivating