### PR TITLE
fix: disable publish button while page settings mutation is pending

### DIFF
--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -114,28 +114,28 @@ const PageSettingsModalContent = ({
 
   const { mutate: updatePageSettings, isPending } =
     trpc.page.updateSettings.useMutation({
-    onSuccess: async () => {
-      // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
-      await utils.page.invalidate()
-      await utils.resource.invalidate()
-      await utils.folder.invalidate()
-      await utils.collection.invalidate()
+      onSuccess: async () => {
+        // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
+        await utils.page.invalidate()
+        await utils.resource.invalidate()
+        await utils.folder.invalidate()
+        await utils.collection.invalidate()
 
-      toast({
-        title: "Saved and published settings",
-        description: "Check your site in 5-10 minutes to view it live.",
-        status: "success",
-      })
-    },
-    onError: (error) => {
-      toast({
-        title: "Failed to save settings",
-        description: error.message,
-        status: "error",
-      })
-      reset()
-    },
-  })
+        toast({
+          title: "Saved and published settings",
+          description: "Check your site in 5-10 minutes to view it live.",
+          status: "success",
+        })
+      },
+      onError: (error) => {
+        toast({
+          title: "Failed to save settings",
+          description: error.message,
+          status: "error",
+        })
+        reset()
+      },
+    })
 
   const onSubmit = handleSubmit((data) => {
     if (isDirty) {

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -112,7 +112,8 @@ const PageSettingsModalContent = ({
   const utils = trpc.useUtils()
   const toast = useToast(BRIEF_TOAST_SETTINGS)
 
-  const { mutate: updatePageSettings } = trpc.page.updateSettings.useMutation({
+  const { mutate: updatePageSettings, isPending } =
+    trpc.page.updateSettings.useMutation({
     onSuccess: async () => {
       // TODO: we should use a specialised query for this rather than the general one that retrives the page and the blob
       await utils.page.invalidate()
@@ -232,7 +233,9 @@ const PageSettingsModalContent = ({
         <Button mr={3} variant="clear" onClick={onClose}>
           Close
         </Button>
-        <Button onClick={onSubmit}>Publish immediately</Button>
+        <Button onClick={onSubmit} isLoading={isPending}>
+          Publish immediately
+        </Button>
       </ModalFooter>
     </ModalContent>
   )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The "Publish immediately" button in the Page Settings modal could be clicked multiple times before the mutation completed, potentially triggering duplicate publish requests.

## Solution

<!-- How did you solve the problem? -->

Destructure `isPending` from the `updateSettings` tRPC mutation and pass it as `isLoading` to the "Publish immediately" button. Chakra UI's `Button` natively disables the element when `isLoading` is true, preventing further clicks while the request is in-flight.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Prevent spam-clicking "Publish immediately" in `PageSettingsModal` by showing a loading spinner and disabling the button during the in-flight mutation.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Open a page's settings modal (via the dashboard page options menu).
- [ ] Click "Publish immediately" and verify the button shows a loading spinner and cannot be clicked again while the request is processing.
- [ ] Verify the modal closes and a success toast appears once the mutation completes.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A