### PR TITLE
chore: shift over index page creation to collection

### DIFF
--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server"
 import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import { get, pick } from "lodash"
 
+import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
 import {
   createCollectionSchema,
   editLinkSchema,
@@ -13,7 +14,13 @@ import { readFolderSchema } from "~/schemas/folder"
 import { createCollectionPageSchema } from "~/schemas/page"
 import { protectedProcedure, router } from "~/server/trpc"
 import { logResourceEvent } from "../audit/audit.service"
-import { db, jsonb, ResourceState, ResourceType } from "../database"
+import {
+  AuditLogEvent,
+  db,
+  jsonb,
+  ResourceState,
+  ResourceType,
+} from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import {
@@ -26,6 +33,7 @@ import {
 import { validateUserPermissionsForSite } from "../site/site.service"
 import { defaultCollectionSelect } from "./collection.select"
 import {
+  createCollectionIndexJson,
   createCollectionLinkJson,
   createCollectionPageJson,
 } from "./collection.service"
@@ -125,6 +133,44 @@ export const collectionRouter = router({
             eventType: AuditLogEvent.ResourceCreate,
             delta: { before: null, after: collection },
             by: user,
+          })
+
+          const indexJson = createCollectionIndexJson(collection.title)
+
+          const blob = await tx
+            .insertInto("Blob")
+            .values({ content: jsonb(indexJson) })
+            .returning("Blob.id")
+            .executeTakeFirstOrThrow()
+
+          const addedResource = await tx
+            .insertInto("Resource")
+            .values({
+              title: collection.title,
+              permalink: INDEX_PAGE_PERMALINK,
+              siteId,
+              parentId: collection.id,
+              draftBlobId: blob.id,
+              type: ResourceType.IndexPage,
+              state: ResourceState.Draft,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow()
+            .catch((err) => {
+              if (get(err, "code") === PG_ERROR_CODES.uniqueViolation) {
+                throw new TRPCError({
+                  code: "CONFLICT",
+                  message: "A resource with the same permalink already exists",
+                })
+              }
+              throw err
+            })
+
+          await logResourceEvent(tx, {
+            siteId,
+            by: user,
+            delta: { before: null, after: addedResource },
+            eventType: AuditLogEvent.ResourceCreate,
           })
 
           return collection

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -1,4 +1,10 @@
 import type { UnwrapTagged } from "type-fest"
+import {
+  COLLECTION_PAGE_DEFAULT_SORT_BY,
+  COLLECTION_PAGE_DEFAULT_SORT_DIRECTION,
+  CollectionPagePageProps,
+  ISOMER_USABLE_PAGE_LAYOUTS,
+} from "@opengovsg/isomer-components"
 import { format } from "date-fns"
 
 import type { ResourceType } from "../database"
@@ -37,4 +43,18 @@ export const createCollectionLinkJson = ({}: {
     // TODO: Add pdf blob to content
     version: "0.1.0",
   } satisfies UnwrapTagged<PrismaJson.BlobJsonContent>
+}
+
+export const createCollectionIndexJson = (title: string) => {
+  return {
+    layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
+    page: {
+      title,
+      subtitle: `Read more on ${title.toLowerCase()} here.`,
+      defaultSortBy: COLLECTION_PAGE_DEFAULT_SORT_BY,
+      defaultSortDirection: COLLECTION_PAGE_DEFAULT_SORT_DIRECTION,
+    } as CollectionPagePageProps,
+    content: [],
+    version: "0.1.0",
+  }
 }


### PR DESCRIPTION
## Problem
we want to auto create index pages for collections because we will store the collection tags on the collection index page itself.


## Solution
duplicate logic for folder index pages but take note that the layout is `Collection`
