### PR TITLE
style: reduce site notification padding and revise typography

### DIFF
--- a/apps/studio/public/assets/css/preview-tw.css
+++ b/apps/studio/public/assets/css/preview-tw.css
@@ -783,7 +783,7 @@ video {
   line-height: 1.2;
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 768px) {
   .prose-display-md {
     font-size: 2.25rem;
   }
@@ -792,25 +792,12 @@ video {
 .prose-display-sm {
   font-weight: 600;
   letter-spacing: -0.022em;
-  font-size: 1.5rem;
-  line-height: 1.2;
-}
-
-@media (min-width: 1024px) {
-  .prose-display-sm {
-    font-size: 1.938rem;
-  }
-}
-
-.prose-display-xs {
-  font-weight: 600;
-  letter-spacing: -0.022em;
   font-size: 1.25rem;
   line-height: 1.2;
 }
 
 @media (min-width: 1024px) {
-  .prose-display-xs {
+  .prose-display-sm {
     font-size: 1.5rem;
   }
 }
@@ -1176,6 +1163,10 @@ video {
   top: 0px;
 }
 
+.top-1 {
+  top: 0.25rem;
+}
+
 .top-1\/2 {
   top: 50%;
 }
@@ -1226,6 +1217,10 @@ video {
 
 .col-span-3 {
   grid-column: span 3 / span 3;
+}
+
+.col-span-full {
+  grid-column: 1 / -1;
 }
 
 .row-span-1 {
@@ -1444,6 +1439,10 @@ video {
 
 .mt-9 {
   margin-top: 2.25rem;
+}
+
+.mt-\[3px\] {
+  margin-top: 3px;
 }
 
 .box-border {
@@ -2206,6 +2205,10 @@ video {
   align-content: center;
 }
 
+.content-start {
+  align-content: flex-start;
+}
+
 .items-start {
   align-items: flex-start;
 }
@@ -2369,6 +2372,10 @@ video {
   row-gap: 1rem;
 }
 
+.gap-y-5 {
+  row-gap: 1.25rem;
+}
+
 .gap-y-8 {
   row-gap: 2rem;
 }
@@ -2459,6 +2466,10 @@ video {
   border-radius: 1rem;
 }
 
+.rounded-\[0\.25rem\] {
+  border-radius: 0.25rem;
+}
+
 .rounded-\[10px\] {
   border-radius: 10px;
 }
@@ -2485,6 +2496,16 @@ video {
 
 .rounded-sm {
   border-radius: 0.125rem;
+}
+
+.rounded-l-sm {
+  border-top-left-radius: 0.125rem;
+  border-bottom-left-radius: 0.125rem;
+}
+
+.rounded-t-md {
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
 }
 
 .border {
@@ -4637,6 +4658,11 @@ video {
   color: rgb(75 85 99 / var(--tw-text-opacity));
 }
 
+.group:where([data-rac])[data-hovered] .group-hover\:text-link-hover {
+  --tw-text-opacity: 1;
+  color: rgb(21 71 190 / var(--tw-text-opacity));
+}
+
 .group:where([data-rac])[data-hovered] .group-hover\:underline {
   text-decoration-line: underline;
 }
@@ -4685,6 +4711,11 @@ video {
 .group:where(:not([data-rac])):hover .group-hover\:text-gray-600 {
   --tw-text-opacity: 1;
   color: rgb(75 85 99 / var(--tw-text-opacity));
+}
+
+.group:where(:not([data-rac])):hover .group-hover\:text-link-hover {
+  --tw-text-opacity: 1;
+  color: rgb(21 71 190 / var(--tw-text-opacity));
 }
 
 .group:where(:not([data-rac])):hover .group-hover\:underline {
@@ -4943,6 +4974,11 @@ video {
   color: rgb(17 24 39 / var(--tw-text-opacity));
 }
 
+.focus-visible\:text-content-strong:where([data-rac])[data-focus-visible] {
+  --tw-text-opacity: 1;
+  color: rgb(44 46 52 / var(--tw-text-opacity));
+}
+
 .focus-visible\:decoration-transparent:where([data-rac])[data-focus-visible] {
   text-decoration-color: transparent;
 }
@@ -5082,6 +5118,11 @@ video {
 .focus-visible\:text-base-content-strong:where(:not([data-rac])):focus-visible {
   --tw-text-opacity: 1;
   color: rgb(17 24 39 / var(--tw-text-opacity));
+}
+
+.focus-visible\:text-content-strong:where(:not([data-rac])):focus-visible {
+  --tw-text-opacity: 1;
+  color: rgb(44 46 52 / var(--tw-text-opacity));
 }
 
 .focus-visible\:decoration-transparent:where(:not([data-rac])):focus-visible {
@@ -5449,6 +5490,20 @@ video {
   .max-md\:gap-y-5 {
     row-gap: 1.25rem;
   }
+
+  .max-md\:border-b {
+    border-bottom-width: 1px;
+  }
+
+  .max-md\:border-b-base-divider-subtle {
+    --tw-border-opacity: 1;
+    border-bottom-color: rgb(226 232 240 / var(--tw-border-opacity));
+  }
+
+  .max-md\:px-5 {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+  }
 }
 
 @media (min-width: 576px) {
@@ -5634,6 +5689,10 @@ video {
 
   .md\:col-span-2 {
     grid-column: span 2 / span 2;
+  }
+
+  .md\:col-span-3 {
+    grid-column: span 3 / span 3;
   }
 
   .md\:col-span-4 {
@@ -5865,6 +5924,15 @@ video {
     row-gap: 1.25rem;
   }
 
+  .md\:border-r {
+    border-right-width: 1px;
+  }
+
+  .md\:border-r-base-divider-subtle {
+    --tw-border-opacity: 1;
+    border-right-color: rgb(226 232 240 / var(--tw-border-opacity));
+  }
+
   .md\:p-12 {
     padding: 3rem;
   }
@@ -5893,6 +5961,11 @@ video {
     padding-bottom: 4rem;
   }
 
+  .md\:py-4 {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
   .md\:py-5 {
     padding-top: 1.25rem;
     padding-bottom: 1.25rem;
@@ -5915,6 +5988,10 @@ video {
     padding-bottom: 6rem;
   }
 
+  .md\:pr-5 {
+    padding-right: 1.25rem;
+  }
+
   .md\:pt-0 {
     padding-top: 0px;
   }
@@ -5930,6 +6007,10 @@ video {
   .md\:text-5xl {
     font-size: 3rem;
     line-height: 1;
+  }
+
+  .md\:text-\[2\.25rem\] {
+    font-size: 2.25rem;
   }
 
   @media not all and (min-width: 1024px) {

--- a/packages/components/src/stories/helpers/generateSiteConfig.ts
+++ b/packages/components/src/stories/helpers/generateSiteConfig.ts
@@ -20,15 +20,6 @@ export const generateSiteConfig = (
     isGovernment: true,
     url: "https://www.isomer.gov.sg",
     logoUrl: "/isomer-logo.svg",
-    notification: {
-      title: "Government officials will never ask you to transfer money over a phone call.",
-      content: [
-        {
-          type: "text",
-          text: "If you're unsure if something is a scam, call ScamShield at 1799.",
-        },
-      ],
-    },
     navbar: {
       items: [
         {

--- a/packages/components/src/stories/helpers/generateSiteConfig.ts
+++ b/packages/components/src/stories/helpers/generateSiteConfig.ts
@@ -20,6 +20,15 @@ export const generateSiteConfig = (
     isGovernment: true,
     url: "https://www.isomer.gov.sg",
     logoUrl: "/isomer-logo.svg",
+    notification: {
+      title: "Government officials will never ask you to transfer money over a phone call.",
+      content: [
+        {
+          type: "text",
+          text: "If you're unsure if something is a scam, call ScamShield at 1799.",
+        },
+      ],
+    },
     navbar: {
       items: [
         {

--- a/packages/components/src/templates/next/components/internal/Notification/Notification.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/Notification.stories.tsx
@@ -20,54 +20,7 @@ const meta: Meta<NotificationProps> = {
 export default meta
 type Story = StoryObj<typeof Notification>
 
-export const NoTitle: Story = {
-  args: {
-    content: {
-      type: "prose",
-      content: [
-        {
-          type: "paragraph",
-          content: [
-            {
-              text: "This site will be on maintenance from 0900 to 1400 (Standard Singapore Time) this Tuesday, 24th May. E-services may be intermittently available during this period. For more information, please reach out to ",
-              type: "text",
-            },
-            {
-              text: "hello@example.com",
-              type: "text",
-              marks: [
-                {
-                  type: "link",
-                  attrs: {
-                    href: "mailto:hello@example.com",
-                    target: "_blank",
-                  },
-                },
-              ],
-            },
-            { text: ". ", type: "text" },
-          ],
-        },
-      ],
-    },
-  },
-}
-
-export const ShortText: Story = {
-  args: {
-    content: {
-      type: "prose",
-      content: [
-        {
-          type: "paragraph",
-          content: [{ type: "text", text: "This is a short notification" }],
-        },
-      ],
-    },
-  },
-}
-
-export const WithTitle: Story = {
+export const TitleAndDescription: Story = {
   args: {
     title: "This is a staging site for internal testing purposes.",
     content: {
@@ -78,6 +31,65 @@ export const WithTitle: Story = {
           content: [
             {
               text: "Contents on this site are neither accurate nor are representative of any Ministry's views. ",
+              type: "text",
+            },
+            {
+              text: "Internal link",
+              type: "text",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "/internal-link",
+                  },
+                },
+              ],
+            },
+            { text: ", ", type: "text" },
+            {
+              text: "external link",
+              type: "text",
+              marks: [
+                {
+                  type: "link",
+                  attrs: {
+                    href: "https://open.gov.sg/",
+                    target: "_blank",
+                  },
+                },
+              ],
+            },
+            { text: ".", type: "text" },
+          ],
+        },
+      ],
+    },
+  },
+}
+
+export const ShortTitle: Story = {
+  args: {
+    title: "Short notification with just a title. Description is optional.",
+  },
+}
+
+export const LongTitle: Story = {
+  args: {
+    title: "This is a staging site for internal testing purposes. You should not use this site for any official purposes. This is a long title that spans multiple lines.",
+  },
+}
+
+export const LongContent: Story = {
+  args: {
+    title: "This is a staging site for internal testing purposes. You should not use this site for any official purposes. This is a long title that spans multiple lines.",
+    content: {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              text: "Contents on this site are neither accurate nor are representative of any Ministry's views. It may contain outdated or incorrect information. For accurate information, go to individual agency websites. ",
               type: "text",
             },
             {

--- a/packages/components/src/templates/next/components/internal/Notification/Notification.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/Notification.stories.tsx
@@ -75,13 +75,15 @@ export const ShortTitle: Story = {
 
 export const LongTitle: Story = {
   args: {
-    title: "This is a staging site for internal testing purposes. You should not use this site for any official purposes. This is a long title that spans multiple lines.",
+    title:
+      "This is a staging site for internal testing purposes. You should not use this site for any official purposes. This is a long title that spans multiple lines.",
   },
 }
 
 export const LongContent: Story = {
   args: {
-    title: "This is a staging site for internal testing purposes. You should not use this site for any official purposes. This is a long title that spans multiple lines.",
+    title:
+      "This is a staging site for internal testing purposes. You should not use this site for any official purposes. This is a long title that spans multiple lines.",
     content: {
       type: "prose",
       content: [

--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -19,17 +19,17 @@ export const NotificationClient = ({
   return (
     !isDismissed && (
       <div className="bg-utility-feedback-info-faint">
-        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
-          <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
+        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-5">
+          <BiInfoCircle className="mt-0.5 h-5 w-5 shrink-0" />
           <div className="flex flex-1 flex-col gap-1">
-            {!!title && <h2 className="prose-headline-lg-medium">{title}</h2>}
+            {!!title && <h2 className="prose-headline-base-medium">{title}</h2>}
             <div className="[&_p]:!mb-0 [&_p]:!mt-0">{children}</div>
           </div>
           <div aria-hidden className="flex h-6 w-6 shrink-0" />
           <IconButton
             onPress={onDismiss}
             icon={BiX}
-            className="absolute right-3 top-[22px] md:right-7 md:top-3.5"
+            className="absolute right-3 top-3 md:right-7 md:top-3"
             aria-label="Dismiss notification temporarily"
           />
         </div>

--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -19,11 +19,15 @@ export const NotificationClient = ({
   return (
     !isDismissed && (
       <div className="bg-utility-feedback-info-faint">
-        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-4">
-          <BiInfoCircle className="mt-[3px] h-4 w-4 shrink-0" />
-          <div className="flex flex-1 flex-col gap-0.5">
-            {!!title && <h2 className="prose-headline-base-medium">{title}</h2>}
-            <div className="[&_p]:!mb-0 [&_p]:!mt-0">{children}</div>
+        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-4 text-base-content md:px-10 md:py-4">
+          <div className="flex flex-row gap-2">
+            <BiInfoCircle className="mt-[3px] h-4 w-4 shrink-0" />
+            <div className="flex flex-1 flex-col gap-0.5">
+              {!!title && (
+                <h2 className="prose-headline-base-medium">{title}</h2>
+              )}
+              <div className="[&_p]:!mb-0 [&_p]:!mt-0">{children}</div>
+            </div>
           </div>
           <div aria-hidden className="flex h-6 w-6 shrink-0" />
           <IconButton

--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -19,8 +19,8 @@ export const NotificationClient = ({
   return (
     !isDismissed && (
       <div className="bg-utility-feedback-info-faint">
-        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-5">
-          <BiInfoCircle className="mt-0.5 h-5 w-5 shrink-0" />
+        <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-4">
+          <BiInfoCircle className="mt-[3px] h-4 w-4 shrink-0" />
           <div className="flex flex-1 flex-col gap-1">
             {!!title && <h2 className="prose-headline-base-medium">{title}</h2>}
             <div className="[&_p]:!mb-0 [&_p]:!mt-0">{children}</div>
@@ -29,7 +29,7 @@ export const NotificationClient = ({
           <IconButton
             onPress={onDismiss}
             icon={BiX}
-            className="absolute right-3 top-3 md:right-7 md:top-3"
+            className="absolute right-3 top-1 md:right-7"
             aria-label="Dismiss notification temporarily"
           />
         </div>

--- a/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Notification/NotificationClient.tsx
@@ -21,7 +21,7 @@ export const NotificationClient = ({
       <div className="bg-utility-feedback-info-faint">
         <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-4">
           <BiInfoCircle className="mt-[3px] h-4 w-4 shrink-0" />
-          <div className="flex flex-1 flex-col gap-1">
+          <div className="flex flex-1 flex-col gap-0.5">
             {!!title && <h2 className="prose-headline-base-medium">{title}</h2>}
             <div className="[&_p]:!mb-0 [&_p]:!mt-0">{children}</div>
           </div>

--- a/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
@@ -35,11 +35,11 @@ export const UnsupportedBrowserBanner = ({
 
   return (
     <div className="bg-utility-feedback-warning">
-      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-4 px-6 py-8 text-base-content md:px-10 md:py-6">
-        <BiInfoCircle className="mt-0.5 h-6 w-6 shrink-0" />
+      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-5">
+        <BiInfoCircle className="mt-0.5 h-5 w-5 shrink-0" />
         <div className="flex flex-1 flex-col gap-1">
-          <div className="base-content-default prose-headline-lg-medium [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">
-            This browser is not supported
+          <div className="base-content-default prose-headline-base-medium [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">
+            This browser is not supported.
           </div>
           <div className="prose-body-base [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">
             Your experience on this site might not be ideal. Please update to

--- a/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
+++ b/packages/components/src/templates/next/components/internal/UnsupportedBrowserBanner/UnsupportedBrowserBanner.tsx
@@ -35,9 +35,9 @@ export const UnsupportedBrowserBanner = ({
 
   return (
     <div className="bg-utility-feedback-warning">
-      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-5">
-        <BiInfoCircle className="mt-0.5 h-5 w-5 shrink-0" />
-        <div className="flex flex-1 flex-col gap-1">
+      <div className="relative mx-auto flex max-w-screen-xl flex-row gap-2 px-6 py-4 text-base-content md:px-10 md:py-4">
+        <BiInfoCircle className="mt-[3px] h-4 w-4 shrink-0" />
+        <div className="flex flex-1 flex-col gap-0.5">
           <div className="base-content-default prose-headline-base-medium [&:not(:first-child)]:mt-0 [&:not(:last-child)]:mb-0">
             This browser is not supported.
           </div>


### PR DESCRIPTION
## Problem

- Site notification was too tall. It was taking up critical real estate especially on mobile.
- Font sizes were too big.

Closes [ISOM-2015]

## Solution

- Reduced padding on site notification, used smaller font token, other minor style changes
- Applied same styling to `unsupported browsers banner`
- Removed stories with no title (not allowed), added stories with title only and long title

## Before & After Screenshots

**BEFORE**:

Notif:
<img width="1205" height="221" alt="image" src="https://github.com/user-attachments/assets/f8cea6d4-d27b-48d9-9661-e80b44d7d31a" />

Unsupported browser banner:
<img width="1168" height="144" alt="image" src="https://github.com/user-attachments/assets/3b6f4664-b881-4bae-a217-3e3103bb931b" />

**AFTER**:

Notif:
<img width="1222" height="201" alt="image" src="https://github.com/user-attachments/assets/c91ce312-8885-4d1f-9738-60f52c0f5327" />

Unsupported browser banner:
<img width="1220" height="143" alt="image" src="https://github.com/user-attachments/assets/c478b9c5-9589-4ae0-93df-0d8dfcdf692d" />

## Tests

- Visually review site notification at different content lengths and breakpoints 