### PR TITLE
refactor: update S3 deletion tag to use deletedAt timestamp

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -197,7 +197,7 @@ Delete flow (`asset.deleteAssets`):
 
 - Validates delete permission first
 - Rejects any key not prefixed with `<siteId>/`
-- Performs soft-delete by setting S3 tag `ISOMER_STATUS=DELETED`
+- Performs soft-delete by setting S3 tag `deletedAt=<timestamp>`
 
 ### OTP email sign-in troubleshooting
 

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -11,6 +11,7 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
 import { env } from "~/env.mjs"
 
+const DELETE_TAG = 'deletedAt'
 const { NEXT_PUBLIC_S3_REGION } = env
 
 const storage = new S3Client({
@@ -63,10 +64,11 @@ export const deleteFile = async ({
       // until the page is published
       Tagging: {
         TagSet: [
-          ...originalTagSet.filter(({ Key }) => Key !== "ISOMER_STATUS"),
+          ...originalTagSet.filter(({ Key }) => Key !== DELETE_TAG),
           {
-            Key: "ISOMER_STATUS",
-            Value: "DELETED",
+            Key: DELETE_TAG,
+            // NOTE: UNIX time
+            Value: Date.now().toString(),
           },
         ],
       },

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -67,7 +67,7 @@ export const deleteFile = async ({
           ...originalTagSet.filter(({ Key }) => Key !== DELETE_TAG),
           {
             Key: DELETE_TAG,
-            // NOTE: UNIX time
+            // NOTE: milliseconds since epoch
             Value: Date.now().toString(),
           },
         ],

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -11,7 +11,7 @@ import {
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner"
 import { env } from "~/env.mjs"
 
-const DELETE_TAG = 'deletedAt'
+const DELETE_TAG = "deletedAt"
 const { NEXT_PUBLIC_S3_REGION } = env
 
 const storage = new S3Client({


### PR DESCRIPTION
## Problem

The current S3 soft-delete implementation uses a static `ISOMER_STATUS=DELETED` tag, which doesn't provide information about when the deletion occurred. This makes it difficult to implement time-based cleanup policies for soft-deleted assets.

## Solution

Updated the S3 deletion tagging strategy to use a `deletedAt=<timestamp>` tag instead, which stores the UNIX timestamp of when the file was marked for deletion.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

Note: Existing files tagged with `ISOMER_STATUS=DELETED` will remain with the old tag. New deletions will use the new `deletedAt` tag format.

**Improvements**:

- Changed deletion tag from `ISOMER_STATUS=DELETED` to `deletedAt=<UNIX timestamp>`
- Extracted tag key to a constant (`DELETE_TAG`) for maintainability
- Updated README documentation to reflect the new tagging scheme

## Before & After Screenshots

N/A - Backend change only

## Tests

- Verify soft-delete sets the `deletedAt` tag with a valid UNIX timestamp
- Verify subsequent soft-deletes update the `deletedAt` timestamp

**New scripts**:

None

**New dependencies**:

None

**New dev dependencies**:

None