### PR TITLE
feat: pass-through showThumbnail fallback for CollectionBlock

### DIFF
--- a/packages/components/src/interfaces/complex/CollectionBlock.ts
+++ b/packages/components/src/interfaces/complex/CollectionBlock.ts
@@ -56,7 +56,12 @@ export type CollectionBlockProps = Static<typeof CollectionBlockSchema> & {
 
 export type CollectionBlockSingleCardProps = Pick<
   ProcessedCollectionCardProps,
-  "title" | "image" | "category" | "referenceLinkHref" | "formattedDate"
+  | "title"
+  | "image"
+  | "isContainNeeded"
+  | "category"
+  | "referenceLinkHref"
+  | "formattedDate"
 > &
   Pick<CollectionBlockProps, "displayThumbnail" | "displayCategory"> &
   CollectionBlockNumberOfCards & {

--- a/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.tsx
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.tsx
@@ -77,6 +77,7 @@ const compoundStyles = createInfoCardsStyles()
 const SingleCard = ({
   title,
   image,
+  isContainNeeded,
   category,
   referenceLinkHref,
   displayThumbnail,
@@ -90,20 +91,18 @@ const SingleCard = ({
   const isExternalLink = !!referenceLinkHref && isExternalUrl(referenceLinkHref)
 
   const renderImage = () => {
-    const hasImage = image?.src !== undefined
-
-    // Fallback to site logo if user want to display thumbnail but no image is provided
-    const imageSrc = hasImage ? image.src : site.logoUrl
-    const imageAlt = hasImage ? image.alt : `Site logo for ${site.siteName}`
+    if (!image?.src) {
+      return null
+    }
 
     return (
       <div className={compoundStyles.cardImageContainer({ numberOfCards })}>
         <ImageClient
-          src={imageSrc}
-          alt={imageAlt}
+          src={image.src}
+          alt={image.alt}
           width="100%"
           className={compoundStyles.cardImage({
-            imageFit: hasImage ? "cover" : "contain",
+            imageFit: isContainNeeded ? "contain" : "cover",
           })}
           lazyLoading={shouldLazyLoad}
           assetsBaseUrl={site.assetsBaseUrl}

--- a/packages/components/src/templates/next/components/complex/CollectionBlock/utils/__tests__/getCollectionPages.test.ts
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/utils/__tests__/getCollectionPages.test.ts
@@ -49,10 +49,14 @@ describe("getCollectionPages", () => {
     id,
     permalink,
     date = "2021-01-01",
+    image,
+    firstImage,
   }: {
     id: string
     permalink: string
     date?: string
+    image?: { src: string; alt: string }
+    firstImage?: { src: string; alt: string }
   }): IsomerSitemap => ({
     id,
     title: `${id} title`,
@@ -61,6 +65,8 @@ describe("getCollectionPages", () => {
     lastModified: date,
     layout: "article",
     date,
+    image,
+    firstImage,
   })
 
   it("should return an empty array when the collection exists but has no items", () => {
@@ -173,6 +179,128 @@ describe("getCollectionPages", () => {
     // Assert
     expect(result[0]?.itemTitle).toEqual(`${collectionId}2 title`)
     expect(result[1]?.itemTitle).toEqual(`${collectionId}1 title`)
+  })
+
+  describe("thumbnail resolution", () => {
+    const itemWithImage = createMockCollectionItem({
+      id: `${collectionId}1`,
+      permalink: `${collectionPermalink}/1`,
+      image: { src: "/item-image.jpg", alt: "Item image" },
+    })
+    const itemWithoutImageButWithFirstImage = createMockCollectionItem({
+      id: `${collectionId}2`,
+      permalink: `${collectionPermalink}/2`,
+      firstImage: { src: "/first-image.jpg", alt: "First image" },
+    })
+    const itemWithNoImages = createMockCollectionItem({
+      id: `${collectionId}3`,
+      permalink: `${collectionPermalink}/3`,
+    })
+
+    const buildSite = () => ({
+      ...site,
+      siteMap: {
+        ...site.siteMap,
+        children: [collectionParent],
+      },
+    })
+
+    let collectionParent: IsomerSitemap
+
+    it("should use the item's own image when present, regardless of showThumbnail setting", () => {
+      collectionParent = {
+        id: collectionId,
+        title: "Collection 1",
+        permalink: collectionPermalink,
+        layout: "collection",
+        summary: "summary",
+        lastModified: new Date("2021-01-01").toISOString(),
+        children: [itemWithImage],
+        collectionPagePageProps: {
+          showThumbnail: { fallback: "first-image" },
+        },
+      }
+      const result = getCollectionPages({ site: buildSite(), collectionParent })
+      expect(result[0]?.image).toEqual({
+        src: "/item-image.jpg",
+        alt: "Item image",
+      })
+      expect(result[0]?.isContainNeeded).toBeFalsy()
+    })
+
+    it("should fall back to the site logo when showThumbnail is undefined on the referenced Collection", () => {
+      collectionParent = {
+        id: collectionId,
+        title: "Collection 1",
+        permalink: collectionPermalink,
+        layout: "collection",
+        summary: "summary",
+        lastModified: new Date("2021-01-01").toISOString(),
+        children: [itemWithoutImageButWithFirstImage, itemWithNoImages],
+      }
+      const result = getCollectionPages({ site: buildSite(), collectionParent })
+      // Both items should resolve to the site logo since showThumbnail is undefined
+      result.forEach((item) => {
+        expect(item.image).toEqual({
+          src: site.logoUrl,
+          alt: `${site.siteName} site logo`,
+          isContainNeeded: true,
+        })
+        expect(item.isContainNeeded).toBe(true)
+      })
+    })
+
+    it("should fall back to the site logo when showThumbnail.fallback is 'logo'", () => {
+      collectionParent = {
+        id: collectionId,
+        title: "Collection 1",
+        permalink: collectionPermalink,
+        layout: "collection",
+        summary: "summary",
+        lastModified: new Date("2021-01-01").toISOString(),
+        children: [itemWithoutImageButWithFirstImage],
+        collectionPagePageProps: {
+          showThumbnail: { fallback: "logo" },
+        },
+      }
+      const result = getCollectionPages({ site: buildSite(), collectionParent })
+      expect(result[0]?.image).toEqual({
+        src: site.logoUrl,
+        alt: `${site.siteName} site logo`,
+        isContainNeeded: true,
+      })
+    })
+
+    it("should fall back to the first image on the page when showThumbnail.fallback is 'first-image'", () => {
+      collectionParent = {
+        id: collectionId,
+        title: "Collection 1",
+        permalink: collectionPermalink,
+        layout: "collection",
+        summary: "summary",
+        lastModified: new Date("2021-01-01").toISOString(),
+        children: [itemWithoutImageButWithFirstImage, itemWithNoImages],
+        collectionPagePageProps: {
+          showThumbnail: { fallback: "first-image" },
+        },
+      }
+      const result = getCollectionPages({ site: buildSite(), collectionParent })
+      const first = result.find(
+        (r) => r.id === itemWithoutImageButWithFirstImage.permalink,
+      )
+      const second = result.find((r) => r.id === itemWithNoImages.permalink)
+      expect(first?.image).toEqual({
+        src: "/first-image.jpg",
+        alt: "First image",
+      })
+      // When 'first-image' is set but no firstImage exists, should still
+      // fall back to the site logo
+      expect(second?.image).toEqual({
+        src: site.logoUrl,
+        alt: `${site.siteName} site logo`,
+        isContainNeeded: true,
+      })
+    })
   })
 
   it("should use default sort values (date desc) when collectionPagePageProps sort values are absent", () => {

--- a/packages/components/src/templates/next/components/complex/CollectionBlock/utils/__tests__/getCollectionPages.test.ts
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/utils/__tests__/getCollectionPages.test.ts
@@ -208,6 +208,7 @@ describe("getCollectionPages", () => {
     let collectionParent: IsomerSitemap
 
     it("should use the item's own image when present, regardless of showThumbnail setting", () => {
+      // Arrange
       collectionParent = {
         id: collectionId,
         title: "Collection 1",
@@ -220,7 +221,11 @@ describe("getCollectionPages", () => {
           showThumbnail: { fallback: "first-image" },
         },
       }
+
+      // Act
       const result = getCollectionPages({ site: buildSite(), collectionParent })
+
+      // Assert
       expect(result[0]?.image).toEqual({
         src: "/item-image.jpg",
         alt: "Item image",
@@ -229,6 +234,7 @@ describe("getCollectionPages", () => {
     })
 
     it("should fall back to the site logo when showThumbnail is undefined on the referenced Collection", () => {
+      // Arrange
       collectionParent = {
         id: collectionId,
         title: "Collection 1",
@@ -238,7 +244,11 @@ describe("getCollectionPages", () => {
         lastModified: new Date("2021-01-01").toISOString(),
         children: [itemWithoutImageButWithFirstImage, itemWithNoImages],
       }
+
+      // Act
       const result = getCollectionPages({ site: buildSite(), collectionParent })
+
+      // Assert
       // Both items should resolve to the site logo since showThumbnail is undefined
       result.forEach((item) => {
         expect(item.image).toEqual({
@@ -251,6 +261,7 @@ describe("getCollectionPages", () => {
     })
 
     it("should fall back to the site logo when showThumbnail.fallback is 'logo'", () => {
+      // Arrange
       collectionParent = {
         id: collectionId,
         title: "Collection 1",
@@ -263,7 +274,11 @@ describe("getCollectionPages", () => {
           showThumbnail: { fallback: "logo" },
         },
       }
+
+      // Act
       const result = getCollectionPages({ site: buildSite(), collectionParent })
+
+      // Assert
       expect(result[0]?.image).toEqual({
         src: site.logoUrl,
         alt: `${site.siteName} site logo`,
@@ -272,6 +287,7 @@ describe("getCollectionPages", () => {
     })
 
     it("should fall back to the first image on the page when showThumbnail.fallback is 'first-image'", () => {
+      // Arrange
       collectionParent = {
         id: collectionId,
         title: "Collection 1",
@@ -284,7 +300,11 @@ describe("getCollectionPages", () => {
           showThumbnail: { fallback: "first-image" },
         },
       }
+
+      // Act
       const result = getCollectionPages({ site: buildSite(), collectionParent })
+
+      // Assert
       const first = result.find(
         (r) => r.id === itemWithoutImageButWithFirstImage.permalink,
       )

--- a/packages/components/src/templates/next/components/complex/CollectionBlock/utils/getCollectionPages.ts
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/utils/getCollectionPages.ts
@@ -18,6 +18,13 @@ export const getCollectionPages = ({
   site,
   collectionParent,
 }: GetCollectionPagesProps): ProcessedCollectionCardProps[] => {
+  // Respect the referenced Collection's showThumbnail setting. When the
+  // Collection has it undefined (i.e. the Collection page itself hides
+  // thumbnails), CollectionBlock still wants to render a thumbnail and
+  // falls back to the site logo.
+  const showThumbnail = collectionParent.collectionPagePageProps
+    ?.showThumbnail ?? { fallback: "logo" }
+
   const items = getCollectionItems({
     site,
     permalink: collectionParent.permalink,
@@ -25,6 +32,7 @@ export const getCollectionPages = ({
     sortBy: collectionParent.collectionPagePageProps?.defaultSortBy,
     sortDirection:
       collectionParent.collectionPagePageProps?.defaultSortDirection,
+    showThumbnail,
   })
 
   return processCollectionItems(items).slice(0, NUMBER_OF_PAGES_TO_DISPLAY)

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -34,6 +34,7 @@ export interface IsomerCollectionPageSitemap extends IsomerBaseSitemap {
     sortOrder?: CollectionPagePageProps["sortOrder"]
     defaultSortBy?: CollectionPagePageProps["defaultSortBy"]
     defaultSortDirection?: CollectionPagePageProps["defaultSortDirection"]
+    showThumbnail?: CollectionPagePageProps["showThumbnail"]
   }
 }
 

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -147,6 +147,7 @@ async function main() {
             sortOrder: resource.content.page?.sortOrder,
             defaultSortBy: resource.content.page?.defaultSortBy,
             defaultSortDirection: resource.content.page?.defaultSortDirection,
+            showThumbnail: resource.content.page?.showThumbnail,
           },
         }
 


### PR DESCRIPTION
## Problem

[CollectionBlock](packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.tsx) ignored the referenced Collection's `showThumbnail` setting and always rendered the item's own image (or, if absent, the site logo). After [#1973](https://github.com/opengovsg/isomer-next/pull/1973) introduced a `showThumbnail.fallback` setting on Collection pages (`"logo"` vs `"first-image"`), the linked Collection block on the homepage no longer matched the Collection page's own thumbnail behaviour — e.g. a Collection configured to fall back to the page's first image still showed the site logo when surfaced via CollectionBlock.

## Solution

Thread the referenced Collection's `showThumbnail` setting through the sitemap into CollectionBlock, and reuse the existing `getItemImage` resolver from the Collection layout. When the referenced Collection does not have `showThumbnail` set (i.e. the Collection page itself hides thumbnails), CollectionBlock substitutes `{ fallback: "logo" }` so it always renders something — preserving the existing block-level "always show a thumbnail" expectation.

The block-level `displayThumbnail` toggle remains the master switch: when off, no thumbnail is rendered regardless of the Collection's setting.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- CollectionBlock now respects the referenced Collection's `showThumbnail.fallback` setting (`"logo"` or `"first-image"`), matching the Collection page's own thumbnail rendering.

**Improvements**:

- `showThumbnail` is now serialised onto `IsomerCollectionPageSitemap.collectionPagePageProps` during publishing, alongside the existing `sortOrder`, `defaultSortBy`, etc.
- `SingleCard` in CollectionBlock no longer duplicates the logo-fallback logic — it consumes the already-resolved `image` and `isContainNeeded` from `getCollectionItems`, the same path the Collection page uses.

**Bug Fixes**:

- A linked Collection on the homepage that points at a Collection configured with `showThumbnail.fallback = "first-image"` will now correctly use the item's first image as the fallback thumbnail, rather than the site logo.

## Before & After Screenshots

**BEFORE**:

<!-- CollectionBlock always falls back to the site logo, regardless of the referenced Collection's setting -->

**AFTER**:

<!-- CollectionBlock matches the referenced Collection's fallback strategy (logo or first-image) -->

## Tests

Unit tests added in [`getCollectionPages.test.ts`](packages/components/src/templates/next/components/complex/CollectionBlock/utils/__tests__/getCollectionPages.test.ts) cover:

- Item's own image is used regardless of `showThumbnail`.
- `showThumbnail` undefined → site logo (with `isContainNeeded`).
- `showThumbnail.fallback = "logo"` → site logo.
- `showThumbnail.fallback = "first-image"` → uses `firstImage`, with logo as a backstop when `firstImage` is absent.

`npm run typecheck` passes across the monorepo. `oxlint` passes (the 2 new warnings on the publishing line match the existing `no-unsafe-*` pattern on adjacent fields like `tagCategories` and `sortOrder`).

**Manual Verification Steps**:

- [ ] On a site with at least one Collection containing items where some items have their own thumbnail and some do not, set the Collection page's "Display thumbnail on all items" setting to fall back to **first image on page**.
- [ ] On the same site, add a CollectionBlock on the homepage that references that Collection, with the block's "Display thumbnail of all pages" toggle **on**.
- [ ] Publish the site and load the homepage. Confirm that for items without their own thumbnail, the CollectionBlock now shows the item's first inline image (matching the Collection page's behaviour), rather than the site logo.
- [ ] Update the same Collection's "Display thumbnail on all items" setting to fall back to **site logo**, republish, and confirm CollectionBlock now shows the site logo as the fallback.
- [ ] Toggle the Collection page's "Display thumbnail on all items" setting **off** entirely, republish, and confirm the Collection page itself hides thumbnails while the CollectionBlock still renders the site logo as a fallback.
- [ ] Toggle the CollectionBlock's "Display thumbnail of all pages" **off**, republish, and confirm no thumbnails are rendered in the block (block-level toggle still takes precedence).

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.