### PR TITLE
fix: sync Site.name on config update and prefer config.siteName when reading

### DIFF
--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -481,6 +481,14 @@ describe("site.router", async () => {
         url: "https://www.isomer.gov.sg",
         theme: "isomer-next",
       })
+
+      // Verify Site.name column is also updated
+      const updatedSite = await db
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .select("name")
+        .executeTakeFirstOrThrow()
+      expect(updatedSite.name).toEqual(MOCK_SITE_NAME)
     })
     it("should generate an audit log entry", async () => {
       // Arrange

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -121,7 +121,7 @@ export const siteRouter = router({
       const updatedConfig = await db.transaction().execute(async (tx) => {
         const updatedSite = await tx
           .updateTable("Site")
-          .set({ config: jsonb({ ...rest, siteName }) })
+          .set({ name: siteName, config: jsonb({ ...rest, siteName }) })
           .where("id", "=", siteId)
           .returningAll()
           .executeTakeFirstOrThrow()

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -65,11 +65,16 @@ export const getSiteTheme = async (siteId: number) => {
   return theme
 }
 export const getSiteNameAndCodeBuildId = async (siteId: number) => {
-  return await db
+  const site = await db
     .selectFrom("Site")
     .where("id", "=", siteId)
-    .select(["Site.codeBuildId", "Site.name"])
+    .select(["Site.codeBuildId", "Site.name", "Site.config"])
     .executeTakeFirstOrThrow()
+
+  return {
+    codeBuildId: site.codeBuildId,
+    name: site.config.siteName || site.name,
+  }
 }
 
 export const getNotification = async (


### PR DESCRIPTION
## Problem

The `Site.name` column was not updated when editors saved site config via `updateSiteConfig`, causing it to drift from the canonical `config.siteName` value. Separately, `getSiteNameAndCodeBuildId` read directly from `Site.name`, which could return a stale name if `config.siteName` had been updated but `Site.name` had not been kept in sync.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- `updateSiteConfig` now sets `Site.name = siteName` alongside updating `Site.config`, keeping both values in sync (`site.router.ts`)
- `getSiteNameAndCodeBuildId` now reads `Site.config` and prefers `config.siteName` over `Site.name`, falling back to `Site.name` when `siteName` is absent (`site.service.ts`)

**Bug Fixes**:

- Fixed `Site.name` column not being updated when site config is saved, which could cause downstream consumers (e.g. CodeBuild, user router) to use a stale site name

## Before & After Screenshots

N/A — backend-only changes.

## Tests

- Updated the existing `"should update the site config if the user is a site admin"` test in `site.router.test.ts` to verify that the `Site.name` column is updated after calling `updateSiteConfig`

**Manual verification steps**:

- [ ] Go to any site's Settings page in Studio
- [ ] Change the site name and save
- [ ] Verify in the database that the `Site.name` column matches the new site name (not just `Site.config.siteName`)

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None