### PR TITLE
chore: adjust CollectionTable spacing and count text

### DIFF
--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -132,31 +132,39 @@ export const CollectionTable = ({
             Sort by:
           </Text>
           <Menu size="sm" variant="clear">
-            <Menu.Button
-              variant="clear"
-              size="sm"
-              p="0"
-              minH="auto"
-              colorScheme="sub"
-              fontSize="0.75rem"
-            >
-              {COLLECTION_TABLE_SORT_OPTIONS[sortOption]}
-            </Menu.Button>
-            <Menu.List pt="0.75rem" pb="0.5rem">
-              {Object.entries(COLLECTION_TABLE_SORT_OPTIONS).map(
-                ([option, label]) => (
-                  <Menu.Item
-                    key={option}
-                    onClick={() => {
-                      setSortOption(option as CollectionTableSortOptions)
-                      onPaginationChange((old) => ({ ...old, pageIndex: 0 }))
-                    }}
-                  >
-                    {label}
-                  </Menu.Item>
-                ),
-              )}
-            </Menu.List>
+            {({ isOpen }) => (
+              <>
+                <Menu.Button
+                  variant="clear"
+                  size="sm"
+                  p="0"
+                  minH="auto"
+                  colorScheme="sub"
+                  fontSize="0.75rem"
+                  isOpen={isOpen}
+                >
+                  {COLLECTION_TABLE_SORT_OPTIONS[sortOption]}
+                </Menu.Button>
+                <Menu.List pt="0.75rem" pb="0.5rem">
+                  {Object.entries(COLLECTION_TABLE_SORT_OPTIONS).map(
+                    ([option, label]) => (
+                      <Menu.Item
+                        key={option}
+                        onClick={() => {
+                          setSortOption(option as CollectionTableSortOptions)
+                          onPaginationChange((old) => ({
+                            ...old,
+                            pageIndex: 0,
+                          }))
+                        }}
+                      >
+                        {label}
+                      </Menu.Item>
+                    ),
+                  )}
+                </Menu.List>
+              </>
+            )}
           </Menu>
         </HStack>
       </HStack>

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -117,7 +117,12 @@ export const CollectionTable = ({
 
   return (
     <>
-      <HStack px="0.75rem" mb="-0.25rem" w="full" justifyContent="space-between">
+      <HStack
+        px="0.75rem"
+        mb="-0.25rem"
+        w="full"
+        justifyContent="space-between"
+      >
         <Text textStyle="caption-1" color="base.content.default">
           {totalRowCount} {totalRowCount === 1 ? "item" : "items"}
         </Text>
@@ -137,7 +142,7 @@ export const CollectionTable = ({
             >
               {COLLECTION_TABLE_SORT_OPTIONS[sortOption]}
             </Menu.Button>
-            <Menu.List>
+            <Menu.List pt="0.75rem" pb="0.5rem">
               {Object.entries(COLLECTION_TABLE_SORT_OPTIONS).map(
                 ([option, label]) => (
                   <Menu.Item

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -117,9 +117,9 @@ export const CollectionTable = ({
 
   return (
     <>
-      <HStack px="0.75rem" w="full" justifyContent="space-between">
+      <HStack px="0.75rem" mb="-0.25rem" w="full" justifyContent="space-between">
         <Text textStyle="caption-1" color="base.content.default">
-          {totalRowCount} items
+          {totalRowCount} {totalRowCount === 1 ? "item" : "items"}
         </Text>
 
         <HStack>
@@ -129,7 +129,7 @@ export const CollectionTable = ({
           <Menu size="sm" variant="clear">
             <Menu.Button
               variant="clear"
-              size="xs"
+              size="sm"
               p="0"
               minH="auto"
               colorScheme="sub"


### PR DESCRIPTION
## Problem

The `CollectionTable` header on the dashboard had minor visual issues: the spacing between the count row and the table felt loose, the sort menu button used an `xs` size that didn't match adjacent controls, and the item count always read "items" even when there was only one item (e.g. "1 items").

## Solution

Tightens the gap beneath the header row with a negative bottom margin, bumps the sort menu button from `xs` to `sm` for visual consistency, and pluralizes the count label correctly based on `totalRowCount`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Tighten spacing between the `CollectionTable` header row and the table body
- Increase sort menu button size from `xs` to `sm` to align with neighboring controls
- Pluralize count label: show `1 item` when there is a single row, `N items` otherwise

**Bug Fixes**:

- Fix grammatical issue where a single-row collection displayed "1 items"

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Log into Studio and open a site that contains a collection
- [ ] Navigate to the collection's dashboard view so the `CollectionTable` renders
- [ ] Verify the count text reads "N items" when there are 2+ rows and "1 item" when there is exactly one row
- [ ] Confirm the spacing between the count/sort header row and the table body looks tight (no extra gap)
- [ ] Confirm the sort menu button is visually consistent in size with other adjacent header controls
- [ ] Click the sort menu and confirm it still opens and functions correctly