### PR TITLE
feat(scheduled-publishing): Add BE endpoint for cancelling schedule

### DIFF
--- a/apps/studio/src/features/mail/service.ts
+++ b/apps/studio/src/features/mail/service.ts
@@ -2,6 +2,7 @@ import type {
   AccountDeactivationEmailTemplateData,
   AccountDeactivationWarningEmailTemplateData,
   BaseEmailTemplateData,
+  CancelSchedulePageTemplateData,
   EmailTemplate,
   InvitationEmailTemplateData,
   LoginAlertEmailTemplateData,
@@ -77,6 +78,16 @@ export async function sendScheduledPageEmail(
     data,
     template: templates.schedulePage(data),
     emailType: "scheduled page",
+  })
+}
+
+export async function sendCancelSchedulePageEmail(
+  data: CancelSchedulePageTemplateData,
+): Promise<void> {
+  await sendEmailWithTemplate({
+    data,
+    template: templates.cancelSchedulePage(data),
+    emailType: "cancel scheduled page",
   })
 }
 

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -5,6 +5,7 @@ import type {
   AccountDeactivationEmailTemplateData,
   AccountDeactivationWarningEmailTemplateData,
   BaseEmailTemplateData,
+  CancelSchedulePageTemplateData,
   EmailTemplate,
   InvitationEmailTemplateData,
   LoginAlertEmailTemplateData,
@@ -88,6 +89,20 @@ export const schedulePageTemplate = (
     body: `<p>Hi ${recipientEmail},</p>
 <p>You’ve scheduled a page to be published at a later time. Your page will publish at: <strong>${format(scheduledAt, "MMMM d, yyyy hh:mm a")}</strong>.</p>
 <p>Log in to Isomer Studio at ${constructStudioRedirect()} to change or cancel this.</p>
+<p>Best,</p>
+<p>Isomer team</p>`,
+  }
+}
+
+export const cancelSchedulePageTemplate = (
+  data: CancelSchedulePageTemplateData,
+): EmailTemplate => {
+  const { recipientEmail, resource } = data
+  return {
+    subject: `[Isomer Studio] Your scheduled publish for ${resource.title} has been cancelled`,
+    body: `<p>Hi ${recipientEmail},</p>
+<p>Your scheduled publish for ${resource.title} has been cancelled.</p>
+<p>Log in to Isomer Studio at ${constructStudioRedirect()} to manage your content.</p>
 <p>Best,</p>
 <p>Isomer team</p>`,
   }
@@ -190,6 +205,8 @@ export const templates = {
     loginAlertTemplate satisfies EmailTemplateFunction<LoginAlertEmailTemplateData>,
   publishAlertContentPublisher:
     publishAlertContentPublisherTemplate satisfies EmailTemplateFunction<PublishAlertContentPublisherEmailTemplateData>,
+  cancelSchedulePage:
+    cancelSchedulePageTemplate satisfies EmailTemplateFunction<CancelSchedulePageTemplateData>,
   schedulePage:
     schedulePageTemplate satisfies EmailTemplateFunction<SchedulePageTemplateData>,
   publishAlertSiteAdmin:

--- a/apps/studio/src/features/mail/templates/types.ts
+++ b/apps/studio/src/features/mail/templates/types.ts
@@ -26,6 +26,10 @@ export interface SchedulePageTemplateData extends BaseEmailTemplateData {
   scheduledAt: Date
 }
 
+export interface CancelSchedulePageTemplateData extends BaseEmailTemplateData {
+  resource: Resource
+}
+
 export interface PublishAlertSiteAdminEmailTemplateData
   extends BaseEmailTemplateData {
   publisherEmail: string

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -42,6 +42,10 @@ interface ResourceEventDeltaMap {
     before: FullResource
     after: FullResource
   }
+  CancelSchedulePublish: {
+    before: FullResource
+    after: FullResource
+  }
 }
 
 interface BaseResourceEventLogProps {

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -264,6 +264,7 @@ export const setupPageResource = async ({
   permalink,
   parentId,
   title,
+  scheduledAt = null,
 }: {
   siteId?: number
   blobId?: string
@@ -273,6 +274,7 @@ export const setupPageResource = async ({
   permalink?: string
   parentId?: string | null
   title?: string
+  scheduledAt?: Date | null
 }) => {
   const { site, navbar, footer } = await setupSite(siteIdProp, !!siteIdProp)
   const blob = await setupBlob(blobIdProp)
@@ -285,7 +287,7 @@ export const setupPageResource = async ({
       siteId: site.id,
       parentId,
       publishedVersionId: null,
-      scheduledAt: null,
+      scheduledAt,
       draftBlobId: blob.id,
       type: resourceType,
       state,


### PR DESCRIPTION
## Problem

Adds cancel scheduled publishing endpoint, as part of the https://www.notion.so/opengov/Scheduled-Publishing-23f77dbba7888089a4eecd375faf350a?source=copy_link RFC

## Solution

1. Add initial cancelSchedulePageSchema
2. Add cancelSchedulePage endpoint, with (1) checks the user perms, (2) verifies the page is scheduled and (3) adds an audit log call with a special resource type ResourceSchedule to indicate a schedule change for a resource
3. Add integration tests for success/failure case

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Tests

1. Integration test added to ensure that cancelling a scheduled resource leads to the scheduledAt timestamp being nulled out
2. Integration test added to ensure calling this endpoint throws an error if the resource is not scheduled