### PR TITLE
chore: fix logs

### DIFF
--- a/apps/studio/src/lib/mail.ts
+++ b/apps/studio/src/lib/mail.ts
@@ -28,7 +28,7 @@ export const sendMail = async (params: SendMailParams): Promise<void> => {
         .post(params)
         .res()
 
-      if (response.status !== 200) {
+      if (response.status >= 300) {
         logger.error({
           error: "Postman API error",
           status: response.status,


### PR DESCRIPTION
## Problem
postman will return 201 on successful emails, which we log errors for. this is wrong and should be fiexd

Closes [insert issue #]

## Solution
update status code to >= 300. thought about setting to >500 but i think more visibility now might still be good since postman hasn't sent over non 201/200 for now