### PR TITLE
feat: add support for development staging script in Vica components

### DIFF
--- a/packages/components/src/engine/renderLayoutComponents.tsx
+++ b/packages/components/src/engine/renderLayoutComponents.tsx
@@ -52,7 +52,7 @@ export const RenderApplicationScripts = ({
       {/* Note: did not account for both being added to the config as it's a very unlikely scenario and there's "correct" way to handle this */}
       {site.vica && (
         <>
-          <VicaStylesheet environment={site.environment} />
+          <VicaStylesheet useDevStagingScript={site.vica.useDevStagingScript} />
           <VicaWidget
             site={site}
             ScriptComponent={ScriptComponent}

--- a/packages/components/src/interfaces/internal/Vica.ts
+++ b/packages/components/src/interfaces/internal/Vica.ts
@@ -68,6 +68,12 @@ export const VicaSchema = Type.Object(
     "app-environment-override": HiddenOptionalString,
     "app-translation-languages": HiddenOptionalString,
     "app-enable-hide-translation": Type.Optional(BooleanStringOptions),
+    // Dev Testing
+    // note: this is only enabled so that VICA's engineering team can test changes to the script
+    // agency's users testing their draft bot should still use the production script
+    // with "app-environment-override"=draft
+    // Reference: https://opengovproducts.slack.com/archives/C087MUEJAMA/p1761820927407499?thread_ts=1761800290.229459&cid=C087MUEJAMA
+    useDevStagingScript: Type.Optional(Type.Boolean({ format: "hidden" })),
   },
   { format: "widget-integration/vica" },
 )
@@ -75,15 +81,12 @@ export const VicaSchema = Type.Object(
 export type VicaProps = Static<typeof VicaSchema>
 
 export interface VicaWidgetClientProps extends VicaProps {
-  environment: IsomerSiteProps["environment"]
   ScriptComponent: ScriptComponentType
 }
 
 export interface VicaWidgetProps extends VicaProps {
-  site: Pick<IsomerSiteProps, "environment" | "siteMap" | "assetsBaseUrl">
+  site: Pick<IsomerSiteProps, "siteMap" | "assetsBaseUrl">
   ScriptComponent: ScriptComponentType
 }
 
-export interface VicaStylesheetProps {
-  environment: IsomerSiteProps["environment"]
-}
+export type VicaStylesheetProps = Pick<VicaProps, "useDevStagingScript">

--- a/packages/components/src/templates/next/components/internal/Vica/VicaStylesheet.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaStylesheet.tsx
@@ -1,10 +1,11 @@
 import type { VicaStylesheetProps } from "~/interfaces"
 
-export const VicaStylesheet = ({ environment }: VicaStylesheetProps) => {
-  const stylesheetUrl =
-    environment === "production"
-      ? "https://webchat.vica.gov.sg/static/css/chat.css"
-      : "https://webchat.mol-vica.com/static/css/chat.css"
+export const VicaStylesheet = ({
+  useDevStagingScript,
+}: VicaStylesheetProps) => {
+  const stylesheetUrl = useDevStagingScript
+    ? "https://webchat.mol-vica.com/static/css/chat.css"
+    : "https://webchat.vica.gov.sg/static/css/chat.css"
 
   return (
     <>

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -11,7 +11,6 @@ export const VicaWidget = ({
 }: VicaWidgetProps) => {
   return (
     <VicaWidgetClient
-      environment={site.environment}
       ScriptComponent={ScriptComponent}
       app-icon={
         appIcon

--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidgetClient.tsx
@@ -3,14 +3,13 @@
 import type { VicaWidgetClientProps } from "~/interfaces"
 
 export const VicaWidgetClient = ({
-  environment,
   ScriptComponent,
+  useDevStagingScript,
   ...vicaProps
 }: VicaWidgetClientProps) => {
-  const scriptUrl =
-    environment === "production"
-      ? "https://webchat.vica.gov.sg/static/js/chat.js"
-      : "https://webchat.mol-vica.com/static/js/chat.js"
+  const scriptUrl = useDevStagingScript
+    ? "https://webchat.mol-vica.com/static/js/chat.js"
+    : "https://webchat.vica.gov.sg/static/js/chat.js"
 
   return (
     <>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Users cannot test their staging vica vot

References:
- From Ryan on usage of staging link: https://opengovproducts.slack.com/archives/C087MUEJAMA/p1761820927407499?thread_ts=1761800290.229459&cid=C087MUEJAMA

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- switch to pass in `useDevStagingScript` config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `useDevStagingScript` toggle to Vica and switches stylesheet/script URLs to use it instead of `environment`, removing env from Vica component props.
> 
> - **Vica Integration**
>   - **Config/Schema**: Add hidden boolean `useDevStagingScript` to `VicaSchema` and expose via `VicaProps`.
>   - **Types**: Remove `environment` from `VicaWidgetProps`/`VicaWidgetClientProps`; define `VicaStylesheetProps` as `Pick<VicaProps, "useDevStagingScript">`.
>   - **Runtime Behavior**:
>     - `VicaStylesheet` and `VicaWidgetClient` now select CSS/JS URLs based on `useDevStagingScript` (prod `vica.gov.sg` vs staging `mol-vica.com`).
>     - Update `renderLayoutComponents` to pass `useDevStagingScript` to `VicaStylesheet` and stop passing environment to Vica components.
>   - **Widget Wiring**: `VicaWidget` forwards props to client without environment and continues resolving `app-icon` asset URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4f2287101f24f9bafc047f833000d81fe9b6e8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->