### PR TITLE
add data.gov.sg to CSP

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -101,6 +101,7 @@ const ContentSecurityPolicy = `
     https://uploads.au.intercomcdn.com
     https://uploads.eu.intercomcdn.com
     https://uploads.intercomusercontent.com
+    https://data.gov.sg
     https://*.data.gov.sg
     ;
   worker-src


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

currently only wildcard domain added to CSP, but DGS endpoints are not very standardized so some are hosted on root domain

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- add root domain to CSP for DGS
