### PR TITLE
refactor: migrate to t3-oss/env-* for env handling

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -83,6 +83,7 @@
     "@paralleldrive/cuid2": "catalog:",
     "@prisma/client": "catalog:prisma",
     "@sinclair/typebox": "catalog:",
+    "@t3-oss/env-nextjs": "catalog:env",
     "@tanstack/query-devtools": "catalog:tanstack-query",
     "@tanstack/react-query": "catalog:tanstack-query",
     "@tanstack/react-query-devtools": "catalog:tanstack-query",

--- a/apps/studio/src/env.mjs
+++ b/apps/studio/src/env.mjs
@@ -1,22 +1,39 @@
+import { createEnv } from "@t3-oss/env-nextjs"
 import { z } from "zod"
 
-const s3Schema = z.object({
-  NEXT_PUBLIC_S3_REGION: z.string().default("us-east-1"),
-  NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME: z.string(),
-  NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME: z.string(),
-})
-
-const cronHeartbeatSchema = z.object({
-  SCHEDULED_PUBLISHING_HEARTBEAT_URL: z.string().url().optional(),
-  DEACTIVATE_INACTIVE_USERS_HEARTBEAT_URL: z.string().url().optional(),
-})
-
-/**
- * Specify your client-side environment variables schema here. This way you can ensure the app isn't
- * built with invalid env vars. To expose them to the client, prefix them with `NEXT_PUBLIC_`.
- */
-const client = z
-  .object({
+export const env = createEnv({
+  shared: {
+    NODE_ENV: z.enum(["development", "test", "production"]),
+  },
+  /**
+   * Specify your server-side environment variables schema here. This way you can ensure the app
+   * isn't built with invalid env vars.
+   */
+  server: {
+    DATABASE_URL: z.string().url(),
+    CI: z.coerce.boolean().default(false),
+    OTP_EXPIRY: z.coerce.number().positive().optional().default(600),
+    POSTMAN_API_KEY: z.string().optional(),
+    SESSION_SECRET: z.string().min(32),
+    GROWTHBOOK_CLIENT_KEY: z.string().optional(),
+    STUDIO_SSM_WEBHOOK_API_KEY: z.string().optional(),
+    SEARCHSG_API_KEY: z.string(),
+    SCHEDULED_PUBLISHING_HEARTBEAT_URL: z.string().url().optional(),
+    DEACTIVATE_INACTIVE_USERS_HEARTBEAT_URL: z.string().url().optional(),
+    SINGPASS_CLIENT_ID: z.string().min(1),
+    SINGPASS_ISSUER_ENDPOINT: z.string().url().min(1),
+    SINGPASS_REDIRECT_URI: z.string().url().optional(),
+    SINGPASS_ENCRYPTION_PRIVATE_KEY: z.string().min(1),
+    SINGPASS_ENCRYPTION_KEY_ALG: z.string().min(1).default("ECDH-ES+A256KW"),
+    SINGPASS_SIGNING_PRIVATE_KEY: z.string().min(1),
+    SINGPASS_SIGNING_KEY_ALG: z.string().min(1).default("ES512"),
+  },
+  /**
+   * Specify your client-side environment variables schema here. This way you can ensure the app
+   * isn't built with invalid env vars. To expose them to the client, prefix them with
+   * `NEXT_PUBLIC_`.
+   */
+  client: {
     NEXT_PUBLIC_APP_ENV: z.enum([
       "development",
       "staging",
@@ -30,139 +47,33 @@ const client = z
     NEXT_PUBLIC_APP_VERSION: z.string().default("0.0.0"),
     NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY: z.string().optional(),
     NEXT_PUBLIC_INTERCOM_APP_ID: z.string().optional(),
-  })
-  .merge(s3Schema)
-  .merge(cronHeartbeatSchema)
-
-const singpassSchema = z.object({
-  SINGPASS_CLIENT_ID: z.string().min(1),
-  SINGPASS_ISSUER_ENDPOINT: z.string().url().min(1),
-  SINGPASS_REDIRECT_URI: z.string().url().optional(),
-  SINGPASS_ENCRYPTION_PRIVATE_KEY: z.string().min(1),
-  SINGPASS_ENCRYPTION_KEY_ALG: z.string().min(1).default("ECDH-ES+A256KW"),
-  SINGPASS_SIGNING_PRIVATE_KEY: z.string().min(1),
-  SINGPASS_SIGNING_KEY_ALG: z.string().min(1).default("ES512"),
+    NEXT_PUBLIC_S3_REGION: z.string().default("us-east-1"),
+    NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME: z.string(),
+    NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME: z.string(),
+  },
+  /**
+   * You can't destruct `process.env` as a regular object in the Next.js edge runtimes (e.g.
+   * middlewares) or client-side so we need to destruct manually.
+   */
+  experimental__runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
+    NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
+    NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
+    NEXT_PUBLIC_APP_VERSION:
+      process.env.NEXT_PUBLIC_APP_VERSION ??
+      process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+    NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY:
+      process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY,
+    NEXT_PUBLIC_INTERCOM_APP_ID: process.env.NEXT_PUBLIC_INTERCOM_APP_ID,
+    NEXT_PUBLIC_S3_REGION: process.env.NEXT_PUBLIC_S3_REGION,
+    NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME:
+      process.env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME,
+    NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME:
+      process.env.NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
+  },
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint" ||
+    !!process.env.STORYBOOK,
 })
-
-/**
- * Specify your server-side environment variables schema here. This way you can ensure the app isn't
- * built with invalid env vars.
- */
-const server = z
-  .object({
-    DATABASE_URL: z.string().url(),
-    CI: z.coerce.boolean().default(false),
-    NODE_ENV: z.enum(["development", "test", "production"]),
-    OTP_EXPIRY: z.coerce.number().positive().optional().default(600),
-    POSTMAN_API_KEY: z.string().optional(),
-    SESSION_SECRET: z.string().min(32),
-    GROWTHBOOK_CLIENT_KEY: z.string().optional(),
-    STUDIO_SSM_WEBHOOK_API_KEY: z.string().optional(),
-    SEARCHSG_API_KEY: z.string(),
-  })
-  .merge(s3Schema)
-  .merge(singpassSchema)
-  .merge(client)
-
-/**
- * You can't destruct `process.env` as a regular object in the Next.js edge runtimes (e.g.
- * middlewares) or client-side so we need to destruct manually.
- * Intellisense should work due to inference.
- *
- * @type {Record<keyof z.infer<typeof server> | keyof z.infer<typeof client>, string | undefined>}
- */
-const processEnv = {
-  // Server-side env vars
-  DATABASE_URL: process.env.DATABASE_URL,
-  CI: process.env.CI,
-  NODE_ENV: process.env.NODE_ENV,
-  OTP_EXPIRY: process.env.OTP_EXPIRY,
-  POSTMAN_API_KEY: process.env.POSTMAN_API_KEY,
-  SESSION_SECRET: process.env.SESSION_SECRET,
-  GROWTHBOOK_CLIENT_KEY: process.env.GROWTHBOOK_CLIENT_KEY,
-  NEXT_PUBLIC_S3_REGION: process.env.NEXT_PUBLIC_S3_REGION,
-  NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME:
-    process.env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME,
-  NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME:
-    process.env.NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
-  SINGPASS_CLIENT_ID: process.env.SINGPASS_CLIENT_ID,
-  SINGPASS_ISSUER_ENDPOINT: process.env.SINGPASS_ISSUER_ENDPOINT,
-  SINGPASS_REDIRECT_URI: process.env.SINGPASS_REDIRECT_URI,
-  SINGPASS_ENCRYPTION_PRIVATE_KEY: process.env.SINGPASS_ENCRYPTION_PRIVATE_KEY,
-  SINGPASS_ENCRYPTION_KEY_ALG: process.env.SINGPASS_ENCRYPTION_KEY_ALG,
-  SINGPASS_SIGNING_PRIVATE_KEY: process.env.SINGPASS_SIGNING_PRIVATE_KEY,
-  SINGPASS_SIGNING_KEY_ALG: process.env.SINGPASS_SIGNING_KEY_ALG,
-  STUDIO_SSM_WEBHOOK_API_KEY: process.env.STUDIO_SSM_WEBHOOK_API_KEY,
-  // Client-side env vars
-  NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
-  NEXT_PUBLIC_APP_NAME: process.env.NEXT_PUBLIC_APP_NAME,
-  NEXT_PUBLIC_APP_VERSION:
-    process.env.NEXT_PUBLIC_APP_VERSION ??
-    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
-  NEXT_PUBLIC_APP_URL: process.env.NEXT_PUBLIC_APP_URL,
-  NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY:
-    process.env.NEXT_PUBLIC_GROWTHBOOK_CLIENT_KEY,
-  NEXT_PUBLIC_INTERCOM_APP_ID: process.env.NEXT_PUBLIC_INTERCOM_APP_ID,
-  SEARCHSG_API_KEY: process.env.SEARCHSG_API_KEY,
-  SCHEDULED_PUBLISHING_HEARTBEAT_URL:
-    process.env.SCHEDULED_PUBLISHING_HEARTBEAT_URL,
-  DEACTIVATE_INACTIVE_USERS_HEARTBEAT_URL:
-    process.env.DEACTIVATE_INACTIVE_USERS_HEARTBEAT_URL,
-}
-
-// Don't touch the part below
-// --------------------------
-/** @typedef {z.input<typeof server>} MergedInput */
-/** @typedef {z.infer<typeof server>} MergedOutput */
-/** @typedef {z.ZodSafeParseResult<MergedOutput>} MergedSafeParseReturn */
-
-// @ts-expect-error Types are wonky from refinement
-let env = /** @type {MergedOutput} */ (process.env)
-
-if (!!process.env.SKIP_ENV_VALIDATION == false) {
-  const isServer = typeof window === "undefined"
-
-  const parsed = /** @type {MergedSafeParseReturn} */ (
-    isServer
-      ? server.safeParse(processEnv) // on server we can validate all env vars
-      : client.safeParse(processEnv) // on client we can only validate the ones that are exposed
-  )
-
-  if (parsed.success === false) {
-    console.error(
-      "❌ Invalid environment variables:",
-      parsed.error.flatten().fieldErrors,
-    )
-    throw new Error("Invalid environment variables")
-  }
-
-  env = new Proxy(parsed.data, {
-    get(target, prop) {
-      if (typeof prop !== "string") return undefined
-      // Throw a descriptive error if a server-side env var is accessed on the client
-      // Otherwise it would just be returning `undefined` and be annoying to debug
-      if (!isServer && !prop.startsWith("NEXT_PUBLIC_"))
-        throw new Error(
-          process.env.NODE_ENV === "production"
-            ? "❌ Attempted to access a server-side environment variable on the client"
-            : `❌ Attempted to access server-side environment variable '${prop}' on the client`,
-        )
-      return target[/** @type {keyof typeof target} */ (prop)]
-    },
-  })
-} else if (process.env.STORYBOOK) {
-  const parsed = client
-    .partial()
-    .safeParse(JSON.parse(process.env.STORYBOOK_ENVIRONMENT ?? "{}"))
-  if (parsed.success === false) {
-    console.error(
-      "❌ Invalid environment variables:",
-      parsed.error.flatten().fieldErrors,
-    )
-    throw new Error("Invalid environment variables")
-  }
-  // @ts-expect-error Injection of environment variables is optional
-  env = parsed.data
-}
-
-export { env }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsgo"
   },
   "dependencies": {
+    "@t3-oss/env-core": "catalog:env",
     "dd-trace": "catalog:",
     "nanoid": "catalog:",
     "pino": "catalog:",

--- a/packages/logging/src/env.ts
+++ b/packages/logging/src/env.ts
@@ -1,31 +1,33 @@
+import { createEnv } from "@t3-oss/env-core"
 import { z } from "zod"
 
-// TODO: This package duplicates the NEXT_PUBLIC_APP_ENV / NEXT_PUBLIC_APP_VERSION
+// TODO: this package duplicates the NEXT_PUBLIC_APP_ENV / NEXT_PUBLIC_APP_VERSION
 // validation that already lives in apps/studio/src/env.mjs and quietly couples
 // this "shared" package to Next.js conventions:
 //   - A non-Next.js consumer (standalone worker, CLI) wont set NEXT_PUBLIC_*
 //     and the tracer will silently fall back to "development" / "0.0.0".
-//   - The skipValidation heuristic (npm_lifecycle_event === "lint") is brittle.
 // Follow-up: change initTracer to accept env/version as arguments from the
 // caller (which already validates env via ~/env.mjs) and delete this file.
 // This PR is a pure port of the existing logger out of apps/studio; the
 // refactor is intentionally deferred to keep the diff minimal.
-const schema = z.object({
-  NEXT_PUBLIC_APP_ENV: z
-    .enum(["development", "staging", "production", "test", "vapt", "uat"])
-    .default("development"),
-  NEXT_PUBLIC_APP_VERSION: z.string().default("0.0.0"),
+export const env = createEnv({
+  server: {
+    NODE_ENV: z
+      .enum(["development", "production", "test"])
+      .default("development"),
+    NEXT_PUBLIC_APP_ENV: z
+      .enum(["development", "staging", "production", "test", "vapt", "uat"])
+      .default("development"),
+    NEXT_PUBLIC_APP_VERSION: z.string().default("0.0.0"),
+  },
+  runtimeEnv: {
+    NODE_ENV: process.env.NODE_ENV,
+    NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
+    NEXT_PUBLIC_APP_VERSION:
+      process.env.NEXT_PUBLIC_APP_VERSION ??
+      process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
+  },
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint",
 })
-
-const skipValidation =
-  !!process.env.SKIP_ENV_VALIDATION ||
-  process.env.npm_lifecycle_event === "lint"
-
-export const env = skipValidation
-  ? schema.parse({})
-  : schema.parse({
-      NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV,
-      NEXT_PUBLIC_APP_VERSION:
-        process.env.NEXT_PUBLIC_APP_VERSION ??
-        process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA,
-    })

--- a/packages/logging/src/env.ts
+++ b/packages/logging/src/env.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 // this "shared" package to Next.js conventions:
 //   - A non-Next.js consumer (standalone worker, CLI) wont set NEXT_PUBLIC_*
 //     and the tracer will silently fall back to "development" / "0.0.0".
+//   - The skipValidation heuristic (npm_lifecycle_event === "lint") is brittle.
 // Follow-up: change initTracer to accept env/version as arguments from the
 // caller (which already validates env via ~/env.mjs) and delete this file.
 // This PR is a pure port of the existing logger out of apps/studio; the

--- a/packages/logging/src/env.ts
+++ b/packages/logging/src/env.ts
@@ -9,8 +9,6 @@ import { z } from "zod"
 //   - The skipValidation heuristic (npm_lifecycle_event === "lint") is brittle.
 // Follow-up: change initTracer to accept env/version as arguments from the
 // caller (which already validates env via ~/env.mjs) and delete this file.
-// This PR is a pure port of the existing logger out of apps/studio; the
-// refactor is intentionally deferred to keep the diff minimal.
 export const env = createEnv({
   server: {
     NODE_ENV: z

--- a/packages/pgboss/package.json
+++ b/packages/pgboss/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@isomer/logging": "workspace:*",
+    "@t3-oss/env-core": "catalog:env",
     "pg-boss": "catalog:",
     "vitest": "catalog:vitest",
     "zod": "catalog:"

--- a/packages/pgboss/src/env.ts
+++ b/packages/pgboss/src/env.ts
@@ -1,10 +1,16 @@
+import { createEnv } from "@t3-oss/env-core"
 import { z } from "zod"
 
-const envSchema = z.object({
-  DATABASE_URL: z.string().url(),
-  NODE_ENV: z
-    .enum(["development", "test", "production"])
-    .default("development"),
+export const env = createEnv({
+  server: {
+    DATABASE_URL: z.string().url(),
+    NODE_ENV: z
+      .enum(["development", "test", "production"])
+      .default("development"),
+  },
+  runtimeEnv: process.env,
+  emptyStringAsUndefined: true,
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint",
 })
-
-export const env = envSchema.parse(process.env)

--- a/packages/pgboss/src/env.ts
+++ b/packages/pgboss/src/env.ts
@@ -9,7 +9,6 @@ export const env = createEnv({
       .default("development"),
   },
   runtimeEnv: process.env,
-  emptyStringAsUndefined: true,
   skipValidation:
     !!process.env.SKIP_ENV_VALIDATION ||
     process.env.npm_lifecycle_event === "lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -410,6 +410,13 @@ catalogs:
     zod:
       specifier: ^4.4.3
       version: 4.4.3
+  env:
+    '@t3-oss/env-core':
+      specifier: ^0.13.8
+      version: 0.13.11
+    '@t3-oss/env-nextjs':
+      specifier: ^0.13.8
+      version: 0.13.11
   growthbook:
     '@growthbook/growthbook':
       specifier: ^1.2.0
@@ -748,6 +755,9 @@ importers:
       '@sinclair/typebox':
         specifier: 'catalog:'
         version: 0.33.22
+      '@t3-oss/env-nextjs':
+        specifier: catalog:env
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       '@tanstack/query-devtools':
         specifier: catalog:tanstack-query
         version: 5.100.10
@@ -1317,6 +1327,9 @@ importers:
 
   packages/logging:
     dependencies:
+      '@t3-oss/env-core':
+        specifier: catalog:env
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       dd-trace:
         specifier: 'catalog:'
         version: 5.103.0(@openfeature/server-sdk@1.21.0(@openfeature/core@1.10.0))
@@ -1354,6 +1367,9 @@ importers:
       '@isomer/logging':
         specifier: workspace:*
         version: link:../logging
+      '@t3-oss/env-core':
+        specifier: catalog:env
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       pg-boss:
         specifier: 'catalog:'
         version: 12.14.0
@@ -1696,6 +1712,9 @@ importers:
       '@octokit/rest':
         specifier: 'catalog:'
         version: 22.0.1
+      '@t3-oss/env-core':
+        specifier: catalog:env
+        version: 0.13.11(typescript@6.0.3)(zod@4.4.3)
       axios:
         specifier: 'catalog:'
         version: 1.16.1
@@ -5606,6 +5625,40 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
+
+  '@t3-oss/env-core@0.13.11':
+    resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
+
+  '@t3-oss/env-nextjs@0.13.11':
+    resolution: {integrity: sha512-NC+3j7YWgpzdFu1t5y/8wqibTK0lm5RS4bjXA1n8uwik3wIR4iZM4Fa+U2BaMa5k3Qk8RZiYhoAIX0WogmGkzg==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@tanstack/query-core@5.100.10':
     resolution: {integrity: sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==}
@@ -15757,6 +15810,18 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@t3-oss/env-core@0.13.11(typescript@6.0.3)(zod@4.4.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
+
+  '@t3-oss/env-nextjs@0.13.11(typescript@6.0.3)(zod@4.4.3)':
+    dependencies:
+      '@t3-oss/env-core': 0.13.11(typescript@6.0.3)(zod@4.4.3)
+    optionalDependencies:
+      typescript: 6.0.3
+      zod: 4.4.3
 
   '@tanstack/query-core@5.100.10': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,6 +154,9 @@ catalog:
   wretch: ^3.0.7
 
 catalogs:
+  env:
+    "@t3-oss/env-core": ^0.13.8
+    "@t3-oss/env-nextjs": ^0.13.8
   atlaskitPragmaticDnd:
     "@atlaskit/pragmatic-drag-and-drop": ^1.7.7
     "@atlaskit/pragmatic-drag-and-drop-hitbox": ^1.1.0

--- a/tooling/site-launch/env.ts
+++ b/tooling/site-launch/env.ts
@@ -1,30 +1,23 @@
+import { createEnv } from "@t3-oss/env-core"
 import { z } from "zod"
 
-const envSchema = z.object({
-  SEARCHSG_API_KEY: z.string().min(1, "SEARCHSG_API_KEY is required"),
-  GITHUB_TOKEN: z
-    .string()
-    .min(1, "GITHUB_TOKEN is required")
-    .startsWith("ghp_"),
-  PUBLISHER_USER_ID: z.string().min(1, "PUBLISHER_USER_ID is required"),
-  DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
-  S3_BUCKET_URI: z
-    .string()
-    .min(1, "S3_BUCKET_URI is required")
-    .startsWith("s3://"),
-  AWS_PROFILE: z.string().min(1, "AWS_PROFILE is required"),
+export const env = createEnv({
+  server: {
+    SEARCHSG_API_KEY: z.string().min(1, "SEARCHSG_API_KEY is required"),
+    GITHUB_TOKEN: z
+      .string()
+      .min(1, "GITHUB_TOKEN is required")
+      .startsWith("ghp_"),
+    PUBLISHER_USER_ID: z.string().min(1, "PUBLISHER_USER_ID is required"),
+    DATABASE_URL: z.string().min(1, "DATABASE_URL is required"),
+    S3_BUCKET_URI: z
+      .string()
+      .min(1, "S3_BUCKET_URI is required")
+      .startsWith("s3://"),
+    AWS_PROFILE: z.string().min(1, "AWS_PROFILE is required"),
+  },
+  runtimeEnv: process.env,
+  skipValidation:
+    !!process.env.SKIP_ENV_VALIDATION ||
+    process.env.npm_lifecycle_event === "lint",
 })
-
-const processEnv = process.env
-
-const parsed = envSchema.safeParse(processEnv)
-
-if (parsed.success === false) {
-  console.error(
-    "❌ Invalid environment variables:",
-    parsed.error.flatten().fieldErrors,
-  )
-  throw new Error("Invalid environment variables")
-}
-
-export const env = parsed.data

--- a/tooling/site-launch/package.json
+++ b/tooling/site-launch/package.json
@@ -12,6 +12,7 @@
     "@inquirer/prompts": "catalog:",
     "@isomer/seed-from-repo": "workspace:*",
     "@octokit/rest": "catalog:",
+    "@t3-oss/env-core": "catalog:env",
     "axios": "catalog:",
     "commander-ts": "catalog:",
     "dotenv-cli": "catalog:",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes #2205

## Solution

Replaces the hand-rolled Zod + Proxy env validation in `apps/studio/src/env.mjs` and the manual `schema.parse` patterns in the shared packages with [`@t3-oss/env-nextjs`](https://env.t3.gg) and [`@t3-oss/env-core`](https://env.t3.gg), following the same approach used in the starter-kit.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- `apps/studio/src/env.mjs` — replaced ~160 lines of custom validation/Proxy logic with `createEnv` from `@t3-oss/env-nextjs`; `SCHEDULED_PUBLISHING_HEARTBEAT_URL` and `DEACTIVATE_INACTIVE_USERS_HEARTBEAT_URL` correctly moved to `server`-only (they were never client-accessible); Storybook skip handled via `!!process.env.STORYBOOK` in `skipValidation`
- `packages/logging/src/env.ts` — migrated to `createEnv` from `@t3-oss/env-core`
- `packages/pgboss/src/env.ts` — migrated to `createEnv` from `@t3-oss/env-core`
- `tooling/site-launch/env.ts` — migrated to `createEnv` from `@t3-oss/env-core`
- `pnpm-workspace.yaml` — added a dedicated `env` named catalog for `@t3-oss/env-core` and `@t3-oss/env-nextjs`

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Run `pnpm dev` from the repo root and confirm the app starts without env validation errors
- [ ] Run `SKIP_ENV_VALIDATION=true pnpm build` from `apps/studio` and confirm it builds successfully
- [ ] Confirm that accessing a server-side env var (e.g. `SESSION_SECRET`) from client-side code throws the expected error in development

**New dependencies**:

- `@t3-oss/env-nextjs` (`catalog:env`): type-safe env validation for the Next.js studio app
- `@t3-oss/env-core` (`catalog:env`): type-safe env validation for `logging`, `pgboss`, and `site-launch` packages