### PR TITLE
chore(components): remove unused Rollup toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32015,27 +32015,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-dts": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "LGPL-3.0-only",
-      "dependencies": {
-        "magic-string": "^0.30.17"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Swatinem"
-      },
-      "optionalDependencies": {
-        "@babel/code-frame": "^7.26.2"
-      },
-      "peerDependencies": {
-        "rollup": "^3.29.4 || ^4",
-        "typescript": "^4.5 || ^5.0"
-      }
-    },
     "node_modules/rooks": {
       "version": "7.14.1",
       "license": "MIT",
@@ -36652,8 +36631,6 @@
         "postcss-preset-env": "^10.0.8",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "rollup": "^4.32.1",
-        "rollup-plugin-dts": "^6.2.1",
         "storybook": "9.1.19",
         "storybook-addon-pseudo-states": "9.1.19",
         "tailwindcss": "^3.4.4",
@@ -36808,7 +36785,7 @@
       "devDependencies": {
         "@isomer/tsconfig": "*",
         "@types/node": "^22.15.21",
-        "typescript": "*"
+        "typescript": "latest"
       }
     },
     "tooling/oxlint": {
@@ -36954,7 +36931,7 @@
         "@isomer/migrate-tags": "*",
         "@isomer/tsconfig": "*",
         "@types/node": "^22.15.21",
-        "typescript": "*"
+        "typescript": "latest"
       }
     },
     "tooling/storybook": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -48,8 +48,6 @@
     "lint": "oxlint --type-aware .",
     "lint:fix": "oxlint --type-aware --fix .",
     "prebuild": "rimraf dist",
-    "publish-package": "rollup -c && npm run publish",
-    "rollup": "rollup -c",
     "storybook": "storybook dev -p 6006",
     "supportedBrowsers": "echo \"export default $(browserslist-useragent-regexp --allowHigherVersions)\" > src/utils/supportedBrowsers.ts",
     "test": "run-s test:*",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -116,8 +116,6 @@
     "postcss-preset-env": "^10.0.8",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "rollup": "^4.32.1",
-    "rollup-plugin-dts": "^6.2.1",
     "storybook": "9.1.19",
     "storybook-addon-pseudo-states": "9.1.19",
     "tailwindcss": "^3.4.4",


### PR DESCRIPTION
## Problem

The `@opengovsg/isomer-components` package listed Rollup and `rollup-plugin-dts` as dev dependencies and exposed `rollup` / `publish-package` scripts even though the package build already uses TypeScript (`tsc` / `tsc-alias`) for `dist` output. That added unnecessary install surface and maintenance noise without affecting the published library.

## Solution

Remove the unused Rollup-related dev dependencies and npm scripts from `packages/components/package.json`, and refresh `package-lock.json` so the dependency tree no longer pulls in Rollup or `rollup-plugin-dts`. The lockfile also reflects updated TypeScript version pins for affected workspace entries (`typescript` moved from `*` to `latest` where applicable).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Smaller dev dependency tree for the components package and fewer redundant scripts (`publish-package`, `rollup`).
- Aligns declared tooling with the actual build path (TypeScript-only builds).

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

N/A (dependency and script cleanup only)

**AFTER**:

N/A

## Tests

CI should continue to pass for `packages/components` (build, lint, tests). No application behaviour changes.

**New scripts**:

- None

**New dependencies**:

- None

**Removed dev dependencies** (from `@opengovsg/isomer-components`):

- `rollup`
- `rollup-plugin-dts`

**New dev dependencies**:

- None
