### PR TITLE
chore: fix port forwarding in test container configuration

### DIFF
--- a/apps/studio/tests/common.ts
+++ b/apps/studio/tests/common.ts
@@ -118,9 +118,9 @@ export const setup = async (
         type === "image"
           ? new GenericContainer(configuration.image)
           : await GenericContainer.fromDockerfile(
-            context,
-            configuration.dockerfile,
-          ).build(name)
+              context,
+              configuration.dockerfile,
+            ).build(name)
 
       if (ports.length) {
         container = container.withExposedPorts(...ports)

--- a/apps/studio/tests/common.ts
+++ b/apps/studio/tests/common.ts
@@ -24,7 +24,7 @@ export const CONTAINER_CONFIGURATIONS: Record<
   mockpass: {
     name: "mockpass",
     image: "opengovsg/mockpass:4.5.1",
-    ports: [{ container: 5156, host: 5156 }],
+    ports: [5156],
     extraHosts: [{ host: "host.docker.internal", ipAddress: "host-gateway" }],
     environment: {
       MOCKPASS_NRIC: "S6005038D",
@@ -118,9 +118,9 @@ export const setup = async (
         type === "image"
           ? new GenericContainer(configuration.image)
           : await GenericContainer.fromDockerfile(
-              context,
-              configuration.dockerfile,
-            ).build(name)
+            context,
+            configuration.dockerfile,
+          ).build(name)
 
       if (ports.length) {
         container = container.withExposedPorts(...ports)

--- a/apps/studio/tests/mocks/mockpass.ts
+++ b/apps/studio/tests/mocks/mockpass.ts
@@ -1,0 +1,23 @@
+import { parse } from "superjson"
+
+import { CONTAINER_INFORMATION_SCHEMA } from "../common"
+
+const parsed = CONTAINER_INFORMATION_SCHEMA.parse(
+  parse(process.env.testcontainers ?? ""),
+)
+
+const container = parsed.find((c) => c.configuration.name === "mockpass")
+
+if (!container) {
+  console.log("cannot find mockpass container")
+  throw new Error("Cannot find mockpass container")
+}
+
+const { host, ports } = container
+const port = ports.get(5156)
+
+if (!port) {
+  throw new Error("Cannot find mapped port for mockpass")
+}
+
+process.env.SINGPASS_ISSUER_ENDPOINT = `http://${host}:${port}/singpass/v2`

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     retry: 0,
     globals: true,
     exclude: [...configDefaults.exclude, "**/tests/e2e/**", "tests/load/**"],
-    setupFiles: ["tests/mocks/db.ts"],
+    setupFiles: ["tests/mocks/db.ts", "tests/mocks/mockpass.ts"],
     globalSetup: ["tests/global-setup.ts"],
     coverage: {
       provider: "istanbul",


### PR DESCRIPTION
## Problem

The mockpass test container was configured with explicit host port mapping (`{ container: 5156, host: 5156 }`), which can cause port conflicts when tests run in parallel or when the port is already in use on the host machine.

## Solution

Changed the mockpass container port configuration to use dynamic port mapping by specifying only the container port (`5156`). This allows Docker to automatically assign an available host port, preventing port conflicts during test execution.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Simplified port configuration for mockpass container to use dynamic host port allocation
- Fixed code formatting/indentation for the `GenericContainer.fromDockerfile` call

## Before & After Screenshots

N/A - Infrastructure change with no visual impact

## Tests

Run the test suite to verify mockpass container starts correctly:

```bash
pnpm --filter=studio test
```

**New scripts**:

N/A

**New dependencies**:

N/A

**New dev dependencies**:

N/A