### PR TITLE
fix(LogoCloud): adjust image width for better Safari compatibility

### DIFF
--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
@@ -26,8 +26,10 @@ export const LogoCloud = ({
           {images.map((props) => (
             <ImageClient
               {...props}
-              width="100%"
-              className="inset-0 max-h-24 w-fit object-contain p-2"
+              // have to pass in here instead of w-fit because
+              // flex-wrap in parent div doesn't work well with w-fit for safari
+              width="auto"
+              className="inset-0 max-h-24 object-contain p-2"
               assetsBaseUrl={assetsBaseUrl}
             />
           ))}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

ogocloud on firefox and safari browsers (desktop) will actually turn into a vertical line instead of a horizontal line

reference: https://opengovproducts.slack.com/archives/C07CWUNUL68/p1761190529091979?thread_ts=1761094806.568079&cid=C07CWUNUL68

<img width="569" height="720" alt="image" src="https://github.com/user-attachments/assets/fbbfc74e-de2a-443c-bd08-dc2d77974594" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
    - Details ...
- [ ] No - this PR is backwards compatible

## Before & After Screenshots

(refer to chromatic)

## Test

1. add a logocloud with many items (can reference MTI rootpage schema)
2. publish and view on safari -> should stack side by side instead of vertically

<!-- CURSOR_SUMMARY -->

---

> [!NOTE]
> Tweak `LogoCloud` image sizing (set width to `auto`, remove `w-fit`) to fix Safari wrapping/layout issues.
>
> - **UI -** **`LogoCloud`**:
>     - Update `ImageClient` props in `LogoCloud.tsx`:
>         - Set `width` from `"100%"` to `"auto"`.
>         - Remove `w-fit` from `className` (now `"inset-0 max-h-24 object-contain p-2"`).
>         - Add inline comment explaining Safari flex-wrap compatibility.
>
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 341cd490f58d4e4ce69258ff2795e3102893f52e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>

<!-- /CURSOR_SUMMARY -->