### PR TITLE
feat: switch feature flag to boolean with attributes

### DIFF
--- a/apps/studio/src/hooks/useNewSettingsPage.ts
+++ b/apps/studio/src/hooks/useNewSettingsPage.ts
@@ -1,18 +1,6 @@
 import { useFeatureValue } from "@growthbook/growthbook-react"
-import { ISOMER_ADMINS_AND_MIGRATORS_EMAILS } from "~prisma/constants"
 
-import { useMe } from "~/features/me/api"
-import { USE_NEW_SETTINGS_PAGE_FEATURE_KEY } from "~/lib/growthbook"
+import { IS_NEW_SETTINGS_PAGE_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 
-export const useNewSettingsPage = () => {
-  const {
-    me: { email },
-  } = useMe()
-
-  const { enabledFor } = useFeatureValue<{ enabledFor: string[] }>(
-    USE_NEW_SETTINGS_PAGE_FEATURE_KEY,
-    { enabledFor: ISOMER_ADMINS_AND_MIGRATORS_EMAILS },
-  )
-
-  return enabledFor.includes(email)
-}
+export const useNewSettingsPage = () =>
+  useFeatureValue<boolean>(IS_NEW_SETTINGS_PAGE_ENABLED_FEATURE_KEY, false)

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -4,11 +4,13 @@ export const SCHEDULED_PUBLISHING_SITES_FEATURE_KEY =
   "scheduled-publishing-sites"
 export const BANNER_FEATURE_KEY = "isomer-next-banner"
 export const ISOMER_ADMIN_FEATURE_KEY = "isomer_admins"
-export const USE_NEW_SETTINGS_PAGE_FEATURE_KEY = "use-new-settings-page"
+export const IS_NEW_SETTINGS_PAGE_ENABLED_FEATURE_KEY =
+  "is-new-settings-page-enabled"
 export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
-export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 export const ENABLE_DATABASE_LAYOUT_FEATURE_KEY = "enable-database-layout"
+
+export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 
 interface GetIsSingpassEnabledProps {
   gb: GrowthBook


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We previously used `enabledFor` with a list of email addresses, which requires us to dump the entire users table inside the feature flag contents to enable the new settings page for general availability.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Switch to a different feature flag that uses boolean with attribute targeting using `email`, which is already in use currently by the Singpass feature flag.
- Remove the older feature flag that checks the `enabledFor`. It will be completely deleted from Growthbook after release is complete.