### PR TITLE
🐞 fix: add Slack notification secrets to staging and UAT deployment workflow

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -15,6 +15,10 @@ jobs:
     name: Deploy app to staging
     uses: ./.github/workflows/aws_deploy.yml
     # NOTE: deploy in `staging` env to set env specific secrets
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_NOTIFY_TEAM_ID: ${{ secrets.SLACK_NOTIFY_TEAM_ID }}
     with:
       aws-region: "ap-southeast-1"
       aws-account-id: "058264420411"

--- a/.github/workflows/deploy_uat.yml
+++ b/.github/workflows/deploy_uat.yml
@@ -16,6 +16,10 @@ jobs:
   deploy_uat:
     name: Deploy app to uat
     uses: ./.github/workflows/aws_deploy.yml
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_NOTIFY_TEAM_ID: ${{ secrets.SLACK_NOTIFY_TEAM_ID }}
     with:
       aws-region: "ap-southeast-1"
       aws-account-id: "343218177745"


### PR DESCRIPTION
without it, when vulnerability threshold exceeded, it will fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI/workflow-only change limited to wiring existing secrets into reusable workflows. Risk is mainly misconfiguration causing staging/UAT deploy notifications (or runs) to fail if the secrets are absent or incorrect.
> 
> **Overview**
> Staging and UAT deployment workflows now **explicitly pass Slack notification secrets** (bot token, channel ID, team ID) into the reusable `aws_deploy.yml` workflow via `secrets:`.
> 
> This prevents deployments from failing when the Inspector vulnerability scan triggers the Slack alert step that requires these secrets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d50c249efb587958d9089af7fdb75c6607173bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->