### PR TITLE
(cursor) isom-1949 - Enable image gallery for article pages

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -397,6 +397,10 @@ export const ARTICLE_ALLOWED_BLOCKS: AllowedBlockSections = [
     label: "Basic content blocks",
     types: ["prose", "image", "accordion", "callout", "blockquote"],
   },
+  {
+    label: "Add a new section",
+    types: [IMAGE_GALLERY_TYPE],
+  },
   { label: "Embed external content", types: ["map", "video"] },
 ]
 

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -395,11 +395,14 @@ type AllowedBlockSections = {
 export const ARTICLE_ALLOWED_BLOCKS: AllowedBlockSections = [
   {
     label: "Basic content blocks",
-    types: ["prose", "image", "accordion", "callout", "blockquote"],
-  },
-  {
-    label: "Add a new section",
-    types: [IMAGE_GALLERY_TYPE],
+    types: [
+      "prose",
+      "image",
+      "accordion",
+      "callout",
+      "blockquote",
+      IMAGE_GALLERY_TYPE,
+    ],
   },
   { label: "Embed external content", types: ["map", "video"] },
 ]
@@ -415,11 +418,12 @@ export const CONTENT_ALLOWED_BLOCKS: AllowedBlockSections = [
       "blockquote",
       "contentpic",
       "infobar",
+      IMAGE_GALLERY_TYPE,
     ],
   },
   {
     label: "Add a new section",
-    types: ["infocards", "infocols", "keystatistics", IMAGE_GALLERY_TYPE],
+    types: ["infocards", "infocols", "keystatistics"],
   },
   { label: "Embed external content", types: ["map", "video"] },
 ]


### PR DESCRIPTION
> [!NOTE]
> this entire PR and description is created by Cursor's background agent, to test its capabilities to improve engineering output

## Problem

The image gallery component was not selectable in the Page Editor UI for article pages, limiting content creation options.

Closes https://linear.app/ogp/issue/ISOM-1949/image-gallery-enable-for-article

## Solution

The `IMAGE_GALLERY_TYPE` has been added to the `ARTICLE_ALLOWED_BLOCKS` configuration in `apps/studio/src/components/PageEditor/constants.ts`. This makes the image gallery block available under a new "Add a new section" category for article pages.

**Breaking Changes**

- [ ] No - this PR is backwards compatible

**Features**:

- Enabled the Image Gallery component for Article Pages in the Page Editor.

**Improvements**:

- Enhanced content creation flexibility for article pages.

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details

**Manual Tests**:
- Navigate to an Article Page in the Studio Page Editor.
- Verify that "Image Gallery" is available as an option under "Add a new section".
- Add an Image Gallery block and confirm it functions as expected.