### PR TITLE
fix: handle removal of link on footer and navbar

### DIFF
--- a/apps/studio/src/features/settings/FooterEditor/FooterEditor.tsx
+++ b/apps/studio/src/features/settings/FooterEditor/FooterEditor.tsx
@@ -44,9 +44,8 @@ export const FooterEditor = ({
 
   const handleChange = useCallback(
     (data: FooterSchemaType) => {
-      const updatedData = { ...previewFooterState, ...data }
-      if (!isEqual(previewFooterState, updatedData)) {
-        setPreviewFooterState(updatedData)
+      if (!isEqual(previewFooterState, data)) {
+        setPreviewFooterState(data)
         setIsDirty(true)
       }
     },

--- a/apps/studio/src/features/settings/NavbarEditor/NavbarEditor.tsx
+++ b/apps/studio/src/features/settings/NavbarEditor/NavbarEditor.tsx
@@ -59,13 +59,11 @@ export const NavbarEditor = ({
 
   const handleItemsChange = useCallback(
     (data: Static<typeof NavbarItemsSchema>) => {
-      const updatedData = { ...previewNavbarState, ...data }
-
-      if (isEqual(previewNavbarState, updatedData)) {
+      if (isEqual(previewNavbarState, data)) {
         return
       }
 
-      setPreviewNavbarState(updatedData)
+      setPreviewNavbarState(data)
     },
     [previewNavbarState, setPreviewNavbarState],
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

It is not possible to remove links on the footer, even if it is optional.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Avoid doing object spreading with the original data, so that undefined keys remain undefined.

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to any site's footer editing page.
- [ ] Add any link to the contact us or feedback page.
- [ ] Publish the changes and make sure the publish button becomes disabled.
- [ ] Remove that link.
- [ ] Verify that the publish button becomes enabled, and the preview is updated.