### PR TITLE
fix(studio): stop logging OAuth PKCE secrets in Singpass error logs

### DIFF
--- a/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
@@ -96,12 +96,14 @@ export const singpassRouter = router({
         ctx.session.singpass.sessionState
 
       if (!code || !codeVerifier || !nonce || !userId) {
+        // Do not log `code`, `codeVerifier`, or `nonce` — they are OAuth/OIDC secrets
+        // (PKCE verifier + auth code complete the token exchange; nonce binds the ID token).
         ctx.logger.error(
           {
             hasCode: !!code,
             hasCodeVerifier: !!codeVerifier,
             hasNonce: !!nonce,
-            hasUserId: !!userId,
+            userId,
           },
           "Invalid Singpass session state",
         )
@@ -120,12 +122,13 @@ export const singpassRouter = router({
       })
 
       if (!uuid) {
+        // Do not log `code`, `codeVerifier`, or `nonce` — see comment above.
         ctx.logger.error(
           {
             hasCode: !!code,
             hasCodeVerifier: !!codeVerifier,
             hasNonce: !!nonce,
-            hasState: !!state,
+            state,
           },
           "Failed to login to Singpass",
         )

--- a/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
@@ -97,7 +97,12 @@ export const singpassRouter = router({
 
       if (!code || !codeVerifier || !nonce || !userId) {
         ctx.logger.error(
-          { code, codeVerifier, nonce, userId },
+          {
+            hasCode: !!code,
+            hasCodeVerifier: !!codeVerifier,
+            hasNonce: !!nonce,
+            hasUserId: !!userId,
+          },
           "Invalid Singpass session state",
         )
 
@@ -116,7 +121,12 @@ export const singpassRouter = router({
 
       if (!uuid) {
         ctx.logger.error(
-          { code, codeVerifier, nonce, state },
+          {
+            hasCode: !!code,
+            hasCodeVerifier: !!codeVerifier,
+            hasNonce: !!nonce,
+            hasState: !!state,
+          },
           "Failed to login to Singpass",
         )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Singpass OAuth error handlers in `singpass.router.ts` logged PKCE `codeVerifier`, `nonce`, and authorization `code` as structured log fields. Anyone with access to log aggregation could read these secrets. The project logger does not redact sensitive fields globally.

## Solution

Replaced `code`, `codeVerifier`, and `nonce` in both error log contexts with boolean presence flags. `userId` and `state` are still logged for debugging. Added inline comments explaining why the three OAuth/OIDC secrets must not be logged.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Stop emitting PKCE `codeVerifier`, `nonce`, and authorization `code` in Singpass callback error logs (defense-in-depth / OAuth secret handling per RFC 8252 §8).

## Tests

Existing unit tests in `singpass.router.test.ts` cover callback error paths; no test changes required.

**Manual Verification Steps**:

- [ ] Trigger a Singpass callback with missing session fields and confirm error logs show `hasCode` / `hasCodeVerifier` / `hasNonce` booleans plus `userId`, without raw OAuth secret values.
- [ ] Trigger a Singpass login failure where `login()` returns no UUID and confirm error logs show presence booleans plus `state`, without raw `code` / `codeVerifier` / `nonce`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ea38c4e-3654-4739-9e28-c1e31d552f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ea38c4e-3654-4739-9e28-c1e31d552f9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

