### PR TITLE
chore(ci): upgrade aws_deploy actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -136,15 +136,15 @@ jobs:
             text: "<!subteam^${{ secrets.SLACK_NOTIFY_TEAM_ID }}> Starting deployment of *${{ inputs.app-name }}* to *${{ inputs.environment }}* environment :rocket: \n> Version: *${{ inputs.app-version }}*\n> Initiated by: ${{ github.actor }}\n> Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v4
         with:
           driver-opts: network=host
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.cicd-role }}
           role-session-name: github-action-application-deploy
@@ -152,15 +152,15 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: "true"
 
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Build installer stage for sourcemap extraction
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: "./apps/studio/Dockerfile"
@@ -185,7 +185,7 @@ jobs:
           docker rm $CONTAINER_ID
 
       - name: Build and load image to Docker
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v7
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
@@ -233,7 +233,7 @@ jobs:
       # from the GitHub actions job summary page.
       - name: Upload Scan Results
         id: upload-scan-results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           path: |
             ${{ steps.inspector.outputs.inspector_scan_results }}
@@ -285,10 +285,10 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ inputs.cicd-role }}
           role-session-name: github-action-application-deploy
@@ -296,12 +296,12 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
         with:
           mask-password: "true"
 
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Replace variables in task definition file
         id: replace-variables


### PR DESCRIPTION
## Problem

GitHub Actions deprecated Node.js 20 and will force-default actions to Node.js 24 on **2026-06-02**, then remove Node.js 20 on **2026-09-16**. CI emitted a deprecation warning listing seven action versions in `aws_deploy.yml` that still run on Node 20.

## Solution

Bumped each flagged pin in `.github/workflows/aws_deploy.yml` to the smallest Node-24-default release. All upgrades preserve behaviour for the inputs/outputs this workflow actually uses (verified against upstream release notes and PRs).

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v3 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `docker/setup-qemu-action` | v2 | v4 |
| `docker/setup-buildx-action` | v2 | v4 |
| `docker/build-push-action` | v4 | v7 |
| `aws-actions/configure-aws-credentials` | v1, v2 | v4 |
| `aws-actions/amazon-ecr-login` | v1 | v2 |

Notes on upstream breaking changes that do **not** affect us:
- `docker/build-push-action@v7` removes env vars `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` — not set anywhere in this repo.
- `docker/setup-buildx-action@v4` removes deprecated inputs `config`, `config-inline`, `install` and outputs `endpoint`, `status`, `flags` — workflow only uses `driver-opts`.
- `aws-actions/amazon-ecr-login@v2` flips `mask-password` to default true — workflow already passes `mask-password: "true"` explicitly.
- All Node-24 releases require GitHub Actions Runner v2.327.1+; `ubuntu-latest` already satisfies this.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Eliminates Node 20 deprecation warning emitted on every deploy run.
- Ensures the deploy pipeline continues to work past the 2026-06-02 forced cutover.

## Tests

**Manual Verification Steps**:

- [ ] Trigger `deploy_uat.yml` (or `deploy_staging.yml`) and confirm the run summary no longer shows the Node 20 deprecation warning.
- [ ] Confirm the `Build and push image to ECR` job completes: QEMU + Buildx setup, AWS credential config, ECR login, both `build-push-action` calls, Inspector scan, scan-results artifact upload, ECR push.
- [ ] Confirm the `Deploy image to ECS` job completes: AWS credential config, ECR login, checkout, ECS render + deploy succeed end-to-end.
- [ ] Verify the uploaded Inspector scan-results artifact is present and downloadable from the run summary page.