### PR TITLE
Fix webhook API key auth bypass

### DIFF
--- a/apps/studio/src/schemas/__tests__/webhook.test.ts
+++ b/apps/studio/src/schemas/__tests__/webhook.test.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next"
 import type { z } from "zod"
+import type { env } from "~/env.mjs"
 import { createMocks } from "node-mocks-http"
 import { resetTables } from "tests/integration/helpers/db"
 import { createTestUser } from "tests/integration/helpers/iron-session"
@@ -11,10 +12,10 @@ import type { codeBuildWebhookSchema } from "../webhook"
 
 vi.mock("~/env.mjs", async () => {
   // Import the real module first to get all default values
-  const actual = await vi.importActual("~/env.mjs")
+  const actual = await vi.importActual<{ env: typeof env }>("~/env.mjs")
   return {
     env: {
-      ...actual,
+      ...actual.env,
       // override some env variables for testing
       STUDIO_SSM_WEBHOOK_API_KEY: "test-webhook-api-key",
       GROWTHBOOK_CLIENT_KEY: "test-growthbook-client-key",
@@ -33,7 +34,7 @@ const createMockRequest = ({
   apiKey = "test-webhook-api-key",
 }: {
   arn: string
-  apiKey?: string
+  apiKey?: string | null
 }) => {
   const body: z.input<typeof codeBuildWebhookSchema> = {
     projectName: "test-project",
@@ -45,7 +46,7 @@ const createMockRequest = ({
       method: "POST",
       headers: {
         "content-type": "application/json",
-        [WEBHOOK_X_API_KEY_HEADER]: apiKey,
+        ...(apiKey === null ? {} : { [WEBHOOK_X_API_KEY_HEADER]: apiKey }),
       },
       body,
     })
@@ -106,7 +107,7 @@ describe("webhook", () => {
       })
       const { req, res } = createMockRequest({
         arn: "build/test-id",
-        apiKey: "wrong-api-key",
+        apiKey: null,
       })
 
       // Act

--- a/apps/studio/src/server/modules/webhook/__test__/webhook.router.test.ts
+++ b/apps/studio/src/server/modules/webhook/__test__/webhook.router.test.ts
@@ -1,6 +1,7 @@
 import type { GrowthBook } from "@growthbook/growthbook"
 import type { User } from "@prisma/client"
 import type { Mock } from "vitest"
+import type { env } from "~/env.mjs"
 import type { Session } from "~/lib/types/session"
 import MockDate from "mockdate"
 import { auth } from "tests/integration/helpers/auth"
@@ -21,10 +22,20 @@ import {
   sendSuccessfulPublishEmail,
 } from "~/features/mail/service"
 import { buildIdFromArn } from "~/schemas/webhook"
-import { createCallerFactory } from "~/server/trpc"
+import { WEBHOOK_X_API_KEY_HEADER, createCallerFactory } from "~/server/trpc"
 
 import { db } from "../../database"
 import { webhookRouter } from "../webhook.router"
+
+vi.mock("~/env.mjs", async () => {
+  const actual = await vi.importActual<{ env: typeof env }>("~/env.mjs")
+  return {
+    env: {
+      ...actual.env,
+      STUDIO_SSM_WEBHOOK_API_KEY: "test-webhook-api-key",
+    },
+  }
+})
 
 // Mock the publishSite function to avoid sending emails
 vi.mock("~/features/mail/service", () => ({
@@ -35,8 +46,17 @@ vi.mock("~/features/mail/service", () => ({
 const getCallerWithMockGrowthbook = (
   session: Session,
   mockReturnValue = true,
+  apiKey: string | null = "test-webhook-api-key",
 ): ReturnType<typeof createCaller> => {
-  const mockRequest = createMockRequest(session)
+  const mockRequest = createMockRequest(session, {
+    headers:
+      apiKey === null
+        ? undefined
+        : {
+            [WEBHOOK_X_API_KEY_HEADER]: apiKey,
+          },
+    method: "GET",
+  })
   const mockGrowthBook: Partial<GrowthBook> = {
     isOn: vi.fn().mockReturnValue(mockReturnValue),
     destroy: vi.fn(),
@@ -107,6 +127,25 @@ describe("webhook.router", async () => {
           emailSent: true,
         }),
       )
+    })
+    it("rejects authenticated callers that do not provide the webhook API key", async () => {
+      // Arrange
+      await setupCodeBuildJob({
+        userId: user.id,
+        arn: "build/test-id",
+        startedAt: FIXED_NOW,
+      })
+      const caller = getCallerWithMockGrowthbook(session, true, null)
+
+      // Act + Assert
+      await expect(
+        caller.updateCodebuildWebhook({
+          projectName: "test-project",
+          arn: "build/test-id",
+          status: "SUCCEEDED",
+        }),
+      ).rejects.toThrow("Invalid Webhook API key provided")
+      expect(sendSuccessfulPublishEmail).not.toHaveBeenCalled()
     })
     it("it should update the codebuildjobs table when multiple resources specify the same buildId", async () => {
       // Arrange

--- a/apps/studio/src/server/modules/webhook/webhook.router.ts
+++ b/apps/studio/src/server/modules/webhook/webhook.router.ts
@@ -6,6 +6,7 @@ import { updateCodebuildStatusAndSendEmails } from "./webhook.utils"
 export const webhookRouter = router({
   updateCodebuildWebhook: webhookProcedure
     .input(codeBuildWebhookSchema)
+    .meta({ rateLimitOptions: { max: 60, windowMs: 60_000 } })
     .mutation(async ({ ctx: { logger, gb }, input: { buildId, status } }) => {
       await updateCodebuildStatusAndSendEmails(logger, gb, buildId, status)
     }),

--- a/apps/studio/src/server/modules/webhook/webhook.router.ts
+++ b/apps/studio/src/server/modules/webhook/webhook.router.ts
@@ -6,7 +6,6 @@ import { updateCodebuildStatusAndSendEmails } from "./webhook.utils"
 export const webhookRouter = router({
   updateCodebuildWebhook: webhookProcedure
     .input(codeBuildWebhookSchema)
-    .meta({ rateLimitOptions: { max: 60, windowMs: 60_000 } })
     .mutation(async ({ ctx: { logger, gb }, input: { buildId, status } }) => {
       await updateCodebuildStatusAndSendEmails(logger, gb, buildId, status)
     }),

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -173,29 +173,26 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
 
 /**
  * Webhook middleware to protect endpoints that do not need a user context
- * but still need to be protected via an API key. We still check the session
- * in case the request is made by a logged in user (via the FE), and to allow for easier testing.
+ * but still need to be protected via an API key.
  * */
 
 export const WEBHOOK_X_API_KEY_HEADER = "x-api-key"
 
 const webhookMiddleware = t.middleware(async ({ next, ctx }) => {
-  if (!ctx.session?.userId) {
-    const apiKey = ctx.req.headers[WEBHOOK_X_API_KEY_HEADER]
-    // Ensure that the API key is set in the env
-    if (!env.STUDIO_SSM_WEBHOOK_API_KEY) {
-      throw new TRPCError({
-        code: "INTERNAL_SERVER_ERROR",
-        message: "Webhook API key is not configured",
-      })
-    }
-    // Ensure that the API key is valid and matches
-    if (!apiKey || apiKey !== env.STUDIO_SSM_WEBHOOK_API_KEY) {
-      throw new TRPCError({
-        code: "UNAUTHORIZED",
-        message: "Invalid Webhook API key provided",
-      })
-    }
+  const apiKey = ctx.req.headers[WEBHOOK_X_API_KEY_HEADER]
+  // Ensure that the API key is set in the env
+  if (!env.STUDIO_SSM_WEBHOOK_API_KEY) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: "Webhook API key is not configured",
+    })
+  }
+  // Ensure that the API key is valid and matches
+  if (!apiKey || apiKey !== env.STUDIO_SSM_WEBHOOK_API_KEY) {
+    throw new TRPCError({
+      code: "UNAUTHORIZED",
+      message: "Invalid Webhook API key provided",
+    })
   }
   return next()
 })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Fixes a webhook authorization bypass where authenticated users could invoke webhook procedures without providing the shared webhook API key.

## Solution

**Breaking Changes**

- [x] Yes - this PR contains breaking changes
  - Webhook procedure callers must now provide the `x-api-key` header even if they have an authenticated Studio session.
- [ ] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Always validate `x-api-key` in `webhookMiddleware` before allowing webhook procedures to proceed.
- Updated webhook tests to include the API key on successful webhook calls.
- Added a regression test that rejects an authenticated caller without the webhook API key.
- Corrected the missing API key test helper so it actually omits the header.

## Before & After Screenshots

**BEFORE**:

N/A

**AFTER**:

N/A

## Tests

**Manual Verification Steps**:

- [x] `pnpm exec oxlint --type-aware src/server/trpc.ts src/server/modules/webhook/webhook.router.ts src/server/modules/webhook/__test__/webhook.router.test.ts src/schemas/__tests__/webhook.test.ts`
- [x] `pnpm exec oxfmt --check src/server/trpc.ts src/server/modules/webhook/webhook.router.ts src/server/modules/webhook/__test__/webhook.router.test.ts src/schemas/__tests__/webhook.test.ts`
- [x] `pnpm exec oxlint --type-aware src/server/modules/webhook/webhook.router.ts`
- [x] `pnpm exec oxfmt --check src/server/modules/webhook/webhook.router.ts`
- [ ] `pnpm test:unit -- src/server/modules/webhook/__test__/webhook.router.test.ts src/schemas/__tests__/webhook.test.ts` (blocked in this cloud environment: Docker is not installed, and Vitest global setup requires testcontainers.)

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac7fb604-6c12-4a46-87f3-3fc8a753562e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac7fb604-6c12-4a46-87f3-3fc8a753562e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

