### PR TITLE
chore: add sites to audit logs

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -115,6 +115,8 @@ const SITES_WITH_AUDIT_LOGS = [
   287, // www.mot.gov.sg
   289, // www.toteboard.gov.sg
   336, // www.caringcommuters.gov.sg
+  343, // www.motawardsceremony.gov.sg
+  397, // www.rp.edu.sg
 ]
 
 // Month and year to get audit logs for, in the format of YYYY-MM,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Need to include additional sites in the audit logs tracking for compliance and monitoring purposes.

## Solution

<!-- How did you solve the problem? -->

Added two new sites to the `SITES_WITH_AUDIT_LOGS` array in the audit logs script:
- Site ID 343 (www.motawardsceremony.gov.sg)
- Site ID 397 (www.rp.edu.sg)

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Extended audit log coverage to include two additional sites

## Before & After Screenshots

N/A - No UI changes

## Tests

<!-- What tests should be run to confirm functionality? -->

- Run the audit log script and verify the new sites are included in the output

**New scripts**:

N/A

**New dependencies**:

N/A

**New dev dependencies**:

N/A