### PR TITLE
chore: remove tag limit

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -11,8 +11,6 @@ import { collectionItemSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 
-const MAX_TAG_CATEGORY_ITEMS = 3 as const
-
 export const jsonFormsTaggedControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.TaggedControl,
   schemaMatches((schema) => schema.format === "tagged"),
@@ -78,11 +76,6 @@ const SuspendableJsonFormsTaggedControl = ({
             )
             const tagOptionsIds = options.map(({ id }) => id)
 
-            // NOTE: This refers to whether we should render and show
-            // ONLY the options that the user has selected
-            const shouldOnlyRenderSelected =
-              currentTagCategoryOptions.length >= MAX_TAG_CATEGORY_ITEMS
-
             return (
               <FormControl isRequired={required} gap="0.5rem">
                 <FormLabel description={description}>{label}</FormLabel>
@@ -91,19 +84,12 @@ const SuspendableJsonFormsTaggedControl = ({
                   nothingFoundLabel="No tags found. Search for something else or contact your site owner(s) to create new tags."
                   values={currentTagCategoryOptions.map(({ id }) => id)}
                   name={label}
-                  items={
-                    shouldOnlyRenderSelected
-                      ? currentTagCategoryOptions.map(({ id, label }) => ({
-                          value: id,
-                          label,
-                        }))
-                      : options.map(({ id, label }) => {
-                          return {
-                            value: id,
-                            label,
-                          }
-                        })
-                  }
+                  items={options.map(({ id, label }) => {
+                    return {
+                      value: id,
+                      label,
+                    }
+                  })}
                   // NOTE: `value` is the new set of selected options
                   onChange={(value) => {
                     const others =


### PR DESCRIPTION
## Problem
- we want to remove the tag limit from tag categories so users can select > 3 items 

## Solution
- remove the hardcoded limit and let users choose
