### PR TITLE
feat(studio): add ScheduledJobs table for scheduled publishing

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -135,6 +135,7 @@
     "next": "^15.5.9",
     "openid-client": "^5.7.1",
     "papaparse": "^5.5.3",
+    "pdfreader": "^3.0.8",
     "pg": "^8.16.2",
     "pino": "^9.6.0",
     "pino-pretty": "^13.0.0",

--- a/apps/studio/prisma/generated/selectableTypes.ts
+++ b/apps/studio/prisma/generated/selectableTypes.ts
@@ -11,6 +11,7 @@ export type Navbar = Selectable<T.Navbar>
 export type RateLimiterFlexible = Selectable<T.RateLimiterFlexible>
 export type Resource = Selectable<T.Resource>
 export type ResourcePermission = Selectable<T.ResourcePermission>
+export type ScheduledJobs = Selectable<T.ScheduledJobs>
 export type Site = Selectable<T.Site>
 export type User = Selectable<T.User>
 export type VerificationToken = Selectable<T.VerificationToken>

--- a/apps/studio/prisma/migrations/20260211073407_refactor_scheduled_publishing/migration.sql
+++ b/apps/studio/prisma/migrations/20260211073407_refactor_scheduled_publishing/migration.sql
@@ -1,0 +1,38 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `scheduledAt` on the `Resource` table. All the data in the column will be lost.
+  - You are about to drop the column `scheduledBy` on the `Resource` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "ScheduledJobType" AS ENUM ('PublishResource', 'PushDocument');
+
+-- DropForeignKey
+ALTER TABLE "Resource" DROP CONSTRAINT "Resource_scheduledBy_fkey";
+
+-- AlterTable
+ALTER TABLE "Resource" DROP COLUMN "scheduledAt",
+DROP COLUMN "scheduledBy";
+
+-- CreateTable
+CREATE TABLE "ScheduledJobs" (
+    "id" BIGSERIAL NOT NULL,
+    "type" "ScheduledJobType" NOT NULL,
+    "resourceId" BIGINT NOT NULL,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "scheduledBy" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ScheduledJobs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ScheduledJobs_id_idx" ON "ScheduledJobs"("id");
+
+-- AddForeignKey
+ALTER TABLE "ScheduledJobs" ADD CONSTRAINT "ScheduledJobs_resourceId_fkey" FOREIGN KEY ("resourceId") REFERENCES "Resource"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ScheduledJobs" ADD CONSTRAINT "ScheduledJobs_scheduledBy_fkey" FOREIGN KEY ("scheduledBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -68,12 +68,6 @@ model Resource {
   state ResourceState? @default(Draft)
   type  ResourceType
 
-  // This is only set if the resource is scheduled to be published at a later date
-  // If set, this indicates the time at which the resource should be published
-  scheduledAt DateTime?
-  scheduledBy String?
-  scheduler   User?     @relation(fields: [scheduledBy], references: [id])
-
   createdAt          DateTime             @default(now())
   updatedAt          DateTime             @default(now()) @updatedAt
   ResourcePermission ResourcePermission[]
@@ -139,7 +133,6 @@ model User {
   versions           Version[]
   AuditLog           AuditLog[]
   CodeBuildJobs      CodeBuildJobs[]
-  ScheduledResources Resource[]
   scheduledJobs      ScheduledJobs[]
 
   // This unique index is subsequently replaced with a custom index that
@@ -304,6 +297,11 @@ enum BuildStatusType {
   STOPPED
 }
 
+enum ScheduledJobType {
+  PublishResource
+  PushDocument
+}
+
 model CodeBuildJobs {
   id                  BigInt          @id @default(autoincrement())
   buildId             String // The AWS CodeBuild build ID
@@ -329,11 +327,6 @@ model CodeBuildJobs {
   @@index([siteId])
   @@index([userId])
   @@index([buildId])
-}
-
-enum ScheduledJobType {
-  PublishResource
-  PushDocument
 }
 
 model ScheduledJobs {

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -43,6 +43,10 @@ const SuspendablePublishButton = ({
   const scheduledPublishingDisclosure = useDisclosure()
 
   const [currPage] = trpc.page.readPage.useSuspenseQuery({ pageId, siteId })
+  const [job] = trpc.page.getScheduledTime.useSuspenseQuery({
+    pageId,
+    siteId,
+  })
   const isChangesPendingPublish = !!currPage.draftBlobId
 
   const { mutate, isPending } = trpc.page.publishPage.useMutation({
@@ -98,11 +102,11 @@ const SuspendablePublishButton = ({
                   {...publishNowDisclosure}
                 />
               )}
-              {currPage.scheduledAt ? (
+              {job.scheduledAt ? (
                 <CancelSchedulePublishIndicator
                   siteId={siteId}
                   pageId={pageId}
-                  scheduledAt={currPage.scheduledAt}
+                  scheduledAt={job.scheduledAt}
                 />
               ) : (
                 <HStack spacing={0} position="relative">

--- a/apps/studio/src/features/editing-experience/components/PublishingModal/CancelScheduleModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishingModal/CancelScheduleModal.tsx
@@ -30,6 +30,10 @@ export const CancelScheduleModal = ({
   const { mutate, isPending } = trpc.page.cancelSchedulePage.useMutation({
     onSettled: async () => {
       await utils.page.readPage.refetch({ pageId, siteId })
+      await utils.page.getScheduledTime.invalidate({
+        siteId,
+        pageId,
+      })
       onClose()
     },
     onSuccess: () => {

--- a/apps/studio/src/features/editing-experience/components/PublishingModal/DocumentIngestionCheckbox.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishingModal/DocumentIngestionCheckbox.tsx
@@ -1,0 +1,52 @@
+import type { UseFormRegisterReturn } from "react-hook-form"
+import { forwardRef, Suspense } from "react"
+import { Text } from "@chakra-ui/react"
+import { Checkbox } from "@opengovsg/design-system-react"
+import { z } from "zod"
+
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { trpc } from "~/utils/trpc"
+
+const linkSchema = z.object({
+  linkId: z.string(),
+  siteId: z.coerce.number().min(1),
+})
+
+type DocumentIngestionCheckboxProps =
+  UseFormRegisterReturn<"shouldIngestDocument">
+
+const DocumentIngestionCheckboxContent = forwardRef<
+  HTMLInputElement,
+  DocumentIngestionCheckboxProps
+>((props, ref) => {
+  const { linkId, siteId } = useQueryParse(linkSchema)
+  const [{ url }] = trpc.resource.getAssetUrlOfResource.useSuspenseQuery({
+    resourceId: linkId.toString(),
+    siteId,
+  })
+
+  // NOTE: We should only show this checkbox for files - we cannot ingest an image
+  return (
+    url?.endsWith(".pdf") && (
+      <Checkbox ref={ref} {...props}>
+        <Text>Show this document in search results</Text>
+      </Checkbox>
+    )
+  )
+})
+
+DocumentIngestionCheckboxContent.displayName =
+  "DocumentIngestionCheckboxContent"
+
+export const DocumentIngestionCheckbox = forwardRef<
+  HTMLInputElement,
+  DocumentIngestionCheckboxProps
+>((props, ref) => {
+  return (
+    <Suspense fallback={null}>
+      <DocumentIngestionCheckboxContent ref={ref} {...props} />
+    </Suspense>
+  )
+})
+
+DocumentIngestionCheckbox.displayName = "DocumentIngestionCheckbox"

--- a/apps/studio/src/features/editing-experience/components/PublishingModal/DocumentIngestionCheckbox.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishingModal/DocumentIngestionCheckbox.tsx
@@ -8,7 +8,7 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 
 const linkSchema = z.object({
-  linkId: z.string(),
+  linkId: z.string().optional(),
   siteId: z.coerce.number().min(1),
 })
 
@@ -17,9 +17,12 @@ type DocumentIngestionCheckboxProps =
 
 const DocumentIngestionCheckboxContent = forwardRef<
   HTMLInputElement,
-  DocumentIngestionCheckboxProps
+  DocumentIngestionCheckboxProps & {
+    linkId: string
+    siteId: number
+  }
 >((props, ref) => {
-  const { linkId, siteId } = useQueryParse(linkSchema)
+  const { linkId, siteId } = props
   const [{ url }] = trpc.resource.getAssetUrlOfResource.useSuspenseQuery({
     resourceId: linkId.toString(),
     siteId,
@@ -42,9 +45,17 @@ export const DocumentIngestionCheckbox = forwardRef<
   HTMLInputElement,
   DocumentIngestionCheckboxProps
 >((props, ref) => {
+  const { linkId, siteId } = useQueryParse(linkSchema)
   return (
     <Suspense fallback={null}>
-      <DocumentIngestionCheckboxContent ref={ref} {...props} />
+      {linkId && (
+        <DocumentIngestionCheckboxContent
+          ref={ref}
+          {...props}
+          linkId={linkId}
+          siteId={siteId}
+        />
+      )}
     </Suspense>
   )
 })

--- a/apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishDetails.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishDetails.tsx
@@ -14,7 +14,7 @@ import {
   TimeSelect,
 } from "~/components/Select/TimeSelect"
 import { MINIMUM_SCHEDULE_LEAD_TIME_MINUTES } from "~/schemas/schedule"
-
+import { DocumentIngestionCheckbox } from "./DocumentIngestionCheckbox"
 import { QuickSelectTimeSection } from "./QuickSelectTimeSection"
 import { getEarliestAllowableTime } from "./utils"
 
@@ -24,6 +24,7 @@ export const SchedulePublishDetails = () => {
     watch,
     control,
     formState: { errors },
+    register,
   } = useFormContext<z.input<typeof schedulePublishClientSchema>>()
 
   const publishDate = watch("publishDate")
@@ -93,6 +94,7 @@ export const SchedulePublishDetails = () => {
         </FormControl>
       </HStack>
       <QuickSelectTimeSection earliestAllowableTime={earliestAllowableTime} />
+      <DocumentIngestionCheckbox {...register("shouldIngestDocument")} />
     </VStack>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishingModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishingModal.tsx
@@ -76,6 +76,10 @@ export const ScheduledPublishingModal = ({
           title: "Page scheduled successfully",
           ...BRIEF_TOAST_SETTINGS,
         })
+        utils.page.getScheduledTime.invalidate({
+          siteId,
+          pageId,
+        })
       },
       onError: (error) => {
         console.error(`Error occurred when scheduling page: ${error.message}`)

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -3,6 +3,7 @@ import type {
   PutObjectTaggingCommandInput,
 } from "@aws-sdk/client-s3"
 import {
+  GetObjectCommand,
   GetObjectTaggingCommand,
   PutObjectCommand,
   PutObjectTaggingCommand,
@@ -72,4 +73,30 @@ export const deleteFile = async ({
       },
     }),
   )
+}
+
+export const getBlob = async (bucketName: string, key: string) => {
+  try {
+    const getParams = {
+      Bucket: bucketName,
+      Key: key,
+    }
+
+    const data = await storage.send(new GetObjectCommand(getParams))
+    const byteArr = await data.Body?.transformToByteArray()
+    if (!byteArr) {
+      throw new Error("Error when transforming blob to byte array")
+    }
+    return byteArr
+  } catch (err) {
+    console.error({
+      message: `Error when getting blob`,
+      error: err,
+      merged: {
+        bucketName,
+        key,
+      },
+    })
+    throw err
+  }
 }

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -156,8 +156,6 @@ export const readPageOutputSchema = z.object({
   draftBlobId: z.string().nullable(),
   state: z.nativeEnum(ResourceState).nullable(),
   type: z.nativeEnum(ResourceType),
-  scheduledAt: z.date().nullable(),
-  scheduledBy: z.string().nullable(),
   createdAt: z.date(),
   updatedAt: z.date(),
 })

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -158,6 +158,7 @@ export const readPageOutputSchema = z.object({
   type: z.nativeEnum(ResourceType),
   createdAt: z.date(),
   updatedAt: z.date(),
+  scheduledAt: z.date().nullable(),
 })
 
 export const updatePageMetaSchema = z.object({

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -154,3 +154,8 @@ export const getIndexPageSchema = z.object({
 export const getIndexPageOutputSchema = z.object({
   id: z.string(),
 })
+
+export const getAssetUrlOfResourceSchema = z.object({
+  siteId: z.number().min(1),
+  resourceId: z.string(),
+})

--- a/apps/studio/src/schemas/schedule.ts
+++ b/apps/studio/src/schemas/schedule.ts
@@ -17,6 +17,7 @@ export const schedulePublishClientSchema = basePageSchema
       const parsed = parseTimeStringToDate(time)
       return isValid(parsed) && format(parsed, "HH:mm") === time
     }),
+    shouldIngestDocument: z.boolean().optional().default(false),
   })
   .transform((schema) => {
     const { publishDate, publishTime, ...rest } = schema
@@ -51,4 +52,5 @@ export const schedulePublishClientSchema = basePageSchema
 
 export const scheduledPublishServerSchema = basePageSchema.extend({
   scheduledAt: z.date(),
+  shouldIngestDocument: z.boolean().optional().default(false),
 })

--- a/apps/studio/src/server/cron/index.ts
+++ b/apps/studio/src/server/cron/index.ts
@@ -2,6 +2,7 @@ import { createBaseLogger } from "../../lib/logger"
 import { deactivateInactiveUsersJob } from "./jobs/deactivateInactiveUsersJob"
 import { schedulePublishingJob } from "./jobs/schedulePublishingJob"
 import { sendAccountDeactivationWarningEmailsJob } from "./jobs/sendAccountDeactivationWarningEmailsJob"
+import { schedulePushDocumentJob } from "./jobs/schedulePushDocumentJob"
 
 const logger = createBaseLogger({ path: "cron:index" })
 
@@ -15,6 +16,7 @@ export const initializeCronJobs = async () => {
   cronJobs.push(
     await deactivateInactiveUsersJob(),
     await schedulePublishingJob(),
+    await schedulePushDocumentJob(),
     await sendAccountDeactivationWarningEmailsJob({ inHowManyDays: 1 }),
     await sendAccountDeactivationWarningEmailsJob({ inHowManyDays: 7 }),
     await sendAccountDeactivationWarningEmailsJob({ inHowManyDays: 14 }),

--- a/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
+++ b/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
@@ -1,36 +1,44 @@
+import { z } from "zod"
+
+import { registerPgbossJob } from "@isomer/pgboss"
+
 import type { Resource } from "~/server/modules/database"
 import { env } from "~/env.mjs"
 import { sendFailedPublishEmail } from "~/features/mail/service"
-import {
-  ENABLE_CODEBUILD_JOBS,
-  ENABLE_EMAILS_FOR_SCHEDULED_PUBLISHES_FEATURE_KEY,
-} from "~/lib/growthbook"
 import { createBaseLogger } from "~/lib/logger"
-import { createGrowthBookContext } from "~/server/context"
-import { publishSite } from "~/server/modules/aws/codebuild.service"
 import { db } from "~/server/modules/database"
 import {
   defaultResourceSelect,
   publishPageResource,
 } from "~/server/modules/resource/resource.service"
 
-import { registerPgbossJob } from "@isomer/pgboss"
-
-const JOB_NAME = "schedule-publishing"
+const JOB_NAME = "schedule-push-document"
 const CRON_SCHEDULE = "* * * * *" // every minute
+const EGAZETTE_DOCUMENT_INDEX = "0ea348e0-8276-4b93-95dd-3c6f62e017d6"
 
-const logger = createBaseLogger({ path: "cron:schedulePublishingJob" })
+const logger = createBaseLogger({ path: "cron:schedulePushDocumentJob" })
+
+const pushDocumentContentSchema = z.object({
+  page: z.object({
+    ref: z.string(),
+    category: z.string(),
+  }),
+})
+
+const CONTENT_TYPES = {
+  Informational: "Informational",
+}
 
 /**
- * Registers the schedule publishing job with the specified cron schedule.
+ * Registers the schedule push document job with the specified cron schedule.
  * @returns A promise that resolves when the job is registered.
  */
-export const schedulePublishingJob = async () => {
+export const schedulePushDocumentJob = async () => {
   return await registerPgbossJob(
     logger,
     JOB_NAME,
     CRON_SCHEDULE,
-    schedulePublishJobHandler,
+    schedulePushDocumentJobHandler,
     // do NOT retry failed jobs, since we send failure emails on a per-resource basis
     // use singletonKey to ensure only one instance of the job runs at a time
     { retryLimit: 0, singletonKey: JOB_NAME },
@@ -45,20 +53,71 @@ export const schedulePublishingJob = async () => {
  * Publishes all resources scheduled for publishing up to the current time,
  * publishes their associated sites, and resets their scheduledAt fields.
  */
-const schedulePublishJobHandler = async () => {
+const schedulePushDocumentJobHandler = async () => {
   const scheduledAtCutoff = new Date()
-  const gb = await createGrowthBookContext()
-  const enableCodebuildJobs = gb.isOn(ENABLE_CODEBUILD_JOBS)
-  const enableEmailsForScheduledPublishes = gb.isOn(
-    ENABLE_EMAILS_FOR_SCHEDULED_PUBLISHES_FEATURE_KEY,
+
+  // NOTE: get all documents that are scheduled to publish
+  const scheduledResources = await db
+    .selectFrom("ScheduledJobs")
+    .innerJoin("Resource", "Resource.id", "ScheduledJobs.resourceId")
+    .innerJoin("Blob", "Blob.id", "Resource.draftBlobId")
+    .where("scheduledAt", "<=", scheduledAtCutoff)
+    .where("type", "=", "PushDocument")
+    .select([
+      "Blob.content",
+      "Resource.title",
+      "Resource.id as resourceId",
+      "Resource.parentId",
+      "scheduledAt",
+    ])
+    .execute()
+
+  const documentPromises = scheduledResources.map(
+    async ({ scheduledAt, resourceId, title, parentId, content }) => {
+      const parsed = pushDocumentContentSchema.safeParse(content)
+      if (!parsed.success) {
+        logger.error({ content }, "Invalid content structure for push document")
+        return null
+      }
+
+      const url = parsed.data.page.ref
+
+      const { parentTitle } = await db
+        .selectFrom("Resource")
+        .where("id", "=", parentId)
+        .select(["title as parentTitle"])
+        .executeTakeFirstOrThrow()
+
+      return {
+        // NOTE: the document id is what they (searchsg) uses to
+        // uniquely identify a document
+        // so this should be indicative of that same pdf
+        // ie, if a user deletes and re-uploads a slightly different file,
+        // we should NOT show 2 search results
+        documentId: generateDocumentId(url, resourceId),
+        content: await parsePdfContent(url),
+        title,
+        url,
+        contentType: CONTENT_TYPES.Informational,
+        date: scheduledAt,
+        // NOTE: This is the `subcategory`
+        customFilter1: [parsed.data.page.category],
+        categories: [parentTitle],
+      }
+    },
   )
-  // Publish all scheduled resources up to the cutoff time
-  const siteResourcesMap = await publishScheduledResources(
-    enableEmailsForScheduledPublishes,
-    scheduledAtCutoff,
+
+  const resolvedDocuments = await Promise.all(documentPromises)
+  const documents = resolvedDocuments.filter(
+    (document): document is PushDocument => document !== null,
   )
-  // Publish all sites that have resources published
-  await publishScheduledSites(siteResourcesMap, enableCodebuildJobs)
+
+  await pushDocumentsForIngestion(documents)
+}
+
+// TODO: add this in using the egazette implementation
+const parsePdfContent = async (url: string) => {
+  return "test"
 }
 
 type ResourceWithUser = Omit<Resource, "scheduledBy"> & {
@@ -92,7 +151,7 @@ export const publishScheduledResources = async (
   await resetScheduledAtForPublishedResources(scheduledAtCutoff)
 
   for (const job of jobsWithUser) {
-    const { resourceId, scheduledBy, id: jobId } = job
+    const { resourceId, scheduledBy } = job
     if (!scheduledBy) {
       logger.error(
         `Resource ${resourceId} is missing user information, skipping publish`,
@@ -161,55 +220,6 @@ export const publishScheduledResources = async (
   return siteResourcesMap
 }
 
-export const publishScheduledSites = async (
-  siteResourcesMap: Record<string, ResourceWithUser[]>,
-  enableCodebuildJobs: boolean,
-) => {
-  for (const [siteId, resources] of Object.entries(siteResourcesMap)) {
-    try {
-      await publishSite(logger, {
-        siteId: Number(siteId),
-        codebuildJob: enableCodebuildJobs
-          ? {
-              isScheduled: true,
-              resourceWithUserIds: resources.map(
-                ({ id: resourceId, scheduledBy }) => {
-                  return { resourceId, userId: scheduledBy }
-                },
-              ),
-            }
-          : undefined,
-      })
-      logger.info(`Successfully published site for siteId: ${siteId}`)
-    } catch (error) {
-      logger.error({ error }, `Failed to publish site for siteId: ${siteId}`)
-      for (const resource of resources) {
-        if (resource.userDeletedAt || !resource.email) {
-          logger.warn(
-            `Resource ${resource.id} is missing user email information or deleted, cannot send failed publish email`,
-          )
-          continue
-        }
-        try {
-          await sendFailedPublishEmail({
-            recipientEmail: resource.email,
-            isScheduled: true,
-            resource,
-          })
-          logger.warn(
-            `Sent failed publish email to ${resource.email} for resource: ${resource.id}, since site publish failed for site ${siteId}`,
-          )
-        } catch (emailError) {
-          logger.error(
-            { error: emailError },
-            `Failed to send failed publish email to ${resource.email} for resource: ${resource.id}, since site publish failed for site ${siteId}`,
-          )
-        }
-      }
-    }
-  }
-}
-
 /**
  * Reset the scheduledAt field for all resources that have been published as of the given cutoff date
  * Even IF there were errors publishing some resources, we still reset the scheduledAt for all resources
@@ -222,6 +232,84 @@ const resetScheduledAtForPublishedResources = async (
   await db
     .deleteFrom("ScheduledJobs")
     .where("scheduledAt", "<=", scheduledAtCutoff)
-    .where("type", "=", "PublishResource")
+    .where("type", "=", "PushDocument")
     .execute()
+}
+
+const generateDocumentId = (url: string, resourceId: string) => {
+  return `${url}-${resourceId}`
+}
+
+interface PushDocument {
+  documentId: string
+  title: string
+  url: string
+  contentType: string
+  content: string
+  date: Date
+  customFilter1: string[]
+  categories: string[]
+}
+
+const SEARCHSG_BASE_URL = "https://api.services.search.gov.sg/admin" as const
+const ISOMER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) isomer" as const
+
+const getSearchSGAuthToken = async () => {
+  const response = await fetch(`${SEARCHSG_BASE_URL}/v1/auth/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${env.SEARCHSG_API_KEY}`,
+      "User-Agent": ISOMER_UA,
+    },
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to get SearchSG auth token: ${response.statusText}`)
+  }
+
+  const { accessToken, tokenType } = (await response.json()) as {
+    accessToken: string
+    tokenType: string
+  }
+
+  return { accessToken, tokenType }
+}
+
+const pushDocumentsForIngestion = async (documents: PushDocument[]) => {
+  if (documents.length === 0) {
+    logger.info("No documents to push for ingestion")
+    return
+  }
+
+  const { accessToken, tokenType } = await getSearchSGAuthToken()
+
+  const response = await fetch(
+    `${SEARCHSG_BASE_URL}/v2/indexes/${EGAZETTE_DOCUMENT_INDEX}/documents`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `${tokenType} ${accessToken}`,
+        "Content-Type": "application/json",
+        "User-Agent": ISOMER_UA,
+      },
+      body: JSON.stringify({ documentsToAdd: documents }),
+    },
+  )
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    logger.error(
+      { status: response.status, error: errorText },
+      "Failed to push documents for ingestion",
+    )
+    throw new Error(
+      `Failed to push documents for ingestion: ${response.statusText}`,
+    )
+  }
+
+  logger.info(
+    { count: documents.length },
+    "Successfully pushed documents for ingestion",
+  )
 }

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -7,12 +7,14 @@ import filenamify from "filenamify"
 import { env } from "~/env.mjs"
 import { FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import { deleteFile, generateSignedPutUrl } from "~/lib/s3"
+import { PdfReader } from "pdfreader"
 
 import type { AssetPermissionsProps } from "../permissions/permissions.type"
 import { db } from "../database"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 
 const { NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME } = env
+const pdfReader = new PdfReader({})
 
 // Server-side allowlist: extension (lowercase, e.g. ".jpg") -> MIME (used for signed upload metadata)
 const EXTENSION_TO_MIME: Record<string, string> = {
@@ -129,4 +131,23 @@ export const markFileAsDeleted = async ({ key }: { key: string }) => {
     Key: key,
     Bucket: NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
   })
+}
+
+// NOTE: Taken as is from egazette codebase
+export const parseFullTextFromPDF = async (pdfBuffer: Uint8Array) => {
+  const data: string[] = await new Promise((resolve, reject) => {
+    const parsedData: string[] = []
+    pdfReader.parseBuffer(Buffer.from(pdfBuffer), (err, item) => {
+      if (err) {
+        reject(err)
+      } else if (!item) {
+        console.warn("end of buffer")
+        resolve(parsedData)
+      } else if (item.text) {
+        parsedData.push(item.text)
+      }
+    })
+  })
+
+  return data.join(" ")
 }

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -286,6 +286,7 @@ export const collectionRouter = router({
 
         let query = db
           .selectFrom("Resource")
+          .leftJoin("ScheduledJobs", "ScheduledJobs.resourceId", "Resource.id")
           .where("parentId", "=", String(resourceId))
           .where("Resource.siteId", "=", siteId)
           .where("Resource.type", "in", [
@@ -307,7 +308,10 @@ export const collectionRouter = router({
           .orderBy("Resource.id", "asc") // to ensure deterministic ordering
           .limit(limit)
           .offset(offset)
-          .select(defaultResourceSelect)
+          .select([
+            ...defaultResourceSelect,
+            "ScheduledJobs.scheduledAt as scheduledAt",
+          ])
           .execute()
       },
     ),

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2638,9 +2638,9 @@ describe("page.router", async () => {
       })
 
       // Assert
-      const actual = await db
-        .selectFrom("Resource")
-        .where("id", "=", expectedPage.id)
+      const actualScheduledJob = await db
+        .selectFrom("ScheduledJobs")
+        .where("resourceId", "=", expectedPage.id)
         .selectAll()
         .executeTakeFirstOrThrow()
       // expect the scheduledAt to be tomorrow at 10am
@@ -2650,8 +2650,8 @@ describe("page.router", async () => {
         seconds: 0,
         milliseconds: 0,
       })
-      expect(actual.scheduledAt).toEqual(expectedDate)
-      expect(actual.scheduledBy).toEqual(session.userId)
+      expect(actualScheduledJob.scheduledAt).toEqual(expectedDate)
+      expect(actualScheduledJob.scheduledBy).toEqual(session.userId)
       // expect the audit log to be created, with the updated scheduledAt time
       const auditLog = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLog).toHaveLength(1)
@@ -2803,14 +2803,13 @@ describe("page.router", async () => {
       })
 
       // Assert
-      // The scheduledAt field of the page should be null
-      const actual = await db
-        .selectFrom("Resource")
-        .where("id", "=", expectedPage.id)
+      // The scheduled job should be deleted
+      const actualScheduledJob = await db
+        .selectFrom("ScheduledJobs")
+        .where("resourceId", "=", expectedPage.id)
         .selectAll()
-        .executeTakeFirstOrThrow()
-      expect(actual.scheduledAt).toBeNull()
-      expect(actual.scheduledBy).toBeNull()
+        .executeTakeFirst()
+      expect(actualScheduledJob).toBeUndefined()
     })
     it("cancelling a scheduled publish throws an error if the page is not scheduled", async () => {
       // Arrange

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -60,7 +60,6 @@ import {
   publishPageResource,
   publishResource,
   updateBlobById,
-  updatePageById,
 } from "../resource/resource.service"
 import { getSiteConfig } from "../site/site.service"
 import { createDefaultPage, createFolderIndexPage } from "./page.service"
@@ -384,89 +383,108 @@ export const pageRouter = router({
     }),
   schedulePage: protectedProcedure
     .input(scheduledPublishServerSchema)
-    .mutation(async ({ ctx, input: { scheduledAt, siteId, pageId } }) => {
-      await bulkValidateUserPermissionsForResources({
-        siteId,
-        action: "publish",
-        userId: ctx.user.id,
-      })
-      // check if the input.scheduledAt is after the current time
-      if (isBefore(scheduledAt, new Date())) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Scheduled time must be in the future",
+    .mutation(
+      async ({
+        ctx,
+        input: { scheduledAt, siteId, pageId, shouldIngestDocument },
+      }) => {
+        await bulkValidateUserPermissionsForResources({
+          siteId,
+          action: "publish",
+          userId: ctx.user.id,
         })
-      }
-      const by = await db
-        .selectFrom("User")
-        .where("id", "=", ctx.user.id)
-        .selectAll()
-        .executeTakeFirstOrThrow()
-
-      const updatedPage = await db.transaction().execute(async (tx) => {
-        // fetch the resource to be scheduled inside the transaction, to guard against concurrent update issues (race conditions)
-        const resource = await getPageById(tx, { resourceId: pageId, siteId })
-        if (!resource) {
-          throw new TRPCError({
-            code: "NOT_FOUND",
-            message: "Resource not found",
-          })
-        }
-
-        const scheduledJob = await db
-          .selectFrom("ScheduledJobs")
-          .where("resourceId", "=", resource.id)
-          .select("ScheduledJobs.scheduledAt")
-          .executeTakeFirst()
-
-        if (scheduledJob) {
+        // check if the input.scheduledAt is after the current time
+        if (isBefore(scheduledAt, new Date())) {
           throw new TRPCError({
             code: "BAD_REQUEST",
-            message: `Page is already scheduled to be published at ${format(
-              scheduledJob.scheduledAt,
-              "yyyy-MM-dd HH:mm",
-            )}`,
+            message: "Scheduled time must be in the future",
           })
         }
-        // update the resource's scheduled field
-        const updatedPage = await updatePageById(
-          {
-            id: pageId,
+        const by = await db
+          .selectFrom("User")
+          .where("id", "=", ctx.user.id)
+          .selectAll()
+          .executeTakeFirstOrThrow()
+
+        const updatedPage = await db.transaction().execute(async (tx) => {
+          // fetch the resource to be scheduled inside the transaction, to guard against concurrent update issues (race conditions)
+          const resource = await getPageById(tx, { resourceId: pageId, siteId })
+          if (!resource) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message: "Resource not found",
+            })
+          }
+
+          const scheduledJob = await tx
+            .selectFrom("ScheduledJobs")
+            .where("resourceId", "=", resource.id)
+            .select("ScheduledJobs.scheduledAt")
+            .executeTakeFirst()
+
+          if (scheduledJob) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: `Page is already scheduled to be published at ${format(
+                scheduledJob.scheduledAt,
+                "yyyy-MM-dd HH:mm",
+              )}`,
+            })
+          }
+
+          const jobsToInsert = [
+            {
+              resourceId: String(pageId),
+              type: "PublishResource" as const,
+              scheduledAt,
+              scheduledBy: by.id,
+            },
+            // NOTE: Insert an identical job into our db so that we ingest the document
+            // and push it to our search provider.
+            // This is required so that our search results will show this page at runtime
+            // TODO: handle de-duplication between the ingested document and the
+            // page at runtime - this is because searchsg will ingest this pdf as a result
+            // of this job but also will crawl the site and see the newly updated page
+            ...(shouldIngestDocument
+              ? [
+                  {
+                    resourceId: String(pageId),
+                    type: "PushDocument" as const,
+                    scheduledAt,
+                    scheduledBy: by.id,
+                  },
+                ]
+              : []),
+          ]
+
+          const successfulJob = await tx
+            .insertInto("ScheduledJobs")
+            .values(jobsToInsert)
+            .executeTakeFirst()
+
+          // verify that the update was successful
+          if (!successfulJob) {
+            throw new TRPCError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Failed to schedule page",
+            })
+          }
+          await logResourceEvent(tx, {
             siteId,
-          },
-          tx,
-        )
-
-        await db
-          .insertInto("ScheduledJobs")
-          .values({
-            resourceId: String(pageId),
-            type: "PublishResource",
-            scheduledAt,
+            by,
+            delta: { before: resource, after: resource },
+            eventType: AuditLogEvent.SchedulePublish,
           })
-          .executeTakeFirst()
 
-        // verify that the update was successful
-        if (!updatedPage) {
-          throw new TRPCError({
-            code: "INTERNAL_SERVER_ERROR",
-            message: "Failed to schedule page",
-          })
-        }
-        await logResourceEvent(tx, {
-          siteId,
-          by,
-          delta: { before: resource, after: updatedPage },
-          eventType: AuditLogEvent.SchedulePublish,
+          return resource
         })
-        return updatedPage
-      })
-      await sendScheduledPageEmail({
-        resource: updatedPage,
-        scheduledAt,
-        recipientEmail: by.email,
-      })
-    }),
+        await sendScheduledPageEmail({
+          resource: updatedPage,
+          scheduledAt,
+          recipientEmail: by.email,
+        })
+      },
+    ),
   cancelSchedulePage: protectedProcedure
     .input(basePageSchema)
     .mutation(async ({ ctx, input: { siteId, pageId } }) => {
@@ -520,7 +538,7 @@ export const pageRouter = router({
         await logResourceEvent(tx, {
           siteId,
           by,
-          delta: { before: resource, after: updatedPage },
+          delta: { before: resource, after: resource },
           eventType: AuditLogEvent.CancelSchedulePublish,
         })
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -204,6 +204,7 @@ export const pageRouter = router({
       const job = await db
         .selectFrom("ScheduledJobs")
         .where("resourceId", "=", String(pageId))
+        .where("type", "=", "PublishResource")
         .selectAll()
         .executeTakeFirst()
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -193,6 +193,24 @@ export const pageRouter = router({
       return { categories }
     }),
 
+  getScheduledTime: protectedProcedure
+    .input(basePageSchema)
+    .query(async ({ ctx, input: { pageId, siteId } }) => {
+      await bulkValidateUserPermissionsForResources({
+        siteId,
+        action: "read",
+        userId: ctx.user.id,
+      })
+
+      const job = await db
+        .selectFrom("ScheduledJobs")
+        .where("resourceId", "=", String(pageId))
+        .selectAll()
+        .executeTakeFirst()
+
+      return { scheduledAt: job?.scheduledAt }
+    }),
+
   readPage: protectedProcedure
     .input(basePageSchema)
     .output(readPageOutputSchema)

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -394,20 +394,40 @@ export const pageRouter = router({
             message: "Resource not found",
           })
         }
-        if (resource.scheduledAt) {
+
+        const scheduledJob = await db
+          .selectFrom("ScheduledJobs")
+          .where("resourceId", "=", resource.id)
+          .select("ScheduledJobs.scheduledAt")
+          .executeTakeFirst()
+
+        if (scheduledJob) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: `Page is already scheduled to be published at ${format(
-              resource.scheduledAt,
+              scheduledJob.scheduledAt,
               "yyyy-MM-dd HH:mm",
             )}`,
           })
         }
         // update the resource's scheduled field
         const updatedPage = await updatePageById(
-          { id: pageId, siteId, scheduledAt, scheduledBy: by.id },
+          {
+            id: pageId,
+            siteId,
+          },
           tx,
         )
+
+        await db
+          .insertInto("ScheduledJobs")
+          .values({
+            resourceId: String(pageId),
+            type: "PublishResource",
+            scheduledAt,
+          })
+          .executeTakeFirst()
+
         // verify that the update was successful
         if (!updatedPage) {
           throw new TRPCError({
@@ -450,19 +470,30 @@ export const pageRouter = router({
             message: "Resource not found",
           })
         }
-        if (!resource.scheduledAt) {
+
+        const scheduledJob = await db
+          .selectFrom("ScheduledJobs")
+          .where("resourceId", "=", resource.id)
+          .select("ScheduledJobs.scheduledAt")
+          .executeTakeFirst()
+
+        if (!scheduledJob?.scheduledAt) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message:
               "Unable to cancel schedule for a page that is not scheduled",
           })
         }
-        // update the resource's scheduled field
-        const updatedPage = await updatePageById(
-          { id: pageId, siteId, scheduledAt: null, scheduledBy: null },
-          tx,
-        )
-        if (!updatedPage) {
+
+        // NOTE: Remove the job from the ScheduledJobs table
+        const deleted = await db
+          .deleteFrom("ScheduledJobs")
+          .where("ScheduledJobs.resourceId", "=", resource.id)
+          .executeTakeFirst()
+
+        // NOTE: need to convert because `numDeletedRows` is a bigint which
+        // cannot be directly compared to a number
+        if (Number(deleted.numDeletedRows) === 0) {
           throw new TRPCError({
             code: "INTERNAL_SERVER_ERROR",
             message: "Failed to cancel page schedule",
@@ -474,7 +505,8 @@ export const pageRouter = router({
           delta: { before: resource, after: updatedPage },
           eventType: AuditLogEvent.CancelSchedulePublish,
         })
-        return updatedPage
+
+        return resource
       })
       await sendCancelSchedulePageEmail({
         resource: updatedPage,

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1986,13 +1986,15 @@ describe("resource.router", async () => {
     ] as const
 
     const testListComparable = (
-      a: { updatedAt: Date; title: string },
-      b: { updatedAt: Date; title: string },
+      a: { updatedAt?: Date; title?: string },
+      b: { updatedAt?: Date; title?: string },
     ) => {
-      if (b.updatedAt.valueOf() === a.updatedAt.valueOf()) {
-        return a.title.localeCompare(b.title)
+      const aUpdatedAt = a.updatedAt?.valueOf() ?? 0
+      const bUpdatedAt = b.updatedAt?.valueOf() ?? 0
+      if (bUpdatedAt === aUpdatedAt) {
+        return (a.title ?? "").localeCompare(b.title ?? "")
       }
-      return b.updatedAt.valueOf() - a.updatedAt.valueOf()
+      return bUpdatedAt - aUpdatedAt
     }
 
     it("should throw 401 if not logged in", async () => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -586,6 +586,7 @@ export const resourceRouter = router({
 
       let query = db
         .selectFrom("Resource")
+        .leftJoin("ScheduledJobs", "Resource.id", "ScheduledJobs.resourceId")
         .where("Resource.siteId", "=", siteId)
         .where("Resource.type", "!=", ResourceType.RootPage)
         .where("Resource.type", "!=", ResourceType.IndexPage)
@@ -613,7 +614,7 @@ export const resourceRouter = router({
           "Resource.type",
           "Resource.parentId",
           "Resource.updatedAt",
-          "Resource.scheduledAt",
+          "scheduledAt",
         ])
         .execute()
     }),

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -7,6 +7,7 @@ import {
   deleteResourceSchema,
   getAncestryStackOutputSchema,
   getAncestryStackSchema,
+  getAssetUrlOfResourceSchema,
   getBatchAncestryWithSelfOutputSchema,
   getBatchAncestryWithSelfSchema,
   getChildrenOutputSchema,
@@ -98,6 +99,37 @@ const validateUserPermissionsForMove = async ({
 }
 
 export const resourceRouter = router({
+  getAssetUrlOfResource: protectedProcedure
+    .input(getAssetUrlOfResourceSchema)
+    .query(async ({ ctx, input: { siteId, resourceId } }) => {
+      await bulkValidateUserPermissionsForResources({
+        siteId,
+        resourceIds: [resourceId],
+        action: "read",
+        userId: ctx.user.id,
+      })
+
+      const resource = await db
+        .selectFrom("Resource")
+        .innerJoin("Blob", "Resource.draftBlobId", "Blob.id")
+        .where("Resource.id", "=", resourceId)
+        .select("content")
+        .executeTakeFirst()
+
+      // NOTE: Throw here because this method
+      // should only be invoked when trying to publish a resource,
+      // which means that the draft blob should exist
+      if (!resource) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Resource not found",
+        })
+      }
+
+      // TODO: parse this properly
+      return { url: (resource.content.page as any).ref }
+    }),
+
   getMetadataById: protectedProcedure
     .input(getMetadataSchema)
     .query(async ({ ctx, input: { siteId, resourceId } }) => {

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -44,8 +44,6 @@ export const defaultResourceSelect = [
   "Resource.state",
   "Resource.createdAt",
   "Resource.updatedAt",
-  "Resource.scheduledAt",
-  "Resource.scheduledBy",
 ] satisfies SelectExpression<DB, "Resource">[]
 
 const defaultResourceWithBlobSelect = [

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -155,18 +155,19 @@ export const getPageById = (
   args: { resourceId: number; siteId: number },
 ) => {
   return getById(db, args)
+    .leftJoin("ScheduledJobs", "Resource.id", "ScheduledJobs.resourceId")
     .where((eb) =>
       eb.or([
-        eb("type", "=", ResourceType.Page),
-        eb("type", "=", ResourceType.CollectionPage),
-        eb("type", "=", ResourceType.RootPage),
-        eb("type", "=", ResourceType.IndexPage),
-        eb("type", "=", ResourceType.CollectionLink),
-        eb("type", "=", ResourceType.FolderMeta),
-        eb("type", "=", ResourceType.CollectionMeta),
+        eb("Resource.type", "=", ResourceType.Page),
+        eb("Resource.type", "=", ResourceType.CollectionPage),
+        eb("Resource.type", "=", ResourceType.RootPage),
+        eb("Resource.type", "=", ResourceType.IndexPage),
+        eb("Resource.type", "=", ResourceType.CollectionLink),
+        eb("Resource.type", "=", ResourceType.FolderMeta),
+        eb("Resource.type", "=", ResourceType.CollectionMeta),
       ]),
     )
-    .select(defaultResourceSelect)
+    .select([...defaultResourceSelect, "ScheduledJobs.scheduledAt"])
     .executeTakeFirst()
 }
 

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -292,14 +292,24 @@ export const setupPageResource = async ({
       siteId: site.id,
       parentId,
       publishedVersionId: null,
-      scheduledAt,
-      scheduledBy,
       draftBlobId: blob.id,
       type: resourceType,
       state,
     })
     .returningAll()
     .executeTakeFirstOrThrow()
+
+  if (scheduledAt && scheduledBy) {
+    await db
+      .insertInto("ScheduledJobs")
+      .values({
+        resourceId: page.id,
+        scheduledAt,
+        scheduledBy,
+        type: "PublishResource",
+      })
+      .execute()
+  }
 
   if (state === ResourceState.Published && !userId) {
     throw new Error(

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
         "next": "^15.5.9",
         "openid-client": "^5.7.1",
         "papaparse": "^5.5.3",
+        "pdfreader": "^3.0.8",
         "pg": "^8.16.2",
         "pino": "^9.6.0",
         "pino-pretty": "^13.0.0",
@@ -28873,6 +28874,45 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/pdf2json": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/pdf2json/-/pdf2json-3.1.4.tgz",
+      "integrity": "sha512-rS+VapXpXZr+5lUpHmRh3ugXdFXp24p1RyG24yP1DMpqP4t0mrYNGpLtpSbWD42PnQ59GIXofxF+yWb7M+3THg==",
+      "bundleDependencies": [
+        "@xmldom/xmldom"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.10"
+      },
+      "bin": {
+        "pdf2json": "bin/pdf2json.js"
+      },
+      "engines": {
+        "node": ">=18.12.1",
+        "npm": ">=8.19.2"
+      }
+    },
+    "node_modules/pdf2json/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/pdfreader": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/pdfreader/-/pdfreader-3.0.8.tgz",
+      "integrity": "sha512-95X/7bIYfetvu2J12i1MwPIqMo6niWn2fcZU64UJh7agV7/tKNOhp01z7WVAcblpY+bosvwIZG18Pku9VpMulQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pdf2json": "3.1.4"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/performance-now": {

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "redis",
+  "version": "0.0.0",
+  "private": true
+}

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -194,7 +194,7 @@ aws s3 sync --only-show-errors . s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUIL
 
 # Set all files in the _next folder to be cached indefinitely (1 year) on users' browsers
 # Next.js uses unique content hashes in filenames, allowing updated content to have different filenames and invalidate the cache on new builds.
-aws s3 sync --only-show-errors _next s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest/_next --delete --no-progress --cache-control "max-age=31536000, public"
+aws s3 sync --only-show-errors _next s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/static/_next --delete --no-progress --cache-control "max-age=31536000, public"
 
 calculate_duration $start_time
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The system needs a way to track and manage scheduled jobs for resources, such as scheduled publishing and document pushing to external services like SearchSG.

## Solution

<!-- How did you solve the problem? -->

Added a new `ScheduledJobs` table to store scheduled job information with the following structure:

- `id`: Auto-incrementing primary key
- `type`: Enum (`PublishResource`, `PushDocument`) to identify job type
- `resourceId`: Foreign key linking to the associated `Resource`
- `scheduledAt`: Timestamp indicating when the job should execute
- `scheduledBy`: Foreign key linking to the `User` who scheduled the job
- `createdAt` / `updatedAt`: Timestamps for record tracking

The table includes appropriate indexes and foreign key relationships to `Resource` and `User` tables.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- New `ScheduledJobs` model for tracking scheduled resource operations
- New `ScheduledJobType` enum with `PublishResource` and `PushDocument` types
- Relations added to `Resource` and `User` models for scheduled jobs

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Before & After Screenshots

N/A - Database schema change only

## Tests

<!-- What tests should be run to confirm functionality? -->

- Verify migration runs successfully with `npx prisma migrate deploy`
- Verify Prisma client generates correctly with `npx prisma generate`

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A