### PR TITLE
fix: update PermissionsProvider to use site perms instead of resource perms

### DIFF
--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -1051,7 +1051,8 @@ describe("getResourcePermission", () => {
     expect(permissions[0]?.role).toBe(RoleType.Admin)
   })
 
-  it("should return resource-specific permissions when resourceId is provided", async () => {
+  // TODO: add this back in when we have resource-specific permissions
+  it.skip("should return resource-specific permissions when resourceId is provided", async () => {
     // Arrange
     const user = await setupUser({ email: "test@example.com" })
     const { page, site } = await setupPageResource({
@@ -1115,7 +1116,8 @@ describe("getResourcePermission", () => {
     expect(permissions).toHaveLength(0)
   })
 
-  it("should not return site-wide permissions when resourceId is provided and is not null", async () => {
+  // TODO: add this back in when we have resource-specific permissions
+  it.skip("should not return site-wide permissions when resourceId is provided and is not null", async () => {
     // Arrange
     const user = await setupUser({ email: "test@example.com" })
     const { page, site } = await setupPageResource({

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -165,7 +165,7 @@ export const bulkValidateUserPermissionsForResources = async ({
 export const getResourcePermission = async ({
   userId,
   siteId,
-  resourceId,
+  resourceId: _resourceId,
 }: PermissionsProps) => {
   let query = db
     .selectFrom("ResourcePermission")
@@ -173,11 +173,9 @@ export const getResourcePermission = async ({
     .where("siteId", "=", siteId)
     .where("deletedAt", "is", null)
 
-  if (resourceId) {
-    query = query.where("resourceId", "=", resourceId)
-  } else {
-    query = query.where("resourceId", "is", null)
-  }
+  // NOTE: we are using site-wide permissions for now
+  // because there's no granular resource role
+  query = query.where("resourceId", "is", null)
 
   return query.select("role").execute()
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Publish button not shown https://opengovproducts.slack.com/archives/C06R4DX966P/p1753944863938479?thread_ts=1753939513.304439&cid=C06R4DX966P

previously, did a fix on a buggy query that does not return resource perms even when resourceId is passed in. Turns out that bug was pulling site perms always which make it return a correct value

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- use site perms by force passing in `resourceId: null`