### PR TITLE
Fix/index page images not eager loading

### DIFF
--- a/packages/components/src/interfaces/complex/ChildrenPages.ts
+++ b/packages/components/src/interfaces/complex/ChildrenPages.ts
@@ -54,6 +54,7 @@ export const DEFAULT_CHILDREN_PAGES_BLOCK = Value.Parse(
 )
 
 export interface ChildrenPagesProps extends Static<typeof ChildrenPagesSchema> {
+  shouldLazyLoad?: boolean
   permalink: string
   site: IsomerSiteProps
   LinkComponent?: LinkComponentType

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
@@ -48,15 +48,15 @@ interface Childpage {
 
 interface ChildpageLayoutProps
   extends Pick<
-    ChildrenPagesProps,
-    | "showSummary"
-    | "showThumbnail"
-    | "shouldLazyLoad"
-    | "LinkComponent"
-    | "site"
-  > {
+      ChildrenPagesProps,
+      | "showSummary"
+      | "showThumbnail"
+      | "shouldLazyLoad"
+      | "LinkComponent"
+      | "site"
+    >,
+    Pick<ImageClientProps, "assetsBaseUrl"> {
   childpages: Childpage[]
-  assetsBaseUrl?: string
   fallback: Required<NonNullable<IsomerSitemap["image"]>>
 }
 

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
@@ -17,7 +17,11 @@ const ChildpageImage = ({
   alt,
   assetsBaseUrl,
   className,
-}: Pick<ImageClientProps, "className" | "assetsBaseUrl" | "src" | "alt">) => {
+  lazyLoading,
+}: Pick<
+  ImageClientProps,
+  "className" | "assetsBaseUrl" | "src" | "alt" | "lazyLoading"
+>) => {
   const imgSrc =
     isExternalUrl(src) || assetsBaseUrl === undefined
       ? src
@@ -30,6 +34,7 @@ const ChildpageImage = ({
       className={className}
       alt={alt}
       src={imgSrc}
+      lazyLoading={lazyLoading}
     />
   )
 }
@@ -42,10 +47,15 @@ interface Childpage {
 }
 
 interface ChildpageLayoutProps
-  extends Pick<ChildrenPagesProps, "LinkComponent" | "site"> {
+  extends Pick<
+    ChildrenPagesProps,
+    | "showSummary"
+    | "showThumbnail"
+    | "shouldLazyLoad"
+    | "LinkComponent"
+    | "site"
+  > {
   childpages: Childpage[]
-  showSummary: boolean
-  showThumbnail: boolean
   assetsBaseUrl?: string
   fallback: Required<NonNullable<IsomerSitemap["image"]>>
 }
@@ -91,6 +101,7 @@ const BoxLayout = ({
   showThumbnail,
   assetsBaseUrl,
   fallback,
+  shouldLazyLoad,
   LinkComponent,
   site,
 }: ChildpageLayoutProps) => {
@@ -112,6 +123,7 @@ const BoxLayout = ({
               <div className={styles.imageContainer()}>
                 <ChildpageImage
                   assetsBaseUrl={assetsBaseUrl}
+                  lazyLoading={shouldLazyLoad}
                   {...renderedImage}
                   className={styles.image({ hasFallbackImage: !image?.src })}
                 />
@@ -178,6 +190,7 @@ const RowLayout = ({
   showThumbnail,
   assetsBaseUrl,
   fallback,
+  shouldLazyLoad,
   LinkComponent,
   site,
 }: ChildpageLayoutProps): JSX.Element => {
@@ -201,6 +214,7 @@ const RowLayout = ({
               <div className={styles.imageContainer()}>
                 <ChildpageImage
                   assetsBaseUrl={assetsBaseUrl}
+                  lazyLoading={shouldLazyLoad}
                   {...renderedImage}
                   className={styles.image({ hasFallbackImage: !image?.src })}
                 />
@@ -231,6 +245,7 @@ const ChildrenPages = ({
   variant,
   showSummary = true,
   showThumbnail,
+  shouldLazyLoad,
 }: ChildrenPagesProps) => {
   const currentPageNode = getNodeFromSiteMap(site.siteMap, permalink)
 
@@ -257,6 +272,7 @@ const ChildrenPages = ({
         showSummary={showSummary}
         showThumbnail={showThumbnail}
         fallback={{ src: site.logoUrl, alt: "Default logo of the site" }}
+        shouldLazyLoad={shouldLazyLoad}
         site={site}
       />
     )
@@ -274,6 +290,7 @@ const ChildrenPages = ({
       showSummary={showSummary}
       showThumbnail={showThumbnail}
       fallback={{ src: site.logoUrl, alt: "Default logo of the site" }}
+      shouldLazyLoad={shouldLazyLoad}
       site={site}
     />
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Images in index pages chilren are all lazy loaded because (by default) since no value passed in.

This can have an implication on lighthouse performance and UX.

<img width="2248" height="910" alt="Screenshot 2025-09-08 at 11 51 01 AM" src="https://github.com/user-attachments/assets/1f6250dd-b6f5-4ae8-bf55-900921ad82a4" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Passed the `shouldLazyLoad` value in

## Tests

<!-- What tests should be run to confirm functionality? -->

1. rebuild site with index pages containing children-with-image
2. inspect the image `loading` prop in dev console -> it should shows `eager` not `lazy` 