### PR TITLE
chore: upgrade pnpm from v10 to v11

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       with:
-        version: 10.33.0
+        version: 11.1.1
 
     - uses: actions/setup-node@v4
       with:

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -43,7 +43,7 @@ WORKDIR /app
 # pnpm global bin is under PNPM_HOME (not on PATH by default); npm's -g used /usr/local/bin.
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack install -g pnpm@10.33.0
+RUN corepack enable && corepack install -g pnpm@11.1.1
 # fixed version to prevent supply chain attacks (to ensure it's same version as pnpm-workspace.yaml)
 RUN pnpm add -g turbo@2.9.6
 COPY . .
@@ -58,7 +58,7 @@ RUN apk update
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-RUN corepack enable && corepack install -g pnpm@10.33.0
+RUN corepack enable && corepack install -g pnpm@11.1.1
 
 # First install the dependencies (as they change less often)
 COPY --from=builder /app/out/json/ .

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "engines": {
     "node": ">=22",
-    "pnpm": ">=10"
+    "pnpm": ">=11"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.1.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,18 +32,6 @@ allowBuilds:
   "@prisma/engines": true
   esbuild: true
   prisma: true
-  "@datadog/native-appsec": false
-  "@datadog/native-iast-taint-tracking": false
-  "@datadog/native-metrics": false
-  "@datadog/pprof": false
-  "@parcel/watcher": false
-  core-js-pure: false
-  cpu-features: false
-  dd-trace: false
-  msw: false
-  protobufjs: false
-  sharp: false
-  ssh2: false
 
 catalog:
   ajv: ^8.17.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,11 +27,23 @@ publicHoistPattern:
   - rimraf
   - tsc-alias
 
-onlyBuiltDependencies:
-  - "@prisma/client"
-  - "@prisma/engines"
-  - esbuild
-  - prisma
+allowBuilds:
+  "@prisma/client": true
+  "@prisma/engines": true
+  esbuild: true
+  prisma: true
+  "@datadog/native-appsec": false
+  "@datadog/native-iast-taint-tracking": false
+  "@datadog/native-metrics": false
+  "@datadog/pprof": false
+  "@parcel/watcher": false
+  core-js-pure: false
+  cpu-features: false
+  dd-trace: false
+  msw: false
+  protobufjs: false
+  sharp: false
+  ssh2: false
 
 catalog:
   ajv: ^8.17.1

--- a/tooling/build/1password/package.json
+++ b/tooling/build/1password/package.json
@@ -13,5 +13,5 @@
     "@1password/sdk": "catalog:",
     "dotenv": "catalog:"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.1.1"
 }

--- a/tooling/build/amplify/package.json
+++ b/tooling/build/amplify/package.json
@@ -13,5 +13,5 @@
     "@aws-sdk/client-amplify": "catalog:aws-sdk",
     "dotenv": "catalog:"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.1.1"
 }

--- a/tooling/build/github/package.json
+++ b/tooling/build/github/package.json
@@ -13,5 +13,5 @@
     "@octokit/rest": "catalog:",
     "dotenv": "catalog:"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.1.1"
 }

--- a/tooling/build/scripts/build.sh
+++ b/tooling/build/scripts/build.sh
@@ -61,7 +61,7 @@ fi
 echo "Building site..."
 start_time=$(date +%s)
 corepack enable
-corepack install -g pnpm@10.33.0
+corepack install -g pnpm@11.1.1
 pnpm add ./opengovsg-isomer-components-0.0.13.tgz
 pnpm run build:template
 calculate_duration $start_time

--- a/tooling/build/scripts/preBuild.sh
+++ b/tooling/build/scripts/preBuild.sh
@@ -45,7 +45,7 @@ git checkout $ISOMER_BUILD_REPO_BRANCH
 calculate_duration $start_time
 
 corepack enable
-corepack install -g pnpm@10.33.0
+corepack install -g pnpm@11.1.1
 
 # Install dependencies
 echo "Installing dependencies..."

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -42,7 +42,7 @@ git checkout $ISOMER_BUILD_REPO_BRANCH
 calculate_duration $start_time
 
 corepack enable
-corepack install -g pnpm@10.33.0
+corepack install -g pnpm@11.1.1
 
 # Use a project-local store only in this CodeBuild job so the S3 tarball is self-contained.
 # Do not set storeDir in pnpm-workspace.yaml: local dev keeps the default global store.

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/pg": "catalog:"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.1.1"
 }


### PR DESCRIPTION
## Problem

pnpm v10 reaches the next major boundary; v11 brings perf wins (SQLite-backed store, bundled manifests in the package index), stricter security defaults, and lockfile improvements. Staying on v10 means continued exposure to v10-only bug fixes and missing v11 features.

Closes [insert issue #]

## Solution

Bumps pnpm to **11.1.1** in every place it is pinned: root + sub-workspace `packageManager` fields, the GitHub Actions setup action, the Studio `Dockerfile` (both `corepack install` stages), and the three CodeBuild scripts (`build.sh`, `preBuild.sh`, `publisher.sh`). Also bumps `engines.pnpm` to `>=11`.

Migrates the one v11-breaking config in this repo: `onlyBuiltDependencies` (array) → `allowBuilds` (map) in `pnpm-workspace.yaml`. The 4 originally-whitelisted packages (`@prisma/client`, `@prisma/engines`, `esbuild`, `prisma`) are set to `true`; every other discovered build-script package (datadog natives, parcel watcher, sharp, ssh2, msw, etc.) is set to `false` to preserve v10's whitelist semantics exactly.

Other v11 breaking changes did not require action: Node 22+ was already enforced, no `.npmrc` exists, no `pnpm` field in any `package.json`, no `npm_config_*` env vars, no `auditConfig` / `ignorePatchFailures` / `executionEnv` usage. The `pnpm config set --location project` call in `publisher.sh` was verified to keep working — in v11 it writes to `pnpm-workspace.yaml` instead of `.npmrc`, but the effect on `storeDir` is identical.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible
  - Postinstall-script behavior matches v10: only the same 4 packages are allowed to run build scripts.
  - `pnpm-lock.yaml` is unchanged (still lockfileVersion 9.0); `pnpm install --frozen-lockfile` succeeds clean.

**Features**: n/a

**Improvements**:

- Pulls in v11 perf gains (SQLite-backed package index, bundled manifests, slimmer runtime installs).
- Stays current with pnpm security/maintenance releases.

**Bug Fixes**: n/a

## Tests

Locally verified with pnpm 11.1.1:
- `pnpm install --frozen-lockfile` → clean, lockfile unchanged.
- `pnpm run typecheck` → 7/7 tasks pass.
- `pnpm run lint` → 10/10 tasks pass (no new warnings introduced).
- `pnpm exec sherif` (workspace lint) → no issues.

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)