### PR TITLE
refactor(gazette): replace uuidv4 with crypto.randomUUID for permalink generation

### DIFF
--- a/apps/studio/src/features/gazettes/components/CreateGazetteModal/CreateGazetteModal.tsx
+++ b/apps/studio/src/features/gazettes/components/CreateGazetteModal/CreateGazetteModal.tsx
@@ -14,7 +14,6 @@ import {
 } from "@opengovsg/design-system-react"
 import { format, parse } from "date-fns"
 import { useState } from "react"
-import { v4 as uuidv4 } from "uuid"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
 import { useZodForm } from "~/lib/form"
@@ -110,7 +109,7 @@ const CreateGazetteModalContent = ({
         siteId,
         collectionId,
         title: data.title,
-        permalink: uuidv4(),
+        permalink: crypto.randomUUID(),
         ref,
         category: data.category,
         date: format(data.publishDate, "dd/MM/yyyy"),

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -15,7 +15,6 @@ import {
   setupIsomerAdmin,
   setupUser,
 } from "tests/integration/helpers/seed"
-import { v4 as uuidv4 } from "uuid"
 import { describe, expect, it } from "vitest"
 import { createCallerFactory } from "~/server/trpc"
 import { IsomerAdminRole, ResourceType } from "~prisma/generated/generatedEnums"
@@ -155,7 +154,7 @@ describe("gazette.router", async () => {
         siteId: site.id,
         collectionId: Number(collection.id),
         title: "Notice 123",
-        permalink: uuidv4(),
+        permalink: crypto.randomUUID(),
         ref: "/1/abc/notice-123.pdf",
         category: "Government Gazette",
         date: "30/04/2026",
@@ -210,7 +209,7 @@ describe("gazette.router", async () => {
           siteId: site.id,
           collectionId: Number(collection.id),
           title: "Notice 123",
-          permalink: uuidv4(),
+          permalink: crypto.randomUUID(),
           ref: "/1/abc/notice.pdf",
           category: "Government Gazette",
           date: "30/04/2026",
@@ -237,7 +236,7 @@ describe("gazette.router", async () => {
         siteId: site.id,
         collectionId: Number(collection.id),
         title: "Original",
-        permalink: uuidv4(),
+        permalink: crypto.randomUUID(),
         ref: "/1/abc/notice.pdf",
         category: "Government Gazette",
         date: "30/04/2026",


### PR DESCRIPTION
## Problem

The gazette permalink generation relied on the `uuid` package's `v4` function, adding an external dependency for functionality that is natively available in modern Node.js and browser runtimes via `crypto.randomUUID()`.

Closes [insert issue #]

## Solution

Replaced `uuidv4()` calls with the native `crypto.randomUUID()` Web Crypto API in the gazette permalink generation flow and its associated tests. Both produce RFC 4122 v4 UUIDs, so behaviour is equivalent.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Removed reliance on the `uuid` package for gazette permalink generation by switching to the native `crypto.randomUUID()` API, reducing third-party dependency surface for this code path.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

Existing gazette router unit tests cover the create flow and were updated to use `crypto.randomUUID()` in their setup. No new tests required since the generated value remains an RFC 4122 v4 UUID.

**Manual Verification Steps**:

- [ ] Navigate to a site's gazette collection in Studio
- [ ] Click "Create gazette" to open the Create Gazette modal
- [ ] Fill in the title, category, publish date, and upload a PDF, then submit
- [ ] Verify that the gazette is created successfully without errors
- [ ] Inspect the created gazette's permalink and confirm it is a valid v4 UUID (8-4-4-4-12 hex pattern, e.g. `f47ac10b-58cc-4372-a567-0e02b2c3d479`)
- [ ] Create a second gazette and verify the permalink differs from the first (uniqueness)

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)