### PR TITLE
chore: update width

### DIFF
--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -33,7 +33,7 @@ export const CollectionCard = ({
       isExternal={isExternalLink}
     >
       {shouldShowDate && (
-        <p className="prose-label-md-regular shrink-0 text-base-content-subtle lg:w-[140px]">
+        <p className="prose-label-md-regular shrink-0 text-base-content-subtle md:w-[140px]">
           {formattedDate ? formattedDate : "-"}
         </p>
       )}

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -9,7 +9,7 @@ import { generateSiteConfig } from "~/stories/helpers"
 import { CollectionLayout } from "./Collection"
 
 const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
-  times(10, (index) => [
+  times(5, (index) => [
     {
       id: `${index}`,
       title: `This is a publication title that is really long because ${index}`,
@@ -18,7 +18,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       layout: "article",
       summary:
         "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months.",
-      date: "07/05/2024",
+      date: "27/12/2024",
       category: "Category Name",
       tags: [
         {


### PR DESCRIPTION
# Fix Collection Card Date Width Breakpoint

## Summary

This PR fixes the responsive behavior of collection cards by adjusting the date column width breakpoint from large (`lg`) to medium (`md`) screens.

## Changes

- **CollectionCard.tsx**: Changed date column width breakpoint from `lg:w-[140px]` to `md:w-[140px]`
  - This ensures the fixed width for the date column applies at the medium breakpoint (768px) instead of large (1024px)
  - Improves layout consistency across tablet and smaller desktop screens

- **Collection.stories.tsx**: Updated story configuration
  - Reduced test items from 10 to 5 for better story visualization
  - Updated sample date to current date

## Impact

This change improves the responsive behavior of collection cards, particularly on medium-sized screens where the date column was previously allowed to shrink, potentially causing layout issues. By applying the fixed width at an earlier breakpoint, the layout remains more consistent and predictable across different screen sizes.

## Test Plan

- [ ] Verify collection cards render correctly on mobile screens (< 768px)
- [ ] Verify date column has fixed width on medium screens (>= 768px)
- [ ] Verify date column has fixed width on large screens (>= 1024px)
- [ ] Check that collection card layout is consistent across breakpoints
- [ ] Review Storybook story to confirm changes display correctly
