### PR TITLE
chore(deps): remove unused tslib

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -117,7 +117,6 @@
     "storybook-addon-pseudo-states": "catalog:storybook",
     "tailwindcss": "catalog:",
     "tsc-alias": "catalog:",
-    "tslib": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:vitest",
     "vite-tsconfig-paths": "catalog:vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,9 +389,6 @@ catalogs:
     tsc-alias:
       specifier: ^1.8.16
       version: 1.8.16
-    tslib:
-      specifier: ^2.6.3
-      version: 2.8.1
     tsx:
       specifier: ^4.20.4
       version: 4.21.0
@@ -1302,9 +1299,6 @@ importers:
       tsc-alias:
         specifier: 'catalog:'
         version: 1.8.16
-      tslib:
-        specifier: 'catalog:'
-        version: 2.8.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -78,7 +78,6 @@ catalog:
   start-server-and-test: ^3.0.2
   tailwindcss: ^3.4.4
   testcontainers: ^10.13.1
-  tslib: ^2.6.3
   tsc-alias: ^1.8.16
   type-fest: ^4.23.0
   tsx: ^4.20.4


### PR DESCRIPTION
## Summary
- Remove `tslib` as a direct dependency from `packages/components` and the pnpm catalog
- `tslib` is only required when TypeScript's `importHelpers` compiler option is enabled, which isn't set anywhere in this repo, and no source files import from it directly
- Supersedes #2083 (Dependabot bump) — closing that PR since the dep can just be dropped

## Test plan
- [ ] CI passes (build, typecheck, lint, tests)