### PR TITLE
Fix: DGS rate limit for CI and local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,7 @@ NEXT_PUBLIC_APP_ENV='development'
 
 # Growthbook
 GROWTHBOOK_CLIENT_KEY=xyz
+
+# data.gov.sg API key (optional for local Storybook; avoids rate limits)
+# Loaded by dotenv when running `npm run storybook`
+DATAGOVSG_API_KEY=

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -56,9 +56,16 @@ jobs:
           fetch-depth: 0 # Required for v4
       - name: Setup
         uses: ./.github/actions/setup
+      - name: Check DATAGOVSG_API_KEY
+        run: |
+          if [ -z "${{ secrets.DATAGOVSG_API_KEY }}" ]; then
+            echo "::warning::DATAGOVSG_API_KEY is not set; Storybook/Chromatic may hit data.gov.sg rate limits"
+          fi
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest
+        env:
+          DATAGOVSG_API_KEY: ${{ secrets.DATAGOVSG_API_KEY }}
         # Chromatic GitHub Action options
         with:
           workingDir: packages/components
@@ -85,9 +92,16 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build Isomer Components
         run: npm run --workspace packages/components build
+      - name: Check DATAGOVSG_API_KEY
+        run: |
+          if [ -z "${{ secrets.DATAGOVSG_API_KEY }}" ]; then
+            echo "::warning::DATAGOVSG_API_KEY is not set; Storybook/Chromatic may hit data.gov.sg rate limits"
+          fi
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest
+        env:
+          DATAGOVSG_API_KEY: ${{ secrets.DATAGOVSG_API_KEY }}
         # Chromatic GitHub Action options
         with:
           workingDir: apps/studio

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -57,8 +57,10 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Check DATAGOVSG_API_KEY
+        env:
+          DATAGOVSG_API_KEY: ${{ secrets.DATAGOVSG_API_KEY }}
         run: |
-          if [ -z "${{ secrets.DATAGOVSG_API_KEY }}" ]; then
+          if [ -z "${DATAGOVSG_API_KEY:-}" ]; then
             echo "::warning::DATAGOVSG_API_KEY is not set; Storybook/Chromatic may hit data.gov.sg rate limits"
           fi
       # 👇 Adds Chromatic as a step in the workflow

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -92,16 +92,9 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build Isomer Components
         run: npm run --workspace packages/components build
-      - name: Check DATAGOVSG_API_KEY
-        run: |
-          if [ -z "${{ secrets.DATAGOVSG_API_KEY }}" ]; then
-            echo "::warning::DATAGOVSG_API_KEY is not set; Storybook/Chromatic may hit data.gov.sg rate limits"
-          fi
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
         uses: chromaui/action@latest
-        env:
-          DATAGOVSG_API_KEY: ${{ secrets.DATAGOVSG_API_KEY }}
         # Chromatic GitHub Action options
         with:
           workingDir: apps/studio

