### PR TITLE
fix: add additional ordering by createdAt in user query

### DIFF
--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -235,6 +235,7 @@ export const userRouter = router({
 
       return getUsersQuery({ siteId, adminType })
         .orderBy("ActiveUser.lastLoginAt", sql.raw(`DESC NULLS LAST`))
+        .orderBy("ActiveUser.createdAt", "desc")
         .select((eb) => [
           "ActiveUser.id",
           "ActiveUser.email",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C07CWUNUL68/p1752655893507529

issue: order not preserved for pagination due to similarly sorted order (all no lastLoginAt) with no tie breaker

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- use user's createdAt as tiebreaker
