### PR TITLE
test: enhance getTagFilters tests with ordering and insertion logic

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getTagFilters.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getTagFilters.test.ts
@@ -223,4 +223,291 @@ describe("getTagFilters", () => {
     // Assert
     expect(result).toEqual([])
   })
+
+  it("handles mixed scenarios: some categories in tagCategories, some not", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      {
+        title: "Item 1",
+        tags: [
+          { selected: ["Brain"], category: "Body parts" },
+          { selected: ["Acute"], category: "Condition" },
+          { selected: ["Red"], category: "Color" },
+        ],
+        category: "category1",
+      } as ProcessedCollectionCardProps,
+      {
+        title: "Item 2",
+        tags: [
+          { selected: ["Heart"], category: "Body parts" },
+          { selected: ["Blue"], category: "Color" },
+        ],
+        category: "category2",
+      } as ProcessedCollectionCardProps,
+    ]
+
+    const tagCategories: CollectionPageSchemaType["page"]["tagCategories"] = [
+      {
+        label: "Condition",
+        id: "c-1",
+        options: [
+          { label: "Acute", id: "c-acute" },
+          { label: "Chronic", id: "c-chronic" },
+        ],
+      },
+      {
+        label: "Body parts",
+        id: "b-1",
+        options: [
+          { label: "Heart", id: "bp-heart" },
+          { label: "Brain", id: "bp-brain" },
+        ],
+      },
+      // Note: "Color" category is NOT in tagCategories
+    ]
+
+    // Act
+    const result = getTagFilters(items, tagCategories)
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "Condition",
+        label: "Condition",
+        items: [{ id: "Acute", label: "Acute", count: 1 }],
+      },
+      {
+        id: "Body parts",
+        label: "Body parts",
+        items: [
+          { id: "Heart", label: "Heart", count: 1 },
+          { id: "Brain", label: "Brain", count: 1 },
+        ],
+      },
+      {
+        id: "Color",
+        label: "Color",
+        items: [
+          { id: "Red", label: "Red", count: 1 },
+          { id: "Blue", label: "Blue", count: 1 },
+        ],
+      },
+    ])
+  })
+
+  it("handles empty options arrays in tagCategories", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      {
+        title: "Item 1",
+        tags: [
+          { selected: ["Brain", "Heart"], category: "Body parts" },
+          { selected: ["Acute"], category: "Condition" },
+        ],
+        category: "category1",
+      } as ProcessedCollectionCardProps,
+    ]
+
+    const tagCategories: CollectionPageSchemaType["page"]["tagCategories"] = [
+      {
+        label: "Condition",
+        id: "c-1",
+        options: [], // Empty options array
+      },
+      {
+        label: "Body parts",
+        id: "b-1",
+        options: [
+          { label: "Heart", id: "bp-heart" },
+          { label: "Brain", id: "bp-brain" },
+        ],
+      },
+    ]
+
+    // Act
+    const result = getTagFilters(items, tagCategories)
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "Condition",
+        label: "Condition",
+        items: [{ id: "Acute", label: "Acute", count: 1 }], // Unlisted item appears first
+      },
+      {
+        id: "Body parts",
+        label: "Body parts",
+        items: [
+          { id: "Heart", label: "Heart", count: 1 },
+          { id: "Brain", label: "Brain", count: 1 },
+        ],
+      },
+    ])
+  })
+
+  it("handles duplicate tags across multiple items correctly", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      {
+        title: "Item 1",
+        tags: [
+          { selected: ["Brain", "Heart"], category: "Body parts" },
+          { selected: ["Acute"], category: "Condition" },
+        ],
+        category: "category1",
+      } as ProcessedCollectionCardProps,
+      {
+        title: "Item 2",
+        tags: [
+          { selected: ["Brain"], category: "Body parts" },
+          { selected: ["Acute", "Chronic"], category: "Condition" },
+        ],
+        category: "category2",
+      } as ProcessedCollectionCardProps,
+      {
+        title: "Item 3",
+        tags: [
+          { selected: ["Heart"], category: "Body parts" },
+          { selected: ["Acute"], category: "Condition" },
+        ],
+        category: "category3",
+      } as ProcessedCollectionCardProps,
+    ]
+
+    // Act
+    const result = getTagFilters(items)
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "Body parts",
+        label: "Body parts",
+        items: [
+          { id: "Brain", label: "Brain", count: 2 }, // Appears in 2 items
+          { id: "Heart", label: "Heart", count: 2 }, // Appears in 2 items
+        ],
+      },
+      {
+        id: "Condition",
+        label: "Condition",
+        items: [
+          { id: "Acute", label: "Acute", count: 3 }, // Appears in 3 items
+          { id: "Chronic", label: "Chronic", count: 1 }, // Appears in 1 item
+        ],
+      },
+    ])
+  })
+
+  it("handles items with no tags gracefully", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      {
+        title: "Item 1",
+        tags: [{ selected: ["Brain"], category: "Body parts" }],
+        category: "category1",
+      } as ProcessedCollectionCardProps,
+      {
+        title: "Item 2",
+        // No tags property
+        category: "category2",
+        id: "item2",
+        description: "Description 2",
+        date: new Date("2023-01-01"),
+        image: undefined,
+        referenceLinkHref: undefined,
+        imageSrc: undefined,
+        itemTitle: "Item 2",
+      } as ProcessedCollectionCardProps,
+      {
+        title: "Item 3",
+        tags: [], // Empty tags array
+        category: "category3",
+        id: "item3",
+        description: "Description 3",
+        date: new Date("2023-01-01"),
+        image: undefined,
+        referenceLinkHref: undefined,
+        imageSrc: undefined,
+        itemTitle: "Item 3",
+      } as unknown as ProcessedCollectionCardProps,
+      {
+        title: "Item 4",
+        tags: [
+          { selected: [], category: "Body parts" }, // Empty selected array
+        ],
+        category: "category4",
+        id: "item4",
+        description: "Description 4",
+        date: new Date("2023-01-01"),
+        image: undefined,
+        referenceLinkHref: undefined,
+        imageSrc: undefined,
+        itemTitle: "Item 4",
+      } as unknown as ProcessedCollectionCardProps,
+    ]
+
+    // Act
+    const result = getTagFilters(items)
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "Body parts",
+        label: "Body parts",
+        items: [{ id: "Brain", label: "Brain", count: 1 }],
+      },
+    ])
+  })
+
+  it("handles partial tagCategories configuration", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      {
+        title: "Item 1",
+        tags: [
+          { selected: ["Brain", "Heart"], category: "Body parts" },
+          { selected: ["Acute"], category: "Condition" },
+          { selected: ["Red"], category: "Color" },
+        ],
+        category: "category1",
+      } as ProcessedCollectionCardProps,
+    ]
+
+    const tagCategories: CollectionPageSchemaType["page"]["tagCategories"] = [
+      {
+        label: "Body parts",
+        id: "b-1",
+        options: [
+          { label: "Heart", id: "bp-heart" },
+          { label: "Brain", id: "bp-brain" },
+        ],
+      },
+      // Note: "Condition" and "Color" are not in tagCategories
+    ]
+
+    // Act
+    const result = getTagFilters(items, tagCategories)
+
+    // Assert
+    expect(result).toEqual([
+      {
+        id: "Body parts",
+        label: "Body parts",
+        items: [
+          { id: "Heart", label: "Heart", count: 1 },
+          { id: "Brain", label: "Brain", count: 1 },
+        ],
+      },
+      {
+        id: "Condition",
+        label: "Condition",
+        items: [{ id: "Acute", label: "Acute", count: 1 }],
+      },
+      {
+        id: "Color",
+        label: "Color",
+        items: [{ id: "Red", label: "Red", count: 1 }],
+      },
+    ])
+  })
 })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

abit hard to understand what the method does at first glance

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- add more tests as a form of documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands `getTagFilters` tests to validate category/item ordering based on `tagCategories` and various edge cases.
> 
> - **Tests** (`packages/components/src/templates/next/layouts/Collection/utils/__tests__/getTagFilters.test.ts`):
>   - Validate category ordering by `tagCategories` label order; unlisted last.
>   - Validate item ordering within categories by `options`; unlisted items first.
>   - Ensure insertion-order behavior when `tagCategories` is omitted.
>   - Handle mixed scenarios where some categories are configured and others are not.
>   - Support empty `options` arrays with unlisted items appearing first.
>   - Count duplicates across multiple items correctly.
>   - Gracefully handle items with no tags or empty tag selections.
>   - Support partial `tagCategories` configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d413b30477ece2f93225e12fd857e4619acae7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->