### PR TITLE
(DO NOT REVIEW) comment out app-color for VICA V3

### DIFF
--- a/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
+++ b/packages/components/src/templates/next/components/internal/Vica/VicaWidget.tsx
@@ -20,7 +20,7 @@ export const VicaWidget = ({
       // the following attributes to ensure consistency and best brand appearance
       app-font-family="Inter, system-ui, sans-serif"
       app-foreground-color={colors.base.canvas.DEFAULT}
-      app-color={colors.brand.canvas.inverse}
+      // app-color={colors.brand.canvas.inverse}
       app-button-border-color={colors.brand.canvas.inverse}
       app-canvas-background-color={colors.brand.canvas.DEFAULT}
       app-quick-reply-button-background-color={colors.base.canvas.DEFAULT}


### PR DESCRIPTION
re: https://opengovproducts.slack.com/archives/C087MUEJAMA/p1767929177549149?thread_ts=1767682585.650749&cid=C087MUEJAMA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Disables the `app-color` override in `VicaWidget` while leaving other enforced style attributes intact.
> 
> - Comments out `app-color={colors.brand.canvas.inverse}` in `VicaWidget.tsx`, allowing default/configured color to apply
> - Other appearance props (e.g., `app-font-family`, `app-foreground-color`, button/canvas/autocomplete/recommendations colors) remain explicitly set
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e536bfcaae3ecf0de40338c81960d60806b5755f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->