### PR TITLE
fix: add default header summary to database pages

### DIFF
--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -1753,6 +1753,12 @@ describe("page.router", async () => {
         ...expectedPageArgs,
         content: createDefaultPage({ layout: "database" }),
       })
+      expect(actual.content).toMatchObject({
+        layout: "database",
+        page: {
+          contentPageHeader: { summary: "This is the page summary" },
+        },
+      })
       await assertAuditLogRows(1)
       const auditLog = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLog).toHaveLength(1)

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -1753,12 +1753,6 @@ describe("page.router", async () => {
         ...expectedPageArgs,
         content: createDefaultPage({ layout: "database" }),
       })
-      expect(actual.content).toMatchObject({
-        layout: "database",
-        page: {
-          contentPageHeader: { summary: "This is the page summary" },
-        },
-      })
       await assertAuditLogRows(1)
       const auditLog = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLog).toHaveLength(1)

--- a/apps/studio/src/server/modules/page/page.service.ts
+++ b/apps/studio/src/server/modules/page/page.service.ts
@@ -41,9 +41,7 @@ export const createDefaultPage = ({
       const databaseDefaultPage = {
         layout: ISOMER_USABLE_PAGE_LAYOUTS.Database,
         page: {
-          title: "New database layout",
-          description:
-            "This is a layout where you can link your dataset from Data.gov.sg. Users can search through the table.",
+          contentPageHeader: { summary: "This is the page summary" },
           database: {
             dataSource: {
               type: "dgs", // we only support DGS creation on studio for now


### PR DESCRIPTION
## Problem

Database pages created in Studio were initialized with an invalid default page shape.

The database page renderer expects the page summary to come from `page.contentPageHeader.summary`, but the default database page data used `title` and `description` fields instead. As a result, newly created database pages could render an empty header summary.

Closes #1955

## Solution

<!-- How did you solve the problem? -->

Updated the default database page payload to include `page.contentPageHeader.summary` and added an unit test. 

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible


## Before & After Screenshots

**BEFORE**:

<img width="1074" height="203" alt="Screenshot 2026-05-27 at 5 06 04 PM" src="https://github.com/user-attachments/assets/a122004c-45f4-42c3-9bdf-b7e4c8530695" />


**AFTER**:

<img width="1065" height="248" alt="Screenshot 2026-05-27 at 5 05 21 PM" src="https://github.com/user-attachments/assets/a3867318-d561-42b6-a2f5-5d94e2e1e51b" />


## Tests

- `pnpm --filter isomer-studio test:unit -- src/server/modules/page/__tests__/page.router.test.ts`

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Create a new page with the database page layout
- [ ] Add a title and start editing
- [ ] Verify that the "This is the page summary" text appears below the title
