### PR TITLE
fix: remove first-list top gap in contentpic

### DIFF
--- a/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.stories.tsx
@@ -198,3 +198,107 @@ export const ShortParagraph: Story = {
     },
   },
 }
+
+export const UnorderedListFirst: Story = {
+  args: {
+    content: {
+      type: "prose",
+      content: [
+        {
+          type: "unorderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "Feeds on grasses, leaves, and shoots.",
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "Uses its horn for defence and foraging.",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Rhinos are large, sturdy mammals known for their thick, protective skin and one or two horns on their snouts. They inhabit parts of Africa and Asia and are primarily herbivores, feeding on grasses, leaves, and shoots. Despite their imposing size and strength, rhinos are endangered due to habitat loss and poaching. Conservation efforts are crucial to ensuring their survival.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+}
+
+export const OrderedListFirst: Story = {
+  args: {
+    content: {
+      type: "prose",
+      content: [
+        {
+          type: "orderedList",
+          content: [
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "Feeds on grasses, leaves, and shoots.",
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              type: "listItem",
+              content: [
+                {
+                  type: "paragraph",
+                  content: [
+                    {
+                      type: "text",
+                      text: "Uses its horn for defence and foraging.",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Rhinos are large, sturdy mammals known for their thick, protective skin and one or two horns on their snouts. They inhabit parts of Africa and Asia and are primarily herbivores, feeding on grasses, leaves, and shoots. Despite their imposing size and strength, rhinos are endangered due to habitat loss and poaching. Conservation efforts are crucial to ensuring their survival.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+}

--- a/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
+++ b/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
@@ -12,7 +12,7 @@ const contentpicStyles = tv({
       "mb-7 flex flex-col gap-7 sm:flex-row [&:not(:first-child)]:mt-7",
     image: "aspect-[5/6] h-auto rounded object-cover sm:h-[240px] sm:w-[200px]",
     content:
-      "flex-1 break-words text-base-content lg:justify-self-start [&>ol:first-child>li:first-child]:mt-0 [&>ol:first-child]:mt-0 [&>ul:first-child>li:first-child]:mt-0 [&>ul:first-child]:mt-0",
+      "flex-1 break-words text-base-content lg:justify-self-start [&>:is(ol,ul):first-child>li:first-child]:mt-0 [&>:is(ol,ul):first-child]:mt-0",
   },
 })
 const compoundStyles = contentpicStyles()

--- a/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
+++ b/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
@@ -11,7 +11,8 @@ const contentpicStyles = tv({
     container:
       "mb-7 flex flex-col gap-7 sm:flex-row [&:not(:first-child)]:mt-7",
     image: "aspect-[5/6] h-auto rounded object-cover sm:h-[240px] sm:w-[200px]",
-    content: "flex-1 break-words text-base-content lg:justify-self-start",
+    content:
+      "flex-1 break-words text-base-content lg:justify-self-start [&>ol:first-child>li:first-child]:mt-0 [&>ol:first-child]:mt-0 [&>ul:first-child>li:first-child]:mt-0 [&>ul:first-child]:mt-0",
   },
 })
 const compoundStyles = contentpicStyles()


### PR DESCRIPTION
## Problem

When an ordered or unordered list is the first prose element inside a contentpic, the list appears with extra top spacing. This spacing is expected for lists inside normal prose flow, but it makes first-list content in a contentpic look vertically misaligned with the image.

Closes #1801 

Closes https://linear.app/ogp/issue/ISOM-2016/big-gap-above-bullet-list-when-its-used-in-a-contentpic

## Solution

Add a contentpic-local CSS override on the content wrapper to remove top margin only when the first direct prose child is an ordered or unordered list.

```
[&>ol:first-child]:mt-0
[&>ul:first-child]:mt-0
[&>ol:first-child>li:first-child]:mt-0
[&>ul:first-child>li:first-child]:mt-0
```

* If the first prose element inside a Contentpic is an ordered list, remove the list’s top margin.
* If the first prose element inside a Contentpic is an unordered list, remove the list’s top margin.
* Also remove the first list item’s own top margin, because li has vertical margin too.
* Only direct child lists are targeted, so nested lists are unaffected.
* Lists outside Contentpic are unaffected.
* Lists that come after a paragraph/heading inside Contentpic are unaffected because they are not :first-child.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- None.

**Bug Fixes**:

- Removes the extra top gap when a contentpic starts with an ordered or unordered list.

## Before & After Screenshots

**BEFORE**:

<img width="1503" height="256" alt="image" src="https://github.com/user-attachments/assets/a2ac0f38-8f9c-460e-87cb-19eb11cba8a6" />

<img width="1498" height="264" alt="image" src="https://github.com/user-attachments/assets/9c23e15a-7d33-42dd-bf31-b21f0f43fe6e" />

**AFTER**:

<img width="756" height="135" alt="image" src="https://github.com/user-attachments/assets/521ab803-7b7b-426e-91a3-8d2d030c9439" />

<img width="1500" height="262" alt="image" src="https://github.com/user-attachments/assets/99c17ef6-9fca-4af4-8e23-98e0d8c26405" />


## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ]  Open the Contentpic Storybook story where the first prose child is an unordered list and confirm the list aligns with the top of the content column.
- [ ]  Open the Contentpic Storybook story where the first prose child is an ordered list and confirm the list aligns with the top of the content column.
- [ ]  Confirm normal prose list spacing outside contentpic is unchanged.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None