### PR TITLE
chore: enable pnpm blockExoticSubdeps

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,8 @@ packages:
 
 linkWorkspacePackages: true
 
+blockExoticSubdeps: true
+
 minimumReleaseAge: 1440
 
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Problem

pnpm 10.26+ introduced [`blockExoticSubdeps`](https://pnpm.io/settings#blockexoticsubdeps), a supply-chain hardening setting that restricts exotic sources (git repositories, direct tarball URLs) to direct dependencies only. Transitive dependencies must resolve from the configured registry, local file paths, workspace links, or trusted GitHub repositories.

The project is already on `pnpm@10.33.0` (root `package.json`, `apps/studio/Dockerfile`, all `tooling/build/*` configs), so the setting is available. While the default is `true`, setting it explicitly documents the intent and guards against future config drift.

## Solution

Added `blockExoticSubdeps: true` to `pnpm-workspace.yaml` alongside the other supply-chain settings (`minimumReleaseAge`).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

The current lockfile contains no exotic transitive dependencies, so `pnpm install --frozen-lockfile` succeeds with the setting enabled. Should a future direct dependency pull an exotic transitive in, the install will fail loudly — which is the intended protection.

**Improvements**:

- Explicit supply-chain guard against transitive dependencies resolving from untrusted sources (git/tarball URLs)

## Tests

Verified locally with `pnpm install --frozen-lockfile` against the current lockfile — install completes successfully with no resolution changes.

**Manual Verification Steps**:

- [ ] After this PR is deployed, run `pnpm install --frozen-lockfile` on a clean checkout and confirm it completes without errors
- [ ] Confirm CI's setup step (`.github/actions/setup`) succeeds on this branch