### PR TITLE
chore: update testcontainers to version 11.13.0

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -201,7 +201,7 @@
     "storybook": "^9.1.20",
     "storybook-mock-date-decorator": "^3.0.0",
     "tailwindcss": "^3.4.4",
-    "testcontainers": "^10.13.1",
+    "testcontainers": "^11.13.0",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
     "vite": "^5.4.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,7 +171,7 @@
         "storybook": "^9.1.20",
         "storybook-mock-date-decorator": "^3.0.0",
         "tailwindcss": "^3.4.4",
-        "testcontainers": "^10.13.1",
+        "testcontainers": "^11.13.0",
         "tsx": "^4.20.4",
         "typescript": "^5.9.2",
         "vite": "^5.4.21",
@@ -5458,14 +5458,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.4",
       "license": "MIT",
@@ -6815,6 +6807,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
       }
     },
     "node_modules/@mdx-js/react": {
@@ -11294,9 +11296,9 @@
       }
     },
     "node_modules/@types/dockerode": {
-      "version": "3.3.47",
-      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-3.3.47.tgz",
-      "integrity": "sha512-ShM1mz7rCjdssXt7Xz0u1/R2BJC7piWa3SJpUBiVjCf2A3XNn4cP6pUVaD8bLanpPVVn4IKzJuw3dOvkJ8IbYw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13302,12 +13304,11 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.1.tgz",
-      "integrity": "sha512-zGUCsm3yv/ePt2PHNbVxjjn0nNB1MkIaR4wOCxJ2ig5pCf5cCVAYJXVhQg/3OhhJV6DB1ts7Hv0oUaElc2TPQg==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.5.tgz",
+      "integrity": "sha512-XvwYM6VZqKoqDll8BmSww5luA5eflDzY0uEFfBJtFKe4PAAtxBjU3YIxzIBzhyaEQBy1VXEQBto4cpN5RZJw+w==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -13328,12 +13329,11 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-      "integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.0.tgz",
+      "integrity": "sha512-Dc9/SlwfxkXIGYhvMQNUtKaXCaGkZYGcd1vuNUUADVqzu4/vQfvnMkYYOUnt2VwQ2AqKr/8qAVFRtwETljgeFg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -13344,20 +13344,19 @@
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.8.1.tgz",
+      "integrity": "sha512-bSeR8RfvbRwDpD7HWZvn8M3uYNDrk7m9DQjYOFkENZlXW8Ju/MPaqUPQq5LqJ3kyjEm07siTaAQ7wBKCU59oHg==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "streamx": "^2.21.0"
+        "streamx": "^2.21.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
         "bare-buffer": "*",
@@ -13378,7 +13377,6 @@
       "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -14373,15 +14371,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/cheerio/node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/chevrotain": {
@@ -15857,7 +15846,9 @@
       "license": "MIT"
     },
     "node_modules/docker-compose": {
-      "version": "0.24.8",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.3.2.tgz",
+      "integrity": "sha512-FO/Jemn08gf9o9E6qtqOPQpyauwf2rQAzfpoUlMyqNpdaVb0ImR/wXKoutLZKp1tks58F8Z8iR7va7H1ne09cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15868,9 +15859,9 @@
       }
     },
     "node_modules/docker-compose/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -15878,6 +15869,9 @@
       },
       "engines": {
         "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/docker-modem": {
@@ -20174,15 +20168,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/jsdom/node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/jsdom/node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -21529,14 +21514,19 @@
       "license": "MIT"
     },
     "node_modules/mkdirp": {
-      "version": "1.0.4",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -24634,14 +24624,17 @@
       }
     },
     "node_modules/properties-reader": {
-      "version": "2.3.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mkdirp": "^1.0.4"
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "type": "github",
@@ -27793,9 +27786,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -27808,11 +27801,14 @@
       }
     },
     "node_modules/tar-fs/node_modules/tar-stream": {
-      "version": "3.1.7",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+      "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
@@ -27841,6 +27837,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/temp-dir": {
@@ -28151,27 +28157,27 @@
       }
     },
     "node_modules/testcontainers": {
-      "version": "10.28.0",
-      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-10.28.0.tgz",
-      "integrity": "sha512-1fKrRRCsgAQNkarjHCMKzBKXSJFmzNTiTbhb5E/j5hflRXChEtHvkefjaHlgkNUjfw92/Dq8LTgwQn6RDBFbMg==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.13.0.tgz",
+      "integrity": "sha512-fzTvgOtd6U/esOzgmDatJh79OSK0tU6vjDOJ3B6ICrrJf0dqCWtFdpOr6f/g/KixMxKDTDbszmZYjSORJXsVCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@balena/dockerignore": "^1.0.2",
-        "@types/dockerode": "^3.3.35",
+        "@types/dockerode": "^4.0.1",
         "archiver": "^7.0.1",
         "async-lock": "^1.4.1",
         "byline": "^5.0.0",
-        "debug": "^4.3.5",
-        "docker-compose": "^0.24.8",
-        "dockerode": "^4.0.5",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.3.2",
+        "dockerode": "^4.0.9",
         "get-port": "^7.1.0",
         "proper-lockfile": "^4.1.2",
-        "properties-reader": "^2.3.0",
+        "properties-reader": "^3.0.1",
         "ssh-remote-port-forward": "^1.0.4",
-        "tar-fs": "^3.0.7",
-        "tmp": "^0.2.3",
-        "undici": "^5.29.0"
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.5",
+        "undici": "^7.24.3"
       }
     },
     "node_modules/testcontainers/node_modules/archiver": {
@@ -28242,6 +28248,31 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/testcontainers/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/testcontainers/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/testcontainers/node_modules/tar-stream": {
       "version": "3.1.7",
@@ -28925,16 +28956,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
-      "dev": true,
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
+      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {


### PR DESCRIPTION
**New dev dependencies**:

- `testcontainers` : ^10.13.1 -> ^11.13.0

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Major version bump of `testcontainers` updates the transitive dependency graph (notably `undici` now requiring Node >=20.18.1), which can break local/CI test environments even though no application code changes.
> 
> **Overview**
> Updates Studio dev dependency `testcontainers` from `^10.13.1` to `^11.13.0`.
> 
> Regenerates `package-lock.json` to reflect the new `testcontainers` dependency tree, including updated Docker-related typings and networking/util packages and a newer `undici` with a higher Node engine requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6a13edca5d2cf9c6103d6f3baf6488e5d4e539e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->