### PR TITLE
feat: collection thumbnail toggle with logo or first-image fallback

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -389,6 +389,13 @@ export const getLocalisedSitemap = async (
       ELSE ''
     END
 `.as("date")
+  const contentSql = sql<string>`
+    CASE
+      WHEN (published.content ->> 'layout') IN ('article','link')
+      THEN published.content ->> 'content'
+      ELSE ''
+    END
+`.as("content")
 
   // Get the actual resource first
   const resource = await getById(db, { resourceId, siteId })
@@ -410,6 +417,7 @@ export const getLocalisedSitemap = async (
           thumbnailSql,
           categorySql,
           dateSql,
+          contentSql,
           ...defaultResourceSelect,
         ])
         .unionAll((fb) =>
@@ -427,6 +435,7 @@ export const getLocalisedSitemap = async (
               eb.cast<string>(eb.val(""), "text").as("thumbnail"),
               eb.cast<string>(eb.val(""), "text").as("category"),
               eb.cast<string>(eb.val(""), "text").as("date"),
+              eb.cast<string>(eb.val(""), "text").as("content"),
               ...defaultResourceSelect,
             ]),
         ),
@@ -453,6 +462,7 @@ export const getLocalisedSitemap = async (
           thumbnailSql,
           categorySql,
           dateSql,
+          contentSql,
           ...defaultResourceSelect,
         ]),
     )
@@ -474,6 +484,7 @@ export const getLocalisedSitemap = async (
           thumbnailSql,
           categorySql,
           dateSql,
+          contentSql,
           ...defaultResourceSelect,
         ])
         .unionAll((fb) =>
@@ -498,6 +509,7 @@ export const getLocalisedSitemap = async (
               thumbnailSql,
               categorySql,
               dateSql,
+              contentSql,
               ...defaultResourceSelect,
             ]),
         ),
@@ -509,6 +521,7 @@ export const getLocalisedSitemap = async (
       "thumbnail",
       "category",
       "date",
+      "content",
       ...defaultResourceSelect,
     ])
     .union((eb) =>
@@ -519,6 +532,7 @@ export const getLocalisedSitemap = async (
           "thumbnail",
           "category",
           "date",
+          "content",
           ...defaultResourceSelect,
         ]),
     )
@@ -530,6 +544,7 @@ export const getLocalisedSitemap = async (
           "thumbnail",
           "category",
           "date",
+          "content",
           ...defaultResourceSelect,
         ]),
     )

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -2,6 +2,7 @@ import type {
   ArticlePagePageProps,
   CollectionPagePageProps,
   FileRefPageProps,
+  IsomerComponent,
   IsomerSitemap,
   LinkRefPageProps,
 } from "@opengovsg/isomer-components"
@@ -26,6 +27,7 @@ type ResourceDto = Omit<
   thumbnail?: string
   category?: string
   date?: string
+  content?: string
 }
 
 type CollectionItemResourceDto = Omit<ResourceDto, "type" | "parentId"> & {
@@ -71,6 +73,16 @@ const getSitemapTreeFromArray = (
   // TODO: Sort the children by the page ordering if the FolderMeta resource exists
   return children.map((resource) => {
     const permalink = `${path}${resource.permalink}`
+    const parsedContent =
+      typeof resource.content === "string" && resource.content !== ""
+        ? (JSON.parse(resource.content) as IsomerComponent[])
+        : undefined
+    const firstImageComponent = Array.isArray(parsedContent)
+      ? parsedContent.find(
+          (item): item is Extract<IsomerComponent, { type: "image" }> =>
+            item.type === "image",
+        )
+      : undefined
 
     if (resource.type === ResourceType.Page) {
       return {
@@ -85,6 +97,12 @@ const getSitemapTreeFromArray = (
           src: resource.thumbnail ?? "",
           alt: "",
         },
+        firstImage: firstImageComponent
+          ? {
+              src: firstImageComponent.src,
+              alt: firstImageComponent.alt,
+            }
+          : undefined,
       }
     } else if (resource.type === ResourceType.CollectionPage) {
       return {
@@ -101,6 +119,12 @@ const getSitemapTreeFromArray = (
           src: resource.thumbnail ?? "",
           alt: "",
         },
+        firstImage: firstImageComponent
+          ? {
+              src: firstImageComponent.src,
+              alt: firstImageComponent.alt,
+            }
+          : undefined,
       }
     } else if (resource.type === ResourceType.CollectionLink) {
       return {
@@ -117,6 +141,12 @@ const getSitemapTreeFromArray = (
           src: resource.thumbnail ?? "",
           alt: "",
         },
+        firstImage: firstImageComponent
+          ? {
+              src: firstImageComponent.src,
+              alt: firstImageComponent.alt,
+            }
+          : undefined,
         ref: "/",
       }
     }
@@ -145,6 +175,12 @@ const getSitemapTreeFromArray = (
       permalink,
       image: !!indexPage?.thumbnail
         ? { src: indexPage.thumbnail, alt: "" }
+        : undefined,
+      firstImage: firstImageComponent
+        ? {
+            src: firstImageComponent.src,
+            alt: firstImageComponent.alt,
+          }
         : undefined,
       children: getSitemapTreeFromArray(
         resources,

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -21,7 +21,7 @@ interface BaseCardProps {
   url: string
   description: string
   image?: Pick<ImageProps, "src" | "alt">
-  isFallbackImage?: boolean
+  isContainNeeded?: boolean
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }
@@ -54,7 +54,7 @@ export type CollectionCardProps = Pick<
   | "image"
   | "tags"
   | "tagged"
-  | "isFallbackImage"
+  | "isContainNeeded"
 > & {
   referenceLinkHref: string | undefined
   imageSrc: string | undefined

--- a/packages/components/src/interfaces/internal/CollectionCard.ts
+++ b/packages/components/src/interfaces/internal/CollectionCard.ts
@@ -21,6 +21,7 @@ interface BaseCardProps {
   url: string
   description: string
   image?: Pick<ImageProps, "src" | "alt">
+  isFallbackImage?: boolean
   LinkComponent?: LinkComponentType
   site: IsomerSiteProps
 }
@@ -53,6 +54,7 @@ export type CollectionCardProps = Pick<
   | "image"
   | "tags"
   | "tagged"
+  | "isFallbackImage"
 > & {
   referenceLinkHref: string | undefined
   imageSrc: string | undefined

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -12,6 +12,7 @@ export const BlogCard = ({
   description,
   category,
   image,
+  isFallbackImage,
   referenceLinkHref,
   imageSrc,
   itemTitle,
@@ -36,13 +37,13 @@ export const BlogCard = ({
       isExternal={isExternalLink}
     >
       {image && (
-        <div className="relative mb-3 aspect-[2/1] h-auto min-h-40 shrink-0">
+        <div className="relative mb-3 flex aspect-[2/1] h-auto min-h-40 shrink-0 items-center justify-center">
           {
             <ImageClient
               src={imageSrc || ""}
               alt={image.alt}
               width="100%"
-              className="absolute left-0 h-full w-full rounded object-cover"
+              className={`absolute left-0 h-full w-full rounded ${isFallbackImage ? "object-contain" : "object-cover"}`}
               assetsBaseUrl={siteAssetsBaseUrl}
             />
           }

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.tsx
@@ -12,7 +12,7 @@ export const BlogCard = ({
   description,
   category,
   image,
-  isFallbackImage,
+  isContainNeeded,
   referenceLinkHref,
   imageSrc,
   itemTitle,
@@ -43,7 +43,7 @@ export const BlogCard = ({
               src={imageSrc || ""}
               alt={image.alt}
               width="100%"
-              className={`absolute left-0 h-full w-full rounded ${isFallbackImage ? "object-contain" : "object-cover"}`}
+              className={`absolute left-0 h-full w-full rounded ${isContainNeeded ? "object-contain" : "object-cover"}`}
               assetsBaseUrl={siteAssetsBaseUrl}
             />
           }

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -12,6 +12,7 @@ export const CollectionCard = ({
   description,
   category,
   image,
+  isFallbackImage,
   referenceLinkHref,
   imageSrc,
   itemTitle,
@@ -63,12 +64,12 @@ export const CollectionCard = ({
         <p className="prose-label-md text-base-content-subtle">{category}</p>
       </div>
       {image && (
-        <div className="relative mt-3 h-[160px] w-[200px] shrink-0 md:ml-4 md:mt-0">
+        <div className="relative mt-3 flex h-[160px] w-[200px] shrink-0 items-center justify-center md:ml-4 md:mt-0">
           <ImageClient
             src={imageSrc || ""}
             alt={image.alt}
             width="100%"
-            className="absolute left-0 h-full w-full rounded object-cover"
+            className={`absolute left-0 h-full w-full rounded ${isFallbackImage ? "object-contain" : "object-cover"}`}
             assetsBaseUrl={siteAssetsBaseUrl}
           />
         </div>

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.tsx
@@ -12,7 +12,7 @@ export const CollectionCard = ({
   description,
   category,
   image,
-  isFallbackImage,
+  isContainNeeded,
   referenceLinkHref,
   imageSrc,
   itemTitle,
@@ -69,7 +69,7 @@ export const CollectionCard = ({
             src={imageSrc || ""}
             alt={image.alt}
             width="100%"
-            className={`absolute left-0 h-full w-full rounded ${isFallbackImage ? "object-contain" : "object-cover"}`}
+            className={`absolute left-0 h-full w-full rounded ${isContainNeeded ? "object-contain" : "object-cover"}`}
             assetsBaseUrl={siteAssetsBaseUrl}
           />
         </div>

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -23,6 +23,7 @@ export const CollectionLayout = ({
     defaultSortDirection,
     tagCategories,
     showDate,
+    showThumbnail,
   } = page
 
   const items = getCollectionItems({
@@ -33,6 +34,7 @@ export const CollectionLayout = ({
     sortDirection: defaultSortDirection,
     tagCategories,
     showDate,
+    showThumbnail,
   })
   const processedItems = processCollectionItems(items)
   const breadcrumb = getBreadcrumbFromSiteMap(

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
@@ -6,6 +6,11 @@ import { getCollectionItems } from "../getCollectionItems"
 
 const SITE_LOGO_URL = "/isomer-logo.svg"
 const SITE_NAME = "Isomer Next"
+const SITE_LOGO_FALLBACK = {
+  src: SITE_LOGO_URL,
+  alt: `${SITE_NAME} site logo`,
+  isContainNeeded: true,
+}
 
 const createArticleChild = (
   overrides?: Partial<IsomerSitemap>,
@@ -44,7 +49,42 @@ const createSiteWithChildren = (children: IsomerSitemap[]) =>
   })
 
 describe("getCollectionItems", () => {
-  describe("image fallback to site logo", () => {
+  describe("showThumbnail is undefined", () => {
+    it("should not include image when showThumbnail is undefined, even if item has an image", () => {
+      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
+      const site = createSiteWithChildren([
+        createArticleChild({ image: itemImage }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: undefined,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toBeUndefined()
+      expect(result[0]!.isContainNeeded).toBe(false)
+    })
+
+    it("should not include image when showThumbnail is undefined and item has no image", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({ image: undefined }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: undefined,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toBeUndefined()
+      expect(result[0]!.isContainNeeded).toBe(false)
+    })
+  })
+
+  describe("showThumbnail with fallback 'logo'", () => {
     it("should use the item image when item has an image with a non-empty src", () => {
       const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
       const site = createSiteWithChildren([
@@ -54,12 +94,12 @@ describe("getCollectionItems", () => {
       const result = getCollectionItems({
         site,
         permalink: "/collection",
-        showThumbnail: true,
+        showThumbnail: { fallback: "logo" },
       })
 
       expect(result).toHaveLength(1)
       expect(result[0]!.image).toEqual(itemImage)
-      expect(result[0]!.isFallbackImage).toBe(false)
+      expect(result[0]!.isContainNeeded).toBe(false)
     })
 
     it("should fall back to site logo when item has no image", () => {
@@ -70,15 +110,12 @@ describe("getCollectionItems", () => {
       const result = getCollectionItems({
         site,
         permalink: "/collection",
-        showThumbnail: true,
+        showThumbnail: { fallback: "logo" },
       })
 
       expect(result).toHaveLength(1)
-      expect(result[0]!.image).toEqual({
-        src: SITE_LOGO_URL,
-        alt: `${SITE_NAME} site logo`,
-      })
-      expect(result[0]!.isFallbackImage).toBe(true)
+      expect(result[0]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[0]!.isContainNeeded).toBe(true)
     })
 
     it("should fall back to site logo when item image has an empty src", () => {
@@ -89,15 +126,12 @@ describe("getCollectionItems", () => {
       const result = getCollectionItems({
         site,
         permalink: "/collection",
-        showThumbnail: true,
+        showThumbnail: { fallback: "logo" },
       })
 
       expect(result).toHaveLength(1)
-      expect(result[0]!.image).toEqual({
-        src: SITE_LOGO_URL,
-        alt: `${SITE_NAME} site logo`,
-      })
-      expect(result[0]!.isFallbackImage).toBe(true)
+      expect(result[0]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[0]!.isContainNeeded).toBe(true)
     })
 
     it("should fall back to site logo when item image has an empty src but non-empty alt", () => {
@@ -108,36 +142,123 @@ describe("getCollectionItems", () => {
       const result = getCollectionItems({
         site,
         permalink: "/collection",
-        showThumbnail: true,
+        showThumbnail: { fallback: "logo" },
       })
 
       expect(result).toHaveLength(1)
-      expect(result[0]!.image).toEqual({
-        src: SITE_LOGO_URL,
-        alt: `${SITE_NAME} site logo`,
-      })
-      expect(result[0]!.isFallbackImage).toBe(true)
+      expect(result[0]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[0]!.isContainNeeded).toBe(true)
     })
 
-    it("should not include image when showThumbnail is false", () => {
+    it("should ignore item firstImage when fallback is 'logo'", () => {
+      const firstImage = { src: "/images/first.png", alt: "First image" }
       const site = createSiteWithChildren([
-        createArticleChild({ image: undefined }),
+        createArticleChild({ image: undefined, firstImage }),
       ])
 
       const result = getCollectionItems({
         site,
         permalink: "/collection",
-        showThumbnail: false,
+        showThumbnail: { fallback: "logo" },
       })
 
       expect(result).toHaveLength(1)
-      expect(result[0]!.image).toBeUndefined()
-      expect(result[0]!.isFallbackImage).toBe(false)
+      expect(result[0]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[0]!.isContainNeeded).toBe(true)
     })
   })
 
-  describe("showThumbnail not explicitly set (auto-detection)", () => {
-    it("should show thumbnails when at least one item has an image", () => {
+  describe("showThumbnail with fallback 'first-image'", () => {
+    it("should use the item image when item has an image with a non-empty src, ignoring firstImage", () => {
+      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
+      const firstImage = { src: "/images/first.png", alt: "First image" }
+      const site = createSiteWithChildren([
+        createArticleChild({ image: itemImage, firstImage }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: { fallback: "first-image" },
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(itemImage)
+      expect(result[0]!.isContainNeeded).toBe(false)
+    })
+
+    it("should fall back to firstImage when item has no image but has a firstImage", () => {
+      const firstImage = { src: "/images/first.png", alt: "First image" }
+      const site = createSiteWithChildren([
+        createArticleChild({ image: undefined, firstImage }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: { fallback: "first-image" },
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(firstImage)
+      expect(result[0]!.isContainNeeded).toBe(false)
+    })
+
+    it("should fall back to firstImage when item image has an empty src", () => {
+      const firstImage = { src: "/images/first.png", alt: "First image" }
+      const site = createSiteWithChildren([
+        createArticleChild({ image: { src: "", alt: "" }, firstImage }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: { fallback: "first-image" },
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(firstImage)
+      expect(result[0]!.isContainNeeded).toBe(false)
+    })
+
+    it("should fall back to site logo when item has no image and no firstImage", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({ image: undefined, firstImage: undefined }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: { fallback: "first-image" },
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[0]!.isContainNeeded).toBe(true)
+    })
+
+    it("should fall back to site logo when firstImage has an empty src", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({
+          image: undefined,
+          firstImage: { src: "", alt: "" },
+        }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: { fallback: "first-image" },
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[0]!.isContainNeeded).toBe(true)
+    })
+  })
+
+  describe("mixed items with showThumbnail", () => {
+    it("should resolve images per-item with fallback 'logo'", () => {
       const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
       const site = createSiteWithChildren([
         createArticleChild({
@@ -155,58 +276,52 @@ describe("getCollectionItems", () => {
       const result = getCollectionItems({
         site,
         permalink: "/collection",
+        showThumbnail: { fallback: "logo" },
       })
 
       expect(result).toHaveLength(2)
-      // Item with image uses its own image
       expect(result[0]!.image).toEqual(itemImage)
-      expect(result[0]!.isFallbackImage).toBe(false)
-      // Item without image falls back to site logo
-      expect(result[1]!.image).toEqual({
-        src: SITE_LOGO_URL,
-        alt: `${SITE_NAME} site logo`,
-      })
-      expect(result[1]!.isFallbackImage).toBe(true)
+      expect(result[0]!.isContainNeeded).toBe(false)
+      expect(result[1]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[1]!.isContainNeeded).toBe(true)
     })
 
-    it("should not show thumbnails when no items have images", () => {
+    it("should resolve images per-item with fallback 'first-image'", () => {
+      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
+      const firstImage = { src: "/images/first.png", alt: "First image" }
       const site = createSiteWithChildren([
         createArticleChild({
           id: "article-1",
           permalink: "/collection/article-1",
-          image: undefined,
+          image: itemImage,
         }),
         createArticleChild({
           id: "article-2",
           permalink: "/collection/article-2",
-          image: { src: "", alt: "" },
+          image: undefined,
+          firstImage,
+        }),
+        createArticleChild({
+          id: "article-3",
+          permalink: "/collection/article-3",
+          image: undefined,
+          firstImage: undefined,
         }),
       ])
 
       const result = getCollectionItems({
         site,
         permalink: "/collection",
+        showThumbnail: { fallback: "first-image" },
       })
 
-      expect(result).toHaveLength(2)
-      expect(result[0]!.image).toBeUndefined()
-      expect(result[1]!.image).toBeUndefined()
-    })
-
-    it("should use the item image when only one item exists and has an image", () => {
-      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
-      const site = createSiteWithChildren([
-        createArticleChild({ image: itemImage }),
-      ])
-
-      const result = getCollectionItems({
-        site,
-        permalink: "/collection",
-      })
-
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(3)
       expect(result[0]!.image).toEqual(itemImage)
-      expect(result[0]!.isFallbackImage).toBe(false)
+      expect(result[0]!.isContainNeeded).toBe(false)
+      expect(result[1]!.image).toEqual(firstImage)
+      expect(result[1]!.isContainNeeded).toBe(false)
+      expect(result[2]!.image).toEqual(SITE_LOGO_FALLBACK)
+      expect(result[2]!.isContainNeeded).toBe(true)
     })
   })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
@@ -1,0 +1,212 @@
+import type { IsomerSitemap } from "~/types"
+import { describe, expect, it } from "vitest"
+import { generateSiteConfig } from "~/stories/helpers/generateSiteConfig"
+
+import { getCollectionItems } from "../getCollectionItems"
+
+const SITE_LOGO_URL = "/isomer-logo.svg"
+const SITE_NAME = "Isomer Next"
+
+const createArticleChild = (
+  overrides?: Partial<IsomerSitemap>,
+): IsomerSitemap =>
+  ({
+    id: "article-1",
+    title: "Article 1",
+    summary: "Summary",
+    lastModified: "2024-01-01",
+    permalink: "/collection/article-1",
+    layout: "article" as const,
+    ...overrides,
+  }) as IsomerSitemap
+
+const createSiteWithChildren = (children: IsomerSitemap[]) =>
+  generateSiteConfig({
+    siteMap: {
+      id: "root",
+      title: SITE_NAME,
+      summary: "",
+      lastModified: "2024-01-01",
+      permalink: "/",
+      layout: "homepage",
+      children: [
+        {
+          id: "collection",
+          title: "Collection",
+          summary: "",
+          lastModified: "2024-01-01",
+          permalink: "/collection",
+          layout: "collection",
+          children,
+        },
+      ],
+    },
+  })
+
+describe("getCollectionItems", () => {
+  describe("image fallback to site logo", () => {
+    it("should use the item image when item has an image with a non-empty src", () => {
+      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
+      const site = createSiteWithChildren([
+        createArticleChild({ image: itemImage }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: true,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(itemImage)
+      expect(result[0]!.isFallbackImage).toBe(false)
+    })
+
+    it("should fall back to site logo when item has no image", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({ image: undefined }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: true,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual({
+        src: SITE_LOGO_URL,
+        alt: `${SITE_NAME} site logo`,
+      })
+      expect(result[0]!.isFallbackImage).toBe(true)
+    })
+
+    it("should fall back to site logo when item image has an empty src", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({ image: { src: "", alt: "" } }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: true,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual({
+        src: SITE_LOGO_URL,
+        alt: `${SITE_NAME} site logo`,
+      })
+      expect(result[0]!.isFallbackImage).toBe(true)
+    })
+
+    it("should fall back to site logo when item image has an empty src but non-empty alt", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({ image: { src: "", alt: "Some alt text" } }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: true,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual({
+        src: SITE_LOGO_URL,
+        alt: `${SITE_NAME} site logo`,
+      })
+      expect(result[0]!.isFallbackImage).toBe(true)
+    })
+
+    it("should not include image when showThumbnail is false", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({ image: undefined }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        showThumbnail: false,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toBeUndefined()
+      expect(result[0]!.isFallbackImage).toBe(false)
+    })
+  })
+
+  describe("showThumbnail not explicitly set (auto-detection)", () => {
+    it("should show thumbnails when at least one item has an image", () => {
+      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
+      const site = createSiteWithChildren([
+        createArticleChild({
+          id: "article-1",
+          permalink: "/collection/article-1",
+          image: itemImage,
+        }),
+        createArticleChild({
+          id: "article-2",
+          permalink: "/collection/article-2",
+          image: undefined,
+        }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+      })
+
+      expect(result).toHaveLength(2)
+      // Item with image uses its own image
+      expect(result[0]!.image).toEqual(itemImage)
+      expect(result[0]!.isFallbackImage).toBe(false)
+      // Item without image falls back to site logo
+      expect(result[1]!.image).toEqual({
+        src: SITE_LOGO_URL,
+        alt: `${SITE_NAME} site logo`,
+      })
+      expect(result[1]!.isFallbackImage).toBe(true)
+    })
+
+    it("should not show thumbnails when no items have images", () => {
+      const site = createSiteWithChildren([
+        createArticleChild({
+          id: "article-1",
+          permalink: "/collection/article-1",
+          image: undefined,
+        }),
+        createArticleChild({
+          id: "article-2",
+          permalink: "/collection/article-2",
+          image: { src: "", alt: "" },
+        }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+      })
+
+      expect(result).toHaveLength(2)
+      expect(result[0]!.image).toBeUndefined()
+      expect(result[1]!.image).toBeUndefined()
+    })
+
+    it("should use the item image when only one item exists and has an image", () => {
+      const itemImage = { src: "/images/thumbnail.png", alt: "Thumbnail" }
+      const site = createSiteWithChildren([
+        createArticleChild({ image: itemImage }),
+      ])
+
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.image).toEqual(itemImage)
+      expect(result[0]!.isFallbackImage).toBe(false)
+    })
+  })
+})

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -9,6 +9,59 @@ import { sortCollectionItems } from "./sortCollectionItems"
 
 const CATEGORY_OTHERS = "Others"
 
+interface GetItemImageProps {
+  showThumbnail: CollectionPagePageProps["showThumbnail"]
+  item: IsomerSitemap
+  site: IsomerSiteProps
+}
+
+type GetItemImageResult =
+  | {
+      src: string
+      alt: string
+      isContainNeeded?: boolean
+    }
+  | undefined
+
+const getItemImage = ({
+  showThumbnail,
+  item,
+  site,
+}: GetItemImageProps): GetItemImageResult => {
+  // If showThumbnail is undefined, we will hide all the thumbnails of the
+  // collection, regardless of whether the individual items have images or not
+  if (!showThumbnail) {
+    return undefined
+  }
+
+  // If the item has an image, we will show the item's image
+  if (item.image?.src) {
+    return item.image
+  }
+
+  switch (showThumbnail.fallback) {
+    case "logo":
+      return {
+        src: site.logoUrl,
+        alt: `${site.siteName} site logo`,
+        isContainNeeded: true,
+      }
+    case "first-image":
+      if (item.firstImage?.src) {
+        return item.firstImage
+      }
+
+      return {
+        src: site.logoUrl,
+        alt: `${site.siteName} site logo`,
+        isContainNeeded: true,
+      }
+    default:
+      const _: never = showThumbnail.fallback
+      return undefined
+  }
+}
+
 export type GetCollectionItemsProps = Pick<
   CollectionPagePageProps,
   "sortOrder" | "showDate" | "showThumbnail" | "tagCategories"
@@ -63,25 +116,12 @@ export const getCollectionItems = ({
         item.layout === "article",
     )
 
-  const isAnyItemHaveImage = items.some((item) => !!item.image?.src)
-  // If showThumbnail is not explicitly set, show the thumbnail if any of the
-  // items have an image
-  const shouldShowThumbnail = showThumbnail ?? isAnyItemHaveImage
-
   const transformedItems = items.map((item) => {
     const date =
       showDate !== false && item.date !== undefined && item.date !== ""
         ? getParsedDate(item.date)
         : undefined
-    const hasOriginalImage = !!item.image?.src
-    const image = shouldShowThumbnail
-      ? hasOriginalImage
-        ? item.image
-        : {
-            src: site.logoUrl,
-            alt: `${site.siteName} site logo`,
-          }
-      : undefined
+    const image = getItemImage({ showThumbnail, item, site })
 
     const baseItem = {
       type: "collectionCard" as const,
@@ -92,7 +132,7 @@ export const getCollectionItems = ({
       title: item.title,
       description: item.summary,
       image,
-      isFallbackImage: shouldShowThumbnail && !hasOriginalImage,
+      isContainNeeded: image?.isContainNeeded || false,
       site,
       tags:
         tagCategories && item.tagged

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -11,7 +11,7 @@ const CATEGORY_OTHERS = "Others"
 
 export type GetCollectionItemsProps = Pick<
   CollectionPagePageProps,
-  "sortOrder" | "showDate" | "tagCategories"
+  "sortOrder" | "showDate" | "showThumbnail" | "tagCategories"
 > & {
   site: IsomerSiteProps
   permalink: string
@@ -26,6 +26,7 @@ export const getCollectionItems = ({
   sortDirection,
   sortOrder,
   showDate,
+  showThumbnail,
   tagCategories,
 }: GetCollectionItemsProps): AllCardProps[] => {
   let currSitemap: IsomerSitemap = site.siteMap
@@ -62,11 +63,25 @@ export const getCollectionItems = ({
         item.layout === "article",
     )
 
+  const isAnyItemHaveImage = items.some((item) => !!item.image?.src)
+  // If showThumbnail is not explicitly set, show the thumbnail if any of the
+  // items have an image
+  const shouldShowThumbnail = showThumbnail ?? isAnyItemHaveImage
+
   const transformedItems = items.map((item) => {
     const date =
       showDate !== false && item.date !== undefined && item.date !== ""
         ? getParsedDate(item.date)
         : undefined
+    const hasOriginalImage = !!item.image?.src
+    const image = shouldShowThumbnail
+      ? hasOriginalImage
+        ? item.image
+        : {
+            src: site.logoUrl,
+            alt: `${site.siteName} site logo`,
+          }
+      : undefined
 
     const baseItem = {
       type: "collectionCard" as const,
@@ -76,7 +91,8 @@ export const getCollectionItems = ({
       category: item.category || CATEGORY_OTHERS,
       title: item.title,
       description: item.summary,
-      image: item.image,
+      image,
+      isFallbackImage: shouldShowThumbnail && !hasOriginalImage,
       site,
       tags:
         tagCategories && item.tagged

--- a/packages/components/src/templates/next/layouts/Collection/utils/processCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/processCollectionItems.ts
@@ -19,7 +19,7 @@ export const processCollectionItems = (
       title,
       description,
       image,
-      isFallbackImage,
+      isContainNeeded,
       url,
       tags,
     } = item
@@ -31,7 +31,7 @@ export const processCollectionItems = (
       title,
       description,
       image,
-      isFallbackImage,
+      isContainNeeded,
       tags,
       referenceLinkHref: getReferenceLinkHref(
         url,

--- a/packages/components/src/templates/next/layouts/Collection/utils/processCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/processCollectionItems.ts
@@ -19,6 +19,7 @@ export const processCollectionItems = (
       title,
       description,
       image,
+      isFallbackImage,
       url,
       tags,
     } = item
@@ -30,6 +31,7 @@ export const processCollectionItems = (
       title,
       description,
       image,
+      isFallbackImage,
       tags,
       referenceLinkHref: getReferenceLinkHref(
         url,

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -219,6 +219,14 @@ export const CollectionPagePageSchema = Type.Intersect([
         },
       ),
     ),
+    showThumbnail: Type.Optional(
+      Type.Boolean({
+        title: "Show thumbnail on all items",
+        description:
+          "If an item doesn't have a thumbnail, we'll display the site's logo.",
+        default: false,
+      }),
+    ),
     showDate: Type.Optional(
       Type.Boolean({
         title: "Show date on all items",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -2,6 +2,7 @@ import type { Static, StringOptions } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 import {
   AltTextSchema,
+  ARRAY_RADIO_FORMAT,
   ArticlePageHeaderSchema,
   ContentPageHeaderSchema,
   generateImageSrcSchema,
@@ -220,12 +221,26 @@ export const CollectionPagePageSchema = Type.Intersect([
       ),
     ),
     showThumbnail: Type.Optional(
-      Type.Boolean({
-        title: "Show thumbnail on all items",
-        description:
-          "If an item doesn't have a thumbnail, we'll display the site's logo.",
-        default: false,
-      }),
+      Type.Object(
+        {
+          fallback: Type.Union(
+            [
+              Type.Literal("logo", { title: "Use site logo" }),
+              Type.Literal("first-image", {
+                title: "Use first image on page, if available",
+              }),
+            ],
+            {
+              title: "If an item doesn’t have a thumbnail",
+              format: ARRAY_RADIO_FORMAT,
+              default: "logo",
+            },
+          ),
+        },
+        {
+          title: "Display thumbnail on all items",
+        },
+      ),
     ),
     showDate: Type.Optional(
       Type.Boolean({

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -15,6 +15,7 @@ interface IsomerBaseSitemap {
   // so that the properties that are exclusive to, for example, `CollectionCard`
   // will only be available there
   image?: CollectionCardProps["image"]
+  firstImage?: CollectionCardProps["image"]
   date?: string
   children?: IsomerSitemap[]
   tags?: CollectionCardProps["tags"]

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -18,7 +18,7 @@ import {
   getCollectionIndexPageContents,
   getFolderIndexPageContents,
 } from "./utils/getIndexPageContent"
-import { getResourceImage } from "./utils/getResourceImage"
+import { getResourceFirstImage } from "./utils/getResourceFirstImage"
 
 dotenv.config()
 
@@ -139,7 +139,8 @@ async function main() {
           tags: resource.content.page.tags,
           tagged: resource.content.page.tagged,
           date: resource.content.page.date,
-          image: getResourceImage(resource),
+          image: resource.content.page.image,
+          firstImage: getResourceFirstImage(resource),
           ref: resource.content.page.ref, // For file and link layouts
           collectionPagePageProps: {
             tagCategories: resource.content.page?.tagCategories,

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -44,6 +44,10 @@ export type SitemapEntry = Pick<
     src?: string
     alt?: string
   }
+  firstImage?: {
+    src?: string
+    alt?: string
+  }
   ref?: string
   children?: SitemapEntry[]
   tags?: Tag[]

--- a/tooling/build/scripts/publishing/utils/getResourceFirstImage.ts
+++ b/tooling/build/scripts/publishing/utils/getResourceFirstImage.ts
@@ -1,8 +1,6 @@
 import type { Resource } from "../types"
 
-export const getResourceImage = (resource: Resource) => {
-  if (resource.content.page.image) return resource.content.page.image
-
+export const getResourceFirstImage = (resource: Resource) => {
   if (!Array.isArray(resource.content?.content)) return undefined
 
   const firstImageComponent = resource.content.content.find(


### PR DESCRIPTION
## Problem

Closes ISOM-2057

Collection index pages did not let site editors control whether thumbnails are displayed on collection items. Items without images had no visual representation, and there was no fallback mechanism to keep a consistent visual layout across items with and without their own thumbnail.

## Solution

Introduce a `showThumbnail` setting on the collection page schema that toggles thumbnails on for the entire collection and lets the editor choose how items without their own thumbnail are filled in.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - `showThumbnail` is optional. Existing collections render unchanged (no thumbnails) until the editor opts in.

**Features**:

- New `showThumbnail` field on `CollectionPagePageSchema`. When set, thumbnails display on every item in the collection. Editors pick a fallback for items that lack their own image:
  - `logo` — fall back to the site logo (rendered with `object-contain`)
  - `first-image` — fall back to the first image found in the item's page content; if none exists, fall back to the site logo
- Build/publishing pipeline now populates a new `firstImage` field on each sitemap entry by scanning the item's content array for the first `image` block (`getResourceFirstImage`, replacing the old `getResourceImage`).
- Studio sitemap loader (`getLocalisedSitemap`) now also selects the page `content` column and `getSitemapTreeFromArray` parses it to derive `firstImage` for live previews.

**Improvements**:

- `CollectionCard` and `BlogCard` accept an `isContainNeeded` prop that switches the image from `object-cover` to `object-contain` (used for logo fallbacks so the logo isn't cropped or stretched). Image containers use flex centering to position the contained image correctly.
- `getCollectionItems` resolves the displayed image per item: item image → fallback (logo or first-image) → site logo. The flag `isContainNeeded` is propagated through `processCollectionItems` to the card.
- Test suite for `getCollectionItems` rewritten to cover the new `{ fallback: ... }` shape, both fallback strategies, and mixed-item collections (14 tests).

**Bug Fixes**:

None

## Before & After Screenshots

**BEFORE**:

Collection items render without thumbnails; no editor control exists.

**AFTER**:

Editors can enable thumbnails for the whole collection and choose between site-logo and first-image fallback for items without their own thumbnail.

## Tests

**Manual Verification Steps**:

- [ ] Open a collection index page in Studio's collection editor and confirm the \"Display thumbnail on all items\" control is visible, with a radio choice between \"Use site logo\" and \"Use first image on page, if available\"
- [ ] Leave `showThumbnail` unset and confirm no thumbnails render for any item (existing behaviour preserved)
- [ ] Set `showThumbnail` with fallback `logo`. Verify items with their own image show that image (`object-cover`) and items without one show the site logo (`object-contain`, centered, not cropped)
- [ ] Set `showThumbnail` with fallback `first-image`. For an item without its own image but with at least one image block in its body content, verify that body image is used as the thumbnail. For an item with neither, verify the site logo fallback is used instead
- [ ] Verify the same behaviour for both card variants — 1-column (`CollectionCard`) and 2-column / Blog (`BlogCard`)
- [ ] Publish the site and confirm the published output (via the build pipeline) renders the same thumbnails as the Studio preview, including `firstImage` fallbacks

**New scripts**:

None

**New dependencies**:

None

**New dev dependencies**:

None