### PR TITLE
chore: remove sorting

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
@@ -27,17 +27,15 @@ export const getTagFilters = (
     }
   })
 
-  return Array.from(tagCategories.entries())
-    .reduce((acc: Filter[], [category, values]) => {
-      const items: FilterItem[] = Array.from(values.entries())
-        .map(([label, count]) => ({
+  return Array.from(tagCategories.entries()).reduce(
+    (acc: Filter[], [category, values]) => {
+      const items: FilterItem[] = Array.from(values.entries()).map(
+        ([label, count]) => ({
           label,
           count,
           id: label,
-        }))
-        .sort((a, b) =>
-          a.label.localeCompare(b.label, undefined, { numeric: true }),
-        )
+        }),
+      )
 
       const filters: Filter[] = [
         ...acc,
@@ -49,8 +47,7 @@ export const getTagFilters = (
       ]
 
       return filters
-    }, [])
-    .sort((a, b) =>
-      a.label.localeCompare(b.label, undefined, { numeric: true }),
-    )
+    },
+    [],
+  )
 }


### PR DESCRIPTION
## Problem
we already ran the migration to sort `tagCategories` alphabetically, so we should remove the sort in our codebase

## Solution
remove sorting function in `getTagFilters`
