### PR TITLE
fix: mobile navbar top position stale after masthead/notification height change

### DIFF
--- a/packages/components/src/templates/next/components/internal/Navbar/Navbar.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/Navbar.stories.tsx
@@ -7,13 +7,37 @@ import { getViewportByMode, withChromaticModes } from "@isomer/storybook-config"
 
 import { Button } from "../Button"
 import { Masthead } from "../Masthead"
+import { Notification } from "../Notification"
 import { Navbar } from "./Navbar"
 
 const Renderer = (props: NavbarProps) => {
   return (
     <div className="flex min-h-dvh flex-col">
-      <Masthead />
-      <Navbar {...props} />
+      <header>
+        <Masthead />
+        <Navbar {...props} />
+      </header>
+      <div className="h-[calc(100vh+300px)] bg-red-500">
+        This mimics content that may overflow in a real preview
+        <div>
+          <Button>Focusable button</Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const RendererWithNotification = (props: NavbarProps) => {
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <header>
+        <Masthead />
+        <Notification
+          title="This is an important site notification"
+          site={generateSiteConfig()}
+        />
+        <Navbar {...props} />
+      </header>
       <div className="h-[calc(100vh+300px)] bg-red-500">
         This mimics content that may overflow in a real preview
         <div>
@@ -445,6 +469,68 @@ export const CTAAndUtilityLinksMobile: Story = {
     const canvas = within(canvasElement)
     await userEvent.click(
       canvas.getByRole("button", { name: /open navigation menu/i }),
+    )
+  },
+}
+
+// Regression tests for https://github.com/opengovsg/isomer/issues/2120:
+// the mobile menu's `top` should update when masthead/notification height changes
+// while the menu is open.
+
+const mobileRegressionBase: Story = {
+  args: generateNavbarArgs(),
+  globals: {
+    viewport: getViewportByMode("mobile"),
+  },
+  parameters: {
+    chromatic: withChromaticModes(["mobile"]),
+  },
+}
+
+const mobileRegressionWithNotificationBase: Story = {
+  ...mobileRegressionBase,
+  render: (args) => <RendererWithNotification {...args} />,
+  beforeEach: () => {
+    sessionStorage.removeItem("notification-dismissed")
+  },
+}
+
+export const MobileNavbarAfterMastheadCollapsed: Story = {
+  ...mobileRegressionBase,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByText(/how to identify/i))
+    await userEvent.click(
+      canvas.getByRole("button", { name: /open navigation menu/i }),
+    )
+    await userEvent.click(canvas.getByText(/how to identify/i))
+  },
+}
+
+export const MobileNavbarAfterNotificationDismissed: Story = {
+  ...mobileRegressionWithNotificationBase,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      canvas.getByRole("button", { name: /open navigation menu/i }),
+    )
+    await userEvent.click(
+      canvas.getByRole("button", { name: /dismiss notification/i }),
+    )
+  },
+}
+
+export const MobileNavbarAfterMastheadAndNotificationClosed: Story = {
+  ...mobileRegressionWithNotificationBase,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByText(/how to identify/i))
+    await userEvent.click(
+      canvas.getByRole("button", { name: /open navigation menu/i }),
+    )
+    await userEvent.click(canvas.getByText(/how to identify/i))
+    await userEvent.click(
+      canvas.getByRole("button", { name: /dismiss notification/i }),
     )
   },
 }

--- a/packages/components/src/templates/next/components/internal/Navbar/NavbarClient.tsx
+++ b/packages/components/src/templates/next/components/internal/Navbar/NavbarClient.tsx
@@ -1,7 +1,13 @@
 "use client"
 
 import type { NavbarClientProps } from "~/interfaces"
