### PR TITLE
fix: prevent spaces-only table caption

### DIFF
--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -27,9 +27,11 @@ const tableSettingsSchema = z.object({
     .string({
       required_error: "Enter a caption for this table",
     })
-    .min(1, { message: "Enter a caption for this table" })
     .max(MAX_CAPTION_LENGTH, {
       message: `Table caption should be shorter than ${MAX_CAPTION_LENGTH} characters.`,
+    })
+    .refine((value) => value.trim().length > 0, {
+      message: "Enter a caption for this table",
     }),
 })
 
@@ -86,14 +88,15 @@ export const TableSettingsModal = ({
 
             <Textarea
               placeholder="This is the caption for your table"
+              mb="0.5rem"
               {...register("caption")}
             />
 
             {errors.caption?.message ? (
               <FormErrorMessage>{errors.caption.message}</FormErrorMessage>
             ) : (
-              <FormHelperText mt="0.5rem" color="base.content.medium">
-                {MAX_CAPTION_LENGTH - caption.length} characters left
+              <FormHelperText color="base.content.medium">
+                {MAX_CAPTION_LENGTH - caption.trim().length} characters left
               </FormHelperText>
             )}
           </FormControl>

--- a/packages/components/src/interfaces/native/Table.ts
+++ b/packages/components/src/interfaces/native/Table.ts
@@ -107,6 +107,9 @@ export const TableSchema = Type.Object(
         title: "Table caption",
         description: "The caption of the table",
         pattern: NON_EMPTY_STRING_REGEX,
+        errorMessage: {
+          pattern: "cannot be empty or contain only spaces",
+        },
       }),
     }),
     content: Type.Array(

--- a/packages/components/src/interfaces/native/Table.ts
+++ b/packages/components/src/interfaces/native/Table.ts
@@ -1,6 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import type { IsomerSiteProps, LinkComponentType } from "~/types"
 import { Type } from "@sinclair/typebox"
+import { NON_EMPTY_STRING_REGEX } from "~/utils/validation"
 
 import type { DividerProps } from "./Divider"
 import type { OrderedListProps } from "./OrderedList"
@@ -105,6 +106,7 @@ export const TableSchema = Type.Object(
       caption: Type.String({
         title: "Table caption",
         description: "The caption of the table",
+        pattern: NON_EMPTY_STRING_REGEX,
       }),
     }),
     content: Type.Array(


### PR DESCRIPTION
## Problem

The table caption field in the Page Editor accepted strings consisting only of whitespace as a valid caption. This bypassed the required-caption validation because the existing `z.string().min(1)` check only validated raw character length, not meaningful content. As a result, users could save tables with effectively empty captions (e.g. `"   "`), which produced inaccessible/empty `<caption>` elements on the rendered site.

The character counter also counted whitespace toward the length, which was inconsistent with the validation we want to enforce.

## Solution

- In the Studio table settings form, replace the `.min(1)` check with a `.refine()` that requires `value.trim().length > 0`, so spaces-only input is rejected with the same "Enter a caption for this table" error.
- Compute the "characters left" helper text against the trimmed length so it reflects the meaningful content the user has entered.
- Move the textarea bottom margin onto the `Textarea` itself so the helper text and error message share consistent spacing.
- In the shared Table schema in `@opengovsg/isomer-components`, add the `NON_EMPTY_STRING_REGEX` pattern to the caption field so the same constraint is enforced at the data layer (and any other consumer of the schema).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Character counter for the table caption now reflects the trimmed length, so leading/trailing whitespace no longer inflates the count.

**Bug Fixes**:

- Table captions containing only whitespace are now rejected with the existing required-caption error message, preventing empty captions from being saved.

## Tests

**Manual Verification Steps**:

- [ ] Open the Studio, navigate to a page in the editor, and insert a new Table block.
- [ ] In the table settings modal, leave the caption empty and try to save — confirm the "Enter a caption for this table" error appears.
- [ ] Enter only spaces (e.g. `"   "`) into the caption field and try to save — confirm the same "Enter a caption for this table" error appears and the form does not submit.
- [ ] Type a valid caption with leading and trailing spaces (e.g. `"  My table  "`) and confirm the "characters left" counter reflects the trimmed length.
- [ ] Save the table with a valid caption and confirm it persists correctly and renders on the page preview.
- [ ] Edit an existing table that has a valid caption and confirm the form opens and saves without regression.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A