### PR TITLE
chore(studio): block move/delete mutations on default Search page

### DIFF
--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1386,6 +1386,40 @@ describe("resource.router", async () => {
       )
     })
 
+    it("should return 400 if resource to move is the search page (permalink /search, no parent)", async () => {
+      // Arrange
+      const { page: searchPage, site } = await setupPageResource({
+        resourceType: "Page",
+        permalink: "search",
+        parentId: null,
+      })
+      const { folder: destinationFolder } = await setupFolder({
+        siteId: site.id,
+        permalink: "destination-folder",
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.move({
+        siteId: site.id,
+        movedResourceId: searchPage.id,
+        destinationResourceId: destinationFolder.id,
+      })
+
+      // Assert
+      expect(auditSpy).not.toHaveBeenCalled()
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "The search page cannot be moved",
+        }),
+      )
+    })
+
     it("should return 403 if source and destination resources belong to different sites", async () => {
       // Arrange
       const auditSpy = vitest.spyOn(auditService, "logResourceEvent")

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -363,6 +363,15 @@ export const resourceRouter = router({
               throw new TRPCError({ code: "BAD_REQUEST" })
             }
 
+            // Prevent users from moving the search page (permalink /search, no parent)
+            // This is a special page that is used to display the SearchSG results
+            if (toMove.permalink === "search" && toMove.parentId === null) {
+              throw new TRPCError({
+                code: "BAD_REQUEST",
+                message: "The search page cannot be moved",
+              })
+            }
+
             let query = tx.selectFrom("Resource")
             query = !!destinationResourceId
               ? query.where("id", "=", destinationResourceId)


### PR DESCRIPTION
## Problem

The default Search page (`permalink: "search"`, `parentId: null`) is a special, system-owned resource. The frontend already disables "Move to..." and "Delete" options for it in the resource table menu, but the backend tRPC mutations had no equivalent guard for `move` — meaning a crafted API call could still relocate the page. Delete was already guarded; move was not.

Closes [insert issue #]

## Solution

Added a backend guard in the `move` mutation (`apps/studio/src/server/modules/resource/resource.router.ts`) that mirrors the existing delete guard: if `toMove.permalink === "search" && toMove.parentId === null`, the mutation throws `BAD_REQUEST` with message "The search page cannot be moved". An accompanying unit test was added following the pattern of the existing delete-search-page test.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Backend now enforces the same protection on the default Search page that the frontend already shows, closing a gap where API callers could bypass the UI block.

**Bug Fixes**:

- None

## Tests

Unit test added: `"should return 400 if resource to move is the search page (permalink /search, no parent)"` in `resource.router.test.ts`.

**Manual Verification Steps**:

- [ ] Navigate to the dashboard of any site that has a default Search page and confirm the "Move to..." menu item is still disabled (frontend behavior unchanged).
- [ ] Using a tRPC client or browser devtools, attempt to call `resource.move` with `movedResourceId` set to the Search page's id and any valid `destinationResourceId`. Confirm the request fails with a 400 and the message "The search page cannot be moved".
- [ ] Confirm that moving any other (non-search) page/folder still works as expected.
- [ ] Confirm that the existing delete guard still rejects deletion of the Search page with "The search page cannot be deleted".