### PR TITLE
feat: add Polyglot translation widget

### DIFF
--- a/packages/components/src/interfaces/internal/Polyglot.ts
+++ b/packages/components/src/interfaces/internal/Polyglot.ts
@@ -1,0 +1,5 @@
+import type { ScriptComponentType } from "~/types"
+
+export interface PolyglotProps {
+  ScriptComponent?: ScriptComponentType
+}

--- a/packages/components/src/interfaces/internal/Polyglot.ts
+++ b/packages/components/src/interfaces/internal/Polyglot.ts
@@ -2,4 +2,5 @@ import type { ScriptComponentType } from "~/types"
 
 export interface PolyglotProps {
   ScriptComponent?: ScriptComponentType
+  isStaging?: boolean
 }

--- a/packages/components/src/interfaces/internal/Polyglot.ts
+++ b/packages/components/src/interfaces/internal/Polyglot.ts
@@ -1,0 +1,5 @@
+import type { IsomerSiteProps } from "~/types"
+
+export interface PolyglotProps {
+  environment: IsomerSiteProps["environment"]
+}

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -72,3 +72,4 @@ export {
   type NativeSearchableTableProps,
   type DGSSearchableTableProps,
 } from "./SearchableTable"
+export type { PolyglotProps } from "./Polyglot"

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -73,6 +73,7 @@ export {
   type ZendeskProps,
 } from "./Zendesk"
 export type { ImageClientProps } from "./Image"
