### PR TITLE
chore(studio): scope collection editing flag to tags management

### DIFF
--- a/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
@@ -10,7 +10,7 @@ import { Badge, BadgeLeftIcon } from "@opengovsg/design-system-react"
 import Link from "next/link"
 import { useEffect } from "react"
 import { BiChevronRight, BiSolidCircle } from "react-icons/bi"
-import { useNewCollectionEditingExperience } from "~/hooks/useNewCollectionEditingExperience"
+import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { trpc } from "~/utils/trpc"
 import { ResourceState } from "~prisma/generated/generatedEnums"
 
@@ -49,8 +49,7 @@ export const IndexpageRow = ({
     resourceId,
   ])
 
-  const isNewCollectionEditingExperienceEnabled =
-    useNewCollectionEditingExperience()
+  const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
 
   return (
     <Skeleton w="full" isLoaded={!isPending && !!data}>
@@ -92,7 +91,7 @@ export const IndexpageRow = ({
           <Text textStyle="caption-2" textColor="base.content.medium">
             {getIndexPageSubtitle({
               type,
-              isNewCollectionEditingExperienceEnabled,
+              isNewCollectionTagsManagementEnabled,
             })}
           </Text>
         </VStack>

--- a/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
@@ -19,14 +19,14 @@ export const getIndexPageIcon = (
 
 export const getIndexPageSubtitle = ({
   type,
-  isNewCollectionEditingExperienceEnabled = false,
+  isNewCollectionTagsManagementEnabled = false,
 }: {
   type: ResourceTypesWithIndexPage
-  isNewCollectionEditingExperienceEnabled: boolean
+  isNewCollectionTagsManagementEnabled: boolean
 }) => {
   switch (type) {
     case "collection":
-      return isNewCollectionEditingExperienceEnabled
+      return isNewCollectionTagsManagementEnabled
         ? "Manage the Collection’s layout, filters, and sorting."
         : "Manage how your Collection looks like and behaves"
     case "folder":

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -508,17 +508,12 @@ export default function RootStateDrawer() {
                 <VStack gap="1.5rem" w="100%">
                   <VStack w="100%" h="100%" gap="1rem">
                     <Flex flexDirection="row" w="100%">
-                      {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection && (
-                        <VStack gap="0.25rem" align="start" flex={1}>
-                          <Text textStyle="subhead-1">Custom blocks</Text>
-                          <Text
-                            textStyle="caption-2"
-                            color="base.content.medium"
-                          >
-                            Use blocks to display your content.
-                          </Text>
-                        </VStack>
-                      )}
+                      <VStack gap="0.25rem" align="start" flex={1}>
+                        <Text textStyle="subhead-1">Custom blocks</Text>
+                        <Text textStyle="caption-2" color="base.content.medium">
+                          Use blocks to display your content.
+                        </Text>
+                      </VStack>
                       {/* TODO: we should swap over to using the `resource.type` */}
                       {/* rather than the `page.layout` but we are unable to do so due */}
                       {/* to the existence of custom index page that are `layout: */}

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -35,7 +35,7 @@ import { BlockEditingPlaceholder } from "~/components/Svg"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
-import { useNewCollectionEditingExperience } from "~/hooks/useNewCollectionEditingExperience"
+import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
@@ -91,7 +91,7 @@ const FixedBlock = () => {
     useEditorDrawerContext()
   const pageLayout = previewPageState.layout
   const isHeroFixedBlock = getIsHeroFirstBlock(pageLayout, previewPageState)
-  const isNewEditingExperienceEnabled = useNewCollectionEditingExperience()
+  const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
 
   if (isHeroFixedBlock) {
     // Assuming only one fixedBlock can exist at a time for now
@@ -113,10 +113,7 @@ const FixedBlock = () => {
     )
   }
 
-  if (
-    pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
-    isNewEditingExperienceEnabled
-  ) {
+  if (pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection) {
     const containerProps: StackProps = {
       px: "1.25rem",
       py: "1.25rem",
@@ -140,7 +137,7 @@ const FixedBlock = () => {
           icon={BiCog}
           iconProps={iconProps}
         />
-        {isUserIsomerAdmin && (
+        {isUserIsomerAdmin && isNewCollectionTagsManagementEnabled && (
           <BaseBlock
             onClick={() => console.log("to implement")}
             label="Filters"
@@ -380,8 +377,6 @@ export default function RootStateDrawer() {
   // for collection index pages
   const canAddBlocks = pageLayout !== "collection"
 
-  const isNewEditingExperienceEnabled = useNewCollectionEditingExperience()
-
   return (
     <Flex direction="column" h="full">
       <ConfirmConvertIndexPageModal
@@ -455,8 +450,7 @@ export default function RootStateDrawer() {
             </Infobox>
           )}
 
-          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
-          isNewEditingExperienceEnabled ? (
+          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection ? (
             <Disable when={disableBlocks}>
               <VStack gap="1rem" w="100%" align="start">
                 <VStack gap="0.25rem" align="start">

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -113,7 +113,11 @@ const FixedBlock = () => {
     )
   }
 
-  if (pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection) {
+  if (
+    pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
+    isNewCollectionTagsManagementEnabled
+  ) {
+    // New collection editing UI introduced in https://github.com/opengovsg/isomer/pull/2002
     const containerProps: StackProps = {
       px: "1.25rem",
       py: "1.25rem",
@@ -137,7 +141,7 @@ const FixedBlock = () => {
           icon={BiCog}
           iconProps={iconProps}
         />
-        {isUserIsomerAdmin && isNewCollectionTagsManagementEnabled && (
+        {isUserIsomerAdmin && (
           <BaseBlock
             onClick={() => console.log("to implement")}
             label="Filters"
@@ -148,6 +152,20 @@ const FixedBlock = () => {
           />
         )}
       </>
+    )
+  }
+
+  if (pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection) {
+    return (
+      <BaseBlock
+        onClick={() => {
+          setCurrActiveIdx(0)
+          setDrawerState({ state: "collectionEditor" })
+        }}
+        label="Collection settings"
+        description="Summary, style, categories and sorting"
+        icon={BiPin}
+      />
     )
   }
 
@@ -377,6 +395,8 @@ export default function RootStateDrawer() {
   // for collection index pages
   const canAddBlocks = pageLayout !== "collection"
 
+  const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
+
   return (
     <Flex direction="column" h="full">
       <ConfirmConvertIndexPageModal
@@ -450,7 +470,9 @@ export default function RootStateDrawer() {
             </Infobox>
           )}
 
-          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection ? (
+          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
+          isNewCollectionTagsManagementEnabled ? (
+            // New collection editing UI introduced in https://github.com/opengovsg/isomer/pull/2002
             <Disable when={disableBlocks}>
               <VStack gap="1rem" w="100%" align="start">
                 <VStack gap="0.25rem" align="start">
@@ -508,12 +530,17 @@ export default function RootStateDrawer() {
                 <VStack gap="1.5rem" w="100%">
                   <VStack w="100%" h="100%" gap="1rem">
                     <Flex flexDirection="row" w="100%">
-                      <VStack gap="0.25rem" align="start" flex={1}>
-                        <Text textStyle="subhead-1">Custom blocks</Text>
-                        <Text textStyle="caption-2" color="base.content.medium">
-                          Use blocks to display your content.
-                        </Text>
-                      </VStack>
+                      {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection && (
+                        <VStack gap="0.25rem" align="start" flex={1}>
+                          <Text textStyle="subhead-1">Custom blocks</Text>
+                          <Text
+                            textStyle="caption-2"
+                            color="base.content.medium"
+                          >
+                            Use blocks to display your content.
+                          </Text>
+                        </VStack>
+                      )}
                       {/* TODO: we should swap over to using the `resource.type` */}
                       {/* rather than the `page.layout` but we are unable to do so due */}
                       {/* to the existence of custom index page that are `layout: */}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionVariantControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCollectionVariantControl.tsx
@@ -6,7 +6,6 @@ import { FormLabel, Radio } from "@opengovsg/design-system-react"
 import { COLLECTION_VARIANT_OPTIONS } from "@opengovsg/isomer-components"
 import { IconOneColumnLayout, IconTwoColumnLayout } from "~/components/icons"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
-import { useNewCollectionEditingExperience } from "~/hooks/useNewCollectionEditingExperience"
 
 export const jsonFormsCollectionVariantControlTester: RankedTester = rankWith(
   JSON_FORMS_RANKING.CollectionVariantControl,
@@ -20,13 +19,6 @@ function JsonFormsCollectionVariantControl({
   path,
   description,
 }: ControlProps): JSX.Element {
-  const isNewCollectionEditingExperienceEnabled =
-    useNewCollectionEditingExperience()
-
-  if (!isNewCollectionEditingExperienceEnabled) {
-    return <></>
-  }
-
   return (
     <Box>
       <FormControl isRequired gap="0.5rem">

--- a/apps/studio/src/hooks/useNewCollectionEditingExperience.ts
+++ b/apps/studio/src/hooks/useNewCollectionEditingExperience.ts
@@ -1,8 +1,0 @@
-import { useFeatureValue } from "@growthbook/growthbook-react"
-import { IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
-
-export const useNewCollectionEditingExperience = () =>
-  useFeatureValue<boolean>(
-    IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY,
-    false,
-  )

--- a/apps/studio/src/hooks/useNewCollectionTagsManagement.ts
+++ b/apps/studio/src/hooks/useNewCollectionTagsManagement.ts
@@ -1,0 +1,8 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+
+export const useNewCollectionTagsManagement = () =>
+  useFeatureValue<boolean>(
+    IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY,
+    false,
+  )

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -6,8 +6,8 @@ export const ENABLE_EMAILS_FOR_SCHEDULED_PUBLISHES_FEATURE_KEY =
 export const ENABLE_EMAILS_FOR_REGULAR_PUBLISHES_FEATURE_KEY =
   "enable-emails-for-regular-publishes"
 export const BANNER_FEATURE_KEY = "isomer-next-banner"
-export const IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY =
-  "is-new-collection-editing-experience-enabled"
+export const IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY =
+  "is-new-collection-tags-management-enabled"
 export const CATEGORY_DROPDOWN_FEATURE_KEY = "category-dropdown"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 export const IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY =

--- a/apps/studio/src/stories/Page/CollectionPage.stories.tsx
+++ b/apps/studio/src/stories/Page/CollectionPage.stories.tsx
@@ -6,7 +6,7 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
-import { IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import CollectionPage from "~/pages/sites/[siteId]/collections/[collectionId]"
 
 import { createBannerGbParameters } from "../utils/growthbook"
@@ -122,10 +122,10 @@ export const ExpandedProfileDropdown: Story = {
   },
 }
 
-export const NewCollectionEditingExperience: Story = {
+export const NewCollectionTagsManagement: Story = {
   parameters: {
     growthbook: [
-      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
     ],
   },
   play: async ({ canvasElement }) => {

--- a/apps/studio/src/stories/Page/CollectionPage.stories.tsx
+++ b/apps/studio/src/stories/Page/CollectionPage.stories.tsx
@@ -124,9 +124,7 @@ export const ExpandedProfileDropdown: Story = {
 
 export const NewCollectionTagsManagement: Story = {
   parameters: {
-    growthbook: [
-      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
-    ],
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -112,9 +112,7 @@ export const WithBanner: Story = {
 
 export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
   parameters: {
-    growthbook: [
-      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
-    ],
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
@@ -125,9 +123,7 @@ export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
 // "Filters" block is currently only accessible by Isomer Admin
 export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
   parameters: {
-    growthbook: [
-      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
-    ],
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
       handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
     },
@@ -140,9 +136,7 @@ export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
 
 export const NewCollectionIndexEditingExperienceForDisplay: Story = {
   parameters: {
-    growthbook: [
-      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
-    ],
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
@@ -157,9 +151,7 @@ export const NewCollectionIndexEditingExperienceForDisplay: Story = {
 // Currently only accessible by Isomer Admin
 export const NewCollectionIndexEditingExperienceForFilters: Story = {
   parameters: {
-    growthbook: [
-      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
-    ],
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
       handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
     },

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -63,7 +63,7 @@ export const EditFixedBlockState: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const button = await canvas.findByRole("button", {
-      name: /Page description and summary/i,
+      name: /Collection settings/i,
     })
     await userEvent.click(button)
   },

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -5,7 +5,7 @@ import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import { userHandlers } from "tests/msw/handlers/user"
-import { IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
 import { ResourceState } from "~prisma/generated/generatedEnums"
@@ -113,7 +113,7 @@ export const WithBanner: Story = {
 export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
   parameters: {
     growthbook: [
-      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
     ],
   },
   play: async ({ canvasElement }) => {
@@ -126,7 +126,7 @@ export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
 export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
   parameters: {
     growthbook: [
-      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
     ],
     msw: {
       handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
@@ -141,7 +141,7 @@ export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
 export const NewCollectionIndexEditingExperienceForDisplay: Story = {
   parameters: {
     growthbook: [
-      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
     ],
   },
   play: async ({ canvasElement }) => {
@@ -158,7 +158,7 @@ export const NewCollectionIndexEditingExperienceForDisplay: Story = {
 export const NewCollectionIndexEditingExperienceForFilters: Story = {
   parameters: {
     growthbook: [
-      [IS_NEW_COLLECTION_EDITING_EXPERIENCE_ENABLED_FEATURE_KEY, true],
+      [IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true],
     ],
     msw: {
       handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],


### PR DESCRIPTION
## Problem

The GrowthBook flag `is-new-collection-editing-experience-enabled` was being used to gate three unrelated changes: the collection variant layout radio (from PR #1825), and the refreshed collection root drawer + dashboard subtitle copy (from PR #2002). With those refreshes ready to roll out by default, we want to retire the broad flag and keep only the still-unfinished Filters block behind a more narrowly named flag.

## Solution

Renames `is-new-collection-editing-experience-enabled` to `is-new-collection-tags-management-enabled` (constant `IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY`, hook `useNewCollectionTagsManagement`) and rewires usages. The flag is now only checked for the Filters BaseBlock in the collection root drawer; everything else that previously consulted the flag now renders unconditionally.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- The Filters block in the collection root drawer is gated by both `isUserIsomerAdmin` and the new `is-new-collection-tags-management-enabled` flag.

**Improvements**:

- The refreshed collection root drawer layout (Manage Collection section, Collection display block) renders by default for `collection` pages.
- The dashboard collection row subtitle now always reads "Manage the Collection's layout, filters, and sorting."
- The 1-column/2-column collection variant radio in `JsonFormsCollectionVariantControl` always renders.
- Removed the old `useNewCollectionEditingExperience` hook and renamed the variable/parameter `isNewCollectionEditingExperienceEnabled` to `isNewCollectionTagsManagementEnabled`.

## Tests

**Manual Verification Steps**:

- [ ] On the dashboard, open a site with a collection resource and confirm the subtitle reads "Manage the Collection's layout, filters, and sorting." regardless of any flag state.
- [ ] Open a collection index page in Studio and confirm the drawer shows the "Manage Collection" section with the "Collection display" block by default (no flag needed).
- [ ] As a non Isomer Admin user with `is-new-collection-tags-management-enabled` off, confirm the Filters block does NOT appear.
- [ ] As an Isomer Admin (Core or Migrator) with `is-new-collection-tags-management-enabled` on, confirm the Filters block appears and clicking it does not crash.
- [ ] As an Isomer Admin with `is-new-collection-tags-management-enabled` off, confirm the Filters block does NOT appear.
- [ ] Open a page that renders the collection variant control and confirm the 1-column / 2-column radio is visible (no flag needed).