### PR TITLE
Navbar logo alignment and megamenu arrow alignment are off

### DIFF
--- a/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavItem.tsx
@@ -126,11 +126,11 @@ const Megamenu = ({
         showExternalIcon={isExternal}
         isWithFocusVisibleHighlight
         href={referenceLinkHref}
-        className="group inline-flex w-fit items-center gap-1.5 hover:text-brand-interaction-hover hover:no-underline"
+        className="group relative w-fit items-center gap-1.5 hover:text-brand-interaction-hover hover:no-underline"
       >
         {name}
         {!isExternal && (
-          <BiRightArrowAlt className="text-[1.5rem] transition ease-in group-hover:translate-x-2.5" />
+          <BiRightArrowAlt className="inline text-[1.5rem] transition ease-in group-hover:translate-x-2.5" />
         )}
       </Link>
     )
@@ -179,11 +179,11 @@ const Megamenu = ({
                         showExternalIcon={isExternal}
                         isWithFocusVisibleHighlight
                         href={subItem.referenceLinkHref}
-                        className="group prose-label-md-medium inline-flex w-fit items-center gap-1 text-base-content hover:text-brand-interaction-hover hover:no-underline"
+                        className="group prose-label-md-medium relative w-fit items-center gap-1 text-base-content hover:text-brand-interaction-hover hover:no-underline"
                       >
                         {subItem.name}
                         {!isExternal && (
-                          <BiRightArrowAlt className="text-[1.25rem] transition ease-in group-hover:translate-x-1" />
+                          <BiRightArrowAlt className="mb-0.5 ml-1 inline text-[1.25rem] transition ease-in group-hover:translate-x-1" />
                         )}
                       </Link>
                       <p className="prose-label-sm-regular text-base-content-subtle">

--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.tsx
@@ -40,7 +40,7 @@ export const Navbar = ({
         alt: logoAlt,
         width: "100%",
         className:
-          "max-h-[48px] max-w-[128px] object-contain object-center lg:mr-3",
+          "max-h-[48px] max-w-[128px] object-contain object-left lg:mr-3",
         assetsBaseUrl: site.assetsBaseUrl,
         lazyLoading: false, // will always be above the fold
       }}


### PR DESCRIPTION
## Problem

- On megamenu, arrow is not inline with megamenu items.
- On navbar, logo is aligned to the center on iPhones, which leaves an awkward gap. Potentially because of `object-position: center`

Closes [ISOM-1978]

## Solution

- Make arrow inline
- Change to `object-position: left`

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x ] No - this PR is backwards compatible

## Before & After Screenshots

For the second issue of logo alignment, please check on Chromatic the browser modes that Adrian blessed us with ⭐ 

**BEFORE**:
Spot the tiny arrow:
<img width="366" height="194" alt="image" src="https://github.com/user-attachments/assets/6ad5d9f6-188e-4f30-acd8-90dc6c8afc35" />

**AFTER**:
<img width="393" height="188" alt="image" src="https://github.com/user-attachments/assets/fac854ed-5747-4da3-a697-4207c224a08f" />
