### PR TITLE
fix: Set Wogaa to be beforeInteractive

### DIFF
--- a/packages/components/src/templates/next/components/internal/Wogaa/Wogaa.tsx
+++ b/packages/components/src/templates/next/components/internal/Wogaa/Wogaa.tsx
@@ -9,5 +9,7 @@ export const Wogaa = ({
       ? "https://assets.wogaa.sg/scripts/wogaa.js"
       : "https://assets.dcube.cloud/scripts/wogaa.js"
 
-  return <ScriptComponent src={scriptUrl} />
+  // Wogaa needs to be loaded before the page loads so that it can track the page view
+  // While default recommendation is afterInteractive, it actually affected WOGAA's tracking
+  return <ScriptComponent src={scriptUrl} strategy="beforeInteractive" />
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Load Wogaa tracking script with beforeInteractive strategy to initialize before page load.
> 
> - **Templates (Next)**:
>   - **`packages/components/src/templates/next/components/internal/Wogaa/Wogaa.tsx`**:
>     - Set `ScriptComponent` to use `strategy="beforeInteractive"` so the Wogaa script loads before page render.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd20887b22b5c6295a57038c1159c206896a4b14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->