### PR TITLE
GitHub AI (nit): Fix wrong name

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -41,7 +41,6 @@ RUN apk add --no-cache libc6-compat
 # Set working directory
 WORKDIR /app
 # Replace <your-major-version> with the major version installed in your repository. For example:
-# RUN npm i -g turbo@^2
 RUN npm install -g turbo@^2
 COPY . .
 


### PR DESCRIPTION
_This PR applies 2/3 suggestions from code quality [AI findings](https://github.com/opengovsg/isomer/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Installs Turbo globally and updates prune target to `isomer-studio` in `apps/studio/Dockerfile`.
> 
> - **Dockerfile (`apps/studio/Dockerfile`)**:
>   - Install Turbo globally with `npm install -g turbo@^2`.
>   - Update `turbo prune` target to `isomer-studio` (monorepo workspace).
>   - Minor comment cleanup aligned to the new workspace name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c820de52e6960acfd1fda87ed0554342ccdbdd73. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->