### PR TITLE
remove hidden format from Search bar in HeroSchema

### DIFF
--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -88,7 +88,6 @@ export const HeroSchema = Type.Composite(
           }),
           Type.Literal(HERO_STYLE.searchbar, {
             title: "Search bar",
-            format: "hidden",
           }),
         ],
         {


### PR DESCRIPTION
rachel says we leggo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the hidden format from `HeroSchema`'s `searchbar` variant, making it selectable in the hero style options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 384811fc8555cf5300680cf43aa320900b116c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->