### PR TITLE
Revert: Remove spaces-only table caption validation

### DIFF
--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -27,11 +27,9 @@ const tableSettingsSchema = z.object({
     .string({
       error: "Enter a caption for this table",
     })
+    .min(1, { message: "Enter a caption for this table" })
     .max(MAX_CAPTION_LENGTH, {
       message: `Table caption should be shorter than ${MAX_CAPTION_LENGTH} characters.`,
-    })
-    .refine((value) => value.trim().length > 0, {
-      message: "Enter a caption for this table",
     }),
 })
 
@@ -88,15 +86,14 @@ export const TableSettingsModal = ({
 
             <Textarea
               placeholder="This is the caption for your table"
-              mb="0.5rem"
               {...register("caption")}
             />
 
             {errors.caption?.message ? (
               <FormErrorMessage>{errors.caption.message}</FormErrorMessage>
             ) : (
-              <FormHelperText color="base.content.medium">
-                {MAX_CAPTION_LENGTH - caption.trim().length} characters left
+              <FormHelperText mt="0.5rem" color="base.content.medium">
+                {MAX_CAPTION_LENGTH - caption.length} characters left
               </FormHelperText>
             )}
           </FormControl>

--- a/packages/components/src/interfaces/native/Table.ts
+++ b/packages/components/src/interfaces/native/Table.ts
@@ -1,7 +1,6 @@
 import type { Static } from "@sinclair/typebox"
 import type { IsomerSiteProps } from "~/types"
 import { Type } from "@sinclair/typebox"
-import { NON_EMPTY_STRING_REGEX } from "~/utils/validation"
 
 import type { DividerProps } from "./Divider"
 import type { OrderedListProps } from "./OrderedList"
@@ -106,10 +105,6 @@ export const TableSchema = Type.Object(
       caption: Type.String({
         title: "Table caption",
         description: "The caption of the table",
-        pattern: NON_EMPTY_STRING_REGEX,
-        errorMessage: {
-          pattern: "cannot be empty or contain only spaces",
-        },
       }),
     }),
     content: Type.Array(


### PR DESCRIPTION
## Problem

The previous change (#2121) that prevented spaces-only table captions introduced validation that may have caused issues with existing table configurations or user workflows.

This reverts commit b9cd46389a2990cf2890a3a3c481e229bd4d205a.

## Solution

Reverts the validation changes to restore the previous behavior for table captions.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Reverts to simpler validation using `.min(1)` instead of `.refine()` with trim check
- Removes `NON_EMPTY_STRING_REGEX` pattern validation from the Table schema
- Restores original character count display (without trim)

## Before & After Screenshots

N/A - Validation behavior change only

## Tests

Manual testing: Verify table caption validation works as expected in the table settings modal.

**New scripts**:

None

**New dependencies**:

None

**New dev dependencies**:

None