### PR TITLE
feat(Wogaa): add environment prop to dynamically set script URL

### DIFF
--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -27,7 +27,12 @@ export const RenderApplicationScripts = ({
     <>
       <FontPreload />
 
-      {site.isGovernment && <Wogaa ScriptComponent={ScriptComponent} />}
+      {site.isGovernment && (
+        <Wogaa
+          environment={site.environment}
+          ScriptComponent={ScriptComponent}
+        />
+      )}
 
       {shouldIncludeGTM && (
         <>

--- a/packages/components/src/interfaces/internal/Wogaa.ts
+++ b/packages/components/src/interfaces/internal/Wogaa.ts
@@ -1,5 +1,6 @@
-import type { ScriptComponentType } from "~/types"
+import type { IsomerSiteProps, ScriptComponentType } from "~/types"
 
 export interface WogaaProps {
+  environment: IsomerSiteProps["environment"]
   ScriptComponent?: ScriptComponentType
 }

--- a/packages/components/src/templates/next/components/internal/Wogaa/Wogaa.tsx
+++ b/packages/components/src/templates/next/components/internal/Wogaa/Wogaa.tsx
@@ -1,5 +1,13 @@
 import type { WogaaProps } from "~/interfaces"
 
-export const Wogaa = ({ ScriptComponent = "script" }: WogaaProps) => {
-  return <ScriptComponent src="https://assets.wogaa.sg/scripts/wogaa.js" />
+export const Wogaa = ({
+  environment,
+  ScriptComponent = "script",
+}: WogaaProps) => {
+  const scriptUrl =
+    environment === "production"
+      ? "https://assets.wogaa.sg/scripts/wogaa.js"
+      : "https://assets.dcube.cloud/scripts/wogaa.js"
+
+  return <ScriptComponent src={scriptUrl} />
 }


### PR DESCRIPTION
for wogaa team to do testing

re: https://opengovproducts.slack.com/archives/C05KGF41MSL/p1759911065371239?thread_ts=1752543109.071429&cid=C05KGF41MSL

note: will update infra repo separately

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make `Wogaa` environment-aware by passing `site.environment` and selecting the script URL based on environment.
> 
> - **Wogaa**:
>   - Accepts `environment` in `WogaaProps` and selects script URL (`production` -> `https://assets.wogaa.sg/scripts/wogaa.js`, else -> `https://assets.dcube.cloud/scripts/wogaa.js`).
> - **Engine wiring**:
>   - Pass `site.environment` to `Wogaa` in `packages/components/src/engine/renderLayoutComponents.tsx`.
> - **Types**:
>   - Update `WogaaProps` to include `environment: IsomerSiteProps["environment"]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2437a98069ee852354f1e9ad5ccf6fae1c6b3756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->