### PR TITLE
chore: remove flag check for wogaa

### DIFF
--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -26,13 +26,12 @@ export const RenderApplicationScripts = ({
   return (
     <>
       <FontPreload />
-
-      {site.isGovernment && (
-        <Wogaa
-          environment={site.environment}
-          ScriptComponent={ScriptComponent}
-        />
-      )}
+      {/* NOTE: we load in wogaa regardless of whether the site is  */}
+      {/* a government site as wogaa still requires the agency to register their site */}
+      {/* and wogaa is still gated behind techpass login. */}
+      {/* Additionally, wogaa will still load but not track metrics if the site  */}
+      {/* is not registered, so no end impact to user */}
+      <Wogaa environment={site.environment} ScriptComponent={ScriptComponent} />
 
       {shouldIncludeGTM && (
         <>


### PR DESCRIPTION
## Problem
we want to enable wogaa **for non gov.sg sites**. refer to [this](https://opengovproducts.slack.com/archives/C083KGWTX5X/p1761621883104059) slack message for more context

Closes [insert issue #]

## Solution
remove the `isGovernment` check for wogaa