### PR TITLE
fix: exclude span from default allowlist in BaseParagraph

### DIFF
--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -1,6 +1,6 @@
 import type { Node } from "interweave"
 import type { BaseParagraphProps } from "~/interfaces"
-import { Interweave } from "interweave"
+import { ALLOWED_TAG_LIST, Interweave } from "interweave"
 import { twMerge } from "~/lib/twMerge"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 
@@ -14,6 +14,10 @@ if (typeof window === "undefined") {
     polyfill()
   })
 }
+
+// Explicitly excluding span tags as they can be abused to adjust the font size,
+// colours and other styles of the text, which can cause accessibility issues
+const ALLOWED_TAG_LIST_WITHOUT_SPAN = ALLOWED_TAG_LIST.filter((tag) => tag !== 'span')
 
 export const BaseParagraph = ({
   content,
@@ -44,7 +48,7 @@ export const BaseParagraph = ({
 
   return (
     <Interweave
-      allowList={allowedTags}
+      allowList={allowedTags ?? ALLOWED_TAG_LIST_WITHOUT_SPAN}
       attributes={{
         ...(attrs?.dir && { dir: attrs.dir }),
       }}

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -17,7 +17,9 @@ if (typeof window === "undefined") {
 
 // Explicitly excluding span tags as they can be abused to adjust the font size,
 // colours and other styles of the text, which can cause accessibility issues
-const ALLOWED_TAG_LIST_WITHOUT_SPAN = ALLOWED_TAG_LIST.filter((tag) => tag !== 'span')
+const ALLOWED_TAG_LIST_WITHOUT_SPAN = ALLOWED_TAG_LIST.filter(
+  (tag) => tag !== "span",
+)
 
 export const BaseParagraph = ({
   content,


### PR DESCRIPTION
## Problem

The `BaseParagraph` component currently passes `allowedTags` directly to Interweave's `allowList`. When `allowedTags` is `undefined`, Interweave falls back to its full default allowlist, which includes `<span>`. Authors can use `<span>` with inline styles or attributes to override font size, color, and other typography in rich text content, leading to accessibility issues (e.g. unreadable contrast, oversized text, broken design system spacing).

Closes [insert issue #]

## Solution

Define `ALLOWED_TAG_LIST_WITHOUT_SPAN` from Interweave's exported `ALLOWED_TAG_LIST` minus `span`, and use it as the default when no `allowedTags` prop is provided. Callers that explicitly pass `allowedTags` are unaffected.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

Existing callers that pass `allowedTags` keep their current behaviour. Callers relying on the default allowlist will now have `<span>` tags stripped from rendered paragraphs — any existing content containing `<span>` will lose those wrappers (text content is preserved by Interweave).

**Bug Fixes**:

- Strip `<span>` from the default allowlist used by `BaseParagraph` so authors cannot override styling/typography via inline `<span>` styles, which was a recurring accessibility regression vector.

## Tests

**Manual Verification Steps**:

- [ ] In Studio, open a page that uses a Prose / Paragraph / Text block and add rich text containing a `<span style="font-size: 40px; color: red">…</span>` (e.g. via the Edit HTML option or by pasting from an external source).
- [ ] Save the page and view the published preview — confirm the text renders without the inline span styling (no oversized/red text), with the inner text content still intact.
- [ ] Verify other inline formatting (bold, italic, underline, links — including external links rendering with the `↗` indicator) still renders correctly in the same paragraph.
- [ ] Check a callout / Notification / Table / FormSG / ContactInformation / DynamicDataBanner / Map / SearchableTable block that uses `BaseParagraph` and confirm normal paragraph content still renders as expected.
- [ ] Confirm callers that pass an explicit `allowedTags` prop still render their permitted tags (no regression on components that intentionally restrict tags further).