### PR TITLE
Enhancement/contactinformation whitelisting order

### DIFF
--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/HomepageContactInformationUI.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/HomepageContactInformationUI.tsx
@@ -8,6 +8,7 @@ import {
   commonContactMethodStyles,
 } from "./common"
 import { ContactMethod, LoadingContactMethod } from "./ContactMethod"
+import { filterContactMethods } from "./filterContactMethods"
 
 const createHomepageContactInformationStyles = tv({
   extend: commonContactInformationStyles,
@@ -98,11 +99,7 @@ export const HomepageContactInformationUI = ({
   isLoading,
   acceptHtmlTags = false,
 }: ContactInformationUIProps) => {
-  const filteredMethods = whitelistedMethods
-    ? methods.filter(
-        (method) => method.method && whitelistedMethods.includes(method.method),
-      )
-    : methods
+  const filteredMethods = filterContactMethods({ methods, whitelistedMethods })
 
   const numberOfContactMethods: NumberOfContactMethods = isLoading
     ? MAX_CONTACT_METHODS_FOR_HOMEPAGE

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/__tests__/filterContactMethods.test.ts
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/__tests__/filterContactMethods.test.ts
@@ -117,5 +117,97 @@ describe("filterContactMethods", () => {
       expect(result[2]?.method).toBe("telephone")
       expect(result[3]?.method).toBe("email")
     })
+
+    it("should handle multiple methods of the same type", () => {
+      // Arrange - Create methods with multiple instances of the same type
+      const methods: ContactInformationUIProps["methods"] = [
+        {
+          method: "telephone",
+          label: "Main Phone",
+          values: ["+65-1234-5678"],
+          caption: "Main office",
+        },
+        {
+          method: "email",
+          label: "General Email",
+          values: ["info@example.com"],
+          caption: "General inquiries",
+        },
+        {
+          method: "telephone",
+          label: "Emergency Phone",
+          values: ["+65-9876-5432"],
+          caption: "Emergency only",
+        },
+        {
+          method: "website",
+          label: "Main Website",
+          values: ["https://example.com"],
+          caption: "Official website",
+        },
+        {
+          method: "email",
+          label: "Support Email",
+          values: ["support@example.com"],
+          caption: "Technical support",
+        },
+      ]
+      const whitelistedMethods: ContactInformationUIProps["whitelistedMethods"] =
+        ["telephone", "email"]
+
+      // Act
+      const result = filterContactMethods({ methods, whitelistedMethods })
+
+      // Assert
+      expect(result).toHaveLength(4)
+      // Should return all telephone methods first (in original order)
+      expect(result[0]?.method).toBe("telephone")
+      expect(result[0]?.label).toBe("Main Phone")
+      expect(result[1]?.method).toBe("telephone")
+      expect(result[1]?.label).toBe("Emergency Phone")
+      // Then all email methods (in original order)
+      expect(result[2]?.method).toBe("email")
+      expect(result[2]?.label).toBe("General Email")
+      expect(result[3]?.method).toBe("email")
+      expect(result[3]?.label).toBe("Support Email")
+    })
+
+    it("should filter out methods with falsy method values", () => {
+      // Arrange - Include methods with falsy method values
+      const methods: ContactInformationUIProps["methods"] = [
+        {
+          method: "telephone",
+          label: "Phone",
+          values: ["+65-1234-5678"],
+        },
+        {
+          method: undefined, // Falsy method
+          label: "Invalid Method",
+          values: ["invalid"],
+        },
+        {
+          method: "email",
+          label: "Email",
+          values: ["info@example.com"],
+        },
+        {
+          // disable eslint because we want to test falsy method
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+          method: null as any, // Falsy method
+          label: "Another Invalid",
+          values: ["also-invalid"],
+        },
+      ]
+      const whitelistedMethods: ContactInformationUIProps["whitelistedMethods"] =
+        ["telephone", "email", "website"]
+
+      // Act
+      const result = filterContactMethods({ methods, whitelistedMethods })
+
+      // Assert
+      expect(result).toHaveLength(2)
+      expect(result[0]?.method).toBe("telephone")
+      expect(result[1]?.method).toBe("email")
+    })
   })
 })

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/__tests__/filterContactMethods.test.ts
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/__tests__/filterContactMethods.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  CONTACT_INFORMATION_SUPPORT_METHODS,
+  ContactInformationUIProps,
+} from "~/interfaces"
+import { filterContactMethods } from "../filterContactMethods"
+
+// Helper function to create mock contact methods
+const createMockMethods = (
+  methodTypes: (typeof CONTACT_INFORMATION_SUPPORT_METHODS)[number][],
+): ContactInformationUIProps["methods"] => {
+  return methodTypes.map((method, index) => ({
+    method,
+    label: `${method} label ${index + 1}`,
+    values: [`${method} value ${index + 1}`],
+    caption: `${method} caption ${index + 1}`,
+  }))
+}
+
+describe("filterContactMethods", () => {
+  describe("when whitelistedMethods is undefined", () => {
+    it("should return all methods", () => {
+      // Arrange
+      const methods = createMockMethods(["telephone", "email", "website"])
+
+      // Act
+      const result = filterContactMethods({ methods })
+
+      // Assert
+      expect(result).toEqual(methods)
+      expect(result).toHaveLength(3)
+    })
+
+    it("should return empty array when methods is empty", () => {
+      // Arrange
+      const methods: ContactInformationUIProps["methods"] = []
+
+      // Act
+      const result = filterContactMethods({ methods })
+
+      // Assert
+      expect(result).toEqual([])
+    })
+  })
+
+  describe("when whitelistedMethods is provided", () => {
+    it("should return only methods that match whitelisted methods", () => {
+      // Arrange
+      const methods = createMockMethods([
+        "telephone",
+        "email",
+        "website",
+        "fax",
+        "address",
+      ])
+      const whitelistedMethods: ContactInformationUIProps["whitelistedMethods"] =
+        ["email", "website"]
+
+      // Act
+      const result = filterContactMethods({ methods, whitelistedMethods })
+
+      // Assert
+      expect(result).toHaveLength(2)
+      expect(result[0]?.method).toBe("email")
+      expect(result[1]?.method).toBe("website")
+    })
+
+    it("should return methods in the order of whitelistedMethods", () => {
+      // Arrange
+      const methods = createMockMethods(["telephone", "email", "website"])
+      const whitelistedMethods: ContactInformationUIProps["whitelistedMethods"] =
+        ["website", "telephone", "email"]
+
+      // Act
+      const result = filterContactMethods({ methods, whitelistedMethods })
+
+      // Assert
+      expect(result).toHaveLength(3)
+      expect(result[0]?.method).toBe("website")
+      expect(result[1]?.method).toBe("telephone")
+      expect(result[2]?.method).toBe("email")
+    })
+
+    it("should return empty array when whitelistedMethods is empty", () => {
+      // Arrange
+      const methods = createMockMethods(["telephone", "email", "website"])
+      const whitelistedMethods: ContactInformationUIProps["whitelistedMethods"] =
+        []
+
+      // Act
+      const result = filterContactMethods({ methods, whitelistedMethods })
+
+      // Assert
+      expect(result).toEqual([])
+      expect(result).toHaveLength(0)
+    })
+
+    it("should handle duplicate whitelisted methods", () => {
+      // Arrange
+      const methods = createMockMethods(["telephone", "email"])
+      const whitelistedMethods: ContactInformationUIProps["whitelistedMethods"] =
+        [
+          "telephone",
+          "email",
+          "telephone", // Duplicate
+          "email", // Duplicate
+        ]
+
+      // Act
+      const result = filterContactMethods({ methods, whitelistedMethods })
+
+      // Assert
+      expect(result).toHaveLength(4)
+      expect(result[0]?.method).toBe("telephone")
+      expect(result[1]?.method).toBe("email")
+      expect(result[2]?.method).toBe("telephone")
+      expect(result[3]?.method).toBe("email")
+    })
+  })
+})

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/filterContactMethods.ts
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/filterContactMethods.ts
@@ -13,13 +13,15 @@ export const filterContactMethods = ({
     return methods
   }
 
-  const filteredMethodsInOrder = whitelistedMethods.map((whitelistedMethod) =>
-    methods.find((method) => method.method === whitelistedMethod),
+  // Filter methods that have a valid method type and are whitelisted
+  const filteredMethods = methods.filter(
+    (method) => method.method && whitelistedMethods.includes(method.method),
   )
 
-  const definedFilteredMethods = filteredMethodsInOrder.filter(
-    (method): method is NonNullable<typeof method> => method !== undefined,
+  // Sort the filtered methods according to the order in whitelistedMethods
+  const sortedMethods = whitelistedMethods.flatMap((whitelistedMethod) =>
+    filteredMethods.filter((method) => method.method === whitelistedMethod),
   )
 
-  return definedFilteredMethods
+  return sortedMethods
 }

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/filterContactMethods.ts
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/filterContactMethods.ts
@@ -1,0 +1,25 @@
+import type { ContactInformationUIProps } from "~/interfaces"
+
+interface FilterContactMethodsProps {
+  methods: ContactInformationUIProps["methods"]
+  whitelistedMethods?: ContactInformationUIProps["whitelistedMethods"]
+}
+
+export const filterContactMethods = ({
+  methods,
+  whitelistedMethods,
+}: FilterContactMethodsProps) => {
+  if (!whitelistedMethods) {
+    return methods
+  }
+
+  const filteredMethodsInOrder = whitelistedMethods.map((whitelistedMethod) =>
+    methods.find((method) => method.method === whitelistedMethod),
+  )
+
+  const definedFilteredMethods = filteredMethodsInOrder.filter(
+    (method): method is NonNullable<typeof method> => method !== undefined,
+  )
+
+  return definedFilteredMethods
+}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Currently the filtering logic only filters based on the whitelisting but does not respect the order of the whitelisting

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- update logic to respect the ordering
- add unit test for it
