### PR TITLE
Revert "⚡ Performance: Font optimization"

### DIFF
--- a/packages/components/src/presets/index.ts
+++ b/packages/components/src/presets/index.ts
@@ -1,3 +1,3 @@
 export { default as ClassicPreset } from "./classic"
-export { NextPreset, createNextPreset } from "./next"
+export { default as NextPreset } from "./next"
 export { isomerSiteTheme } from "./next/site-theme"

--- a/packages/components/src/presets/next/index.ts
+++ b/packages/components/src/presets/next/index.ts
@@ -6,381 +6,365 @@ import plugin from "tailwindcss/plugin"
 import { colors } from "./colors"
 import { isomerTypography } from "./typography"
 
-// Inter font-face definitions from Google Fonts
-// CSS taken from https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap
-const interFontFaces = [
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa2JL7W0Q5n-wU.woff2) format('woff2')",
-    unicodeRange:
-      "U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F",
-  },
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa0ZL7W0Q5n-wU.woff2) format('woff2')",
-    unicodeRange: "U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116",
-  },
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa2ZL7W0Q5n-wU.woff2) format('woff2')",
-    unicodeRange: "U+1F00-1FFF",
-  },
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1pL7W0Q5n-wU.woff2) format('woff2')",
-    unicodeRange:
-      "U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF",
-  },
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa2pL7W0Q5n-wU.woff2) format('woff2')",
-    unicodeRange:
-      "U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB",
-  },
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa25L7W0Q5n-wU.woff2) format('woff2')",
-    unicodeRange:
-      "U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF",
-  },
-  {
-    fontFamily: "Inter",
-    fontStyle: "normal",
-    fontWeight: "100 900",
-    fontDisplay: "swap",
-    src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7W0Q5nw.woff2) format('woff2')",
-    unicodeRange:
-      "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD",
-  },
-]
-
-export function createNextPreset({
-  /**
-   * Whether to include @font-face rules for Inter font from Google Fonts CDN.
-   * Set to `false` if you're using `next/font/google` to load Inter,
-   * as that will handle font loading with better optimization.
-   */
-  includeFonts = true,
-}: {
-  includeFonts?: boolean
-} = {}): Config {
-  return {
-    content: [],
-    theme: {
+const config: Config = {
+  content: [],
+  theme: {
+    screens: {
+      // breakpoints need to be sorted from smallest to largest in order to work as expected with a min-width breakpoint system
+      // See https://tailwindcss.com/docs/screens#adding-smaller-breakpoints
+      xs: "576px",
+      //
+      ...defaultTheme.screens,
+    },
+    extend: {
       screens: {
-        // breakpoints need to be sorted from smallest to largest in order to work as expected with a min-width breakpoint system
-        // See https://tailwindcss.com/docs/screens#adding-smaller-breakpoints
-        xs: "576px",
-        //
-        ...defaultTheme.screens,
+        xl: "1240px",
       },
-      extend: {
-        screens: {
-          xl: "1240px",
+      keyframes: {
+        buttonPulse: {
+          "0%, 100%": { backgroundColor: "rgba(0, 0, 0, 0.65)" },
+          "50%": { backgroundColor: "rgba(0, 0, 0, 0.325)" },
         },
-        keyframes: {
-          buttonPulse: {
-            "0%, 100%": { backgroundColor: "rgba(0, 0, 0, 0.65)" },
-            "50%": { backgroundColor: "rgba(0, 0, 0, 0.325)" },
-          },
-          slideUpFadeIn: {
-            "0%": { opacity: "0" },
-            "100%": { opacity: "1" },
-          },
+        slideUpFadeIn: {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
         },
-        animation: {
-          "button-pulse": "buttonPulse 2s ease-in infinite",
-          "slide-up-fade-in": "slideUpFadeIn 0.3s ease-in-out",
+      },
+      animation: {
+        "button-pulse": "buttonPulse 2s ease-in infinite",
+        "slide-up-fade-in": "slideUpFadeIn 0.3s ease-in-out",
+      },
+      boxShadow: {
+        sm: "0 0px 10px 0px rgba(191, 191, 191, 0.5)",
+        "focus-visible": `0px -2px ${colors.utility.highlight}, 0 2px ${colors.base.content.strong}`,
+      },
+      colors: {
+        ...colors,
+        // Everything below is deprecated and should be removed when
+        // all components are using the new color tokens above
+        canvas: {
+          DEFAULT: "#ffffff",
+          overlay: "#00000066",
+          dark: "#2B2313",
+          inverse: "#2c2c2c",
         },
-        boxShadow: {
-          sm: "0 0px 10px 0px rgba(191, 191, 191, 0.5)",
-          "focus-visible": `0px -2px ${colors.utility.highlight}, 0 2px ${colors.base.content.strong}`,
-        },
-        colors: {
-          ...colors,
-          // Everything below is deprecated and should be removed when
-          // all components are using the new color tokens above
-          canvas: {
+        content: {
+          DEFAULT: "#333333",
+          medium: "#5d5d5d",
+          strong: "#2c2e34",
+          inverse: {
             DEFAULT: "#ffffff",
-            overlay: "#00000066",
-            dark: "#2B2313",
-            inverse: "#2c2c2c",
+            light: "#c1c1c1",
           },
-          content: {
-            DEFAULT: "#333333",
-            medium: "#5d5d5d",
-            strong: "#2c2e34",
-            inverse: {
-              DEFAULT: "#ffffff",
-              light: "#c1c1c1",
-            },
+        },
+        hyperlink: {
+          DEFAULT: "#1361f0",
+          inverse: "#ffffff",
+          hover: {
+            DEFAULT: "#0d4fca",
+            inverse: "#ededed",
           },
-          hyperlink: {
-            DEFAULT: "#1361f0",
+          visited: {
+            DEFAULT: "#530085",
             inverse: "#ffffff",
-            hover: {
-              DEFAULT: "#0d4fca",
-              inverse: "#ededed",
-            },
-            visited: {
-              DEFAULT: "#530085",
-              inverse: "#ffffff",
-            },
-          },
-          focus: {
-            outline: "#0d4fca",
-          },
-          divider: {
-            medium: "#d0d0d0",
-            strong: "#484848",
-            subtle: "#f2f2f2",
-          },
-          utility: {
-            ...colors.utility,
-            info: {
-              DEFAULT: "#87bdff",
-              subtle: "#e0eeff",
-            },
-            neutral: {
-              DEFAULT: "#f3f2f1",
-              subtle: "#fcfcfc",
-              neutral: "#f4f2f1",
-            },
-          },
-          interaction: {
-            main: {
-              DEFAULT: "#333333",
-              hover: "#191919",
-              active: "#191919",
-              subtle: {
-                hover: "#f4f9ff",
-              },
-            },
-            link: {
-              DEFAULT: "#333333",
-              hover: "#333333",
-              active: "#333333",
-            },
-            sub: {
-              DEFAULT: "#f3f3f3",
-            },
-            support: {
-              placeholder: "#838894",
-            },
-          },
-          site: {
-            primary: {
-              DEFAULT: "#f78f1e",
-              100: "#fef4e8",
-              200: "#ffeec2",
-            },
-            secondary: {
-              DEFAULT: "#877664",
-            },
           },
         },
-        fontFamily: {
-          sans: ['"Inter"', ...defaultTheme.fontFamily.sans],
+        focus: {
+          outline: "#0d4fca",
         },
-        letterSpacing: {
-          tight: "-0.022em",
+        divider: {
+          medium: "#d0d0d0",
+          strong: "#484848",
+          subtle: "#f2f2f2",
         },
+        utility: {
+          ...colors.utility,
+          info: {
+            DEFAULT: "#87bdff",
+            subtle: "#e0eeff",
+          },
+          neutral: {
+            DEFAULT: "#f3f2f1",
+            subtle: "#fcfcfc",
+            neutral: "#f4f2f1",
+          },
+        },
+        interaction: {
+          main: {
+            DEFAULT: "#333333",
+            hover: "#191919",
+            active: "#191919",
+            subtle: {
+              hover: "#f4f9ff",
+            },
+          },
+          link: {
+            DEFAULT: "#333333",
+            hover: "#333333",
+            active: "#333333",
+          },
+          sub: {
+            DEFAULT: "#f3f3f3",
+          },
+          support: {
+            placeholder: "#838894",
+          },
+        },
+        site: {
+          primary: {
+            DEFAULT: "#f78f1e",
+            100: "#fef4e8",
+            200: "#ffeec2",
+          },
+          secondary: {
+            DEFAULT: "#877664",
+          },
+        },
+      },
+      fontFamily: {
+        sans: ['"Inter"', ...defaultTheme.fontFamily.sans],
+      },
+      letterSpacing: {
+        tight: "-0.022em",
       },
     },
-    plugins: [
-      racPlugin,
-      isomerTypography,
-      plugin(({ addBase }) => {
-        addBase({
-          "::-webkit-details-marker": {
-            display: "none",
+  },
+  plugins: [
+    racPlugin,
+    isomerTypography,
+    plugin(({ addBase }) => {
+      addBase({
+        "::-webkit-details-marker": {
+          display: "none",
+        },
+      })
+    }),
+    plugin(function ({ addUtilities }) {
+      const newUtilities = {
+        // Using tailwind v3 which lacks "wrap-anywhere" utility (only from v4)
+        // https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere
+        ".tailwindv3-wrap-anywhere": {
+          "overflow-wrap": "anywhere",
+        },
+      }
+      addUtilities(newUtilities)
+    }),
+    // !! @deprecated, use isomerTypography plugin instead
+    // Delete after no components are using these classes anymore,
+    plugin(({ addBase, addUtilities, theme }) => {
+      addUtilities({
+        /* Heading typography tokens */
+        ".text-heading-01": {
+          fontSize: "2.75rem",
+          lineHeight: "3.25rem",
+          fontWeight: "600",
+          letterSpacing: theme("letterSpacing.tight"),
+          "@media (min-width: 1024px)": {
+            fontSize: "3.75rem",
+            lineHeight: "4rem",
           },
-        })
-      }),
-      plugin(function ({ addUtilities }) {
-        const newUtilities = {
-          // Using tailwind v3 which lacks "wrap-anywhere" utility (only from v4)
-          // https://tailwindcss.com/docs/overflow-wrap#wrapping-anywhere
-          ".tailwindv3-wrap-anywhere": {
-            "overflow-wrap": "anywhere",
-          },
-        }
-        addUtilities(newUtilities)
-      }),
-      // !! @deprecated, use isomerTypography plugin instead
-      // Delete after no components are using these classes anymore,
-      plugin(({ addBase, addUtilities, theme }) => {
-        addUtilities({
-          /* Heading typography tokens */
-          ".text-heading-01": {
-            fontSize: "2.75rem",
-            lineHeight: "3.25rem",
-            fontWeight: "600",
-            letterSpacing: theme("letterSpacing.tight"),
-            "@media (min-width: 1024px)": {
-              fontSize: "3.75rem",
-              lineHeight: "4rem",
-            },
-          },
+        },
 
-          ".text-heading-02": {
-            fontSize: "2.375rem",
-            lineHeight: "2.75rem",
-            fontWeight: "600",
-            letterSpacing: theme("letterSpacing.tight"),
-            "@media (min-width: 1024px)": {
-              fontSize: "2.7rem",
-              lineHeight: "3.2rem",
-            },
+        ".text-heading-02": {
+          fontSize: "2.375rem",
+          lineHeight: "2.75rem",
+          fontWeight: "600",
+          letterSpacing: theme("letterSpacing.tight"),
+          "@media (min-width: 1024px)": {
+            fontSize: "2.7rem",
+            lineHeight: "3.2rem",
           },
+        },
 
-          ".text-heading-03": {
-            fontSize: "1.625rem",
+        ".text-heading-03": {
+          fontSize: "1.625rem",
+          lineHeight: "2rem",
+          fontWeight: "600",
+          letterSpacing: theme("letterSpacing.tight"),
+          "@media (min-width: 1024px)": {
+            fontSize: "2.25rem",
+            lineHeight: "3rem",
+          },
+        },
+
+        ".text-heading-04": {
+          fontSize: "1.125rem",
+          lineHeight: "1.5rem",
+          fontWeight: "600",
+          letterSpacing: theme("letterSpacing.tight"),
+          "@media (min-width: 1024px)": {
+            fontSize: "1.5rem",
+            lineHeight: "2.25rem",
+          },
+        },
+
+        ".text-heading-04-medium": {
+          fontSize: "1.125rem",
+          lineHeight: "1.5rem",
+          fontWeight: "500",
+          letterSpacing: theme("letterSpacing.tight"),
+          "@media (min-width: 1024px)": {
+            fontSize: "1.5rem",
+            lineHeight: "2.25rem",
+          },
+        },
+
+        ".text-heading-05": {
+          fontSize: "1rem",
+          lineHeight: "1.5rem",
+          fontWeight: "600",
+          "@media (min-width: 1024px)": {
+            fontSize: "1.25rem",
+            lineHeight: "1.5rem",
+          },
+        },
+
+        ".text-heading-06": {
+          fontSize: "1rem",
+          lineHeight: "1.5rem",
+          fontWeight: "500",
+          letterSpacing: "0.05em",
+        },
+
+        /* Sub-heading typography tokens */
+        ".text-subheading-01": {
+          fontSize: "1rem",
+          lineHeight: "1.25rem",
+          fontWeight: "500",
+        },
+
+        /* Paragraph typography tokens */
+        ".text-paragraph-01": {
+          fontSize: "1rem",
+          lineHeight: "1.5rem",
+          "@media (min-width: 1024px)": {
+            fontSize: "1.25rem",
             lineHeight: "2rem",
-            fontWeight: "600",
-            letterSpacing: theme("letterSpacing.tight"),
-            "@media (min-width: 1024px)": {
-              fontSize: "2.25rem",
-              lineHeight: "3rem",
-            },
           },
+        },
 
-          ".text-heading-04": {
+        ".text-paragraph-01-medium": {
+          fontSize: "1rem",
+          lineHeight: "1.5rem",
+          fontWeight: "500",
+          "@media (min-width: 1024px)": {
+            fontSize: "1.25rem",
+            lineHeight: "2rem",
+          },
+        },
+
+        ".text-paragraph-02": {
+          fontSize: "0.875rem",
+          lineHeight: "1.5",
+          "@media (min-width: 1024px)": {
             fontSize: "1.125rem",
-            lineHeight: "1.5rem",
-            fontWeight: "600",
-            letterSpacing: theme("letterSpacing.tight"),
-            "@media (min-width: 1024px)": {
-              fontSize: "1.5rem",
-              lineHeight: "2.25rem",
-            },
+            lineHeight: "1.75rem",
           },
+        },
 
-          ".text-heading-04-medium": {
+        ".text-paragraph-03": {
+          fontSize: "0.875rem",
+          lineHeight: "1.5",
+          "@media (min-width: 1024px)": {
+            fontSize: "1rem",
+            lineHeight: "1.5rem",
+          },
+        },
+
+        /* Caption typography tokens */
+        ".text-caption-01": {
+          fontSize: "0.875rem",
+          lineHeight: "1.25rem",
+        },
+
+        ".text-caption-01-medium": {
+          fontSize: "0.875rem",
+          lineHeight: "1.25rem",
+          fontWeight: "500",
+        },
+
+        /* Other typography tokens */
+        ".text-button-link-01": {
+          fontSize: "1rem",
+          lineHeight: "1.5rem",
+          "@media (min-width: 1024px)": {
             fontSize: "1.125rem",
-            lineHeight: "1.5rem",
-            fontWeight: "500",
-            letterSpacing: theme("letterSpacing.tight"),
-            "@media (min-width: 1024px)": {
-              fontSize: "1.5rem",
-              lineHeight: "2.25rem",
-            },
+            lineHeight: "1.75rem",
           },
+        },
+      })
 
-          ".text-heading-05": {
-            fontSize: "1rem",
-            lineHeight: "1.5rem",
-            fontWeight: "600",
-            "@media (min-width: 1024px)": {
-              fontSize: "1.25rem",
-              lineHeight: "1.5rem",
-            },
+      // Add Inter as a base font
+      // CSS taken from https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap
+      addBase({
+        // @ts-expect-error Tailwind types did not account for @font-face
+        "@font-face": [
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa2JL7W0Q5n-wU.woff2) format('woff2')",
+            unicodeRange:
+              "U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F",
           },
-
-          ".text-heading-06": {
-            fontSize: "1rem",
-            lineHeight: "1.5rem",
-            fontWeight: "500",
-            letterSpacing: "0.05em",
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa0ZL7W0Q5n-wU.woff2) format('woff2')",
+            unicodeRange:
+              "U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116",
           },
-
-          /* Sub-heading typography tokens */
-          ".text-subheading-01": {
-            fontSize: "1rem",
-            lineHeight: "1.25rem",
-            fontWeight: "500",
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa2ZL7W0Q5n-wU.woff2) format('woff2')",
+            unicodeRange: "U+1F00-1FFF",
           },
-
-          /* Paragraph typography tokens */
-          ".text-paragraph-01": {
-            fontSize: "1rem",
-            lineHeight: "1.5rem",
-            "@media (min-width: 1024px)": {
-              fontSize: "1.25rem",
-              lineHeight: "2rem",
-            },
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1pL7W0Q5n-wU.woff2) format('woff2')",
+            unicodeRange:
+              "U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF",
           },
-
-          ".text-paragraph-01-medium": {
-            fontSize: "1rem",
-            lineHeight: "1.5rem",
-            fontWeight: "500",
-            "@media (min-width: 1024px)": {
-              fontSize: "1.25rem",
-              lineHeight: "2rem",
-            },
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa2pL7W0Q5n-wU.woff2) format('woff2')",
+            unicodeRange:
+              "U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329, U+1EA0-1EF9, U+20AB",
           },
-
-          ".text-paragraph-02": {
-            fontSize: "0.875rem",
-            lineHeight: "1.5",
-            "@media (min-width: 1024px)": {
-              fontSize: "1.125rem",
-              lineHeight: "1.75rem",
-            },
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa25L7W0Q5n-wU.woff2) format('woff2')",
+            unicodeRange:
+              "U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF",
           },
-
-          ".text-paragraph-03": {
-            fontSize: "0.875rem",
-            lineHeight: "1.5",
-            "@media (min-width: 1024px)": {
-              fontSize: "1rem",
-              lineHeight: "1.5rem",
-            },
+          {
+            fontFamily: "Inter",
+            fontStyle: "normal",
+            fontWeight: "100 900",
+            fontDisplay: "swap",
+            src: "url(https://fonts.gstatic.com/s/inter/v13/UcC73FwrK3iLTeHuS_fvQtMwCp50KnMa1ZL7W0Q5nw.woff2) format('woff2')",
+            unicodeRange:
+              "U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD",
           },
-
-          /* Caption typography tokens */
-          ".text-caption-01": {
-            fontSize: "0.875rem",
-            lineHeight: "1.25rem",
-          },
-
-          ".text-caption-01-medium": {
-            fontSize: "0.875rem",
-            lineHeight: "1.25rem",
-            fontWeight: "500",
-          },
-
-          /* Other typography tokens */
-          ".text-button-link-01": {
-            fontSize: "1rem",
-            lineHeight: "1.5rem",
-            "@media (min-width: 1024px)": {
-              fontSize: "1.125rem",
-              lineHeight: "1.75rem",
-            },
-          },
-        })
-
-        // Add Inter as a base font (only if includeFonts is true)
-        if (includeFonts) {
-          addBase({
-            // @ts-expect-error Tailwind types did not account for @font-face
-            "@font-face": interFontFaces,
-          })
-        }
-      }),
-    ],
-  }
+        ],
+      })
+    }),
+  ],
 }
 
-// Default preset with fonts included
-export const NextPreset = createNextPreset({ includeFonts: true })
+export default config

--- a/packages/components/tailwind.config.ts
+++ b/packages/components/tailwind.config.ts
@@ -1,5 +1,5 @@
 import classicPreset from "./src/presets/classic"
-import { NextPreset } from "./src/presets/next"
+import nextPreset from "./src/presets/next"
 
 /**
  * This file is only used for storybook. The actual tailwind configuration that
@@ -20,7 +20,7 @@ export default {
     // Note: This is here temporarily until we can figure out how to load the
     // presets dynamically depending on the template being used.
     classicPreset,
-    NextPreset,
+    nextPreset,
   ],
   theme: {
     extend: {

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -4,17 +4,8 @@ import sitemap from "@/sitemap.json"
 import "@/styles/globals.css"
 
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
 import Script from "next/script"
 import { RenderApplicationScripts } from "@opengovsg/isomer-components"
-
-const inter = Inter({
-  // while we support other languages, we should only preload the latin subset
-  // as it is the most common subset and the most likely to be used
-  // we accept that non-latin languages will not be self hosted and preloaded
-  subsets: ["latin"],
-  display: "swap",
-})
 
 export const dynamic = "force-static"
 
@@ -27,11 +18,7 @@ export const metadata: Metadata = {
 
 const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <html
-      lang="en"
-      data-theme={config.site.theme || "isomer-next"}
-      className={inter.className}
-    >
+    <html lang="en" data-theme={config.site.theme || "isomer-next"}>
       <body className="antialiased">
         {children}
         <RenderApplicationScripts

--- a/tooling/template/tailwind.config.js
+++ b/tooling/template/tailwind.config.js
@@ -1,6 +1,6 @@
 // @ts-nocheck
 /** @type {import('tailwindcss').Config} */
-import { createNextPreset, isomerSiteTheme } from "@opengovsg/isomer-components"
+import { isomerSiteTheme, NextPreset } from "@opengovsg/isomer-components"
 import plugin from "tailwindcss/plugin"
 
 import siteConfig from "./data/config.json"
@@ -11,8 +11,7 @@ const config = {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
     "./node_modules/@opengovsg/isomer-components/**/*.{js,ts,jsx,tsx}",
   ],
-  // Use createNextPreset with includeFonts: false since we load Inter via next/font/google in layout.tsx
-  presets: [createNextPreset({ includeFonts: false })],
+  presets: [NextPreset],
   plugins: [
     isomerSiteTheme({
       colors: siteConfig.colors.brand,


### PR DESCRIPTION
Reverts opengovsg/isomer#1772

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies the Next Tailwind preset to a default export with built‑in Inter @font-face and updates templates/configs to use it instead of next/font.
> 
> - **Presets**:
>   - Convert `NextPreset` to a default-exported static Tailwind config; remove `createNextPreset` API.
>   - Inline Inter `@font-face` in the preset; keep typography/utilities and theme extensions.
>   - Update `packages/components/tailwind.config.ts` to consume `nextPreset`.
> - **Template**:
>   - Remove `next/font/google` Inter and `className` from `app/layout.tsx`.
>   - Switch `tooling/template/tailwind.config.js` from `createNextPreset({ includeFonts: false })` to `NextPreset`.
> - **Exports**:
>   - Update `packages/components/src/presets/index.ts` to export `NextPreset` as default and keep `isomerSiteTheme`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c5d692f0dc1d268d45868fe92dd2d53d778e25f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->