### PR TITLE
fix: hero banner image upload silently fails on certain devices

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
@@ -172,15 +172,13 @@ export default function HeroEditorDrawer(): JSX.Element {
 
   const handleChange = useCallback(
     (data: IsomerComponent) => {
-      const updatedBlocks = Array.from(previewPageState.content)
-      updatedBlocks[currActiveIdx] = data
-      const newPageState = {
-        ...previewPageState,
-        content: updatedBlocks,
-      }
-      setPreviewPageState(newPageState)
+      setPreviewPageState((oldPageState) => {
+        const updatedBlocks = Array.from(oldPageState.content)
+        updatedBlocks[currActiveIdx] = data
+        return { ...oldPageState, content: updatedBlocks }
+      })
     },
-    [currActiveIdx, previewPageState, setPreviewPageState],
+    [currActiveIdx, setPreviewPageState],
   )
 
   return (

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -56,6 +56,7 @@ function JsonFormsImageControl({
           siteId={siteId}
           resourceId={(pageId ?? linkId) ? String(pageId ?? linkId) : undefined}
           setHref={(src) => handleChange(path, src)}
+          shouldFetchResource={false}
         />
       )}
       {!!errors && (


### PR DESCRIPTION
## Summary

Fixes the bug where uploading an image to the Hero Banner editor silently fails — the image appears briefly then disappears — reported on Comet/Edge devices.

### Root cause

Two interacting issues in the image upload flow:

**1. Stale closure in `HeroEditorDrawer.handleChange`**

`handleChange` read `previewPageState` directly from its closure instead of using a functional update. Because `FileAttachment` has a `useEffect` that calls `setHref("")` repeatedly while `isLoading` is true (see below), multiple `setPreviewPageState` calls were racing. Since all of them closed over the same stale snapshot of `previewPageState`, the last writer won — and the final `setHref(imagePath)` call's state update was overwritten.

`ComplexEditorStateDrawer` (used for all other image blocks) already used the correct functional-update pattern; `HeroEditorDrawer` was the odd one out.

**2. `FileAttachment.useEffect` repeatedly clears the image URL**

```ts
useEffect(() => {
  // NOTE: The outer link modal uses this to disable the button
  if (isLoading) setHref("")
}, [isLoading, setHref])
```

`isLoading` (from `useAssetUpload`) becomes `true` for at least 1 second — the `delayFirstAttempt` pause before the first CloudFront availability check. In `JsonFormsImageControl` the `setHref` prop is an inline arrow function `(src) => handleChange(path, src)`, which creates a new reference on every render. Because `flushSync` forces a synchronous re-render on each state update, the effect fires in a tight loop, calling `handleChange(path, "")` over and over until the CDN check resolves.

If the CDN check ultimately fails (common on SafeSurf/filtered networks), `setHref(undefined)` is called, which fails Hero schema validation (`backgroundUrl` is required), so `handleChange` is never called and the blank URL is persisted.

### Fix

- **`HeroEditorDrawer`**: switch `handleChange` to a functional update (same pattern as `ComplexEditorStateDrawer`), eliminating the stale-closure race.
- **`JsonFormsImageControl`**: pass `shouldFetchResource={false}` to `FileAttachment`. The CDN-verification step is not needed here — `handleAssetUpload` returns the same path it receives regardless, and `LinkEditorModal` already uses `shouldFetchResource={false}` for the same reason. This keeps `isLoading` false, stopping the `setHref("")` loop entirely.

## Test plan

- [ ] Open a Hero Banner editor on any page
- [ ] Upload an image — it should persist in the preview and the Save button should become enabled
- [ ] Save and confirm the image is stored correctly
- [ ] Verify the same flow works for non-Hero image blocks (ComplexEditorStateDrawer path) — should be unaffected
- [ ] Verify the Link Editor modal file attachment still works correctly

https://claude.ai/code/session_016izFWWfUECfP4kpH4pxHDy

---
_Generated by [Claude Code](https://claude.ai/code/session_016izFWWfUECfP4kpH4pxHDy)_