### PR TITLE
feat: allow OGP Maps to be embedded in Isomer Next

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -44,6 +44,7 @@ const ContentSecurityPolicy = `
     https://www.youtube-nocookie.com
     https://www.onemap.gov.sg
     https://www.facebook.com
+    https://maps.gov.sg
     ;
   object-src 'none';
   script-src

--- a/apps/studio/src/features/editing-experience/components/utils.ts
+++ b/apps/studio/src/features/editing-experience/components/utils.ts
@@ -22,9 +22,10 @@ export const EMBED_NAME_MAPPING: Record<
   keyof typeof MAPS_EMBED_URL_REGEXES | keyof typeof VIDEO_EMBED_URL_REGEXES,
   string
 > = {
-  fbvideo: "Facebook Video",
   googlemaps: "Google Map",
   onemap: "OneMap",
+  ogpmaps: "Maps.gov.sg",
+  fbvideo: "Facebook Video",
   youtube: "YouTube",
   vimeo: "Vimeo",
 }

--- a/packages/components/src/interfaces/complex/Map.ts
+++ b/packages/components/src/interfaces/complex/Map.ts
@@ -1,6 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
+import type { IsomerSiteProps, LinkComponentType } from "~/types"
 import { MAPS_EMBED_URL_PATTERN } from "~/utils/validation"
 
 export const MapSchema = Type.Object(
@@ -25,4 +26,7 @@ export const MapSchema = Type.Object(
   },
 )
 
-export type MapProps = Static<typeof MapSchema>
+export type MapProps = Static<typeof MapSchema> & {
+  site: IsomerSiteProps
+  LinkComponent?: LinkComponentType
+}

--- a/packages/components/src/templates/next/components/complex/Map/Map.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.stories.tsx
@@ -12,6 +12,34 @@ const meta: Meta<MapProps> = {
       themeOverride: "Isomer Next",
     },
   },
+  args: {
+    site: {
+      siteName: "Isomer Next",
+      siteMap: {
+        id: "1",
+        title: "Home",
+        permalink: "/",
+        lastModified: "",
+        layout: "homepage",
+        summary: "",
+      },
+      theme: "isomer-next",
+      isGovernment: true,
+      url: "https://www.isomer.gov.sg",
+      logoUrl: "/isomer-logo.svg",
+      navbar: { items: [] },
+      footerItems: {
+        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
+        termsOfUseLink: "https://www.isomer.gov.sg/terms",
+        siteNavItems: [],
+      },
+      lastUpdated: "1 Jan 2021",
+      search: {
+        type: "searchSG",
+        clientId: "",
+      },
+    },
+  },
 }
 export default meta
 type Story = StoryObj<typeof Map>

--- a/packages/components/src/templates/next/components/complex/Map/Map.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.stories.tsx
@@ -37,3 +37,11 @@ export const OneMapLocation: Story = {
     url: "https://www.onemap.gov.sg/minimap/minimap.html?mapStyle=Default&zoomLevel=15&latLng=1.29793747849037,103.850182257356&ewt=JTNDcCUzRSUzQ3N0cm9uZyUzRU9wZW4lMjBHb3Zlcm5tZW50JTIwUHJvZHVjdHMlMjBvZmZpY2UlM0MlMkZzdHJvbmclM0UlM0MlMkZwJTNF&popupWidth=200&showPopup=true",
   },
 }
+
+export const OGPMaps: Story = {
+  name: "Maps.gov.sg",
+  args: {
+    title: "Public AED Locations",
+    url: "https://maps.gov.sg/scdf-aed",
+  },
+}

--- a/packages/components/src/templates/next/components/complex/Map/Map.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react"
 
 import type { MapProps } from "~/interfaces"
+import { generateSiteConfig } from "~/stories/helpers"
 import { Map } from "./Map"
 
 const meta: Meta<MapProps> = {
@@ -13,32 +14,7 @@ const meta: Meta<MapProps> = {
     },
   },
   args: {
-    site: {
-      siteName: "Isomer Next",
-      siteMap: {
-        id: "1",
-        title: "Home",
-        permalink: "/",
-        lastModified: "",
-        layout: "homepage",
-        summary: "",
-      },
-      theme: "isomer-next",
-      isGovernment: true,
-      url: "https://www.isomer.gov.sg",
-      logoUrl: "/isomer-logo.svg",
-      navbar: { items: [] },
-      footerItems: {
-        privacyStatementLink: "https://www.isomer.gov.sg/privacy",
-        termsOfUseLink: "https://www.isomer.gov.sg/terms",
-        siteNavItems: [],
-      },
-      lastUpdated: "1 Jan 2021",
-      search: {
-        type: "searchSG",
-        clientId: "",
-      },
-    },
+    site: generateSiteConfig(),
   },
 }
 export default meta

--- a/packages/components/src/templates/next/components/complex/Map/Map.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.tsx
@@ -36,6 +36,7 @@ export const Map = ({ title, url, site, LinkComponent }: MapProps) => {
       {isOgpMapsEmbed && (
         <BaseParagraph
           content={`You can also view the map below on <a href="${url}">Maps.gov.sg</a>.`}
+          className={compoundStyles.paragraph()}
           site={site}
           LinkComponent={LinkComponent}
         />

--- a/packages/components/src/templates/next/components/complex/Map/Map.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.tsx
@@ -1,20 +1,42 @@
 import type { MapProps } from "~/interfaces"
-import { isValidMapEmbedUrl } from "~/utils/validation"
+import { tv } from "~/lib/tv"
+import { isValidMapEmbedUrl, isValidOGPMapsEmbedUrl } from "~/utils/validation"
 import { ComponentContent } from "../../internal/customCssClass"
+
+const createMapStyles = tv({
+  slots: {
+    outerContainer: `${ComponentContent} mt-7 first:mt-0`,
+    innerContainer: "relative w-full overflow-hidden pt-[75%]",
+    iframe: "absolute bottom-0 left-0 right-0 top-0 border-0",
+  },
+  variants: {
+    isOgpMapsUrl: {
+      true: {
+        innerContainer: "min-h-[45rem]",
+      },
+    },
+  },
+})
 
 export const Map = ({ title, url }: MapProps) => {
   if (!isValidMapEmbedUrl(url)) {
     return <></>
   }
 
+  const isOgpMapsUrl = isValidOGPMapsEmbedUrl(new URL(url))
+
+  const compoundStyles = createMapStyles({
+    isOgpMapsUrl,
+  })
+
   return (
-    <section className={`${ComponentContent} mt-7 first:mt-0`}>
+    <section className={compoundStyles.outerContainer()}>
       {/* NOTE: 75% is a 4:3 aspect ratio */}
-      <div className="relative w-full overflow-hidden pt-[75%]">
+      <div className={compoundStyles.innerContainer()}>
         <iframe
           height="100%"
           width="100%"
-          className="absolute bottom-0 left-0 right-0 top-0 border-0"
+          className={compoundStyles.iframe()}
           src={url}
           title={title || "Map embedded in the page"}
           allowFullScreen

--- a/packages/components/src/templates/next/components/complex/Map/Map.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.tsx
@@ -1,6 +1,7 @@
 import type { MapProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { isValidMapEmbedUrl, isValidOGPMapsEmbedUrl } from "~/utils/validation"
+import { BaseParagraph } from "../../internal"
 import { ComponentContent } from "../../internal/customCssClass"
 
 const createMapStyles = tv({
@@ -8,9 +9,10 @@ const createMapStyles = tv({
     outerContainer: `${ComponentContent} mt-7 first:mt-0`,
     innerContainer: "relative w-full overflow-hidden pt-[75%]",
     iframe: "absolute bottom-0 left-0 right-0 top-0 border-0",
+    paragraph: "prose-body-base text-base-content",
   },
   variants: {
-    isOgpMapsUrl: {
+    isOgpMapsEmbed: {
       true: {
         innerContainer: "min-h-[45rem]",
       },
@@ -18,19 +20,27 @@ const createMapStyles = tv({
   },
 })
 
-export const Map = ({ title, url }: MapProps) => {
+export const Map = ({ title, url, site, LinkComponent }: MapProps) => {
   if (!isValidMapEmbedUrl(url)) {
     return <></>
   }
 
-  const isOgpMapsUrl = isValidOGPMapsEmbedUrl(new URL(url))
+  const isOgpMapsEmbed = isValidOGPMapsEmbedUrl(new URL(url))
 
   const compoundStyles = createMapStyles({
-    isOgpMapsUrl,
+    isOgpMapsEmbed,
   })
 
   return (
     <section className={compoundStyles.outerContainer()}>
+      {isOgpMapsEmbed && (
+        <BaseParagraph
+          content={`You can also view the map below on <a href="${url}">Maps.gov.sg</a>.`}
+          site={site}
+          LinkComponent={LinkComponent}
+        />
+      )}
+
       {/* NOTE: 75% is a 4:3 aspect ratio */}
       <div className={compoundStyles.innerContainer()}>
         <iframe

--- a/packages/components/src/templates/next/components/complex/Map/Map.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.tsx
@@ -14,7 +14,7 @@ const createMapStyles = tv({
   variants: {
     isOgpMapsEmbed: {
       true: {
-        innerContainer: "min-h-[45rem]",
+        innerContainer: "min-h-[45rem] lg:min-h-0",
       },
     },
   },

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -24,7 +24,7 @@ export const BaseParagraph = ({
   LinkComponent,
 }: Omit<BaseParagraphProps, "type">) => {
   const transform = (node: HTMLElement, children: Node[]): React.ReactNode => {
-    if (node.tagName === "a") {
+    if (node.tagName === "A") {
       const href = node.getAttribute("href") ?? undefined
       const isExternalLink = !!href && isExternalUrl(href)
 

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -24,7 +24,7 @@ export const BaseParagraph = ({
   LinkComponent,
 }: Omit<BaseParagraphProps, "type">) => {
   const transform = (node: HTMLElement, children: Node[]): React.ReactNode => {
-    if (node.tagName === "A") {
+    if (node.tagName === "a") {
       const href = node.getAttribute("href") ?? undefined
       const isExternalLink = !!href && isExternalUrl(href)
 

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react"
 
 import { withChromaticModes } from "@isomer/storybook-config"
 
-import { IMAGE_GALLERY_TYPE } from "~/interfaces"
 import { generateSiteConfig } from "~/stories/helpers"
 import Content from "./Content"
 
@@ -2976,6 +2975,12 @@ export const NoTable: Story = {
           ],
         },
       },
+
+      {
+        type: "map",
+        title: "Public AED locations",
+        url: "https://maps.gov.sg/scdf-aed",
+      },
       {
         type: "prose",
         content: [
@@ -3234,6 +3239,11 @@ export const NoTable: Story = {
             ],
           },
         ],
+      },
+      {
+        type: "map",
+        title: "Error map",
+        url: "https://maps.gov.sg/this-map-should-not-exist!",
       },
       {
         type: "image",

--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -148,22 +148,6 @@ describe("validation", () => {
       })
     })
 
-    it("should not allow OGP Maps embed URLs with invalid slugs or from staging", () => {
-      const testCases = [
-        "https://maps.gov.sg/invalid_slug!",
-        "https://maps.gov.sg/1234567890-",
-        "https://maps.gov.sg/-abc-def_ghi-jkl",
-        "https://maps.gov.sg/abc-def_ghi-jkl@123",
-        "https://staging.maps.gov.sg/alphanumeric12354",
-        "https://staging.maps.gov.sg/alphabets",
-      ]
-
-      testCases.forEach((testCase) => {
-        const result = new RegExp(MAPS_EMBED_URL_PATTERN).test(testCase)
-        expect(result).toBe(false)
-      })
-    })
-
     it("should not allow any other site's URLs", () => {
       const testCases = [
         "https://www.example.com/maps/embed?pb=!1m18!1m12!1m3!1d3961.473373876674!2d103.8486973142665!3d1.3035969990313745!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19b8b4c6e1e1%3A0x2f1f6b8f0a1b2a7d!2sMinistry%20of%20Communications%20and%20Information!5e0!3m2!1sen!2ssg!4v1632291134655!5m2!1en!2sg",

--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -133,6 +133,37 @@ describe("validation", () => {
       })
     })
 
+    it("should allow OGP Maps embed URLs", () => {
+      const testCases = [
+        "https://maps.gov.sg/scdf-aed",
+        "https://maps.gov.sg/alphanumeric12354",
+        "https://maps.gov.sg/alphabets",
+        "https://maps.gov.sg/1234567890",
+        "https://maps.gov.sg/abc-def_ghi-jkl",
+      ]
+
+      testCases.forEach((testCase) => {
+        const result = new RegExp(MAPS_EMBED_URL_PATTERN).test(testCase)
+        expect(result).toBe(true)
+      })
+    })
+
+    it("should not allow OGP Maps embed URLs with invalid slugs or from staging", () => {
+      const testCases = [
+        "https://maps.gov.sg/invalid_slug!",
+        "https://maps.gov.sg/1234567890-",
+        "https://maps.gov.sg/-abc-def_ghi-jkl",
+        "https://maps.gov.sg/abc-def_ghi-jkl@123",
+        "https://staging.maps.gov.sg/alphanumeric12354",
+        "https://staging.maps.gov.sg/alphabets",
+      ]
+
+      testCases.forEach((testCase) => {
+        const result = new RegExp(MAPS_EMBED_URL_PATTERN).test(testCase)
+        expect(result).toBe(false)
+      })
+    })
+
     it("should not allow any other site's URLs", () => {
       const testCases = [
         "https://www.example.com/maps/embed?pb=!1m18!1m12!1m3!1d3961.473373876674!2d103.8486973142665!3d1.3035969990313745!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19b8b4c6e1e1%3A0x2f1f6b8f0a1b2a7d!2sMinistry%20of%20Communications%20and%20Information!5e0!3m2!1sen!2ssg!4v1632291134655!5m2!1en!2sg",

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -38,6 +38,20 @@ const isValidOneMapEmbedUrl = (urlObject: URL) => {
   )
 }
 
+// Slug pattern obtained from:
+// https://github.com/opengovsg/maps/blob/8c3f2e6c9af1be78fac5fc69115858241ae1f720/apps/web/modules/map/schema.ts#L3-L16
+const OGP_MAPS_SLUG_REGEX_PATTERN = "[a-z0-9][a-z0-9_-]*[a-z0-9]"
+
+const isValidOGPMapsEmbedUrl = (urlObject: URL) => {
+  return (
+    urlObject.hostname === "maps.gov.sg" &&
+    urlObject.pathname.startsWith("/") &&
+    new RegExp(`^${OGP_MAPS_SLUG_REGEX_PATTERN}$`).test(
+      urlObject.pathname.slice(1),
+    )
+  )
+}
+
 export const isValidMapEmbedUrl = (url: string) => {
   if (!url) {
     return false
@@ -48,7 +62,8 @@ export const isValidMapEmbedUrl = (url: string) => {
 
     return (
       (isValidGoogleMapsEmbedUrl(urlObject) ||
-        isValidOneMapEmbedUrl(urlObject)) &&
+        isValidOneMapEmbedUrl(urlObject) ||
+        isValidOGPMapsEmbedUrl(urlObject)) &&
       new RegExp(MAPS_EMBED_URL_PATTERN).test(url)
     )
   } catch (_) {
@@ -63,6 +78,7 @@ export const MAPS_EMBED_URL_REGEXES = {
   googlemaps: "^https://www\\.google\\.com/maps(?:/d)?/embed?.*$",
   onemap:
     "^https://www\\.onemap\\.gov\\.sg(/minimap/minimap\\.html|/amm/amm\\.html).*$",
+  ogpmaps: `^https://maps\\.gov\\.sg/${OGP_MAPS_SLUG_REGEX_PATTERN}$`,
 } as const
 
 export const MAPS_EMBED_URL_PATTERN = Object.values(MAPS_EMBED_URL_REGEXES)

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -38,7 +38,7 @@ const isValidOneMapEmbedUrl = (urlObject: URL) => {
   )
 }
 
