### PR TITLE
fix: add trailing slash for permalinks on sitemap

### DIFF
--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -173,8 +173,17 @@ export const getSitemapXml = (sitemap: IsomerSitemap, siteUrl?: string) => {
         item.layout !== ISOMER_PAGE_LAYOUTS.File &&
         item.layout !== ISOMER_PAGE_LAYOUTS.Link,
     )
-    .map(({ permalink, lastModified }) => ({
-      url: siteUrl !== undefined ? `${siteUrl}${permalink}` : permalink,
-      lastModified,
-    }))
+    .map(({ permalink, lastModified }) => {
+      const permalinkWithTrailingSlash = permalink.endsWith("/")
+        ? permalink
+        : `${permalink}/`
+
+      return {
+        url:
+          siteUrl !== undefined
+            ? `${siteUrl}${permalinkWithTrailingSlash}`
+            : permalinkWithTrailingSlash,
+        lastModified,
+      }
+    })
 }

--- a/tooling/template/app/[[...permalink]]/page.tsx
+++ b/tooling/template/app/[[...permalink]]/page.tsx
@@ -72,7 +72,8 @@ const getSchema = async ({ permalink }: Pick<ParamsContent, "permalink">) => {
     // TODO: fixup all the typing errors
     // @ts-expect-error to fix when types are proper
     getSitemapXml(sitemap).find(
-      ({ url }) => joinedPermalink === url.replace(/^\//, ""),
+      ({ url }) =>
+        joinedPermalink === url.replace(/^\//, "").replace(/\/$/, ""),
     ).lastModified || new Date().toISOString()
 
   schema.page.permalink = "/" + joinedPermalink
@@ -85,7 +86,7 @@ export const generateStaticParams = () => {
   // TODO: fixup all the typing errors
   // @ts-expect-error to fix when types are proper
   return getSitemapXml(sitemap).map(({ url }) => ({
-    permalink: url.replace(/^\//, "").split("/"),
+    permalink: url.replace(/^\//, "").replace(/\/$/, "").split("/"),
   }))
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

We have enforced trailing slash for permalinks, but have not done so for the sitemap.xml.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Force the permalinks on the sitemap.xml file to have a trailing slash.