### PR TITLE
chore: update thresholds

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -190,8 +190,8 @@ jobs:
         with:
           artifact_type: "container"
           artifact_path: "${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}"
-          critical_threshold: 0
-          high_threshold: 10
+          critical_threshold: 3
+          high_threshold: 20
 
       # Display Inspector results in the GitHub Actions terminal
       - name: Display CycloneDX SBOM (JSON)


### PR DESCRIPTION
## Problem
- our threshold got blown past already, short term fix to increase first whilst we investigate

## Solution
- increase aws threshold for inspector vulns on high/critical. 
- from 0 -> 3 critical (presently, we have 1)
- from 10 -> 20 high (presently, we have 16)
