### PR TITLE
fix(studio): remove unused meta field from PageSettingsModal form schema

### DIFF
--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -69,7 +69,6 @@ const PageSettingsModalContent = ({
     formState: { isDirty, errors },
   } = useZodForm({
     schema: basePageSettingsSchema.omit({ pageId: true, siteId: true }).extend({
-      meta: z.unknown(),
       permalink: generateBasePermalinkSchema("page")
         .min(1, {
           message: "Enter a URL for this page",


### PR DESCRIPTION
## Problem

The page settings modal ("Publish immediately" button) in the dashboard was not working - clicking the button did nothing and the modal would not close.

## Solution

Removed the unused `meta: z.unknown()` field from the form schema in `PageSettingsModal.tsx`.

The form schema included a `meta` field that:
1. Had no corresponding default value
2. Had no form input to set it
3. Was not used by the tRPC mutation endpoint

This caused form validation to fail silently, preventing the `handleSubmit` callback from executing.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed page settings modal not submitting when clicking "Publish immediately" button
- Form now properly validates and submits title/permalink changes

## Before & After Screenshots

**BEFORE**:
Clicking "Publish immediately" does nothing - modal stays open, no network request

**AFTER**:
Clicking "Publish immediately" submits the form, shows success toast, and closes modal

## Tests

Manually tested by:
1. Opening page settings modal from dashboard
2. Modifying title or permalink
3. Clicking "Publish immediately"
4. Verifying toast appears and modal closes

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None