### PR TITLE
chore(vica/askgov): add widget icons

### DIFF
--- a/apps/studio/src/components/Askgov/index.tsx
+++ b/apps/studio/src/components/Askgov/index.tsx
@@ -1,38 +1,42 @@
-import { Flex } from "@chakra-ui/react"
-
 export const AskgovWidget = () => {
   return (
-    <Flex
-      position="fixed"
-      bottom="4"
-      right="4"
-      zIndex={999998}
-      h="72px"
-      flexDir="row"
-      align="center"
-      justify="center"
-      gap={2}
-      borderRadius="32px"
-      border="2px"
-      borderColor="#c1d2ef"
-      bg="whiteAlpha.500"
-      p={4}
-      shadow="md"
-      backdropFilter="blur(16px)"
+    <div
+      style={{
+        position: "fixed",
+        bottom: "1rem",
+        right: "1rem",
+        zIndex: 999998,
+        display: "flex",
+        height: "72px",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "0.5rem",
+        borderRadius: "32px",
+        border: "2px solid #c1d2ef",
+        backgroundColor: "rgba(255, 255, 255, 0.5)",
+        padding: "1rem",
+        boxShadow:
+          "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+        backdropFilter: "blur(16px)",
+      }}
     >
-      <Flex
-        position="relative"
-        w="50px"
-        h="50px"
-        flexShrink={0}
-        flexDir="column"
-        align="center"
-        justify="center"
-        gap="5px"
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          width: "50px",
+          height: "50px",
+          flexShrink: 0,
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "5px",
+        }}
       >
         <ChatButtonIcon />
-      </Flex>
-    </Flex>
+      </div>
+    </div>
   )
 }
 

--- a/apps/studio/src/components/Vica/index.tsx
+++ b/apps/studio/src/components/Vica/index.tsx
@@ -1,0 +1,38 @@
+export const VicaWidget = () => {
+  return (
+    <div id="webchat-container">
+      <div
+        style={{
+          cursor: "pointer",
+          display: "block",
+          visibility: "visible",
+          height: "55px",
+          width: "55px",
+          position: "fixed",
+          bottom: "40px",
+          right: "40px",
+          zIndex: 9999,
+          transform: "translateZ(0)",
+        }}
+      >
+        <div
+          style={{
+            borderRadius: "50%",
+            height: "55px",
+            width: "55px",
+            touchAction: "none",
+          }}
+        >
+          <img
+            style={{
+              height: "55px",
+              width: "55px",
+            }}
+            alt="Bot Launcher"
+            src="https://bucket-common.vica.gov.sg/unified_webchat_image_launcher.webp"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/EditSettingsPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/EditSettingsPreview.tsx
@@ -3,6 +3,8 @@ import type {
   IsomerSiteProps,
 } from "@opengovsg/isomer-components"
 
+import { AskgovWidget } from "~/components/Askgov"
+import { VicaWidget } from "~/components/Vica"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 import { siteSchema } from "../schema"
@@ -39,6 +41,8 @@ export const EditSettingsPreview = ({
         page={content.page}
         overrides={{ site: { siteName, ...rest } }}
       />
+      {!!rest.askgov && <AskgovWidget />}
+      {!!rest.vica && <VicaWidget />}
     </ViewportContainer>
   )
 }


### PR DESCRIPTION
## Problem
The current integrations page is misisng the widget icons for feedback to the end users

## Solution
- Add the icons into the page; these were done on studio because it didn't feel like they were part of components. to get the styling, i looked at the component on askgov (w/ some help from adrian) then translated into `styles` (no chakra on iframe)
- for vica, i inspected our sample vica site and took the styling. 

## Videos

https://github.com/user-attachments/assets/fb379ba2-0e5a-421e-b68f-d16e02d7258a


