### PR TITLE
(DO NOT MERGE) chore(build): set ISOMER_BUILD_REPO_BRANCH to "main" in preBuild.sh

### DIFF
--- a/tooling/build/scripts/preBuild.sh
+++ b/tooling/build/scripts/preBuild.sh
@@ -21,7 +21,8 @@ if [ -z "$ISOMER_BUILD_REPO_BRANCH" ]; then
   # awk '{print $2}': Prints the second column of the last line, which is the tag name.
   # sed -E 's|refs/tags/||; s/\^.*$//': Removes the 'refs/tags/' prefix from the tag name.
   # - If tag is annotated (maybe due to signing), the tag name will have a caret (^) and optional text after it.
-  ISOMER_BUILD_REPO_BRANCH=$(git ls-remote --tags --sort='v:refname' https://github.com/opengovsg/isomer.git | tail -n1 | awk '{print $2}' | sed -E 's|refs/tags/||; s/\^.*$//')
+  # ISOMER_BUILD_REPO_BRANCH=$(git ls-remote --tags --sort='v:refname' https://github.com/opengovsg/isomer.git | tail -n1 | awk '{print $2}' | sed -E 's|refs/tags/||; s/\^.*$//')
+  ISOMER_BUILD_REPO_BRANCH="main"
 fi
 
 # Store the current directory


### PR DESCRIPTION
Replaces the dynamic retrieval of the latest tag with a static assignment to "main" for the ISOMER_BUILD_REPO_BRANCH variable.

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ ] No - this PR is backwards compatible

**Features**:

- Details ...

**Improvements**:

- Details ...

**Bug Fixes**:

- Details ...

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3

**New scripts**:

- `script` : script details

**New dependencies**:

- `dependency` : dependency details

**New dev dependencies**:

- `dependency` : dependency details
