### PR TITLE
chore(studio): disable "Move to..." for default Search page

### DIFF
--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -68,13 +68,23 @@ export const CollectionTableMenu = ({
               Edit settings
             </MenuItem>
           )}
-          <MenuItem
-            as="button"
-            icon={<BiFolderOpen fontSize="1rem" />}
-            onClick={handleMoveResourceClick}
-          >
-            Move to...
-          </MenuItem>
+          {isSearchPage ? (
+            <MenuItem
+              isDisabled
+              icon={<BiFolderOpen fontSize="1rem" />}
+              tooltip="This is a default page that cannot be moved."
+            >
+              Move to...
+            </MenuItem>
+          ) : (
+            <MenuItem
+              as="button"
+              icon={<BiFolderOpen fontSize="1rem" />}
+              onClick={handleMoveResourceClick}
+            >
+              Move to...
+            </MenuItem>
+          )}
           {resourceType !== ResourceType.IndexPage && isSearchPage && (
             <MenuItem
               isDisabled

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -83,19 +83,30 @@ export const ResourceTableMenu = ({
               Edit folder settings
             </MenuItem>
           )}
-          {(type === ResourceType.Page || type === ResourceType.Folder) && (
-            // TODO: we need to change the resourceid next time when we implement root level permissions
-            <Can do="move" on={{ parentId }}>
+          {(type === ResourceType.Page || type === ResourceType.Folder) &&
+            isSearchPage && (
               <MenuItem
-                as="button"
-                onClick={handleMoveResourceClick}
+                isDisabled
                 icon={<BiFolderOpen fontSize="1rem" />}
-                aria-label={`Move resource to another location for ${title}`}
+                tooltip="This is a default page that cannot be moved."
               >
                 Move to...
               </MenuItem>
-            </Can>
-          )}
+            )}
+          {(type === ResourceType.Page || type === ResourceType.Folder) &&
+            !isSearchPage && (
+              // TODO: we need to change the resourceid next time when we implement root level permissions
+              <Can do="move" on={{ parentId }}>
+                <MenuItem
+                  as="button"
+                  onClick={handleMoveResourceClick}
+                  icon={<BiFolderOpen fontSize="1rem" />}
+                  aria-label={`Move resource to another location for ${title}`}
+                >
+                  Move to...
+                </MenuItem>
+              </Can>
+            )}
           {resourceType !== ResourceType.RootPage && isSearchPage && (
             <MenuItem
               isDisabled


### PR DESCRIPTION
## Problem

The Search resource (`permalink === "search"` at root) already has its **Delete** action disabled in the resource dropdown menus, but **Move to...** was still active. Moving the default Search page would put it in an unexpected location and break the site's search experience.

## Solution

Mirror the existing disabled-Delete treatment for **Move to...** in both dropdown menus that render this action:

- `apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx` — when `isSearchPage`, render a disabled `Move to...` MenuItem with the tooltip `"This is a default page that cannot be moved."`; otherwise keep the existing `Can do="move"`-gated active item.
- `apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx` — same ternary on `isSearchPage`.

The tooltip wording follows the parallel pattern already used for Delete (`"This is a default page that cannot be removed."`).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Default Search page can no longer be moved via the dashboard dropdown menus, with a tooltip explaining why.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In Studio, open a site dashboard that contains the default Search page (permalink `search` at root level).
- [ ] Click the `...` (options) dropdown on the Search row in the resource table.
- [ ] Verify `Move to...` appears greyed out / disabled with the tooltip "This is a default page that cannot be moved." on hover.
- [ ] Verify `Delete` is also still disabled with its existing tooltip.
- [ ] Open the dropdown on a non-Search page/folder and confirm `Move to...` is still active and functional (clicking opens the move modal).
- [ ] Repeat the same checks inside a collection view (CollectionTable dropdown).