### PR TITLE
fix: provide for Growthbook attribute targeting on frontend

### DIFF
--- a/apps/studio/src/components/AvatarMenu.tsx
+++ b/apps/studio/src/components/AvatarMenu.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react"
 import { Divider, Flex, Text } from "@chakra-ui/react"
+import { useGrowthBook } from "@growthbook/growthbook-react"
 import {
   Menu,
   AvatarMenu as OgpAvatarMenu,
@@ -6,14 +8,24 @@ import {
 import { useSetAtom } from "jotai"
 import { BiLogOut, BiPencil, BiUser } from "react-icons/bi"
 
+import type { GrowthbookAttributes } from "~/types/growthbook"
 import { useMe } from "~/features/me/api"
 import { updateProfileModalOpenAtom } from "~/features/users/atoms"
 import { EditProfileModal } from "~/features/users/components"
 
 export const AvatarMenu = () => {
   const { me, logout } = useMe()
+  const gb = useGrowthBook()
 
   const setIsEditProfileModalOpen = useSetAtom(updateProfileModalOpenAtom)
+
+  useEffect(() => {
+    const newAttributes: Partial<GrowthbookAttributes> = {
+      email: me.email,
+    }
+
+    void gb.setAttributes(newAttributes)
+  }, [gb, me])
 
   return (
     <>

--- a/apps/studio/src/server/modules/auth/auth.router.ts
+++ b/apps/studio/src/server/modules/auth/auth.router.ts
@@ -14,6 +14,7 @@ export const authRouter = router({
   logout: publicProcedure.mutation(async ({ ctx }) => {
     const { userId } = ctx.session
     ctx.session.destroy()
+    await ctx.gb.setAttributes({})
 
     if (!userId) {
       throw new TRPCError({ code: "BAD_REQUEST", message: "User not found" })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We don't currently have the ability to do attribute targeting via Growthbook for frontend-only feature flags.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Ensure that attributes are set on the frontend as well.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Growthbook and edit the `is-new-settings-page-enabled` feature flag for the staging environment.
- [ ] Create a new force rule to disable the new settings page for your own email, while ensuring the default value remain enabled.
- [ ] Go to Studio and verify that you are not able to view the new settings page.
- [ ] Log in to an alternative account, verify that you can view the new settings page on that alternative account.