### PR TITLE
chore: update thumbnail toggle description copy

### DIFF
--- a/packages/components/src/interfaces/complex/ChildrenPages/ChildrenPages.ts
+++ b/packages/components/src/interfaces/complex/ChildrenPages/ChildrenPages.ts
@@ -25,7 +25,7 @@ export const ChildrenPagesSchema = Type.Object(
     showThumbnail: Type.Boolean({
       title: "Show thumbnail of all child pages",
       description:
-        "We will use the child pages' feature images as their thumbnail.",
+        "Publish the child page for thumbnail changes to appear here. Pages without a thumbnail will show the site’s logo.",
       default: false,
     }),
     // NOTE: We set this to `Optional` for now due to backcompat


### PR DESCRIPTION
## Problem

The description text for the "Show thumbnail of all child pages" toggle was unclear about the behavior of thumbnails.

Closes #

## Solution

Updated the description copy to clarify:
- Thumbnail changes require publishing the child page to appear
- Pages without a thumbnail will show the site's logo

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Clearer description text for the thumbnail toggle in ChildrenPages component

## Before & After Screenshots

**BEFORE**:
> "We will use the child pages' feature images as their thumbnail."

**AFTER**:
> "Publish the child page for thumbnail changes to appear here. Pages without a thumbnail will show the site's logo."

## Tests

No tests required - copy change only.

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None