### PR TITLE
feat: add feature flag for redirections

### DIFF
--- a/apps/studio/src/features/settings/SettingsSidenav/SettingsSidenav.tsx
+++ b/apps/studio/src/features/settings/SettingsSidenav/SettingsSidenav.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router"
 import { BiDirections, BiPaint, BiWrench } from "react-icons/bi"
 import { CmsCollapsibleSidenav } from "~/components/CmsSidebar/CmsCollapsibleSidenav"
 import { siteSchema } from "~/features/editing-experience/schema"
+import { useIsRedirectionsEnabled } from "~/hooks/useIsRedirectionsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 
 import { HeaderRow } from "./components"
@@ -28,6 +29,7 @@ interface SideNavItem {
 export const SettingsSidenav = ({ onSidenavClose }: SettingsSidenavProps) => {
   const { siteId } = useQueryParse(siteSchema)
   const router = useRouter()
+  const isRedirectionsEnabled = useIsRedirectionsEnabled()
 
   const SIDENAV_ITEMS: SideNavItem[] = [
     {
@@ -42,6 +44,14 @@ export const SettingsSidenav = ({ onSidenavClose }: SettingsSidenavProps) => {
           label: "Integrations",
           href: `/sites/${siteId}/settings/integrations`,
         },
+        ...(isRedirectionsEnabled
+          ? [
+              {
+                label: "Redirects",
+                href: `/sites/${siteId}/settings/redirects`,
+              },
+            ]
+          : []),
       ],
     },
     {

--- a/apps/studio/src/hooks/useIsRedirectionsEnabled.ts
+++ b/apps/studio/src/hooks/useIsRedirectionsEnabled.ts
@@ -1,0 +1,5 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import { IS_REDIRECTIONS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+
+export const useIsRedirectionsEnabled = () =>
+  useFeatureValue<boolean>(IS_REDIRECTIONS_ENABLED_FEATURE_KEY, false)

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -11,6 +11,7 @@ export const IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY =
 export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 export const EGAZETTE_INFO_FEATURE_KEY = "egazette-info"
+export const IS_REDIRECTIONS_ENABLED_FEATURE_KEY = "is-redirections-enabled"
 
 export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 

--- a/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
@@ -1,0 +1,43 @@
+import type { NextPageWithLayout } from "~/lib/types"
+import { Center, Text } from "@chakra-ui/react"
+import { useRouter } from "next/router"
+import { useEffect } from "react"
+import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { siteSchema } from "~/features/editing-experience/schema"
+import { useIsRedirectionsEnabled } from "~/hooks/useIsRedirectionsEnabled"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+const RedirectsSettingsPage: NextPageWithLayout = () => {
+  const { siteId } = useQueryParse(siteSchema)
+  const router = useRouter()
+  const isRedirectionsEnabled = useIsRedirectionsEnabled()
+
+  useEffect(() => {
+    if (!isRedirectionsEnabled) {
+      void router.replace(`/sites/${siteId}/settings/agency`)
+    }
+  }, [isRedirectionsEnabled, router, siteId])
+
+  if (!isRedirectionsEnabled) return null
+
+  return (
+    <Center flex={1}>
+      <Text textStyle="h5" color="base.content.medium">
+        Redirects — coming soon
+      </Text>
+    </Center>
+  )
+}
+
+RedirectsSettingsPage.getLayout = (page) => {
+  return (
+    <PermissionsBoundary
+      resourceType={ResourceType.RootPage}
+      page={SiteSettingsLayout(page)}
+    />
+  )
+}
+
+export default RedirectsSettingsPage

--- a/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
@@ -1,5 +1,6 @@
 import type { NextPageWithLayout } from "~/lib/types"
 import { Center, Text } from "@chakra-ui/react"
+import { useGrowthBook } from "@growthbook/growthbook-react"
 import { useRouter } from "next/router"
 import { useEffect } from "react"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
@@ -12,15 +13,16 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 const RedirectsSettingsPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteSchema)
   const router = useRouter()
+  const gb = useGrowthBook()
   const isRedirectionsEnabled = useIsRedirectionsEnabled()
 
   useEffect(() => {
-    if (!isRedirectionsEnabled) {
+    if (gb?.ready && !isRedirectionsEnabled) {
       void router.replace(`/sites/${siteId}/settings/agency`)
     }
-  }, [isRedirectionsEnabled, router, siteId])
+  }, [gb?.ready, isRedirectionsEnabled, router, siteId])
 
-  if (!isRedirectionsEnabled) return null
+  if (!gb?.ready || !isRedirectionsEnabled) return null
 
   return (
     <Center flex={1}>

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { pageHandlers } from "tests/msw/handlers/page"
+import { sitesHandlers } from "tests/msw/handlers/sites"
+import RedirectsSettingsPage from "~/pages/sites/[siteId]/settings/redirects"
+import { ADMIN_HANDLERS } from "~/stories/handlers"
+import { createRedirectionsEnabledGbParameters } from "~/stories/utils/growthbook"
+
+const COMMON_HANDLERS = [
+  ...ADMIN_HANDLERS,
+  sitesHandlers.getNotification.default(),
+  sitesHandlers.getTheme.default(),
+  pageHandlers.getRootPage.default(),
+  pageHandlers.readPageAndBlob.homepage(),
+  sitesHandlers.getLocalisedSitemap.default(),
+  sitesHandlers.getConfig.default(),
+  sitesHandlers.getFooter.default(),
+  sitesHandlers.getNavbar.default(),
+]
+
+const COMMON_NEXTJS = {
+  router: {
+    asPath: "/sites/1/settings/redirects",
+    query: {
+      siteId: "1",
+    },
+  },
+}
+
+const meta: Meta<typeof RedirectsSettingsPage> = {
+  title: "Pages/Site Management/Agency Settings Page/Redirects",
+  component: RedirectsSettingsPage,
+  parameters: {
+    getLayout: RedirectsSettingsPage.getLayout,
+    msw: {
+      handlers: COMMON_HANDLERS,
+    },
+    nextjs: COMMON_NEXTJS,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  parameters: {
+    growthbook: [createRedirectionsEnabledGbParameters(true)],
+  },
+}

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -3,6 +3,7 @@ import { GrowthBook } from "@growthbook/growthbook"
 import {
   BANNER_FEATURE_KEY,
   CATEGORY_DROPDOWN_FEATURE_KEY,
+  IS_REDIRECTIONS_ENABLED_FEATURE_KEY,
   IS_SINGPASS_ENABLED_FEATURE_KEY,
 } from "~/lib/growthbook"
 
@@ -35,4 +36,8 @@ export const createDropdownGbParameters = (siteId: string) => {
 
 export const createSingpassEnabledGbParameters = (isEnabled: boolean) => {
   return [IS_SINGPASS_ENABLED_FEATURE_KEY, isEnabled]
+}
+
+export const createRedirectionsEnabledGbParameters = (isEnabled: boolean) => {
+  return [IS_REDIRECTIONS_ENABLED_FEATURE_KEY, isEnabled]
 }


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes ISOM-2261

## Solution

<!-- How did you solve the problem? -->

Adds a GrowthBook feature flag (`is-redirections-enabled`) that gates the redirections feature. This allows the redirections UI to be incrementally rolled out to sites without exposing it to all users at once.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- New GrowthBook feature flag constant `IS_REDIRECTIONS_ENABLED_FEATURE_KEY` (`"is-redirections-enabled"`) in `lib/growthbook.ts`
- New `useIsRedirectionsEnabled` hook that reads the flag value (defaults to `false`)
- New `/sites/:siteId/settings/redirects` settings page with a placeholder; redirects to the agency settings page when the flag is off
- "Redirects" entry added to the General section of `SettingsSidenav`, visible only when the flag is enabled
- Storybook story for the redirects page with the flag enabled

**Improvements**:

- `stories/utils/growthbook.ts` extended with `createRedirectionsEnabledGbParameters` helper for use in Storybook stories

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In GrowthBook, enable the `is-redirections-enabled` flag for your test account/site
- [ ] Navigate to `/sites/<siteId>/settings/agency` — confirm a new "Redirects" item appears in the General section of the settings sidenav
- [ ] Click "Redirects" in the sidenav — confirm the page loads at `/sites/<siteId>/settings/redirects` and shows the "Redirects — coming soon" placeholder text
- [ ] Disable the `is-redirections-enabled` flag in GrowthBook, then navigate directly to `/sites/<siteId>/settings/redirects` — confirm it redirects to `/sites/<siteId>/settings/agency` and the sidenav entry is no longer visible
- [ ] Open Storybook and navigate to `Pages/Site Management/Agency Settings Page/Redirects` — confirm the `Default` story renders the placeholder page correctly

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None