### PR TITLE
fix amplify script: change password generation function to use CommonJS module syntax

### DIFF
--- a/tooling/build/amplify/utils.js
+++ b/tooling/build/amplify/utils.js
@@ -1,6 +1,6 @@
 const crypto = require("crypto")
 
-export const generatePassword = () => {
+const generatePassword = () => {
   let password = ""
 
   // Keep generating until we have at least 12 characters
@@ -14,3 +14,5 @@ export const generatePassword = () => {
 
   return password.substring(0, 12)
 }
+
+module.exports = { generatePassword }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert tooling/build/amplify/utils.js to CommonJS, exporting generatePassword via module.exports.
> 
> - **Tooling**:
>   - **Module System**: Switch `tooling/build/amplify/utils.js` to CommonJS.
>     - Replace `export const generatePassword` with `const generatePassword` and add `module.exports = { generatePassword }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0020a598b7eddd71f0800fd805e35e89311b50ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->