### PR TITLE
fix: allow only admins to publish

### DIFF
--- a/apps/studio/src/features/settings/SettingsHeader.tsx
+++ b/apps/studio/src/features/settings/SettingsHeader.tsx
@@ -41,7 +41,7 @@ export const SettingsHeader = ({
           {title}
         </Text>
       </Flex>
-      <Can do="publish" on={{ parentId: null }}>
+      <Can do="create" on={{ parentId: null }}>
         <Button
           type="submit"
           isLoading={isLoading}


### PR DESCRIPTION
## Problem
refer to [ticket](https://linear.app/ogp/issue/ISOM-2172/site-settings-is-editable-by-non-admin)

Closes ISOM-2172

## Solution
update condition for publish button to be shown
\