### PR TITLE
chore: add hpb.gov.sg to audit logs subscription

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -116,6 +116,7 @@ const SITES_WITH_AUDIT_LOGS = [
   336, // www.caringcommuters.gov.sg
   343, // www.motawardsceremony.gov.sg
   397, // www.rp.edu.sg
+  484, // www.hpb.gov.sg
 ]
 
 // Month and year to get audit logs for, in the format of YYYY-MM,


### PR DESCRIPTION
## Problem

hpb.gov.sg (site ID 484) is not currently included in the audit logs extraction script, so it is excluded when audit logs are generated for sites that have subscribed to receive them.

## Solution

Add site ID 484 (www.hpb.gov.sg) to the `SITES_WITH_AUDIT_LOGS` array in [getAuditLogs.ts](apps/studio/prisma/scripts/getAuditLogs.ts), so HPB is included the next time the script runs.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- HPB will now be included when the audit logs extraction script is run.

## Tests

**Manual Verification Steps**:

- [ ] Run the audit logs script (`npx tsx apps/studio/prisma/scripts/getAuditLogs.ts`) against a database containing HPB activity for the target month
- [ ] Confirm a CSV is produced for site ID 484 (www.hpb.gov.sg) alongside the other subscribed sites