-import { useCallback, useLayoutEffect, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
 import { BiMenu, BiSearch, BiX } from "react-icons/bi"
 import { useResizeObserver } from "usehooks-ts"
 import { tv } from "~/lib/tv"
@@ -100,6 +106,20 @@ export const NavbarClient = ({
     ref: siteHeaderRef,
     onResize: refreshMenuOffset,
   })
+
+  // When the hamburger menu is open, also watch the full <header> for height
+  // changes caused by siblings like masthead/notification toggling, since those
+  // don't resize the navbar container but do shift its position.
+  useEffect(() => {
+    if (!isHamburgerOpen) return
+
+    const header = siteHeaderRef.current?.closest("header")
+    if (!header) return
+
+    const observer = new ResizeObserver(() => refreshMenuOffset())
+    observer.observe(header)
+    return () => observer.disconnect()
+  }, [isHamburgerOpen, refreshMenuOffset])
 
   const onCloseMenu = useCallback(() => {
     setIsHamburgerOpen(false)


### PR DESCRIPTION
## Problem

When the mobile navigation menu is open, toggling the Govt Masthead (expand/collapse) or dismissing the Notification banner does not reposition the menu — it stays anchored to a stale `top` value. This causes the menu to overlap masthead content or leave a gap after the masthead collapses.

Closes #2120

## Solution

**Root cause**: `mobileNavbarTopPx` is calculated via `getBoundingClientRect().bottom` on the navbar container. The existing `useResizeObserver` only watches that container — but when masthead/notification change height, the navbar container doesn't change *size*, only *position*. So `refreshMenuOffset` was never called on those changes.

**Fix**: Added a `useEffect` in `NavbarClient` that attaches a native `ResizeObserver` to the nearest `<header>` ancestor while the hamburger menu is open. The `<header>` *does* change total height when masthead/notification toggle, so `refreshMenuOffset` is called and `top` updates correctly. The observer disconnects when the menu closes.

**Approaches considered and rejected**:

- **Raise masthead z-index above the mobile menu**: Adding `relative z-[60]` to the masthead puts expanded content on top of the menu, but the menu's `top` stays stale after collapse — the gap doesn't close. Treats the symptom, not the cause.
- **Custom data attribute selector instead of `closest("header")`**: A `data-*` attribute decouples from the HTML tag but still requires DOM traversal with the same coupling — more coordination overhead for no meaningful benefit.
- **Pass a `headerRef` prop from `Skeleton.tsx`**: Would be fully explicit and type-safe, but `Skeleton.tsx` is a server component — `useRef` can't be called there. To make it work, you'd need to extract a new `"use client"` `HeaderClient` wrapper around the entire `<header>`, which forces `Masthead`, `Notification`, `SkipToContent`, and `UnsupportedBrowserBanner` out of server rendering. That's a meaningful SSR regression for a fix that `closest("header")` handles in 3 lines.
- **Watch `document.documentElement`**: Too broad — fires on any page height change, not just the header.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `NavbarClient`: attach a `ResizeObserver` to the `<header>` ancestor while the hamburger menu is open, so `mobileNavbarTopPx` recalculates whenever masthead or notification height changes

**Improvements**:

- `Navbar.stories.tsx`: wrap existing `Renderer` in `<header>` to match the real `Skeleton.tsx` DOM structure (required for the fix to apply in Storybook)
- `Navbar.stories.tsx`: add `RendererWithNotification` and three Chromatic regression stories — masthead-only collapse, notification-only dismiss, and both combined

## Before & After Screenshots

**BEFORE**:

Mobile menu `top` stays at the stale pre-collapse value after masthead is collapsed while the menu is open.

**AFTER**:

Mobile menu `top` recalculates and the menu sits flush below the navbar after masthead/notification height changes.

## Tests

**Manual Verification Steps**:

- [ ] On mobile (or responsive mode), expand the Govt Masthead ("How to identify"), open the hamburger menu, then collapse the masthead — verify the mobile menu moves up to sit flush below the navbar
- [ ] On mobile, open the hamburger menu, then dismiss the notification banner (× button) — verify the mobile menu moves up to sit flush below the navbar
- [ ] On mobile, expand the masthead, open the hamburger menu, collapse the masthead and dismiss the notification — verify the menu repositions correctly after each action