+export type { PolyglotProps } from "./Polyglot"
 export {
   SearchableTableSchema,
   type SearchableTableProps,

--- a/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/ContentPageHeader/ContentPageHeader.tsx
@@ -91,7 +91,7 @@ export const ContentPageHeader = ({
             )}
             <div
               className={styles.lastUpdated()}
-            >{`Last updated ${getFormattedDate(lastUpdated)}`}</div>
+            >{`Last updated on ${getFormattedDate(lastUpdated)}`}</div>
           </div>
 
           {hasImage && showThumbnail && (

--- a/packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx
@@ -2,9 +2,10 @@
 
 import type { IsomerSiteProps } from "~/types"
 
-interface ClientCopyrightProps {
-  isGovernment: IsomerSiteProps["isGovernment"]
-  agencyName: string
+interface ClientCopyrightProps extends Pick<
+  IsomerSiteProps,
+  "isGovernment" | "agencyName"
+> {
   // Pre-formatted on the server so date-fns stays out of the client bundle.
   formattedLastUpdated: string
 }

--- a/packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { getFormattedDate } from "~/utils/getFormattedDate"
+
+interface ClientCopyrightProps {
+  isGovernment?: boolean
+  agencyName: string
+  lastUpdated: string
+}
+
+// Rendered on the client so the copyright year reflects the visitor's current
+// year rather than the (static) build-time year.
+export const ClientCopyright = ({
+  isGovernment,
+  agencyName,
+  lastUpdated,
+}: ClientCopyrightProps) => {
+  return `© ${new Date().getFullYear()} ${isGovernment ? "Government of Singapore" : agencyName}, last updated on ${getFormattedDate(lastUpdated)}`
+}

--- a/packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { getFormattedDate } from "~/utils/getFormattedDate"
+import type { IsomerSiteProps } from "~/types"
 
 interface ClientCopyrightProps {
-  isGovernment?: boolean
+  isGovernment: IsomerSiteProps["isGovernment"]
   agencyName: string
-  lastUpdated: string
+  // Pre-formatted on the server so date-fns stays out of the client bundle.
+  formattedLastUpdated: string
 }
 
 // Rendered on the client so the copyright year reflects the visitor's current
@@ -13,7 +14,7 @@ interface ClientCopyrightProps {
 export const ClientCopyright = ({
   isGovernment,
   agencyName,
-  lastUpdated,
+  formattedLastUpdated,
 }: ClientCopyrightProps) => {
-  return `© ${new Date().getFullYear()} ${isGovernment ? "Government of Singapore" : agencyName}, last updated on ${getFormattedDate(lastUpdated)}`
+  return `© ${new Date().getFullYear()} ${isGovernment ? "Government of Singapore" : agencyName}, last updated on ${formattedLastUpdated}`
 }

--- a/packages/components/src/templates/next/components/internal/Footer/ClientCopyrightYear.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/ClientCopyrightYear.tsx
@@ -1,5 +1,0 @@
-"use client"
-
-export const ClientCopyrightYear = () => {
-  return <>&copy; {new Date().getFullYear()}</>
-}

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -24,6 +24,7 @@ import { IsomerLogo } from "~/assets/IsomerLogo"
 import { OgpLogo } from "~/assets/OgpLogo"
 import { tv } from "~/lib/tv"
 import { twMerge } from "~/lib/twMerge"
+import { getFormattedDate } from "~/utils/getFormattedDate"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 import { focusVisibleHighlight } from "~/utils/tailwind"
@@ -240,7 +241,7 @@ const LegalSection = ({
           <ClientCopyright
             isGovernment={isGovernment}
             agencyName={agencyName}
-            lastUpdated={lastUpdated}
+            formattedLastUpdated={getFormattedDate(lastUpdated)}
           />
         </p>
         <div className="prose-body-sm flex flex-col gap-3 lg:flex-row lg:gap-8">

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -24,13 +24,12 @@ import { IsomerLogo } from "~/assets/IsomerLogo"
 import { OgpLogo } from "~/assets/OgpLogo"
 import { tv } from "~/lib/tv"
 import { twMerge } from "~/lib/twMerge"
-import { getFormattedDate } from "~/utils/getFormattedDate"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 import { focusVisibleHighlight } from "~/utils/tailwind"
 
 import { Link } from "../Link"
-import { ClientCopyrightYear } from "./ClientCopyrightYear"
+import { ClientCopyright } from "./ClientCopyright"
 
 const SocialMediaTypeToIconMap: Record<SocialMediaType, IconType> = {
   facebook: FaFacebook,
@@ -238,9 +237,11 @@ const LegalSection = ({
     <div className="flex h-full">
       <div className="flex flex-col justify-end gap-4 lg:gap-2">
         <p className="prose-label-md-regular text-base-content-inverse-subtle">
-          <ClientCopyrightYear />{" "}
-          {isGovernment ? "Government of Singapore" : agencyName}, last updated{" "}
-          {getFormattedDate(lastUpdated)}
+          <ClientCopyright
+            isGovernment={isGovernment}
+            agencyName={agencyName}
+            lastUpdated={lastUpdated}
+          />
         </p>
         <div className="prose-body-sm flex flex-col gap-3 lg:flex-row lg:gap-8">
           {isGovernment && (

--- a/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
+++ b/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
@@ -1,0 +1,13 @@
+import type { PolyglotProps } from "~/interfaces"
+
+export const Polyglot = ({ ScriptComponent = "script" }: PolyglotProps) => {
+  // to not render during static site generation on the server
+  if (typeof window === "undefined") return null
+  return (
+    <ScriptComponent
+      defer
+      type="text/javascript"
+      src="https://isomer-user-content-stg.by.gov.sg/polyglot/polyglot.widget.js"
+    />
+  )
+}

--- a/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
+++ b/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
@@ -1,12 +1,10 @@
 import type { PolyglotProps } from "~/interfaces"
 
 export const Polyglot = ({ ScriptComponent = "script" }: PolyglotProps) => {
-  // to not render during static site generation on the server
-  if (typeof window === "undefined") return null
   return (
     <ScriptComponent
-      defer
       type="text/javascript"
+      // src="http://localhost:3001/polyglot.widget.js"
       src="https://isomer-user-content-stg.by.gov.sg/polyglot/polyglot.widget.js"
     />
   )

--- a/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
+++ b/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
@@ -1,11 +1,17 @@
 import type { PolyglotProps } from "~/interfaces"
 
-export const Polyglot = ({ ScriptComponent = "script" }: PolyglotProps) => {
+export const Polyglot = ({
+  ScriptComponent = "script",
+  isStaging = false,
+}: PolyglotProps) => {
+  const host = isStaging
+    ? "staging-assets.polyglot.gov.sg"
+    : "assets.polyglot.gov.sg"
+
   return (
     <ScriptComponent
       type="text/javascript"
-      // src="http://localhost:3001/polyglot.widget.js"
-      src="https://isomer-user-content-stg.by.gov.sg/polyglot/polyglot.widget.js"
+      src={`https://${host}/polyglot.widget.js`}
     />
   )
 }

--- a/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
+++ b/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import type { PolyglotProps } from "~/interfaces"
+import { useInteractionScriptLoader } from "~/hooks/useInteractionScriptLoader"
+
+// Reference: https://polyglot.gov.sg
+export const Polyglot = ({ environment }: PolyglotProps) => {
+  const scriptUrl =
+    environment === "staging"
+      ? "https://staging-assets.polyglot.gov.sg/widget.js"
+      : "https://assets.polyglot.gov.sg/widget.js"
+
+  useInteractionScriptLoader({ src: scriptUrl })
+
+  return <div id="polyglot-widget" />
+}

--- a/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
+++ b/packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { PolyglotProps } from "~/interfaces"
-import { useInteractionScriptLoader } from "~/hooks/useInteractionScriptLoader"
+import { useScript } from "usehooks-ts"
 
 // Reference: https://polyglot.gov.sg
 export const Polyglot = ({ environment }: PolyglotProps) => {
@@ -10,7 +10,7 @@ export const Polyglot = ({ environment }: PolyglotProps) => {
       ? "https://staging-assets.polyglot.gov.sg/widget.js"
       : "https://assets.polyglot.gov.sg/widget.js"
 
-  useInteractionScriptLoader({ src: scriptUrl })
+  useScript(scriptUrl)
 
   return <div id="polyglot-widget" />
 }

--- a/packages/components/src/templates/next/components/internal/Polyglot/index.ts
+++ b/packages/components/src/templates/next/components/internal/Polyglot/index.ts
@@ -1,0 +1,1 @@
+export { Polyglot } from "./Polyglot"

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -23,13 +23,10 @@ export const Skeleton = ({
   return (
     <>
       <ScrollToTop />
-      <div id="polyglot-widget"></div>
+      {site.enablePolyglot && <Polyglot />}
       <header>
         <SkipToContent LinkComponent={LinkComponent} />
-
         {site.isGovernment && <Masthead isStaging={isStaging} />}
-        {site.enablePolyglot && <Polyglot />}
-
         {site.notification?.title && (
           <Notification
             {...site.notification}
@@ -37,9 +34,7 @@ export const Skeleton = ({
             site={site}
           />
         )}
-
         <UnsupportedBrowserBanner />
-
         <Navbar
           logoUrl={site.logoUrl}
           logoAlt={site.siteName}
@@ -56,6 +51,7 @@ export const Skeleton = ({
         tabIndex={-1}
         className="focus-visible:outline-none"
       >
+        <div id="polyglot-widget"></div>
         {children}
       </main>
 

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -23,7 +23,7 @@ export const Skeleton = ({
   return (
     <>
       <ScrollToTop />
-      {site.enablePolyglot && <Polyglot />}
+      {site.enablePolyglot && <Polyglot isStaging={isStaging} />}
       <header>
         <SkipToContent LinkComponent={LinkComponent} />
         {site.isGovernment && <Masthead isStaging={isStaging} />}

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -4,6 +4,7 @@ import { Footer } from "../../components/internal/Footer"
 import { Masthead } from "../../components/internal/Masthead"
 import { Navbar } from "../../components/internal/Navbar"
 import { Notification } from "../../components/internal/Notification"
+import { Polyglot } from "../../components/internal/Polyglot"
 import { ScrollToTop } from "../../components/internal/ScrollToTop"
 import { SkipToContent } from "../../components/internal/SkipToContent"
 import { UnsupportedBrowserBanner } from "../../components/internal/UnsupportedBrowserBanner"
@@ -22,11 +23,12 @@ export const Skeleton = ({
   return (
     <>
       <ScrollToTop />
-
+      <div id="polyglot-widget"></div>
       <header>
         <SkipToContent LinkComponent={LinkComponent} />
 
         {site.isGovernment && <Masthead isStaging={isStaging} />}
+        {site.enablePolyglot && <Polyglot />}
 
         {site.notification?.title && (
           <Notification

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -23,7 +23,6 @@ export const Skeleton = ({
   return (
     <>
       <ScrollToTop />
-      <Polyglot />
       {site.enablePolyglot && <Polyglot />}
       <header>
         <SkipToContent LinkComponent={LinkComponent} />

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -23,6 +23,7 @@ export const Skeleton = ({
   return (
     <>
       <ScrollToTop />
+      <Polyglot />
       {site.enablePolyglot && <Polyglot />}
       <header>
         <SkipToContent LinkComponent={LinkComponent} />

--- a/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
+++ b/packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx
@@ -4,6 +4,7 @@ import { Footer } from "../../components/internal/Footer"
 import { Masthead } from "../../components/internal/Masthead"
 import { Navbar } from "../../components/internal/Navbar"
 import { Notification } from "../../components/internal/Notification"
+import { Polyglot } from "../../components/internal/Polyglot"
 import { ScrollToTop } from "../../components/internal/ScrollToTop"
 import { SkipToContent } from "../../components/internal/SkipToContent"
 import { UnsupportedBrowserBanner } from "../../components/internal/UnsupportedBrowserBanner"
@@ -52,6 +53,7 @@ export const Skeleton = ({
         tabIndex={-1}
         className="focus-visible:outline-none"
       >
+        {site.enablePolyglot && <Polyglot environment={site.environment} />}
         {children}
       </main>
 

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -100,6 +100,13 @@ export const SiteConfigSchema = Type.Intersect([
         format: "hidden",
       }),
     ),
+    enablePolyglot: Type.Optional(
+      Type.Boolean({
+        title: "Enable Polyglot",
+        description: "Whether to enable Polyglot on the site.",
+        format: "hidden",
+      }),
+    ),
   }),
   NotificationSettingsSchema,
 ])

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -109,6 +109,13 @@ export const SiteConfigSchema = Type.Intersect([
         format: "hidden",
       }),
     ),
+    enablePolyglot: Type.Optional(
+      Type.Boolean({
+        title: "Enable Polyglot",
+        description: "Whether to enable Polyglot on the site.",
+        format: "hidden",
+      }),
+    ),
   }),
   NotificationSettingsSchema,
 ])


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 10 | +65 | -10 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Isomer sites have no built-in way to surface the Polyglot translation widget. We want agencies to be able to opt in to Polyglot on a per-site basis, loading the widget from the correct environment-specific CDN.

## Solution

Adds a new internal `Polyglot` component that loads the Polyglot widget script and renders its mount point, gated behind a new optional `site.enablePolyglot` site config flag.

Following the existing third-party widget conventions (`Askgov`, `Vica`):

- The script is loaded via `useInteractionScriptLoader`, so the large third-party bundle only loads after the first user interaction (or a short timeout). This keeps it out of the Total Blocking Time window that Lighthouse/WOGAA measure.
- The widget host is derived from `site.environment`: staging sites load from `staging-assets.polyglot.gov.sg`, and all other environments load from `assets.polyglot.gov.sg`.
- The component renders its `<div id="polyglot-widget" />` mount point at the top of the page content (`<main>`) in `Skeleton`, so the widget appears above the rest of the page.

This PR also tidies up the footer copyright line: it now reads "last updated on <date>" (matching the content page header) and inlines the copyright year, removing the now-redundant `ClientCopyrightYear` client component.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible (`enablePolyglot` is an optional field)

**Features**:

- New optional `enablePolyglot` boolean on `SiteConfigSchema` (hidden field) to opt a site into the Polyglot widget.
- New internal `Polyglot` component at `packages/components/src/templates/next/components/internal/Polyglot` that loads the Polyglot widget script and renders its mount point.
- `Polyglot` derives the widget host from `site.environment` and defers loading via `useInteractionScriptLoader`.
- `Skeleton` conditionally renders `<Polyglot environment={site.environment} />` at the top of `<main>` when `site.enablePolyglot` is true.

**Improvements**:

- Footer copyright line now reads "last updated on <date>", consistent with the content page header.

**Bug Fixes**:

- N/A

## Tests

**Manual Verification Steps**:

- [ ] On a staging site with `enablePolyglot: true`, load any page, interact (scroll/click), and confirm the DOM gains a `<script src="https://staging-assets.polyglot.gov.sg/widget.js">` tag.
- [ ] On a production site with `enablePolyglot: true`, load any page, interact, and confirm the DOM gains a `<script src="https://assets.polyglot.gov.sg/widget.js">` tag.
- [ ] On a site with `enablePolyglot` unset or false, load any page and confirm no Polyglot script tag is ever added.
- [ ] On a site with `enablePolyglot: true`, confirm the Polyglot widget mounts into `#polyglot-widget` and renders its translation UI at the top of the page.
- [ ] Confirm enabling Polyglot does not visibly break layout, navbar, masthead, or notifications.
- [ ] Confirm the footer now reads "... last updated on <date>" with the current copyright year.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an opt-in Polyglot translation widget and updates footer date wording. The main changes are:

- Optional hidden `site.enablePolyglot` config flag.
- New internal `Polyglot` client component with environment-specific widget script URLs.
- Conditional Polyglot rendering at the top of `main` in `Skeleton`.
- Footer copyright text moved into a client component so the year stays current.
- Last-updated copy aligned to “Last updated on …”.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The new site field is optional, the widget follows existing deferred third-party script loading patterns, and the footer keeps the copyright year client-rendered.

No files require special attention.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before changes, the polyglot opt-in state showed no widget or scripts and the staging environment timed out on opt-in.
- After interaction, the head staging state showed the polyglot widget present and scripts loaded, with production later loading the widget script as well and opt-out remaining false.
- The harness source and validation config were saved to enable repeatable tests for polyglot opt-in verification.
- The footer wording update was captured, showing the updated inline year and the new phrasing consistent with the page header.
- The site-config polyglot validation harness was executed, validating enablePolyglot metadata and enforcing required fields while rejecting invalid strings.

<a href="https://app.greptile.com/trex/runs/13251676/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/components/internal/Polyglot/Polyglot.tsx | Adds a client Polyglot widget mount that defers loading the correct environment-specific script through the existing interaction loader. |
| packages/components/src/templates/next/layouts/Skeleton/Skeleton.tsx | Conditionally renders the Polyglot mount at the start of main content when the optional site flag is enabled. |
| packages/components/src/types/site.ts | Adds an optional hidden `enablePolyglot` site config flag without breaking existing site schemas. |
| packages/components/src/templates/next/components/internal/Footer/ClientCopyright.tsx | Replaces the year-only client component with a client-rendered full copyright line. |
| packages/components/src/templates/next/components/internal/Footer/Footer.tsx | Uses the new client copyright component while keeping last-updated formatting server-side. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Site as Site config
participant Skeleton as Skeleton layout
participant Polyglot as Polyglot client component
participant Loader as useInteractionScriptLoader
participant CDN as Polyglot CDN

Site->>Skeleton: enablePolyglot + environment
alt enablePolyglot is true
    Skeleton->>Polyglot: render with environment
    Polyglot->>Loader: register script URL
    alt environment is staging
        Polyglot->>Loader: staging-assets.polyglot.gov.sg/widget.js
    else other environments
        Polyglot->>Loader: assets.polyglot.gov.sg/widget.js
    end
    Loader->>CDN: load script after interaction or timeout
    CDN-->>Polyglot: "widget mounts into #polyglot-widget"
else enablePolyglot is false or unset
    Skeleton-->>Site: no Polyglot mount or script
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Site as Site config
participant Skeleton as Skeleton layout
participant Polyglot as Polyglot client component
participant Loader as useInteractionScriptLoader
participant CDN as Polyglot CDN

Site->>Skeleton: enablePolyglot + environment
alt enablePolyglot is true
    Skeleton->>Polyglot: render with environment
    Polyglot->>Loader: register script URL
    alt environment is staging
        Polyglot->>Loader: staging-assets.polyglot.gov.sg/widget.js
    else other environments
        Polyglot->>Loader: assets.polyglot.gov.sg/widget.js
    end
    Loader->>CDN: load script after interaction or timeout
    CDN-->>Polyglot: "widget mounts into #polyglot-widget"
else enablePolyglot is false or unset
    Skeleton-->>Site: no Polyglot mount or script
end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Polyglot script loads before the requested user interaction checkpoint**

   - **Bug**
     - In the head build, both enabled scenarios insert the environment-specific Polyglot script before the test's explicit click interaction. The validation contract expected the mount point to exist immediately but the widget.js script to be absent until user interaction or the fallback timeout. The DOM evidence records `https://staging-assets.polyglot.gov.sg/widget.js` and `https://assets.polyglot.gov.sg/widget.js` already present in `document.scripts` at the BEFORE checkpoint.
   - **Cause**
     - `Polyglot.tsx` calls `useInteractionScriptLoader({ src: scriptUrl })`, whose default 3000ms timeout can fire during initial page load/waiting before the manual interaction checkpoint, so the script may be inserted without user interaction.
   - **Fix**
     - If the contract requires script absence until a real interaction in manual verification, pass a longer/disabled timeout for Polyglot or adjust the loader to distinguish interaction-triggered loading from timeout-triggered loading in the expected timing window.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["refactor(footer): Pick ClientCopyright p..."](https://github.com/opengovsg/isomer/commit/7b934069f6011797ce9e133043f82ad7b22cc0de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39747116)</sub>

<!-- /greptile_comment -->