### PR TITLE
chore(template): ignore TS build errors in next.config.mjs

### DIFF
--- a/tooling/template/next.config.mjs
+++ b/tooling/template/next.config.mjs
@@ -7,6 +7,8 @@ const nextConfig = {
   // Next resolves them the same from the app root as from the workspace package (pnpm); otherwise
   // Next may bundle jsdom and break __dirname (default-stylesheet.css ENOENT).
   serverExternalPackages: ["isomorphic-dompurify", "jsdom"],
+  // No need as this only runs for packages of versions that passes in CI
+  typescript: { ignoreBuildErrors: true },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Problem

TypeScript errors during `next build` for the template package cause unnecessary build time (additional 4 seconds) since type checking is already performed as a dedicated step in CI.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Added `typescript: { ignoreBuildErrors: true }` to `tooling/template/next.config.mjs` to skip redundant TypeScript checking during the Next.js build step, since CI runs a separate typecheck task.

## Before & After Screenshots

N/A — configuration-only change.

## Tests

No production code functionality changes — no manual verification steps required.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A