### PR TITLE
feat: style nested list markers in Tiptap editor

### DIFF
--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -16,7 +16,7 @@ $max-depth: 13;
 @mixin nested-orderedlist($level: 1) {
   $index: (($level - 1) % list.length($orderedlist-styles)) + 1;
   list-style-type: list.nth($orderedlist-styles, $index);
-  padding-inline-start: 2.25rem;
+  padding-inline-start: 1.25rem;
 
   @if $level < $max-depth {
     > li > ol {
@@ -29,7 +29,7 @@ $max-depth: 13;
 @mixin nested-unorderedlist($level: 1) {
   $index: (($level - 1) % list.length($unorderedlist-styles)) + 1;
   list-style-type: list.nth($unorderedlist-styles, $index);
-  padding-inline-start: 2.25rem;
+  padding-inline-start: 1.25rem;
 
   @if $level < $max-depth {
     > li > ul {
@@ -58,38 +58,35 @@ $max-depth: 13;
   }
 
   h2 {
-    font-size: 2.75rem;
-    line-height: 4rem;
-    font-weight: 400;
+    font-size: 2.25rem;
+    line-height: 1.2;
+    font-weight: 600;
     letter-spacing: -0.022em;
   }
 
   h3 {
-    font-size: 2rem;
-    line-height: 3rem;
-    font-weight: 400;
+    font-size: 1.5rem;
+    line-height: 1.2;
+    font-weight: 600;
     letter-spacing: -0.022em;
   }
 
   h4 {
-    font-size: 1.625rem;
-    line-height: 2.5rem;
-    font-weight: 400;
-    letter-spacing: -0.02em;
+    font-size: 1.25rem;
+    line-height: 1.3;
+    font-weight: 600;
   }
 
   h5 {
-    font-size: 1.375rem;
-    line-height: 2rem;
-    font-weight: 400;
-    letter-spacing: -0.018em;
+    font-size: 1.125rem;
+    line-height: 1.3;
+    font-weight: 600;
   }
 
   h6 {
     font-size: 1rem;
-    line-height: 1.5rem;
-    font-weight: 400;
-    letter-spacing: -0.011em;
+    line-height: 1.4;
+    font-weight: 600;
   }
 
   ol {
@@ -159,7 +156,7 @@ $max-depth: 13;
 
   ul,
   ol {
-    padding: 0 1rem;
+    padding-left: 1rem;
   }
 
   code {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

One year [after we added support](https://github.com/opengovsg/isomer/issues/857) for alternating list marker types in the components, we still don't support this inside the Tiptap editor.

The styles for headings were also accidentally removed.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add alternating list marker styles inside the Tiptap editor up till the 13th level of nesting (much more than most use-cases).

**Bug Fixes**:

- Add back the styling for the headings.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->
<img width="852" height="992" alt="image" src="https://github.com/user-attachments/assets/11d4223d-6670-478f-9ab9-f593d9f610a1" />

**AFTER**:

<!-- [insert screenshot here] -->
<img width="857" height="974" alt="image" src="https://github.com/user-attachments/assets/5be8ae5b-17fe-4261-a792-29bdbb274ccc" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Studio and add a text block to the page.
- [ ] Add a section heading, verify that the text is bigger than the normal paragraph.
- [ ] Add a nested ordered list, verify that the list markers in the nested lists alternate similarly to how it is shown in the preview.
- [ ] Add a nested unordered list, verify that the list markers in the nested lists alternate similarly to how it is shown in the preview.