### PR TITLE
fix: redirect on Singpass error to prevent infinite loading

### DIFF
--- a/apps/studio/src/features/sign-in/components/SingpassErrorFallback/SingpassErrorFallback.tsx
+++ b/apps/studio/src/features/sign-in/components/SingpassErrorFallback/SingpassErrorFallback.tsx
@@ -10,7 +10,7 @@ export const SingpassErrorFallback: ComponentType<FallbackProps> = () => {
   const router = useRouter()
 
   useEffect(() => {
-    void router.push(
+    void router.replace(
       `${SIGN_IN}?error=${encodeURIComponent("Unable to match Singpass profile")}`,
     )
   }, [router])


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When the Singpass profile does not match the one stored in the database used by the user, Studio just shows the loading spinner with no feedback.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Redirect the user to the login page with a proper error message on error.

## Before & After Screenshots
<img width="1512" height="862" alt="image" src="https://github.com/user-attachments/assets/c36a7c6c-0389-4279-a7c2-824eb02db006" />

## Tests

<!-- What tests should be run to confirm functionality? -->

- [ ] Go to Isomer Studio and attempt to log in.
- [ ] On the Singpass page, log in with an account that is different from what is originally stored in the database to simulate using someone else's Singpass account.
- [ ] Verify that you are redirected back to the login page with the error message shown in the screenshot above.
- [ ] Try to log in again but with the correct Singpass account.
- [ ] Verify that you are able to successfully log in.