### PR TITLE
chore: revert unsafe-eval CSP restriction to development only

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -4,6 +4,8 @@
  */
 const { env } = await import("./src/env.mjs")
 
+// NOTE: Keep the `unsafe-eval` for `script-src` as the removal
+// led to nextjs crashing on start
 /*
 TODO: Removing this CSP first
   // img-src 'self' data: blob: ${


### PR DESCRIPTION
## Problem

PR #1847 changed the Content Security Policy (CSP) to only allow `'unsafe-eval'` in development mode. However, this caused issues because some dependencies or features require `'unsafe-eval'` in production as well.

## Solution

Reverted the conditional `'unsafe-eval'` back to always being present in the CSP `script-src` directive, regardless of environment.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Reverted CSP change that was causing script execution issues by conditionally removing `'unsafe-eval'` in production

## Tests

Verify that the application works correctly in both development and production environments without CSP violations.

```bash
npm run build && npm run start
```