### PR TITLE
chore: update next.js version to 15.5.9

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -131,7 +131,7 @@
     "kysely": "^0.27.3",
     "lodash": "^4.17.21",
     "nanoid": "^5.0.9",
-    "next": "^15.5.8",
+    "next": "^15.5.9",
     "node-cron": "^3.0.3",
     "openid-client": "^5.7.1",
     "papaparse": "^5.5.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,7 @@
         "kysely": "^0.27.3",
         "lodash": "^4.17.21",
         "nanoid": "^5.0.9",
-        "next": "^15.5.8",
+        "next": "^15.5.9",
         "node-cron": "^3.0.3",
         "openid-client": "^5.7.1",
         "papaparse": "^5.5.3",
@@ -36869,7 +36869,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@opengovsg/isomer-components": "*",
-        "next": "^15.5.8",
+        "next": "^15.5.9",
         "postcss": "^8.4.39",
         "postcss-preset-env": "^10.0.8",
         "tailwindcss": "^3.4.4",

--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@opengovsg/isomer-components": "*",
-    "next": "^15.5.8",
+    "next": "^15.5.9",
     "postcss": "^8.4.39",
     "postcss-preset-env": "^10.0.8",
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
here we go again

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Next.js to 15.5.9 in `apps/studio` and `tooling/template`, updating lockfile and `@next/env` accordingly.
> 
> - **Dependencies**:
>   - Bump `next` from `15.5.7` to `15.5.9` in `apps/studio/package.json` and `tooling/template/package.json`.
>   - Update lockfile entries for `next` and `@next/env` to `15.5.9`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a1e291e2601ecd723734c7b18b55cacba49331. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->