### PR TITLE
chore: prevent whitespace-only Hero title

### DIFF
--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -4,7 +4,7 @@ import type { IsomerSiteProps, LinkComponentType } from "~/types"
 import { Type } from "@sinclair/typebox"
 import { omit } from "lodash-es"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "~/constants/image"
-import { LINK_HREF_PATTERN } from "~/utils/validation"
+import { LINK_HREF_PATTERN, NON_EMPTY_STRING_REGEX } from "~/utils/validation"
 
 import { ARRAY_RADIO_FORMAT } from "../format"
 import { generateImageSrcSchema } from "./Image"
@@ -23,6 +23,10 @@ const HeroBaseSchema = Type.Object({
     title: "Hero text",
     description: "The title of the hero banner",
     maxLength: 100,
+    pattern: NON_EMPTY_STRING_REGEX,
+    errorMessage: {
+      pattern: "cannot be empty or contain only spaces",
+    },
   }),
   subtitle: Type.Optional(
     Type.String({


### PR DESCRIPTION
## Problem

The Hero component's `title` field accepts strings consisting solely of whitespace characters. A user can save a hero banner with a blank-looking title (e.g. `"   "`), which produces an empty-looking banner without any validation feedback.

## Solution

Apply the existing `NON_EMPTY_STRING_REGEX` pattern (already used by `InfoCards`) to the Hero `title` field so the schema rejects empty strings and whitespace-only input. A user-friendly `errorMessage` is added so the editor surfaces the message *"cannot be empty or contain only spaces"* instead of a raw regex failure.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Hero `title` field now validates against whitespace-only input across all hero variants (gradient, block, large image, floating, searchbar) since the rule is applied on the shared `HeroBaseSchema`.

**Bug Fixes**:

- Prevents users from saving a Hero block with a title containing only spaces.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In Studio, open a page and add (or edit) a Hero block.
- [ ] In the Hero text field, enter only spaces (e.g. `"   "`) and confirm the field shows the validation error *"cannot be empty or contain only spaces"* and that saving is blocked.
- [ ] Clear the field entirely and confirm the same validation error appears.
- [ ] Enter a valid title with leading/trailing spaces (e.g. `"  Hello  "`) and confirm the field validates successfully and the hero block can be saved.
- [ ] Repeat the above for each Hero variant (gradient, block, large image, floating, searchbar) to confirm consistent validation behaviour.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A