### PR TITLE
chore: remove tRPC dependabot ignore and clarify React 19 block reason

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,7 +83,8 @@ updates:
           - "@jsonforms/react"
     ignore:
       # Currently dependabot doesn't support ignoring by group so we have to ignore each dependency individually
-      # Ignore major version updates for react, trpc as they rely on React 19
+      # Ignore major version updates for react — we cannot upgrade to React 19 yet because some dependencies
+      # like @chakra-ui/react v2 (from the OGP design system) don't support React 19
       ### React 19
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
@@ -92,15 +93,6 @@ updates:
       - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
-        update-types: ["version-update:semver-major"]
-      ### TRPC 11
-      - dependency-name: "@trpc/client"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@trpc/next"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@trpc/react-query"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@trpc/server"
         update-types: ["version-update:semver-major"]
       # Ignore major version updates for Prisma 6 due to installation issues
       ### Could not resolve @prisma/client despite the installation that we just tried.


### PR DESCRIPTION
## Problem

The dependabot config was suppressing major-version updates for tRPC (4 packages) even though tRPC v11 no longer requires React 19. The comment explaining why React major-version updates are blocked was also vague.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Removed the tRPC major-version ignore block from `dependabot.yml` so dependabot can now propose tRPC v11 upgrades.
- Updated the React 19 block comment to clearly state that the blocker is `@chakra-ui/react` v2 (from the OGP design system) not supporting React 19.

## Before & After Screenshots

N/A — CI/CD config change only.

## Tests

No production code changes; no manual verification steps required.

**New scripts**: N/A

**New dependencies**: N/A

**New dev dependencies**: N/A