### PR TITLE
fix(scheduled-publishing): do not restrict sent emails by resource type

### DIFF
--- a/apps/studio/src/server/modules/webhook/webhook.utils.ts
+++ b/apps/studio/src/server/modules/webhook/webhook.utils.ts
@@ -1,7 +1,6 @@
 import type { GrowthBook } from "@growthbook/growthbook"
 import type { BuildStatusType } from "@prisma/client"
 import type pino from "pino"
-import { ResourceType } from "@prisma/client"
 import _ from "lodash"
 
 import {
@@ -100,7 +99,6 @@ const sendEmails = async (
           eb("CodeBuildJobs.supersededByBuildId", "=", buildId),
         ]),
         eb("CodeBuildJobs.emailSent", "=", false), // only consider builds that haven't had an email sent yet
-        eb("Resource.type", "=", ResourceType.Page), // only consider page resources for sending emails
         eb("User.email", "is not", null), // only consider users with an email
       ])
     })


### PR DESCRIPTION
## Problem

One of our users was unable to get emails, since the updateWebhook functionality erroneously checks for a ResourceType of **ResourceType.Page**, when we allow scheduled publishing for a **ResourceType.CollectionPage** as well. Removing this check fixes the issue.
