### PR TITLE
⚡ Performance: replace RAC (Breadcrumbs)

### DIFF
--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -1,14 +1,4 @@
-"use client"
-
-import type { ElementType } from "react"
-import type {
-  BreadcrumbProps as AriaBreadcrumbProps,
-  BreadcrumbsProps,
-} from "react-aria-components"
-import {
-  Breadcrumb as AriaBreadcrumb,
-  Breadcrumbs as AriaBreadcrumbs,
-} from "react-aria-components"
+import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react"
 import { BiChevronRight } from "react-icons/bi"
 
 import type { BreadcrumbProps, LinkProps } from "~/interfaces"
@@ -40,36 +30,60 @@ const createBreadcrumbLinkStyles = tv({
   defaultVariants: { colorScheme: "default" },
 })
 
-function BaseBreadcrumbs<T extends object>(props: BreadcrumbsProps<T>) {
+type BaseBreadcrumbsProps = ComponentPropsWithoutRef<"div"> & {
+  children: ReactNode
+}
+
+function BaseBreadcrumbs({
+  className,
+  children,
+  "aria-label": ariaLabel = "Breadcrumb",
+  ...props
+}: BaseBreadcrumbsProps) {
   return (
-    <AriaBreadcrumbs
+    <div
       {...props}
-      className={twMerge("flex flex-wrap gap-1", props.className)}
-    />
+      aria-label={ariaLabel}
+      role="navigation"
+      className={twMerge("flex flex-wrap gap-1", className)}
+    >
+      <ol className="m-0 flex list-none flex-wrap items-center gap-1 p-0">
+        {children}
+      </ol>
+    </div>
   )
+}
+
+type BaseBreadcrumbProps = LinkProps & {
+  LinkComponent?: ElementType
+  colorScheme?: "default" | "inverse"
 }
 
 function BaseBreadcrumb({
   LinkComponent,
   colorScheme,
-  ...props
-}: AriaBreadcrumbProps &
-  LinkProps & {
-    LinkComponent?: ElementType
-    colorScheme?: "default" | "inverse"
-  }) {
+  children,
+  label,
+  className,
+  href,
+  ...linkProps
+}: BaseBreadcrumbProps) {
   const styles = createBreadcrumbLinkStyles({ colorScheme })
+  const mergedLinkClassName = twMerge(styles.link(), className)
 
   return (
-    <AriaBreadcrumb {...props} className={styles.container()}>
+    <li className={styles.container()}>
       <Link
-        {...props}
-        label={typeof props.children === "string" ? props.children : undefined}
-        className={styles.link()}
+        {...linkProps}
+        href={href}
+        label={label}
+        className={mergedLinkClassName}
         LinkComponent={LinkComponent}
-      />
-      {props.href && <BiChevronRight className={styles.icon()} />}
-    </AriaBreadcrumb>
+      >
+        {children}
+      </Link>
+      {href && <BiChevronRight aria-hidden="true" className={styles.icon()} />}
+    </li>
   )
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

closes https://linear.app/ogp/issue/ISOM-2084/performance-improvements

Reduce bundle size

- we use react-aria-components for development ease and good accessibility
- however in most cases, we aren’t utilizing a big part of the features. for example, Breadcrumb is 6.3kB because of the underlying hooks (thus the need for “use client”) but it is static in our case
- This approach saves about 6kB off my entire client bundle

Reference: https://www.notion.so/opengov/performance-bundle-size-2a277dbba78880a18e80cc2f95b805ce?source=copy_link

note: there are other RAC that can be stripped out, but its not as straightforward or not worth the tradeoff. This Breadcrumb is a simple and direct one since its pure static

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- Replace RAC with native HTML so that it is no longer a "use client" component

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors Breadcrumb to remove react-aria-components in favor of semantic HTML with custom Link, updated types, and improved a11y handling.
> 
> - **components/internal/Breadcrumb**:
>   - Replace `react-aria-components` (`Breadcrumbs`, `Breadcrumb`) with native markup: `div[role="navigation"]` + `ol > li` and custom `Link`.
>   - New props/types: `BaseBreadcrumbsProps` (`ComponentPropsWithoutRef<'div'>`, `children`), `BaseBreadcrumbProps` (extends `LinkProps`, optional `LinkComponent`, `colorScheme`).
>   - Accessibility: default `aria-label="Breadcrumb"`, `role="navigation"`, chevron icon set `aria-hidden="true"`; last item marked `current="page"` and rendered without `href`.
>   - Styling/structure: maintain slots via `tv`; merge link classes with `twMerge`; render chevron only when `href` is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bf257b3b1fecd310885045cbeadcb09fa3d8422. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->