### PR TITLE
chore: update outdated package lock

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -1706,6 +1706,10 @@ video {
   min-height: 360px;
 }
 
+.min-h-\[45rem\] {
+  min-height: 45rem;
+}
+
 .min-h-dvh {
   min-height: 100dvh;
 }
@@ -5790,6 +5794,10 @@ video {
 
   .lg\:max-h-full {
     max-height: 100%;
+  }
+
+  .lg\:min-h-0 {
+    min-height: 0px;
   }
 
   .lg\:min-h-\[31\.25rem\] {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34772,6 +34772,21 @@
     "tooling/typescript": {
       "name": "@isomer/tsconfig",
       "version": "0.0.0"
+    },
+    "tooling/template/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
+      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The package-lock.json file is outdated and Dependabot is not running.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Update package-lock.json by running `npm run build`.