### PR TITLE
minor typography and colour tweaks in infobar and contact info

### DIFF
--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/common.ts
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/common.ts
@@ -6,12 +6,11 @@ export const commonContactInformationStyles = tv({
     screenWideOuterContainer: "",
     container: `${ComponentContent} flex flex-col`,
     titleAndDescriptionContainer: "flex flex-col",
-    title: "prose-display-md font-bold text-base-content-strong",
+    title: "prose-display-md text-base-content-strong",
     description: "text-base-content-strong [&:not(:first-child)]:mt-0",
     contactMethodsContainer: "flex flex-col gap-10",
     otherInformationContainer: "mt-8 flex flex-col gap-6",
-    otherInformationTitle:
-      "prose-display-sm font-bold text-base-content-strong",
+    otherInformationTitle: "prose-display-sm text-base-content-strong",
     urlButtonContainer: "mx-auto",
   },
   variants: {

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -63,7 +63,8 @@ export const createInfobarStyles = tv({
       colorScheme: "light",
       layout: "homepage",
       className: {
-        outerContainer: "text-base-content",
+        outerContainer: "text-base-content-strong",
+        description: "text-base-content",
       },
     },
     {


### PR DESCRIPTION
## Problem

2 things I missed!
- infobar heading was not using content-base instead of -strong
- infobar description colour was not defined
- contact info titles were bolded

Closes [ISOM-2108]

## Solution

- added/removed classes as necessary
