### PR TITLE
feat: add Redirect table

### DIFF
--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -88,6 +88,14 @@ export interface RateLimiterFlexible {
   points: number
   expire: Timestamp | null
 }
+export interface Redirect {
+  id: GeneratedAlways<string>
+  siteId: number
+  source: string
+  destination: string
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
 export interface Resource {
   id: GeneratedAlways<string>
   title: string
@@ -171,6 +179,7 @@ export interface DB {
   IsomerAdmin: IsomerAdmin
   Navbar: Navbar
   RateLimiterFlexible: RateLimiterFlexible
+  Redirect: Redirect
   Resource: Resource
   ResourcePermission: ResourcePermission
   Site: Site

--- a/apps/studio/prisma/generated/generatedTypes.ts
+++ b/apps/studio/prisma/generated/generatedTypes.ts
@@ -95,6 +95,7 @@ export interface Redirect {
   destination: string
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
+  deletedAt: Timestamp | null
 }
 export interface Resource {
   id: GeneratedAlways<string>

--- a/apps/studio/prisma/generated/selectableTypes.ts
+++ b/apps/studio/prisma/generated/selectableTypes.ts
@@ -9,6 +9,7 @@ export type Footer = Selectable<T.Footer>
 export type IsomerAdmin = Selectable<T.IsomerAdmin>
 export type Navbar = Selectable<T.Navbar>
 export type RateLimiterFlexible = Selectable<T.RateLimiterFlexible>
+export type Redirect = Selectable<T.Redirect>
 export type Resource = Selectable<T.Resource>
 export type ResourcePermission = Selectable<T.ResourcePermission>
 export type Site = Selectable<T.Site>

--- a/apps/studio/prisma/migrations/20260508000001_add_redirects_table/migration.sql
+++ b/apps/studio/prisma/migrations/20260508000001_add_redirects_table/migration.sql
@@ -6,6 +6,7 @@ CREATE TABLE "Redirect" (
     "destination" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deletedAt" TIMESTAMP(3),
 
     CONSTRAINT "Redirect_pkey" PRIMARY KEY ("id")
 );

--- a/apps/studio/prisma/migrations/20260508000001_add_redirects_table/migration.sql
+++ b/apps/studio/prisma/migrations/20260508000001_add_redirects_table/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "Redirect" (
+    "id" BIGSERIAL NOT NULL,
+    "siteId" INTEGER NOT NULL,
+    "source" TEXT NOT NULL,
+    "destination" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Redirect_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Redirect_siteId_source_key" ON "Redirect"("siteId", "source");
+
+-- CreateIndex
+CREATE INDEX "Redirect_siteId_idx" ON "Redirect"("siteId");
+
+-- AddForeignKey
+ALTER TABLE "Redirect" ADD CONSTRAINT "Redirect_siteId_fkey"
+  FOREIGN KEY ("siteId") REFERENCES "Site"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Auto-update updatedAt on row modification (matches other table patterns)
+CREATE TRIGGER update_timestamp
+  BEFORE UPDATE ON "Redirect"
+  FOR EACH ROW EXECUTE PROCEDURE moddatetime("updatedAt");

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -170,6 +170,20 @@ model Site {
   ResourcePermission ResourcePermission[]
   AuditLog           AuditLog[]
   CodeBuildJobs      CodeBuildJobs[]
+  Redirect           Redirect[]
+}
+
+model Redirect {
+  id          BigInt   @id @default(autoincrement())
+  siteId      Int
+  site        Site     @relation(fields: [siteId], references: [id])
+  source      String
+  destination String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now()) @updatedAt
+
+  @@unique([siteId, source])
+  @@index([siteId])
 }
 
 model Navbar {

--- a/apps/studio/prisma/schema.prisma
+++ b/apps/studio/prisma/schema.prisma
@@ -179,8 +179,9 @@ model Redirect {
   site        Site     @relation(fields: [siteId], references: [id])
   source      String
   destination String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @default(now()) @updatedAt
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @default(now()) @updatedAt
+  deletedAt   DateTime?
 
   @@unique([siteId, source])
   @@index([siteId])


### PR DESCRIPTION
## Problem

Sites need a way to define URL redirects when pages are moved or renamed. This PR adds the database foundation for storing per-site redirect rules and wires them into the CodeBuild publishing pipeline so that redirects take effect on every deploy.

Closes [insert issue #]

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- New `Redirect` model in `apps/studio/prisma/schema.prisma`:
  - `id` — `BIGSERIAL` primary key
  - `siteId` — FK to `Site` (`ON DELETE RESTRICT`)
  - `source` — the path being redirected from (e.g. `/old-page`)
  - `destination` — the path or URL being redirected to
  - `createdAt` / `updatedAt` timestamps
  - Unique constraint on `(siteId, source)` — prevents duplicate rules for the same source within a site

- Publishing pipeline now reads redirect rows and uploads each as an empty S3 object with `x-amz-meta-redirect-destination` metadata, which the downstream CloudFront Function converts into an HTTP 301/302 response

**Improvements**:

- Redirect uploads use a worker-pool (default concurrency 20, tunable via `UPLOAD_CONCURRENCY` env var) so large redirect tables don't significantly extend build times
- Source paths are normalised (leading/trailing slashes stripped, repeated slashes collapsed) and validated (path-traversal segments and control characters rejected) before upload
- Duplicate normalised sources are deduplicated with a warning rather than racing each other to the same S3 key
- `--metadata` is passed as JSON to `aws s3 cp` to correctly handle commas and equals signs in destination URLs (common in query strings)
- Individual upload failures are logged as warnings; the build continues so the CloudFront origin-path update always proceeds even if some redirects fail

## Before & After Screenshots

N/A — no UI changes in this PR.

## Tests

**Manual Verification Steps**:

- [ ] Seed a `Redirect` row for a test site (e.g. `source="/old-page"`, `destination="/new-page"`) and trigger a publish build
- [ ] After the build completes, run `aws s3api head-object --bucket <bucket> --key <site>/<build>/latest/old-page/index.html` and confirm `x-amz-meta-redirect-destination` is set to `/new-page`
- [ ] Confirm the object body is 0 bytes
- [ ] Hit the source path through CloudFront and confirm it issues a 301/302 to the destination
- [ ] Trigger a publish for a site with zero redirects and confirm the build succeeds with no redirect objects uploaded

**New scripts**:

- `npm run upload-redirects` (in `tooling/build/scripts/publishing`) — reads `redirects.json` and uploads redirect objects to S3; called by `publisher.sh` after the main `s3 sync`

**New dependencies**:

- None

**New dev dependencies**:

- None