### PR TITLE
Fix/collection dropdown only those with children

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionDropdownControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionDropdownControl.tsx
@@ -31,6 +31,7 @@ function SuspendableJsonFormsCollectionDropdownControl({
 
   const [collections] = trpc.collection.getCollections.useSuspenseQuery({
     siteId: Number(siteId),
+    hasChildren: true,
   })
 
   return (

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -68,4 +68,5 @@ export const createCollectionSchema = z.object({
 
 export const getCollectionsSchema = z.object({
   siteId: z.number().min(1),
+  hasChildren: z.boolean().optional().default(false),
 })

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1243,7 +1243,7 @@ describe("collection.router", async () => {
       expect(result).toEqual([])
     })
 
-    it("should return all collections for the site ordered by title", async () => {
+    it("should return all collections for the site ordered by title (default behavior)", async () => {
       // Arrange
       const { site } = await setupSite()
       await setupEditorPermissions({ userId: session.userId, siteId: site.id })
@@ -1342,6 +1342,40 @@ describe("collection.router", async () => {
       expect(result[0]?.title).toBe("Test Collection")
       expect(result[0]?.id).toBe(collection.id)
       expect(result[0]?.type).toBe(ResourceType.Collection)
+    })
+
+    it("should return only collections that have children when hasChildren is true", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+
+      // Create collections
+      const { collection: collectionWithChildren } = await setupCollection({
+        siteId: site.id,
+        permalink: "collection-with-children",
+      })
+      const { collection: _emptyCollection } = await setupCollection({
+        siteId: site.id,
+        permalink: "empty-collection",
+      })
+
+      // Add children to the first collection
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collectionWithChildren.id,
+        permalink: "child-page",
+      })
+
+      // Act
+      const result = await caller.getCollections({
+        siteId: site.id,
+        hasChildren: true,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]?.id).toBe(collectionWithChildren.id)
     })
   })
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

collection dropdown selection include collection without children, which should not be selectable for collectionblock

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- extend API to allow one to filter only for collections with children
