### PR TITLE
fix(studio): add default value to collection variant radio buttons

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionVariantControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionVariantControl.tsx
@@ -39,6 +39,7 @@ function JsonFormsCollectionVariantControl({
             handleChange(path, value)
           }}
           value={data as string}
+          defaultValue={COLLECTION_VARIANT_OPTIONS.Collection}
         >
           <Radio
             value={COLLECTION_VARIANT_OPTIONS.Collection}

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -3,6 +3,7 @@ import type {
   IsomerSchema,
 } from "@opengovsg/isomer-components"
 import {
+  COLLECTION_VARIANT_OPTIONS,
   getLayoutMetadataSchema,
   ISOMER_USABLE_PAGE_LAYOUTS,
   renderPrefillText,
@@ -979,15 +980,16 @@ export const pageRouter = router({
       const blobContent =
         parent.type === ResourceType.Collection
           ? {
-              layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
-              page: {
-                title: parent.title,
-                subtitle: `Read more on ${parent.title.toLowerCase()} here.`,
-                sortOrder: "date-desc",
-              } as CollectionPagePageProps,
-              content: [],
-              version: "0.1.0",
-            }
+            layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
+            page: {
+              title: parent.title,
+              subtitle: `Read more on ${parent.title.toLowerCase()} here.`,
+              sortOrder: "date-desc",
+              variant: COLLECTION_VARIANT_OPTIONS.Collection,
+            } as CollectionPagePageProps,
+            content: [],
+            version: "0.1.0",
+          }
           : createFolderIndexPage(parent.title)
 
       const page = await db.transaction().execute(async (tx) => {

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -980,16 +980,16 @@ export const pageRouter = router({
       const blobContent =
         parent.type === ResourceType.Collection
           ? {
-            layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
-            page: {
-              title: parent.title,
-              subtitle: `Read more on ${parent.title.toLowerCase()} here.`,
-              sortOrder: "date-desc",
-              variant: COLLECTION_VARIANT_OPTIONS.Collection,
-            } as CollectionPagePageProps,
-            content: [],
-            version: "0.1.0",
-          }
+              layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
+              page: {
+                title: parent.title,
+                subtitle: `Read more on ${parent.title.toLowerCase()} here.`,
+                sortOrder: "date-desc",
+                variant: COLLECTION_VARIANT_OPTIONS.Collection,
+              } as CollectionPagePageProps,
+              content: [],
+              version: "0.1.0",
+            }
           : createFolderIndexPage(parent.title)
 
       const page = await db.transaction().execute(async (tx) => {


### PR DESCRIPTION
## Problem

When opening the collection drawer, the radio buttons for selecting the collection layout variant (1-column vs 2-column) did not have a default selection. This could lead to a confusing user experience where no option appears selected initially.

## Solution

Added a `defaultValue` prop to the `Radio.RadioGroup` component in `JsonFormsCollectionVariantControl`, setting it to `COLLECTION_VARIANT_OPTIONS.Collection` (1-column layout). This ensures users see the 1-column option selected by default when the drawer opens without a pre-existing value.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed radio button group not showing a default selection when no value is present

## Before & After Screenshots

**BEFORE**:
No radio button selected by default when opening collection drawer

**AFTER**:
1-column layout radio button is selected by default

## Tests

- Open the collection drawer for a collection page
- Verify that the 1-column layout option is selected by default
- Verify that selecting a different option still works correctly
- Verify that existing collections with a saved variant still display the correct selection