### PR TITLE
fix: stories for collection

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -9,7 +9,7 @@ import { generateSiteConfig } from "~/stories/helpers"
 import { CollectionLayout } from "./Collection"
 
 const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
-  times(5, (index) => [
+  times(10, (index) => [
     {
       id: `${index}`,
       title: `This is a publication title that is really long because ${index}`,
@@ -18,7 +18,7 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
       layout: "article",
       summary:
         "We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months. We’ve looked at how people’s spending correlates with how much microscopic plastic they consumed over the months.",
-      date: "27/12/2024",
+      date: "07/05/2024",
       category: "Category Name",
       tags: [
         {


### PR DESCRIPTION

## Problem
some assertions rely on the old value, which causes storybook tests to fail 

## Solution
update to old number for `times` and use old date to pass assertions. we'll add a new story testing the widht later
