### PR TITLE
chore: add mti.gov.sg to audit logs requests

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -20,6 +20,7 @@ const SITES_WITH_AUDIT_LOGS = [
   61, // ipos.gov.sg
   109, // agc.gov.sg
   145, // ite.edu.sg
+  166, // mti.gov.sg
 ]
 
 // Month and year to get audit logs for, in the format of YYYY-MM,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

MTI requested for monthly audit logs.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Include MTI (site 166) in the monthly audit logs cadence.