### PR TITLE
fix: use text-base-content for list markers

### DIFF
--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
@@ -21,7 +21,7 @@ const OrderedList = ({
 }: OrderedListProps) => {
   return (
     <ol
-      className={`mt-6 ps-9 ${getOrderedListType(level)}`}
+      className={`mt-6 ps-9 marker:text-base-content ${getOrderedListType(level)}`}
       start={attrs?.start}
     >
       {content.map((item, index) => (

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
@@ -19,7 +19,9 @@ const UnorderedList = ({
   site,
 }: UnorderedListProps) => {
   return (
-    <ul className={`mt-6 ps-9 ${getUnorderedListType(level)}`}>
+    <ul
+      className={`mt-6 ps-9 marker:text-base-content ${getUnorderedListType(level)}`}
+    >
       {content.map((item, index) => (
         <ListItem
           key={index}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Got sharp eyed users identified that our list marker colour is not using the text-base-content.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Make the list markers use text-base-content.