### PR TITLE
hotfix(failing-builds): webpack config

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -140,16 +140,6 @@ const config = {
   publicRuntimeConfig: {
     NODE_ENV: env.NODE_ENV,
   },
-  webpack: (config, { isServer }) => {
-    if (!isServer) {
-      config.externals = config.externals || []
-      config.externals.push({
-        // don't bundle `dd-trace` on the client side
-        "dd-trace": "dd-trace",
-      })
-    }
-    return config
-  },
   transpilePackages: ["@sinclair/typebox"],
   /** We run eslint as a separate task in CI */
   eslint: { ignoreDuringBuilds: true },


### PR DESCRIPTION
## Problem

#1634 introduced some changes to the webpack config, which are causing staging builds to fail. TODO: figure out why:
https://ap-southeast-1.console.aws.amazon.com/codesuite/codebuild/058264420411/projects/test-vica-ncss/build/test-vica-ncss%3A5c249786-7449-46d7-8358-4de949d70203/?region=ap-southeast-1

Logic behind the introduction:
1. config.externals tells Webpack not to bundle certain modules, instead treat them as already present at runtime.
2. "dd-trace" marked as external on the client build (which is correct, since dd-trace is node-only).

Merge this in before the next release