### PR TITLE
chore: show only errors to reduce exec buffer usage

### DIFF
--- a/tooling/export-import/index.ts
+++ b/tooling/export-import/index.ts
@@ -238,6 +238,7 @@ const main = async () => {
         "sync",
         `s3://${bucketName}/${sourceSiteId}`,
         `${tempDir}/public/${sourceSiteId}`,
+        "--only-show-errors",
       ],
       {
         cwd: exportDir,
@@ -313,6 +314,7 @@ const main = async () => {
         "sync",
         `public/${sourceSiteId}`,
         `s3://${bucketName}/${finalDestSiteId}`,
+        "--only-show-errors",
       ],
       {
         cwd: tempDir,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `execFile` function has a buffer limit and S3 sync is very easy to hit this limit.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Set the flag to show only errors when performing `aws s3 sync`.