### PR TITLE
fix: prevent scrolling to top if URL contains an anchor

### DIFF
--- a/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
+++ b/packages/components/src/templates/next/components/internal/ScrollToTop.tsx
@@ -14,6 +14,10 @@ export const ScrollToTop = () => {
   // as Next.js may attempt it during static site generation when "window" is unavailable.
   // Ref: https://nextjs.org/docs/app/building-your-application/deploying/static-exports#browser-apis
   useEffect(() => {
+    // Only scroll to top if there's no anchor in the URL
+    if (window.location.hash) {
+      return
+    }
     window.scrollTo(0, 0)
   }, [])
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently when user click on an anchor link, it ignores it and auto scrolls to the top, making it jank

reason due to a fix previously to force position to reset, due to next/link issue (as stated in the component)

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- only scroll to the top if URL does not have any hash

## Tests

1. create a page with multiple sections, and publish
2. once build finish, go to that page and copy the link to a section from the table of content
3. open new tab and paste it in the search bar -> you should be directed to that section instead of teleporting back to the top