### PR TITLE
fix: add back missing check on children pages block

### DIFF
--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -1,4 +1,5 @@
 import type { IndexPageSchemaType } from "~/types"
+import { DEFAULT_CHILDREN_PAGES_BLOCK } from "~/interfaces/complex/ChildrenPages/constants"
 import { tv } from "~/lib/tv"
 import { getBreadcrumbFromSiteMap } from "~/utils/getBreadcrumbFromSiteMap"
 import { getTableOfContents } from "~/utils/getTableOfContents"
@@ -32,8 +33,12 @@ export const IndexPageLayout = ({
     page.permalink.split("/").slice(1),
   )
 
+  const hasChildpageBlock = content.some(({ type }) => type === "childrenpages")
+  const pageContent: IndexPageSchemaType["content"] = hasChildpageBlock
+    ? content
+    : [...content, DEFAULT_CHILDREN_PAGES_BLOCK]
   // auto-inject ids for heading level 2 blocks if does not exist
-  const transformedContent = getTransformedPageContent(content)
+  const transformedContent = getTransformedPageContent(pageContent)
   const tableOfContents = getTableOfContents(site, transformedContent)
 
   return (


### PR DESCRIPTION
## Problem

Index pages were not correctly displaying the children pages block when one wasn't explicitly present in the content. The check to auto-inject the default children pages block was missing, causing index pages to appear without their child page listings.

## Solution

Added back the missing logic to check if a `childrenpages` block exists in the index page content. If no children pages block is present, the default `DEFAULT_CHILDREN_PAGES_BLOCK` is automatically appended to the page content before rendering.

**Changes:**
- Import `DEFAULT_CHILDREN_PAGES_BLOCK` constant from `~/interfaces/complex/ChildrenPages/constants`
- Check if content already has a `childrenpages` block using `content.some(({ type }) => type === "childrenpages")`
- If not present, append the default children pages block to the content
- Pass the updated `pageContent` to `getTransformedPageContent()` instead of raw `content`

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Index pages now correctly display the children pages block even when one isn't explicitly defined in the page content

## Before & After Screenshots

**BEFORE**:
Index pages without an explicit children pages block would not show child pages.

**AFTER**:
Index pages automatically include the default children pages block if one isn't present.

## Tests

- [ ] Create a folder with child pages/folders/collections
- [ ] Ensure the index page of the folder does NOT have an explicit children pages block in its content
- [ ] View the index page - it should now display the children pages automatically
- [ ] Verify that index pages WITH an explicit children pages block still work correctly

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A