-const isValidOGPMapsEmbedUrl = (urlObject: URL) => {
+export const isValidOGPMapsEmbedUrl = (urlObject: URL) => {
   return (
     urlObject.hostname === "maps.gov.sg" && urlObject.pathname.startsWith("/")
   )

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -38,17 +38,9 @@ const isValidOneMapEmbedUrl = (urlObject: URL) => {
   )
 }
 
-// Slug pattern obtained from:
-// https://github.com/opengovsg/maps/blob/8c3f2e6c9af1be78fac5fc69115858241ae1f720/apps/web/modules/map/schema.ts#L3-L16
-const OGP_MAPS_SLUG_REGEX_PATTERN = "[a-z0-9][a-z0-9_-]*[a-z0-9]"
-
 const isValidOGPMapsEmbedUrl = (urlObject: URL) => {
   return (
-    urlObject.hostname === "maps.gov.sg" &&
-    urlObject.pathname.startsWith("/") &&
-    new RegExp(`^${OGP_MAPS_SLUG_REGEX_PATTERN}$`).test(
-      urlObject.pathname.slice(1),
-    )
+    urlObject.hostname === "maps.gov.sg" && urlObject.pathname.startsWith("/")
   )
 }
 
@@ -78,7 +70,7 @@ export const MAPS_EMBED_URL_REGEXES = {
   googlemaps: "^https://www\\.google\\.com/maps(?:/d)?/embed?.*$",
   onemap:
     "^https://www\\.onemap\\.gov\\.sg(/minimap/minimap\\.html|/amm/amm\\.html).*$",
-  ogpmaps: `^https://maps\\.gov\\.sg/${OGP_MAPS_SLUG_REGEX_PATTERN}$`,
+  ogpmaps: `^https://maps\\.gov\\.sg/.*$`,
 } as const
 
 export const MAPS_EMBED_URL_PATTERN = Object.values(MAPS_EMBED_URL_REGEXES)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

OGP Maps is not supported on Isomer Next.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add support for OGP Maps.
    - CSP whitelist is on infra repo: https://github.com/opengovsg/isomer-next-infra/pull/191

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit any content page.
- [ ] Add a new Map component to the page.
- [ ] Edit the embed and insert the following:
```
<iframe src="https://maps.gov.sg/scdf-aed" width="100%" height="600" frameborder="0"></iframe>
```
- [ ] Verify that the embed is able to be created, and the map loads as expected.