### PR TITLE
fix: update staging S3 assets bucket name

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -41,6 +41,6 @@ jobs:
       app-name: "Isomer Studio (Staging)"
       app-version: ${{ github.sha }}
       app-s3-region: "ap-southeast-1"
-      app-s3-assets-bucket-name: "isomer-next-infra-stg-assets-private-61710b8"
+      app-s3-assets-bucket-name: "isomer-next-infra-stg-assets-private-b18ec1f"
       app-s3-assets-domain-name: "isomer-user-content-stg.by.gov.sg"
       app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"


### PR DESCRIPTION
## Problem

The staging deployment workflow was referencing an incorrect S3 assets bucket name, causing deployment failures.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Updated the `app-s3-assets-bucket-name` in the staging deployment workflow from `isomer-next-infra-stg-assets-private-61710b8` to `isomer-next-infra-stg-assets-private-b18ec1f`

## Before & After Screenshots

**BEFORE**:

N/A - infrastructure change

**AFTER**:

N/A - infrastructure change

## Tests

Staging deployment should complete successfully after this change.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A