### PR TITLE
chore: update build:template script to increase stack size

### DIFF
--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "PORT=3001 next",
     "build:local": "rm -rf .next && curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/build/scripts/preBuild.sh | bash && npm run build",
-    "build:template": "next build",
+    "build:template": "node --stack_size=10240 ./node_modules/next/dist/bin/next build",
     "start": "next start",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are encountering maximum call stack size exceeded errors for pmo-corp due to the large size of the national awards winners SearchableTable.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Specify a higher call stack size.