### PR TITLE
feat: add Huaying's quote as default blockquote

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -36,9 +36,10 @@ export const DEFAULT_BLOCKS: Record<
   },
   blockquote: {
     type: "blockquote",
-    quote: "This is a quote",
-    source: "This is the source of the quote",
-    imageAlt: "This is the alt text for the image",
+    quote:
+      "Enforcing the gold standards of building government informational websites at Isomer (OGP)",
+    source: "Huaying Zhu",
+    imageAlt: "Portrait of Huaying Zhu",
   },
   callout: {
     type: "callout",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The default blockquote is too bland.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add a legendary quote from Huaying as the default blockquote component copy.

## Before & After Screenshots
https://github.com/user-attachments/assets/cba99d7c-d35a-4bfd-99e0-51d2e94d056c

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to any page and add a blockquote component
- [ ] Verify that the blockquote component shows the updated quote copy