### PR TITLE
fix(studio): God Mode hub and navbar for migrators (whitelist-only links)

### DIFF
--- a/apps/studio/src/components/AppNavbar.tsx
+++ b/apps/studio/src/components/AppNavbar.tsx
@@ -11,7 +11,7 @@ import { AvatarMenu } from "./AvatarMenu"
 
 export function AppNavbar(): JSX.Element {
   const { isAdmin: isUserIsomerAdmin } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core],
+    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
   })
 
   return (

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -39,10 +39,6 @@ const GODMODE_LINKS: readonly GodmodeLink[] = [
   },
 ]
 
-const GODMODE_PAGE_ACCESS_ROLES: readonly IsomerAdminRole[] = [
-  ...new Set(GODMODE_LINKS.flatMap((link) => [...link.roles])),
-]
-
 const GodModePage: NextPageWithLayout = () => {
   const toast = useToast()
   const router = useRouter()
@@ -67,11 +63,8 @@ const GodModePage: NextPageWithLayout = () => {
   const visibleGodmodeLinks = GODMODE_LINKS.filter((link) =>
     link.roles.some((role) => userGodmodeRoles.has(role)),
   )
-  const canAccessGodmode = GODMODE_PAGE_ACCESS_ROLES.some((role) =>
-    userGodmodeRoles.has(role),
-  )
 
-  if (!isLoading && !canAccessGodmode) {
+  if (!isLoading && visibleGodmodeLinks.length === 0) {
     toast({
       title: "You do not have permission to access this page.",
       status: "error",

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -14,7 +14,7 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-type GodmodeLink = {
+interface GodmodeLink {
   href: string
   label: string
   /** Isomer admin roles that may see this hub link */

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -14,7 +14,7 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-const GODMODE_LINKS = [
+const GODMODE_CORE_LINKS = [
   {
     href: "/godmode/create-site",
     label: "Create a new site",
@@ -23,20 +23,32 @@ const GODMODE_LINKS = [
     href: "/godmode/publishing",
     label: "Publishing",
   },
-  {
-    href: "/godmode/whitelist",
-    label: "Whitelist",
-  },
 ] as const
+
+const GODMODE_WHITELIST_LINK = {
+  href: "/godmode/whitelist",
+  label: "Whitelist",
+} as const
 
 const GodModePage: NextPageWithLayout = () => {
   const toast = useToast()
   const router = useRouter()
-  const { isAdmin: isUserIsomerAdmin, isLoading } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core],
-  })
+  const { isAdmin: isCoreIsomerAdmin, isLoading: isCoreRoleLoading } =
+    useIsUserIsomerAdmin({
+      roles: [IsomerAdminRole.Core],
+    })
+  const { isAdmin: isMigratorIsomerAdmin, isLoading: isMigratorRoleLoading } =
+    useIsUserIsomerAdmin({
+      roles: [IsomerAdminRole.Migrator],
+    })
 
-  if (!isLoading && !isUserIsomerAdmin) {
+  const isLoading = isCoreRoleLoading || isMigratorRoleLoading
+  const canAccessGodmode = isCoreIsomerAdmin || isMigratorIsomerAdmin
+  const godmodeLinks = isCoreIsomerAdmin
+    ? [...GODMODE_CORE_LINKS, GODMODE_WHITELIST_LINK]
+    : [GODMODE_WHITELIST_LINK]
+
+  if (!isLoading && !canAccessGodmode) {
     toast({
       title: "You do not have permission to access this page.",
       status: "error",
@@ -60,22 +72,24 @@ const GodModePage: NextPageWithLayout = () => {
       </Text>
 
       <Flex flexDirection="column" mt="1.5rem" gap="1rem">
-        {GODMODE_LINKS.map((link) => (
-          <Flex
-            as={NextLink}
-            href={link.href}
-            p="1rem"
-            borderWidth="1px"
-            alignItems="center"
-            bg="base.canvas.default"
-            border="1px solid"
-            borderColor="base.divider.medium"
-            borderRadius="0.5rem"
-            _hover={{ background: "interaction.muted.main.hover" }}
-          >
-            <Text textStyle="subhead-2">{link.label}</Text>
-          </Flex>
-        ))}
+        {!isLoading &&
+          godmodeLinks.map((link) => (
+            <Flex
+              key={link.href}
+              as={NextLink}
+              href={link.href}
+              p="1rem"
+              borderWidth="1px"
+              alignItems="center"
+              bg="base.canvas.default"
+              border="1px solid"
+              borderColor="base.divider.medium"
+              borderRadius="0.5rem"
+              _hover={{ background: "interaction.muted.main.hover" }}
+            >
+              <Text textStyle="subhead-2">{link.label}</Text>
+            </Flex>
+          ))}
       </Flex>
     </Flex>
   )

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -14,21 +14,34 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-const GODMODE_CORE_LINKS = [
+type GodmodeLink = {
+  href: string
+  label: string
+  /** Isomer admin roles that may see this hub link */
+  roles: readonly IsomerAdminRole[]
+}
+
+const GODMODE_LINKS: readonly GodmodeLink[] = [
   {
     href: "/godmode/create-site",
     label: "Create a new site",
+    roles: [IsomerAdminRole.Core],
   },
   {
     href: "/godmode/publishing",
     label: "Publishing",
+    roles: [IsomerAdminRole.Core],
   },
-] as const
+  {
+    href: "/godmode/whitelist",
+    label: "Whitelist",
+    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
+  },
+]
 
-const GODMODE_WHITELIST_LINK = {
-  href: "/godmode/whitelist",
-  label: "Whitelist",
-} as const
+const GODMODE_PAGE_ACCESS_ROLES: readonly IsomerAdminRole[] = [
+  ...new Set(GODMODE_LINKS.flatMap((link) => [...link.roles])),
+]
 
 const GodModePage: NextPageWithLayout = () => {
   const toast = useToast()
@@ -43,10 +56,20 @@ const GodModePage: NextPageWithLayout = () => {
     })
 
   const isLoading = isCoreRoleLoading || isMigratorRoleLoading
-  const canAccessGodmode = isCoreIsomerAdmin || isMigratorIsomerAdmin
-  const godmodeLinks = isCoreIsomerAdmin
-    ? [...GODMODE_CORE_LINKS, GODMODE_WHITELIST_LINK]
-    : [GODMODE_WHITELIST_LINK]
+  const userGodmodeRoles = new Set<IsomerAdminRole>()
+  if (isCoreIsomerAdmin) {
+    userGodmodeRoles.add(IsomerAdminRole.Core)
+  }
+  if (isMigratorIsomerAdmin) {
+    userGodmodeRoles.add(IsomerAdminRole.Migrator)
+  }
+
+  const visibleGodmodeLinks = GODMODE_LINKS.filter((link) =>
+    link.roles.some((role) => userGodmodeRoles.has(role)),
+  )
+  const canAccessGodmode = GODMODE_PAGE_ACCESS_ROLES.some((role) =>
+    userGodmodeRoles.has(role),
+  )
 
   if (!isLoading && !canAccessGodmode) {
     toast({
@@ -73,7 +96,7 @@ const GodModePage: NextPageWithLayout = () => {
 
       <Flex flexDirection="column" mt="1.5rem" gap="1rem">
         {!isLoading &&
-          godmodeLinks.map((link) => (
+          visibleGodmodeLinks.map((link) => (
             <Flex
               key={link.href}
               as={NextLink}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Isomer admin migrators could use Whitelist but the `/godmode` hub required Core access, so they were redirected home and only effectively had Whitelist when navigating directly. They also did not see the God Mode control in the navbar. Migrators must not gain list-all-sites, create-site, or publish capabilities; those stay Core-only.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `/godmode` hub access matches whether the user matches any link in `GODMODE_LINKS` (after filtering by each link's `roles`). Core admins see Create site, Publishing, and Whitelist. Migrators see only Whitelist.
- Navbar God Mode button is shown for Core and Migrator roles. Site APIs for create / publish / listAllSites remain Core-only.

**Chore**:

- `GodmodeLink` uses an `interface` to satisfy `@typescript-eslint/consistent-type-definitions` (root `npm run lint`).

## Before & After Screenshots

**BEFORE**: Not captured.

**AFTER**: Not captured.

## Tests

**Manual Verification Steps**:

- [ ] Sign in as an Isomer **Migrator** admin. Confirm the navbar shows **God Mode**.
- [ ] Open `/godmode`. Confirm only **Whitelist** appears as a hub link; opening it works.
- [ ] As Migrator, open `/godmode/create-site` and `/godmode/publishing` directly; confirm access is denied (redirect / error as today).
- [ ] Sign in as an Isomer **Core** admin. Confirm `/godmode` shows all three links and subpages behave as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://opengovproducts.slack.com/archives/D0ACWJJBBHD/p1776679627236029?thread_ts=1776679627.236029&cid=D0ACWJJBBHD)

<div><a href="https://cursor.com/agents/bc-2a11fec3-4382-5b80-9926-a818a36afba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a11fec3-4382-5b80-9926-a818a36afba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

