### PR TITLE
feat: add JSON-LD for SEO site name

### DIFF
--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -20,8 +20,8 @@ const inter = Inter({
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "WebSite",
-  "name": config.site.siteName || "Isomer",
-  "url": config.site.url || "https://www.isomer.gov.sg",
+  name: config.site.siteName || "Isomer",
+  url: config.site.url || "https://www.isomer.gov.sg",
 }
 
 export const dynamic = "force-static"
@@ -59,7 +59,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c'),
+            __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
           }}
         />
       </body>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Our sites are not showing the site name correctly in Google Search results, instead showing the domain which may not be recognisable by MOPs. For example:

<img width="680" height="292" alt="image" src="https://github.com/user-attachments/assets/285951fe-7174-49d8-9126-9ff951f2da3a" />

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Make use of JSON-LD to provide a hint to Google on what the site name should be.
    - Information on adding JSON-LD to Next.js: https://nextjs.org/docs/app/guides/json-ld
    - Providing a site name to Google: https://developers.google.com/search/docs/appearance/site-names#website