### PR TITLE
Notification - show once per session

### DIFF
--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useState } from "react"
 import { BiInfoCircle, BiX } from "react-icons/bi"
+import { useSessionStorage } from "usehooks-ts"
 
 import type { NotificationClientProps } from "~/interfaces"
 import { IconButton } from "../IconButton"
@@ -10,13 +10,17 @@ const NotificationClient = ({
   title,
   baseParagraph,
 }: NotificationClientProps) => {
-  const [isShown, setIsShown] = useState(true)
+  const [isDismissed, setIsDismissed] = useSessionStorage(
+    "notification-dismissed",
+    false,
+  )
+
   const onDismiss = () => {
-    setIsShown(false)
+    setIsDismissed(true)
   }
 
   return (
-    isShown && (
+    !isDismissed && (
       <div className="bg-utility-feedback-info-faint">
         <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
           <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Notification keep showing up when navigating between pages despite being dismissed

damn annoying sia!

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- use `useSessionStorage` from `usehooks-ts` instead.
  - Note: was thinking whether i should use localstorage with arbitrary 24 hours TTL instead of sessionstorage but a bit lazy to implement that so shall pass for now
- refactor: update state name as `isShown` was a bit confusing to me as its unclear if it "is being shown" or "has been shown"

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to a site with notifcation and dismiss it
2. navigate to another page -> it should not show
3. restart session (either by closing tab, or going into dev console to remove the session storage key)
4. reload the page -> it should show again