### PR TITLE
fix: record siteId for permissions audit logs

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -201,7 +201,14 @@ const getAuditLogQuery = ({
                   AUDIT_LOGS_EVENTS_QUERIES,
                 ) as DisplayableAuditLogEvent[],
               ),
-              eb("al.siteId", "=", siteId),
+              eb.or([
+                eb.eb("al.siteId", "=", siteId),
+                eb.eb(
+                  sql<number>`"al".delta -> 'after' ->> 'siteId'`,
+                  "=",
+                  siteId,
+                ),
+              ]),
             ]),
             eb.and([
               eb("al.eventType", "=", AuditLogEvent.Login),

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -314,11 +314,12 @@ interface PermissionEventLogProps {
   delta: CreatePermissionDelta | DeletePermissionDelta | UpdatePermissionDelta
   metadata?: Record<string, unknown>
   ip?: string
+  siteId: Site["id"]
 }
 
 export const logPermissionEvent: AuditLogger<PermissionEventLogProps> = async (
   tx,
-  { eventType, by, delta, ip, metadata = {} },
+  { eventType, by, delta, ip, siteId, metadata = {} },
 ) => {
   await tx
     .insertInto("AuditLog")
@@ -327,6 +328,7 @@ export const logPermissionEvent: AuditLogger<PermissionEventLogProps> = async (
       delta,
       userId: by.id,
       ipAddress: ip,
+      siteId,
       metadata,
     })
     .execute()

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -256,6 +256,7 @@ export const updateUserSitewidePermission = async ({
       eventType: AuditLogEvent.PermissionDelete,
       by: byUser,
       delta: { before: sitePermissionToRemove, after: deletedSitePermission },
+      siteId,
     })
 
     const createdSitePermission = await tx
@@ -277,6 +278,7 @@ export const updateUserSitewidePermission = async ({
       eventType: AuditLogEvent.PermissionCreate,
       by: byUser,
       delta: { before: null, after: createdSitePermission },
+      siteId,
     })
 
     return createdSitePermission

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -140,6 +140,7 @@ export const createUserWithPermission = async ({
       eventType: AuditLogEvent.PermissionCreate,
       by: byUser,
       delta: { before: null, after: resourcePermission },
+      siteId,
     })
 
     return resourcePermission
@@ -260,6 +261,7 @@ export const deleteUserPermission = async ({
         eventType: AuditLogEvent.PermissionDelete,
         by: byUser,
         delta: { before, after: deletedUserPermission },
+        siteId,
       })
     }
   })


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We are not recording the siteId when logging to the audit logs table when doing permission changes.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Log the siteId in the audit logs for permission changes.
- Also adjusted the audit logs script to handle the previous case (since we are not able to adjust the audit logs).

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Add a user to a site on Studio
- [ ] Verify on the AuditLog table that the PermissionCreate audit log entry shows the siteId
- [ ] Remove the user from the site
- [ ] Verify that the AuditLog table shows the PermissionDelete entry with the siteId