### PR TITLE
migration(collection-tags): sort tag categories and options alphabetically

### DIFF
--- a/apps/studio/prisma/scripts/sortTagCategories/index.ts
+++ b/apps/studio/prisma/scripts/sortTagCategories/index.ts
@@ -1,0 +1,103 @@
+import { CollectionPagePageProps } from "@opengovsg/isomer-components"
+
+import { db, jsonb, sql } from "~/server/modules/database"
+import { updateBlobById } from "~/server/modules/resource/resource.service"
+
+const getAllIndexPagesWithTagCategories = async () => {
+  const indexPagesOfCollections = await db
+    .selectFrom("Resource")
+    .leftJoin("Version", "Version.id", "Resource.publishedVersionId")
+    .leftJoin("Blob as draftBlob", "draftBlob.id", "Resource.draftBlobId")
+    .leftJoin("Blob as publishedBlob", "publishedBlob.id", "Version.blobId")
+    .select([
+      "draftBlob.content as draftBlobContent",
+      "publishedBlob.content as publishedBlobContent",
+      // NOTE: If the published version has tags, we need to also
+      // update it in place so that we don't have a long tail
+      // and we can remove the outdated code
+      sql<boolean>`jsonb_array_length("publishedBlob"."content" -> 'page' -> 'tagCategories') > 0`.as(
+        "requiresPublish",
+      ),
+      "Resource.id",
+      "Resource.siteId",
+      // NOTE: can update `draftBlobId` (if it exists) directly
+      // but we need to create a new `draftBlob` if `draftBlobId`
+      // doesn't exist
+      "blobId as publishedBlobId",
+      "draftBlobId",
+    ])
+    .where("type", "=", "IndexPage")
+    .where("parentId", "in", (eb) =>
+      eb
+        .selectFrom("Resource")
+        .where("type", "=", "Collection")
+        .select("parentId"),
+    )
+    .where((eb) =>
+      eb.or([
+        sql<boolean>`jsonb_array_length("draftBlob"."content" -> 'page' -> 'tagCategories') > 0`,
+        sql<boolean>`jsonb_array_length("publishedBlob"."content" -> 'page' -> 'tagCategories') > 0`,
+      ]),
+    )
+    .execute()
+
+  return indexPagesOfCollections
+}
+
+export const up = async () => {
+  const indexPages = await getAllIndexPagesWithTagCategories()
+  await db.transaction().execute(async (tx) => {
+    for (const indexPage of indexPages) {
+      if (indexPage.requiresPublish && indexPage.publishedBlobContent) {
+        const updatedContent = getUpdatedContent(indexPage.publishedBlobContent)
+        await tx
+          .updateTable("Blob")
+          .set({
+            content: jsonb(updatedContent),
+          })
+          .where("id", "=", indexPage.publishedBlobId)
+          .execute()
+      }
+
+      if (indexPage.draftBlobContent) {
+        const updatedContent = getUpdatedContent(indexPage.draftBlobContent)
+        await updateBlobById(tx, {
+          siteId: indexPage.siteId,
+          content: updatedContent,
+          pageId: Number(indexPage.id),
+        })
+      }
+    }
+  })
+}
+
+const getUpdatedContent = (content: PrismaJson.BlobJsonContent) => {
+  // NOTE: do this cast because we know that it's an index page for sure
+  // due to the query where we specified the type
+  const indexPagePageContent = content.page as CollectionPagePageProps
+  const updatedContent = {
+    ...content,
+    page: {
+      ...indexPagePageContent,
+      tagCategories: indexPagePageContent.tagCategories
+        ?.sort(sortFn)
+        .map(({ options, ...rest }) => {
+          return {
+            ...rest,
+            options: options.sort(sortFn),
+          }
+        }),
+    },
+  }
+
+  return updatedContent
+}
+
+interface WithLabel {
+  label: string
+}
+const sortFn = (a: WithLabel, b: WithLabel) => {
+  return a.label.localeCompare(b.label, undefined, {
+    numeric: true,
+  })
+}

