### PR TITLE
fix: remove inactive users only for production

### DIFF
--- a/apps/studio/src/server/cron/index.ts
+++ b/apps/studio/src/server/cron/index.ts
@@ -1,3 +1,4 @@
+import { env } from "~/env.mjs"
 import { createBaseLogger } from "../../lib/logger"
 import { deactivateInactiveUsersJob } from "./jobs"
 
@@ -10,7 +11,12 @@ export const initializeCronJobs = () => {
   logger.info("Initializing cron jobs...")
 
   // Initialize and track all cron jobs
-  cronJobs.push(deactivateInactiveUsersJob())
+  if (env.NEXT_PUBLIC_APP_ENV === "production") {
+    // NOTE: We only remove inactive users in production as UAT and staging
+    // environments are free for users to play around with for an indefinite
+    // period of time
+    cronJobs.push(deactivateInactiveUsersJob())
+  }
 
   logger.info("Cron jobs initialized successfully")
 }

--- a/apps/studio/src/server/cron/index.ts
+++ b/apps/studio/src/server/cron/index.ts
@@ -1,4 +1,3 @@
-import { env } from "~/env.mjs"
 import { createBaseLogger } from "../../lib/logger"
 import { deactivateInactiveUsersJob } from "./jobs"
 
@@ -11,12 +10,7 @@ export const initializeCronJobs = () => {
   logger.info("Initializing cron jobs...")
 
   // Initialize and track all cron jobs
-  if (env.NEXT_PUBLIC_APP_ENV === "production") {
-    // NOTE: We only remove inactive users in production as UAT and staging
-    // environments are free for users to play around with for an indefinite
-    // period of time
-    cronJobs.push(deactivateInactiveUsersJob())
-  }
+  cronJobs.push(deactivateInactiveUsersJob())
 
   logger.info("Cron jobs initialized successfully")
 }

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -4,6 +4,7 @@ import { toZonedTime } from "date-fns-tz"
 
 import type { ResourcePermission, Site, User } from "../database"
 import type { BulkSendAccountDeactivationWarningEmailsProps } from "./types"
+import { env } from "~/env.mjs"
 import {
   sendAccountDeactivationEmail,
   sendAccountDeactivationWarningEmail,
@@ -226,6 +227,12 @@ export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
 
   if (deactivatedUsersAndSiteIds.length === 0) {
     logger.info("No deactivated users and sites found")
+    return
+  }
+
+  if (env.NEXT_PUBLIC_APP_ENV !== "production") {
+    // NOTE: We do not notify users in UAT or staging environments, so as to
+    // avoid inducing unnecessary panic
     return
   }
 

--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -230,7 +230,10 @@ export const bulkDeactivateInactiveUsers = async (): Promise<void> => {
     return
   }
 
-  if (env.NEXT_PUBLIC_APP_ENV !== "production") {
+  if (
+    env.NEXT_PUBLIC_APP_ENV !== "production" &&
+    env.NEXT_PUBLIC_APP_ENV !== "test"
+  ) {
     // NOTE: We do not notify users in UAT or staging environments, so as to
     // avoid inducing unnecessary panic
     return


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We do not want to remove users for all envs, only production.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Schedule the remove inactive users cron job only for the production env.