### PR TITLE
chore(deps): bump axios to ^1.15.0 in tooling packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15267,12 +15267,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.10.0",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -19340,7 +19342,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -19533,9 +19537,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -30727,8 +30731,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ps-tree": {
       "version": "1.2.0",
@@ -36790,7 +36799,7 @@
         "@isomer/seed-from-repo": "*",
         "@octokit/rest": "^22.0.0",
         "@opengovsg/isomer-components": "*",
-        "axios": "^1.10.0",
+        "axios": "^1.15.0",
         "commander-ts": "^0.2.0",
         "npx": "^10.2.2",
         "tsx": "^4.20.4"
@@ -36935,7 +36944,7 @@
         "@inquirer/prompts": "^7.6.0",
         "@isomer/seed-from-repo": "*",
         "@octokit/rest": "^22.0.0",
-        "axios": "^1.10.0",
+        "axios": "^1.15.0",
         "commander-ts": "^0.2.0",
         "npx": "^10.2.2",
         "tsx": "^4.20.4"

--- a/tooling/migrate-tags/package.json
+++ b/tooling/migrate-tags/package.json
@@ -17,7 +17,7 @@
     "@isomer/seed-from-repo": "*",
     "@octokit/rest": "^22.0.0",
     "@opengovsg/isomer-components": "*",
-    "axios": "^1.10.0",
+    "axios": "^1.15.0",
     "commander-ts": "^0.2.0",
     "npx": "^10.2.2",
     "tsx": "^4.20.4"

--- a/tooling/site-launch/package.json
+++ b/tooling/site-launch/package.json
@@ -18,7 +18,7 @@
     "@inquirer/prompts": "^7.6.0",
     "@isomer/seed-from-repo": "*",
     "@octokit/rest": "^22.0.0",
-    "axios": "^1.10.0",
+    "axios": "^1.15.0",
     "commander-ts": "^0.2.0",
     "npx": "^10.2.2",
     "tsx": "^4.20.4"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Direct `axios` usage in Isomer tooling workspaces was pinned to `^1.10.0`, which does not guarantee a minimum of 1.15.0 for installs and audits.

## Solution

Updated `axios` to `^1.15.0` in `@isomer/site-launch` and `@isomer/migrate-tags`, and ran `npm install` so the root lockfile resolves `axios@1.15.0`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Tooling packages that depend on `axios` now require at least 1.15.x per the caret range.

**Bug Fixes**:

- None.

## Before & After Screenshots

Not applicable (dependency-only change).

## Tests

Confirm installs succeed: `npm install` at the repo root (already run for lockfile refresh).

**New scripts**:

- None.

**New dependencies**:

- None (version range bump only).

**New dev dependencies**:

- None.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://opengovproducts.slack.com/archives/D0ACWJJBBHD/p1775874974967689?thread_ts=1775874974.967689&cid=D0ACWJJBBHD)

<div><a href="https://cursor.com/agents/bc-cdf4fd40-50da-599c-bd85-90355f22c8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdf4fd40-50da-599c-bd85-90355f22c8d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

