### PR TITLE
chore: do not jump to footer for integrations page

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
@@ -184,7 +184,6 @@ const IntegrationsSettingsPage: NextPageWithLayout = () => {
         <SettingsPreviewGridItem>
           <EditSettingsPreview
             siteName={siteName}
-            jumpToFooter
             {...complexIntegrationSettings}
             {...simpleIntegrationSettings}
           />


### PR DESCRIPTION
## Problem
- previously, i had a misconception that the vica/askgov widgets appear at the bottom of the page. because of this, i set `jumpToFooter` for integrations. however, i realised they are fixed positioned at the bottom of viewport, so it's ok even if the user is at the top of the page (can still see widget) 


## Solution
remove `jumpToFooter` for integrations

