### PR TITLE
fix: allow newlines in article summary

### DIFF
--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.tsx
@@ -45,9 +45,9 @@ const ArticlePageHeader = ({
         )}
 
         {summary && (
-          <div className="prose-title-lg text-base-content-light">
+          <p className="prose-title-lg whitespace-pre-wrap text-base-content-light">
             {summary}
-          </div>
+          </p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our article page summary accidentally no longer allows newlines.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add `whitespace-pre-wrap` to allow newlines in the article page summary.
- Also fix `div` to `p` which is the more semantically correct HTML tag.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and edit any article page.
- [ ] Edit the summary and add newlines to the text.
- [ ] Verify that the summary respects the newlines.