### PR TITLE
update limits for image and infocard descriptions

### DIFF
--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -46,7 +46,8 @@ export const ImageSchema = Type.Object(
     caption: Type.Optional(
       Type.String({
         title: "Caption",
-        maxLength: 250,
+        description:
+          "Describe the image or add attributions. To make sure your caption is readable, keep it under 250 characters.",
         format: "textarea",
       }),
     ),

--- a/packages/components/src/interfaces/complex/InfoCards.ts
+++ b/packages/components/src/interfaces/complex/InfoCards.ts
@@ -94,7 +94,8 @@ const InfoCardsBaseSchema = Type.Object({
   subtitle: Type.Optional(
     Type.String({
       title: "Description",
-      maxLength: 200,
+      description:
+        "To make sure your description is readable, keep it under 200 characters.",
     }),
   ),
   maxColumns: Type.Optional(


### PR DESCRIPTION
## Problem

Character limits for components are limiting with not enough user education, causing migration inefficiencies.

Closes [ISOM-2076]

## Solution

This PR focuses on loosening limitations for the two components:
- Individual image captions 
- Image gallery image captions
- Individual infocard descriptions