### PR TITLE
chore: only notify channel on production releases

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -212,8 +212,8 @@ jobs:
             ${{ steps.inspector.outputs.inspector_scan_results_markdown }}
             ${{ steps.inspector.outputs.artifact_sbom }}
 
-      - name: Notify if vulnerability threshold is exceeded
-        if: ${{ steps.inspector.outputs.vulnerability_threshold_exceeded }}
+      - name: Notify if vulnerability threshold is exceeded (for production deployments only)
+        if: ${{ steps.inspector.outputs.vulnerability_threshold_exceeded && inputs.environment == 'production' }}
         uses: slackapi/slack-github-action@v2.1.1
         with:
           method: chat.postMessage


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Slack channel gets pinged for every deploy, including staging and UAT, which can be quite noisy.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Perform the Slack notification only if the deployment is for the production environment.