### PR TITLE
fix: remove dependency array in JsonFormsAnyOfControl useeffect hook

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAnyOfControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAnyOfControl.tsx
@@ -97,7 +97,8 @@ export function JsonFormsAnyOfControl({
     if (options[0]) {
       setVariant(options[0].label)
     }
-  }, [options, indexOfFittingSchema])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes https://opengovproducts.slack.com/archives/C06R4DX966P/p1761200958850479?thread_ts=1761035476.955119&cid=C06R4DX966P

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- remove dependency from useeffect dependency array

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize `variant` in JsonFormsAnyOfControl only on mount by emptying the useEffect dependency array and suppressing the exhaustive-deps lint rule.
> 
> - **Form Builder**
>   - `apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsAnyOfControl.tsx`:
>     - Initialize `variant` in `useEffect` only on mount by changing dependency array to `[]`.
>     - Add `eslint-disable-next-line react-hooks/exhaustive-deps` to suppress lint warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae1341be6d571c88e104497fe878c974a3b58e75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->