### PR TITLE
fix: remove duplicate site name in meta title

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -2,7 +2,7 @@ import type { IsomerPageSchemaType, IsomerSitemap } from "~/types"
 import { ISOMER_PAGE_LAYOUTS } from "~/types/constants"
 import { getSitemapAsArray } from "~/utils"
 
-const getMetaTitle = (props: IsomerPageSchemaType) => {
+const getOpenGraphTitle = (props: IsomerPageSchemaType) => {
   // NOTE: We show the site name as the title for the homepage, as places like
   // WhatsApp do not use the site_name property of the OpenGraph metadata when
   // displaying the page preview, which can be confusing for users
@@ -92,7 +92,9 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
 
   const metadata = {
     metadataBase: props.site.url ? new URL(props.site.url) : undefined,
-    title: getMetaTitle(props),
+    // NOTE: The title will be used like "{title} | {siteName}" inside the
+    // NextJS template
+    title: props.page.title,
     description: getMetaDescription(props),
     robots: {
       index:
@@ -107,7 +109,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
       shortcut: faviconUrl,
     },
     openGraph: {
-      title: getMetaTitle(props),
+      title: getOpenGraphTitle(props),
       description: getMetaDescription(props),
       url: canonicalUrl,
       siteName: props.site.siteName,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Some agency feedback that we are duplicating our sitename on the homepage (e.g. `Isomer | Isomer`) rather than showing the page title (e.g. `Home | Isomer`).

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Separate the treatment of the title inside the open graph title vs the meta title.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Build the site on staging
- [ ] Verify that the title of the homepage is showing `Home | <sitename>` instead of `<sitename> | <sitename>`