### PR TITLE
fix: pass transaction down to underlying services

### DIFF
--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -200,9 +200,9 @@ export const pageRouter = router({
           })
         }
 
-        const siteMeta = await getSiteConfig(page.siteId)
-        const navbar = await getNavBar(page.siteId)
-        const footer = await getFooter(page.siteId)
+        const siteMeta = await getSiteConfig(tx, page.siteId)
+        const navbar = await getNavBar(tx, page.siteId)
+        const footer = await getFooter(tx, page.siteId)
 
         const { title, type, permalink, content, updatedAt } = page
 

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -744,7 +744,7 @@ describe("resource.service", () => {
       // Arrange
       const { site } = await setupSite()
       // Act
-      const result = await getNavBar(site.id)
+      const result = await getNavBar(db, site.id)
       // Assert
       expect(result).toBeDefined()
       expect(result.siteId).toBe(site.id)
@@ -752,7 +752,7 @@ describe("resource.service", () => {
 
     it("should throw an error if the `siteId` is not found", async () => {
       // Act
-      const result = getNavBar(99999)
+      const result = getNavBar(db, 99999)
       // Assert
       await expect(result).rejects.toThrowError()
     })
@@ -763,7 +763,7 @@ describe("resource.service", () => {
       // Arrange
       const { site } = await setupSite()
       // Act
-      const result = await getNavBar(site.id)
+      const result = await getNavBar(db, site.id)
       // Assert
       expect(result).toBeDefined()
       expect(result.siteId).toBe(site.id)
@@ -771,7 +771,7 @@ describe("resource.service", () => {
 
     it("should throw an error if the `siteId` is not found", async () => {
       // Act
-      const result = getNavBar(99999)
+      const result = getNavBar(db, 99999)
       // Assert
       await expect(result).rejects.toThrowError()
     })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -270,7 +270,7 @@ export const updateBlobById = async (
 }
 
 // TODO: should be selecting from new table
-export const getNavBar = async (siteId: number) => {
+export const getNavBar = async (db: SafeKysely, siteId: number) => {
   const { content, ...rest } = await db
     .selectFrom("Navbar")
     .where("siteId", "=", siteId)
@@ -281,7 +281,7 @@ export const getNavBar = async (siteId: number) => {
   return { ...rest, content }
 }
 
-export const getFooter = async (siteId: number) => {
+export const getFooter = async (db: SafeKysely, siteId: number) => {
   const { content, ...rest } = await db
     .selectFrom("Footer")
     .where("siteId", "=", siteId)
@@ -304,7 +304,7 @@ export const getLocalisedSitemap = async (
     CASE
       WHEN (published.content ->> 'layout') IN ('index','content')
       THEN (published.content -> 'page' -> 'contentPageHeader' ->> 'summary')
-      WHEN (published.content ->> 'layout') = 'collection' 
+      WHEN (published.content ->> 'layout') = 'collection'
       THEN (published.content -> 'page' ->> 'subtitle')
       ELSE (published.content -> 'page' -> 'articlePageHeader' ->> 'summary')
     END

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -88,7 +88,7 @@ export const siteRouter = router({
         userId: ctx.user.id,
         action: "read",
       })
-      return getSiteConfig(id)
+      return getSiteConfig(db, id)
     }),
   getTheme: protectedProcedure
     .input(getConfigSchema)
@@ -109,7 +109,7 @@ export const siteRouter = router({
         userId: ctx.user.id,
         action: "read",
       })
-      return getFooter(id)
+      return getFooter(db, id)
     }),
   getNavbar: protectedProcedure
     .input(getConfigSchema)
@@ -119,7 +119,7 @@ export const siteRouter = router({
         userId: ctx.user.id,
         action: "read",
       })
-      return getNavBar(id)
+      return getNavBar(db, id)
     }),
   getLocalisedSitemap: protectedProcedure
     .input(getLocalisedSitemapSchema)

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -2,7 +2,13 @@ import { TRPCError } from "@trpc/server"
 import { ISOMER_ADMINS, ISOMER_MIGRATORS } from "~prisma/constants"
 import { addUsersToSite } from "~prisma/scripts/addUsersToSite"
 
-import type { DB, Resource, Transaction, Version } from "../database"
+import type {
+  DB,
+  Resource,
+  SafeKysely,
+  Transaction,
+  Version,
+} from "../database"
 import type { UserPermissionsProps } from "../permissions/permissions.type"
 import {
   ResourceState,
@@ -38,7 +44,7 @@ export const validateUserPermissionsForSite = async ({
   }
 }
 
-export const getSiteConfig = async (siteId: number) => {
+export const getSiteConfig = async (db: SafeKysely, siteId: number) => {
   const { config } = await db
     .selectFrom("Site")
     .where("id", "=", siteId)


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are not using the transaction context when getting site config, navbar and footer, which causes the transactions to be locked.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Pass the transaction object to the functions to get the site config, navbar and footer, so that they operate within this context.