### PR TITLE
chore: allow SearchSG crawling regardless of env

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -159,7 +159,7 @@ export const getRobotsTxt = (props: IsomerPageSchemaType) => {
           },
           {
             userAgent: "SearchSG",
-            disallow: "",
+            allow: "/",
           },
         ]
       : rules,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

SearchSG is unable to crawl a staging site since we blanket disable crawling.

Context: https://opengovproducts.slack.com/archives/C0770B5RU03/p1767593949434919?thread_ts=1767592714.032779&cid=C0770B5RU03

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Specifically whitelist SearchSG even when disabling indexing for staging sites.