### PR TITLE
⚡️ Perf: remove gstatic fontpreload

### DIFF
--- a/packages/components/src/engine/renderApplicationScripts.tsx
+++ b/packages/components/src/engine/renderApplicationScripts.tsx
@@ -1,6 +1,5 @@
 import type { IsomerSiteProps, ScriptComponentType } from "~/types"
 import { AskgovWidget } from "../templates/next/components/internal/Askgov"
-import { FontPreload } from "../templates/next/components/internal/FontPreload"
 import {
   GoogleTagManagerBody,
   GoogleTagManagerHeader,
@@ -24,8 +23,6 @@ export const RenderApplicationScripts = ({
 }: RenderApplicationScriptsProps) => {
   return (
     <>
-      <FontPreload />
-
       {/* NOTE: we load in wogaa regardless of whether the site is  */}
       {/* a government site as wogaa still requires the agency to register their site */}
       {/* and wogaa is still gated behind techpass login. */}

--- a/packages/components/src/templates/next/components/internal/FontPreload.tsx
+++ b/packages/components/src/templates/next/components/internal/FontPreload.tsx
@@ -1,5 +1,0 @@
-import { PreloadHelper } from "./utils"
-
-export const FontPreload = () => {
-  return <PreloadHelper href="https://fonts.gstatic.com" />
-}


### PR DESCRIPTION
no longer needed after https://github.com/opengovsg/isomer/pull/1780 since fonts are served from site's S3 instead of 3rd party google

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes an unused resource-hint component and its invocation; change is limited to script rendering and should only affect optional preconnect behavior.
> 
> **Overview**
> Removes the `FontPreload` preconnect to `https://fonts.gstatic.com` from `RenderApplicationScripts` and deletes the `FontPreload` component entirely, reducing unnecessary third-party resource hints now that fonts are no longer loaded from Google.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 722a6c745f59898dd710fe44bb81f8e858a3dc14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->