### PR TITLE
chore(studio): lock down default Search page from edit/move/delete

### DIFF
--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -22,39 +22,6 @@ interface CollectionTableMenuProps {
   resourceType: CollectionTableData["type"]
 }
 
-// The default Search page (permalink /search, no parent) is a system-managed
-// page used to render SearchSG results. Its slug is hardcoded into the site
-// renderer, so users must not be able to edit its settings, move it, or
-// delete it — any of those would break search on the published site.
-const SearchPageMenuItems = () => {
-  return (
-    <>
-      <MenuItem
-        isDisabled
-        icon={<BiCog fontSize="1rem" />}
-        tooltip="This is a default page and its settings cannot be edited."
-      >
-        Edit settings
-      </MenuItem>
-      <MenuItem
-        isDisabled
-        icon={<BiFolderOpen fontSize="1rem" />}
-        tooltip="This is a default page that cannot be moved."
-      >
-        Move to...
-      </MenuItem>
-      <MenuItem
-        isDisabled
-        colorScheme="critical"
-        icon={<BiTrash fontSize="1rem" />}
-        tooltip="This is a default page that cannot be removed."
-      >
-        Delete
-      </MenuItem>
-    </>
-  )
-}
-
 export const CollectionTableMenu = ({
   title,
   resourceId,
@@ -74,7 +41,6 @@ export const CollectionTableMenu = ({
       type: resourceType,
     })
   }
-  const isSearchPage = permalink === "search" && parentId === null
 
   return (
     <Menu isLazy size="sm">
@@ -87,47 +53,41 @@ export const CollectionTableMenu = ({
       />
       <Portal>
         <MenuList>
-          {isSearchPage ? (
-            <SearchPageMenuItems />
-          ) : (
-            <>
-              {(resourceType === ResourceType.CollectionPage ||
-                resourceType === ResourceType.CollectionLink) && (
-                <MenuItem
-                  icon={<BiCog fontSize="1rem" />}
-                  onClick={() =>
-                    setPageSettingsModalState({
-                      pageId: resourceId,
-                      type: resourceType,
-                    })
-                  }
-                >
-                  Edit settings
-                </MenuItem>
-              )}
-              <MenuItem
-                as="button"
-                icon={<BiFolderOpen fontSize="1rem" />}
-                onClick={handleMoveResourceClick}
-              >
-                Move to...
-              </MenuItem>
-              {resourceType !== ResourceType.IndexPage && (
-                <MenuItem
-                  onClick={() => {
-                    setValue({
-                      title,
-                      resourceId,
-                      resourceType,
-                    })
-                  }}
-                  colorScheme="critical"
-                  icon={<BiTrash fontSize="1rem" />}
-                >
-                  Delete
-                </MenuItem>
-              )}
-            </>
+          {(resourceType === ResourceType.CollectionPage ||
+            resourceType === ResourceType.CollectionLink) && (
+            <MenuItem
+              icon={<BiCog fontSize="1rem" />}
+              onClick={() =>
+                setPageSettingsModalState({
+                  pageId: resourceId,
+                  type: resourceType,
+                })
+              }
+            >
+              Edit settings
+            </MenuItem>
+          )}
+          <MenuItem
+            as="button"
+            icon={<BiFolderOpen fontSize="1rem" />}
+            onClick={handleMoveResourceClick}
+          >
+            Move to...
+          </MenuItem>
+          {resourceType !== ResourceType.IndexPage && (
+            <MenuItem
+              onClick={() => {
+                setValue({
+                  title,
+                  resourceId,
+                  resourceType,
+                })
+              }}
+              colorScheme="critical"
+              icon={<BiTrash fontSize="1rem" />}
+            >
+              Delete
+            </MenuItem>
           )}
         </MenuList>
       </Portal>

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -36,6 +36,13 @@ const SearchPageMenu = ({ title }: { title: string }) => {
         <MenuList>
           <MenuItem
             isDisabled
+            icon={<BiCog fontSize="1rem" />}
+            tooltip="This is a default page and its settings cannot be edited."
+          >
+            Edit settings
+          </MenuItem>
+          <MenuItem
+            isDisabled
             icon={<BiFolderOpen fontSize="1rem" />}
             tooltip="This is a default page that cannot be moved."
           >

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -22,6 +22,10 @@ interface CollectionTableMenuProps {
   resourceType: CollectionTableData["type"]
 }
 
+// The default Search page (permalink /search, no parent) is a system-managed
+// page used to render SearchSG results. Its slug is hardcoded into the site
+// renderer, so users must not be able to edit its settings, move it, or
+// delete it — any of those would break search on the published site.
 const SearchPageMenuItems = () => {
   return (
     <>

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -22,6 +22,39 @@ interface CollectionTableMenuProps {
   resourceType: CollectionTableData["type"]
 }
 
+const SearchPageMenu = ({ title }: { title: string }) => {
+  return (
+    <Menu isLazy size="sm">
+      <MenuButton
+        aria-label={`Options for ${title}`}
+        as={IconButton}
+        colorScheme="neutral"
+        icon={<BiDotsHorizontalRounded />}
+        variant="clear"
+      />
+      <Portal>
+        <MenuList>
+          <MenuItem
+            isDisabled
+            icon={<BiFolderOpen fontSize="1rem" />}
+            tooltip="This is a default page that cannot be moved."
+          >
+            Move to...
+          </MenuItem>
+          <MenuItem
+            isDisabled
+            colorScheme="critical"
+            icon={<BiTrash fontSize="1rem" />}
+            tooltip="This is a default page that cannot be removed."
+          >
+            Delete
+          </MenuItem>
+        </MenuList>
+      </Portal>
+    </Menu>
+  )
+}
+
 export const CollectionTableMenu = ({
   title,
   resourceId,
@@ -42,6 +75,10 @@ export const CollectionTableMenu = ({
     })
   }
   const isSearchPage = permalink === "search" && parentId === null
+
+  if (isSearchPage) {
+    return <SearchPageMenu title={title} />
+  }
 
   return (
     <Menu isLazy size="sm">
@@ -68,34 +105,14 @@ export const CollectionTableMenu = ({
               Edit settings
             </MenuItem>
           )}
-          {isSearchPage ? (
-            <MenuItem
-              isDisabled
-              icon={<BiFolderOpen fontSize="1rem" />}
-              tooltip="This is a default page that cannot be moved."
-            >
-              Move to...
-            </MenuItem>
-          ) : (
-            <MenuItem
-              as="button"
-              icon={<BiFolderOpen fontSize="1rem" />}
-              onClick={handleMoveResourceClick}
-            >
-              Move to...
-            </MenuItem>
-          )}
-          {resourceType !== ResourceType.IndexPage && isSearchPage && (
-            <MenuItem
-              isDisabled
-              colorScheme="critical"
-              icon={<BiTrash fontSize="1rem" />}
-              tooltip="This is a default page that cannot be removed."
-            >
-              Delete
-            </MenuItem>
-          )}
-          {resourceType !== ResourceType.IndexPage && !isSearchPage && (
+          <MenuItem
+            as="button"
+            icon={<BiFolderOpen fontSize="1rem" />}
+            onClick={handleMoveResourceClick}
+          >
+            Move to...
+          </MenuItem>
+          {resourceType !== ResourceType.IndexPage && (
             <MenuItem
               onClick={() => {
                 setValue({

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -22,43 +22,32 @@ interface CollectionTableMenuProps {
   resourceType: CollectionTableData["type"]
 }
 
-const SearchPageMenu = ({ title }: { title: string }) => {
+const SearchPageMenuItems = () => {
   return (
-    <Menu isLazy size="sm">
-      <MenuButton
-        aria-label={`Options for ${title}`}
-        as={IconButton}
-        colorScheme="neutral"
-        icon={<BiDotsHorizontalRounded />}
-        variant="clear"
-      />
-      <Portal>
-        <MenuList>
-          <MenuItem
-            isDisabled
-            icon={<BiCog fontSize="1rem" />}
-            tooltip="This is a default page and its settings cannot be edited."
-          >
-            Edit settings
-          </MenuItem>
-          <MenuItem
-            isDisabled
-            icon={<BiFolderOpen fontSize="1rem" />}
-            tooltip="This is a default page that cannot be moved."
-          >
-            Move to...
-          </MenuItem>
-          <MenuItem
-            isDisabled
-            colorScheme="critical"
-            icon={<BiTrash fontSize="1rem" />}
-            tooltip="This is a default page that cannot be removed."
-          >
-            Delete
-          </MenuItem>
-        </MenuList>
-      </Portal>
-    </Menu>
+    <>
+      <MenuItem
+        isDisabled
+        icon={<BiCog fontSize="1rem" />}
+        tooltip="This is a default page and its settings cannot be edited."
+      >
+        Edit settings
+      </MenuItem>
+      <MenuItem
+        isDisabled
+        icon={<BiFolderOpen fontSize="1rem" />}
+        tooltip="This is a default page that cannot be moved."
+      >
+        Move to...
+      </MenuItem>
+      <MenuItem
+        isDisabled
+        colorScheme="critical"
+        icon={<BiTrash fontSize="1rem" />}
+        tooltip="This is a default page that cannot be removed."
+      >
+        Delete
+      </MenuItem>
+    </>
   )
 }
 
@@ -83,10 +72,6 @@ export const CollectionTableMenu = ({
   }
   const isSearchPage = permalink === "search" && parentId === null
 
-  if (isSearchPage) {
-    return <SearchPageMenu title={title} />
-  }
-
   return (
     <Menu isLazy size="sm">
       <MenuButton
@@ -98,41 +83,47 @@ export const CollectionTableMenu = ({
       />
       <Portal>
         <MenuList>
-          {(resourceType === ResourceType.CollectionPage ||
-            resourceType === ResourceType.CollectionLink) && (
-            <MenuItem
-              icon={<BiCog fontSize="1rem" />}
-              onClick={() =>
-                setPageSettingsModalState({
-                  pageId: resourceId,
-                  type: resourceType,
-                })
-              }
-            >
-              Edit settings
-            </MenuItem>
-          )}
-          <MenuItem
-            as="button"
-            icon={<BiFolderOpen fontSize="1rem" />}
-            onClick={handleMoveResourceClick}
-          >
-            Move to...
-          </MenuItem>
-          {resourceType !== ResourceType.IndexPage && (
-            <MenuItem
-              onClick={() => {
-                setValue({
-                  title,
-                  resourceId,
-                  resourceType,
-                })
-              }}
-              colorScheme="critical"
-              icon={<BiTrash fontSize="1rem" />}
-            >
-              Delete
-            </MenuItem>
+          {isSearchPage ? (
+            <SearchPageMenuItems />
+          ) : (
+            <>
+              {(resourceType === ResourceType.CollectionPage ||
+                resourceType === ResourceType.CollectionLink) && (
+                <MenuItem
+                  icon={<BiCog fontSize="1rem" />}
+                  onClick={() =>
+                    setPageSettingsModalState({
+                      pageId: resourceId,
+                      type: resourceType,
+                    })
+                  }
+                >
+                  Edit settings
+                </MenuItem>
+              )}
+              <MenuItem
+                as="button"
+                icon={<BiFolderOpen fontSize="1rem" />}
+                onClick={handleMoveResourceClick}
+              >
+                Move to...
+              </MenuItem>
+              {resourceType !== ResourceType.IndexPage && (
+                <MenuItem
+                  onClick={() => {
+                    setValue({
+                      title,
+                      resourceId,
+                      resourceType,
+                    })
+                  }}
+                  colorScheme="critical"
+                  icon={<BiTrash fontSize="1rem" />}
+                >
+                  Delete
+                </MenuItem>
+              )}
+            </>
           )}
         </MenuList>
       </Portal>

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -28,6 +28,10 @@ interface ResourceTableMenuProps {
   parentId: ResourceTableData["parentId"]
 }
 
+// The default Search page (permalink /search, no parent) is a system-managed
+// page used to render SearchSG results. Its slug is hardcoded into the site
+// renderer, so users must not be able to edit its settings, move it, or
+// delete it — any of those would break search on the published site.
 const SearchPageMenuItems = () => {
   return (
     <>

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -28,43 +28,32 @@ interface ResourceTableMenuProps {
   parentId: ResourceTableData["parentId"]
 }
 
-const SearchPageMenu = ({ title }: { title: string }) => {
+const SearchPageMenuItems = () => {
   return (
-    <Menu isLazy size="sm">
-      <MenuButton
-        aria-label={`Options for ${title}`}
-        as={IconButton}
-        colorScheme="neutral"
-        icon={<BiDotsHorizontalRounded />}
-        variant="clear"
-      />
-      <Portal>
-        <MenuList minWidth="8rem">
-          <MenuItem
-            isDisabled
-            icon={<BiCog fontSize="1rem" />}
-            tooltip="This is a default page and its settings cannot be edited."
-          >
-            Edit settings
-          </MenuItem>
-          <MenuItem
-            isDisabled
-            icon={<BiFolderOpen fontSize="1rem" />}
-            tooltip="This is a default page that cannot be moved."
-          >
-            Move to...
-          </MenuItem>
-          <MenuItem
-            isDisabled
-            colorScheme="critical"
-            icon={<BiTrash fontSize="1rem" />}
-            tooltip="This is a default page that cannot be removed."
-          >
-            Delete
-          </MenuItem>
-        </MenuList>
-      </Portal>
-    </Menu>
+    <>
+      <MenuItem
+        isDisabled
+        icon={<BiCog fontSize="1rem" />}
+        tooltip="This is a default page and its settings cannot be edited."
+      >
+        Edit settings
+      </MenuItem>
+      <MenuItem
+        isDisabled
+        icon={<BiFolderOpen fontSize="1rem" />}
+        tooltip="This is a default page that cannot be moved."
+      >
+        Move to...
+      </MenuItem>
+      <MenuItem
+        isDisabled
+        colorScheme="critical"
+        icon={<BiTrash fontSize="1rem" />}
+        tooltip="This is a default page that cannot be removed."
+      >
+        Delete
+      </MenuItem>
+    </>
   )
 }
 
@@ -84,10 +73,6 @@ export const ResourceTableMenu = ({
   const setPageSettingsModalState = useSetAtom(pageSettingsModalAtom)
   const isSearchPage = permalink === "search" && parentId === null
 
-  if (isSearchPage) {
-    return <SearchPageMenu title={title} />
-  }
-
   return (
     <Menu isLazy size="sm">
       <MenuButton
@@ -99,61 +84,68 @@ export const ResourceTableMenu = ({
       />
       <Portal>
         <MenuList minWidth="8rem">
-          {/* TODO: Open edit modal depending on resource  */}
-          {type === ResourceType.Page && (
-            <MenuItem
-              onClick={() =>
-                setPageSettingsModalState({
-                  pageId: resourceId,
-                  type,
-                })
-              }
-              icon={<BiCog fontSize="1rem" />}
-            >
-              Edit settings
-            </MenuItem>
-          )}
-          {type === ResourceType.Folder && (
-            <MenuItem
-              onClick={() =>
-                setFolderSettingsModalState({
-                  folderId: resourceId,
-                })
-              }
-              icon={<BiCog fontSize="1rem" />}
-            >
-              Edit folder settings
-            </MenuItem>
-          )}
-          {(type === ResourceType.Page || type === ResourceType.Folder) && (
-            // TODO: we need to change the resourceid next time when we implement root level permissions
-            <Can do="move" on={{ parentId }}>
-              <MenuItem
-                as="button"
-                onClick={handleMoveResourceClick}
-                icon={<BiFolderOpen fontSize="1rem" />}
-                aria-label={`Move resource to another location for ${title}`}
-              >
-                Move to...
-              </MenuItem>
-            </Can>
-          )}
-          {resourceType !== ResourceType.RootPage && (
-            <Can do="delete" on={{ parentId }}>
-              <MenuItem
-                onClick={() => {
-                  setResourceModalState({
-                    title,
-                    resourceId,
-                    resourceType,
-                  })
-                }}
-                colorScheme="critical"
-                icon={<BiTrash fontSize="1rem" />}
-              >
-                Delete
-              </MenuItem>
-            </Can>
+          {isSearchPage ? (
+            <SearchPageMenuItems />
+          ) : (
+            <>
+              {/* TODO: Open edit modal depending on resource  */}
+              {type === ResourceType.Page && (
+                <MenuItem
+                  onClick={() =>
+                    setPageSettingsModalState({
+                      pageId: resourceId,
+                      type,
+                    })
+                  }
+                  icon={<BiCog fontSize="1rem" />}
+                >
+                  Edit settings
+                </MenuItem>
+              )}
+              {type === ResourceType.Folder && (
+                <MenuItem
+                  onClick={() =>
+                    setFolderSettingsModalState({
+                      folderId: resourceId,
+                    })
+                  }
+                  icon={<BiCog fontSize="1rem" />}
+                >
+                  Edit folder settings
+                </MenuItem>
+              )}
+              {(type === ResourceType.Page ||
+                type === ResourceType.Folder) && (
+                // TODO: we need to change the resourceid next time when we implement root level permissions
+                <Can do="move" on={{ parentId }}>
+                  <MenuItem
+                    as="button"
+                    onClick={handleMoveResourceClick}
+                    icon={<BiFolderOpen fontSize="1rem" />}
+                    aria-label={`Move resource to another location for ${title}`}
+                  >
+                    Move to...
+                  </MenuItem>
+                </Can>
+              )}
+              {resourceType !== ResourceType.RootPage && (
+                <Can do="delete" on={{ parentId }}>
+                  <MenuItem
+                    onClick={() => {
+                      setResourceModalState({
+                        title,
+                        resourceId,
+                        resourceType,
+                      })
+                    }}
+                    colorScheme="critical"
+                    icon={<BiTrash fontSize="1rem" />}
+                  >
+                    Delete
+                  </MenuItem>
+                </Can>
+              )}
+            </>
           )}
         </MenuList>
       </Portal>

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -56,20 +56,27 @@ export const ResourceTableMenu = ({
       <Portal>
         <MenuList minWidth="8rem">
           {/* TODO: Open edit modal depending on resource  */}
-          {type === ResourceType.Page && (
-            <>
-              <MenuItem
-                onClick={() =>
-                  setPageSettingsModalState({
-                    pageId: resourceId,
-                    type,
-                  })
-                }
-                icon={<BiCog fontSize="1rem" />}
-              >
-                Edit settings
-              </MenuItem>
-            </>
+          {type === ResourceType.Page && isSearchPage && (
+            <MenuItem
+              isDisabled
+              icon={<BiCog fontSize="1rem" />}
+              tooltip="This is a default page and its settings cannot be edited."
+            >
+              Edit settings
+            </MenuItem>
+          )}
+          {type === ResourceType.Page && !isSearchPage && (
+            <MenuItem
+              onClick={() =>
+                setPageSettingsModalState({
+                  pageId: resourceId,
+                  type,
+                })
+              }
+              icon={<BiCog fontSize="1rem" />}
+            >
+              Edit settings
+            </MenuItem>
           )}
           {type === ResourceType.Folder && (
             <MenuItem

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -118,8 +118,7 @@ export const ResourceTableMenu = ({
                   Edit folder settings
                 </MenuItem>
               )}
-              {(type === ResourceType.Page ||
-                type === ResourceType.Folder) && (
+              {(type === ResourceType.Page || type === ResourceType.Folder) && (
                 // TODO: we need to change the resourceid next time when we implement root level permissions
                 <Can do="move" on={{ parentId }}>
                   <MenuItem

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -28,6 +28,46 @@ interface ResourceTableMenuProps {
   parentId: ResourceTableData["parentId"]
 }
 
+const SearchPageMenu = ({ title }: { title: string }) => {
+  return (
+    <Menu isLazy size="sm">
+      <MenuButton
+        aria-label={`Options for ${title}`}
+        as={IconButton}
+        colorScheme="neutral"
+        icon={<BiDotsHorizontalRounded />}
+        variant="clear"
+      />
+      <Portal>
+        <MenuList minWidth="8rem">
+          <MenuItem
+            isDisabled
+            icon={<BiCog fontSize="1rem" />}
+            tooltip="This is a default page and its settings cannot be edited."
+          >
+            Edit settings
+          </MenuItem>
+          <MenuItem
+            isDisabled
+            icon={<BiFolderOpen fontSize="1rem" />}
+            tooltip="This is a default page that cannot be moved."
+          >
+            Move to...
+          </MenuItem>
+          <MenuItem
+            isDisabled
+            colorScheme="critical"
+            icon={<BiTrash fontSize="1rem" />}
+            tooltip="This is a default page that cannot be removed."
+          >
+            Delete
+          </MenuItem>
+        </MenuList>
+      </Portal>
+    </Menu>
+  )
+}
+
 export const ResourceTableMenu = ({
   resourceId,
   title,
@@ -44,6 +84,10 @@ export const ResourceTableMenu = ({
   const setPageSettingsModalState = useSetAtom(pageSettingsModalAtom)
   const isSearchPage = permalink === "search" && parentId === null
 
+  if (isSearchPage) {
+    return <SearchPageMenu title={title} />
+  }
+
   return (
     <Menu isLazy size="sm">
       <MenuButton
@@ -56,16 +100,7 @@ export const ResourceTableMenu = ({
       <Portal>
         <MenuList minWidth="8rem">
           {/* TODO: Open edit modal depending on resource  */}
-          {type === ResourceType.Page && isSearchPage && (
-            <MenuItem
-              isDisabled
-              icon={<BiCog fontSize="1rem" />}
-              tooltip="This is a default page and its settings cannot be edited."
-            >
-              Edit settings
-            </MenuItem>
-          )}
-          {type === ResourceType.Page && !isSearchPage && (
+          {type === ResourceType.Page && (
             <MenuItem
               onClick={() =>
                 setPageSettingsModalState({
@@ -90,41 +125,20 @@ export const ResourceTableMenu = ({
               Edit folder settings
             </MenuItem>
           )}
-          {(type === ResourceType.Page || type === ResourceType.Folder) &&
-            isSearchPage && (
+          {(type === ResourceType.Page || type === ResourceType.Folder) && (
+            // TODO: we need to change the resourceid next time when we implement root level permissions
+            <Can do="move" on={{ parentId }}>
               <MenuItem
-                isDisabled
+                as="button"
+                onClick={handleMoveResourceClick}
                 icon={<BiFolderOpen fontSize="1rem" />}
-                tooltip="This is a default page that cannot be moved."
+                aria-label={`Move resource to another location for ${title}`}
               >
                 Move to...
               </MenuItem>
-            )}
-          {(type === ResourceType.Page || type === ResourceType.Folder) &&
-            !isSearchPage && (
-              // TODO: we need to change the resourceid next time when we implement root level permissions
-              <Can do="move" on={{ parentId }}>
-                <MenuItem
-                  as="button"
-                  onClick={handleMoveResourceClick}
-                  icon={<BiFolderOpen fontSize="1rem" />}
-                  aria-label={`Move resource to another location for ${title}`}
-                >
-                  Move to...
-                </MenuItem>
-              </Can>
-            )}
-          {resourceType !== ResourceType.RootPage && isSearchPage && (
-            <MenuItem
-              isDisabled
-              colorScheme="critical"
-              icon={<BiTrash fontSize="1rem" />}
-              tooltip="This is a default page that cannot be removed."
-            >
-              Delete
-            </MenuItem>
+            </Can>
           )}
-          {resourceType !== ResourceType.RootPage && !isSearchPage && (
+          {resourceType !== ResourceType.RootPage && (
             <Can do="delete" on={{ parentId }}>
               <MenuItem
                 onClick={() => {

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2302,6 +2302,62 @@ describe("page.router", async () => {
     })
 
     it.skip("should throw 403 if user does not have write access to page", async () => {})
+
+    it("should throw 400 if attempting to change the search page permalink", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+        permalink: "search",
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.updateSettings({
+        siteId: site.id,
+        pageId: Number(page.id),
+        type: "Page",
+        title: "New Title",
+        permalink: "not-search",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "The search page permalink cannot be changed",
+        }),
+      )
+    })
+
+    it("should allow updating the search page title without changing permalink", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+        permalink: "search",
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.updateSettings({
+        siteId: site.id,
+        pageId: Number(page.id),
+        type: "Page",
+        title: "New Search Title",
+        permalink: "search",
+      })
+
+      // Assert
+      expect(result).toMatchObject({
+        title: "New Search Title",
+        permalink: "search",
+      })
+    })
   })
 
   describe("getFullPermalink", () => {

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2303,7 +2303,7 @@ describe("page.router", async () => {
 
     it.skip("should throw 403 if user does not have write access to page", async () => {})
 
-    it("should throw 400 if attempting to change the search page permalink", async () => {
+    it("should throw 400 if attempting to update the search page settings", async () => {
       // Arrange
       const { site, page } = await setupPageResource({
         resourceType: "Page",
@@ -2320,43 +2320,16 @@ describe("page.router", async () => {
         pageId: Number(page.id),
         type: "Page",
         title: "New Title",
-        permalink: "not-search",
+        permalink: "search",
       })
 
       // Assert
       await expect(result).rejects.toThrowError(
         new TRPCError({
           code: "BAD_REQUEST",
-          message: "The search page permalink cannot be changed",
+          message: "The search page settings cannot be edited",
         }),
       )
-    })
-
-    it("should allow updating the search page title without changing permalink", async () => {
-      // Arrange
-      const { site, page } = await setupPageResource({
-        resourceType: "Page",
-        permalink: "search",
-      })
-      await setupAdminPermissions({
-        userId: session.userId ?? undefined,
-        siteId: site.id,
-      })
-
-      // Act
-      const result = await caller.updateSettings({
-        siteId: site.id,
-        pageId: Number(page.id),
-        type: "Page",
-        title: "New Search Title",
-        permalink: "search",
-      })
-
-      // Assert
-      expect(result).toMatchObject({
-        title: "New Search Title",
-        permalink: "search",
-      })
     })
   })
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -807,6 +807,20 @@ export const pageRouter = router({
             })
           }
 
+          // Prevent users from renaming the search page (permalink /search, no parent).
+          // Without this, the delete restriction could be bypassed by renaming first.
+          if (
+            resource.permalink === "search" &&
+            resource.parentId === null &&
+            "permalink" in settings &&
+            settings.permalink !== "search"
+          ) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message: "The search page permalink cannot be changed",
+            })
+          }
+
           try {
             const updatedResource = await tx
               .updateTable("Resource")

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -807,17 +807,12 @@ export const pageRouter = router({
             })
           }
 
-          // Prevent users from renaming the search page (permalink /search, no parent).
-          // Without this, the delete restriction could be bypassed by renaming first.
-          if (
-            resource.permalink === "search" &&
-            resource.parentId === null &&
-            "permalink" in settings &&
-            settings.permalink !== "search"
-          ) {
+          // The search page (permalink /search, no parent) is a default page
+          // whose settings cannot be edited.
+          if (resource.permalink === "search" && resource.parentId === null) {
             throw new TRPCError({
               code: "BAD_REQUEST",
-              message: "The search page permalink cannot be changed",
+              message: "The search page settings cannot be edited",
             })
           }
 


### PR DESCRIPTION
## Problem

Follow-up to #2073. After disabling "Move to..." and "Delete" for the default Search page, "Edit settings" was still enabled — a user could rename the Search page's permalink to something other than `search`, which would defeat the existing delete restriction (which keys off `permalink === "search" && parentId === null`). The backend `page.updateSettings` mutation also had no guard, so the same bypass was reachable via the API.

The default Search page's `/search` slug is hardcoded into the site renderer (`engine/metadata.ts` robots disallow, `searchUrl` default in site configs), so renaming, moving, or deleting it would break search on the published site.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Disable the "Edit settings" menu item for the default Search page in `ResourceTableMenu`, with a tooltip explaining why. The disabled "Move to..." and "Delete" items from #2073 remain.
- Refactor `ResourceTableMenu`: extract `SearchPageMenuItems` and switch between it and the regular menu items via a single ternary inside `MenuList`, so the outer `Menu` / `MenuButton` / `Portal` wrapper is no longer duplicated.
- Add a server-side guard in `page.updateSettings` so any settings update for the default Search page is rejected with a `BAD_REQUEST`, matching the frontend.
- Remove the defensive `isSearchPage` branch from `CollectionTableMenu`. The Search page lives at the site root (`parentId === null`) so it cannot appear inside a collection — the prior defensive code was unreachable.
- Document why the default Search page is locked down with a comment above `SearchPageMenuItems`.

## Tests

**Manual Verification Steps**:

- [ ] Open a site in Studio and navigate to the root resource list.
- [ ] Click the "..." menu on the "Search" row and confirm "Edit settings", "Move to...", and "Delete" are all disabled, each with an explanatory tooltip.
- [ ] Confirm the same menu on a regular Page still shows "Edit settings", "Move to...", and "Delete" as enabled.
- [ ] Open a collection and confirm its rows still show enabled "Edit settings", "Move to...", and "Delete" menu items (the defensive disabled-state removal did not regress the normal flow).
- [ ] Attempt to call `page.updateSettings` for the Search page via the tRPC API (e.g. devtools / a crafted request) and confirm it returns `BAD_REQUEST` with message "The search page settings cannot be edited".
- [ ] Run `npm run test:unit -- src/server/modules/page/__tests__/page.router.test.ts` and confirm the new "should throw 400 if attempting to update the search page settings" test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)