### PR TITLE
feat: add toggle for optional and relax asset permissions

### DIFF
--- a/apps/studio/src/features/editing-experience/__tests__/schema.test.ts
+++ b/apps/studio/src/features/editing-experience/__tests__/schema.test.ts
@@ -196,23 +196,20 @@ describe("editing-experience schemas", () => {
       }
     })
 
-    it("should reject when neither pageId nor linkId is provided", () => {
+    it("should still pass when neither pageId nor linkId is provided", () => {
       // Arrange + Act
       const result = pageOrLinkSchema.safeParse({
         siteId: "123",
       })
 
       // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error.issues).toHaveLength(1)
-        expect(result.error.issues[0]?.message).toBe(
-          "At least one of pageId or linkId must be present",
-        )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual({ siteId: 123 })
       }
     })
 
-    it("should reject when both pageId and linkId are undefined", () => {
+    it("should still pass when both pageId and linkId are undefined", () => {
       // Arrange + Act
       const result = pageOrLinkSchema.safeParse({
         siteId: "123",
@@ -221,12 +218,9 @@ describe("editing-experience schemas", () => {
       })
 
       // Assert
-      expect(result.success).toBe(false)
-      if (!result.success) {
-        expect(result.error.issues).toHaveLength(1)
-        expect(result.error.issues[0]?.message).toBe(
-          "At least one of pageId or linkId must be present",
-        )
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual({ siteId: 123 })
       }
     })
   })

--- a/apps/studio/src/features/editing-experience/schema.ts
+++ b/apps/studio/src/features/editing-experience/schema.ts
@@ -15,13 +15,8 @@ export const collectionItemSchema = pageSchema
   })
   .partial({ pageId: true, linkId: true })
 
-export const pageOrLinkSchema = z
-  .object({
-    siteId: z.coerce.number(),
-    pageId: z.coerce.number().optional(),
-    linkId: z.coerce.number().optional(),
-  })
-  .refine((data) => data.pageId !== undefined || data.linkId !== undefined, {
-    message: "At least one of pageId or linkId must be present",
-    path: [], // General form error since either field could be the solution
-  })
+export const pageOrLinkSchema = z.object({
+  siteId: z.coerce.number(),
+  pageId: z.coerce.number().optional(),
+  linkId: z.coerce.number().optional(),
+})

--- a/apps/studio/src/schemas/asset.ts
+++ b/apps/studio/src/schemas/asset.ts
@@ -13,7 +13,7 @@ const ALLOWED_EXTENSIONS = [
 
 export const getPresignedPutUrlSchema = z.object({
   siteId: z.number().min(1),
-  resourceId: z.string(),
+  resourceId: z.string().optional(),
   fileName: z
     .string({
       required_error: "Missing file name",

--- a/apps/studio/src/server/modules/permissions/permissions.type.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.type.ts
@@ -42,6 +42,6 @@ export interface UserPermissionsProps extends PermissionsProps {
 
 export interface AssetPermissionsProps
   extends Pick<PermissionsProps, "siteId" | "userId"> {
-  resourceId: string
+  resourceId?: string
   action: "create" | "delete"
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Two problems to fix in one PR:
1. We don't have a toggle right now for optional objects
2. Asset permissions is tied to resources, but there are use-cases where we need to upload assets on the root/site-wide level

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add a toggle to ObjectControl if the entire object is optional.
- Allow for the case where both the pageId and linkId is missing, then default to root-level/site-wide permissions

## Tests

_No tests, this is more internal, will be visible in downstream PRs (navbar/footer/site settings)_