### PR TITLE
chore: disable turbo cache for db:connect

### DIFF
--- a/apps/studio/.env.test
+++ b/apps/studio/.env.test
@@ -12,6 +12,10 @@ NEXT_PUBLIC_APP_ENV='test'
 DATABASE_URL=postgres://root:root@localhost:5432/test
 CI=true
 PINO_LOG_LEVEL=silent
+# Required due to the following error:
+# SyntaxError: TypeScript parameter property is not supported in strip-only mode
+# Reference: https://github.com/microsoft/playwright/issues/34868
+NODE_OPTIONS='--no-experimental-strip-types'
 
 # Singpass settings
 # =============

--- a/apps/studio/.env.test
+++ b/apps/studio/.env.test
@@ -12,10 +12,6 @@ NEXT_PUBLIC_APP_ENV='test'
 DATABASE_URL=postgres://root:root@localhost:5432/test
 CI=true
 PINO_LOG_LEVEL=silent
-# Required due to the following error:
-# SyntaxError: TypeScript parameter property is not supported in strip-only mode
-# Reference: https://github.com/microsoft/playwright/issues/34868
-NODE_OPTIONS='--no-experimental-strip-types'
 
 # Singpass settings
 # =============

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:e2e": "dotenv -- turbo run test:e2e",
     "setup:test": "turbo setup:test",
     "storybook": "dotenv -- turbo run storybook --parallel",
-    "storybook:build": "turbo run storybook:build --parallel",
+    "build-storybook": "turbo run build-storybook --parallel",
     "teardown": "turbo teardown",
     "test-start": "turbo test-start",
     "typecheck": "turbo typecheck",

--- a/turbo.json
+++ b/turbo.json
@@ -19,10 +19,18 @@
     "build": {},
     "build:template": {},
     "clean": {},
-    "db:connect": {},
-    "db:connect:staging": {},
-    "db:connect:uat": {},
-    "db:connect:vapt": {},
+    "db:connect": {
+      "cache": false
+    },
+    "db:connect:staging": {
+      "cache": false
+    },
+    "db:connect:uat": {
+      "cache": false
+    },
+    "db:connect:vapt": {
+      "cache": false
+    },
     "dev": {
       "dependsOn": ["services:setup"],
       "cache": false,
@@ -35,7 +43,7 @@
     "storybook": {
       "cache": false
     },
-    "storybook:build": {
+    "build-storybook": {
       "inputs": ["!storybook-static/**"],
       "outputs": ["storybook-static/**"]
     },


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The turbo cache is active for the `db:connect` command which is incorrect.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Disabled turbo cache for the db:connect commands
- Fix the `build-storybook` turbo command