### PR TITLE
Feat/partytown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9287,6 +9287,21 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@qwik.dev/partytown": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@qwik.dev/partytown/-/partytown-0.11.2.tgz",
+      "integrity": "sha512-795y49CqBiKiwKAD+QBZlzlqEK275hVcazZ7wBPSfgC23L+vWuA7PJmMpgxojOucZHzYi5rAAQ+IP1I3BKVZxw==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.7"
+      },
+      "bin": {
+        "partytown": "bin/partytown.cjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@react-aria/autocomplete": {
       "version": "3.0.0-beta.4",
       "resolved": "https://registry.npmjs.org/@react-aria/autocomplete/-/autocomplete-3.0.0-beta.4.tgz",
@@ -19118,9 +19133,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.5",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
-      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -34738,6 +34754,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@opengovsg/isomer-components": "*",
+        "@qwik.dev/partytown": "^0.11.2",
         "next": "^15.2.3",
         "postcss": "^8.4.39",
         "postcss-preset-env": "^10.0.8",

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -18,6 +18,7 @@ const GoogleTagManagerHeaderScript = ({
 					'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','${gtmId}');`,
       }}
+      type="text/partytown"
     />
   )
 }

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -168,6 +168,12 @@ if [ ! -d "./out" ]; then
   exit 1
 fi
 
+# Create partytown folder and scripts
+echo "Creating partytown folder and scripts..."
+start_time=$(date +%s)
+npm run partytown
+calculate_duration $start_time
+
 ls -al
 find ./out -type f | wc -l
 

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -17,10 +17,10 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en" data-theme={config.site.theme || "isomer-next"}>
-      <body className="antialiased">
+      <head>
         <Partytown debug={false} forward={["dataLayer.push"]} />
-        {children}
-      </body>
+      </head>
+      <body className="antialiased">{children}</body>
     </html>
   )
 }

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -3,6 +3,7 @@ import config from "@/data/config.json"
 import "@/styles/globals.css"
 
 import type { Metadata } from "next"
+import { Partytown } from "@qwik.dev/partytown/react"
 
 export const dynamic = "force-static"
 
@@ -16,7 +17,10 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en" data-theme={config.site.theme || "isomer-next"}>
-      <body className="antialiased">{children}</body>
+      <body className="antialiased">
+        <Partytown debug={false} forward={["dataLayer.push"]} />
+        {children}
+      </body>
     </html>
   )
 }

--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@opengovsg/isomer-components": "*",
+    "@qwik.dev/partytown": "^0.11.2",
     "next": "^15.2.3",
     "postcss": "^8.4.39",
     "postcss-preset-env": "^10.0.8",

--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -12,7 +12,8 @@
     "format": "prettier --check . --ignore-path ../../.gitignore",
     "format:fix": "prettier --write . --ignore-path ../../.gitignore",
     "typecheck": "tsc --noEmit",
-    "clean": "git clean -xdf .next .turbo node_modules out"
+    "clean": "git clean -xdf .next .turbo node_modules out",
+    "partytown": "partytown copylib out/~partytown"
   },
   "dependencies": {
     "@opengovsg/isomer-components": "*",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

This PR addresses addresses high Total Blocking Time (TBT) for Lighthouse's performance and user experience.

## Solution

<!-- How did you solve the problem? -->

Implemented Partytown integration to move third-party scripts (specifically Google Tag Manager) to a web worker, reducing main thread blocking and improving page performance.

We use this over Next.js's native `worker` strategy as the [native solution doesn't work for app router yet](https://nextjs.org/docs/app/api-reference/components/script#worker)

Reference:
- [example of performance improvement](https://wpengine.com/builders/boost-next-js-performance-by-offloading-third-party-scripts-with-partytown/)
- trade-offs: [we can't use this for UI scripts](https://partytown.qwik.dev/trade-offs/) e.g. VICA, AskGov 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Added Partytown integration for third-party script optimization
- Implemented web worker-based execution for Google Tag Manager scripts
- Added automatic partytown library copying during build process

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

**New scripts**:

- `partytown` : Copies partytown library files to build output directory (`partytown copylib out/~partytown`)

**New dependencies**:

- `@qwik.dev/partytown` : Partytown library for moving third-party scripts to web workers