### PR TITLE
fix: use a random state with Singpass OIDC

### DIFF
--- a/apps/studio/src/schemas/auth/singpass.ts
+++ b/apps/studio/src/schemas/auth/singpass.ts
@@ -1,6 +1,5 @@
 import { z } from "zod"
 
-import { SINGPASS_SIGN_IN_STATE } from "~/server/modules/auth/singpass/singpass.constants"
 import { callbackUrlSchema } from "../url"
 
 export const singpassLoginSchema = z.object({
@@ -10,8 +9,4 @@ export const singpassLoginSchema = z.object({
 export const singpassCallbackSchema = z.object({
   state: z.string(),
   code: z.string(),
-})
-
-export const singpassStateSchema = z.object({
-  state: z.literal(SINGPASS_SIGN_IN_STATE),
 })

--- a/apps/studio/src/server/modules/auth/singpass/__tests__/singpass.router.test.ts
+++ b/apps/studio/src/server/modules/auth/singpass/__tests__/singpass.router.test.ts
@@ -11,7 +11,6 @@ import type { SessionData } from "~/lib/types/session"
 import { env } from "~/env.mjs"
 import { AuditLogEvent, db } from "~/server/modules/database"
 import { createCallerFactory } from "~/server/trpc"
-import { SINGPASS_SIGN_IN_STATE } from "../singpass.constants"
 import { singpassRouter } from "../singpass.router"
 import * as SingpassService from "../singpass.service"
 
@@ -165,34 +164,6 @@ describe("auth.singpass", () => {
       )
     })
 
-    it("should throw if Singpass callback state is invalid", async () => {
-      // Arrange
-      session.singpass = {
-        sessionState: {
-          userId: "user-id" as NonNullable<
-            NonNullable<SessionData["singpass"]>["sessionState"]
-          >["userId"],
-          verificationToken: {} as never,
-          codeVerifier: "code-verifier",
-          nonce: "nonce",
-        },
-      }
-      await session.save()
-
-      // Assert
-      await expect(
-        caller.callback({
-          state: "invalid-state",
-          code: "code",
-        }),
-      ).rejects.toThrowError(
-        new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Invalid Singpass callback state",
-        }),
-      )
-    })
-
     it("should throw if the Singpass UUID cannot be extracted", async () => {
       // Arrange
       session.singpass = {
@@ -214,7 +185,7 @@ describe("auth.singpass", () => {
       // Assert
       await expect(
         caller.callback({
-          state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+          state: JSON.stringify({ state: expect.any(String) }),
           code: "code",
         }),
       ).rejects.toThrowError(
@@ -252,7 +223,7 @@ describe("auth.singpass", () => {
       // Assert
       await expect(
         caller.callback({
-          state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+          state: JSON.stringify({ state: expect.any(String) }),
           code: "code",
         }),
       ).rejects.toThrowError(
@@ -289,7 +260,7 @@ describe("auth.singpass", () => {
 
       // Act
       await caller.callback({
-        state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+        state: JSON.stringify({ state: expect.any(String) }),
         code: "code",
       })
 
@@ -349,7 +320,7 @@ describe("auth.singpass", () => {
 
       // Act
       await caller.callback({
-        state: JSON.stringify({ state: SINGPASS_SIGN_IN_STATE }),
+        state: JSON.stringify({ state: expect.any(String) }),
         code: "code",
       })
 

--- a/apps/studio/src/server/modules/auth/singpass/singpass.constants.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.constants.ts
@@ -3,7 +3,6 @@ import { calculateJwkThumbprint, exportJWK, importPKCS8 } from "jose"
 import { env } from "~/env.mjs"
 import { getBaseUrl } from "~/utils/getBaseUrl"
 
-export const SINGPASS_SIGN_IN_STATE = "sign-in"
 export const SINGPASS_SCOPES = ["openid"]
 
 export const SINGPASS_REDIRECT_URI =

--- a/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
@@ -7,10 +7,8 @@ import { DASHBOARD } from "~/lib/routes"
 import {
   singpassCallbackSchema,
   singpassLoginSchema,
-  singpassStateSchema,
 } from "~/schemas/auth/singpass"
 import { publicProcedure, router } from "~/server/trpc"
-import { safeSchemaJsonParse } from "~/utils/zod"
 import { logUserEvent } from "../../audit/audit.service"
 import { recordUserLogin } from "../auth.service"
 import { generateSessionOptions } from "../session"
@@ -94,20 +92,6 @@ export const singpassRouter = router({
         })
       }
 
-      const parsedState = safeSchemaJsonParse(singpassStateSchema, state)
-
-      if (!parsedState.success) {
-        ctx.logger.error(
-          { state, error: parsedState.error },
-          "Invalid Singpass callback state",
-        )
-
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Invalid Singpass callback state",
-        })
-      }
-
       const { codeVerifier, nonce, userId, verificationToken } =
         ctx.session.singpass.sessionState
 
@@ -127,12 +111,12 @@ export const singpassRouter = router({
         code,
         codeVerifier,
         nonce,
-        state: parsedState.data,
+        state,
       })
 
       if (!uuid) {
         ctx.logger.error(
-          { code, codeVerifier, nonce, state: parsedState.data },
+          { code, codeVerifier, nonce, state },
           "Failed to login to Singpass",
         )
 

--- a/apps/studio/src/server/modules/auth/singpass/singpass.service.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.service.ts
@@ -1,13 +1,10 @@
-import type { z } from "zod"
 import { generators, Issuer } from "openid-client"
 
-import type { singpassStateSchema } from "~/schemas/auth/singpass"
 import { env } from "~/env.mjs"
 import {
   SINGPASS_ENCRYPTION_JWK,
   SINGPASS_REDIRECT_URI,
   SINGPASS_SCOPES,
-  SINGPASS_SIGN_IN_STATE,
   SINGPASS_SIGNING_JWK,
 } from "./singpass.constants"
 import { extractUuid } from "./singpass.utils"
@@ -29,7 +26,7 @@ export const getAuthorizationUrl = () => {
   const codeVerifier = generators.codeVerifier()
   const codeChallenge = generators.codeChallenge(codeVerifier)
   const nonce = generators.nonce()
-  const state = JSON.stringify({ state: SINGPASS_SIGN_IN_STATE })
+  const state = generators.state()
 
   const authorizationUrl = singpassClient.authorizationUrl({
     redirect_uri: SINGPASS_REDIRECT_URI,
@@ -51,7 +48,7 @@ interface LoginParams {
   code: string
   codeVerifier: string
   nonce: string
-  state: z.infer<typeof singpassStateSchema>
+  state: string
 }
 
 export const login = async ({


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

See https://opengovproducts.slack.com/archives/C0949RH4NTA/p1751898618082599 for more details.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- A randomised `state` is used alongside `nonce` for better protection.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Log in to Isomer Studio
- [ ] Attempt to log in using Singpass
- [ ] Verify that you are able to log in to Singpass successfully