### PR TITLE
Remove unused Duplicate page menu option from Studio 

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -54,7 +54,7 @@ export const ResourceTableMenu = ({
         variant="clear"
       />
       <Portal>
-        <MenuList>
+        <MenuList minWidth="8rem">
           {/* TODO: Open edit modal depending on resource  */}
           {type === ResourceType.Page && (
             <>


### PR DESCRIPTION
## Problem

"Duplicate page" has been a skeleton option on Isomer Studio. Users would ask Ops about the feature. We want to hide the menu item until the feature is ready. 

## Solution

Removed menu item.