### PR TITLE
fix(Breadcrumb): add missing focus highlight

### DIFF
--- a/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
+++ b/packages/components/src/templates/next/components/internal/Breadcrumb/Breadcrumb.tsx
@@ -78,6 +78,7 @@ function BaseBreadcrumb({
         href={href}
         label={label}
         className={mergedLinkClassName}
+        isWithFocusVisibleHighlight
         LinkComponent={LinkComponent}
       >
         {children}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

It was missing for a long time, we just realized last week

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

<img width="836" height="450" alt="Screenshot 2025-11-24 at 12 50 00 PM" src="https://github.com/user-attachments/assets/c5f83e61-16d8-48f4-bf07-d9edce05f312" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds focus-visible highlight to breadcrumb links by enabling `isWithFocusVisibleHighlight` on `Link`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32bc49d9c2ef9ec0e8ac7db8a415d20a1f4b5d37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->