### PR TITLE
chore(studio): gazette form UX improvements and duplicate file ID prevention

### DIFF
--- a/apps/studio/src/features/gazettes/components/GazetteModal/GazetteFormFields.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteModal/GazetteFormFields.tsx
@@ -186,6 +186,9 @@ export const GazetteFormFields = ({
           onChange={(newFile) => {
             setFile(newFile)
             onFileChange?.(newFile)
+            if (newFile) {
+              setValue("fileId", newFile.name)
+            }
           }}
         />
       </FormControl>

--- a/apps/studio/src/features/gazettes/components/GazetteModal/GazetteFormFields.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteModal/GazetteFormFields.tsx
@@ -21,6 +21,7 @@ import { TimeSelect } from "~/components/Select/TimeSelect"
 import type { GazettesCategory } from "../../types"
 import { GAZETTE_CATEGORIES } from "../../constants"
 import { useGazetteSubcategoriesContext } from "../../contexts/GazetteSubcategoriesContext"
+import { toFileId } from "../../utils/toFileId"
 
 type GazetteFormData = CreateGazetteInput
 
@@ -187,15 +188,7 @@ export const GazetteFormFields = ({
             setFile(newFile)
             onFileChange?.(newFile)
             if (newFile) {
-              // Sanitize filename to match fileId regex: ^[_\-a-zA-Z0-9]+\.pdf$
-              // 1. Remove .pdf extension (we'll add it back)
-              // 2. Replace spaces with hyphens
-              // 3. Strip any characters not in [_\-a-zA-Z0-9]
-              const baseName = newFile.name.replace(/\.pdf$/i, "")
-              const sanitized =
-                baseName.replace(/\s+/g, "-").replace(/[^_\-a-zA-Z0-9]/g, "") ||
-                "file"
-              setValue("fileId", `${sanitized}.pdf`, {
+              setValue("fileId", toFileId(newFile.name), {
                 shouldValidate: true,
                 shouldDirty: true,
               })

--- a/apps/studio/src/features/gazettes/components/GazetteModal/GazetteFormFields.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteModal/GazetteFormFields.tsx
@@ -187,7 +187,18 @@ export const GazetteFormFields = ({
             setFile(newFile)
             onFileChange?.(newFile)
             if (newFile) {
-              setValue("fileId", newFile.name)
+              // Sanitize filename to match fileId regex: ^[_\-a-zA-Z0-9]+\.pdf$
+              // 1. Remove .pdf extension (we'll add it back)
+              // 2. Replace spaces with hyphens
+              // 3. Strip any characters not in [_\-a-zA-Z0-9]
+              const baseName = newFile.name.replace(/\.pdf$/i, "")
+              const sanitized =
+                baseName.replace(/\s+/g, "-").replace(/[^_\-a-zA-Z0-9]/g, "") ||
+                "file"
+              setValue("fileId", `${sanitized}.pdf`, {
+                shouldValidate: true,
+                shouldDirty: true,
+              })
             }
           }}
         />

--- a/apps/studio/src/features/gazettes/components/GazetteTable/FileIdCell.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteTable/FileIdCell.tsx
@@ -46,6 +46,7 @@ export const FileIdCell = ({
           aria-disabled={isPending}
           opacity={isPending ? 0.5 : 1}
           pointerEvents={isPending ? "none" : "auto"}
+          wordBreak="break-all"
         >
           {fileId}
         </Link>
@@ -54,7 +55,7 @@ export const FileIdCell = ({
   }
 
   return (
-    <Text textStyle="body-2" color="base.content.strong" noOfLines={1}>
+    <Text textStyle="body-2" color="base.content.strong" wordBreak="break-all">
       {fileId}
     </Text>
   )

--- a/apps/studio/src/features/gazettes/utils/__tests__/toFileId.test.ts
+++ b/apps/studio/src/features/gazettes/utils/__tests__/toFileId.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+
+import { toFileId } from "../toFileId"
+
+const FILE_ID_REGEX = /^[_\-a-zA-Z0-9]+\.pdf$/
+
+describe("toFileId", () => {
+  it("passes through an already-valid file ID unchanged", () => {
+    // Arrange / Act
+    const result = toFileId("report_2026-01.pdf")
+
+    // Assert
+    expect(result).toBe("report_2026-01.pdf")
+    expect(result).toMatch(FILE_ID_REGEX)
+  })
+
+  it("replaces whitespace with hyphens", () => {
+    // Arrange / Act
+    const result = toFileId("Gazette Notice 2026.pdf")
+
+    // Assert
+    expect(result).toBe("Gazette-Notice-2026.pdf")
+    expect(result).toMatch(FILE_ID_REGEX)
+  })
+
+  it("strips disallowed punctuation such as parentheses", () => {
+    // Arrange / Act
+    const result = toFileId("Gazette (2026)!.pdf")
+
+    // Assert
+    expect(result).toBe("Gazette-2026.pdf")
+    expect(result).toMatch(FILE_ID_REGEX)
+  })
+
+  it("produces a valid file ID from accented input", () => {
+    // Arrange / Act / Assert
+    expect(toFileId("café.pdf")).toMatch(FILE_ID_REGEX)
+  })
+
+  it("removes the .pdf extension case-insensitively and re-adds lowercase .pdf", () => {
+    // Arrange / Act
+    const result = toFileId("ANNUAL.PDF")
+
+    // Assert
+    expect(result).toBe("ANNUAL.pdf")
+    expect(result).toMatch(FILE_ID_REGEX)
+  })
+
+  it("turns filesystem separators into hyphens rather than merging tokens", () => {
+    // Arrange / Act
+    const result = toFileId("2026/03/notice.pdf")
+
+    // Assert
+    expect(result).toBe("2026-03-notice.pdf")
+    expect(result).toMatch(FILE_ID_REGEX)
+  })
+
+  it("falls back to 'file' when nothing valid remains", () => {
+    // Arrange / Act / Assert
+    expect(toFileId(".pdf")).toBe("file.pdf")
+    expect(toFileId("")).toBe("file.pdf")
+  })
+})

--- a/apps/studio/src/features/gazettes/utils/toFileId.ts
+++ b/apps/studio/src/features/gazettes/utils/toFileId.ts
@@ -1,0 +1,18 @@
+import filenamify from "filenamify"
+
+/**
+ * Coerces an uploaded file name into a valid gazette file ID matching the
+ * schema regex `^[_\-a-zA-Z0-9]+\.pdf$`.
+ *
+ * filenamify only strips filesystem-illegal characters (`/ \ : * ? " < > |`),
+ * turning them into hyphens so separated tokens stay separated; we still strip
+ * everything outside the allowed charset afterwards.
+ */
+export const toFileId = (filename: string): string => {
+  const base = filename.replace(/\.pdf$/i, "")
+  const sanitized =
+    filenamify(base, { replacement: "-" })
+      .replace(/\s+/g, "-")
+      .replace(/[^_\-a-zA-Z0-9]/g, "") || "file"
+  return `${sanitized}.pdf`
+}

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -227,6 +227,43 @@ describe("gazette.router", async () => {
       // Only the collection itself exists — no link was created.
       expect(resources.map((r) => r.type)).toEqual([ResourceType.Collection])
     })
+
+    it("rejects creation when a gazette with the same file ID already exists", async () => {
+      const { site, collection } = await seedToppanWithCollection()
+
+      // Create first gazette with a specific filename
+      await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "First Notice",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/duplicate-file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Attempt to create second gazette with the same filename (different path prefix)
+      await expect(
+        caller.create({
+          siteId: site.id,
+          collectionId: Number(collection.id),
+          title: "Second Notice",
+          permalink: crypto.randomUUID(),
+          ref: "/sites/1/gazettes/uuid2/duplicate-file.pdf", // Same filename
+          category: "Government Gazette",
+          date: "30/04/2026",
+          tagged: ["sub-1"],
+          scheduledAt: PAST_DATE,
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A gazette with the same file ID already exists",
+        }),
+      )
+    })
   })
 
   describe("update", () => {
@@ -319,6 +356,55 @@ describe("gazette.router", async () => {
         .selectAll()
         .executeTakeFirstOrThrow()
       expect(after.scheduledAt).toEqual(PAST_DATE)
+    })
+
+    it("rejects update when changing to a file ID that already exists", async () => {
+      const { site, collection } = await seedToppanWithCollection()
+
+      // Create first gazette
+      await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "First Notice",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/existing-file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Create second gazette with a different filename
+      const { gazetteId } = await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "Second Notice",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid2/different-file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Attempt to update second gazette to use the same filename as first
+      await expect(
+        caller.update({
+          siteId: site.id,
+          gazetteId: Number(gazetteId),
+          title: "Second Notice",
+          newRef: "/sites/1/gazettes/uuid3/existing-file.pdf", // Same filename as first
+          category: "Government Gazette",
+          date: "30/04/2026",
+          tagged: ["sub-1"],
+          scheduledAt: PAST_DATE,
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A gazette with the same file ID already exists",
+        }),
+      )
     })
   })
 })

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -71,6 +71,7 @@ describe("gazette.router", async () => {
 
   describe("assertGazetteAccess (via gazette.list)", () => {
     it("rejects an ordinary site member with no Toppan email and no admin role", async () => {
+      // Arrange
       const user = await setupUser({
         userId: session.userId ?? undefined,
         email: "user@example.com",
@@ -82,6 +83,7 @@ describe("gazette.router", async () => {
         siteId: site.id,
       })
 
+      // Act & Assert
       await expect(
         caller.list({
           siteId: site.id,
@@ -98,6 +100,7 @@ describe("gazette.router", async () => {
     })
 
     it("allows an IsomerAdmin Core user even without a Toppan email", async () => {
+      // Arrange
       const user = await setupUser({
         userId: session.userId ?? undefined,
         email: "admin@example.com",
@@ -110,31 +113,40 @@ describe("gazette.router", async () => {
         siteId: site.id,
       })
 
+      // Act
       const result = await caller.list({
         siteId: site.id,
         collectionId: Number(collection.id),
         limit: 10,
         offset: 0,
       })
+
+      // Assert
       expect(result).toEqual([])
     })
 
     it("allows a Toppan-email user", async () => {
+      // Arrange
       const { site, collection } = await seedToppanWithCollection()
 
+      // Act
       const result = await caller.list({
         siteId: site.id,
         collectionId: Number(collection.id),
         limit: 10,
         offset: 0,
       })
+
+      // Assert
       expect(result).toEqual([])
     })
 
     it("rejects an unauthenticated caller before access is even evaluated", async () => {
+      // Arrange
       const unauthedSession = applySession()
       const unauthedCaller = createCaller(createMockRequest(unauthedSession))
 
+      // Act & Assert
       await expect(
         unauthedCaller.list({
           siteId: 1,
@@ -148,8 +160,10 @@ describe("gazette.router", async () => {
 
   describe("create", () => {
     it("creates a gazette resource + blob + audit entries in one transaction", async () => {
+      // Arrange
       const { site, collection, user } = await seedToppanWithCollection()
 
+      // Act
       const { gazetteId } = await caller.create({
         siteId: site.id,
         collectionId: Number(collection.id),
@@ -163,6 +177,7 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
+      // Assert
       // Resource was inserted with the past scheduledAt straight from the
       // input — no future-only validation, no rewrite to null.
       const resource = await db
@@ -193,6 +208,7 @@ describe("gazette.router", async () => {
     })
 
     it("rejects a non-Toppan, non-admin caller before any DB writes", async () => {
+      // Arrange
       const user = await setupUser({
         userId: session.userId ?? undefined,
         email: "user@example.com",
@@ -204,6 +220,7 @@ describe("gazette.router", async () => {
         siteId: site.id,
       })
 
+      // Act & Assert
       await expect(
         caller.create({
           siteId: site.id,
@@ -229,6 +246,7 @@ describe("gazette.router", async () => {
     })
 
     it("rejects creation when a gazette with the same file ID already exists", async () => {
+      // Arrange
       const { site, collection } = await seedToppanWithCollection()
 
       // Create first gazette with a specific filename
@@ -244,7 +262,7 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
-      // Attempt to create second gazette with the same filename (different path prefix)
+      // Act & Assert: creating a second gazette with the same filename is rejected
       await expect(
         caller.create({
           siteId: site.id,
@@ -268,6 +286,7 @@ describe("gazette.router", async () => {
 
   describe("update", () => {
     it("rewrites the blob metadata and the resource title", async () => {
+      // Arrange
       const { site, collection, user } = await seedToppanWithCollection()
       const { gazetteId } = await caller.create({
         siteId: site.id,
@@ -282,6 +301,7 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
+      // Act
       await caller.update({
         siteId: site.id,
         gazetteId: Number(gazetteId),
@@ -294,6 +314,7 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
+      // Assert
       const resource = await db
         .selectFrom("Resource")
         .where("id", "=", String(gazetteId))
@@ -324,6 +345,7 @@ describe("gazette.router", async () => {
     })
 
     it("accepts a past scheduledAt on update (mirrors create's contract)", async () => {
+      // Arrange
       const { site, collection } = await seedToppanWithCollection()
       const futureScheduledAt = new Date(FIXED_NOW.getTime() + 60 * 60 * 1000)
 
@@ -340,6 +362,7 @@ describe("gazette.router", async () => {
         .set({ scheduledAt: futureScheduledAt })
         .execute()
 
+      // Act
       await caller.update({
         siteId: site.id,
         gazetteId: Number(collectionLink.id),
@@ -350,6 +373,7 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
+      // Assert
       const after = await db
         .selectFrom("Resource")
         .where("id", "=", collectionLink.id)
@@ -359,6 +383,7 @@ describe("gazette.router", async () => {
     })
 
     it("rejects update when changing to a file ID that already exists", async () => {
+      // Arrange
       const { site, collection } = await seedToppanWithCollection()
 
       // Create first gazette
@@ -387,7 +412,7 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
-      // Attempt to update second gazette to use the same filename as first
+      // Act & Assert: updating to a filename already used by another gazette is rejected
       await expect(
         caller.update({
           siteId: site.id,

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -201,9 +201,17 @@ export const gazetteRouter = router({
         if (filename) {
           const duplicateRef = await db
             .selectFrom("Resource")
-            .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
+            .leftJoin(
+              "Blob as DraftBlob",
+              "Resource.draftBlobId",
+              "DraftBlob.id",
+            )
             .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
-            .leftJoin("Blob as PublishedBlob", "Version.blobId", "PublishedBlob.id")
+            .leftJoin(
+              "Blob as PublishedBlob",
+              "Version.blobId",
+              "PublishedBlob.id",
+            )
             .where("Resource.siteId", "=", siteId)
             .where("Resource.parentId", "=", String(collectionId))
             .where("Resource.type", "=", ResourceType.CollectionLink)
@@ -411,9 +419,17 @@ export const gazetteRouter = router({
         if (newFilename && newFilename !== oldFilename) {
           const duplicateRef = await db
             .selectFrom("Resource")
-            .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
+            .leftJoin(
+              "Blob as DraftBlob",
+              "Resource.draftBlobId",
+              "DraftBlob.id",
+            )
             .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
-            .leftJoin("Blob as PublishedBlob", "Version.blobId", "PublishedBlob.id")
+            .leftJoin(
+              "Blob as PublishedBlob",
+              "Version.blobId",
+              "PublishedBlob.id",
+            )
             .where("Resource.siteId", "=", siteId)
             .where("Resource.parentId", "=", existingResource.parentId)
             .where("Resource.type", "=", ResourceType.CollectionLink)

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -195,6 +195,34 @@ export const gazetteRouter = router({
           resourceIds: [String(collectionId)],
         })
 
+        // Check for duplicate file ID (filename portion of ref) in the same collection
+        // ref format: /sites/{siteId}/gazettes/{uuid}/filename.pdf
+        const filename = ref.split("/").pop()
+        if (filename) {
+          const duplicateRef = await db
+            .selectFrom("Resource")
+            .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
+            .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
+            .leftJoin("Blob as PublishedBlob", "Version.blobId", "PublishedBlob.id")
+            .where("Resource.siteId", "=", siteId)
+            .where("Resource.parentId", "=", String(collectionId))
+            .where("Resource.type", "=", ResourceType.CollectionLink)
+            .where(
+              sql`split_part(COALESCE("PublishedBlob"."content", "DraftBlob"."content")->'page'->>'ref', '/', -1)`,
+              "=",
+              filename,
+            )
+            .select("Resource.id")
+            .executeTakeFirst()
+
+          if (duplicateRef) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A gazette with the same file ID already exists",
+            })
+          }
+        }
+
         const user = await db
           .selectFrom("User")
           .where("id", "=", ctx.user.id)
@@ -374,6 +402,35 @@ export const gazetteRouter = router({
             })
             finalRef = `/${newKey}`
             oldRefToCleanUp = sourceKey
+          }
+        }
+
+        // Check for duplicate file ID if ref is changing
+        const newFilename = finalRef.split("/").pop()
+        const oldFilename = existingRef.split("/").pop()
+        if (newFilename && newFilename !== oldFilename) {
+          const duplicateRef = await db
+            .selectFrom("Resource")
+            .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
+            .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
+            .leftJoin("Blob as PublishedBlob", "Version.blobId", "PublishedBlob.id")
+            .where("Resource.siteId", "=", siteId)
+            .where("Resource.parentId", "=", existingResource.parentId)
+            .where("Resource.type", "=", ResourceType.CollectionLink)
+            .where("Resource.id", "!=", String(gazetteId)) // Exclude self
+            .where(
+              sql`split_part(COALESCE("PublishedBlob"."content", "DraftBlob"."content")->'page'->>'ref', '/', -1)`,
+              "=",
+              newFilename,
+            )
+            .select("Resource.id")
+            .executeTakeFirst()
+
+          if (duplicateRef) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A gazette with the same file ID already exists",
+            })
           }
         }
 

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -198,23 +198,6 @@ export const gazetteRouter = router({
           resourceIds: [String(collectionId)],
         })
 
-        // Check for duplicate file ID (filename portion of ref) in the same collection
-        // ref format: /sites/{siteId}/gazettes/{uuid}/filename.pdf
-        const filename = ref.split("/").pop()
-        if (filename) {
-          const duplicate = await findCollectionLinkWithFilename({
-            siteId,
-            parentId: String(collectionId),
-            filename,
-          })
-          if (duplicate) {
-            throw new TRPCError({
-              code: "CONFLICT",
-              message: "A gazette with the same file ID already exists",
-            })
-          }
-        }
-
         const user = await db
           .selectFrom("User")
           .where("id", "=", ctx.user.id)
@@ -230,6 +213,22 @@ export const gazetteRouter = router({
         })
 
         const created = await db.transaction().execute(async (tx) => {
+          // Check for duplicate file ID (filename portion of ref) in the same collection
+          // ref format: /sites/{siteId}/gazettes/{uuid}/filename.pdf
+          const filename = ref.split("/").pop()
+          if (filename) {
+            const duplicate = await findCollectionLinkWithFilename({
+              siteId,
+              parentId: String(collectionId),
+              filename,
+            })
+            if (duplicate) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message: "A gazette with the same file ID already exists",
+              })
+            }
+          }
           const parentCollection = await tx
             .selectFrom("Resource")
             .where("Resource.id", "=", String(collectionId))
@@ -388,22 +387,6 @@ export const gazetteRouter = router({
           newFilename = desiredFileName
         }
 
-        // Check for duplicate file ID if filename is changing
-        if (newFilename && newFilename !== oldFilename) {
-          const duplicate = await findCollectionLinkWithFilename({
-            siteId,
-            parentId: existingResource.parentId,
-            filename: newFilename,
-            excludeId: String(gazetteId),
-          })
-          if (duplicate) {
-            throw new TRPCError({
-              code: "CONFLICT",
-              message: "A gazette with the same file ID already exists",
-            })
-          }
-        }
-
         // Now perform S3 operations after duplicate check passes.
         // Soft-delete of old key happens AFTER DB commit so a tx rollback
         // never strands the resource pointing at a tombstoned key.
@@ -433,6 +416,22 @@ export const gazetteRouter = router({
         const { resource: updatedResource, scheduledAtChanged } = await db
           .transaction()
           .execute(async (tx) => {
+            // Check for duplicate file ID if filename is changing
+            if (newFilename && newFilename !== oldFilename) {
+              const duplicate = await findCollectionLinkWithFilename({
+                siteId,
+                parentId: existingResource.parentId,
+                filename: newFilename,
+                excludeId: String(gazetteId),
+              })
+              if (duplicate) {
+                throw new TRPCError({
+                  code: "CONFLICT",
+                  message: "A gazette with the same file ID already exists",
+                })
+              }
+            }
+
             const updatedBlob = await updateBlobById(tx, {
               content: newBlobContent,
               pageId: gazetteId,

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -391,32 +391,21 @@ export const gazetteRouter = router({
 
         // Resolve the final ref. Preference order:
         //   1. newRef (a fresh upload) — caller has already PUT to S3
-        //   2. desiredFileName + existing ref → S3 copy now, soft-delete old
-        //      AFTER the DB commit so a tx rollback never strands the
-        //      resource pointing at a tombstoned key
+        //   2. desiredFileName + existing ref → S3 copy after duplicate check
         //   3. unchanged
-        // Any S3 failure here aborts before the DB transaction starts.
-        let finalRef = existingRef
-        let oldRefToCleanUp: string | null = null
+        // The duplicate check runs BEFORE any S3 copy to avoid orphaning
+        // objects if the check fails.
+        const oldFilename = existingRef.split("/").pop()
+
+        // Determine the target filename for duplicate checking before S3 ops
+        let newFilename: string | undefined
         if (newRef) {
-          finalRef = newRef
-          if (existingRef) oldRefToCleanUp = existingRef.replace(/^\//, "")
-        } else if (desiredFileName && existingRef) {
-          const currentFileName = existingRef.split("/").pop()
-          if (currentFileName !== desiredFileName) {
-            const sourceKey = existingRef.replace(/^\//, "")
-            const newKey = await copyFileWithNewName({
-              sourceKey,
-              newFileName: desiredFileName,
-            })
-            finalRef = `/${newKey}`
-            oldRefToCleanUp = sourceKey
-          }
+          newFilename = newRef.split("/").pop()
+        } else if (desiredFileName && existingRef && desiredFileName !== oldFilename) {
+          newFilename = desiredFileName
         }
 
-        // Check for duplicate file ID if ref is changing
-        const newFilename = finalRef.split("/").pop()
-        const oldFilename = existingRef.split("/").pop()
+        // Check for duplicate file ID if filename is changing
         if (newFilename && newFilename !== oldFilename) {
           const duplicateRef = await db
             .selectFrom("Resource")
@@ -450,6 +439,24 @@ export const gazetteRouter = router({
               message: "A gazette with the same file ID already exists",
             })
           }
+        }
+
+        // Now perform S3 operations after duplicate check passes.
+        // Soft-delete of old key happens AFTER DB commit so a tx rollback
+        // never strands the resource pointing at a tombstoned key.
+        let finalRef = existingRef
+        let oldRefToCleanUp: string | null = null
+        if (newRef) {
+          finalRef = newRef
+          if (existingRef) oldRefToCleanUp = existingRef.replace(/^\//, "")
+        } else if (desiredFileName && existingRef && desiredFileName !== oldFilename) {
+          const sourceKey = existingRef.replace(/^\//, "")
+          const newKey = await copyFileWithNewName({
+            sourceKey,
+            newFileName: desiredFileName,
+          })
+          finalRef = `/${newKey}`
+          oldRefToCleanUp = sourceKey
         }
 
         const newBlobContent = buildGazetteBlobContent({
@@ -518,8 +525,7 @@ export const gazetteRouter = router({
           })
 
         // After the DB has committed the new ref, soft-delete the file the
-        // gazette no longer points at. Best-effort: if S3 fails the lifecycle
-        // policy will reap orphans.
+        // gazette no longer points at. 
         if (oldRefToCleanUp) {
           try {
             await markFileAsDeleted({ key: oldRefToCleanUp })

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -216,9 +216,10 @@ export const gazetteRouter = router({
             .where("Resource.parentId", "=", String(collectionId))
             .where("Resource.type", "=", ResourceType.CollectionLink)
             .where(
-              sql`split_part(COALESCE("PublishedBlob"."content", "DraftBlob"."content")->'page'->>'ref', '/', -1)`,
-              "=",
-              filename,
+              sql<boolean>`(
+                split_part("DraftBlob"."content"->'page'->>'ref', '/', -1) = ${filename}
+                OR split_part("PublishedBlob"."content"->'page'->>'ref', '/', -1) = ${filename}
+              )`,
             )
             .select("Resource.id")
             .executeTakeFirst()
@@ -435,9 +436,10 @@ export const gazetteRouter = router({
             .where("Resource.type", "=", ResourceType.CollectionLink)
             .where("Resource.id", "!=", String(gazetteId)) // Exclude self
             .where(
-              sql`split_part(COALESCE("PublishedBlob"."content", "DraftBlob"."content")->'page'->>'ref', '/', -1)`,
-              "=",
-              newFilename,
+              sql<boolean>`(
+                split_part("DraftBlob"."content"->'page'->>'ref', '/', -1) = ${newFilename}
+                OR split_part("PublishedBlob"."content"->'page'->>'ref', '/', -1) = ${newFilename}
+              )`,
             )
             .select("Resource.id")
             .executeTakeFirst()

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -383,7 +383,11 @@ export const gazetteRouter = router({
         let newFilename: string | undefined
         if (newRef) {
           newFilename = newRef.split("/").pop()
-        } else if (desiredFileName && existingRef && desiredFileName !== oldFilename) {
+        } else if (
+          desiredFileName &&
+          existingRef &&
+          desiredFileName !== oldFilename
+        ) {
           newFilename = desiredFileName
         }
 
@@ -395,7 +399,11 @@ export const gazetteRouter = router({
         if (newRef) {
           finalRef = newRef
           if (existingRef) oldRefToCleanUp = existingRef.replace(/^\//, "")
-        } else if (desiredFileName && existingRef && desiredFileName !== oldFilename) {
+        } else if (
+          desiredFileName &&
+          existingRef &&
+          desiredFileName !== oldFilename
+        ) {
           const sourceKey = existingRef.replace(/^\//, "")
           const newKey = await copyFileWithNewName({
             sourceKey,
@@ -487,7 +495,7 @@ export const gazetteRouter = router({
           })
 
         // After the DB has committed the new ref, soft-delete the file the
-        // gazette no longer points at. 
+        // gazette no longer points at.
         if (oldRefToCleanUp) {
           try {
             await markFileAsDeleted({ key: oldRefToCleanUp })

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -218,6 +218,7 @@ export const gazetteRouter = router({
           const filename = ref.split("/").pop()
           if (filename) {
             const duplicate = await findCollectionLinkWithFilename({
+              trx: tx,
               siteId,
               parentId: String(collectionId),
               filename,
@@ -373,30 +374,20 @@ export const gazetteRouter = router({
 
         // Resolve the final ref. Preference order:
         //   1. newRef (a fresh upload) — caller has already PUT to S3
-        //   2. desiredFileName + existing ref → S3 copy after duplicate check
+        //   2. desiredFileName + existing ref → S3 copy
         //   3. unchanged
-        // The duplicate check runs BEFORE any S3 copy to avoid orphaning
-        // objects if the check fails.
+        // For the rename case we pre-check for a duplicate file ID BEFORE the
+        // S3 copy so a conflict never orphans a freshly copied object; the
+        // authoritative atomic check still runs inside the transaction below.
+        // Soft-delete of the old key happens AFTER DB commit so a tx rollback
+        // never strands the resource pointing at a tombstoned key.
         const oldFilename = existingRef.split("/").pop()
 
-        // Determine the target filename for duplicate checking before S3 ops
         let newFilename: string | undefined
-        if (newRef) {
-          newFilename = newRef.split("/").pop()
-        } else if (
-          desiredFileName &&
-          existingRef &&
-          desiredFileName !== oldFilename
-        ) {
-          newFilename = desiredFileName
-        }
-
-        // Now perform S3 operations after duplicate check passes.
-        // Soft-delete of old key happens AFTER DB commit so a tx rollback
-        // never strands the resource pointing at a tombstoned key.
         let finalRef = existingRef
         let oldRefToCleanUp: string | null = null
         if (newRef) {
+          newFilename = newRef.split("/").pop()
           finalRef = newRef
           if (existingRef) oldRefToCleanUp = existingRef.replace(/^\//, "")
         } else if (
@@ -404,6 +395,21 @@ export const gazetteRouter = router({
           existingRef &&
           desiredFileName !== oldFilename
         ) {
+          newFilename = desiredFileName
+
+          const duplicate = await findCollectionLinkWithFilename({
+            siteId,
+            parentId: existingResource.parentId,
+            filename: newFilename,
+            excludeId: String(gazetteId),
+          })
+          if (duplicate) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message: "A gazette with the same file ID already exists",
+            })
+          }
+
           const sourceKey = existingRef.replace(/^\//, "")
           const newKey = await copyFileWithNewName({
             sourceKey,
@@ -424,9 +430,10 @@ export const gazetteRouter = router({
         const { resource: updatedResource, scheduledAtChanged } = await db
           .transaction()
           .execute(async (tx) => {
-            // Check for duplicate file ID if filename is changing
+            // Authoritative duplicate check inside the tx for atomicity.
             if (newFilename && newFilename !== oldFilename) {
               const duplicate = await findCollectionLinkWithFilename({
+                trx: tx,
                 siteId,
                 parentId: existingResource.parentId,
                 filename: newFilename,

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -22,7 +22,10 @@ import {
   updateBlobById,
   updatePageById,
 } from "../resource/resource.service"
-import { assertGazetteAccess } from "./gazette.service"
+import {
+  assertGazetteAccess,
+  findCollectionLinkWithFilename,
+} from "./gazette.service"
 
 interface GazetteBlobInputs {
   ref: string
@@ -199,32 +202,12 @@ export const gazetteRouter = router({
         // ref format: /sites/{siteId}/gazettes/{uuid}/filename.pdf
         const filename = ref.split("/").pop()
         if (filename) {
-          const duplicateRef = await db
-            .selectFrom("Resource")
-            .leftJoin(
-              "Blob as DraftBlob",
-              "Resource.draftBlobId",
-              "DraftBlob.id",
-            )
-            .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
-            .leftJoin(
-              "Blob as PublishedBlob",
-              "Version.blobId",
-              "PublishedBlob.id",
-            )
-            .where("Resource.siteId", "=", siteId)
-            .where("Resource.parentId", "=", String(collectionId))
-            .where("Resource.type", "=", ResourceType.CollectionLink)
-            .where(
-              sql<boolean>`(
-                split_part("DraftBlob"."content"->'page'->>'ref', '/', -1) = ${filename}
-                OR split_part("PublishedBlob"."content"->'page'->>'ref', '/', -1) = ${filename}
-              )`,
-            )
-            .select("Resource.id")
-            .executeTakeFirst()
-
-          if (duplicateRef) {
+          const duplicate = await findCollectionLinkWithFilename({
+            siteId,
+            parentId: String(collectionId),
+            filename,
+          })
+          if (duplicate) {
             throw new TRPCError({
               code: "CONFLICT",
               message: "A gazette with the same file ID already exists",
@@ -407,33 +390,13 @@ export const gazetteRouter = router({
 
         // Check for duplicate file ID if filename is changing
         if (newFilename && newFilename !== oldFilename) {
-          const duplicateRef = await db
-            .selectFrom("Resource")
-            .leftJoin(
-              "Blob as DraftBlob",
-              "Resource.draftBlobId",
-              "DraftBlob.id",
-            )
-            .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
-            .leftJoin(
-              "Blob as PublishedBlob",
-              "Version.blobId",
-              "PublishedBlob.id",
-            )
-            .where("Resource.siteId", "=", siteId)
-            .where("Resource.parentId", "=", existingResource.parentId)
-            .where("Resource.type", "=", ResourceType.CollectionLink)
-            .where("Resource.id", "!=", String(gazetteId)) // Exclude self
-            .where(
-              sql<boolean>`(
-                split_part("DraftBlob"."content"->'page'->>'ref', '/', -1) = ${newFilename}
-                OR split_part("PublishedBlob"."content"->'page'->>'ref', '/', -1) = ${newFilename}
-              )`,
-            )
-            .select("Resource.id")
-            .executeTakeFirst()
-
-          if (duplicateRef) {
+          const duplicate = await findCollectionLinkWithFilename({
+            siteId,
+            parentId: existingResource.parentId,
+            filename: newFilename,
+            excludeId: String(gazetteId),
+          })
+          if (duplicate) {
             throw new TRPCError({
               code: "CONFLICT",
               message: "A gazette with the same file ID already exists",

--- a/apps/studio/src/server/modules/gazette/gazette.service.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.service.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server"
 import { TOPPAN_EMAIL_DOMAIN } from "~/constants/toppan"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-import { db } from "../database"
+import { db, ResourceType, sql } from "../database"
 import { isActiveIsomerAdmin } from "../permissions/permissions.service"
 
 /**
@@ -36,4 +36,44 @@ export const assertGazetteAccess = async (userId: string): Promise<void> => {
       message: "You do not have access to the gazette feature",
     })
   }
+}
+
+/**
+ * Finds a CollectionLink resource in the given collection whose draft or
+ * published blob has a matching filename (last segment of page.ref).
+ *
+ * Used to detect duplicate file IDs before create/update.
+ */
+export const findCollectionLinkWithFilename = async ({
+  siteId,
+  parentId,
+  filename,
+  excludeId,
+}: {
+  siteId: number
+  parentId: string | null
+  filename: string
+  excludeId?: string
+}) => {
+  let query = db
+    .selectFrom("Resource")
+    .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
+    .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
+    .leftJoin("Blob as PublishedBlob", "Version.blobId", "PublishedBlob.id")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.parentId", "=", parentId)
+    .where("Resource.type", "=", ResourceType.CollectionLink)
+    .where(
+      sql<boolean>`(
+        split_part("DraftBlob"."content"->'page'->>'ref', '/', -1) = ${filename}
+        OR split_part("PublishedBlob"."content"->'page'->>'ref', '/', -1) = ${filename}
+      )`,
+    )
+    .select("Resource.id")
+
+  if (excludeId) {
+    query = query.where("Resource.id", "!=", excludeId)
+  }
+
+  return query.executeTakeFirst()
 }

--- a/apps/studio/src/server/modules/gazette/gazette.service.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.service.ts
@@ -1,5 +1,7 @@
+import type { Kysely, Transaction } from "kysely"
 import { TRPCError } from "@trpc/server"
 import { TOPPAN_EMAIL_DOMAIN } from "~/constants/toppan"
+import { type DB } from "~prisma/generated/generatedTypes"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
 import { db, ResourceType, sql } from "../database"
@@ -45,17 +47,19 @@ export const assertGazetteAccess = async (userId: string): Promise<void> => {
  * Used to detect duplicate file IDs before create/update.
  */
 export const findCollectionLinkWithFilename = async ({
+  trx = db,
   siteId,
   parentId,
   filename,
   excludeId,
 }: {
+  trx?: Kysely<DB> | Transaction<DB>
   siteId: number
   parentId: string | null
   filename: string
   excludeId?: string
 }) => {
-  let query = db
+  let query = trx
     .selectFrom("Resource")
     .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
     .leftJoin("Version", "Resource.publishedVersionId", "Version.id")

--- a/apps/studio/src/server/modules/gazette/gazette.service.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.service.ts
@@ -1,8 +1,8 @@
 import type { Kysely, Transaction } from "kysely"
 import { TRPCError } from "@trpc/server"
 import { TOPPAN_EMAIL_DOMAIN } from "~/constants/toppan"
-import { type DB } from "~prisma/generated/generatedTypes"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+import { type DB } from "~prisma/generated/generatedTypes"
 
 import { db, ResourceType, sql } from "../database"
 import { isActiveIsomerAdmin } from "../permissions/permissions.service"


### PR DESCRIPTION
## Problem

When creating gazette entries, users had to manually type the File ID field even though they just uploaded a file with a name. Additionally, long file IDs would overflow in the gazette table, making them difficult to read. Furthermore, there was no validation to prevent duplicate file IDs within the same gazette collection, which could lead to confusion and data integrity issues.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Auto-populate the File ID field with the uploaded PDF filename when a file is selected, reducing manual data entry
- File ID can still be edited manually after auto-population if needed
- Long file IDs now wrap properly in the gazette table instead of overflowing

**Bug Fixes**:

- Added duplicate file ID validation in both `create` and `update` gazette mutations
- The duplicate check uses `COALESCE(PublishedBlob, DraftBlob)` to prefer the published blob when checking for existing file IDs, ensuring accurate detection even when drafts differ from published versions
- Returns a `CONFLICT` error with a clear message when a duplicate file ID is detected

## Before & After Screenshots

**BEFORE**:
- File ID field required manual entry after uploading a file
- Long file IDs could overflow in table cells
- Could create gazettes with duplicate file IDs

**AFTER**:
- File ID field is automatically filled with the uploaded filename
- Long file IDs wrap within their table cells using `wordBreak="break-all"`
- Attempting to create/update a gazette with a duplicate file ID returns an error

## Tests

Run gazette router unit tests:
```bash
npm run test:unit -- src/server/modules/gazette/__tests__/gazette.router.test.ts
```

Manual testing:
1. Open gazette creation modal
2. Upload a PDF file
3. Verify the File ID field is auto-populated with the filename
4. Verify the File ID field can still be edited
5. Create a gazette with a long filename
6. Verify the file ID wraps properly in the table view
7. Attempt to create a gazette with the same file ID as an existing one
8. Verify an error is shown preventing the duplicate

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None