### PR TITLE
Limit setSiteConfigByAdmin endpoint to isomer migrators and admins

### DIFF
--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -180,10 +180,10 @@ export const siteRouter = router({
       // validate the input JSON before parsing. Also ensure that existing site
       // configs in the database meets the schema requirements
       async ({ ctx, input: { siteId, config, theme, navbar, footer } }) => {
-        await validateUserPermissionsForSite({
-          siteId,
+        await validateUserIsIsomerCoreAdmin({
           userId: ctx.user.id,
-          action: "update",
+          gb: ctx.gb,
+          roles: [ADMIN_ROLE.CORE, ADMIN_ROLE.MIGRATORS],
         })
 
         await db.transaction().execute(async (tx) => {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently this endpoint is restricted to any admins with admin access to isomer, but in fact, we should play it more safe by only allowing isomer admins and migrators to access it

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- switch ACL validation from using site perms to growthbook list
