### PR TITLE
increase inspector high threshold from 10 to 12

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -174,7 +174,7 @@ jobs:
           artifact_type: "container"
           artifact_path: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}"
           critical_threshold: 5
-          high_threshold: 10
+          high_threshold: 12
 
       # Display Inspector results in the GitHub Actions terminal
       - name: Display CycloneDX SBOM (JSON)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Blocking release while many of the findings raised are relating to esbuild toolchain

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- increase from 10 to 12 in aws_deploy workflow
