### PR TITLE
fix: include published folders without published IndexPages in listChildPages

### DIFF
--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -833,25 +833,24 @@ describe("folder.router", async () => {
       )
     })
 
-    it("should return an empty array if `siteId` does not exist", async () => {
+    it("should return an empty array if there are no published child resources", async () => {
       // Arrange
-      const invalidSiteId = 999
       const { site, folder } = await setupFolder()
       await setupEditorPermissions({
         userId: session.userId,
         siteId: site.id,
       })
-      expect(site.id).not.toEqual(invalidSiteId)
       const { page: indexPage } = await setupPageResource({
         parentId: folder.id,
         siteId: site.id,
         resourceType: "IndexPage",
       })
+      // NOTE: Only draft pages - not published, so should not be returned
       await createChildPages({
         parentId: folder.id,
         siteId: site.id,
         numPages: 3,
-        numFolders: 5,
+        numFolders: 0,
       })
 
       // Act
@@ -940,7 +939,7 @@ describe("folder.router", async () => {
       ).resolves.toHaveLength(0)
     })
 
-    it("should return only the published pages of the parent folder", async () => {
+    it("should return published pages and all published folders of the parent folder", async () => {
       // Arrange
       const { site, folder } = await setupFolder()
       await setupEditorPermissions({ siteId: site.id, userId: session.userId })
@@ -949,17 +948,19 @@ describe("folder.router", async () => {
         siteId: site.id,
         resourceType: "IndexPage",
       })
-      const { pages, folders } = await createChildPages({
-        parentId: folder.id,
-        siteId: site.id,
-        numPages: 3,
-        numFolders: 4,
-        state: "Published",
-        userId: session.userId,
-      })
+      const { pages, folders: foldersWithPublishedIndex } =
+        await createChildPages({
+          parentId: folder.id,
+          siteId: site.id,
+          numPages: 3,
+          numFolders: 4,
+          state: "Published",
+          userId: session.userId,
+        })
 
-      // NOTE: Not `published`
-      await createChildPages({
+      // NOTE: Draft pages should be excluded, but published folders with draft
+      // IndexPages should still be included (consistent with getLocalisedSitemap)
+      const { folders: foldersWithDraftIndex } = await createChildPages({
         parentId: folder.id,
         siteId: site.id,
         numPages: 3,
@@ -972,12 +973,45 @@ describe("folder.router", async () => {
         indexPageId: indexPage.id,
       })
 
-      // Assert
-      expect(result.childPages).toHaveLength(7)
-      const folderPagesId = folders.map(({ id }) => id)
-      const pagesId = pages.map(({ id }) => id)
+      // Assert: 3 published pages + 4 folders with published index + 4 folders with draft index
+      expect(result.childPages).toHaveLength(11)
+      const expectedIds = [
+        ...pages.map(({ id }) => id),
+        ...foldersWithPublishedIndex.map(({ id }) => id),
+        ...foldersWithDraftIndex.map(({ id }) => id),
+      ]
       expect(result.childPages.map(({ id }) => id).toSorted()).toStrictEqual(
-        [...pagesId, ...folderPagesId].toSorted(),
+        expectedIds.toSorted(),
+      )
+    })
+
+    it("should include published folders even if their IndexPage is not published", async () => {
+      // Arrange: this is the bug scenario - folders created but IndexPage not yet published
+      const { site, folder } = await setupFolder()
+      await setupEditorPermissions({ siteId: site.id, userId: session.userId })
+      const { page: indexPage } = await setupPageResource({
+        parentId: folder.id,
+        siteId: site.id,
+        resourceType: "IndexPage",
+      })
+      // Create folders without publishing their IndexPages (default Draft state)
+      const { folders } = await createChildPages({
+        parentId: folder.id,
+        siteId: site.id,
+        numPages: 0,
+        numFolders: 3,
+      })
+
+      // Act
+      const result = await caller.listChildPages({
+        siteId: String(site.id),
+        indexPageId: indexPage.id,
+      })
+
+      // Assert: All 3 published folders should be included
+      expect(result.childPages).toHaveLength(3)
+      expect(result.childPages.map(({ id }) => id).toSorted()).toStrictEqual(
+        folders.map(({ id }) => id).toSorted(),
       )
     })
   })

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -369,7 +369,10 @@ export const folderRouter = router({
       }
 
       // NOTE: This is not a general `resource.list`
-      // but reimplemented here because it makes certain assumptions about what should be shown
+      // but reimplemented here because it makes certain assumptions about what should be shown.
+      // We include all published Folders/Collections/Pages regardless of whether they have
+      // a published IndexPage, to stay consistent with getLocalisedSitemap which also shows
+      // all published folders in the sitemap used for the ChildrenPages block preview.
       const childPages = await db
         .with("directChildren", (eb) => {
           return eb
@@ -384,57 +387,8 @@ export const folderRouter = router({
             ])
             .select(["Resource.id", "title", "type", "permalink"])
         })
-        // NOTE: we need to select the `Folder/Collection`.`id`
-        // rather than the `IndexPage` as our publishing script
-        // uses the actual `id` of the containing `Folder/Collection`.
-        // However, we will use the `IndexPage` as a filter as we should only
-        // show the preview for published `IndexPages` (draft pages won't show on end site)
-        .with("publishedCousinIndexPages", (eb) => {
-          return (
-            eb
-              .selectFrom("Resource")
-              .where("parentId", "in", (qb) =>
-                qb
-                  .selectFrom("directChildren")
-                  .where("type", "in", [
-                    ResourceType.Folder,
-                    ResourceType.Collection,
-                  ])
-                  .select("id"),
-              )
-              // NOTE: Keeping in line with how we select resources for sitemap,
-              // we will only select published index pages here
-              .where("state", "=", ResourceState.Published)
-              .where("type", "=", ResourceType.IndexPage)
-              .select([
-                "Resource.parentId",
-                (eb) =>
-                  eb
-                    .selectFrom("Resource as Parent")
-                    .whereRef("Parent.id", "=", "Resource.parentId")
-                    .select("Parent.type")
-                    .as("parentType"),
-              ])
-          )
-        })
-        .selectFrom("Resource")
-        .where("siteId", "=", Number(siteId))
-        .where("id", "in", (qb) =>
-          qb
-            .selectFrom("publishedCousinIndexPages")
-            .where("parentType", "in", [
-              ResourceType.Collection,
-              ResourceType.Folder,
-            ])
-            .select("parentId"),
-        )
+        .selectFrom("directChildren")
         .select(["id", "title", "type", "permalink"])
-        .unionAll((qb) => {
-          return qb
-            .selectFrom("directChildren")
-            .where("type", "=", ResourceType.Page)
-            .select(["id", "title", "type", "permalink"])
-        })
         .execute()
 
       // TODO: Think about how to handle cases where 2 people are editing the order


### PR DESCRIPTION
## Summary

Fixes the bug reported in [#isomer-next-migrations](https://opengovproducts.slack.com/archives/C07CWUNUL68/p1779152405341589): child pages (like "2025 Term 2", "2025 Term 3", "2026 Term 1") appearing in the ChildrenPages block preview but not in the page ordering drawer.

**Root cause:** When a folder is created in Isomer, the `Folder` resource is automatically set to `state = Published`, but its associated `IndexPage` starts as `Draft`. The `listChildPages` endpoint (used by the ordering drawer) previously required sub-folders to have a **published IndexPage** before returning them. However, `getLocalisedSitemap` (which drives the ChildrenPages block preview) includes all published folders regardless of their IndexPage's state. This caused a discrepancy where newly-created folders were visible in the preview but invisible in the ordering UI.

**Fix:** Simplify `listChildPages` to return all published `Folder`/`Collection`/`Page` direct children, removing the requirement for a published IndexPage. This aligns its behavior with `getLocalisedSitemap`.

## Test plan

- [x] Updated existing `listChildPages` tests to reflect the new behavior (published folders with draft IndexPages are now included)
- [x] Added a new test: "should include published folders even if their IndexPage is not published"
- [x] TypeScript typecheck passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)

https://claude.ai/code/session_012gD35psKwT8QfrPcFpF2yJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012gD35psKwT8QfrPcFpF2yJ)_