--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -16,6 +16,12 @@ const config: StorybookConfig = {
   viteFinal(config) {
     // Merge custom configuration into the default config
     return mergeConfig(config, {
+      // Inject data.gov.sg API key for DGS requests (avoids rate limits in Storybook/Chromatic)
+      define: {
+        "process.env.DATAGOVSG_API_KEY": JSON.stringify(
+          process.env.DATAGOVSG_API_KEY ?? "",
+        ),
+      },
       // Add dependencies to pre-optimization
       optimizeDeps: {
         include: ["storybook-dark-mode"],

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import "bootstrap-icons/font/bootstrap-icons.css"
 import "../src/index.css"
 
 import { viewport } from "@isomer/storybook-config"
+
 import { configureDgs } from "../src/utils/dgs/fetchDgs"
 
 const CUSTOM_GENERAL_VIEWPORTS = {

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -9,6 +9,7 @@ import "bootstrap-icons/font/bootstrap-icons.css"
 import "../src/index.css"
 
 import { viewport } from "@isomer/storybook-config"
+import { configureDgs } from "../src/utils/dgs/fetchDgs"
 
 const CUSTOM_GENERAL_VIEWPORTS = {
   smallDesktop: {
@@ -78,6 +79,11 @@ const CUSTOM_GSIB_VIEWPORTS = {
     },
   },
 }
+
+// Configure data.gov.sg API key for Storybook/Chromatic only.
+configureDgs({
+  getApiKey: () => (process.env.DATAGOVSG_API_KEY ?? "").trim() || undefined,
+})
 
 // Initialize MSW
 initialize({

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -2,6 +2,10 @@
 
 This folder contains a collection of React components for the Isomer Next project.
 
+## Storybook
+
+When running Storybook locally, you can optionally set `DATAGOVSG_API_KEY` in your `.env` (loaded by dotenv) to avoid data.gov.sg rate limits when viewing DGS-related stories. See the root `.env.example` for details.
+
 ## Installation
 
 To use these components in your project, you can install them via npm.

--- a/packages/components/src/hooks/useDgsData/fetchDataFromDgsApi.ts
+++ b/packages/components/src/hooks/useDgsData/fetchDataFromDgsApi.ts
@@ -3,13 +3,14 @@ import type {
   DgsApiDatasetSearchResponse,
   DgsApiDatasetSearchResponseSuccess,
 } from "./types"
+import { fetchDgs } from "~/utils/dgs/fetchDgs"
 import { generateDgsUrl } from "./generateDgsUrl"
 
 export const fetchDataFromDgsApiDataset = async (
   params: DgsApiDatasetSearchParams,
 ): Promise<DgsApiDatasetSearchResponseSuccess> => {
   const url = generateDgsUrl(params)
-  const res = await fetch(url)
+  const res = await fetchDgs(url)
 
   if (!res.ok) {
     throw new Error("Failed to fetch data from DGS API")

--- a/packages/components/src/utils/dgs/fetchDgs.ts
+++ b/packages/components/src/utils/dgs/fetchDgs.ts
@@ -1,5 +1,3 @@
-import { getDgsApiKey } from "./getDgsApiKey"
-
 /**
  * Wrapper around fetch that auto-injects the data.gov.sg API key when present.
  * Works without the API key—requests succeed either way. The key is only for
@@ -16,4 +14,9 @@ export const fetchDgs = (
     headers.set("x-api-key", apiKey)
   }
   return fetch(input, { ...init, headers })
+}
+
+const getDgsApiKey = (): string | undefined => {
+  const key = process.env.DATAGOVSG_API_KEY
+  return typeof key === "string" ? key.trim() || undefined : undefined
 }

--- a/packages/components/src/utils/dgs/fetchDgs.ts
+++ b/packages/components/src/utils/dgs/fetchDgs.ts
@@ -5,7 +5,7 @@
  * the `getApiKey` callback. This keeps environment-variable access outside of
  * the shared components library.
  */
-type DgsConfig = {
+interface DgsConfig {
   getApiKey?: () => string | undefined
 }
 

--- a/packages/components/src/utils/dgs/fetchDgs.ts
+++ b/packages/components/src/utils/dgs/fetchDgs.ts
@@ -1,5 +1,37 @@
 /**
- * Wrapper around fetch that auto-injects the data.gov.sg API key when present.
+ * Configuration for `fetchDgs`.
+ *
+ * Consumers are responsible for providing the data.gov.sg API key (if any) via
+ * the `getApiKey` callback. This keeps environment-variable access outside of
+ * the shared components library.
+ */
+type DgsConfig = {
+  getApiKey?: () => string | undefined
+}
+
+let dgsConfig: DgsConfig = {}
+
+/**
+ * Configure how `fetchDgs` obtains the data.gov.sg API key.
+ *
+ * Example (in an app or Storybook setup file):
+ *   configureDgs({
+ *     getApiKey: () => process.env.DATAGOVSG_API_KEY,
+ *   })
+ */
+export const configureDgs = (next: DgsConfig): void => {
+  dgsConfig = { ...dgsConfig, ...next }
+}
+
+const getConfiguredApiKey = (): string | undefined => {
+  const key = dgsConfig.getApiKey?.()
+  return typeof key === "string" ? key.trim() || undefined : undefined
+}
+
+/**
+ * Wrapper around fetch that optionally injects the data.gov.sg API key when
+ * provided via `configureDgs`.
+ *
  * Works without the API key—requests succeed either way. The key is only for
  * avoiding rate limits during local development and CI (Storybook/Chromatic).
  * Reference: https://guide.data.gov.sg/developer-guide/api-overview/how-to-use-your-api-key
@@ -9,14 +41,9 @@ export const fetchDgs = (
   init?: RequestInit,
 ): Promise<Response> => {
   const headers = new Headers(init?.headers)
-  const apiKey = getDgsApiKey()
+  const apiKey = getConfiguredApiKey()
   if (apiKey) {
     headers.set("x-api-key", apiKey)
   }
   return fetch(input, { ...init, headers })
-}
-
-const getDgsApiKey = (): string | undefined => {
-  const key = process.env.DATAGOVSG_API_KEY
-  return typeof key === "string" ? key.trim() || undefined : undefined
 }

--- a/packages/components/src/utils/dgs/fetchDgs.ts
+++ b/packages/components/src/utils/dgs/fetchDgs.ts
@@ -1,0 +1,19 @@
+import { getDgsApiKey } from "./getDgsApiKey"
+
+/**
+ * Wrapper around fetch that auto-injects the data.gov.sg API key when present.
+ * Works without the API key—requests succeed either way. The key is only for
+ * avoiding rate limits during local development and CI (Storybook/Chromatic).
+ * Reference: https://guide.data.gov.sg/developer-guide/api-overview/how-to-use-your-api-key
+ */
+export const fetchDgs = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> => {
+  const headers = new Headers(init?.headers)
+  const apiKey = getDgsApiKey()
+  if (apiKey) {
+    headers.set("x-api-key", apiKey)
+  }
+  return fetch(input, { ...init, headers })
+}

--- a/packages/components/src/utils/dgs/fetchDgsFileDownloadUrl.ts
+++ b/packages/components/src/utils/dgs/fetchDgsFileDownloadUrl.ts
@@ -1,3 +1,5 @@
+import { fetchDgs } from "./fetchDgs"
+
 interface FetchDgsFileDownloadUrlProps {
   resourceId: string
 }
@@ -23,8 +25,8 @@ export const fetchDgsFileDownloadUrl = async ({
     // Reference: https://opengovproducts.slack.com/archives/C05FKB7JM1U/p1754303394798019
     const baseUrl = `https://api-open.data.gov.sg/v1/public/api/datasets/${resourceId}`
     const downloadResponse = await Promise.race([
-      fetch(`${baseUrl}/initiate-download`),
-      fetch(`${baseUrl}/poll-download`),
+      fetchDgs(`${baseUrl}/initiate-download`),
+      fetchDgs(`${baseUrl}/poll-download`),
     ])
 
     if (!downloadResponse.ok) {

--- a/packages/components/src/utils/dgs/fetchDgsMetadata.ts
+++ b/packages/components/src/utils/dgs/fetchDgsMetadata.ts
@@ -1,3 +1,5 @@
+import { fetchDgs } from "./fetchDgs"
+
 interface FetchDgsMetadataProps {
   resourceId: string
 }
@@ -38,7 +40,7 @@ export const fetchDgsMetadata = async ({
 }: FetchDgsMetadataProps): Promise<FetchDgsMetadataOutput | undefined> => {
   try {
     // For simplicity sake, we will always use data.gov.sg production API
-    const response = await fetch(
+    const response = await fetchDgs(
       `https://api-production.data.gov.sg/v2/public/api/datasets/${resourceId}/metadata`,
     )
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

CI (Chromatic) and local Storybook runs that load data.gov.sg (DGS) content can hit rate limits when many unauthenticated requests are made. Without an API key, all requests share the same anonymous quota, leading to flaky builds and poor local UX when viewing DGS-related stories.

## Solution

<!-- How did you solve the problem? -->

Introduce a configurable `fetchDgs` utility that optionally injects the data.gov.sg API key via an `x-api-key` header. Consumers (e.g. Storybook, apps) provide the key through `configureDgs({ getApiKey })`, keeping env access out of the shared components package. All DGS fetch call sites now use `fetchDgs` instead of raw `fetch`, and Storybook/Chromatic are wired to use `DATAGOVSG_API_KEY` when available.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- `fetchDgs` utility in `packages/components/src/utils/dgs/fetchDgs.ts`: wraps `fetch` and adds `x-api-key` when configured.
- `configureDgs(next)`: allows apps/Storybook to set `getApiKey` (e.g. from `process.env.DATAGOVSG_API_KEY`) so the key is injected for DGS requests.
- Storybook (`packages/components`): `main.ts` defines `process.env.DATAGOVSG_API_KEY` for Vite; `preview.tsx` calls `configureDgs` so DGS stories use the key when running locally or in Chromatic.
- Chromatic workflow: injects `DATAGOVSG_API_KEY` from secrets into the job env and adds a non-blocking check that warns if the secret is missing (avoids rate limits when set).

**Improvements**:

- Centralised DGS fetching via `fetchDgs` in `fetchDataFromDgsApi.ts`, `fetchDgsFileDownloadUrl.ts`, and `fetchDgsMetadata.ts`.
- `.env.example`: documented optional `DATAGOVSG_API_KEY` for local Storybook.
- `packages/components/README.md`: added note on setting `DATAGOVSG_API_KEY` for Storybook to avoid rate limits.

**Bug Fixes**:

- Reduces Chromatic and local Storybook flakiness due to data.gov.sg rate limits when an API key is configured in CI and locally.

## Tests

<!-- What tests should be run to confirm functionality? -->

- Run Storybook locally with and without `DATAGOVSG_API_KEY`; confirm DGS-related stories load (with key avoids rate limits).
- Run Chromatic workflow with `DATAGOVSG_API_KEY` set in repo secrets; confirm build completes without rate-limit failures.
- Verify existing DGS behaviour in Studio/apps is unchanged (key is optional; requests work with or without it).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged when no API key is provided; the main risk is inadvertently altering request headers or environment wiring for Storybook/CI.
> 
> **Overview**
> Reduces flaky Storybook/Chromatic runs caused by data.gov.sg rate limiting by introducing a configurable `fetchDgs` wrapper that optionally injects an `x-api-key` header.
> 
> All data.gov.sg call sites in the components package are switched to use `fetchDgs`, and Storybook/Chromatic are wired to pass `DATAGOVSG_API_KEY` via Vite `define` + `configureDgs`, with CI warning (non-blocking) and documentation updates (`.env.example`, `packages/components/README.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28da0ddcfb6f4c9cefa4f8c728aa0e41af1e8192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->