### PR TITLE
fix: increase asset upload timeout for better reliability

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useAssetUpload.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useAssetUpload.ts
@@ -8,8 +8,8 @@ interface UseAssetUploadProps {
   baseTimeoutMs?: number
 }
 export const useAssetUpload = ({
-  numOfAttempts = 5,
-  baseTimeoutMs = 500,
+  numOfAttempts = 10,
+  baseTimeoutMs = 1000,
 }: UseAssetUploadProps) => {
   const [isLoading, setIsLoading] = useState(false)
   const handleAssetUpload = async (src: string) => {


### PR DESCRIPTION
## Problem

Asset uploads were failing intermittently on GSIB because the exponential backoff parameters were too aggressive. The previous configuration (5 attempts, 500ms base timeout) wasn't providing enough time for assets to propagate and become accessible after upload, causing the verification fetch to fail.

**This is a fix solely for GSIB**

## Solution

Increased the retry parameters in `useAssetUpload` hook:
- `numOfAttempts`: 5 → 10 (double the retry attempts)
- `baseTimeoutMs`: 500ms → 1000ms (double the base delay)

This provides more time for assets to become available after upload, reducing timeout failures.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed intermittent asset upload failures by increasing the exponential backoff parameters for better reliability

## Before & After Screenshots

N/A - internal timing change with no visual impact

## Tests

- Upload an image to a Hero banner component
- Upload an image to an Infopic component
- Verify both uploads complete successfully without timeout errors

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None