### PR TITLE
Enhance/remove inactive isomer admins

### DIFF
--- a/apps/studio/src/server/modules/user/inactiveUsers.service.ts
+++ b/apps/studio/src/server/modules/user/inactiveUsers.service.ts
@@ -41,7 +41,6 @@ export const getInactiveUsers = async ({
     .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
     .where("User.deletedAt", "is", null)
     .where("ResourcePermission.deletedAt", "is", null)
-    .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // needed to provide support for agencies
     .where((eb) =>
       eb.or([
         // Users who have never logged in
@@ -84,7 +83,6 @@ export const bulkSendAccountDeactivationWarningEmails = async ({
       .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
       .innerJoin("Site", "Site.id", "ResourcePermission.siteId")
       .where("User.id", "in", userIds)
-      .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators
       .where("User.deletedAt", "is", null)
       .where("ResourcePermission.deletedAt", "is", null)
       .select([
@@ -188,7 +186,7 @@ const getSiteAndAdmins = async ({ userId, siteIds }: GetSiteAndAdminsProps) => {
           .where("ResourcePermission.userId", "!=", userId) // don't want to ask users to ask themselves for permissions
           .where("ResourcePermission.deletedAt", "is", null)
           .where("ResourcePermission.role", "=", RoleType.Admin) // should only give the admin emails to request reactivation permissions from
-          .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want to send emails to admins and migrators
+          .where("User.email", "not in", ISOMER_ADMINS_AND_MIGRATORS_EMAILS) // we don't want them to request reactivation permissions from isomer admins and migrators
           .select([
             "Site.id as siteId",
             db.fn.agg<string[]>("array_agg", ["User.email"]).as("adminEmails"),


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

past isomer admins aren't removed, which can look like an security issues to agency users

Reference: https://opengovproducts.slack.com/archives/C06R4DX966P/p1759130877982859

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Includes isomer admins and migrators in inactive user selection and notifications, while excluding them from adminEmails in email content.
> 
> - **Backend**:
>   - `getInactiveUsers`: remove exclusion of `ISOMER_ADMINS_AND_MIGRATORS_EMAILS` so isomer admins/migrators are included in inactivity detection.
>   - `bulkSendAccountDeactivationWarningEmails`: include isomer admins/migrators when aggregating users to notify (removed email exclusion in query).
>   - `getSiteAndAdmins`: retain exclusion of `ISOMER_ADMINS_AND_MIGRATORS_EMAILS` from `adminEmails` (clarified comment).
> - **Tests** (`inactiveUsers.service.test.ts`):
>   - Update expectations to ensure isomer admins/migrators are selected as inactive and receive emails, but are not listed in `adminEmails`.
>   - Adjust assertions for email payloads and call counts accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d659e1c6c1288bcecb2fb15daebdff8748d30f32. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->