### PR TITLE
chore: enable Turbopack on @tooling/template

### DIFF
--- a/tooling/template/package.json
+++ b/tooling/template/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "scripts": {
     "build:local": "rm -rf .next && curl https://raw.githubusercontent.com/opengovsg/isomer/main/tooling/build/scripts/preBuild.sh | bash && pnpm run build",
-    "build:template": "next build --webpack",
+    "build:template": "next build",
     "clean": "git clean -xdf .next .turbo node_modules out",
-    "dev": "PORT=3001 next dev --webpack",
+    "dev": "PORT=3001 next dev",
     "format": "oxfmt --check . --ignore-path ../../.gitignore",
     "format:fix": "oxfmt --write . --ignore-path ../../.gitignore",
     "lint": "oxlint --type-aware .",


### PR DESCRIPTION
## Problem

`@tooling/template` was pinned to Webpack via `--webpack` flags on both the `dev` and `build:template` scripts, preventing use of Turbopack. Now that the upstream Next.js 16 compatibility work in #2123 is in place, there is no remaining blocker.

Closes [insert issue #]

## Solution

Removed `--webpack` from `dev` and `build:template` in `tooling/template/package.json`, allowing Next.js to use Turbopack by default for both local development and template builds.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Faster local dev startup and HMR via Turbopack for the template app
- Faster `build:template` compilation

## Before & After Screenshots

N/A — dev tooling change only.

## Tests

No production code changes — this is a dev/build tooling update. No manual verification steps required.

**New scripts**: N/A

**New dependencies**: N/A

**New dev dependencies**: N/A