### PR TITLE
fix(Hero): make scroll event listener passive for better performance (UX)

### DIFF
--- a/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
@@ -40,7 +40,7 @@ export const ImageContainer = ({ imageSrc, imageAlt }: ImageContainerProps) => {
     // to not render during static site generation on the server
     if (typeof window === "undefined") return
 
-    window.addEventListener("scroll", handleScroll)
+    window.addEventListener("scroll", handleScroll, { passive: true })
     window.addEventListener("resize", handleScroll)
     handleScroll()
 


### PR DESCRIPTION
## Problem

Hero scroll listener could block the browser from starting scroll before the handler runs, hurting scroll responsiveness (most noticeable on mobile).

## Solution

Register the Hero large-image scroll listener as passive so the browser can scroll immediately. The handler only reads layout and updates state; it never calls `preventDefault()`, so passive is safe.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

## Tests

Manual: confirm hero “Scroll for more” button still appears/hides correctly when scrolling; no new tests or dependencies.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small client-side performance tweak that only changes the scroll listener options and doesn’t affect data or security-critical logic.
> 
> **Overview**
> Improves Hero large-image scrolling performance by registering the `scroll` event listener with `{ passive: true }`, allowing the browser to start scrolling without waiting for the handler.
> 
> Behavior is otherwise unchanged; the same `handleScroll` logic still drives `ScrollForMoreButton` visibility and positioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db7d9a7be4a13b4954f6f014adf16b18d9265bf4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->