### PR TITLE
chore: move huaying to past members

### DIFF
--- a/apps/studio/prisma/constants.ts
+++ b/apps/studio/prisma/constants.ts
@@ -16,7 +16,6 @@ export const ISOMER_MIGRATORS = [
   "junxiang",
   "rayyan",
   "yongteng",
-  "huaying",
   "weiping",
   "sophie",
   "felicia",
@@ -28,6 +27,7 @@ export const PAST_ISOMER_MEMBERS = [
   "alexander",
   "jan",
   "jinhui",
+  "huaying",
 ] as const
 
 export const ISOMER_ADMINS_AND_MIGRATORS = [


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves huaying from ISOMER_MIGRATORS to PAST_ISOMER_MEMBERS in apps/studio/prisma/constants.ts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5cae36cb509e6dfac22e358af60410b84748b11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->