### PR TITLE
fix: add hidden format to Search bar in HeroSchema

### DIFF
--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -88,6 +88,7 @@ export const HeroSchema = Type.Composite(
           }),
           Type.Literal(HERO_STYLE.searchbar, {
             title: "Search bar",
+            format: "hidden",
           }),
         ],
         {


### PR DESCRIPTION
re: https://opengovproducts.slack.com/archives/C06R4DX966P/p1759286401783889

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks the `searchbar` hero variant as hidden by adding `format: "hidden"` in `packages/components/src/interfaces/complex/Hero.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d9bc0ee3828b7cbf95723d108293a85cdf0f617. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->