### PR TITLE
chore: fix package dependencies and merge upstream changes

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -80,6 +80,7 @@
     "@opengovsg/starter-kitty-validators": "^1.2.13",
     "@paralleldrive/cuid2": "^2.2.2",
     "@prisma/client": "5.10.2",
+    "@tanstack/query-devtools": "^5.85.3",
     "@tanstack/react-query": "^5.85.3",
     "@tanstack/react-query-devtools": "^5.85.3",
     "@tanstack/react-table": "^8.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@opengovsg/starter-kitty-validators": "^1.2.13",
         "@paralleldrive/cuid2": "^2.2.2",
         "@prisma/client": "5.10.2",
+        "@tanstack/query-devtools": "^5.85.3",
         "@tanstack/react-query": "^5.85.3",
         "@tanstack/react-query-devtools": "^5.85.3",
         "@tanstack/react-table": "^8.21.2",
@@ -12391,6 +12392,16 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.93.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.93.0.tgz",
+      "integrity": "sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tanstack/react-table": {
@@ -31395,6 +31406,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/redis": {
+      "resolved": "packages/redis",
+      "link": true
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "license": "MIT"
@@ -32111,6 +32126,10 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/scripts": {
+      "resolved": "tooling/scripts",
+      "link": true
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -36624,23 +36643,7 @@
       }
     },
     "packages/redis": {
-      "name": "@isomer/redis",
-      "version": "0.0.0",
-      "extraneous": true,
-      "dependencies": {
-        "ioredis": "^5.7.0",
-        "pino": "^9.6.0",
-        "redlock": "^5.0.0-beta.2",
-        "zod": "^3.22.4"
-      },
-      "devDependencies": {
-        "@isomer/eslint-config": "*",
-        "@isomer/prettier-config": "*",
-        "@isomer/tsconfig": "*",
-        "eslint": "^9.10.0",
-        "prettier": "^3.3.3",
-        "typescript": "^5.9.2"
-      }
+      "version": "0.0.0"
     },
     "tooling/build": {
       "version": "0.0.0",
@@ -36765,6 +36768,9 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "tooling/scripts": {
+      "version": "0.0.0"
     },
     "tooling/seed-from-repo": {
       "name": "@isomer/seed-from-repo",

--- a/tooling/scripts/package.json
+++ b/tooling/scripts/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "scripts",
+  "version": "0.0.0",
+  "private": true
+}


### PR DESCRIPTION
## Problem

Multiple package and build issues were affecting the repository:
1. Missing `@tanstack/query-devtools` peer dependency causing build failures
2. Missing placeholder `package.json` files for `packages/redis` and `tooling/scripts` workspaces
3. Various upstream fixes needed to be merged

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Added missing `@tanstack/query-devtools` dependency required by `@tanstack/react-query-devtools` v5.x
- Added placeholder `package.json` files for `packages/redis` and `tooling/scripts` to fix npm workspace resolution
- Updated `package-lock.json` to resolve workspace links correctly

**Bug Fixes**:

- Fixed build failure: `Module not found: Can't resolve '@tanstack/query-devtools'`

**Merged Changes from Upstream**:

- **Security**: Fixed stored XSS in asset creation (#1839) - server-signs Content-Type/Content-Disposition for S3 uploads
- **Security**: Prevented DoS via unbounded array in recursive queries (#1845)
- **Security**: Prevented moving folder into its own descendants (#1838)
- **Dependencies**: Bumped fast-xml-parser and @aws-sdk/xml-builder (#1851)
- **UI**: Define display-xs class to improve type hierarchy on Article layout (#1844)
- **Fix**: YouTube embed facade for videoseries (#1834)
- **Feature**: Allow adding blocks to index pages (#1837)
- **CSP**: Added `https://www.youtube.com` to Content Security Policy for video embeds

## Tests

Build should now complete successfully without the `@tanstack/query-devtools` module not found error.

```bash
npm run build
```