### PR TITLE
Enhancement/DGS Ssearchable Table (support for dataset >4MB)

### DIFF
--- a/packages/components/src/hooks/useDgsMetadata.ts
+++ b/packages/components/src/hooks/useDgsMetadata.ts
@@ -7,13 +7,9 @@ import { fetchDgsMetadata } from "~/utils/dgs/fetchDgsMetadata"
 
 interface UseDgsMetadataProps {
   resourceId: string
-  enabled?: boolean
 }
 
-export const useDgsMetadata = ({
-  resourceId,
-  enabled = true,
-}: UseDgsMetadataProps) => {
+export const useDgsMetadata = ({ resourceId }: UseDgsMetadataProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const [isError, setIsError] = useState(false)
   const [metadata, setMetadata] = useState<FetchDgsMetadataOutput | undefined>(
@@ -21,10 +17,6 @@ export const useDgsMetadata = ({
   )
 
   useEffect(() => {
-    if (!enabled) {
-      return
-    }
-
     const fetchMetadata = async () => {
       setIsLoading(true)
       try {
@@ -39,7 +31,7 @@ export const useDgsMetadata = ({
     }
 
     void fetchMetadata()
-  }, [resourceId, enabled])
+  }, [resourceId])
 
   return {
     metadata,

--- a/packages/components/src/templates/next/components/complex/SearchableTable/DGS/StaticDGSSearchableTable.tsx
+++ b/packages/components/src/templates/next/components/complex/SearchableTable/DGS/StaticDGSSearchableTable.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { useMemo } from "react"
+
+import type { DgsApiDatasetSearchParams } from "~/hooks/useDgsData/types"
+import type {
+  DGSSearchableTableProps,
+  SearchableTableClientProps,
+} from "~/interfaces"
+import { useDgsData } from "~/hooks/useDgsData"
+import { SearchableTableClient } from "../shared"
+
+interface StaticDGSSearchableTableProps extends DGSSearchableTableProps {
+  headers: NonNullable<DGSSearchableTableProps["headers"]>
+  isMetadataLoading: boolean
+  isMetadataError: boolean
+}
+
+export const StaticDGSSearchableTable = ({
+  type,
+  dataSource: { resourceId, filters, sort },
+  title,
+  headers,
+  site,
+  LinkComponent,
+  isMetadataLoading,
+  isMetadataError,
+}: StaticDGSSearchableTableProps) => {
+  const params = useMemo(
+    () => ({
+      resourceId,
+      filters: filters?.reduce<
+        NonNullable<DgsApiDatasetSearchParams["filters"]>
+      >((acc, filter) => {
+        acc[filter.fieldKey] = filter.fieldValue
+        return acc
+      }, {}),
+      sort,
+    }),
+    [resourceId, filters, sort],
+  )
+
+  const {
+    records,
+    isLoading: isDataLoading,
+    isError: isDataError,
+  } = useDgsData({
+    ...params,
+    fetchAll: true,
+  })
+
+  const labels = useMemo(
+    () => headers.map((header) => header.label ?? header.key),
+    [headers],
+  )
+
+  const items: SearchableTableClientProps["items"] = useMemo(() => {
+    const keys = headers.map((header) => header.key)
+    return (
+      records?.map((record) => {
+        const content = keys.map((field) => String(record[field] ?? ""))
+        return {
+          key: content.join(" ").toLowerCase(),
+          row: content,
+        }
+      }) ?? []
+    )
+  }, [records, headers])
+
+  return (
+    <SearchableTableClient
+      type={type}
+      title={title}
+      headers={labels}
+      items={items}
+      site={site}
+      LinkComponent={LinkComponent}
+      isLoading={isMetadataLoading || isDataLoading}
+      isError={isMetadataError || isDataError}
+    />
+  )
+}

--- a/packages/components/src/templates/next/components/internal/DownloadButton/strategies.ts
+++ b/packages/components/src/templates/next/components/internal/DownloadButton/strategies.ts
@@ -2,6 +2,7 @@ import {
   fetchDgsFileDownloadUrl,
   fetchDgsMetadata,
   fetchFileMetadata,
+  formatBytes,
   getDgsIdFromDgsLink,
 } from "~/utils"
 
@@ -55,7 +56,10 @@ export const directDownloadStrategy: DownloadStrategy = {
     try {
       const metadata = await fetchFileMetadata({ url })
       if (metadata) {
-        return renderDownloadText(metadata)
+        return renderDownloadText({
+          format: metadata.format,
+          size: metadata.size,
+        })
       }
     } catch (error) {
       console.error("Error fetching file metadata:", error)
@@ -74,15 +78,16 @@ export const defaultDownloadStrategies: DownloadStrategy[] = [
 
 interface RenderDownloadTextProps {
   format: string | undefined
-  size: string | undefined
+  size: number | undefined
 }
 const renderDownloadText = ({ format, size }: RenderDownloadTextProps) => {
-  if (format && size) {
-    return `Download ${format} (${size})`
+  const formattedSize = size ? formatBytes(size) : String(size)
+  if (format && formattedSize) {
+    return `Download ${format} (${formattedSize})`
   } else if (format) {
     return `Download ${format}`
-  } else if (size) {
-    return `Download (${size})`
+  } else if (formattedSize) {
+    return `Download (${formattedSize})`
   } else {
     return "Download"
   }

--- a/packages/components/src/utils/dgs/constants.ts
+++ b/packages/components/src/utils/dgs/constants.ts
@@ -1,1 +1,5 @@
 export const DGS_LINK_REGEX = /\[dgs:([a-zA-Z0-9_]+)\]/
+
+// This is the maximum number of bytes that can be requested from the DGS API
+// https://opengovproducts.slack.com/archives/C05FKB7JM1U/p1757646271300719?thread_ts=1757638807.583389&cid=C05FKB7JM1U
+export const DGS_REQUEST_MAX_BYTES = 4 * 1024 * 1024 // 4MB

--- a/packages/components/src/utils/dgs/fetchDgsMetadata.ts
+++ b/packages/components/src/utils/dgs/fetchDgsMetadata.ts
@@ -1,5 +1,3 @@
-import { formatBytes } from "../formatBytes"
-
 interface FetchDgsMetadataProps {
   resourceId: string
 }
@@ -29,7 +27,7 @@ export type FetchDgsMetadataOutput = Pick<
   FetchDgsMetadataResponse["data"],
   "name" | "format"
 > & {
-  size: string | undefined
+  size: FetchDgsMetadataResponse["data"]["datasetSize"]
   columnMetadata:
     | [string, string][] // 1st string is column field key, 2nd string is column title
     | undefined
@@ -53,7 +51,7 @@ export const fetchDgsMetadata = async ({
     return {
       name: data.data.name,
       format: data.data.format,
-      size: formatBytes(data.data.datasetSize),
+      size: data.data.datasetSize,
       columnMetadata: extractColumnMetadata(data),
     }
   } catch (error) {

--- a/packages/components/src/utils/dgs/index.ts
+++ b/packages/components/src/utils/dgs/index.ts
@@ -1,3 +1,4 @@
 export { getDgsIdFromDgsLink } from "./getDgsIdFromDgsLink"
 export { fetchDgsMetadata } from "./fetchDgsMetadata"
 export { fetchDgsFileDownloadUrl } from "./fetchDgsFileDownloadUrl"
+export { DGS_REQUEST_MAX_BYTES } from "./constants"

--- a/packages/components/src/utils/fetchFileMetadata.ts
+++ b/packages/components/src/utils/fetchFileMetadata.ts
@@ -1,12 +1,10 @@
-import { formatBytes } from "./formatBytes"
-
 interface FetchFileMetadataProps {
   url: string
 }
 
 interface FetchFileMetadataOutput {
   format: string | undefined
-  size: string | undefined
+  size: number | undefined
 }
 
 export const fetchFileMetadata = async ({
@@ -56,11 +54,11 @@ export const fetchFileMetadata = async ({
   const contentLength = response.headers.get("content-length")
 
   // Parse content length safely, handling invalid values
-  let size: string | undefined
+  let size
   if (contentLength) {
     const parsedLength = parseInt(contentLength, 10)
     if (!isNaN(parsedLength) && parsedLength > 0) {
-      size = formatBytes(parsedLength)
+      size = parsedLength
     }
   }
 

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -18,6 +18,7 @@ export {
   getDgsIdFromDgsLink,
 } from "./dgs"
 export { fetchFileMetadata } from "./fetchFileMetadata"
+export { formatBytes } from "./formatBytes"
 export { orderedListSchemaBuilder } from "./orderedListSchemaBuilder"
 export * from "./tailwind"
 export { unorderedListSchemaBuilder } from "./unorderedListSchemaBuilder"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

DGS API only returns up to 4MB of data (it throws 413 error otherwise)

This casue the initial assumption of no such restrictions (or a much larger threshold) to be false. When user select dataset of >4MB of data, the table won't load as DGS returns no valid data

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
