### PR TITLE
hotfix: update Tailwind preset to include fonts for correct rendering of arrow symbol

### DIFF
--- a/tooling/template/tailwind.config.js
+++ b/tooling/template/tailwind.config.js
@@ -12,7 +12,8 @@ const config = {
     "./node_modules/@opengovsg/isomer-components/**/*.{js,ts,jsx,tsx}",
   ],
   // Use createNextPreset with includeFonts: false since we load Inter via next/font/google in layout.tsx
-  presets: [createNextPreset({ includeFonts: false })],
+  // FIXME: Currently set to true as arrow symbols are not rendering correctly when using next/font/google
+  presets: [createNextPreset({ includeFonts: true })],
   plugins: [
     isomerSiteTheme({
       colors: siteConfig.colors.brand,


### PR DESCRIPTION
Currently if its not included, the arrow for external link will show up weirdly as its not gracefully handled by next/font/google for some reasons

<img width="340" height="120" alt="image" src="https://github.com/user-attachments/assets/95e39df0-a28a-4ce0-9c04-1e75c3142643" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable fonts in Tailwind Next preset (`includeFonts: true`) to fix incorrect external-link arrow rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 54ebbd17c3bb67c3fa1ad2f3de70b4b43af7cd91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->