### PR TITLE
chore: add shared Claude Code permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,6 @@
   "permissions": {
     "allow": [
       "Bash(gh pr list:*)",
-      "WebFetch(domain:github.com)",
       "Bash(gh pr view:*)",
       "Bash(gh pr diff:*)",
       "Bash(docker start:*)",
@@ -41,6 +40,7 @@
       "Bash(pnpm run build:*)",
       "Bash(pnpx tsc:*)",
       "Bash(git stash:*)",
+      "WebFetch(domain:github.com)",
       "WebFetch(domain:docs.datadoghq.com)",
       "mcp__figma__get_design_context",
       "mcp__figma__get_code_connect_suggestions",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,5 +27,24 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(gh pr list:*)",
+      "WebFetch(domain:github.com)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(docker start:*)",
+      "Bash(pnpm run test:*)",
+      "Bash(pnpm run test:unit:*)",
+      "Bash(pnpm run typecheck:*)",
+      "Bash(pnpm run build:*)",
+      "Bash(pnpx tsc:*)",
+      "Bash(git stash:*)",
+      "WebFetch(domain:docs.datadoghq.com)",
+      "mcp__figma__get_design_context",
+      "mcp__figma__get_code_connect_suggestions",
+      "mcp__figma__send_code_connect_mappings"
+    ]
   }
 }


### PR DESCRIPTION
## Problem

When using Claude Code, team members repeatedly need to approve the same common commands (gh, pnpm, docker, etc.), slowing down workflows.

## Solution

Adds shared pre-approved permissions to `.claude/settings.json` for common development commands that all team members use:

- **GitHub CLI**: `gh pr list/view/diff`
- **Build/Test**: `pnpm run test/typecheck/build`, `pnpx tsc`
- **Docker**: `docker start`
- **Git**: `git stash`
- **Web**: `github.com`, `docs.datadoghq.com`
- **Figma MCP**: `get_design_context`, `get_code_connect_suggestions`, `send_code_connect_mappings`

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Reduces permission prompts for common safe operations
- Shared across all team members via project settings
- User-specific permissions can still be added to `.claude/settings.local.json`

## Before & After Screenshots

N/A - Developer tooling change with no UI impact

## Tests

Verified manually that permissions are applied correctly.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None