### PR TITLE
chore: add mot.gov.sg to audit logs

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -111,6 +111,7 @@ const SITES_WITH_AUDIT_LOGS = [
   262, // www.mfa.gov.sg
   263, // nagoya.mfa.gov.sg
   284, // www.ptc.gov.sg
+  287, // www.mot.gov.sg
 ]
 
 // Month and year to get audit logs for, in the format of YYYY-MM,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->
As per Ops request: https://opengovproducts.slack.com/archives/C07CWUNUL68/p1766134808801229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add siteId 287 (`www.mot.gov.sg`) to `SITES_WITH_AUDIT_LOGS` in `apps/studio/prisma/scripts/getAuditLogs.ts` to generate audit logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c8f59979afd4ad8fc14c389a1dff87f22df13b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->