### PR TITLE
chore(ci): pin github actions dependencies

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,7 +8,7 @@ runs:
       with:
         version: 10.33.0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: 22
         cache: pnpm

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -115,7 +115,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: monthly
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7 # to mitigate supply chain attacks

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -119,4 +119,3 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7 # to mitigate supply chain attacks
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -112,3 +112,11 @@ updates:
         update-types: ["version-update:semver-major"]
       # markdown-to-jsx is only used in the unmaintained classic template; skip all updates
       - dependency-name: "markdown-to-jsx"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7 # to mitigate supply chain attacks
+

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -336,7 +336,7 @@ jobs:
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9 # v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           cluster: ${{ inputs.ecs-cluster-name }}

--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -127,7 +127,7 @@ jobs:
     steps:
       - name: Notify start of deployment
         if: ${{ inputs.environment == 'production' }}
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -136,15 +136,15 @@ jobs:
             text: "<!subteam^${{ secrets.SLACK_NOTIFY_TEAM_ID }}> Starting deployment of *${{ inputs.app-name }}* to *${{ inputs.environment }}* environment :rocket: \n> Version: *${{ inputs.app-version }}*\n> Initiated by: ${{ github.actor }}\n> Workflow URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
         with:
           driver-opts: network=host
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ inputs.cicd-role }}
           role-session-name: github-action-application-deploy
@@ -152,15 +152,15 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
         with:
           mask-password: "true"
 
       - name: Checkout source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Build installer stage for sourcemap extraction
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: "./apps/studio/Dockerfile"
@@ -185,7 +185,7 @@ jobs:
           docker rm $CONTAINER_ID
 
       - name: Build and load image to Docker
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
@@ -210,7 +210,7 @@ jobs:
             DD_GIT_COMMIT_SHA=${{ github.sha }}
 
       - name: Scan built image with Inspector
-        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@v1
+        uses: aws-actions/vulnerability-scan-github-action-for-amazon-inspector@a8d909f662496d73f97b86ea9acd11cb7decedb7 # v1
         id: inspector
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
@@ -233,7 +233,7 @@ jobs:
       # from the GitHub actions job summary page.
       - name: Upload Scan Results
         id: upload-scan-results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           path: |
             ${{ steps.inspector.outputs.inspector_scan_results }}
@@ -243,7 +243,7 @@ jobs:
 
       - name: Notify if vulnerability threshold is exceeded (for production deployments only)
         if: ${{ steps.inspector.outputs.vulnerability_threshold_exceeded && inputs.environment == 'production' }}
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -268,7 +268,7 @@ jobs:
             exit 0
           fi
 
-          npm install -g @datadog/datadog-ci
+          npm install -g @datadog/datadog-ci@5.17.0
 
           # Upload sourcemaps (extracted earlier from installer stage)
           datadog-ci sourcemaps upload .next-static \
@@ -285,10 +285,10 @@ jobs:
 
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ inputs.cicd-role }}
           role-session-name: github-action-application-deploy
@@ -296,12 +296,12 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
         with:
           mask-password: "true"
 
       - name: Checkout source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Replace variables in task definition file
         id: replace-variables
@@ -324,7 +324,7 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb # v1
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
@@ -336,7 +336,7 @@ jobs:
           image: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9 # v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           cluster: ${{ inputs.ecs-cluster-name }}
@@ -348,7 +348,7 @@ jobs:
 
       - name: Notify end of deployment (success)
         if: ${{ inputs.environment == 'production' && success() }}
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -358,7 +358,7 @@ jobs:
 
       - name: Notify end of deployment (failure)
         if: ${{ inputs.environment == 'production' && failure() }}
-        uses: slackapi/slack-github-action@v2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -58,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@e3eb8ec36101d8f0253c7c3ae66e5a2b4e2197ba # v16.10.0
         # Chromatic GitHub Action options
         with:
           workingDir: packages/components
