### PR TITLE
feat: increase NextJS API payload size to 50MB

### DIFF
--- a/apps/studio/src/pages/api/trpc/[trpc].ts
+++ b/apps/studio/src/pages/api/trpc/[trpc].ts
@@ -6,6 +6,16 @@ import * as trpcNext from "@trpc/server/adapters/next"
 import { createContext } from "~/server/context"
 import { appRouter } from "~/server/modules/_app"
 
+export const config = {
+  api: {
+    bodyParser: {
+      // This is the maximum payload size that NextJS is able to accept, set to
+      // 50MB to allow users to update a very large SearchableTable page
+      sizeLimit: "50MB",
+    },
+  },
+}
+
 export default trpcNext.createNextApiHandler({
   router: appRouter,
   /**


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The default NextJS API payload size is 1MB, which is insufficient when updating very large SearchableTable pages directly within Isomer Studio.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Increase the NextJS payload size from 1MB to 50MB.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Go to the production Isomer Studio and copy the JSON code from this page: https://studio.isomer.gov.sg/sites/157/pages/93748
- Go to any page on staging and paste the JSON code
- Verify that you are able to save the page successfully.