### PR TITLE
feat(studio): add allowed blocks for index pages

### DIFF
--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -26,6 +26,7 @@ import {
   DATABASE_ALLOWED_BLOCKS,
   DEFAULT_BLOCKS,
   HOMEPAGE_ALLOWED_BLOCKS,
+  INDEX_ALLOWED_BLOCKS,
 } from "./constants"
 import { type SectionType } from "./types"
 
@@ -181,8 +182,9 @@ function ComponentSelector() {
         return ARTICLE_ALLOWED_BLOCKS
       case ResourceType.Collection:
       case ResourceType.CollectionLink:
-      case ResourceType.IndexPage:
         return []
+      case ResourceType.IndexPage:
+        return INDEX_ALLOWED_BLOCKS
       case ResourceType.Folder:
       case ResourceType.FolderMeta:
       case ResourceType.CollectionMeta:

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -491,6 +491,14 @@ export const CONTENT_ALLOWED_BLOCKS: AllowedBlockSections = [
   { label: "Embed external content", types: ["map", "video", "formsg"] },
 ]
 
+export const INDEX_ALLOWED_BLOCKS: AllowedBlockSections = [
+  { label: "Basic content blocks", types: ["prose", "image"] },
+  {
+    label: "Add a new section",
+    types: ["infocards"],
+  },
+]
+
 export const DATABASE_ALLOWED_BLOCKS: AllowedBlockSections =
   CONTENT_ALLOWED_BLOCKS
 


### PR DESCRIPTION
wowo thanks claude this is p good
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Index pages currently return an empty array for allowed blocks, meaning users cannot add any content blocks to them. This limits the functionality of index pages in the page editor.

## Solution

<!-- How did you solve the problem? -->

Added a new `INDEX_ALLOWED_BLOCKS` constant that defines which blocks can be added to index pages, and updated the `ComponentSelector` to use this constant for `ResourceType.IndexPage`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Index pages now support adding content blocks:
  - Basic content blocks: `prose`, `image`
  - New section types: `infocards`

## Before & After Screenshots

**BEFORE**:
<img width="1494" height="896" alt="image" src="https://github.com/user-attachments/assets/87018a82-2295-47a8-a536-170daf3f5b2d" />


Index pages showed no available blocks to add.

**AFTER**:
https://github.com/user-attachments/assets/7dd64ef0-dbe7-4bda-ac5f-24933ef7ca81


## Tests

- Navigate to an index page in the page editor
- Verify that the component selector shows the available blocks (prose, image, infocards)
- Add each block type and confirm they render correctly