### PR TITLE
refactor: replace string event types with AuditLogEvent enums

### DIFF
--- a/apps/studio/src/server/modules/auth/auth.router.ts
+++ b/apps/studio/src/server/modules/auth/auth.router.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 
 import { publicProcedure, router } from "~/server/trpc"
 import getIP from "~/utils/getClientIp"
@@ -32,7 +33,7 @@ export const authRouter = router({
       const ip = getIP(ctx.req)
 
       return logAuthEvent(tx, {
-        eventType: "Logout",
+        eventType: AuditLogEvent.Logout,
         delta: {
           before: user,
           after: null,

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -1,5 +1,6 @@
 import type { UnwrapTagged } from "type-fest"
 import { TRPCError } from "@trpc/server"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import { get, pick } from "lodash"
 
 import {
@@ -121,7 +122,7 @@ export const collectionRouter = router({
 
           await logResourceEvent(tx, {
             siteId,
-            eventType: "ResourceCreate",
+            eventType: AuditLogEvent.ResourceCreate,
             delta: { before: null, after: collection },
             by: user,
           })
@@ -207,7 +208,7 @@ export const collectionRouter = router({
 
         await logResourceEvent(tx, {
           siteId,
-          eventType: "ResourceCreate",
+          eventType: AuditLogEvent.ResourceCreate,
           by: user,
           delta: {
             before: null,
@@ -339,7 +340,7 @@ export const collectionRouter = router({
 
           await logResourceEvent(tx, {
             siteId,
-            eventType: "ResourceUpdate",
+            eventType: AuditLogEvent.ResourceUpdate,
             delta: {
               before: { blob: oldBlob, resource },
               after: { blob, resource },

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -316,7 +316,7 @@ export const pageRouter = router({
         })
         await logResourceEvent(tx, {
           siteId,
-          eventType: "ResourceUpdate",
+          eventType: AuditLogEvent.ResourceUpdate,
           delta: {
             before: {
               blob: oldBlob,
@@ -379,7 +379,7 @@ export const pageRouter = router({
             before: { blob: oldBlob, resource },
             after: { blob: updatedBlob, resource },
           },
-          eventType: "ResourceUpdate",
+          eventType: AuditLogEvent.ResourceUpdate,
         })
         return updatedBlob
       })
@@ -472,7 +472,7 @@ export const pageRouter = router({
               siteId,
               by,
               delta: { before: null, after: { blob, resource: addedResource } },
-              eventType: "ResourceCreate",
+              eventType: AuditLogEvent.ResourceCreate,
             })
 
             return addedResource
@@ -626,7 +626,7 @@ export const pageRouter = router({
             before: { resource, blob: oldBlob },
             after: { resource, blob: newBlob },
           },
-          eventType: "ResourceUpdate",
+          eventType: AuditLogEvent.ResourceUpdate,
         })
       })
     }),
@@ -708,7 +708,7 @@ export const pageRouter = router({
               siteId,
               by,
               delta: { before: resource, after: updatedResource },
-              eventType: "ResourceUpdate",
+              eventType: AuditLogEvent.ResourceUpdate,
             })
 
             // We do an implicit publish so that we can make the changes to the

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -1,6 +1,6 @@
 import type { GrowthBook } from "@growthbook/growthbook"
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
-import { RoleType } from "@prisma/client"
+import { AuditLogEvent, RoleType } from "@prisma/client"
 import { TRPCError } from "@trpc/server"
 import get from "lodash/get"
 import partition from "lodash/partition"
@@ -255,7 +255,7 @@ export const updateUserSitewidePermission = async ({
     }
 
     await logPermissionEvent(tx, {
-      eventType: "PermissionDelete",
+      eventType: AuditLogEvent.PermissionDelete,
       by: byUser,
       delta: { before: sitePermissionToRemove, after: deletedSitePermission },
     })
@@ -276,7 +276,7 @@ export const updateUserSitewidePermission = async ({
       })
 
     await logPermissionEvent(tx, {
-      eventType: "PermissionCreate",
+      eventType: AuditLogEvent.PermissionCreate,
       by: byUser,
       delta: { before: null, after: createdSitePermission },
     })

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from "@trpc/server"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import { jsonObjectFrom } from "kysely/helpers/postgres"
 import get from "lodash/get"
 
@@ -469,7 +470,7 @@ export const resourceRouter = router({
 
             await logResourceEvent(tx, {
               siteId,
-              eventType: "ResourceUpdate",
+              eventType: AuditLogEvent.ResourceUpdate,
               delta: { before: toMove, after: moved },
               by: user,
             })
@@ -608,7 +609,7 @@ export const resourceRouter = router({
             before,
           },
           by: user,
-          eventType: "ResourceDelete",
+          eventType: AuditLogEvent.ResourceDelete,
         })
 
         return tx

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -2,6 +2,7 @@ import type { SelectExpression } from "kysely"
 import type { Logger } from "pino"
 import type { UnwrapTagged } from "type-fest"
 import { TRPCError } from "@trpc/server"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import { type DB } from "~prisma/generated/generatedTypes"
 import _ from "lodash"
 
@@ -565,7 +566,7 @@ export const publishPageResource = async ({
             : null,
           after: version,
         },
-        eventType: "Publish",
+        eventType: AuditLogEvent.Publish,
         metadata: fullResource,
       })
 
@@ -617,7 +618,7 @@ export const publishResource = async (
         before: null,
         after: null,
       },
-      eventType: "Publish",
+      eventType: AuditLogEvent.Publish,
       metadata: resource,
     })
 
@@ -653,7 +654,7 @@ export const publishSiteConfig = async (
         before: null,
         after: null,
       },
-      eventType: "Publish",
+      eventType: AuditLogEvent.Publish,
       metadata: { site, ...rest },
     })
 

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -1,6 +1,7 @@
 import cuid2 from "@paralleldrive/cuid2"
 import { TRPCError } from "@trpc/server"
 import { PAST_AND_FORMER_ISOMER_MEMBERS_EMAILS } from "~prisma/constants"
+import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import isEmail from "validator/lib/isEmail"
 
 import type { DB, Transaction } from "../database"
@@ -97,7 +98,7 @@ export const createUserWithPermission = async ({
     // if user is defined, it means it's newly created and there's no conflict
     if (user) {
       await logUserEvent(tx, {
-        eventType: "UserCreate",
+        eventType: AuditLogEvent.UserCreate,
         by: byUser,
         delta: { before: null, after: user },
       })
@@ -136,7 +137,7 @@ export const createUserWithPermission = async ({
     }
 
     await logPermissionEvent(tx, {
-      eventType: "PermissionCreate",
+      eventType: AuditLogEvent.PermissionCreate,
       by: byUser,
       delta: { before: null, after: resourcePermission },
     })
@@ -256,7 +257,7 @@ export const deleteUserPermission = async ({
       }
 
       await logPermissionEvent(tx, {
-        eventType: "PermissionDelete",
+        eventType: AuditLogEvent.PermissionDelete,
         by: byUser,
         delta: { before, after: deletedUserPermission },
       })
@@ -290,7 +291,7 @@ export const updateUserDetails = async ({
       .executeTakeFirstOrThrow()
 
     await logUserEvent(tx, {
-      eventType: "UserUpdate",
+      eventType: AuditLogEvent.UserUpdate,
       by: user,
       delta: { before: user, after: updatedUser },
     })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

A bit hard to debug when trying to search through the codebase

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- use enums instead of hardcoded strings
 