### PR TITLE
feat: accept AVIF as an image upload format

### DIFF
--- a/packages/components/src/constants/image.ts
+++ b/packages/components/src/constants/image.ts
@@ -7,6 +7,7 @@ export const IMAGE_ACCEPTED_MIME_TYPE_MAPPING: Record<string, string> = {
   ".tiff": "image/tiff",
   ".bmp": "image/bmp",
   ".webp": "image/webp",
+  ".avif": "image/avif",
 }
 
 /** Subset of {@link IMAGE_ACCEPTED_MIME_TYPE_MAPPING};


### PR DESCRIPTION
## Problem

Studio's image upload allowlist did not include AVIF, so users could not upload `.avif` images even though it's a widely supported, efficient modern format.

## Solution

Add `.avif` → `image/avif` to the shared `IMAGE_ACCEPTED_MIME_TYPE_MAPPING` in `packages/components/src/constants/image.ts`. This single mapping is the source of truth and propagates through Studio:

- Upload schema whitelist (`apps/studio/src/schemas/asset.ts`)
- Server-side extension→MIME map used for signed upload metadata (`apps/studio/src/server/modules/asset/asset.service.ts`)
- Accepted-types UI message in the form-builder image control constants

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Accept `.avif` (image/avif) as a valid image upload format in Studio.

## Tests

The existing asset schema test (`apps/studio/src/schemas/__tests__/asset.test.ts`) iterates over `IMAGE_ACCEPTED_MIME_TYPE_MAPPING`, so `.avif` is automatically covered.

**Manual Verification Steps**:

- [ ] In Studio, open an image upload control (e.g. Hero image, generic image block, or metadata image).
- [ ] Upload a `.avif` file and confirm it is accepted and renders correctly.
- [ ] Confirm previously supported formats (`.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.tiff`, `.bmp`, `.webp`) still upload successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)