### PR TITLE
fix: adjust spacing for form fields helper text

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -161,7 +161,7 @@ const SuspendableModalContent = ({
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
             <FormControl isRequired isInvalid={!!errors.title}>
-              <FormLabel color="base.content.strong">
+              <FormLabel color="base.content.strong" mb={0}>
                 Folder name
                 <FormHelperText color="base.content.default">
                   This will be the title of the index page of your folder.
@@ -171,12 +171,13 @@ const SuspendableModalContent = ({
               <Input
                 placeholder="This is a title for your new folder"
                 maxLength={MAX_FOLDER_TITLE_LENGTH}
+                my="0.5rem"
                 {...register("title")}
               />
               {errors.title?.message ? (
                 <FormErrorMessage>{errors.title.message}</FormErrorMessage>
               ) : (
-                <FormHelperText mt="0.5rem" color="base.content.medium">
+                <FormHelperText color="base.content.medium">
                   {MAX_FOLDER_TITLE_LENGTH - (title || "").length} characters
                   left
                 </FormHelperText>
@@ -206,7 +207,7 @@ const SuspendableModalContent = ({
               {errors.permalink?.message ? (
                 <FormErrorMessage>{errors.permalink.message}</FormErrorMessage>
               ) : (
-                <Suspense fallback={<Skeleton w="100%" h="2rem" mt="0.5rem" />}>
+                <Suspense fallback={<Skeleton w="100%" h="2rem" my="0.5rem" />}>
                   <Box
                     mt="0.5rem"
                     py="0.5rem"
@@ -214,6 +215,7 @@ const SuspendableModalContent = ({
                     bg="interaction.support.disabled"
                     display="flex"
                     alignItems="center"
+                    my="0.5rem"
                   >
                     <Icon mr="0.5rem" as={BiLink} />
                     <SuspendablePermalink
@@ -224,7 +226,7 @@ const SuspendableModalContent = ({
                 </Suspense>
               )}
 
-              <FormHelperText mt="0.5rem" color="base.content.medium">
+              <FormHelperText color="base.content.medium">
                 {MAX_FOLDER_PERMALINK_LENGTH - (permalink || "").length}{" "}
                 characters left
               </FormHelperText>

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -1,7 +1,7 @@
 import type { ButtonProps, StackProps } from "@chakra-ui/react"
+import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd"
 import type { IconType } from "react-icons"
 import { chakra, Flex, HStack, Icon, Stack, Text } from "@chakra-ui/react"
-import { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd"
 import { BiGridVertical } from "react-icons/bi"
 
 interface BaseBlockProps {

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -294,12 +294,14 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         />
         <ErrorProvider>
           <Box flex={1} overflow="auto" px="1.5rem" py="1rem">
-            <FormBuilder<IsomerComponent>
-              schema={subSchema}
-              validateFn={validateFn}
-              data={component}
-              handleChange={handleChange}
-            />
+            <Box mb="1rem">
+              <FormBuilder<IsomerComponent>
+                schema={subSchema}
+                validateFn={validateFn}
+                data={component}
+                handleChange={handleChange}
+              />
+            </Box>
           </Box>
           <Box
             bgColor="base.canvas.default"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionModal/CreateCollectionModal.tsx
@@ -137,7 +137,7 @@ const CreateCollectionModalContent = ({
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.5rem">
             <FormControl isRequired isInvalid={!!errors.collectionTitle}>
-              <FormLabel color="base.content.strong">
+              <FormLabel color="base.content.strong" mb={0}>
                 Collection name
                 <FormHelperText color="base.content.default">
                   This will be the title of the index page of your collection.
@@ -146,6 +146,7 @@ const CreateCollectionModalContent = ({
 
               <Input
                 placeholder="This is a title for your new collection"
+                my="0.5rem"
                 {...register("collectionTitle")}
               />
               {errors.collectionTitle?.message ? (
@@ -153,7 +154,7 @@ const CreateCollectionModalContent = ({
                   {errors.collectionTitle.message}
                 </FormErrorMessage>
               ) : (
-                <FormHelperText mt="0.5rem" color="base.content.medium">
+                <FormHelperText color="base.content.medium">
                   {MAX_FOLDER_TITLE_LENGTH - collectionTitle.length} characters
                   left
                 </FormHelperText>
@@ -195,12 +196,13 @@ const CreateCollectionModalContent = ({
                 py="0.5rem"
                 px="0.75rem"
                 bg="interaction.support.disabled"
+                my="0.5rem"
               >
                 <Icon mr="0.5rem" as={BiLink} />
                 {permalink}
               </Box>
 
-              <FormHelperText mt="0.5rem" color="base.content.medium">
+              <FormHelperText color="base.content.medium">
                 {MAX_FOLDER_PERMALINK_LENGTH - permalink.length} characters left
               </FormHelperText>
             </FormControl>

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -162,7 +162,7 @@ export const CreateCollectionPageDetailsScreen = () => {
             <Stack gap="1.5rem">
               {/* Section 1: Page Title */}
               <FormControl isRequired isInvalid={!!errors.title}>
-                <FormLabel color="base.content.strong">
+                <FormLabel color="base.content.strong" mb={0}>
                   {type === ResourceType.CollectionPage ? "Page" : "Item"} title
                   <FormHelperText color="base.content.default">
                     Title should be descriptive
@@ -172,6 +172,7 @@ export const CreateCollectionPageDetailsScreen = () => {
                 <Input
                   placeholder="This is a title for your new page"
                   maxLength={MAX_TITLE_LENGTH}
+                  my="0.5rem"
                   {...register("title")}
                 />
                 {errors.title?.message ? (

--- a/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateFolderModal/CreateFolderModal.tsx
@@ -145,6 +145,7 @@ const CreateFolderModalContent = ({
               <Input
                 placeholder="This is a title for your new folder"
                 maxLength={MAX_FOLDER_TITLE_LENGTH}
+                my="0.5rem"
                 {...register("folderTitle")}
               />
               {errors.folderTitle?.message ? (
@@ -152,7 +153,7 @@ const CreateFolderModalContent = ({
                   {errors.folderTitle.message}
                 </FormErrorMessage>
               ) : (
-                <FormHelperText mt="0.5rem" color="base.content.medium">
+                <FormHelperText color="base.content.medium">
                   {MAX_FOLDER_TITLE_LENGTH - folderTitle.length} characters left
                 </FormHelperText>
               )}
@@ -193,12 +194,13 @@ const CreateFolderModalContent = ({
                 py="0.5rem"
                 px="0.75rem"
                 bg="interaction.support.disabled"
+                my="0.5rem"
               >
                 <Icon mr="0.5rem" as={BiLink} />
                 {permalink}
               </Box>
 
-              <FormHelperText mt="0.5rem" color="base.content.medium">
+              <FormHelperText color="base.content.medium">
                 {MAX_FOLDER_PERMALINK_LENGTH - permalink.length} characters left
               </FormHelperText>
             </FormControl>

--- a/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreatePageModal/DetailsScreen.tsx
@@ -119,7 +119,7 @@ export const CreatePageDetailsScreen = () => {
               <Stack gap="1.5rem">
                 {/* Section 1: Page Title */}
                 <FormControl isRequired isInvalid={!!errors.title}>
-                  <FormLabel color="base.content.strong">
+                  <FormLabel color="base.content.strong" mb={0}>
                     Page title
                     <FormHelperText color="base.content.default">
                       Title should be descriptive
@@ -128,8 +128,9 @@ export const CreatePageDetailsScreen = () => {
 
                   <Input
                     placeholder="This is a title for your new page"
-                    {...register("title")}
                     maxLength={MAX_TITLE_LENGTH}
+                    my="0.5rem"
+                    {...register("title")}
                   />
                   {errors.title?.message ? (
                     <FormErrorMessage>{errors.title.message}</FormErrorMessage>

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -203,12 +203,14 @@ export default function HeroEditorDrawer(): JSX.Element {
 
         <ErrorProvider>
           <Box px="1.5rem" py="1rem" flex={1} overflow="auto">
-            <FormBuilder<IsomerComponent>
-              schema={subSchema}
-              validateFn={validateFn}
-              data={previewPageState.content[0]}
-              handleChange={handleChange}
-            />
+            <Box mb="1rem">
+              <FormBuilder<IsomerComponent>
+                schema={subSchema}
+                validateFn={validateFn}
+                data={previewPageState.content[0]}
+                handleChange={handleChange}
+              />
+            </Box>
           </Box>
           <Box
             bgColor="base.canvas.default"

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -138,12 +138,14 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
               </Box>
             )}
 
-            <FormBuilder<Static<typeof metadataSchema>>
-              schema={metadataSchema}
-              validateFn={validateFn}
-              data={previewPageState.page}
-              handleChange={(data) => handleChange(data)}
-            />
+            <Box mb="1rem">
+              <FormBuilder<Static<typeof metadataSchema>>
+                schema={metadataSchema}
+                validateFn={validateFn}
+                data={previewPageState.page}
+                handleChange={(data) => handleChange(data)}
+              />
+            </Box>
           </Box>
           <Box
             bgColor="base.canvas.default"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
@@ -63,7 +63,9 @@ export function JsonFormsTextAreaControl({
   return (
     <Box>
       <FormControl isRequired={required} isInvalid={!!errors}>
-        <FormLabel description={description}>{label}</FormLabel>
+        <FormLabel description={description} mb={0}>
+          {label}
+        </FormLabel>
         <Textarea
           value={String(data || "")}
           onChange={onChange}
@@ -71,9 +73,10 @@ export function JsonFormsTextAreaControl({
           maxLength={maxLength}
           minAutosizeRows={numOfRows}
           maxAutosizeRows={numOfRows}
+          my="0.5rem"
         />
         {maxLength && !errors && (
-          <FormHelperText mt="0.5rem">
+          <FormHelperText>
             {remainingCharacterCount}{" "}
             {remainingCharacterCount === 1 ? "character" : "characters"} left
           </FormHelperText>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextControl.tsx
@@ -52,7 +52,7 @@ export function JsonFormsTextControl({
   return (
     <Box>
       <FormControl isRequired={required} isInvalid={!!errors}>
-        <FormLabel description={description} margin="0rem 0rem 0.5rem 0rem">
+        <FormLabel description={description} mb={0}>
           {label}
         </FormLabel>
         <Input
@@ -61,9 +61,10 @@ export function JsonFormsTextControl({
           onChange={onChange}
           placeholder={label}
           maxLength={maxLength}
+          my="0.5rem"
         />
         {maxLength && !errors && (
-          <FormHelperText mt="0.5rem">
+          <FormHelperText>
             {remainingCharacterCount}{" "}
             {remainingCharacterCount === 1 ? "character" : "characters"} left
           </FormHelperText>

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/__tests__/utils.test.ts
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
 import { cloneDeep } from "lodash"
 import { describe, expect, it } from "vitest"
 
-import { ChildPage } from "../types"
+import type { ChildPage } from "../types"
 import { mergeChildrenPages } from "../utils"
 
 const generateChildrenPages = (extraPages: ChildPage[] = []): ChildPage[] => {

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/types.ts
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/types.ts
@@ -1,4 +1,4 @@
-import { IsomerSitemap } from "~/types"
+import type { IsomerSitemap } from "~/types"
 
 export type ChildPage = Pick<IsomerSitemap, "id" | "title" | "image"> & {
   url: IsomerSitemap["permalink"]

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardContainer.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardContainer.tsx
@@ -1,9 +1,7 @@
-import { PropsWithChildren } from "react"
+import type { PropsWithChildren } from "react"
 
-import {
-  INFOCARD_VARIANT,
-  SingleCardWithImageProps,
-} from "~/interfaces/complex/InfoCards"
+import type { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
+import { INFOCARD_VARIANT } from "~/interfaces/complex/InfoCards"
 import { getReferenceLinkHref } from "~/utils"
 import { Link } from "../../../internal/Link"
 import { compoundStyles } from "../common"

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardImage.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardImage.tsx
@@ -1,11 +1,9 @@
-import {
-  INFOCARD_VARIANT,
-  SingleCardWithImageProps,
-} from "~/interfaces/complex/InfoCards"
+import type { With4Cols } from "./types"
+import type { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
+import { INFOCARD_VARIANT } from "~/interfaces/complex/InfoCards"
 import { getTailwindVariantLayout, isExternalUrl } from "~/utils"
 import { ImageClient } from "../../Image"
 import { compoundStyles } from "../common"
-import { With4Cols } from "./types"
 
 export const InfoCardImage = ({
   imageUrl,

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardNoImage.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardNoImage.tsx
@@ -1,4 +1,4 @@
-import { SingleCardNoImageProps } from "~/interfaces/complex/InfoCards"
+import type { SingleCardNoImageProps } from "~/interfaces/complex/InfoCards"
 import { isExternalUrl } from "~/utils"
 import { InfoCardContainer } from "./InfoCardContainer"
 import { InfoCardText } from "./InfoCardText"

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardText.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardText.tsx
@@ -1,6 +1,6 @@
 import { BiRightArrowAlt } from "react-icons/bi"
 
-import { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
+import type { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
 import { compoundStyles, infoCardTitleStyle } from "../common"
 
 export const InfoCardText = ({

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardWithFullImage.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardWithFullImage.tsx
@@ -1,12 +1,10 @@
-import {
-  INFOCARD_VARIANT,
-  SingleCardWithImageProps,
-} from "~/interfaces/complex/InfoCards"
+import type { With4Cols } from "./types"
+import type { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
+import { INFOCARD_VARIANT } from "~/interfaces/complex/InfoCards"
 import { isExternalUrl } from "~/utils"
 import { InfoCardContainer } from "./InfoCardContainer"
 import { InfoCardImage } from "./InfoCardImage"
 import { InfoCardText } from "./InfoCardText"
-import { With4Cols } from "./types"
 
 export const InfoCardWithFullImage = ({
   title,

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardWithImage.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/InfoCardWithImage.tsx
@@ -1,4 +1,4 @@
-import { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
+import type { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
 import { isExternalUrl } from "~/utils"
 import { InfoCardContainer } from "./InfoCardContainer"
 import { InfoCardImage } from "./InfoCardImage"

--- a/packages/components/src/templates/next/components/complex/InfoCards/components/types.ts
+++ b/packages/components/src/templates/next/components/complex/InfoCards/components/types.ts
@@ -1,4 +1,4 @@
-import { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
+import type { SingleCardWithImageProps } from "~/interfaces/complex/InfoCards"
 
 // NOTE: helper type to extend the base number of columns
 export type With4Cols<T extends Pick<SingleCardWithImageProps, "maxColumns">> =


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

For some reason the spacing between the form field helper text and the input boxes have narrowed.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Restore the spacing between the helper text and the input fields to be 0.5rem.
- We have also not ran lint and formatting fixes for some time, so ran it to clean up the codebase.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

![image](https://github.com/user-attachments/assets/92dcf81b-8975-4c5b-9575-a7c77e362d06)


**AFTER**:

<!-- [insert screenshot here] -->
![image](https://github.com/user-attachments/assets/367e4d7a-0bc7-4587-bf26-a34ed4011c01)

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit any content page
- [ ] Add a new Blockquote component
- [ ] Verify that the number of characters left helper text below the text area and the text input box are not joined together (refer to the screenshots above)