### PR TITLE
feat: allow Spotify playlist embed URLs in audio component

### DIFF
--- a/packages/components/src/interfaces/complex/Audio.ts
+++ b/packages/components/src/interfaces/complex/Audio.ts
@@ -8,7 +8,7 @@ export const AudioSchema = Type.Object(
     url: Type.String({
       title: "Audio to embed",
       description:
-        "Spotify episode or show, or Apple Podcast show/episode embed URL only",
+        "Spotify episode, show, or playlist, or Apple Podcast show/episode embed URL only",
       pattern: AUDIO_EMBED_URL_PATTERN,
       format: "embed",
     }),
@@ -21,7 +21,7 @@ export const AudioSchema = Type.Object(
   {
     title: "Audio",
     description:
-      "The audio component embeds Spotify podcast episodes and shows, or Apple Podcast shows and episodes.",
+      "The audio component embeds Spotify podcast episodes, shows, and playlists, or Apple Podcast shows and episodes.",
   },
 )
 

--- a/packages/components/src/templates/next/components/complex/Audio/Audio.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Audio/Audio.stories.tsx
@@ -35,6 +35,14 @@ export const SpotifyShow: Story = {
   },
 }
 
+export const SpotifyPlaylist: Story = {
+  name: "Spotify playlist",
+  args: {
+    title: "NDP playlist",
+    url: "https://open.spotify.com/embed/playlist/1apUfsI3NR7LqzFOlGieBT",
+  },
+}
+
 export const ApplePodcastShow: Story = {
   name: "Apple Podcast show",
   args: {

--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -275,11 +275,12 @@ describe("validation", () => {
   })
 
   describe("AUDIO_EMBED_URL_PATTERN and isValidAudioEmbedUrl", () => {
-    it("should allow Spotify episode and show embed URLs", () => {
+    it("should allow Spotify episode, show, and playlist embed URLs", () => {
       const testCases = [
         "https://open.spotify.com/embed/episode/7makk4oTQel546B0PZlDM5",
         "https://open.spotify.com/embed/episode/3T5WkragWdHZRwFl7qCHoz?utm_source=generator",
         "https://open.spotify.com/embed/show/66PYiIthr1KqQhJ82XH4DN?utm_source=generator",
+        "https://open.spotify.com/embed/playlist/1apUfsI3NR7LqzFOlGieBT",
       ]
 
       testCases.forEach((testCase) => {
@@ -301,11 +302,10 @@ describe("validation", () => {
       })
     })
 
-    it("should not allow Spotify album, track, playlist, or artist (only episode and show supported)", () => {
+    it("should not allow Spotify album, track, or artist (only episode, show, and playlist supported)", () => {
       const testCases = [
         "https://open.spotify.com/embed/album/6i6folBtxKV28WX3msQ4FE",
         "https://open.spotify.com/embed/track/4cOdK2wGLETKBW3PvgPWqT",
-        "https://open.spotify.com/embed/playlist/37i9dQZF1DXcBWIGoYBM5M",
         "https://open.spotify.com/embed/artist/0OdUWJ0sBJDrq8yp90n0ID",
       ]
 

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -155,14 +155,15 @@ export const VIDEO_EMBED_URL_PATTERN = Object.values(VIDEO_EMBED_URL_REGEXES)
   .join("|")
 
 // Validation for audio embed URLs (Spotify or Apple Podcast) for the "audio" component
-// Only these variants are supported: Spotify episode or show; Apple Podcast show or episode
+// Only these variants are supported: Spotify episode, show, or playlist; Apple Podcast show or episode
 const VALID_AUDIO_EMBED_DOMAINS = {
   spotify: "open.spotify.com",
   applepodcast: "embed.podcasts.apple.com",
 }
 
 export const AUDIO_EMBED_URL_REGEXES = {
-  spotify: "^https://open\\.spotify\\.com/embed/(episode|show)/[a-zA-Z0-9]+.*$",
+  spotify:
+    "^https://open\\.spotify\\.com/embed/(episode|show|playlist)/[a-zA-Z0-9]+.*$",
   applepodcast: "^https://embed\\.podcasts\\.apple\\.com/[a-z]{2}/[a-z-]+/.*$",
 } as const
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The audio embed component's URL whitelist only permitted Spotify `episode` and `show` URLs. Sites such as the NDP site need to embed Spotify playlists (e.g. `https://open.spotify.com/embed/playlist/1apUfsI3NR7LqzFOlGieBT`), which were previously rejected by the validation regex.

## Solution

<!-- How did you solve the problem? -->

Extended the Spotify URL regex in `validation.ts` to also accept `/embed/playlist/*` URLs. The JSON schema description strings in `Audio.ts` were updated to reflect the new supported type, and a new Storybook story was added for Spotify playlists.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Spotify playlist embed URLs (`/embed/playlist/*`) are now accepted by the audio component's URL validator.

**Improvements**:

- Updated `AudioSchema` description strings to document Spotify playlist support.
- Added `SpotifyPlaylist` Storybook story using the NDP example URL.

**Bug Fixes**:

- N/A

## Before & After Screenshots

<img width="662" height="245" alt="Screenshot 2026-05-19 at 7 00 23 PM" src="https://github.com/user-attachments/assets/896443dc-a882-4b7f-a15a-5c50f2a5e39c" />

## Tests

**Manual Verification Steps**:

- [ ] Open an Isomer site in the Studio editor and add an Audio component.
- [ ] Paste `https://open.spotify.com/embed/playlist/1apUfsI3NR7LqzFOlGieBT` as the URL — confirm the embed saves and renders without a validation error.
- [ ] Paste `https://open.spotify.com/embed/album/6i6folBtxKV28WX3msQ4FE` as the URL — confirm it is still rejected with a validation error.
- [ ] Confirm existing Spotify episode and show embed URLs still render correctly.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A