### PR TITLE
chore: update AskGov ID description for clarity and guidance

### DIFF
--- a/packages/components/src/interfaces/internal/Askgov.ts
+++ b/packages/components/src/interfaces/internal/Askgov.ts
@@ -1,7 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-import type { IsomerSiteProps, ScriptComponentType } from "~/types"
+import type { IsomerSiteProps } from "~/types"
 
 export const AskgovSchema = Type.Object(
   {


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Agencies often reach out to us because they're unsure what "ID" means when setting up AskGov widget on isomer sites.

https://opengovproducts.slack.com/archives/C06R4DX966P/p1772702239299619

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- update copywriting text + link to askgov article

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Text-only schema metadata change plus removal of an unused type import; no runtime behavior or data handling is affected.
> 
> **Overview**
> Updates the `AskgovSchema` `data-agency` field description to better explain how to derive the AskGov ID from the AskGov URL.
> 
> Also removes the unused `ScriptComponentType` type import from `Askgov.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a58f04df66a7fce3d030452ae6bb126007218989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->