### PR TITLE
🔖 feat(studio): Refresh collection index drawer and dashboard copy

### DIFF
--- a/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
@@ -10,6 +10,7 @@ import { Badge, BadgeLeftIcon } from "@opengovsg/design-system-react"
 import Link from "next/link"
 import { useEffect } from "react"
 import { BiChevronRight, BiSolidCircle } from "react-icons/bi"
+import { useNewCollectionEditingExperience } from "~/hooks/useNewCollectionEditingExperience"
 import { trpc } from "~/utils/trpc"
 import { ResourceState } from "~prisma/generated/generatedEnums"
 
@@ -47,6 +48,9 @@ export const IndexpageRow = ({
     siteId,
     resourceId,
   ])
+
+  const isNewCollectionEditingExperienceEnabled =
+    useNewCollectionEditingExperience()
 
   return (
     <Skeleton w="full" isLoaded={!isPending && !!data}>
@@ -86,7 +90,10 @@ export const IndexpageRow = ({
           {/* as a relative time. */}
           {/* we also need to give the user who did the update */}
           <Text textStyle="caption-2" textColor="base.content.medium">
-            {getIndexPageSubtitle(type)}
+            {getIndexPageSubtitle({
+              type,
+              isNewCollectionEditingExperienceEnabled,
+            })}
           </Text>
         </VStack>
         <Text

--- a/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
@@ -22,7 +22,7 @@ export const getIndexPageSubtitle = (
 ): string => {
   switch (type) {
     case "collection":
-      return "Manage how your Collection looks like and behaves"
+      return "Manage the Collection’s layout, filters, and sorting."
     case "folder":
       return "Customise the index page for this folder"
     default:

--- a/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
@@ -17,12 +17,18 @@ export const getIndexPageIcon = (
   }
 }
 
-export const getIndexPageSubtitle = (
-  type: ResourceTypesWithIndexPage,
-): string => {
+export const getIndexPageSubtitle = ({
+  type,
+  isNewCollectionEditingExperienceEnabled = false,
+}: {
+  type: ResourceTypesWithIndexPage
+  isNewCollectionEditingExperienceEnabled: boolean
+}) => {
   switch (type) {
     case "collection":
-      return "Manage the Collection’s layout, filters, and sorting."
+      return isNewCollectionEditingExperienceEnabled
+        ? "Manage the Collection’s layout, filters, and sorting."
+        : "Manage how your Collection looks like and behaves"
     case "folder":
       return "Customise the index page for this folder"
     default:

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -9,6 +9,7 @@ export interface BaseBlockProps {
   dragHandle?: React.ReactNode
   label: string
   description?: string
+  variant?: "horizontal" | "vertical"
   containerProps?: StackProps
   onClick?: () => void
   draggableProps?: DraggableProvidedDragHandleProps | null
@@ -23,6 +24,7 @@ export const BaseBlock = ({
   dragHandle,
   label,
   description,
+  variant = "horizontal",
   draggableProps,
   containerProps,
   onClick,
@@ -92,10 +94,10 @@ export const BaseBlock = ({
           borderColor: "utility.feedback.critical",
         }}
         bg={isHidden ? "gray.100" : "white"}
-        py="0.75rem"
-        px="0.75rem"
+        py={variant === "vertical" ? "1.25rem" : "0.75rem"}
+        px={variant === "vertical" ? "1.25rem" : "0.75rem"}
         flexDirection="row"
-        align="center"
+        align={variant === "vertical" ? "flex-start" : "center"}
         textAlign="start"
         onClick={onClick}
         opacity={isHidden ? 0.7 : 1}
@@ -103,31 +105,66 @@ export const BaseBlock = ({
         {...containerProps}
       >
         {dragHandle}
-        {icon && (
-          <Flex
-            p="0.25rem"
-            bg={isHidden ? "gray.200" : "interaction.main-subtle.default"}
-            borderRadius="4px"
-            mr="0.25rem"
-          >
-            <Icon
-              as={icon}
-              fontSize="0.75rem"
-              color={isHidden ? "base.content.medium" : "base.content.default"}
-            />
+        {variant === "vertical" ? (
+          <Flex direction="column" align="flex-start" gap="0.75rem">
+            <Flex
+              p="0.25rem"
+              bg="interaction.main-subtle.default"
+              borderRadius="0.25rem"
+              align="center"
+              justify="center"
+            >
+              <Icon
+                as={icon}
+                boxSize="1.25rem"
+                flexShrink={0}
+                color="base.content.default"
+              />
+            </Flex>
+            <Stack
+              align="start"
+              gap="0.25rem"
+              overflow="auto"
+              w="100%"
+              minW={0}
+            >
+              <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
+                {label}
+              </Text>
+              <Description />
+            </Stack>
           </Flex>
+        ) : (
+          <>
+            {icon && (
+              <Flex
+                p="0.25rem"
+                bg={isHidden ? "gray.200" : "interaction.main-subtle.default"}
+                borderRadius="4px"
+                mr="0.25rem"
+              >
+                <Icon
+                  as={icon}
+                  fontSize="0.75rem"
+                  color={
+                    isHidden ? "base.content.medium" : "base.content.default"
+                  }
+                />
+              </Flex>
+            )}
+            <Stack align="start" gap="0.25rem" overflow="auto">
+              <Text
+                textStyle="subhead-2"
+                noOfLines={1}
+                wordBreak="break-word"
+                color={isHidden ? "base.content.medium" : undefined}
+              >
+                {label}
+              </Text>
+              <Description />
+            </Stack>
+          </>
         )}
-        <Stack align="start" gap="0.25rem" overflow="auto">
-          <Text
-            textStyle="subhead-2"
-            noOfLines={1}
-            wordBreak="break-word"
-            color={isHidden ? "base.content.medium" : undefined}
-          >
-            {label}
-          </Text>
-          <Description />
-        </Stack>
       </HStack>
     )
   )

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -1,15 +1,13 @@
-import type { ButtonProps, StackProps } from "@chakra-ui/react"
+import type { ButtonProps, StackProps, IconProps } from "@chakra-ui/react"
 import type { DraggableProvidedDragHandleProps } from "@hello-pangea/dnd"
 import type { IconType } from "react-icons"
 import { chakra, Flex, HStack, Icon, Stack, Text } from "@chakra-ui/react"
 import { BiGridVertical, BiSolidErrorCircle } from "react-icons/bi"
 
-export interface BaseBlockProps {
-  icon?: IconType
+export type BaseBlockProps = {
   dragHandle?: React.ReactNode
   label: string
   description?: string
-  variant?: "horizontal" | "vertical"
   containerProps?: StackProps
   onClick?: () => void
   draggableProps?: DraggableProvidedDragHandleProps | null
@@ -17,14 +15,23 @@ export interface BaseBlockProps {
     description: string
   }
   isHidden?: boolean
-}
+} & (
+  | {
+      icon: IconType
+      iconProps?: IconProps
+    }
+  | {
+      icon?: undefined
+      iconProps?: never
+    }
+)
 
 export const BaseBlock = ({
   icon,
+  iconProps,
   dragHandle,
   label,
   description,
-  variant = "horizontal",
   draggableProps,
   containerProps,
   onClick,
@@ -97,59 +104,37 @@ export const BaseBlock = ({
         borderColor: "utility.feedback.critical",
       }}
       bg="white"
-      py={variant === "vertical" ? "1.25rem" : "0.75rem"}
-      px={variant === "vertical" ? "1.25rem" : "0.75rem"}
+      py="0.75rem"
+      px="0.75rem"
       flexDirection="row"
-      align={variant === "vertical" ? "flex-start" : "center"}
+      align="center"
       textAlign="start"
       onClick={onClick}
       {...actualDraggableProps}
       {...containerProps}
     >
       {dragHandle}
-      {variant === "vertical" ? (
-        <Flex direction="column" align="flex-start" gap="0.75rem">
-          <Flex
-            p="0.25rem"
-            bg="interaction.main-subtle.default"
-            borderRadius="0.25rem"
-            align="center"
-            justify="center"
-          >
-            <Icon
-              as={icon}
-              boxSize="1.25rem"
-              flexShrink={0}
-              color="base.content.default"
-            />
-          </Flex>
-          <Stack align="start" gap="0.25rem" overflow="auto" w="100%" minW={0}>
-            <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
-              {label}
-            </Text>
-            <Description />
-          </Stack>
+      {icon && (
+        <Flex
+          p="0.25rem"
+          bg="interaction.main-subtle.default"
+          borderRadius="0.25rem"
+          mr="0.25rem"
+        >
+          <Icon
+            as={icon}
+            fontSize="0.75rem"
+            color="base.content.default"
+            {...iconProps}
+          />
         </Flex>
-      ) : (
-        <>
-          {icon && (
-            <Flex
-              p="0.25rem"
-              bg="interaction.main-subtle.default"
-              borderRadius="4px"
-              mr="0.25rem"
-            >
-              <Icon as={icon} fontSize="0.75rem" color="base.content.default" />
-            </Flex>
-          )}
-          <Stack align="start" gap="0.25rem" overflow="auto">
-            <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
-              {label}
-            </Text>
-            <Description />
-          </Stack>
-        </>
       )}
+      <Stack align="start" gap="0.25rem" overflow="auto">
+        <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
+          {label}
+        </Text>
+        <Description />
+      </Stack>
     </HStack>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -155,7 +155,7 @@ export const BaseBlock = ({
                 textStyle="subhead-2"
                 noOfLines={1}
                 wordBreak="break-word"
-                color={isHidden ? "base.content.medium" : undefined}
+                color={undefined}
               >
                 {label}
               </Text>

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -139,7 +139,7 @@ export const BaseBlock = ({
             {icon && (
               <Flex
                 p="0.25rem"
-                bg={isHidden ? "gray.200" : "interaction.main-subtle.default"}
+                bg="interaction.main-subtle.default"
                 borderRadius="4px"
                 mr="0.25rem"
               >

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -30,7 +30,7 @@ export const BaseBlock = ({
   onClick,
   invalidProps,
   isHidden,
-}: BaseBlockProps): JSX.Element | false => {
+}: BaseBlockProps): JSX.Element | null => {
   const actualDraggableProps = draggableProps ?? {}
 
   const Description = () => {
@@ -65,106 +65,92 @@ export const BaseBlock = ({
     }
   }
 
+  if (isHidden) {
+    return null
+  }
+
   return (
-    !isHidden && (
-      <HStack
-        as="button"
-        layerStyle="focusRing"
-        w="100%"
-        borderRadius="6px"
-        border="1px solid"
-        borderColor="base.divider.medium"
-        transitionProperty="common"
-        transitionDuration="normal"
-        aria-invalid={!!invalidProps}
-        _hover={{
-          bg: "interaction.muted.main.hover",
-          borderColor: "interaction.main-subtle.hover",
-          _invalid: {
-            shadow: "0px 1px 6px 0px #C0343426",
-          },
-        }}
-        _active={{
-          bg: "interaction.main-subtle.default",
-          borderColor: "interaction.main-subtle.hover",
-          shadow: "0px 1px 6px 0px #1361F026",
-        }}
-        _invalid={{
-          bg: "utility.feedback.critical-subtle",
-          borderColor: "utility.feedback.critical",
-        }}
-        bg={isHidden ? "gray.100" : "white"}
-        py={variant === "vertical" ? "1.25rem" : "0.75rem"}
-        px={variant === "vertical" ? "1.25rem" : "0.75rem"}
-        flexDirection="row"
-        align={variant === "vertical" ? "flex-start" : "center"}
-        textAlign="start"
-        onClick={onClick}
-        opacity={isHidden ? 0.7 : 1}
-        {...actualDraggableProps}
-        {...containerProps}
-      >
-        {dragHandle}
-        {variant === "vertical" ? (
-          <Flex direction="column" align="flex-start" gap="0.75rem">
+    <HStack
+      as="button"
+      layerStyle="focusRing"
+      w="100%"
+      borderRadius="6px"
+      border="1px solid"
+      borderColor="base.divider.medium"
+      transitionProperty="common"
+      transitionDuration="normal"
+      aria-invalid={!!invalidProps}
+      _hover={{
+        bg: "interaction.muted.main.hover",
+        borderColor: "interaction.main-subtle.hover",
+        _invalid: {
+          shadow: "0px 1px 6px 0px #C0343426",
+        },
+      }}
+      _active={{
+        bg: "interaction.main-subtle.default",
+        borderColor: "interaction.main-subtle.hover",
+        shadow: "0px 1px 6px 0px #1361F026",
+      }}
+      _invalid={{
+        bg: "utility.feedback.critical-subtle",
+        borderColor: "utility.feedback.critical",
+      }}
+      bg="white"
+      py={variant === "vertical" ? "1.25rem" : "0.75rem"}
+      px={variant === "vertical" ? "1.25rem" : "0.75rem"}
+      flexDirection="row"
+      align={variant === "vertical" ? "flex-start" : "center"}
+      textAlign="start"
+      onClick={onClick}
+      {...actualDraggableProps}
+      {...containerProps}
+    >
+      {dragHandle}
+      {variant === "vertical" ? (
+        <Flex direction="column" align="flex-start" gap="0.75rem">
+          <Flex
+            p="0.25rem"
+            bg="interaction.main-subtle.default"
+            borderRadius="0.25rem"
+            align="center"
+            justify="center"
+          >
+            <Icon
+              as={icon}
+              boxSize="1.25rem"
+              flexShrink={0}
+              color="base.content.default"
+            />
+          </Flex>
+          <Stack align="start" gap="0.25rem" overflow="auto" w="100%" minW={0}>
+            <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
+              {label}
+            </Text>
+            <Description />
+          </Stack>
+        </Flex>
+      ) : (
+        <>
+          {icon && (
             <Flex
               p="0.25rem"
               bg="interaction.main-subtle.default"
-              borderRadius="0.25rem"
-              align="center"
-              justify="center"
+              borderRadius="4px"
+              mr="0.25rem"
             >
-              <Icon
-                as={icon}
-                boxSize="1.25rem"
-                flexShrink={0}
-                color="base.content.default"
-              />
+              <Icon as={icon} fontSize="0.75rem" color="base.content.default" />
             </Flex>
-            <Stack
-              align="start"
-              gap="0.25rem"
-              overflow="auto"
-              w="100%"
-              minW={0}
-            >
-              <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
-                {label}
-              </Text>
-              <Description />
-            </Stack>
-          </Flex>
-        ) : (
-          <>
-            {icon && (
-              <Flex
-                p="0.25rem"
-                bg="interaction.main-subtle.default"
-                borderRadius="4px"
-                mr="0.25rem"
-              >
-                <Icon
-                  as={icon}
-                  fontSize="0.75rem"
-                  color="base.content.default"
-                />
-              </Flex>
-            )}
-            <Stack align="start" gap="0.25rem" overflow="auto">
-              <Text
-                textStyle="subhead-2"
-                noOfLines={1}
-                wordBreak="break-word"
-                color={isHidden ? "base.content.medium" : undefined}
-              >
-                {label}
-              </Text>
-              <Description />
-            </Stack>
-          </>
-        )}
-      </HStack>
-    )
+          )}
+          <Stack align="start" gap="0.25rem" overflow="auto">
+            <Text textStyle="subhead-2" noOfLines={1} wordBreak="break-word">
+              {label}
+            </Text>
+            <Description />
+          </Stack>
+        </>
+      )}
+    </HStack>
   )
 }
 

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -146,9 +146,7 @@ export const BaseBlock = ({
                 <Icon
                   as={icon}
                   fontSize="0.75rem"
-                  color={
-                    isHidden ? "base.content.medium" : "base.content.default"
-                  }
+                  color="base.content.default"
                 />
               </Flex>
             )}

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -118,7 +118,8 @@ const FixedBlock = () => {
     isNewEditingExperienceEnabled
   ) {
     const containerProps: StackProps = {
-      p: "1.25rem",
+      px: "1.25rem",
+      py: "1.25rem",
       flexDirection: "column",
       gap: "0.75rem",
       align: "flex-start",

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -20,7 +20,14 @@ import {
   schema,
 } from "@opengovsg/isomer-components"
 import { useCallback, useState } from "react"
-import { BiCog, BiData, BiPin, BiPlus, BiPlusCircle } from "react-icons/bi"
+import {
+  BiCog,
+  BiData,
+  BiPin,
+  BiPlus,
+  BiPlusCircle,
+  BiSlider,
+} from "react-icons/bi"
 import { Disable } from "~/components/Disable"
 import { DEFAULT_BLOCKS } from "~/components/PageEditor/constants"
 import { BlockEditingPlaceholder } from "~/components/Svg"
@@ -106,15 +113,23 @@ const FixedBlock = () => {
     isNewEditingExperienceEnabled
   ) {
     return (
-      <BaseBlock
-        onClick={() => {
-          setCurrActiveIdx(0)
-          setDrawerState({ state: "collectionEditor" })
-        }}
-        label="Collection settings"
-        description="Summary, style, categories and sorting"
-        icon={BiPin}
-      />
+      <>
+        <BaseBlock
+          onClick={() => {
+            setCurrActiveIdx(0)
+            setDrawerState({ state: "collectionEditor" })
+          }}
+          label="Collection display"
+          description="Customise the Collection’s Summary, Layout, Sorting logic, and Thumbnail."
+          icon={BiCog}
+        />
+        <BaseBlock
+          onClick={() => console.log("to implement")}
+          label="Filters"
+          description="Define and manage filters for this Collection."
+          icon={BiSlider}
+        />
+      </>
     )
   }
 
@@ -344,6 +359,8 @@ export default function RootStateDrawer() {
   // for collection index pages
   const canAddBlocks = pageLayout !== "collection"
 
+  const isNewEditingExperienceEnabled = useNewCollectionEditingExperience()
+
   return (
     <Flex direction="column" h="full">
       <ConfirmConvertIndexPageModal
@@ -417,185 +434,201 @@ export default function RootStateDrawer() {
             </Infobox>
           )}
 
-          <Disable when={disableBlocks}>
-            <VStack gap="1.5rem" flex={1} w="full">
-              {/* Fixed Blocks Section */}
-              <VStack gap="1rem" w="100%" align="start">
-                <VStack gap="0.25rem" align="start">
-                  <Text textStyle="subhead-1">
-                    {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection
-                      ? "Manage Collection"
-                      : "Fixed blocks"}
-                  </Text>
-                  <Text textStyle="caption-2" color="base.content.medium">
-                    {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection
-                      ? "Modify the Collection's look and feel or manage filters."
-                      : "These are built into the layout, so you can't delete them."}
-                  </Text>
-                </VStack>
-
-                <FixedBlock />
+          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
+          isNewEditingExperienceEnabled ? (
+            <VStack gap="1rem" w="100%" align="start">
+              <VStack gap="0.25rem" align="start">
+                <Text textStyle="subhead-1">Manage Collection</Text>
+                <Text textStyle="caption-2" color="base.content.medium">
+                  Modify the Collection’s look and feel or manage filters.
+                </Text>
               </VStack>
 
-              {pageLayout === "index" && (
-                <Button
-                  // NOTE: Top offset is only `1rem` but the `gap` on parent component is `1.5rem`
-                  marginTop="-0.5rem"
-                  variant="link"
-                  gap="0.25rem"
-                  cursor="pointer"
-                  alignSelf="flex-start"
-                  onClick={() =>
-                    setDrawerState({ state: "siderailOrderingEditor" })
-                  }
-                >
-                  <Icon
-                    as={BiCog}
-                    color="interaction.main.default"
-                    boxSize="1.25rem"
-                  />
-                  <Text textStyle="subhead-2" color="interaction.links.default">
-                    Reorder siderail for this folder
-                  </Text>
-                </Button>
-              )}
+              <FixedBlock />
+            </VStack>
+          ) : (
+            <Disable when={disableBlocks}>
+              <VStack gap="1.5rem" flex={1} w="full">
+                {/* Fixed Blocks Section */}
+                <VStack gap="1rem" w="100%" align="start">
+                  <VStack gap="0.25rem" align="start">
+                    <Text textStyle="subhead-1">Fixed blocks</Text>
+                    <Text textStyle="caption-2" color="base.content.medium">
+                      These are built into the layout, so you can't delete them.
+                    </Text>
+                  </VStack>
 
-              {/* Custom Blocks Section */}
-              <VStack gap="1.5rem" w="100%">
-                <VStack w="100%" h="100%" gap="1rem">
-                  <Flex flexDirection="row" w="100%">
-                    {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection && (
-                      <VStack gap="0.25rem" align="start" flex={1}>
-                        <Text textStyle="subhead-1">Custom blocks</Text>
-                        <Text textStyle="caption-2" color="base.content.medium">
-                          Use blocks to display your content.
-                        </Text>
-                      </VStack>
-                    )}
-                    {/* TODO: we should swap over to using the `resource.type` */}
-                    {/* rather than the `page.layout` but we are unable to do so due */}
-                    {/* to the existence of custom index page that are `layout: */}
-                    {/* content` but have `resource.type: index` */}
-                    {canAddBlocks && (
-                      <Button
-                        size="xs"
-                        flexShrink={0}
-                        leftIcon={<BiPlusCircle fontSize="1.25rem" />}
-                        variant="clear"
-                        onClick={() => setDrawerState({ state: "addBlock" })}
-                      >
-                        Add block
-                      </Button>
-                    )}
-                  </Flex>
-                  <DragDropContext onDragEnd={onDragEnd}>
-                    <Droppable droppableId="blocks">
-                      {(provided) => (
-                        <VStack
-                          {...provided.droppableProps}
-                          w="100%"
-                          ref={provided.innerRef}
-                        >
-                          <Box w="100%">
-                            {!isPreviewingIndexPage &&
-                              ((isHeroFixedBlock &&
-                                savedPageState.content.length === 1) ||
-                                (savedPageState.content.length === 0 &&
-                                  canAddBlocks)) && (
-                                <>
-                                  <VStack
-                                    justifyContent="center"
-                                    spacing={0}
-                                    mt="2.75rem"
-                                    mb="1.5rem"
-                                  >
-                                    <BlockEditingPlaceholder />
-                                    <Text
-                                      mt="0.75rem"
-                                      textStyle="subhead-1"
-                                      color="base.content.default"
-                                    >
-                                      Blocks you add will appear here
-                                    </Text>
-                                    <Text
-                                      mt="0.25rem"
-                                      textStyle="caption-2"
-                                      color="base.content.medium"
-                                    >
-                                      Click the ‘Add block’ button above to add
-                                      blocks to this page
-                                    </Text>
-                                  </VStack>
+                  <FixedBlock />
+                </VStack>
 
-                                  <Button
-                                    variant="outline"
-                                    w="100%"
-                                    onClick={() =>
-                                      setDrawerState({ state: "addBlock" })
-                                    }
-                                    leftIcon={
-                                      <Icon as={BiPlus} fontSize="1.25rem" />
-                                    }
-                                  >
-                                    Add a new block
-                                  </Button>
-                                </>
-                              )}
+                {pageLayout === "index" && (
+                  <Button
+                    // NOTE: Top offset is only `1rem` but the `gap` on parent component is `1.5rem`
+                    marginTop="-0.5rem"
+                    variant="link"
+                    gap="0.25rem"
+                    cursor="pointer"
+                    alignSelf="flex-start"
+                    onClick={() =>
+                      setDrawerState({ state: "siderailOrderingEditor" })
+                    }
+                  >
+                    <Icon
+                      as={BiCog}
+                      color="interaction.main.default"
+                      boxSize="1.25rem"
+                    />
+                    <Text
+                      textStyle="subhead-2"
+                      color="interaction.links.default"
+                    >
+                      Reorder siderail for this folder
+                    </Text>
+                  </Button>
+                )}
 
-                            <Flex flexDirection="column" mt="-0.25rem">
-                              {previewPageState.content.map((block, index) => {
-                                if (isHeroFixedBlock && index === 0) {
-                                  return <></>
-                                }
-
-                                // Check if block is a hidden childrenpages block
-                                const isHiddenChildrenPages =
-                                  block.type === "childrenpages" &&
-                                  "isHidden" in block &&
-                                  block.isHidden
-
-                                return (
-                                  <DraggableBlock
-                                    block={block}
-                                    // TODO: Generate a block ID instead of index
-                                    key={`${block.type}-${index}`}
-                                    // TODO: Use block ID when instead of index for uniquely identifying blocks
-                                    draggableId={`${block.type}-${index}`}
-                                    index={index}
-                                    onClick={() => {
-                                      setCurrActiveIdx(index)
-                                      // TODO: we should automatically do this probably?
-                                      const nextState =
-                                        savedPageState.content[index]?.type ===
-                                        "prose"
-                                          ? "nativeEditor"
-                                          : "complexEditor"
-                                      // NOTE: SNAPSHOT
-                                      setDrawerState({ state: nextState })
-                                    }}
-                                    invalidProps={
-                                      invalidBlockIndexes.has(index)
-                                        ? {
-                                            description:
-                                              invalidBlockDescription,
-                                          }
-                                        : undefined
-                                    }
-                                    isHidden={isHiddenChildrenPages}
-                                  />
-                                )
-                              })}
-                            </Flex>
-                          </Box>
-                          {provided.placeholder}
+                {/* Custom Blocks Section */}
+                <VStack gap="1.5rem" w="100%">
+                  <VStack w="100%" h="100%" gap="1rem">
+                    <Flex flexDirection="row" w="100%">
+                      {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection && (
+                        <VStack gap="0.25rem" align="start" flex={1}>
+                          <Text textStyle="subhead-1">Custom blocks</Text>
+                          <Text
+                            textStyle="caption-2"
+                            color="base.content.medium"
+                          >
+                            Use blocks to display your content.
+                          </Text>
                         </VStack>
                       )}
-                    </Droppable>
-                  </DragDropContext>
+                      {/* TODO: we should swap over to using the `resource.type` */}
+                      {/* rather than the `page.layout` but we are unable to do so due */}
+                      {/* to the existence of custom index page that are `layout: */}
+                      {/* content` but have `resource.type: index` */}
+                      {canAddBlocks && (
+                        <Button
+                          size="xs"
+                          flexShrink={0}
+                          leftIcon={<BiPlusCircle fontSize="1.25rem" />}
+                          variant="clear"
+                          onClick={() => setDrawerState({ state: "addBlock" })}
+                        >
+                          Add block
+                        </Button>
+                      )}
+                    </Flex>
+                    <DragDropContext onDragEnd={onDragEnd}>
+                      <Droppable droppableId="blocks">
+                        {(provided) => (
+                          <VStack
+                            {...provided.droppableProps}
+                            w="100%"
+                            ref={provided.innerRef}
+                          >
+                            <Box w="100%">
+                              {!isPreviewingIndexPage &&
+                                ((isHeroFixedBlock &&
+                                  savedPageState.content.length === 1) ||
+                                  (savedPageState.content.length === 0 &&
+                                    canAddBlocks)) && (
+                                  <>
+                                    <VStack
+                                      justifyContent="center"
+                                      spacing={0}
+                                      mt="2.75rem"
+                                      mb="1.5rem"
+                                    >
+                                      <BlockEditingPlaceholder />
+                                      <Text
+                                        mt="0.75rem"
+                                        textStyle="subhead-1"
+                                        color="base.content.default"
+                                      >
+                                        Blocks you add will appear here
+                                      </Text>
+                                      <Text
+                                        mt="0.25rem"
+                                        textStyle="caption-2"
+                                        color="base.content.medium"
+                                      >
+                                        Click the ‘Add block’ button above to
+                                        add blocks to this page
+                                      </Text>
+                                    </VStack>
+
+                                    <Button
+                                      variant="outline"
+                                      w="100%"
+                                      onClick={() =>
+                                        setDrawerState({ state: "addBlock" })
+                                      }
+                                      leftIcon={
+                                        <Icon as={BiPlus} fontSize="1.25rem" />
+                                      }
+                                    >
+                                      Add a new block
+                                    </Button>
+                                  </>
+                                )}
+
+                              <Flex flexDirection="column" mt="-0.25rem">
+                                {previewPageState.content.map(
+                                  (block, index) => {
+                                    if (isHeroFixedBlock && index === 0) {
+                                      return <></>
+                                    }
+
+                                    // Check if block is a hidden childrenpages block
+                                    const isHiddenChildrenPages =
+                                      block.type === "childrenpages" &&
+                                      "isHidden" in block &&
+                                      block.isHidden
+
+                                    return (
+                                      <DraggableBlock
+                                        block={block}
+                                        // TODO: Generate a block ID instead of index
+                                        key={`${block.type}-${index}`}
+                                        // TODO: Use block ID when instead of index for uniquely identifying blocks
+                                        draggableId={`${block.type}-${index}`}
+                                        index={index}
+                                        onClick={() => {
+                                          setCurrActiveIdx(index)
+                                          // TODO: we should automatically do this probably?
+                                          const nextState =
+                                            savedPageState.content[index]
+                                              ?.type === "prose"
+                                              ? "nativeEditor"
+                                              : "complexEditor"
+                                          // NOTE: SNAPSHOT
+                                          setDrawerState({ state: nextState })
+                                        }}
+                                        invalidProps={
+                                          invalidBlockIndexes.has(index)
+                                            ? {
+                                                description:
+                                                  invalidBlockDescription,
+                                              }
+                                            : undefined
+                                        }
+                                        isHidden={isHiddenChildrenPages}
+                                      />
+                                    )
+                                  },
+                                )}
+                              </Flex>
+                            </Box>
+                            {provided.placeholder}
+                          </VStack>
+                        )}
+                      </Droppable>
+                    </DragDropContext>
+                  </VStack>
                 </VStack>
               </VStack>
-            </VStack>
-          </Disable>
+            </Disable>
+          )}
         </VStack>
       </VStack>
 

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -83,6 +83,10 @@ const FIXED_BLOCK_CONTENT: Record<string, FixedBlockContent> = {
 }
 
 const FixedBlock = () => {
+  const { isAdmin: isUserIsomerAdmin } = useIsUserIsomerAdmin({
+    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
+  })
+
   const { setCurrActiveIdx, setDrawerState, previewPageState } =
     useEditorDrawerContext()
   const pageLayout = previewPageState.layout
@@ -135,14 +139,16 @@ const FixedBlock = () => {
           icon={BiCog}
           iconProps={iconProps}
         />
-        <BaseBlock
-          onClick={() => console.log("to implement")}
-          label="Filters"
-          description="Define and manage filters for this Collection."
-          containerProps={containerProps}
-          icon={BiSlider}
-          iconProps={iconProps}
-        />
+        {isUserIsomerAdmin && (
+          <BaseBlock
+            onClick={() => console.log("to implement")}
+            label="Filters"
+            description="Define and manage filters for this Collection."
+            containerProps={containerProps}
+            icon={BiSlider}
+            iconProps={iconProps}
+          />
+        )}
       </>
     )
   }

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -1,3 +1,4 @@
+import type { StackProps, IconProps } from "@chakra-ui/react"
 import type { DropResult } from "@hello-pangea/dnd"
 import type {
   IsomerComponent,
@@ -112,24 +113,35 @@ const FixedBlock = () => {
     pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
     isNewEditingExperienceEnabled
   ) {
+    const containerProps: StackProps = {
+      p: "1.25rem",
+      flexDirection: "column",
+      gap: "0.75rem",
+      align: "flex-start",
+    }
+    const iconProps: IconProps = {
+      boxSize: "1.25rem",
+    }
     return (
       <>
         <BaseBlock
-          variant="vertical"
           onClick={() => {
             setCurrActiveIdx(0)
             setDrawerState({ state: "collectionEditor" })
           }}
           label="Collection display"
           description="Customise the Collection’s Summary, Layout, Sorting logic, and Thumbnail."
+          containerProps={containerProps}
           icon={BiCog}
+          iconProps={iconProps}
         />
         <BaseBlock
-          variant="vertical"
           onClick={() => console.log("to implement")}
           label="Filters"
           description="Define and manage filters for this Collection."
+          containerProps={containerProps}
           icon={BiSlider}
+          iconProps={iconProps}
         />
       </>
     )

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -115,6 +115,7 @@ const FixedBlock = () => {
     return (
       <>
         <BaseBlock
+          variant="vertical"
           onClick={() => {
             setCurrActiveIdx(0)
             setDrawerState({ state: "collectionEditor" })
@@ -124,6 +125,7 @@ const FixedBlock = () => {
           icon={BiCog}
         />
         <BaseBlock
+          variant="vertical"
           onClick={() => console.log("to implement")}
           label="Filters"
           description="Define and manage filters for this Collection."

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -438,16 +438,18 @@ export default function RootStateDrawer() {
 
           {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
           isNewEditingExperienceEnabled ? (
-            <VStack gap="1rem" w="100%" align="start">
-              <VStack gap="0.25rem" align="start">
-                <Text textStyle="subhead-1">Manage Collection</Text>
-                <Text textStyle="caption-2" color="base.content.medium">
-                  Modify the Collection’s look and feel or manage filters.
-                </Text>
-              </VStack>
+            <Disable when={disableBlocks}>
+              <VStack gap="1rem" w="100%" align="start">
+                <VStack gap="0.25rem" align="start">
+                  <Text textStyle="subhead-1">Manage Collection</Text>
+                  <Text textStyle="caption-2" color="base.content.medium">
+                    Modify the Collection’s look and feel or manage filters.
+                  </Text>
+                </VStack>
 
-              <FixedBlock />
-            </VStack>
+                <FixedBlock />
+              </VStack>
+            </Disable>
           ) : (
             <Disable when={disableBlocks}>
               <VStack gap="1.5rem" flex={1} w="full">

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -422,9 +422,15 @@ export default function RootStateDrawer() {
               {/* Fixed Blocks Section */}
               <VStack gap="1rem" w="100%" align="start">
                 <VStack gap="0.25rem" align="start">
-                  <Text textStyle="subhead-1">Fixed blocks</Text>
+                  <Text textStyle="subhead-1">
+                    {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection
+                      ? "Manage Collection"
+                      : "Fixed blocks"}
+                  </Text>
                   <Text textStyle="caption-2" color="base.content.medium">
-                    These are built into the layout, so you can't delete them.
+                    {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection
+                      ? "Modify the Collection's look and feel or manage filters."
+                      : "These are built into the layout, so you can't delete them."}
                   </Text>
                 </VStack>
 

--- a/apps/studio/src/stories/Page/CollectionPage.stories.tsx
+++ b/apps/studio/src/stories/Page/CollectionPage.stories.tsx
@@ -6,6 +6,7 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
+import { IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import CollectionPage from "~/pages/sites/[siteId]/collections/[collectionId]"
 
 import { createBannerGbParameters } from "../utils/growthbook"
@@ -118,5 +119,19 @@ export const ExpandedProfileDropdown: Story = {
     if (testUserSelectorButton) {
       await userEvent.click(testUserSelectorButton)
     }
+  },
+}
+
+export const NewCollectionEditingExperience: Story = {
+  parameters: {
+    growthbook: [
+      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText(
+      /Manage the Collection’s layout, filters, and sorting./i,
+    )
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -117,8 +117,36 @@ export const NewCollectionIndexEditingExperience: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
+    await canvas.findByText(/Manage Collection/i)
+  },
+}
+
+export const NewCollectionIndexEditingExperienceForDisplay: Story = {
+  parameters: {
+    growthbook: [
+      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
     const button = await canvas.findByRole("button", {
-      name: /Collection settings/i,
+      name: /Collection display/i,
+    })
+    await userEvent.click(button)
+    await canvas.findByText(/Edit collection settings/i)
+  },
+}
+
+export const NewCollectionIndexEditingExperienceForFilters: Story = {
+  parameters: {
+    growthbook: [
+      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const button = await canvas.findByRole("button", {
+      name: /Filters/i,
     })
     await userEvent.click(button)
   },

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -4,6 +4,7 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
+import { userHandlers } from "tests/msw/handlers/user"
 import { IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
@@ -109,11 +110,27 @@ export const WithBanner: Story = {
   },
 }
 
-export const NewCollectionIndexEditingExperience: Story = {
+export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
   parameters: {
     growthbook: [
       [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
     ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText(/Manage Collection/i)
+  },
+}
+
+// "Filters" block is currently only accessible by Isomer Admin
+export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
+  parameters: {
+    growthbook: [
+      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+    ],
+    msw: {
+      handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
@@ -137,11 +154,15 @@ export const NewCollectionIndexEditingExperienceForDisplay: Story = {
   },
 }
 
+// Currently only accessible by Isomer Admin
 export const NewCollectionIndexEditingExperienceForFilters: Story = {
   parameters: {
     growthbook: [
       [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
     ],
+    msw: {
+      handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
+    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)


### PR DESCRIPTION
## Problem

Collection index pages in Studio needed a clearer editing layout and copy when the **new collection editing experience** is enabled: the root drawer should surface collection-specific actions separately from generic “fixed blocks,” and the dashboard should describe collections consistently with that experience.

Closes https://linear.app/ogp/issue/ISOM-2283/refresh-collection-index-drawer-and-dashboard-copy

## Solution

This PR refreshes the collection index **root drawer** (behind the GrowthBook flag), tightens **BaseBlock** behaviour for this flow, and updates the **dashboard** subtitle for collection resources when the flag is on. **Storybook** coverage is expanded for the new experience, including Isomer Admin vs non-admin cases.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- **Manage Collection** section in `RootStateDrawer` when layout is `collection` and the new collection editing experience flag is enabled: heading, helper text, and fixed actions grouped separately from the generic “Fixed blocks” pattern.
- **Collection display** fixed action (replaces the previous single “Collection settings” entry for this flow): opens the collection editor; updated label and description; supports larger icon via `iconProps` and vertical spacing via `containerProps` on `BaseBlock`.
- **Filters** fixed action, shown only to **Isomer Admin** users (Core or Migrator roles): label, description, and slider icon. _(Click handler is still a placeholder pending implementation.)_
- Dashboard **collection** row subtitle uses `useNewCollectionEditingExperience()`: when the flag is on, copy is “Manage the Collection’s layout, filters, and sorting.”

**Improvements**:

- **`BaseBlock`**: discriminated props for optional `icon` vs `icon` + `iconProps`; early `return null` when `isHidden` instead of rendering a disabled-looking card; return type `null` instead of `false`; removed unused “hidden” styling branches since hidden blocks no longer render here.
- **`getIndexPageSubtitle`**: object parameter for `type` and `isNewCollectionEditingExperienceEnabled` for clearer call sites.
- **Storybook**: `CollectionPage` story asserting new subtitle when the flag is enabled; `EditCollectionIndexPage` stories split for non-admin vs Isomer Admin, plus display and filters interaction plays where applicable.

**Bug Fixes**:

- Code quality: address “useless conditional” findings in the drawer/block flow where appropriate.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Enable the **new collection editing experience** GrowthBook flag for your test user/site (same flag used by `useNewCollectionEditingExperience`).
- [ ] In the **dashboard**, open a site that has a **collection** resource: confirm the collection row subtitle reads **“Manage the Collection’s layout, filters, and sorting.”** with the flag on; with the flag off, confirm the previous subtitle still appears.
- [ ] Open a **collection index page** in the Studio editor with the flag on: confirm a **“Manage Collection”** section with helper text, then **Collection display** (and icon/spacing consistent with the updated layout).
- [ ] As a user **without** Isomer Admin (Core/Migrator): confirm the **Filters** block is **not** shown.
- [ ] As an **Isomer Admin** (Core or Migrator): confirm the **Filters** block **is** shown; clicking it currently only hits a placeholder handler (no full filters UI yet—verify no crash).
- [ ] Click **Collection display** and confirm the drawer transitions to the **collection** editor state as before.
- [ ] With the flag **off**, confirm collection index editing still uses the previous **“Fixed blocks”** drawer layout and behaviour.