@@ -90,7 +90,7 @@ jobs:
         run: pnpm --filter isomer-studio exec prisma generate
       # 👇 Adds Chromatic as a step in the workflow
       - name: Publish to Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@e3eb8ec36101d8f0253c7c3ae66e5a2b4e2197ba # v16.10.0
         # Chromatic GitHub Action options
         with:
           workingDir: apps/studio

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -30,7 +30,7 @@ jobs:
       ui: ${{ steps.filter.outputs.ui }}
       studio: ${{ steps.filter.outputs.studio }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       # For pull requests it's not necessary to checkout the code
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36
         id: filter
@@ -51,7 +51,7 @@ jobs:
     environment: staging
     # Job steps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Required for v4
       - name: Setup
@@ -78,7 +78,7 @@ jobs:
     environment: staging
     # Job steps
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0 # Required for v4
       - name: Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -36,7 +36,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -53,7 +53,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -64,7 +64,7 @@ jobs:
   typecheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -78,14 +78,14 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Install dependencies
         # Not using test:unit dependency in Turbo because Datadog Test Visibility requires only the test suite to be run
         run: pnpm exec turbo run generate --filter=isomer-studio
       - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@v2
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:
           languages: js
           service: isomer-studio
@@ -112,18 +112,18 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup
         uses: ./.github/actions/setup
       - name: Install Playwright (Chromium)
         run: pnpm --filter isomer-studio exec playwright install chromium
       - name: Load .env file
-        uses: opengovsg/dotenv@v2
+        uses: opengovsg/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0 # v2
         with:
           path: apps/studio
           mode: test
       - name: Next.js cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: |
             ${{ github.workspace }}/.next/cache
@@ -136,7 +136,7 @@ jobs:
       - name: Start test containers
         run: pnpm run setup:test
       - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@v2
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:
           languages: js
           service: isomer-studio
@@ -154,7 +154,7 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test results
           path: apps/studio/tests/e2e/test-results

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,11 +32,11 @@ jobs:
            build-mode: none
    steps:
      - name: Checkout repository
-       uses: actions/checkout@v4
+       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
      # Initializes the CodeQL tools for scanning.
      - name: Initialize CodeQL
-       uses: github/codeql-action/init@v3
+       uses: github/codeql-action/init@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
        with:
          languages: ${{matrix.language}}
          build-mode: ${{matrix.build-mode}}
@@ -45,6 +45,6 @@ jobs:
          config-file: opengovsg/codeql-config/codeql-config.yml@prod
 
      - name: Perform CodeQL Analysis
-       uses: github/codeql-action/analyze@v3
+       uses: github/codeql-action/analyze@03e4368ac7daa2bd82b3e85262f3bf87ee112f57 # v3
        with:
          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Closes [insert issue #]

GitHub Actions workflows used a mix of immutable SHAs and mutable action refs such as `actions/setup-node@v4`, `actions/checkout@v4`, `aws-actions/configure-aws-credentials@v4`, `slackapi/slack-github-action@v2.1.1`, and `chromaui/action@latest`. The AWS deploy workflow also installed `@datadog/datadog-ci` without a fixed version.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Pin every external GitHub Action reference under `.github` to a full 40-character commit SHA with a trailing version comment.
- Pin `chromaui/action` to the v16.10.0 commit SHA from the referenced starter-kit fix.
- Pin the AWS deploy workflow's global Datadog CLI install to `@datadog/datadog-ci@5.17.0` instead of installing the latest package at runtime.
- Add Dependabot coverage for the `github-actions` ecosystem on a monthly schedule, with a 7-day cooldown so pinned action refs can be kept current without frequent PR noise.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

N/A

**AFTER**:

N/A

## Tests

**Manual Verification Steps**:

- [x] Resolved each mutable action tag to its current upstream commit SHA with `git ls-remote`.
- [x] Ran a parser check confirming every external `uses:` reference under `.github` is pinned to a full 40-character SHA.
- [x] Confirmed the Datadog CLI install is version-pinned.
- [x] Ran `git diff --check origin/main...HEAD`.
- [x] Confirmed GitHub Actions Dependabot checks are scheduled monthly.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1826d5bc-91ec-4ece-851d-9bfbe49f7311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1826d5bc-91ec-4ece-851d-9bfbe49f7311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

