### PR TITLE
(DO NOT REVIEW) Meta description content

### DIFF
--- a/packages/components/src/engine/__tests__/metadata.test.ts
+++ b/packages/components/src/engine/__tests__/metadata.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest"
+
+import { getMetadata } from "~/engine/metadata"
+import { generateSiteConfig } from "~/stories/helpers/generateSiteConfig"
+import type { IsomerPageSchemaType } from "~/types"
+
+const SITE_NAME = "Embassy of Singapore in Berlin"
+const site = generateSiteConfig({
+  siteName: SITE_NAME,
+  url: "https://berlin.mfa.gov.sg",
+})
+
+const createHomepageProps = ({
+  metaDescription,
+}: {
+  metaDescription?: string
+} = {}): IsomerPageSchemaType =>
+  ({
+    layout: "homepage",
+    version: "0.1.0",
+    site,
+    page: {
+      title: "Home",
+      permalink: "/",
+      lastModified: "",
+    },
+    meta: metaDescription ? { description: metaDescription } : undefined,
+    content: [
+      {
+        type: "hero",
+        subtitle: "Hero subtitle should not be used as meta description",
+      },
+    ],
+  }) as IsomerPageSchemaType
+
+const createContentProps = ({
+  summary = "Default content summary",
+  metaDescription,
+}: {
+  summary?: string
+  metaDescription?: string
+} = {}): IsomerPageSchemaType =>
+  ({
+    layout: "content",
+    version: "0.1.0",
+    site,
+    page: {
+      title: "About",
+      permalink: "/about",
+      lastModified: "",
+      contentPageHeader: {
+        summary,
+        showThumbnail: false,
+      },
+    },
+    meta: metaDescription ? { description: metaDescription } : undefined,
+    content: [],
+  }) as IsomerPageSchemaType
+
+describe("getMetadata", () => {
+  it("uses site name as homepage description even when hero or meta description exists", () => {
+    const metadata = getMetadata(
+      createHomepageProps({ metaDescription: "Custom homepage meta description" }),
+    )
+
+    expect(metadata.description).toBe(SITE_NAME)
+    expect(metadata.openGraph.description).toBe(SITE_NAME)
+  })
+
+  it("uses custom meta description for non-homepages when provided", () => {
+    const metadata = getMetadata(
+      createContentProps({ metaDescription: "Custom content meta description" }),
+    )
+
+    expect(metadata.description).toBe("Custom content meta description")
+    expect(metadata.openGraph.description).toBe("Custom content meta description")
+  })
+
+  it("defaults to page summary for non-homepages", () => {
+    const metadata = getMetadata(createContentProps())
+
+    expect(metadata.description).toBe("Default content summary")
+    expect(metadata.openGraph.description).toBe("Default content summary")
+  })
+
+  it("falls back to site name when non-homepage summary is empty", () => {
+    const metadata = getMetadata(createContentProps({ summary: "" }))
+
+    expect(metadata.description).toBe(SITE_NAME)
+    expect(metadata.openGraph.description).toBe(SITE_NAME)
+  })
+})

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -10,32 +10,48 @@ const getOpenGraphTitle = (props: IsomerPageSchemaType) => {
 }
 
 const getMetaDescription = (props: IsomerPageSchemaType) => {
-  if (props.meta?.description) {
-    return props.meta.description
+  const getNonEmptyValue = (value?: string) => {
+    return value?.trim() ? value : undefined
   }
+
+  // NOTE: Product requirement is to always use site name for homepage
+  // metadata description.
+  if (props.layout === ISOMER_PAGE_LAYOUTS.Homepage) {
+    return getNonEmptyValue(props.site.siteName)
+  }
+
+  if (getNonEmptyValue(props.meta?.description)) {
+    return props.meta?.description
+  }
+
+  let layoutDefaultDescription: string | undefined
 
   switch (props.layout) {
     case ISOMER_PAGE_LAYOUTS.Article:
-      return props.page.articlePageHeader.summary
+      layoutDefaultDescription = props.page.articlePageHeader.summary
+      break
     case ISOMER_PAGE_LAYOUTS.Content:
     case ISOMER_PAGE_LAYOUTS.Database:
     case ISOMER_PAGE_LAYOUTS.Index:
-      return props.page.contentPageHeader.summary
+      layoutDefaultDescription = props.page.contentPageHeader.summary
+      break
     case ISOMER_PAGE_LAYOUTS.Collection:
-      return props.page.subtitle
-    case ISOMER_PAGE_LAYOUTS.Homepage:
-      return props.content.find((item) => item.type === "hero")?.subtitle
+      layoutDefaultDescription = props.page.subtitle
+      break
     case ISOMER_PAGE_LAYOUTS.File:
     case ISOMER_PAGE_LAYOUTS.Link:
     case ISOMER_PAGE_LAYOUTS.Search:
     case ISOMER_PAGE_LAYOUTS.NotFound:
-      // NOTE: These pages do not appear in search results, so we don't need to
-      // provide a meta description
-      return undefined
+      layoutDefaultDescription = undefined
+      break
     default:
       const _: never = props
-      return undefined
+      layoutDefaultDescription = undefined
+      break
   }
+
+  // NOTE: Ensure meta description is present even if default summary is empty.
+  return getNonEmptyValue(layoutDefaultDescription) ?? getNonEmptyValue(props.site.siteName)
 }
 
 const getMetaImage = (props: IsomerPageSchemaType) => {


### PR DESCRIPTION
> [!WARNING]
> NOTE: this is a test of Cursor Cloud Agent for simple stuff 

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-2209

Meta descriptions were missing for some pages, particularly homepages when the hero subtitle was empty, leading to SEO issues. The requirement is to ensure all pages have a meta description, with homepages specifically using the site name.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Homepage meta description now consistently uses the `siteName`, overriding any hero subtitle or explicit `meta.description` on the homepage.
- Non-homepage meta descriptions now correctly prioritize `meta.description` if provided, otherwise defaulting to `summary` (or `subtitle` for collections), and falling back to `siteName` if the summary/subtitle is empty. This prevents empty meta descriptions.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

N/A (backend logic change affecting meta tags)

**AFTER**:

<!-- [insert screenshot here] -->

N/A (backend logic change affecting meta tags)

## Tests

<!-- What tests should be run to confirm functionality? -->

**New scripts**:

- `npm run test:unit -- src/engine/__tests__/metadata.test.ts` (in `packages/components`)

**New dependencies**:

- None

**New dev dependencies**:

- None

---
<p><a href="https://cursor.com/agents/bc-b6928154-8436-4c67-839e-8726e013e35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6928154-8436-4c67-839e-8726e013e35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->