### PR TITLE
fix: use only the headers to determine columns

### DIFF
--- a/packages/components/src/templates/next/components/complex/SearchableTable/shared/SearchableTableClient.tsx
+++ b/packages/components/src/templates/next/components/complex/SearchableTable/shared/SearchableTableClient.tsx
@@ -54,11 +54,7 @@ export const SearchableTableClient = ({
   const [currPage, setCurrPage] = useState(1)
   const titleId = useId()
 
-  const maxNoOfColumns = Math.min(
-    headers.length,
-    ...items.map((row) => row.row.length),
-    MAX_NUMBER_OF_COLUMNS,
-  )
+  const maxNoOfColumns = Math.min(headers.length, MAX_NUMBER_OF_COLUMNS)
   const filteredItems = useMemo(
     () =>
       getFilteredItems({


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We got another issue with the SearchableTable running into the maximum call stack size limit on browsers with limited memory.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Only use the headers to determine the number of columns.
    - Previously was to check through all the rows to make sure everything is present, but we have a fallback anyway if the number of columns in that row is insufficient, so we just need to account for the headers.

## Tests

<!-- What tests should be run to confirm functionality? -->

_No tests, live on pmo-corp already_