### PR TITLE
Refactor/fix: move components into layout

### DIFF
--- a/packages/components/src/engine/index.ts
+++ b/packages/components/src/engine/index.ts
@@ -1,4 +1,5 @@
 export { RenderEngine, renderComponentPreviewText } from "./render"
+export { RenderLayoutComponents } from "./renderLayoutComponents"
 export {
   getMetadata,
   shouldBlockIndexing,

--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -1,0 +1,60 @@
+import type { IsomerPageSchemaType } from "~/types"
+import {
+  AskgovWidget,
+  FontPreload,
+  GoogleTagManagerBody,
+  GoogleTagManagerHeader,
+  GoogleTagManagerPreload,
+  VicaStylesheet,
+  VicaWidget,
+  Wogaa,
+} from "../templates/next/components/internal"
+
+type RenderLayoutComponentsProps = Pick<
+  IsomerPageSchemaType,
+  "site" | "ScriptComponent"
+>
+
+export const RenderLayoutComponents = ({
+  site,
+  ScriptComponent,
+}: RenderLayoutComponentsProps) => {
+  const shouldIncludeGTM =
+    site.environment === "production" &&
+    (!!site.siteGtmId || !!site.isomerGtmId)
+
+  return (
+    <>
+      <FontPreload />
+
+      {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
+
+      {shouldIncludeGTM && (
+        <>
+          <GoogleTagManagerPreload />
+          <GoogleTagManagerHeader
+            siteGtmId={site.siteGtmId}
+            isomerGtmId={site.isomerGtmId}
+            ScriptComponent={ScriptComponent}
+          />
+          <GoogleTagManagerBody
+            siteGtmId={site.siteGtmId}
+            isomerGtmId={site.isomerGtmId}
+          />
+        </>
+      )}
+
+      {/* Ensures that the webchat widget only loads after the page has loaded */}
+      {/* Note: did not account for both being added to the config as it's a very unlikely scenario and there's "correct" way to handle this */}
+      {site.vica && (
+        <>
+          <VicaStylesheet environment={site.environment} />
+          <VicaWidget site={site} {...site.vica} />
+        </>
+      )}
+      {site.askgov && (
+        <AskgovWidget environment={site.environment} {...site.askgov} />
+      )}
+    </>
+  )
+}

--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -49,11 +49,19 @@ export const RenderLayoutComponents = ({
       {site.vica && (
         <>
           <VicaStylesheet environment={site.environment} />
-          <VicaWidget site={site} {...site.vica} />
+          <VicaWidget
+            site={site}
+            ScriptComponent={ScriptComponent}
+            {...site.vica}
+          />
         </>
       )}
       {site.askgov && (
-        <AskgovWidget environment={site.environment} {...site.askgov} />
+        <AskgovWidget
+          environment={site.environment}
+          ScriptComponent={ScriptComponent}
+          {...site.askgov}
+        />
       )}
     </>
   )

--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -1,4 +1,4 @@
-import type { IsomerPageSchemaType } from "~/types"
+import type { IsomerPageSchemaType, ScriptComponentType } from "~/types"
 import {
   AskgovWidget,
   FontPreload,
@@ -10,10 +10,9 @@ import {
   Wogaa,
 } from "../templates/next/components/internal"
 
-type RenderLayoutComponentsProps = Pick<
-  IsomerPageSchemaType,
-  "site" | "ScriptComponent"
->
+type RenderLayoutComponentsProps = Pick<IsomerPageSchemaType, "site"> & {
+  ScriptComponent: ScriptComponentType
+}
 
 export const RenderLayoutComponents = ({
   site,

--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -1,4 +1,4 @@
-import type { IsomerPageSchemaType, ScriptComponentType } from "~/types"
+import type { IsomerSiteProps, ScriptComponentType } from "~/types"
 import {
   AskgovWidget,
   FontPreload,
@@ -10,7 +10,8 @@ import {
   Wogaa,
 } from "../templates/next/components/internal"
 
-type RenderLayoutComponentsProps = Pick<IsomerPageSchemaType, "site"> & {
+interface RenderLayoutComponentsProps {
+  site: Omit<IsomerSiteProps, "lastUpdated" | "navbar" | "footerItems">
   ScriptComponent: ScriptComponentType
 }
 

--- a/packages/components/src/interfaces/internal/Askgov.ts
+++ b/packages/components/src/interfaces/internal/Askgov.ts
@@ -1,7 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerSiteProps } from "~/types"
+import type { IsomerSiteProps, ScriptComponentType } from "~/types"
 
 export const AskgovSchema = Type.Object(
   {
@@ -26,4 +26,5 @@ export type AskgovProps = Static<typeof AskgovSchema>
 
 export interface AskgovWidgetProps extends AskgovProps {
   environment: IsomerSiteProps["environment"]
+  ScriptComponent: ScriptComponentType
 }

--- a/packages/components/src/interfaces/internal/Navbar.ts
+++ b/packages/components/src/interfaces/internal/Navbar.ts
@@ -127,7 +127,6 @@ type BaseNavbarProps = NavbarSchemaType & {
   layout: IsomerPageLayoutType
   search?: LocalSearchProps | SearchSGInputBoxProps
   LinkComponent?: LinkComponentType
-  ScriptComponent?: ScriptComponentType
 }
 
 export type NavbarProps = BaseNavbarProps & {

--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -1,7 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerSiteProps } from "~/types"
+import type { IsomerSiteProps, ScriptComponentType } from "~/types"
 
 // We can only pass in string values to the Vica script
 // as React omit boolean props when spreading onto a DOM element,
@@ -61,10 +61,12 @@ export type VicaProps = Static<typeof VicaSchema>
 
 export interface VicaWidgetClientProps extends VicaProps {
   environment: IsomerSiteProps["environment"]
+  ScriptComponent: ScriptComponentType
 }
 
 export interface VicaWidgetProps extends VicaProps {
   site: IsomerSiteProps
+  ScriptComponent: ScriptComponentType
 }
 
 export interface VicaStylesheetProps {

--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -65,7 +65,7 @@ export interface VicaWidgetClientProps extends VicaProps {
 }
 
 export interface VicaWidgetProps extends VicaProps {
-  site: IsomerSiteProps
+  site: Pick<IsomerSiteProps, "environment" | "siteMap" | "assetsBaseUrl">
   ScriptComponent: ScriptComponentType
 }
 

--- a/packages/components/src/templates/next/components/internal/Askgov/AskgovWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Askgov/AskgovWidget.tsx
@@ -1,12 +1,11 @@
 "use client"
 
-import { useEffect } from "react"
-
 import type { AskgovWidgetProps } from "~/interfaces"
 
 // Reference: https://github.com/opengovsg/askgov-widget
 export const AskgovWidget = ({
   environment,
+  ScriptComponent,
   ...askgovProps
 }: AskgovWidgetProps) => {
   const scriptUrl =
@@ -14,37 +13,10 @@ export const AskgovWidget = ({
       ? "https://script.ask.gov.sg/widget.js"
       : "https://script-staging.ask.gov.sg/widget.js"
 
-  const reloadAskgovScript = () => {
-    const scriptId = "isomer-askgov-script"
-
-    const existingScriptTag = document.getElementById(scriptId)
-    if (existingScriptTag) {
-      existingScriptTag.remove()
-    }
-
-    const scriptTag = document.createElement("script")
-    scriptTag.id = scriptId
-    scriptTag.async = true
-    scriptTag.type = "text/javascript"
-    scriptTag.src = scriptUrl
-    scriptTag.referrerPolicy = "origin"
-    document.body.appendChild(scriptTag)
-  }
-
-  useEffect(() => {
-    // to not render during static site generation on the server
-    if (typeof window === "undefined") return
-
-    // Only inject the script after everything else has finished loading
-    // This is to replicate Next.js lazyOnload behaviour (as recommended for widgets)
-    if (document.readyState === "complete") {
-      reloadAskgovScript()
-    } else {
-      window.addEventListener("load", () => reloadAskgovScript())
-      return () =>
-        window.removeEventListener("load", () => reloadAskgovScript())
-    }
-  }, [])
-
-  return <div id="askgov-widget" {...askgovProps} />
+  return (
+    <>
+      <ScriptComponent src={scriptUrl} strategy="lazyOnload" />
+      <div id="askgov-widget" {...askgovProps} />
+    </>
+  )
 }

--- a/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavbarMenu.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/MobileNavMenu/MobileNavbarMenu.tsx
@@ -14,7 +14,7 @@ import { MobileNavItemAccordion } from "./MobileNavItemAccordion"
 
 type MobileNavMenuProps = Omit<
   NavbarClientProps,
-  "layout" | "imageClientProps" | "ScriptComponent"
+  "layout" | "imageClientProps"
 > & {
   top: number | undefined
   openNavItemIdx: number

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -3,11 +3,16 @@ import { colors } from "~/presets/next/colors"
 import { getReferenceLinkHref } from "~/utils"
 import { VicaWidgetClient } from "./VicaWidgetClient"
 
-export const VicaWidget = (props: VicaWidgetProps) => {
-  const { site, "app-icon": appIcon, ...rest } = props
+export const VicaWidget = ({
+  site,
+  ScriptComponent,
+  "app-icon": appIcon,
+  ...rest
+}: VicaWidgetProps) => {
   return (
     <VicaWidgetClient
       environment={site.environment}
+      ScriptComponent={ScriptComponent}
       app-icon={
         appIcon
           ? getReferenceLinkHref(appIcon, site.siteMap, site.assetsBaseUrl)

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -1,11 +1,10 @@
 "use client"
 
-import { useEffect } from "react"
-
 import type { VicaWidgetClientProps } from "~/interfaces"
 
 export const VicaWidgetClient = ({
   environment,
+  ScriptComponent,
   ...vicaProps
 }: VicaWidgetClientProps) => {
   const scriptUrl =
@@ -13,38 +12,10 @@ export const VicaWidgetClient = ({
       ? "https://webchat.vica.gov.sg/static/js/chat.js"
       : "https://webchat.mol-vica.com/static/js/chat.js"
 
-  // Next.js pre-fetching caused widget to disappear on page navigation
-  // Doing this forces the widget to load in between page navigation
-  const reloadVicaScript = () => {
-    const scriptId = "isomer-vica-script"
-
-    const existingScriptTag = document.getElementById(scriptId)
-    if (existingScriptTag) {
-      existingScriptTag.remove()
-    }
-
-    const scriptTag = document.createElement("script")
-    scriptTag.id = scriptId
-    scriptTag.async = true
-    scriptTag.type = "text/javascript"
-    scriptTag.src = scriptUrl
-    scriptTag.referrerPolicy = "origin"
-    document.body.appendChild(scriptTag)
-  }
-
-  useEffect(() => {
-    // to not render during static site generation on the server
-    if (typeof window === "undefined") return
-
-    // Only inject the script after everything else has finished loading
-    // This is to replicate Next.js lazyOnload behaviour (as recommended for widgets)
-    if (document.readyState === "complete") {
-      reloadVicaScript()
-    } else {
-      window.addEventListener("load", reloadVicaScript)
-      return () => window.removeEventListener("load", reloadVicaScript)
-    }
-  }, [])
-
-  return <div id="webchat" {...vicaProps} />
+  return (
+    <>
+      <ScriptComponent src={scriptUrl} strategy="lazyOnload" />
+      <div id="webchat" {...vicaProps} />
+    </>
+  )
 }

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -13,7 +13,6 @@ const ArticleLayout = ({
   layout,
   content,
   LinkComponent,
-  ScriptComponent,
 }: ArticlePageSchemaType) => {
   const breadcrumb = getBreadcrumbFromSiteMap(
     site.siteMap,
@@ -37,7 +36,6 @@ const ArticleLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <div className="mx-auto flex max-w-[47.8rem] flex-col gap-7 px-6 md:px-10">
         <ArticlePageHeader

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -14,7 +14,6 @@ const CollectionLayout = ({
   page,
   layout,
   LinkComponent,
-  ScriptComponent,
 }: CollectionPageSchemaType) => {
   const { permalink, defaultSortBy, defaultSortDirection, tagCategories } = page
 
@@ -37,7 +36,6 @@ const CollectionLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <CollectionClient
         page={page}

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -42,7 +42,6 @@ const ContentLayout = ({
   layout,
   content,
   LinkComponent,
-  ScriptComponent,
 }: ContentPageSchemaType) => {
   const isParentPageRoot = page.permalink.split("/").length === 2
 
@@ -64,7 +63,6 @@ const ContentLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <ContentPageHeader
         {...page.contentPageHeader}

--- a/packages/components/src/templates/next/layouts/Database/Database.tsx
+++ b/packages/components/src/templates/next/layouts/Database/Database.tsx
@@ -27,7 +27,6 @@ const DatabaseLayout = ({
   layout,
   content,
   LinkComponent,
-  ScriptComponent,
 }: DatabasePageSchemaType) => {
   const breadcrumb = getBreadcrumbFromSiteMap(
     site.siteMap,
@@ -43,7 +42,6 @@ const DatabaseLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <ContentPageHeader
         {...page.contentPageHeader}

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -8,7 +8,6 @@ const HomepageLayout = ({
   layout,
   content,
   LinkComponent,
-  ScriptComponent,
 }: HomePageSchemaType) => {
   return (
     <Skeleton
@@ -16,7 +15,6 @@ const HomepageLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -23,7 +23,6 @@ const IndexPageLayout = ({
   layout,
   content,
   LinkComponent,
-  ScriptComponent,
 }: IndexPageSchemaType) => {
   const breadcrumb = getBreadcrumbFromSiteMap(
     site.siteMap,
@@ -41,7 +40,6 @@ const IndexPageLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <ContentPageHeader
         {...page.contentPageHeader}

--- a/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
+++ b/packages/components/src/templates/next/layouts/NotFound/NotFound.tsx
@@ -10,7 +10,6 @@ const NotFoundLayout = ({
   page,
   layout,
   LinkComponent,
-  ScriptComponent,
 }: NotFoundPageSchemaType) => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const infobarStyles = createInfobarStyles({
@@ -27,7 +26,6 @@ const NotFoundLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       <div
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,

--- a/packages/components/src/templates/next/layouts/Search/Search.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.tsx
@@ -7,7 +7,6 @@ const SearchLayout = ({
   page,
   layout,
   LinkComponent,
-  ScriptComponent = "script",
 }: SearchPageSchemaType) => {
   const clientId =
     (site.search && site.search.type === "searchSG" && site.search.clientId) ||
@@ -19,7 +18,6 @@ const SearchLayout = ({
       page={page}
       layout={layout}
       LinkComponent={LinkComponent}
-      ScriptComponent={ScriptComponent}
     >
       {/* Local search */}
       {site.search && site.search.type === "localSearch" && <></>}

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -1,20 +1,12 @@
 import type { IsomerPageSchemaType } from "~/engine"
 import {
-  AskgovWidget,
-  FontPreload,
   Footer,
-  GoogleTagManagerBody,
-  GoogleTagManagerHeader,
-  GoogleTagManagerPreload,
   Masthead,
   Navbar,
   Notification,
   ScrollToTop,
   SkipToContent,
   UnsupportedBrowserBanner,
-  VicaStylesheet,
-  VicaWidget,
-  Wogaa,
 } from "../../components/internal"
 import { SKIP_TO_CONTENT_ANCHOR_ID } from "../../constants"
 
@@ -22,39 +14,14 @@ export const Skeleton = ({
   site,
   layout,
   LinkComponent,
-  ScriptComponent,
   children,
 }: React.PropsWithChildren<
-  Pick<
-    IsomerPageSchemaType,
-    "site" | "page" | "layout" | "LinkComponent" | "ScriptComponent"
-  >
+  Pick<IsomerPageSchemaType, "site" | "page" | "layout" | "LinkComponent">
 >) => {
   const isStaging = site.environment === "staging"
 
-  const shouldIncludeGTM =
-    site.environment === "production" &&
-    (!!site.siteGtmId || !!site.isomerGtmId)
-
   return (
     <>
-      <FontPreload />
-
-      {shouldIncludeGTM && (
-        <>
-          <GoogleTagManagerPreload />
-          <GoogleTagManagerHeader
-            siteGtmId={site.siteGtmId}
-            isomerGtmId={site.isomerGtmId}
-            ScriptComponent={ScriptComponent}
-          />
-        </>
-      )}
-
-      {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
-
-      {site.vica && <VicaStylesheet environment={site.environment} />}
-
       <ScrollToTop />
 
       <header>
@@ -100,20 +67,6 @@ export const Skeleton = ({
         LinkComponent={LinkComponent}
         {...site.footerItems}
       />
-
-      {shouldIncludeGTM && (
-        <GoogleTagManagerBody
-          siteGtmId={site.siteGtmId}
-          isomerGtmId={site.isomerGtmId}
-        />
-      )}
-
-      {/* Ensures that the webchat widget only loads after the page has loaded */}
-      {/* Note: did not account for both being added to the config as it's a very unlikely scenario and there's "correct" way to handle this */}
-      {site.vica && <VicaWidget site={site} {...site.vica} />}
-      {site.askgov && (
-        <AskgovWidget environment={site.environment} {...site.askgov} />
-      )}
     </>
   )
 }

--- a/packages/components/src/templates/next/render/render.tsx
+++ b/packages/components/src/templates/next/render/render.tsx
@@ -116,13 +116,11 @@ export const renderComponent = ({
 
 export const renderLayout = ({
   LinkComponent = "a",
-  ScriptComponent = "script",
   ...rest
 }: IsomerPageSchemaType) => {
   const props = {
     ...rest,
     LinkComponent,
-    ScriptComponent,
   }
 
   switch (props.layout) {

--- a/packages/components/src/types/schema.ts
+++ b/packages/components/src/types/schema.ts
@@ -1,6 +1,6 @@
 import type { Static } from "@sinclair/typebox"
+import type { SimplifyDeep } from "type-fest"
 import { Type } from "@sinclair/typebox"
-import { SimplifyDeep } from "type-fest"
 
 import type { NotFoundPageMetaProps, SearchPageMetaProps } from "./meta"
 import type { IsomerSiteProps } from "./site"
@@ -14,7 +14,6 @@ import type {
   LinkComponentType,
   LinkRefPageProps,
   NotFoundPagePageProps,
-  ScriptComponentType,
   SearchPagePageProps,
 } from "~/types"
 import { IsomerComponentsSchemas } from "./components"
@@ -260,7 +259,6 @@ export type IsomerSchema = SimplifyDeep<Static<typeof IsomerPageSchema>>
 interface BasePageAdditionalProps {
   site: IsomerSiteProps
   LinkComponent?: LinkComponentType
-  ScriptComponent?: ScriptComponentType
 }
 
 export interface NotFoundPageSchemaType extends BasePageAdditionalProps {

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -1,7 +1,6 @@
 import type { IsomerPageSchemaType } from "@opengovsg/isomer-components"
 import type { Metadata, ResolvingMetadata } from "next"
 import Link from "next/link"
-import Script from "next/script"
 import config from "@/data/config.json"
 import footer from "@/data/footer.json"
 import navbar from "@/data/navbar.json"
@@ -130,7 +129,6 @@ const Page = async (props: DynamicPageProps) => {
         footerItems: footer,
         lastUpdated,
         assetsBaseUrl: process.env.NEXT_PUBLIC_ASSETS_BASE_URL,
-        isomerGtmId: process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID,
       }}
       meta={{
         // TODO: fixup all the typing errors
@@ -140,7 +138,6 @@ const Page = async (props: DynamicPageProps) => {
         ),
       }}
       LinkComponent={Link}
-      ScriptComponent={Script}
     />
   )
 }

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -1,8 +1,11 @@
 import config from "@/data/config.json"
+import sitemap from "@/sitemap.json"
 
 import "@/styles/globals.css"
 
 import type { Metadata } from "next"
+import Script from "next/script"
+import { RenderLayoutComponents } from "@opengovsg/isomer-components"
 
 export const dynamic = "force-static"
 
@@ -16,6 +19,18 @@ export const metadata: Metadata = {
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <html lang="en" data-theme={config.site.theme || "isomer-next"}>
+      <RenderLayoutComponents
+        site={{
+          ...config.site,
+          environment: process.env.NEXT_PUBLIC_ISOMER_NEXT_ENVIRONMENT,
+          // TODO: fixup all the typing errors
+          // @ts-ignore to fix when types are proper
+          siteMap: sitemap,
+          assetsBaseUrl: process.env.NEXT_PUBLIC_ASSETS_BASE_URL,
+          isomerGtmId: process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID,
+        }}
+        ScriptComponent={Script}
+      />
       <body className="antialiased">{children}</body>
     </html>
   )

--- a/tooling/template/app/not-found.tsx
+++ b/tooling/template/app/not-found.tsx
@@ -1,7 +1,6 @@
 import type { IsomerPageSchemaType } from "@opengovsg/isomer-components"
 import type { Metadata, ResolvingMetadata } from "next"
 import Link from "next/link"
-import Script from "next/script"
 import config from "@/data/config.json"
 import footer from "@/data/footer.json"
 import navbar from "@/data/navbar.json"
@@ -75,7 +74,6 @@ const NotFound = () => {
           // @ts-ignore to fix when types are proper
           footerItems: footer,
           assetsBaseUrl: process.env.NEXT_PUBLIC_ASSETS_BASE_URL,
-          isomerGtmId: process.env.NEXT_PUBLIC_ISOMER_GOOGLE_TAG_MANAGER_ID,
         }}
         layout="notfound"
         meta={{
@@ -89,7 +87,6 @@ const NotFound = () => {
         }}
         content={[]}
         LinkComponent={Link}
-        ScriptComponent={Script}
       />
     </>
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some components (e.g. Wogaa, GTM, Widgets like VICA/AskGov) should only be loaded once since they live in the shared layout across all pages.

Normally, this isn’t an issue because we use next/script, which pushes them into <head> so they don’t reload on navigation.

However, for certain widgets, we currently use a hacky approach where they’re unloaded and reloaded between page transitions, which causes flickering.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- refactor and move common components into `layout.tsx`

> [!NOTE]
> we should also move things like navbar, notification, navbar etc. into layout, but we currently pass `layout` into SearchSG component, thus i skip that scope for this PR 

## Tests

rebuild sites
- [ ] it should load properly
- [ ] go to dev console and check and check on WOGAA/GTM -> they should be in the head
- [ ] for sites with WOGAA/AskGov, they should not flicker between navigation -> if you open them and navigate, it should remain open