### PR TITLE
refactor: centralize image src schema usage

### DIFF
--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -4,8 +4,8 @@ import type { IsomerSiteProps, LinkComponentType } from "~/types"
 import { Type } from "@sinclair/typebox"
 import { omit } from "lodash-es"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "~/constants/image"
-import { generateImageSrcSchema } from "~/interfaces"
 import { LINK_HREF_PATTERN } from "~/utils/validation"
+import { generateImageSrcSchema } from "./Image"
 
 import { ARRAY_RADIO_FORMAT } from "../format"
 

--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -4,6 +4,7 @@ import type { IsomerSiteProps, LinkComponentType } from "~/types"
 import { Type } from "@sinclair/typebox"
 import { omit } from "lodash-es"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "~/constants/image"
+import { generateImageSrcSchema } from "~/interfaces"
 import { LINK_HREF_PATTERN } from "~/utils/validation"
 
 import { ARRAY_RADIO_FORMAT } from "../format"
@@ -71,9 +72,8 @@ const BACKGROUND_IMAGE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING = omit(
   ".gif",
 )
 
-const BackgroundUrlSchema = Type.String({
+const BackgroundUrlSchema = generateImageSrcSchema({
   title: "Hero image",
-  format: "image",
   allowedMimeTypeMappings: BACKGROUND_IMAGE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
 })
 

--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -5,9 +5,9 @@ import { Type } from "@sinclair/typebox"
 import { omit } from "lodash-es"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "~/constants/image"
 import { LINK_HREF_PATTERN } from "~/utils/validation"
-import { generateImageSrcSchema } from "./Image"
 
 import { ARRAY_RADIO_FORMAT } from "../format"
+import { generateImageSrcSchema } from "./Image"
 
 export const HERO_STYLE = {
   gradient: "gradient",

--- a/packages/components/src/interfaces/complex/Image.ts
+++ b/packages/components/src/interfaces/complex/Image.ts
@@ -8,15 +8,20 @@ import { ARRAY_RADIO_FORMAT } from "../format"
 export const generateImageSrcSchema = ({
   title = "Image",
   description,
+  allowedMimeTypeMappings = IMAGE_ACCEPTED_MIME_TYPE_MAPPING,
+  maxSizeInBytes,
 }: {
   title?: string
   description?: string
+  allowedMimeTypeMappings?: Record<string, string>
+  maxSizeInBytes?: number
 }) => {
   return Type.String({
     title,
     format: "image",
     description,
-    allowedMimeTypeMappings: IMAGE_ACCEPTED_MIME_TYPE_MAPPING,
+    allowedMimeTypeMappings,
+    maxSizeInBytes,
   })
 }
 

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -1,9 +1,9 @@
 import type { Static } from "@sinclair/typebox"
 import type { FooterSchemaType, NavbarSchemaType } from "~/interfaces"
 import { Type } from "@sinclair/typebox"
-import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "~/constants/image"
 import {
   AskgovSchema,
+  generateImageSrcSchema,
   LocalSearchSchema,
   SearchSGSearchSchema,
   VicaSchema,
@@ -58,20 +58,16 @@ export const IntegrationsSettingsSchema = Type.Intersect([
 ])
 
 export const LogoSettingsSchema = Type.Object({
-  logoUrl: Type.String({
+  logoUrl: generateImageSrcSchema({
     title: "Logo",
     description:
       "The logo appears on the navigation bar. It may also be used as a thumbnail if there’s no thumbnail set on a page.",
-    format: "image",
-    allowedMimeTypeMappings: IMAGE_ACCEPTED_MIME_TYPE_MAPPING,
   }),
   favicon: Type.Optional(
-    Type.String({
+    generateImageSrcSchema({
       title: "Favicon",
       description:
         "This appears on a browser tab to help people recognise your site. We recommend a minimum size of 24px by 24px, in .ico, .svg, or .png format.",
-      format: "image",
-      allowedMimeTypeMappings: IMAGE_ACCEPTED_MIME_TYPE_MAPPING,
       maxSizeInBytes: 50000, // NOTE: 50 kB
     }),
   ),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Several schema definitions re-declared `Type.String({ format: "image", ... })` instead of using the shared `generateImageSrcSchema` helper, leading to duplicated behavior and drift risk.

A follow-up issue was identified: importing `generateImageSrcSchema` from the top-level `~/interfaces` barrel in `Hero.ts` introduced a circular dependency at runtime.

Closes [insert issue #]

## Solution

Updated image schema usage to reuse `generateImageSrcSchema` where equivalent behavior was being redefined, and expanded helper options to support current needs:

- Extended `generateImageSrcSchema` to accept optional:
  - `allowedMimeTypeMappings`
  - `maxSizeInBytes`
- Refactored Hero background image schema to use the helper while preserving the custom mime mapping that excludes GIF.
- Refactored Site logo and favicon schemas to use the helper.
- Preserved favicon max file size behavior via `maxSizeInBytes: 50000`.
- Fixed circular dependency in `Hero.ts` by importing `generateImageSrcSchema` from `./Image` (module-local import) instead of the `~/interfaces` barrel.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Reduced schema duplication for image fields.
- Centralized image schema options behind one helper.
- Removed a runtime initialization risk from circular barrel imports.

**Bug Fixes**:

- Fixed Hero circular dependency causing potential runtime `TypeError` during module evaluation.

## Before & After Screenshots

**BEFORE**:

<!-- N/A (schema-only change) -->

**AFTER**:

<!-- N/A (schema-only change) -->

## Tests

**Manual Verification Steps**:

- [ ] Confirm Hero `backgroundUrl` still only allows expected image types (GIF excluded).
- [ ] Confirm Site `logoUrl` still accepts standard image uploads.
- [ ] Confirm Site `favicon` still enforces 50 kB max size.
- [ ] Confirm importing/rendering Hero schema no longer hits circular-import initialization errors.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b236523-3096-4fa6-a29c-e1867fe7acca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b236523-3096-4fa6-a29c-e1867fe7acca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

