### PR TITLE
back to top is missing when there's no siderail contents

### DIFF
--- a/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
+++ b/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
@@ -6,7 +6,7 @@ import { focusVisibleHighlight } from "~/utils"
 
 const linkStyle = tv({
   extend: focusVisibleHighlight,
-  base: "prose-body-base sticky top-8 mb-8 inline-flex items-center text-link underline-offset-4 hover:underline",
+  base: "prose-body-base sticky top-8 mb-8 mt-16 inline-flex items-center text-link underline-offset-4 first:mt-0 hover:underline",
 })
 
 interface BackToTopLinkProps {

--- a/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
+++ b/packages/components/src/templates/next/components/internal/BackToTopLink.tsx
@@ -6,7 +6,7 @@ import { focusVisibleHighlight } from "~/utils"
 
 const linkStyle = tv({
   extend: focusVisibleHighlight,
-  base: "prose-body-base sticky top-8 mb-8 mt-16 inline-flex items-center text-link underline-offset-4 hover:underline",
+  base: "prose-body-base sticky top-8 mb-8 inline-flex items-center text-link underline-offset-4 hover:underline",
 })
 
 interface BackToTopLinkProps {

--- a/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
+++ b/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
@@ -25,7 +25,7 @@ const createSiderailStyles = tv({
       "-mr-2 h-6 w-6 shrink-0 opacity-0 transition group-hover:translate-x-1 group-hover:opacity-100",
     seeAllContainer:
       "flex-grow-1 mt-1 flex flex-shrink-0 basis-0 items-center justify-between",
-    seeAllLink: "prose-label-md-regular",
+    seeAllLink: "prose-label-md-regular mb-16",
   },
 })
 

--- a/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
+++ b/packages/components/src/templates/next/components/internal/Siderail/Siderail.tsx
@@ -25,7 +25,7 @@ const createSiderailStyles = tv({
       "-mr-2 h-6 w-6 shrink-0 opacity-0 transition group-hover:translate-x-1 group-hover:opacity-100",
     seeAllContainer:
       "flex-grow-1 mt-1 flex flex-shrink-0 basis-0 items-center justify-between",
-    seeAllLink: "prose-label-md-regular mb-16",
+    seeAllLink: "prose-label-md-regular",
   },
 })
 

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -20,17 +20,8 @@ const createContentLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-6 xl:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 flex flex-col gap-16 break-words",
-  },
-  variants: {
-    isSideRailPresent: {
-      true: {
-        content: "lg:col-span-9 lg:mr-24",
-      },
-      false: {
-        content: "max-w-[54rem]",
-      },
-    },
+    content:
+      "col-span-12 flex flex-col gap-16 break-words lg:col-span-9 lg:mr-24",
   },
 })
 
@@ -76,9 +67,7 @@ const ContentLayout = ({
         lastUpdated={page.lastModified}
       />
       <div className={compoundStyles.container()}>
-        <div
-          className={compoundStyles.content({ isSideRailPresent: !!sideRail })}
-        >
+        <div className={compoundStyles.content()}>
           {tableOfContents.length > 1 && (
             <TableOfContents
               items={tableOfContents}
@@ -95,13 +84,10 @@ const ContentLayout = ({
             })}
           </div>
         </div>
-
-        {sideRail && (
-          <div className={compoundStyles.siderailContainer()}>
-            <Siderail {...sideRail} LinkComponent={LinkComponent} />
-            <BackToTopLink />
-          </div>
-        )}
+        <div className={compoundStyles.siderailContainer()}>
+          {sideRail && <Siderail {...sideRail} LinkComponent={LinkComponent} />}
+          <BackToTopLink />
+        </div>
       </div>
     </Skeleton>
   )


### PR DESCRIPTION
## Problem

Back to top is missing when there's no siderail contents (e.g., root page, standalone page)

Closes [ISOM-2104]

## Solution

Added back to top for all variants; removed hasSiderail flag