### PR TITLE
chore(studio): allow adding blocks to index pages

### DIFF
--- a/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/RootStateDrawer.tsx
@@ -328,7 +328,7 @@ export default function RootStateDrawer() {
   // because folder index pages aren't intended to have
   // content yet and components don't render content
   // for collection index pages
-  const canAddBlocks = pageLayout !== "index" && pageLayout !== "collection"
+  const canAddBlocks = pageLayout !== "collection"
 
   return (
     <Flex direction="column" h="full">


### PR DESCRIPTION
## Problem

Index pages currently cannot have content blocks added to them due to a restriction in the `RootStateDrawer` component. This prevents users from adding any content to folder index pages.

## Solution

Removed the `pageLayout !== "index"` check from the `canAddBlocks` condition in `RootStateDrawer.tsx`. This allows users to add blocks to index pages while still maintaining the restriction for collection pages.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Users can now add content blocks to index pages in the page editor

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

Index pages did not show the "Add block" functionality.

**AFTER**:

Index pages now display the block addition controls, allowing users to add content.

## Tests

- Navigate to a folder index page in the page editor
- Verify that the "Add block" option is now available
- Add a block and confirm it saves correctly

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A