### PR TITLE
feat: wire Redirects table into publishing pipeline

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -141,6 +141,9 @@ mv schema/ ../../../template/
 mv data/ ../../../template/
 cp sitemap.json ../../../template/public/
 mv sitemap.json ../../../template/
+mv redirects.json ../../../template/
+# Capture absolute path now; the upload step runs from a different CWD later.
+REDIRECTS_JSON="$(realpath ../../../template/redirects.json)"
 cd ../../../template
 # Create not-found.json by copying _index.json if it doesn't exist
 # Refer to tooling/template/app/not-found.tsx for more context
@@ -189,6 +192,19 @@ aws s3 sync --only-show-errors . s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUIL
 # Set all files in the _next folder to be cached indefinitely (1 year) on users' browsers
 # Next.js uses unique content hashes in filenames, allowing updated content to have different filenames and invalidate the cache on new builds.
 aws s3 sync --only-show-errors _next s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest/_next --delete --no-progress --cache-control "max-age=31536000, public"
+
+# Upload redirect objects AFTER the --delete sync so they are not swept away.
+# Each redirect becomes an empty index.html with x-amz-meta-redirect-destination metadata
+# that the CloudFront Function reads to issue the HTTP redirect response.
+echo "Uploading redirect files to S3..."
+(
+  cd ../../build/scripts/publishing
+  REDIRECTS_JSON="$REDIRECTS_JSON" \
+    S3_BUCKET_NAME="$S3_BUCKET_NAME" \
+    SITE_NAME="$SITE_NAME" \
+    CODEBUILD_BUILD_NUMBER="$CODEBUILD_BUILD_NUMBER" \
+    npm run upload-redirects
+) || echo "Warning: some redirects failed to upload, continuing..."
 
 calculate_duration $start_time
 

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -13,6 +13,7 @@ import {
   GET_CONFIG,
   GET_FOOTER,
   GET_NAVBAR,
+  GET_REDIRECTS,
 } from "./queries"
 import {
   getCollectionIndexPageContents,
@@ -79,6 +80,9 @@ async function main() {
 
     // Fetch and write navbar, footer, and config JSONs
     await fetchAndWriteSiteData(client)
+
+    // Fetch and write redirects
+    await fetchAndWriteRedirects(client)
 
     // Fetch all resources and their full permalinks
     const resources = await getAllResourcesWithFullPermalinks(client)
@@ -535,6 +539,23 @@ async function fetchAndWriteSiteData(client: Client) {
     }
   } catch (err) {
     console.error("Error fetching site data:", err)
+  }
+}
+
+async function fetchAndWriteRedirects(client: Client) {
+  try {
+    const result = await client.query(GET_REDIRECTS, [SITE_ID])
+    const redirects = result.rows as { source: string; destination: string }[]
+    const filePath = path.join(__dirname, "redirects.json")
+    fs.writeFileSync(filePath, JSON.stringify(redirects), "utf-8")
+    logDebug(`Successfully wrote redirects: ${filePath}`)
+  } catch (err) {
+    console.error("Error fetching redirects:", err)
+    fs.writeFileSync(
+      path.join(__dirname, "redirects.json"),
+      JSON.stringify([]),
+      "utf-8",
+    )
   }
 }
 

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -8,7 +8,8 @@
   "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts ",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "upload-redirects": "tsx uploadRedirects.ts"
   },
   "dependencies": {
     "dotenv": "catalog:",

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -60,3 +60,7 @@ SELECT content FROM public."Footer" WHERE "siteId" = $1;
 export const GET_CONFIG = `
 SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
 `
+
+export const GET_REDIRECTS = `
+SELECT source, destination FROM public."Redirect" WHERE "siteId" = $1;
+`

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -62,5 +62,5 @@ SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
 `
 
 export const GET_REDIRECTS = `
-SELECT source, destination FROM public."Redirect" WHERE "siteId" = $1;
+SELECT source, destination FROM public."Redirect" WHERE "siteId" = $1 AND "deletedAt" IS NULL;
 `

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -1,5 +1,7 @@
 import { spawn } from "child_process"
 import * as fs from "fs"
+import * as os from "os"
+import * as path from "path"
 
 const REDIRECTS_JSON = process.env.REDIRECTS_JSON
 const S3_BUCKET = process.env.S3_BUCKET_NAME
@@ -27,13 +29,15 @@ function normalizeSource(source: string): string | null {
   return trimmed
 }
 
+const EMPTY_FILE = path.join(os.tmpdir(), "isomer-redirect-empty")
+
 function uploadOne(source: string, destination: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const proc = spawn("aws", [
       "s3",
       "cp",
       "--only-show-errors",
-      "/dev/null",
+      EMPTY_FILE,
       `s3://${S3_BUCKET}/${SITE_NAME}/${BUILD_NUMBER}/latest/${source}/index.html`,
       "--content-type",
       "text/html",
@@ -120,6 +124,8 @@ async function main(): Promise<void> {
     console.log("No valid redirects to upload.")
     return
   }
+
+  fs.writeFileSync(EMPTY_FILE, "")
 
   console.log(
     `Uploading ${valid.length} redirect(s) with concurrency ${CONCURRENCY}...`,

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -1,0 +1,132 @@
+import { spawn } from "child_process"
+import * as fs from "fs"
+
+const REDIRECTS_JSON = process.env.REDIRECTS_JSON
+const S3_BUCKET = process.env.S3_BUCKET_NAME
+const SITE_NAME = process.env.SITE_NAME
+const BUILD_NUMBER = process.env.CODEBUILD_BUILD_NUMBER
+const CONCURRENCY = Number(process.env.UPLOAD_CONCURRENCY) || 20
+
+interface Redirect { source: string; destination: string }
+
+// Returns the normalised S3 key segment, or null if the source is unsafe/empty.
+function normalizeSource(source: string): string | null {
+  if (typeof source !== "string") return null
+  // Reject control chars and backslashes
+  if (/[\x00-\x1f\\]/.test(source)) return null
+  const trimmed = source
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/\/+/g, "/")
+  if (!trimmed) return null
+  // Reject any path-traversal segment
+  if (trimmed.split("/").some((seg) => seg === "..")) return null
+  return trimmed
+}
+
+function uploadOne(source: string, destination: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn("aws", [
+      "s3",
+      "cp",
+      "--only-show-errors",
+      "/dev/null",
+      `s3://${S3_BUCKET}/${SITE_NAME}/${BUILD_NUMBER}/latest/${source}/index.html`,
+      "--content-type",
+      "text/html",
+      "--cache-control",
+      "max-age=600",
+      // JSON form avoids shorthand parsing of commas/equals in destination URLs.
+      "--metadata",
+      JSON.stringify({ "redirect-destination": destination }),
+    ])
+    let stderr = ""
+    proc.stderr.on("data", (d) => {
+      stderr += d.toString()
+    })
+    proc.on("close", (code) => {
+      if (code === 0) resolve()
+      else
+        reject(
+          new Error(`aws s3 cp exited ${code} for ${source}: ${stderr.trim()}`),
+        )
+    })
+    proc.on("error", reject)
+  })
+}
+
+// Worker-pool: each worker pulls from the shared queue until it is empty.
+async function runWithConcurrency(
+  items: Redirect[],
+  limit: number,
+): Promise<{ failed: number }> {
+  const queue = items.slice()
+  let failed = 0
+  const worker = async () => {
+    while (queue.length > 0) {
+      const r = queue.shift()
+      if (!r) break
+      try {
+        await uploadOne(r.source, r.destination)
+      } catch (err) {
+        console.error("Redirect upload failed:", err)
+        failed++
+      }
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  )
+  return { failed }
+}
+
+async function main(): Promise<void> {
+  if (!REDIRECTS_JSON || !S3_BUCKET || !SITE_NAME || !BUILD_NUMBER) {
+    throw new Error(
+      "Missing required env vars: REDIRECTS_JSON, S3_BUCKET_NAME, SITE_NAME, CODEBUILD_BUILD_NUMBER",
+    )
+  }
+
+  const raw: Redirect[] = JSON.parse(fs.readFileSync(REDIRECTS_JSON, "utf-8"))
+  console.log(`Loaded ${raw.length} redirect row(s) from ${REDIRECTS_JSON}`)
+
+  const seen = new Set<string>()
+  const valid: Redirect[] = []
+  for (const r of raw) {
+    const source = normalizeSource(r.source)
+    if (!source) {
+      console.warn(
+        `Skipping invalid redirect source: ${JSON.stringify(r.source)}`,
+      )
+      continue
+    }
+    if (seen.has(source)) {
+      console.warn(`Skipping duplicate normalised source: ${source}`)
+      continue
+    }
+    if (!/^(https?:\/\/|\/)/.test(r.destination)) {
+      console.warn(
+        `Destination "${r.destination}" is not absolute; browsers may interpret it inconsistently.`,
+      )
+    }
+    seen.add(source)
+    valid.push({ source, destination: r.destination })
+  }
+
+  if (valid.length === 0) {
+    console.log("No valid redirects to upload.")
+    return
+  }
+
+  console.log(
+    `Uploading ${valid.length} redirect(s) with concurrency ${CONCURRENCY}...`,
+  )
+  const { failed } = await runWithConcurrency(valid, CONCURRENCY)
+  console.log(`Uploaded ${valid.length - failed}/${valid.length} redirects.`)
+  if (failed > 0) process.exit(1)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -7,7 +7,10 @@ const SITE_NAME = process.env.SITE_NAME
 const BUILD_NUMBER = process.env.CODEBUILD_BUILD_NUMBER
 const CONCURRENCY = Number(process.env.UPLOAD_CONCURRENCY) || 20
 
-interface Redirect { source: string; destination: string }
+interface Redirect {
+  source: string
+  destination: string
+}
 
 // Returns the normalised S3 key segment, or null if the source is unsafe/empty.
 function normalizeSource(source: string): string | null {

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -7,7 +7,7 @@ const REDIRECTS_JSON = process.env.REDIRECTS_JSON
 const S3_BUCKET = process.env.S3_BUCKET_NAME
 const SITE_NAME = process.env.SITE_NAME
 const BUILD_NUMBER = process.env.CODEBUILD_BUILD_NUMBER
-const CONCURRENCY = Number(process.env.UPLOAD_CONCURRENCY) || 20
+const CONCURRENCY = 20
 
 interface Redirect {
   source: string


### PR DESCRIPTION
## Problem

The `Redirect` table introduced in the base branch stores per-site redirect paths, but nothing in the publishing pipeline reads from it yet. As a result, redirects configured in Studio do not actually take effect on published sites.

Closes ISOM-2260.

## Solution

Extend the publishing pipeline so each site build fetches its redirect rows from Postgres and materialises them as S3 objects that the existing CloudFront Function can act on.

- Add `GET_REDIRECTS` query and `fetchAndWriteRedirects` step in [publishing/index.ts](tooling/build/scripts/publishing/index.ts) that writes `redirects.json` for the current site. On query error the step writes an empty array so the build does not fail.
- Move `redirects.json` into the template output and capture its absolute path in [publisher.sh](tooling/build/scripts/publisher.sh) before changing CWD.
- Add [uploadRedirects.ts](tooling/build/scripts/publishing/uploadRedirects.ts), a standalone script invoked via `npm run upload-redirects`. For each `{source, destination}` row it uploads an empty `index.html` to `s3://$S3_BUCKET_NAME/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest/<source>/index.html` with `x-amz-meta-redirect-destination` set to the destination. The CloudFront Function already reads this header to issue the HTTP redirect.
- The upload runs **after** the `aws s3 sync --delete` of `_next`, so redirect objects are not swept away.
- Source paths are normalised and validated before upload: leading/trailing/duplicate slashes are collapsed, control characters and backslashes are rejected, `..` traversal segments are rejected, and duplicate normalised sources are skipped. Destinations that are not absolute (`http(s)://` or `/`) log a warning but still upload.
- Uploads run through a fixed-size worker pool (default concurrency 20, configurable via `UPLOAD_CONCURRENCY`). If any upload fails the script exits non-zero, but the calling shell step swallows the error so a few bad redirects do not fail the whole publish.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Redirects configured for a site are now applied at publish time: each row in the `Redirect` table becomes an S3 object that triggers a CloudFront 301-style redirect to the configured destination.

**Improvements**:

- Input hardening for redirect sources (path normalisation, traversal rejection, deduplication) so malformed rows cannot produce unexpected S3 keys.
- Bounded concurrency on `aws s3 cp` calls so sites with many redirects do not fork hundreds of processes.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In Studio (or directly in the DB), add a `Redirect` row for a test site with a source like `old-page` and a destination like `https://example.com/new-page`.
- [ ] Trigger a publish for that site and confirm the CodeBuild logs include `Uploading redirect files to S3...` followed by `Uploaded N/N redirects.`
- [ ] In the S3 bucket, confirm an object exists at `<SITE_NAME>/<BUILD_NUMBER>/latest/old-page/index.html` with metadata header `x-amz-meta-redirect-destination: https://example.com/new-page`.
- [ ] Visit `https://<site-domain>/old-page` and confirm the browser is redirected to `https://example.com/new-page`.
- [ ] Add a redirect with a malformed source (e.g. `../etc/passwd` or one containing control characters) and confirm the publish logs `Skipping invalid redirect source: ...` and that no corresponding S3 object is created.
- [ ] Add two redirects whose sources normalise to the same path (e.g. `/foo/` and `foo`) and confirm only one is uploaded with a `Skipping duplicate normalised source` warning.
- [ ] Publish a site with zero redirect rows and confirm the build succeeds with `No valid redirects to upload.` in the logs.
- [ ] Confirm pre-existing `_next` assets are still present after publish (i.e. the redirect upload step running after the `--delete` sync has not regressed normal site assets).

**New scripts**:

- `upload-redirects` (in `tooling/build/scripts/publishing`): runs `uploadRedirects.ts` to upload S3 redirect objects from `redirects.json`.

**New dependencies**:

- None

**New dev dependencies**:

- None