### PR TITLE
fix: disable creating blocks on collection index pages

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -335,17 +335,22 @@ export default function RootStateDrawer() {
                         Use blocks to display your content in various ways
                       </Text>
                     </VStack>
-                    {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Index && (
-                      <Button
-                        size="xs"
-                        flexShrink={0}
-                        leftIcon={<BiPlusCircle fontSize="1.25rem" />}
-                        variant="clear"
-                        onClick={() => setDrawerState({ state: "addBlock" })}
-                      >
-                        Add block
-                      </Button>
-                    )}
+                    {/* TODO: we should swap over to using the `resource.type` */}
+                    {/* rather than the `page.layout` but we are unable to do so due */}
+                    {/* to the existence of custom index page that are `layout: */}
+                    {/* content` but have `resource.type: index` */}
+                    {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
+                      pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Index && (
+                        <Button
+                          size="xs"
+                          flexShrink={0}
+                          leftIcon={<BiPlusCircle fontSize="1.25rem" />}
+                          variant="clear"
+                          onClick={() => setDrawerState({ state: "addBlock" })}
+                        >
+                          Add block
+                        </Button>
+                      )}
                   </Flex>
                   <DragDropContext onDragEnd={onDragEnd}>
                     <Droppable droppableId="blocks">


### PR DESCRIPTION
## Problem
- our current check for disabling creating blocks on index pages uses the `page.layout` property
- unfortunately, this is **only** for `page.layout == index`, which doesn't hold true for collection index pages (`layout == collection`, which leads to users being able to add block but these blocks don't do anything (collection layout just renders the filters)

## Solution
- update the condition to prevent adding blocks whne layout is `collection`
