### PR TITLE
feat: use zstd compression instead for publisher.sh S3 cache

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -59,18 +59,18 @@ fi
 
 # Try to fetch cached node_modules from S3
 echo "Fetching cached node_modules..."
-NODE_MODULES_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/isomer/node_modules.tar.gz"
-aws s3 cp --only-show-errors $NODE_MODULES_CACHE_PATH node_modules.tar.gz || true
-if [ -f "node_modules.tar.gz" ]; then
-  echo "node_modules.tar.gz found in cache"
+NODE_MODULES_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/isomer/node_modules.tar.zst"
+aws s3 cp --only-show-errors $NODE_MODULES_CACHE_PATH node_modules.tar.zst || true
+if [ -f "node_modules.tar.zst" ]; then
+  echo "node_modules.tar.zst found in cache"
 
   echo "Using cached node_modules"
   start_time=$(date +%s)
-  tar -xzf node_modules.tar.gz
-  rm node_modules.tar.gz
+  tar --use-compress-program=zstd -xf node_modules.tar.zst
+  rm node_modules.tar.zst
   calculate_duration $start_time
 else
-  echo "node_modules.tar.gz not found in cache"
+  echo "node_modules.tar.zst not found in cache"
 
   echo "Installing dependencies..."
   start_time=$(date +%s)
@@ -79,9 +79,9 @@ else
 
   echo "Caching node_modules..."
   start_time=$(date +%s)
-  tar -czf node_modules.tar.gz node_modules/
-  aws s3 cp --only-show-errors node_modules.tar.gz $NODE_MODULES_CACHE_PATH
-  rm node_modules.tar.gz
+  tar --use-compress-program="zstd -6" -cf node_modules.tar.zst node_modules/
+  aws s3 cp --only-show-errors node_modules.tar.zst $NODE_MODULES_CACHE_PATH
+  rm node_modules.tar.zst
   echo "Cached node_modules"
   calculate_duration $start_time
 fi
@@ -112,18 +112,18 @@ if [ ! -f "schema/not-found.json" ]; then
 fi
 echo $(pwd)
 echo "Fetching cached tooling-template node_modules..."
-TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/isomer-tooling-template/node_modules.tar.gz"
-aws s3 cp --only-show-errors $TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH node_modules.tar.gz || true
-if [ -f "node_modules.tar.gz" ]; then
-  echo "node_modules.tar.gz found in cache"
+TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH="s3://$S3_CACHE_BUCKET_NAME/$UNIQUE_CACHE_KEY/isomer-tooling-template/node_modules.tar.zst"
+aws s3 cp --only-show-errors $TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH node_modules.tar.zst || true
+if [ -f "node_modules.tar.zst" ]; then
+  echo "node_modules.tar.zst found in cache"
 
   echo "Using cached node_modules"
   start_time=$(date +%s)
-  tar -xzf node_modules.tar.gz
-  rm node_modules.tar.gz
+  tar --use-compress-program=zstd -xf node_modules.tar.zst
+  rm node_modules.tar.zst
   calculate_duration $start_time
 else
-  echo "node_modules.tar.gz not found in cache"
+  echo "node_modules.tar.zst not found in cache"
 
   # Build components
   echo "Building components..."
@@ -149,9 +149,9 @@ else
 
   echo "Caching node_modules..."
   start_time=$(date +%s)
-  tar -czf node_modules.tar.gz node_modules/
-  aws s3 cp --only-show-errors node_modules.tar.gz $TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH
-  rm node_modules.tar.gz
+  tar --use-compress-program="zstd -6" -cf node_modules.tar.zst node_modules/
+  aws s3 cp --only-show-errors node_modules.tar.zst $TOOLING_TEMPLATE_NODE_MODULES_CACHE_PATH
+  rm node_modules.tar.zst
   echo "Cached node_modules"
   calculate_duration $start_time
 fi


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Not much problem except that when cold build (first build after release, or testing build during staging), it is a bit slow at 1-3 minutes (depending on instance size) for compressing and uploading

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- use `zstd` compression instead

***On my local device***

Command + time taken | Compressed size
-- | --
tar -czf node_modules.tar.gz node_modules/  <br>47.90s user 108.27s system 83% cpu 3:07.95 total | 338MB
tar --use-compress-program="zstd -6" -cf node_modules.tar.zst node_modules/  <br>18.99s user 104.06s system 89% cpu 2:17.23 total | 268MB (31% smaller)

***On codebuild***

- on `MEDIUM` size, time to compress and upload to s3 goes down from 42 seconds to 14 seconds
- it also reduced the cache size to be uploaded and stored in S3 (during cold build), and cache size downloaded (on every other hot build) - bring some cost saving (tho prob. negligible lah hahaha)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace gzip tarballs with zstd (.tar.zst) for node_modules caching in publisher.sh, updating fetch/extract and create/upload for both isomer and tooling-template caches.
> 
> - **Build tooling**:
>   - Update `tooling/build/scripts/publisher.sh` to use `zstd` archives for S3 `node_modules` cache.
>     - Change cache paths from `.tar.gz` to `.tar.zst`.
>     - Update extraction to `tar --use-compress-program=zstd -xf`.
>     - Update compression to `tar --use-compress-program="zstd -6" -cf`.
>     - Apply changes to both `isomer/node_modules` and `isomer-tooling-template/node_modules` caches.
>     - Adjust related log messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a14898326df595a789a940ab6742c66c5aa3257. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->