### PR TITLE
fix: remove CollectionLink from search results

### DIFF
--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -6,7 +6,6 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 import type { ResourceItemContent } from "~/schemas/resource"
 import type { SearchResultResource } from "~/server/modules/resource/resource.types"
 import { useSearchQuery } from "~/hooks/useSearchQuery"
-import { getUserViewableResourceTypes } from "~/utils/resources"
 import {
   LoadingResourceItemsResults,
   SuspendableContent,
@@ -211,7 +210,12 @@ export const ResourceSelector = (props: ResourceSelectorProps) => {
     siteId: String(props.siteId),
     resourceTypes: props.onlyShowFolders
       ? [ResourceType.Folder]
-      : getUserViewableResourceTypes(),
+      : [
+          ResourceType.Page,
+          ResourceType.Folder,
+          ResourceType.Collection,
+          ResourceType.CollectionPage,
+        ],
   })
 
   return (

--- a/apps/studio/src/components/Searchbar/SearchModal.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModal.tsx
@@ -9,8 +9,8 @@ import {
 } from "@chakra-ui/react"
 import { Searchbar as OgpSearchBar } from "@opengovsg/design-system-react"
 
+import { USER_VIEWABLE_RESOURCE_TYPES } from "~/constants/resources"
 import { useSearchQuery } from "~/hooks/useSearchQuery"
-import { getUserViewableResourceTypes } from "~/utils/resources"
 import { CommandKey } from "./CommandKey"
 import {
   InitialState,
@@ -36,7 +36,7 @@ export const SearchModal = ({ siteId, isOpen, onClose }: SearchModalProps) => {
     recentlyEditedResources,
   } = useSearchQuery({
     siteId,
-    resourceTypes: getUserViewableResourceTypes(),
+    resourceTypes: USER_VIEWABLE_RESOURCE_TYPES,
     onSearchSuccess: useCallback(() => {
       setQueryCount((prev) => prev + 1)
     }, []),

--- a/apps/studio/src/constants/resources.ts
+++ b/apps/studio/src/constants/resources.ts
@@ -1,0 +1,19 @@
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+// only show user-viewable resources (excluding root page, folder meta etc.)
+export const USER_VIEWABLE_RESOURCE_TYPES: ResourceType[] = [
+  ResourceType.Page,
+  ResourceType.Folder,
+  ResourceType.Collection,
+  ResourceType.CollectionLink,
+  ResourceType.CollectionPage,
+]
+
+// Resource types that users can create links to
+export const USER_LINKABLE_RESOURCE_TYPES = [
+  ResourceType.RootPage,
+  ResourceType.Folder,
+  ResourceType.Page,
+  ResourceType.Collection,
+  ResourceType.CollectionPage,
+] satisfies ResourceType[]

--- a/apps/studio/src/constants/resources.ts
+++ b/apps/studio/src/constants/resources.ts
@@ -11,7 +11,6 @@ export const USER_VIEWABLE_RESOURCE_TYPES: ResourceType[] = [
 
 // Resource types that users can create links to
 export const USER_LINKABLE_RESOURCE_TYPES = [
-  ResourceType.RootPage,
   ResourceType.Folder,
   ResourceType.Page,
   ResourceType.Collection,

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -22,9 +22,9 @@ import {
   setUpWhitelist,
 } from "tests/integration/helpers/seed"
 
+import { USER_VIEWABLE_RESOURCE_TYPES } from "~/constants/resources"
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"
-import { getUserViewableResourceTypes } from "~/utils/resources"
 import { db } from "../../database"
 import { resourceRouter } from "../resource.router"
 import { getFullPageById } from "../resource.service"
@@ -3358,7 +3358,7 @@ describe("resource.router", async () => {
       const result = await caller.search({
         siteId: String(site.id),
         query: "test",
-        resourceTypes: getUserViewableResourceTypes(),
+        resourceTypes: USER_VIEWABLE_RESOURCE_TYPES,
       })
 
       // Assert

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -4,6 +4,7 @@ import { jsonObjectFrom } from "kysely/helpers/postgres"
 import get from "lodash/get"
 
 import type { PermissionsProps } from "../permissions/permissions.type"
+import { USER_LINKABLE_RESOURCE_TYPES } from "~/constants/resources"
 import {
   countResourceSchema,
   deleteResourceSchema,
@@ -227,23 +228,10 @@ export const resourceRouter = router({
         let query = db
           .selectFrom("Resource")
           .select(["title", "permalink", "type", "id", "parentId"])
-          .where("Resource.type", "in", [
-            ResourceType.Page,
-            ResourceType.Folder,
-            ResourceType.Collection,
-            ResourceType.CollectionPage,
-            ResourceType.IndexPage,
-          ])
+          .where("Resource.type", "in", USER_LINKABLE_RESOURCE_TYPES)
           .where("Resource.siteId", "=", Number(siteId))
           .$narrowType<{
-            type: Extract<
-              ResourceType,
-              | typeof ResourceType.Page
-              | typeof ResourceType.Folder
-              | typeof ResourceType.Collection
-              | typeof ResourceType.CollectionPage
-              | typeof ResourceType.IndexPage
-            >
+            type: (typeof USER_LINKABLE_RESOURCE_TYPES)[number]
           }>()
           .orderBy("type", "asc")
           .orderBy("title", "asc")

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -57,17 +57,6 @@ export const isAllowedToHaveLastEditedText = (
   )
 }
 
-// only show user-viewable resources (excluding root page, folder meta etc.)
-export const getUserViewableResourceTypes = (): ResourceType[] => {
-  return [
-    ResourceType.Page,
-    ResourceType.Folder,
-    ResourceType.Collection,
-    ResourceType.CollectionLink,
-    ResourceType.CollectionPage,
-  ]
-}
-
 export const getStudioResourceUrl = (resource: Resource): string => {
   const siteUrlPrefix = `${env.NEXT_PUBLIC_APP_URL}/sites/${resource.siteId}`
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Extension of #1549.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Prevent CollectionLink from appearing in the search result when adding links to internal resources.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit a page
- [ ] Add a new link to the page
- [ ] Try to search for a collection link using its title
- [ ] Verify that the collection link does not appear in the search results