### PR TITLE
chore: replace npm references with pnpm in docs and comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,54 +4,54 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Isomer Next is a monorepo for a government CMS/site builder platform (Open Government Products, Singapore). It uses Turborepo with npm workspaces.
+Isomer Next is a monorepo for a government CMS/site builder platform (Open Government Products, Singapore). It uses Turborepo with pnpm workspaces.
 
 ## Common Commands
 
 ### Development
 ```bash
-npm run dev              # Start all dev servers
-npm run storybook        # Start Storybook in multiple workspaces (e.g. Studio on 6007, Components on 6006)
-npm run watch:packages   # Watch and rebuild packages
+pnpm dev              # Start all dev servers
+pnpm storybook        # Start Storybook in multiple workspaces (e.g. Studio on 6007, Components on 6006)
+pnpm watch:packages   # Watch and rebuild packages
 ```
 
 ### Testing
 ```bash
 # From root
-npm run test:e2e         # Run Playwright E2E tests
-npm run dev:e2e          # Start dev server + run E2E tests
+pnpm test:e2e         # Run Playwright E2E tests
+pnpm dev:e2e          # Start dev server + run E2E tests
 
 # From apps/studio
-npm run test:unit        # Run Vitest unit tests
-npm run test:watch       # Watch mode for unit tests
-npx playwright test tests/e2e/specific-test.spec.ts  # Run single E2E test
-npm run test:unit -- src/path/to/test.test.ts        # Run single unit test
+pnpm test:unit        # Run Vitest unit tests
+pnpm test:watch       # Watch mode for unit tests
+pnpm exec playwright test tests/e2e/specific-test.spec.ts  # Run single E2E test
+pnpm test:unit -- src/path/to/test.test.ts                 # Run single unit test
 ```
 
 ### Code Quality
 ```bash
-npm run lint             # Run Oxlint (type-aware)
-npm run lint:fix         # Fix lint issues
-npm run format           # Check formatting (Oxfmt)
-npm run format:fix       # Fix formatting
-npm run typecheck        # TypeScript type checking
+pnpm lint             # Run Oxlint (type-aware)
+pnpm lint:fix         # Fix lint issues
+pnpm format           # Check formatting (Oxfmt)
+pnpm format:fix       # Fix formatting
+pnpm typecheck        # TypeScript type checking
 ```
 
 ### Database (from apps/studio)
 ```bash
-npm run setup            # Full setup: docker, migrations, seed
-npm run services:setup   # Start PostgreSQL and Mockpass containers
-npm run migrate:dev      # Create new migration
-npm run db:seed          # Seed database
-npm run db:reset         # Reset database
-npm run generate         # Regenerate Prisma client
+pnpm setup            # Full setup: docker, migrations, seed
+pnpm services:setup   # Start PostgreSQL and Mockpass containers
+pnpm migrate:dev      # Create new migration
+pnpm db:seed          # Seed database
+pnpm db:reset         # Reset database
+pnpm generate         # Regenerate Prisma client
 ```
 
 ### Building
 ```bash
-npm run build            # Build all packages
-npm run build:template   # Build template package
-npm run clean            # Clean build artifacts
+pnpm build            # Build all packages
+pnpm build:template   # Build template package
+pnpm clean            # Clean build artifacts
 ```
 
 ## Architecture
@@ -92,14 +92,14 @@ npm run clean            # Clean build artifacts
 
 - E2E tests are in `apps/studio/tests/e2e/`
 - Unit tests use `.test.ts` extension alongside source files
-- E2E tests require `npm run setup:test` first (starts Docker services)
+- E2E tests require `pnpm setup:test` first (starts Docker services)
 - Tests use `.env.test` for environment variables
 
 ## Environment Setup
 
 1. Copy `apps/studio/.env.example` to `apps/studio/.env`
 2. Get secrets from 1Password (search "Isomer Next")
-3. Run `npm run setup` from `apps/studio` to start services and seed DB
+3. Run `pnpm setup` from `apps/studio` to start services and seed DB
 
 ## Formatting Configuration
 

--- a/tooling/oxlint/README.md
+++ b/tooling/oxlint/README.md
@@ -23,7 +23,7 @@ Lint scripts should invoke the hoisted CLI (same as with ESLint):
 }
 ```
 
-`oxlint` is provided transitively via this package and appears under the root `node_modules/.bin` after `npm install`.
+`oxlint` is provided transitively via this package and appears under the root `node_modules/.bin` after `pnpm install`.
 
 ## Extend shared presets in `.oxlintrc.json`
 

--- a/tooling/scripts/isomer-admin/apps/rebuild-all-codebuild-projects.ts
+++ b/tooling/scripts/isomer-admin/apps/rebuild-all-codebuild-projects.ts
@@ -10,7 +10,7 @@
  *   1. Authenticate with AWS first, e.g.:
  *        aws sso login --profile <your-profile>
  *   2. Run the admin CLI from tooling/scripts:
- *        npm run isomer-admin
+ *        pnpm run isomer-admin
  *   3. Select "Rebuild all CodeBuild projects" and answer the prompts.
  *
  * Tip: Run in dry-run mode first to list all project indexes, then rerun with


### PR DESCRIPTION
## Problem

The repository uses pnpm (declared in `package.json` as `packageManager: pnpm@10.33.0`), but several docs and code comments still instructed contributors to run `npm` commands. Following those literally would not work in this workspace.

## Solution

Replaced `npm`-based command examples with their `pnpm` equivalents in documentation and inline comments.

Files updated:
- `CLAUDE.md` — all `npm run …` examples switched to `pnpm …`, `npx playwright` → `pnpm exec playwright`, and "Turborepo with npm workspaces" → "pnpm workspaces".
- `tooling/oxlint/README.md` — `npm install` → `pnpm install`.
- `tooling/scripts/isomer-admin/apps/rebuild-all-codebuild-projects.ts` — JSDoc usage example `npm run isomer-admin` → `pnpm run isomer-admin`.

Intentionally left unchanged: the `npm-run-all2` dependency name, the `npm.pkg.github.com` GitHub Packages registry URL, `npm-debug.log*` gitignore patterns, Dependabot's `package-ecosystem: npm` (correct ecosystem name for pnpm-lock.yaml), the `npm install -g @datadog/datadog-ci` step in `aws_deploy.yml` (pnpm isn't set up in that job), the explanatory `npm`-vs-pnpm bin-path comment in `apps/studio/Dockerfile`, the commented devcontainer template line, and `packages/components/README.md` (addresses external consumers who may use npm/yarn).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Documentation and code comments now match the actual package manager (`pnpm`) used in this repo.

## Tests

Documentation/comment-only change — no runtime behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)