### PR TITLE
fix: use custom error message handler

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/BaseLinkControl.tsx
@@ -26,6 +26,7 @@ import { trpc } from "~/utils/trpc"
 import { LINK_TYPES } from "../../../LinkEditor/constants"
 import { getLinkHrefType } from "../../../LinkEditor/utils"
 import { LinkErrorBoundary } from "../../components/LinkErrorBoundary"
+import { getCustomErrorMessage } from "./utils"
 import { parseHref } from "./utils/parseHref"
 
 interface SuspendableLabelProps {
@@ -132,7 +133,7 @@ export function BaseLinkControl({
           </Flex>
           {required && (
             <FormErrorMessage>
-              {label} {errors}
+              {label} {getCustomErrorMessage(errors)}
             </FormErrorMessage>
           )}
         </LinkErrorBoundary>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -9,6 +9,7 @@ import {
 } from "@opengovsg/design-system-react"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { getCustomErrorMessage } from "./utils"
 
 export const jsonFormsBooleanControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.BooleanControl,
@@ -50,7 +51,7 @@ export function JsonFormsBooleanControl({
             isChecked={!!data}
             onChange={(e) => handleChange(path, e.target.checked)}
           />
-          <FormErrorMessage>{errors}</FormErrorMessage>
+          <FormErrorMessage>{getCustomErrorMessage(errors)}</FormErrorMessage>
         </Flex>
       </FormControl>
     </Box>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDateControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDateControl.tsx
@@ -9,6 +9,7 @@ import {
 } from "@opengovsg/design-system-react"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { getCustomErrorMessage } from "./utils"
 
 export const jsonFormsDateControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.TextControl,
@@ -37,7 +38,7 @@ export function JsonFormsDateControl({
           onInputValueChange={(date) => handleChange(path, date.toString())}
         />
         <FormErrorMessage>
-          {label} {errors}
+          {label} {getCustomErrorMessage(errors)}
         </FormErrorMessage>
       </FormControl>
     </Box>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsEmbedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsEmbedControl.tsx
@@ -41,6 +41,7 @@ import {
   getEmbedNameFromUrl,
   getIframeSrc,
 } from "../../../utils"
+import { getCustomErrorMessage } from "./utils"
 
 const SUPPORTED_FORMS = Object.keys(FORMSG_EMBED_URL_REGEXES).map(
   (key) => EMBED_NAME_MAPPING[key as keyof typeof FORMSG_EMBED_URL_REGEXES],
@@ -237,7 +238,7 @@ export function JsonFormsEmbedControl({
           </HStack>
 
           <FormErrorMessage>
-            {label} {errors}
+            {label} {getCustomErrorMessage(errors)}
           </FormErrorMessage>
         </FormControl>
       </Box>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
@@ -23,6 +23,7 @@ import {
 } from "@opengovsg/design-system-react"
 
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { getCustomErrorMessage } from "./utils"
 
 export const jsonFormsIntegerControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.IntegerControl,
@@ -85,7 +86,7 @@ export function JsonFormsIntegerControl({
           </NumberInputStepper>
         </NumberInput>
         <FormErrorMessage>
-          {label} {errors}
+          {label} {getCustomErrorMessage(errors)}
         </FormErrorMessage>
       </FormControl>
     </Box>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Not all the Controls are using the custom error message handler.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make all the error messages go through the custom error message handler to provide a human-readable error message.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

<img width="552" height="652" alt="image" src="https://github.com/user-attachments/assets/372e63a8-612a-4fcc-bbd4-d25fec8c3173" />


**AFTER**:

<!-- [insert screenshot here] -->

<img width="601" height="563" alt="image" src="https://github.com/user-attachments/assets/abadfb4b-4c6d-442c-b682-b9822637917c" />