### PR TITLE
chore: remove character limit from tag labels

### DIFF
--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -29,7 +29,7 @@ export const TagCategoryUuidSchema = generateUuidSchema({
 // NOTE: single value for now but we might extend this in the future with additional metadata,
 // so we will leave it as is
 const DropdownItemSchema = Type.Object({
-  label: Type.String({ maxLength: 70 }),
+  label: Type.String(),
   id: TagOptionUuidSchema,
 })
 const TagOptionSchema = DropdownItemSchema

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -9,7 +9,7 @@ import {
   SearchableTableSchema,
 } from "~/interfaces"
 import { imageSchemaObject } from "~/schemas/internal"
-import { REF_HREF_PATTERN } from "~/utils/validation"
+import { NON_EMPTY_STRING_REGEX, REF_HREF_PATTERN } from "~/utils/validation"
 
 // NOTE: a tag value is simply a uuid that maps to a given label;
 // essentially, it is just a pointer
@@ -29,7 +29,7 @@ export const TagCategoryUuidSchema = generateUuidSchema({
 // NOTE: single value for now but we might extend this in the future with additional metadata,
 // so we will leave it as is
 const DropdownItemSchema = Type.Object({
-  label: Type.String(),
+  label: Type.String({ pattern: NON_EMPTY_STRING_REGEX }),
   id: TagOptionUuidSchema,
 })
 const TagOptionSchema = DropdownItemSchema


### PR DESCRIPTION
## Problem

Tag labels were limited to 70 characters, which may be too restrictive for some use cases where more descriptive tag names are needed.

## Solution

Removed the `maxLength: 70` constraint from the `DropdownItemSchema` in `packages/components/src/types/page.ts`. This affects both tag category labels and tag option labels.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Tag category labels and tag option labels can now be any length (previously limited to 70 characters)

## Before & After Screenshots

N/A - Schema change only, no visual changes.

## Tests

- Verify tag categories and tag options can be created with labels longer than 70 characters
- Verify existing tags continue to work as expected

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None