### PR TITLE
Force homepage anti-scam banner GrowthBook flag in Storybook

### DIFF
--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -53,9 +53,18 @@ const StorybookEnvDecorator: Decorator = (story) => {
 
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
-  const forcedGrowthbookFeatures = new Map<string, unknown>(
-    parameters.growthbook ?? [],
-  )
+  const forcedGrowthbookFeatures = new Map<string, unknown>()
+  if (Array.isArray(parameters.growthbook)) {
+    for (const feature of parameters.growthbook) {
+      if (
+        Array.isArray(feature) &&
+        feature.length === 2 &&
+        typeof feature[0] === "string"
+      ) {
+        forcedGrowthbookFeatures.set(feature[0], feature[1])
+      }
+    }
+  }
   forcedGrowthbookFeatures.set(
     IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
     true,

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -28,6 +28,7 @@ import { DefaultFallback } from "~/components/ErrorBoundary"
 import Suspense from "~/components/Suspense"
 import { env } from "~/env.mjs"
 import { LoginStateContext } from "~/features/auth"
+import { IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { theme } from "~/theme"
 
 import { viewport, withChromaticModes } from "@isomer/storybook-config"
@@ -52,8 +53,12 @@ const StorybookEnvDecorator: Decorator = (story) => {
 
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
+  const forcedGrowthbookFeatures = new Map<string, unknown>([
+    [IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY, true],
+    ...(parameters.growthbook ?? []),
+  ])
   // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
-  gb.setForcedFeatures(new Map(parameters.growthbook ?? []))
+  gb.setForcedFeatures(forcedGrowthbookFeatures)
 
   const [queryClient] = useState(
     new QueryClient({

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -53,18 +53,9 @@ const StorybookEnvDecorator: Decorator = (story) => {
 
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
-  const forcedGrowthbookFeatures = new Map<string, unknown>()
-  if (Array.isArray(parameters.growthbook)) {
-    for (const feature of parameters.growthbook) {
-      if (
-        Array.isArray(feature) &&
-        feature.length === 2 &&
-        typeof feature[0] === "string"
-      ) {
-        forcedGrowthbookFeatures.set(feature[0], feature[1])
-      }
-    }
-  }
+  const forcedGrowthbookFeatures = new Map<string, unknown>(
+    parameters.growthbook ?? [],
+  )
   forcedGrowthbookFeatures.set(
     IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
     true,

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -54,7 +54,9 @@ const StorybookEnvDecorator: Decorator = (story) => {
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
   // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
-  const forcedGrowthbookFeatures = new Map<string, unknown>(parameters.growthbook ?? [])
+  const forcedGrowthbookFeatures = new Map<string, unknown>(
+    parameters.growthbook ?? [],
+  )
   forcedGrowthbookFeatures.set(
     IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
     true,

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -53,10 +53,13 @@ const StorybookEnvDecorator: Decorator = (story) => {
 
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
-  const forcedGrowthbookFeatures = new Map<string, unknown>([
-    [IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY, true],
-    ...(parameters.growthbook ?? []),
-  ])
+  const forcedGrowthbookFeatures = new Map<string, unknown>(
+    parameters.growthbook ?? [],
+  )
+  forcedGrowthbookFeatures.set(
+    IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
+    true,
+  )
   // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
   gb.setForcedFeatures(forcedGrowthbookFeatures)
 

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -53,9 +53,8 @@ const StorybookEnvDecorator: Decorator = (story) => {
 
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
-  const forcedGrowthbookFeatures = new Map<string, unknown>(
-    parameters.growthbook ?? [],
-  )
+  // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const forcedGrowthbookFeatures = new Map<string, unknown>(parameters.growthbook ?? [])
   forcedGrowthbookFeatures.set(
     IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
     true,

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -53,8 +53,10 @@ const StorybookEnvDecorator: Decorator = (story) => {
 
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
-  // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
-  const forcedGrowthbookFeatures = new Map<string, unknown>(parameters.growthbook ?? [])
+  const forcedGrowthbookFeatures = new Map<string, unknown>(
+    // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
+    parameters.growthbook ?? [],
+  )
   forcedGrowthbookFeatures.set(
     IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
     true,

--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -54,9 +54,7 @@ const StorybookEnvDecorator: Decorator = (story) => {
 const SetupDecorator: Decorator = (Story, { parameters }) => {
   const gb = new GrowthBook()
   // oxlint-disable-next-line @typescript-eslint/no-unsafe-argument
-  const forcedGrowthbookFeatures = new Map<string, unknown>(
-    parameters.growthbook ?? [],
-  )
+  const forcedGrowthbookFeatures = new Map<string, unknown>(parameters.growthbook ?? [])
   forcedGrowthbookFeatures.set(
     IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
     true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Storybook did not globally force the `homepage-antiscam-banner-enabled` GrowthBook feature, so stories could render without anti-scam banner behavior unless each story explicitly provided that feature override.

A lint error was triggered by directly passing `parameters.growthbook` (typed as `any`) into `new Map(...)`.

Closes [insert issue #]

## Solution

Kept the simple Storybook GrowthBook setup and addressed lint via targeted `oxlint` suppression comment, per request.

In `apps/studio/.storybook/preview.tsx`:
- `SetupDecorator` still initializes forced features using:
  - `new Map<string, unknown>(parameters.growthbook ?? [])`
- `homepage-antiscam-banner-enabled` is explicitly set to `true` afterwards so it remains enabled for all stories.
- Added a line-level `oxlint-disable-next-line @typescript-eslint/no-unsafe-argument` directly above the `new Map(...)` call.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Storybook always enables the homepage anti-scam banner GrowthBook flag.

**Improvements**:

- Minimal-change lint handling via explicit oxlint comment.

**Bug Fixes**:

- Fixes inconsistent Storybook behavior for anti-scam-banner-gated UI.
- Restores lint pass after GrowthBook Storybook update.

## Before & After Screenshots

**BEFORE**:

<!-- N/A (configuration change) -->

**AFTER**:

<!-- N/A (configuration change) -->

## Tests

**Manual Verification Steps**:

- [x] Run `npm run lint` at repo root; ensure it passes.
- [ ] Run Studio Storybook and open homepage-related stories.
- [ ] Confirm `homepage-antiscam-banner-enabled` is enabled.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d90b094-1438-442f-ada4-897cce4b5498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d90b094-1438-442f-ada4-897cce4b5498"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

