### PR TITLE
chore: add keep alive timeout

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -30,6 +30,10 @@ ENV NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY=$NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY
 ARG NEXT_PUBLIC_INTERCOM_APP_ID
 ENV NEXT_PUBLIC_INTERCOM_APP_ID=$NEXT_PUBLIC_INTERCOM_APP_ID
 
+# Refer to this PR for the env var and why we need this.
+# https://github.com/vercel/next.js/pull/46052/changes
+ENV KEEP_ALIVE_TIMEOUT 70000
+
 FROM base AS builder
 RUN apk update
 RUN apk add --no-cache libc6-compat


### PR DESCRIPTION
# Add Keep-Alive Timeout Configuration

## Summary

This PR adds the `KEEP_ALIVE_TIMEOUT` environment variable to the Studio Dockerfile to prevent connection issues when deploying behind load balancers and proxies.

## Problem

When deploying Next.js applications behind downstream proxies (such as AWS ELB/ALB), the server's keep-alive timeout must be configured to be larger than the proxy's timeout. Without this configuration, Node.js may terminate connections that the proxy still expects to reuse, leading to proxy errors and connection failures.

AWS load balancers typically have a default idle timeout of 60 seconds. If the Next.js server's keep-alive timeout is lower than this, the proxy may attempt to reuse a connection that the server has already closed, resulting in errors.

## Solution

This PR sets the `KEEP_ALIVE_TIMEOUT` environment variable to `70000` (70 seconds) in the Studio Dockerfile. This value is:
- Higher than the typical AWS load balancer timeout of 60 seconds
- Ensures the load balancer closes idle connections before Next.js does
- Prevents connection reuse errors

## Technical Details

The environment variable is supported by Next.js in standalone mode (as of [Next.js PR #46052](https://github.com/vercel/next.js/pull/46052)) and provides the same functionality as the `--keepAliveTimeout` flag available in the `next start` command.

## Changes

- Added `KEEP_ALIVE_TIMEOUT=70000` environment variable to `apps/studio/Dockerfile`
- Added inline documentation referencing the Next.js PR for context

## Testing

- [ ] Verify the environment variable is correctly set in the Docker container
- [ ] Monitor connection behavior in production behind load balancers
- [ ] Confirm no increase in connection errors or timeouts

## References

- [Next.js PR #46052](https://github.com/vercel/next.js/pull/46052) - Support for KEEP_ALIVE_TIMEOUT in standalone mode
- AWS ELB/ALB default idle timeout: 60 seconds
