### PR TITLE
fix: add correct statuses to toast notifications

### DIFF
--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -85,6 +85,7 @@ export function EditorDrawerProvider({
       },
       onError: (error) => {
         toast({
+          status: "error",
           title: "Failed to update blocks",
           description: error.message,
           ...BRIEF_TOAST_SETTINGS,

--- a/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/ComplexEditorStateDrawer.tsx
@@ -61,6 +61,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         toast({
+          status: "success",
           title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
           ...BRIEF_TOAST_SETTINGS,
         })

--- a/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/HeroEditorDrawer.tsx
@@ -54,6 +54,7 @@ export default function HeroEditorDrawer(): JSX.Element {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         toast({
+          status: "success",
           title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
           ...BRIEF_TOAST_SETTINGS,
         })

--- a/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/MetadataEditorStateDrawer.tsx
@@ -51,6 +51,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
       await utils.page.readPage.invalidate({ pageId, siteId })
       await utils.page.getCategories.invalidate({ pageId, siteId })
       toast({
+        status: "success",
         title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
         ...BRIEF_TOAST_SETTINGS,
       })

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -102,7 +102,11 @@ const MoveResourceContent = withSuspense(
         await utils.resource.getMetadataById.invalidate({
           resourceId: movedItem?.id,
         })
-        toast({ title: "Resource moved!", ...BRIEF_TOAST_SETTINGS })
+        toast({
+          status: "success",
+          title: "Resource moved!",
+          ...BRIEF_TOAST_SETTINGS,
+        })
       },
     })
 

--- a/apps/studio/src/features/editing-experience/components/RawJsonEditorModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RawJsonEditorModeStateDrawer.tsx
@@ -36,6 +36,7 @@ export default function RawJsonEditorModeStateDrawer(): JSX.Element {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
       toast({
+        status: "success",
         title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
         ...BRIEF_TOAST_SETTINGS,
       })

--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -109,6 +109,7 @@ export default function RootStateDrawer() {
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         toast({
+          status: "success",
           title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
           ...BRIEF_TOAST_SETTINGS,
         })

--- a/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
+++ b/apps/studio/src/features/editing-experience/components/TipTapProseComponent.tsx
@@ -51,6 +51,7 @@ function TipTapProseComponent({ content }: TipTapComponentProps) {
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
       toast({
+        status: "success",
         title: CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE,
         ...BRIEF_TOAST_SETTINGS,
       })

--- a/apps/studio/src/features/users/components/UserTable/UserTableMenu.tsx
+++ b/apps/studio/src/features/users/components/UserTable/UserTableMenu.tsx
@@ -55,11 +55,13 @@ export const UserTableMenu = ({
     trpc.user.resendInvite.useMutation({
       onSuccess: (result) => {
         toast({
+          status: "success",
           title: `Invite resent to ${result.email}`,
         })
       },
       onError: (err) => {
         toast({
+          status: "error",
           title: "Failed to resend invite",
           description: err.message,
         })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Fixed incorrect toast status, e.g. should not be green and success

<img width="721" height="119" alt="image" src="https://github.com/user-attachments/assets/d2e07e54-711d-45a4-8e52-6874492d8826" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- add missing `status`
- add explicit `status` for all instances even if its `success` 

## Tests

actually not very easy to simulate this since need to send to a non-whitelisted email, can just assume its fixed