### PR TITLE
feat: allow setting centralised notification banner

### DIFF
--- a/apps/studio/src/components/AppNavbar.tsx
+++ b/apps/studio/src/components/AppNavbar.tsx
@@ -46,6 +46,16 @@ export function AppNavbar(): JSX.Element {
             priority
           />
           {isUserIsomerAdmin && (
+            <Button
+              variant="clear"
+              size="xs"
+              as={NextLink}
+              href="/central-banner"
+            >
+              Central Banner
+            </Button>
+          )}
+          {isUserIsomerAdmin && (
             <Button variant="clear" size="xs" as={NextLink} href="/godmode">
               👁️ God Mode 👁️
             </Button>

--- a/apps/studio/src/constants/misc.ts
+++ b/apps/studio/src/constants/misc.ts
@@ -1,2 +1,9 @@
 export const ISOMER_SUPPORT_EMAIL = "support@isomer.gov.sg"
 export const ISOMER_SUPPORT_LINK = `mailto:${ISOMER_SUPPORT_EMAIL}`
+
+// NOTE: Hardcoded for now as a proof of concept
+export const MOE_SITES = [
+  "https://test-isomer-next-staging.isomer.gov.sg",
+  "https://test-isomer-vica-staging.isomer.gov.sg",
+  "https://test-isomer-vica-ncss-staging.isomer.gov.sg",
+]

--- a/apps/studio/src/pages/central-banner/index.tsx
+++ b/apps/studio/src/pages/central-banner/index.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react"
+import NextLink from "next/link"
+import { useRouter } from "next/router"
+import {
+  Box,
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  Button,
+  Flex,
+  IconButton,
+  Skeleton,
+  Text,
+} from "@chakra-ui/react"
+import { useToast } from "@opengovsg/design-system-react"
+import { NotificationSettingsSchema } from "@opengovsg/isomer-components"
+import { BiPlus, BiTrash } from "react-icons/bi"
+
+import type { NextPageWithLayout } from "~/lib/types"
+import type { Notification } from "~/schemas/site"
+import { ISOMER_SUPPORT_EMAIL, MOE_SITES } from "~/constants/misc"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
+import { ErrorProvider } from "~/features/editing-experience/components/form-builder/ErrorProvider"
+import FormBuilder from "~/features/editing-experience/components/form-builder/FormBuilder"
+import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { ADMIN_ROLE } from "~/lib/growthbook"
+import { notificationValidator } from "~/schemas/site"
+import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
+import { trpc } from "~/utils/trpc"
+
+interface NotificationEntry {
+  notification: Notification
+  targetSites: string[]
+}
+
+const EMPTY_ENTRY: NotificationEntry = {
+  notification: {},
+  targetSites: [],
+}
+
+const CentralBannerPage: NextPageWithLayout = () => {
+  const toast = useToast(BRIEF_TOAST_SETTINGS)
+  const router = useRouter()
+  const trpcUtils = trpc.useUtils()
+
+  // TODO: Change this to a feature flag to allow other users to access
+  const isEnabled = useIsUserIsomerAdmin({
+    roles: [ADMIN_ROLE.CORE],
+  })
+
+  if (!isEnabled) {
+    toast({
+      title: "You do not have permission to access this page.",
+      status: "error",
+    })
+    void router.push(`/`)
+  }
+
+  const { data: existingEntries, isLoading } =
+    trpc.global.getNotification.useQuery(undefined, {
+      enabled: isEnabled,
+    })
+
+  const [entries, setEntries] = useState<NotificationEntry[]>([])
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  // Initialize state from server data once loaded
+  if (existingEntries && !isInitialized) {
+    setEntries(
+      existingEntries.map((entry) => ({
+        notification: (entry.notification
+          ? { notification: entry.notification }
+          : {}) as Notification,
+        targetSites: entry.targetSites,
+      })),
+    )
+    setIsInitialized(true)
+  }
+
+  const mutation = trpc.global.setNotification.useMutation({
+    onSuccess: () => {
+      void trpcUtils.global.getNotification.invalidate()
+      toast({
+        title: "Central notification published",
+        description: "Changes are live immediately on all targeted sites.",
+        status: "success",
+      })
+    },
+    onError: () => {
+      toast({
+        title: "Error publishing central notification!",
+        description: `If this persists, please report this issue at ${ISOMER_SUPPORT_EMAIL}`,
+        status: "error",
+      })
+    },
+  })
+
+  const handleAddEntry = () => {
+    setEntries((prev) => [...prev, { ...EMPTY_ENTRY }])
+  }
+
+  const handleRemoveEntry = (index: number) => {
+    setEntries((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleNotificationChange = (index: number, data: Notification) => {
+    setEntries((prev) =>
+      prev.map((entry, i) =>
+        i === index ? { ...entry, notification: data } : entry,
+      ),
+    )
+  }
+
+  const handleSubmit = () => {
+    const payload = entries
+      .filter((entry) => entry.notification.notification?.title)
+      .map((entry) => ({
+        notification: entry.notification.notification!,
+        targetSites: MOE_SITES,
+      }))
+
+    mutation.mutate({ entries: payload })
+  }
+
+  return (
+    <Flex flexDir="column" py="2rem" maxW="57rem" mx="auto" width="100%">
+      <Breadcrumb>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/" as={NextLink}>
+            Home
+          </BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrentPage>
+          <BreadcrumbLink>Central Notification Banner</BreadcrumbLink>
+        </BreadcrumbItem>
+      </Breadcrumb>
+
+      <Flex justifyContent="space-between" alignItems="center" mt="1rem">
+        <Text as="h3" size="lg" textStyle="h3">
+          Central Notification Banner
+        </Text>
+        <Flex gap="0.5rem">
+          <Button
+            colorScheme="main"
+            size="sm"
+            onClick={handleSubmit}
+            isLoading={mutation.isPending}
+          >
+            Publish
+          </Button>
+        </Flex>
+      </Flex>
+
+      <Text textStyle="body-2" color="base.content.medium" mt="0.5rem">
+        Manage notification banners that are displayed across multiple sites.
+        Each notification targets a specific set of sites. A site will show at
+        most one notification (the first matching entry).
+      </Text>
+
+      {isLoading ? (
+        <Skeleton height="20rem" mt="1.5rem" borderRadius="0.5rem" />
+      ) : (
+        <Flex flexDirection="column" mt="1.5rem" gap="1.5rem">
+          {entries.map((entry, index) => (
+            <Box
+              key={index}
+              p="1.5rem"
+              bg="base.canvas.default"
+              border="1px solid"
+              borderColor="base.divider.medium"
+              borderRadius="0.5rem"
+            >
+              <Flex
+                justifyContent="space-between"
+                alignItems="center"
+                mb="1rem"
+              >
+                <Text textStyle="subhead-1">Notification {index + 1}</Text>
+                <IconButton
+                  aria-label="Remove notification entry"
+                  icon={<BiTrash />}
+                  variant="outline"
+                  colorScheme="critical"
+                  size="sm"
+                  onClick={() => handleRemoveEntry(index)}
+                />
+              </Flex>
+
+              <ErrorProvider>
+                <FormBuilder<Notification>
+                  schema={NotificationSettingsSchema}
+                  validateFn={notificationValidator}
+                  data={entry.notification}
+                  handleChange={(data) => handleNotificationChange(index, data)}
+                />
+              </ErrorProvider>
+            </Box>
+          ))}
+
+          <Button
+            leftIcon={<BiPlus />}
+            variant="outline"
+            onClick={handleAddEntry}
+            width="fit-content"
+          >
+            Add notification
+          </Button>
+        </Flex>
+      )}
+    </Flex>
+  )
+}
+
+CentralBannerPage.getLayout = AuthenticatedLayout
+
+export default CentralBannerPage

--- a/apps/studio/src/schemas/global.ts
+++ b/apps/studio/src/schemas/global.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+const centralNotificationEntrySchema = z.object({
+  notification: z.object({
+    title: z.string().min(1).max(150),
+    content: z.unknown().optional(),
+  }),
+  targetSites: z.array(z.string().url()),
+})
+
+export const setGlobalNotificationSchema = z.object({
+  entries: z.array(centralNotificationEntrySchema),
+})
+
+export type SetGlobalNotificationInput = z.infer<
+  typeof setGlobalNotificationSchema
+>

--- a/apps/studio/src/server/modules/_app.ts
+++ b/apps/studio/src/server/modules/_app.ts
@@ -7,6 +7,7 @@ import { assetRouter } from "./asset/asset.router"
 import { authRouter } from "./auth/auth.router"
 import { collectionRouter } from "./collection/collection.router"
 import { folderRouter } from "./folder/folder.router"
+import { globalRouter } from "./global/global.router"
 import { meRouter } from "./me/me.router"
 import { pageRouter } from "./page/page.router"
 import { resourceRouter } from "./resource/resource.router"
@@ -23,6 +24,7 @@ export const appRouter = router({
   page: pageRouter,
   folder: folderRouter,
   collection: collectionRouter,
+  global: globalRouter,
   site: siteRouter,
   resource: resourceRouter,
   user: userRouter,

--- a/apps/studio/src/server/modules/global/global.router.ts
+++ b/apps/studio/src/server/modules/global/global.router.ts
@@ -1,0 +1,34 @@
+import { ADMIN_ROLE } from "~/lib/growthbook"
+import { setGlobalNotificationSchema } from "~/schemas/global"
+import { protectedProcedure, router } from "~/server/trpc"
+import { validateUserIsIsomerCoreAdmin } from "../permissions/permissions.service"
+import {
+  getGlobalNotification,
+  publishGlobalNotification,
+} from "./global.service"
+
+export const globalRouter = router({
+  getNotification: protectedProcedure.query(async ({ ctx }) => {
+    await validateUserIsIsomerCoreAdmin({
+      userId: ctx.user.id,
+      gb: ctx.gb,
+      roles: [ADMIN_ROLE.CORE],
+    })
+
+    return getGlobalNotification()
+  }),
+
+  setNotification: protectedProcedure
+    .input(setGlobalNotificationSchema)
+    .mutation(async ({ ctx, input: { entries } }) => {
+      await validateUserIsIsomerCoreAdmin({
+        userId: ctx.user.id,
+        gb: ctx.gb,
+        roles: [ADMIN_ROLE.CORE],
+      })
+
+      await publishGlobalNotification(entries)
+
+      return { success: true }
+    }),
+})

--- a/apps/studio/src/server/modules/global/global.service.ts
+++ b/apps/studio/src/server/modules/global/global.service.ts
@@ -1,0 +1,67 @@
+import {
+  GetObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3"
+
+import { env } from "~/env.mjs"
+
+const { NEXT_PUBLIC_S3_REGION, NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME } = env
+
+const storage = new S3Client({
+  region: NEXT_PUBLIC_S3_REGION,
+})
+
+const CENTRAL_NOTIFICATION_KEY = "central-notification.json"
+
+export interface CentralNotificationEntry {
+  notification: {
+    title: string
+    content?: unknown
+  }
+  targetSites: string[]
+}
+
+export type CentralNotificationBroadcast = CentralNotificationEntry[]
+
+export const getGlobalNotification =
+  async (): Promise<CentralNotificationBroadcast> => {
+    try {
+      const response = await storage.send(
+        new GetObjectCommand({
+          Bucket: NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
+          Key: CENTRAL_NOTIFICATION_KEY,
+        }),
+      )
+
+      const body = await response.Body?.transformToString()
+      if (!body) return []
+
+      const data = JSON.parse(body) as CentralNotificationBroadcast
+      return Array.isArray(data) ? data : []
+    } catch (error) {
+      // If the file doesn't exist yet, return empty array
+      if (
+        error instanceof Error &&
+        "name" in error &&
+        error.name === "NoSuchKey"
+      ) {
+        return []
+      }
+      throw error
+    }
+  }
+
+export const publishGlobalNotification = async (
+  data: CentralNotificationBroadcast,
+): Promise<void> => {
+  await storage.send(
+    new PutObjectCommand({
+      Bucket: NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
+      Key: CENTRAL_NOTIFICATION_KEY,
+      Body: JSON.stringify(data),
+      ContentType: "application/json",
+      CacheControl: "no-cache, no-store, must-revalidate",
+    }),
+  )
+}

--- a/packages/components/src/hooks/index.ts
+++ b/packages/components/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export { useDgsMetadata } from "./useDgsMetadata"
+export { useIsCentralNotificationDismissed } from "./useIsCentralNotificationDismissed"
 export { useIsNotificationDismissed } from "./useIsNotificationDismissed"

--- a/packages/components/src/hooks/useIsCentralNotificationDismissed.ts
+++ b/packages/components/src/hooks/useIsCentralNotificationDismissed.ts
@@ -1,0 +1,5 @@
+import { useSessionStorage } from "usehooks-ts"
+
+export const useIsCentralNotificationDismissed = () => {
+  return useSessionStorage("central-notification-dismissed", false)
+}

--- a/packages/components/src/interfaces/internal/CentralNotification.ts
+++ b/packages/components/src/interfaces/internal/CentralNotification.ts
@@ -1,0 +1,35 @@
+import type { Static } from "@sinclair/typebox"
+import { Type } from "@sinclair/typebox"
+
+import type { IsomerSiteProps, LinkComponentType } from "~/types"
+import { NotificationSchema } from "./Notification"
+
+export const CentralNotificationEntrySchema = Type.Object({
+  notification: NotificationSchema,
+  targetSites: Type.Array(Type.String(), {
+    title: "Target sites",
+    description: "List of site URLs to display this notification on.",
+  }),
+})
+
+export const CentralNotificationBroadcastSchema = Type.Array(
+  CentralNotificationEntrySchema,
+  {
+    title: "Central notification broadcast",
+    description:
+      "An array of notification entries, each targeting a set of sites. A site shows at most one notification (first match wins).",
+  },
+)
+
+export type CentralNotificationEntry = Static<
+  typeof CentralNotificationEntrySchema
+>
+
+export type CentralNotificationBroadcast = Static<
+  typeof CentralNotificationBroadcastSchema
+>
+
+export interface CentralNotificationProps {
+  site: IsomerSiteProps
+  LinkComponent?: LinkComponentType
+}

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -2,6 +2,13 @@ export {
   ArticlePageHeaderSchema,
   type ArticlePageHeaderProps,
 } from "./ArticlePageHeader"
+export {
+  CentralNotificationEntrySchema,
+  CentralNotificationBroadcastSchema,
+  type CentralNotificationEntry,
+  type CentralNotificationBroadcast,
+  type CentralNotificationProps,
+} from "./CentralNotification"
 export type { BaseParagraphProps } from "./BaseParagraph"
 export type { BreadcrumbProps } from "./Breadcrumb"
 export type {

--- a/packages/components/src/templates/next/components/internal/CentralNotification/CentralNotification.tsx
+++ b/packages/components/src/templates/next/components/internal/CentralNotification/CentralNotification.tsx
@@ -1,0 +1,18 @@
+import type { CentralNotificationProps } from "~/interfaces"
+import { CentralNotificationClient } from "./CentralNotificationClient"
+
+export const CentralNotification = ({
+  site,
+  LinkComponent,
+}: CentralNotificationProps) => {
+  if (!site.assetsBaseUrl) return null
+
+  return (
+    <CentralNotificationClient
+      assetsBaseUrl={site.assetsBaseUrl}
+      siteUrl={site.url}
+      site={site}
+      LinkComponent={LinkComponent}
+    />
+  )
+}

--- a/packages/components/src/templates/next/components/internal/CentralNotification/CentralNotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/CentralNotification/CentralNotificationClient.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { BiInfoCircle, BiX } from "react-icons/bi"
+
+import type {
+  CentralNotificationBroadcast,
+  CentralNotificationEntry,
+  CentralNotificationProps,
+} from "~/interfaces"
+import { useIsCentralNotificationDismissed } from "~/hooks/useIsCentralNotificationDismissed"
+import { getTextAsHtml } from "~/utils"
+import { Prose } from "../../native/Prose"
+import { hasContent } from "../../native/Prose/utils"
+import { BaseParagraph } from "../BaseParagraph"
+import { IconButton } from "../IconButton"
+
+interface CentralNotificationClientProps extends CentralNotificationProps {
+  assetsBaseUrl: string
+  siteUrl: string
+}
+
+export const CentralNotificationClient = ({
+  assetsBaseUrl,
+  siteUrl,
+  site,
+  LinkComponent,
+}: CentralNotificationClientProps) => {
+  const [isDismissed, setIsDismissed] = useIsCentralNotificationDismissed()
+  const [matchedEntry, setMatchedEntry] =
+    useState<CentralNotificationEntry | null>(null)
+
+  useEffect(() => {
+    if (isDismissed || !assetsBaseUrl) return
+
+    fetch(`${assetsBaseUrl}/central-notification.json`)
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch central notification")
+        return res.json()
+      })
+      .then((data: CentralNotificationBroadcast) => {
+        if (!Array.isArray(data)) return
+
+        const match = data.find((entry) => entry.targetSites.includes(siteUrl))
+        if (match) {
+          setMatchedEntry(match)
+        }
+      })
+      .catch(() => {
+        // Silently fail - no notification is shown if fetch fails
+      })
+  }, [assetsBaseUrl, siteUrl, isDismissed])
+
+  const onDismiss = () => {
+    setIsDismissed(true)
+  }
+
+  if (isDismissed || !matchedEntry) return null
+
+  const { notification } = matchedEntry
+  const { title, content } = notification
+
+  const ContentParagraph = () => {
+    if (!content) return null
+    if (content instanceof Array) {
+      return (
+        <BaseParagraph
+          content={getTextAsHtml({ site, content })}
+          className="prose-body-base"
+          LinkComponent={LinkComponent}
+        />
+      )
+    }
+    if (hasContent(content.content)) {
+      return <Prose {...content} site={site} LinkComponent={LinkComponent} />
+    }
+    return null
+  }
+
+  return (
+    <div className="bg-utility-feedback-info-faint">
+      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
+        <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
+        <div className="flex flex-1 flex-col gap-1">
+          {!!title && <h2 className="prose-headline-lg-medium">{title}</h2>}
+          <div className="[&_p]:!mb-0 [&_p]:!mt-0">
+            <ContentParagraph />
+          </div>
+        </div>
+        <div aria-hidden className="flex h-6 w-6 shrink-0" />
+        <IconButton
+          onPress={onDismiss}
+          icon={BiX}
+          className="absolute right-3 top-[22px] md:right-7 md:top-3.5"
+          aria-label="Dismiss central notification temporarily"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/components/src/templates/next/components/internal/CentralNotification/index.ts
+++ b/packages/components/src/templates/next/components/internal/CentralNotification/index.ts
@@ -1,0 +1,1 @@
+export { CentralNotification } from "./CentralNotification"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -1,4 +1,5 @@
 import type { IsomerPageSchemaType } from "~/types"
+import { CentralNotification } from "../../components/internal/CentralNotification"
 import { Footer } from "../../components/internal/Footer"
 import { Masthead } from "../../components/internal/Masthead"
 import { Navbar } from "../../components/internal/Navbar"
@@ -26,6 +27,8 @@ export const Skeleton = ({
         <SkipToContent LinkComponent={LinkComponent} />
 
         {site.isGovernment && <Masthead isStaging={isStaging} />}
+
+        <CentralNotification site={site} LinkComponent={LinkComponent} />
 
         {site.notification?.title && (
           <Notification


### PR DESCRIPTION
> [!NOTE]
>
> **This is only a prototype to showcase to MOE for now**

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

MOE need a notification banner that is centrally managed and immediately shown live on all MOE schools.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Introduce a new CentralNotification component that pulls a specific JSON file from the S3 assets bucket and displays its content as a notification banner at the top of the site.
- Introduce a new `/central-banner` route on Isomer Studio to edit the central notification banner.

## Screenshots
<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/333bac09-c3f4-4a58-ab02-63e32b32ed71" />
<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/7f547df7-4bc0-4046-b714-4644523952e3" />
<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/6a2c19eb-c6d6-46e6-852b-54a1d208b25f" />

https://github.com/user-attachments/assets/6c8ada6b-bb9d-4b54-80a8-124ac42292d7


## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Isomer Studio and click on the Central Banner button at the top left of the screen.
- [ ] Verify that you are able to see the central notification banner settings page.
- [ ] Make sure that the staging sites are already built using this branch.
- [ ] Add a new central notification banner, verify that the banner immediately appears on the staging sites after a refresh.
- [ ] Make changes to the central notification banner and save, verify that the updated contents immediately appears on the staging sites after a refresh.