### PR TITLE
chore: update UAT to sandbox

### DIFF
--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -34,7 +34,7 @@ jobs:
       ecs-task-role: studio-uat-ecs-task-role
       ecs-task-exec-role: studio-uat-ecs-task-exec-role
       app-url: "https://sandbox-studio.isomer.gov.sg"
-      app-name: "Isomer Studio (Sandbox)"
+      app-name: "Isomer Studio Sandbox"
       app-version: ${{ github.sha }}
       app-s3-region: "ap-southeast-1"
       app-s3-assets-bucket-name: "isomer-next-infra-uat-assets-private-e728930"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We have been giving agencies the false impression that they can populate their sites on the UAT environment then bringing it over to the production instance.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Change UAT environment to sandbox to make it more obvious that it is just for testing and not for actual content.
    - NOTE: The relevant infra change have already been applied.