### PR TITLE
feat: allow tel: and sms: protocols on template

### DIFF
--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -39,6 +39,34 @@ describe("validation", () => {
         })
     })
 
+    it("should allow tel links", () => {
+      const testCases = [
+        "tel:12345678",
+        "tel:+6512345678",
+        "tel:+65-1234-5678",
+        "tel:+65 1234 5678",
+        "tel:1800 123 4567",
+      ]
+
+      testCases.forEach((testCase) => {
+        const result = new RegExp(LINK_HREF_PATTERN).test(testCase)
+        expect(result).toBe(true)
+      })
+    })
+
+    it("should allow sms links", () => {
+      const testCases = [
+        "sms:12345678",
+        "sms:+6512345678",
+        "sms:+6512345678?body=Hello",
+      ]
+
+      testCases.forEach((testCase) => {
+        const result = new RegExp(LINK_HREF_PATTERN).test(testCase)
+        expect(result).toBe(true)
+      })
+    })
+
     it("should allow internal links", () => {
       const testCases = [
         "[resource:1:2]",
@@ -82,12 +110,8 @@ describe("validation", () => {
       })
     })
 
-    it("should not allow external links with protocols other than https and mailto", () => {
-      const testCases = [
-        "http://example.com",
-        "ftp://example.net",
-        "tel:12345678",
-      ]
+    it("should not allow external links with protocols other than https, tel, sms and mailto", () => {
+      const testCases = ["http://example.com", "ftp://example.net"]
 
       testCases.forEach((testCase) => {
         const result = new RegExp(LINK_HREF_PATTERN).test(testCase)

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -1,5 +1,7 @@
 const ALLOWED_URL_REGEXES = {
   external: "^https:\\/\\/",
+  phone: "^tel:",
+  sms: "^sms:",
   mail: "^mailto:",
   internal: "^\\[resource:(\\d+):(\\d+)\\]$",
   // NOTE: This is taken with reference from `convertAssetLinks`
@@ -15,7 +17,7 @@ const ALLOWED_URL_REGEXES = {
 } as const
 
 export const LINK_HREF_PATTERN =
-  `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.mail})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})|(${ALLOWED_URL_REGEXES.legacy})` as const
+  `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.phone})|(${ALLOWED_URL_REGEXES.sms})|(${ALLOWED_URL_REGEXES.mail})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})|(${ALLOWED_URL_REGEXES.legacy})` as const
 export const REF_HREF_PATTERN =
   `(${ALLOWED_URL_REGEXES.external})|(${ALLOWED_URL_REGEXES.internal})|(${ALLOWED_URL_REGEXES.files})|(${ALLOWED_URL_REGEXES.legacy})` as const
 export const REF_INTERNAL_HREF_PATTERN =


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We currently only allow normal links and mailto: links. But, while very rare, there are some sites that would benefit from having tel: and sms: protocol links.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Allow tel: and sms: links as valid link href patterns.
    - NOTE: Studio support is explicitly **NOT** being added as the editing experience based on the current link editor is not ideal. This change is only to unblock migrators.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit any page
- [ ] Create a new link and link it to some random location first, then save
- [ ] Use the raw JSON editor mode and change the href location of the link to start with `tel:` and `sms:`
- [ ] Verify that in both cases, the save changes button is active and you are able to save changes