### PR TITLE
fix: update Content Security Policy for script-src 

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -55,7 +55,7 @@ const ContentSecurityPolicy = `
   object-src 'none';
   script-src
     'self'
-    'unsafe-eval'
+    ${env.NODE_ENV === "production" ? "" : "'unsafe-eval'"}
     https://*.wogaa.sg
     https://app.intercom.io
     https://widget.intercom.io


### PR DESCRIPTION
don't need it outside of production
keeping it for development because the documentation above in the file seems to suggest so, so just keeping to play safe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusting the production `Content-Security-Policy` can break script execution if any bundled code relies on `eval`/`new Function` at runtime. It also tightens security in prod by no longer allowing `unsafe-eval` outside development.
> 
> **Overview**
> Updates the Studio app’s `Content-Security-Policy` so `script-src` only includes `'unsafe-eval'` in non-production environments, removing it from production responses while leaving dev behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7c06417e69ad724ea652c20890488533618945a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->