### PR TITLE
fix: ensure node tagName is targeted correctly

### DIFF
--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -23,7 +23,7 @@ export const BaseParagraph = ({
   LinkComponent,
 }: BaseParagraphProps) => {
   const transform = (node: HTMLElement, children: Node[]): React.ReactNode => {
-    if (node.tagName === "A") {
+    if (node.tagName.toLocaleLowerCase() === "a") {
       const href = node.getAttribute("href") ?? undefined
       const isExternalLink = !!href && isExternalUrl(href)
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

For some reason, `node.tagName` is lower-case when building the site on CodeBuild, even though MDN docs says it is upper-case.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Handle both cases by making `tagName` lower-case before doing comparison, to handle both instances where `tagName` can be either lower-case or upper-case.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit a page.
- [ ] Add a new external link. Verify that the preview shows the external link icon.
- [ ] Save the page and publish the changes.
- [ ] Verify on the staging site that the external link icon appears for that link.