### PR TITLE
chore(dependabot): add cooldown period to mitigate supply chain attacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7 # to mitigate supply chain attacks
     groups:
       aws-sdk:
         applies-to: version-updates


### PR DESCRIPTION
## Problem

Add cooldown period to Dependabot configuration to mitigate supply chain attacks by preventing rapid-fire dependency updates.

reference
- https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-

## Solution

Added a 7-day cooldown period to the Dependabot configuration to reduce the risk of supply chain attacks by limiting how frequently dependency updates can be created.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Added 7-day cooldown period to Dependabot configuration

## Tests

No tests required - this is a configuration-only change.