### PR TITLE
chore: update max length for tags to 70

### DIFF
--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -28,7 +28,7 @@ export const TagCategoryUuidSchema = generateUuidSchema({
 // NOTE: single value for now but we might extend this in the future with additional metadata,
 // so we will leave it as is
 const DropdownItemSchema = Type.Object({
-  label: Type.String({ maxLength: 50 }),
+  label: Type.String({ maxLength: 70 }),
   id: TagOptionUuidSchema,
 })
 const TagOptionSchema = DropdownItemSchema


### PR DESCRIPTION
## Problem
as part of isomer's reformation, we are becoming more permissive and allowing users to have higher charactter limits. 

## Solution
increase the character limit to 70 for tag categories/option