### PR TITLE
chore: add www.ago.gov.sg to audit logs subscription

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -115,6 +115,7 @@ const SITES_WITH_AUDIT_LOGS = [
   289, // www.toteboard.gov.sg
   336, // www.caringcommuters.gov.sg
   343, // www.motawardsceremony.gov.sg
+  357, // www.ago.gov.sg
   397, // www.rp.edu.sg
   484, // www.hpb.gov.sg
 ]


### PR DESCRIPTION
## Summary
- Add site id 357 (www.ago.gov.sg) to the `SITES_WITH_AUDIT_LOGS` list in `apps/studio/prisma/scripts/getAuditLogs.ts`, ordered by site id.

## Test plan
- [ ] Run the audit logs script and confirm www.ago.gov.sg is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)