--- a/apps/studio/prisma/scripts/sortTagCategories/index.ts
+++ b/apps/studio/prisma/scripts/sortTagCategories/index.ts
@@ -28,10 +28,7 @@ const getAllIndexPagesWithTagCategories = async () => {
     ])
     .where("type", "=", "IndexPage")
     .where("parentId", "in", (eb) =>
-      eb
-        .selectFrom("Resource")
-        .where("type", "=", "Collection")
-        .select("parentId"),
+      eb.selectFrom("Resource").where("type", "=", "Collection").select("id"),
     )
     .where((eb) =>
       eb.or([

--- a/apps/studio/prisma/scripts/sortTagCategories/sortTagCategories.test.ts
+++ b/apps/studio/prisma/scripts/sortTagCategories/sortTagCategories.test.ts
@@ -1,0 +1,520 @@
+import { randomUUID } from "crypto"
+import { CollectionPagePageProps } from "@opengovsg/isomer-components"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupCollection,
+  setupFolder,
+  setupPageResource,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { UnwrapTagged } from "type-fest"
+
+import {
+  db,
+  jsonb,
+  ResourceState,
+  ResourceType,
+} from "~/server/modules/database"
+import { up } from "./index"
+
+describe("sortTagCategories migration", async () => {
+  const user = await setupUser({})
+  beforeEach(async () => {
+    await resetTables("Resource", "Blob", "Version", "Site")
+  })
+
+  const createTagCategoriesContent = (
+    sorted = false,
+  ): UnwrapTagged<PrismaJson.BlobJsonContent> => {
+    const categories = sorted
+      ? [
+          {
+            label: "Category A",
+            id: randomUUID(),
+            value: "cat-a",
+            options: [
+              { id: randomUUID(), label: "Option 1", value: "opt-1" },
+              { id: randomUUID(), label: "Option 2", value: "opt-2" },
+            ],
+          },
+          {
+            label: "Category B",
+            value: "cat-b",
+            id: randomUUID(),
+            options: [
+              {
+                id: randomUUID(),
+                label: "Option X",
+                value: "opt-x",
+              },
+              {
+                id: randomUUID(),
+                label: "Option Y",
+                value: "opt-y",
+              },
+            ],
+          },
+        ]
+      : [
+          {
+            label: "Category B",
+            value: "cat-b",
+            id: randomUUID(),
+            options: [
+              {
+                id: randomUUID(),
+                label: "Option Y",
+                value: "opt-y",
+              },
+              {
+                id: randomUUID(),
+                label: "Option X",
+                value: "opt-x",
+              },
+            ],
+          },
+          {
+            label: "Category A",
+            id: randomUUID(),
+            value: "cat-a",
+            options: [
+              {
+                id: randomUUID(),
+                label: "Option 2",
+                value: "opt-2",
+              },
+              {
+                id: randomUUID(),
+                label: "Option 1",
+                value: "opt-1",
+              },
+            ],
+          },
+        ]
+
+    return {
+      layout: "collection",
+      page: {
+        tagCategories: categories,
+        title: "Test Collection",
+        subtitle: "Test subtitle",
+      },
+      content: [],
+      version: "1.0.0",
+    }
+  }
+
+  const getBlobContent = async (blobId: string) => {
+    const blob = await db
+      .selectFrom("Blob")
+      .select("content")
+      .where("id", "=", blobId)
+      .executeTakeFirst()
+    return blob?.content
+  }
+
+  it("should sort tag categories and options on the published index page if the published index page has tag categories", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+    const unsortedContent = createTagCategoriesContent(false)
+    const { id: publishedBlobId } = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(unsortedContent) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    // NOTE: This is a page
+    // without a `draftBlobId`
+    await setupPageResource({
+      siteId: site.id,
+      blobId: publishedBlobId,
+      state: ResourceState.Published,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(publishedBlobId)
+    const page = updatedContent?.page as CollectionPagePageProps
+
+    expect(page.tagCategories).toHaveLength(2)
+    expect(page.tagCategories![0]?.label).toBe("Category A")
+    expect(page.tagCategories![1]?.label).toBe("Category B")
+    expect(page.tagCategories![0]?.options[0]?.label).toBe("Option 1")
+    expect(page.tagCategories![0]?.options[1]?.label).toBe("Option 2")
+  })
+
+  it("should not affect published collection index pages that do not have any tag categories", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({ siteId: site.id })
+    const contentWithoutTags = {
+      page: {
+        title: "Test Collection",
+        layout: "collection" as const,
+      },
+      content: [],
+      version: "1.0.0",
+      layout: "collection",
+    } satisfies UnwrapTagged<PrismaJson.BlobJsonContent>
+    const { id: blobId } = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(contentWithoutTags) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await setupPageResource({
+      siteId: site.id,
+      blobId,
+      state: ResourceState.Published,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(blobId)
+    expect(updatedContent).toEqual(contentWithoutTags)
+  })
+
+  it("should not affect folder index pages even if they have tag categories", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { folder } = await setupFolder({ siteId: site.id })
+    const content = createTagCategoriesContent(false)
+    const { id: blobId } = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(content) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await setupPageResource({
+      siteId: site.id,
+      blobId,
+      state: ResourceState.Published,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: folder.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(blobId)
+    expect(updatedContent).toEqual(content)
+  })
+
+  it("should sort the tag categories and options on the draft blob of the collection index page if the draft blob has tag categories", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+    const unsortedContent = createTagCategoriesContent(false)
+    const { id: blobId } = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(unsortedContent) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await setupPageResource({
+      siteId: site.id,
+      blobId,
+      resourceType: ResourceType.IndexPage,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(blobId)
+    const page = updatedContent?.page as CollectionPagePageProps
+
+    expect(page.tagCategories).toHaveLength(2)
+    expect(page.tagCategories![0]?.label).toBe("Category A")
+    expect(page.tagCategories![1]?.label).toBe("Category B")
+    expect(page.tagCategories![0]?.options[0]?.label).toBe("Option 1")
+    expect(page.tagCategories![0]?.options[1]?.label).toBe("Option 2")
+  })
+
+  it("should sort the tag categories and options on the draft and published blob if both the draft and published blob have tag categories", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+    const unsortedContent = createTagCategoriesContent(false)
+    const { id: publishedBlobId } = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(unsortedContent) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+    const { id: draftBlobId } = await db
+      .insertInto("Blob")
+      .values({ content: jsonb(unsortedContent) })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    // NOTE: This is a page
+    // without a `draftBlobId`
+    const { page: pageResource } = await setupPageResource({
+      siteId: site.id,
+      blobId: publishedBlobId,
+      state: ResourceState.Published,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+    await db
+      .updateTable("Resource")
+      .set({ draftBlobId })
+      .where("id", "=", pageResource.id)
+      .execute()
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedPublishedContent = await getBlobContent(publishedBlobId)
+    const publishedPageProp =
+      updatedPublishedContent?.page as CollectionPagePageProps
+
+    expect(publishedPageProp.tagCategories).toHaveLength(2)
+    expect(publishedPageProp.tagCategories![0]?.label).toBe("Category A")
+    expect(publishedPageProp.tagCategories![1]?.label).toBe("Category B")
+    expect(publishedPageProp.tagCategories![0]?.options[0]?.label).toBe(
+      "Option 1",
+    )
+    expect(publishedPageProp.tagCategories![0]?.options[1]?.label).toBe(
+      "Option 2",
+    )
+
+    const updatedDraftContent = await getBlobContent(draftBlobId)
+    const draftPageProp = updatedDraftContent?.page as CollectionPagePageProps
+
+    expect(draftPageProp.tagCategories).toHaveLength(2)
+    expect(draftPageProp.tagCategories![0]?.label).toBe("Category A")
+    expect(draftPageProp.tagCategories![1]?.label).toBe("Category B")
+    expect(draftPageProp.tagCategories![0]?.options[0]?.label).toBe("Option 1")
+    expect(draftPageProp.tagCategories![0]?.options[1]?.label).toBe("Option 2")
+  })
+
+  it("should not override any other properties on the blob content", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+    const unsortedContent = createTagCategoriesContent(false)
+    const fakeProseBlock = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ text: "Test block", type: "text" }],
+        },
+      ],
+    }
+    const { id: publishedBlobId } = await db
+      .insertInto("Blob")
+      .values({
+        content: jsonb({
+          ...unsortedContent,
+          page: { ...unsortedContent.page, foo: "bar" },
+          content: [fakeProseBlock],
+          // NOTE: need the cast because we have additional property `foo`
+          // that is not in schema
+        }) as unknown as PrismaJson.BlobJsonContent,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await setupPageResource({
+      siteId: site.id,
+      blobId: publishedBlobId,
+      state: ResourceState.Published,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(publishedBlobId)
+    const page = updatedContent?.page as CollectionPagePageProps
+
+    expect((page as unknown as { foo: string }).foo).toBe("bar")
+    expect(page.tagCategories).toHaveLength(2)
+    expect(page.tagCategories![0]?.label).toBe("Category A")
+    expect(page.tagCategories![1]?.label).toBe("Category B")
+    expect(page.tagCategories![0]?.options[0]?.label).toBe("Option 1")
+    expect(page.tagCategories![0]?.options[1]?.label).toBe("Option 2")
+    expect(updatedContent?.content).toHaveLength(1)
+    expect(updatedContent?.content[0]).toEqual(fakeProseBlock)
+  })
+
+  it("should not impact any pages that do not have the `tagCategories` property even if they have `tagged` or `tags` property", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+
+    const contentWithOtherTags = {
+      page: {
+        title: "Test Collection",
+        tagged: ["tag1", "tag2"],
+        tags: [{ label: "hello", value: "world" }],
+      },
+      content: [],
+      version: "1.0.0" as const,
+      layout: "collection",
+    } satisfies UnwrapTagged<PrismaJson.BlobJsonContent>
+    const { id: blobId } = await db
+      .insertInto("Blob")
+      .values({
+        content: jsonb(contentWithOtherTags),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await setupPageResource({
+      siteId: site.id,
+      blobId,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(blobId)
+    expect(updatedContent).toEqual(contentWithOtherTags)
+  })
+
+  it("should handle empty tagCategories array", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+    const { id: publishedBlobId } = await db
+      .insertInto("Blob")
+      .values({
+        content: jsonb({
+          layout: "collection",
+          page: {
+            tagCategories: [],
+            title: "Test Collection",
+            subtitle: "Test subtitle",
+          },
+          content: [],
+          version: "1.0.0",
+        }),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    // NOTE: This is a page
+    // without a `draftBlobId`
+    await setupPageResource({
+      siteId: site.id,
+      blobId: publishedBlobId,
+      state: ResourceState.Published,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(publishedBlobId)
+    const page = updatedContent?.page as CollectionPagePageProps
+
+    expect(page.tagCategories).toHaveLength(0)
+  })
+
+  it("should sort categories and options with numeric labels correctly", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const { collection } = await setupCollection({
+      siteId: site.id,
+    })
+
+    const contentWithNumericLabels = {
+      page: {
+        title: "Test Collection",
+        tagCategories: [
+          {
+            label: "Priority 10",
+            value: "pri-10",
+            options: [
+              { label: "Item 20", value: "item-20" },
+              { label: "Item 2", value: "item-2" },
+              { label: "Item 10", value: "item-10" },
+            ],
+          },
+          {
+            label: "Priority 2",
+            value: "pri-2",
+            options: [],
+          },
+        ],
+      },
+      layout: "collection" as const,
+      version: "1.0.0" as const,
+      content: [],
+    } satisfies UnwrapTagged<PrismaJson.BlobJsonContent>
+
+    const { id: blobId } = await db
+      .insertInto("Blob")
+      .values({
+        content: jsonb(contentWithNumericLabels),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await setupPageResource({
+      siteId: site.id,
+      blobId,
+      resourceType: ResourceType.IndexPage,
+      userId: user.id,
+      parentId: collection.id,
+    })
+
+    // Act
+    await up()
+
+    // Assert
+    const updatedContent = await getBlobContent(blobId)
+    const page = updatedContent?.page as CollectionPagePageProps
+
+    // Categories should be sorted numerically
+    expect(page.tagCategories![0]?.label).toBe("Priority 2")
+    expect(page.tagCategories![1]?.label).toBe("Priority 10")
+
+    // Options should be sorted numerically
+    expect(page.tagCategories![1]?.options[0]?.label).toBe("Item 2")
+    expect(page.tagCategories![1]?.options[1]?.label).toBe("Item 10")
+    expect(page.tagCategories![1]?.options[2]?.label).toBe("Item 20")
+  })
+})


### PR DESCRIPTION
## Problem
1. we want to sort tag categories and options alphabetically for our users, because that is the default view with our inbuilt alphanumeric sort. 
2. in order to allow users to self edit the order whilst still preserving the alphanumeric ordering, we need to run a migration to sort the `tagCategories` and `tagOptions` alphanumerically

## Solution
1. retrieve all index pages belonging to collections
2. for each index page, we retrieve both the published blob and hte draft blob
3. the blobs are retrieved by checking for `tagCategory`
4. if it is the published blob, we directly override the `publishedBlob`
5. if it is the `draftBlob`, we override the `draftBlob`. 
