### PR TITLE
Blogs/Collection links don't get a proper focus highlight

### DIFF
--- a/packages/components/src/templates/next/components/internal/CollectionCard/Title/collectionCardLinkStyle.ts
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/Title/collectionCardLinkStyle.ts
@@ -1,7 +1,7 @@
 import { tv } from "~/lib/tv"
-import { focusVisibleHighlight } from "~/utils"
+import { groupFocusVisibleHighlight } from "~/utils"
 
 export const collectionCardLinkStyle = tv({
-  extend: focusVisibleHighlight,
+  extend: groupFocusVisibleHighlight,
   base: "prose-title-md-semibold flex w-fit flex-col underline-offset-4 group-hover:underline",
 })


### PR DESCRIPTION
## Problem

* When navigating using keyboard, the blogCards and collectionCards titles don't get a proper focus-visible state. This is a violation of WCAG 2.4.7 

Closes [ISOM-2033]

## Solution

* Use groupFocusVisibleHighlight() instead