### PR TITLE
fix(Footer): update twitter to X

### DIFF
--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -160,7 +160,7 @@ const SocialMediaSection = ({
                 site.assetsBaseUrl,
               )}
               isExternal
-              label={`${link.type} page`}
+              label={`${link.type === "twitter" ? "X" : link.type} page`}
               className={footerItemLinkStyle()}
               LinkComponent={LinkComponent}
               isWithFocusVisibleHighlight


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

twitter is dead

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- hotfix to show X instead of twitter. since this is not a common occurence, didn't overengiener this

## Tests

<!-- What tests should be run to confirm functionality? -->

1. go to storybook/studio -> go to a page preview and see the X logo shows "X page" instead of "twitter page" 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates social link label in `Footer` to display "X" instead of "twitter" for the twitter icon.
> 
> - **Footer** (`packages/components/src/templates/next/components/internal/Footer/Footer.tsx`):
>   - Adjust social link `label` to render `"X"` when `link.type === "twitter"` (e.g., `"X page"`), instead of `"twitter page"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55e49f49977c947258c900a06f4934ccd0054cf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->