### PR TITLE
fix: correct grammar in Infocards default title

### DIFF
--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -75,7 +75,7 @@ export const DEFAULT_BLOCKS = {
   },
   infocards: {
     type: "infocards",
-    title: "This is an title of the Infocards component",
+    title: "This is a title of the Infocards component",
     subtitle: "This is an optional subtitle for the Infocards component",
     variant: "cardsWithImages",
     maxColumns: "3",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The default title for the Infocards component block used incorrect grammar: "This is an title of the Infocards component" — "an" before a consonant sound is grammatically incorrect.

## Solution

Corrected the article from "an" to "a" in the default `title` value for the `infocards` block in `constants.ts`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed grammar error in the default placeholder title for the Infocards component ("an title" → "a title").

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Open the page editor in Studio and add an Infocards block; verify the default title reads "This is a title of the Infocards component".

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A