### PR TITLE
chore: remove 120-char max on collection image alt text

### DIFF
--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -51,7 +51,7 @@ export const editLinkSchema = z.object({
   image: z
     .object({
       src: z.string(),
-      alt: z.string().max(120),
+      alt: z.string(),
     })
     .optional(),
 })


### PR DESCRIPTION
## Problem

The `alt` field on collection image schema was constrained to a maximum of 120 characters. Editors writing more descriptive alt text for accessibility were blocked by this validation error, even though there is no underlying business requirement to cap alt text at 120 characters.

## Solution

Remove the `.max(120)` constraint from the `alt` field in `editLinkSchema` (`apps/studio/src/schemas/collection.ts`). The field remains a required string but no longer rejects values longer than 120 characters.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Editors can now save collection items with alt text longer than 120 characters, allowing for more descriptive accessibility text.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- Saving a collection item with alt text > 120 characters fails validation. -->

**AFTER**:

<!-- Saving a collection item with alt text > 120 characters succeeds. -->

## Tests

**Manual Verification Steps**:

- [ ] Navigate to a site in Studio and open a collection (e.g. a publications/news collection).
- [ ] Open an existing collection item (or create a new one) that has a thumbnail image.
- [ ] In the image alt text field, enter a value longer than 120 characters.
- [ ] Save the collection item and confirm that it saves successfully without a validation error.
- [ ] Reload the page and confirm the long alt text persists.
- [ ] Confirm that existing collection items with shorter alt text still save and render correctly.