### PR TITLE
fix: remove trailing slash in canonical URL

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -69,7 +69,10 @@ const getMetaImage = (props: IsomerPageSchemaType) => {
 // The schema serves as our contract - when inputs don't match expectations,
 // we should fail fast rather than accommodate inconsistent data formats.
 const getCanonicalUrl = (props: IsomerPageSchemaType) => {
-  const permalinkWithoutTrailingSlash = props.page.permalink.replace(/\/+$/, "")
+  const permalinkWithoutTrailingSlash =
+    props.page.permalink.endsWith("/") && props.page.permalink !== "/"
+      ? props.page.permalink.slice(0, -1)
+      : props.page.permalink
 
   if (!props.site.url) return permalinkWithoutTrailingSlash
 


### PR DESCRIPTION
> [!WARNING]
>
> This is **NOT** the correct fix. The trailing slash is added by NextJS because we want the URLs to look clean (e.g. /about rather than /about.html), so this is a setting that we enabled (via `trailingSlash` on next.config.mjs). We need to fix the infra side on the redirection function instead, and also the sitemap generation code.

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our page permalink can come with a trailing slash, which makes the canonical URL contain the trailing slash and cause issues on SEO.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Use the page permalink without a trailing slash.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Build a site on staging
- [ ] Go to any random page on the built site
- [ ] Inspect the HTML of the page, go to the `<head>` section, then look for the `<link>` tag with `rel="canonical"`
- [ ] Verify that the `href` attribute has the page URL without a trailing slash