### PR TITLE
fix(studio): redact sensitive fields in tRPC logger middleware

### DIFF
--- a/apps/studio/src/lib/__tests__/redact-log-input.test.ts
+++ b/apps/studio/src/lib/__tests__/redact-log-input.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { redactLogInput } from "../redact-log-input"
+
+describe("redactLogInput", () => {
+  it("redacts known sensitive keys at the top level", () => {
+    expect(
+      redactLogInput({
+        email: "user@example.com",
+        token: "123456",
+        password: "hunter2",
+        apiKey: "sk-live",
+        secret: "shh",
+      }),
+    ).toEqual({
+      email: "user@example.com",
+      token: "[REDACTED]",
+      password: "[REDACTED]",
+      apiKey: "[REDACTED]",
+      secret: "[REDACTED]",
+    })
+  })
+
+  it("redacts sensitive keys case-insensitively", () => {
+    expect(redactLogInput({ OTP: "654321", Token: "abcdef" })).toEqual({
+      OTP: "[REDACTED]",
+      Token: "[REDACTED]",
+    })
+  })
+
+  it("redacts sensitive keys in nested objects and arrays", () => {
+    expect(
+      redactLogInput({
+        users: [
+          { email: "a@example.com", token: "one" },
+          { email: "b@example.com", token: "two" },
+        ],
+        meta: { refreshToken: "rt-123" },
+      }),
+    ).toEqual({
+      users: [
+        { email: "a@example.com", token: "[REDACTED]" },
+        { email: "b@example.com", token: "[REDACTED]" },
+      ],
+      meta: { refreshToken: "[REDACTED]" },
+    })
+  })
+
+  it("returns primitives unchanged", () => {
+    expect(redactLogInput("plain")).toBe("plain")
+    expect(redactLogInput(42)).toBe(42)
+    expect(redactLogInput(null)).toBeNull()
+    expect(redactLogInput(undefined)).toBeUndefined()
+  })
+})

--- a/apps/studio/src/lib/__tests__/redact-log-input.test.ts
+++ b/apps/studio/src/lib/__tests__/redact-log-input.test.ts
@@ -4,15 +4,20 @@ import { redactLogInput } from "../redact-log-input"
 
 describe("redactLogInput", () => {
   it("redacts known sensitive keys at the top level", () => {
-    expect(
-      redactLogInput({
-        email: "user@example.com",
-        token: "123456",
-        password: "hunter2",
-        apiKey: "sk-live",
-        secret: "shh",
-      }),
-    ).toEqual({
+    // Arrange
+    const input = {
+      email: "user@example.com",
+      token: "123456",
+      password: "hunter2",
+      apiKey: "sk-live",
+      secret: "shh",
+    }
+
+    // Act
+    const result = redactLogInput(input)
+
+    // Assert
+    expect(result).toEqual({
       email: "user@example.com",
       token: "[REDACTED]",
       password: "[REDACTED]",
@@ -22,22 +27,34 @@ describe("redactLogInput", () => {
   })
 
   it("redacts sensitive keys case-insensitively", () => {
-    expect(redactLogInput({ OTP: "654321", Token: "abcdef" })).toEqual({
+    // Arrange
+    const input = { OTP: "654321", Token: "abcdef" }
+
+    // Act
+    const result = redactLogInput(input)
+
+    // Assert
+    expect(result).toEqual({
       OTP: "[REDACTED]",
       Token: "[REDACTED]",
     })
   })
 
   it("redacts sensitive keys in nested objects and arrays", () => {
-    expect(
-      redactLogInput({
-        users: [
-          { email: "a@example.com", token: "one" },
-          { email: "b@example.com", token: "two" },
-        ],
-        meta: { refreshToken: "rt-123" },
-      }),
-    ).toEqual({
+    // Arrange
+    const input = {
+      users: [
+        { email: "a@example.com", token: "one" },
+        { email: "b@example.com", token: "two" },
+      ],
+      meta: { refreshToken: "rt-123" },
+    }
+
+    // Act
+    const result = redactLogInput(input)
+
+    // Assert
+    expect(result).toEqual({
       users: [
         { email: "a@example.com", token: "[REDACTED]" },
         { email: "b@example.com", token: "[REDACTED]" },
@@ -47,9 +64,20 @@ describe("redactLogInput", () => {
   })
 
   it("returns primitives unchanged", () => {
-    expect(redactLogInput("plain")).toBe("plain")
-    expect(redactLogInput(42)).toBe(42)
-    expect(redactLogInput(null)).toBeNull()
-    expect(redactLogInput(undefined)).toBeUndefined()
+    // Arrange
+    const stringInput = "plain"
+    const numberInput = 42
+
+    // Act
+    const stringResult = redactLogInput(stringInput)
+    const numberResult = redactLogInput(numberInput)
+    const nullResult = redactLogInput(null)
+    const undefinedResult = redactLogInput(undefined)
+
+    // Assert
+    expect(stringResult).toBe("plain")
+    expect(numberResult).toBe(42)
+    expect(nullResult).toBeNull()
+    expect(undefinedResult).toBeUndefined()
   })
 })

--- a/apps/studio/src/lib/redact-log-input.ts
+++ b/apps/studio/src/lib/redact-log-input.ts
@@ -1,0 +1,35 @@
+const REDACTED = "[REDACTED]"
+
+const SENSITIVE_KEYS = new Set([
+  "token",
+  "otp",
+  "password",
+  "apikey",
+  "secret",
+  "authorization",
+  "accesstoken",
+  "refreshtoken",
+])
+
+const isSensitiveKey = (key: string) => SENSITIVE_KEYS.has(key.toLowerCase())
+
+export const redactLogInput = (input: unknown): unknown => {
+  if (input === null || input === undefined) {
+    return input
+  }
+
+  if (Array.isArray(input)) {
+    return input.map(redactLogInput)
+  }
+
+  if (typeof input === "object") {
+    return Object.fromEntries(
+      Object.entries(input).map(([key, value]) => [
+        key,
+        isSensitiveKey(key) ? REDACTED : redactLogInput(value),
+      ]),
+    )
+  }
+
+  return input
+}

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -61,7 +61,7 @@ const loggerMiddleware = t.middleware(
       path,
       req: ctx.req,
     })
-    const rawInput = redactLogInput(await getRawInput())
+    const redactedInput = redactLogInput(await getRawInput())
 
     const result = await next({
       ctx: { logger },
@@ -71,7 +71,7 @@ const loggerMiddleware = t.middleware(
 
     if (result.ok) {
       logger.info(
-        { durationInMs, rawInput, userId: ctx.session?.userId },
+        { durationInMs, redactedInput, userId: ctx.session?.userId },
         `[${type}]: ${path} - ${durationInMs}ms - OK`,
       )
     } else {
@@ -79,7 +79,7 @@ const loggerMiddleware = t.middleware(
         {
           durationInMs,
           err: result.error,
-          rawInput,
+          redactedInput,
           userId: ctx.session?.userId,
         },
         `[${type}]: ${path} - ${durationInMs}ms - ${result.error.code} ${result.error.message} - ERROR`,

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -14,6 +14,7 @@ import { ZodError } from "zod"
 import { APP_VERSION_HEADER_KEY } from "~/constants/version"
 import { env } from "~/env.mjs"
 import { createBaseLogger } from "~/lib/logger"
+import { redactLogInput } from "~/lib/redact-log-input"
 
 import type { RateLimitMetaOptions } from "./modules/rate-limit/types"
 import { type Context } from "./context"
@@ -60,7 +61,7 @@ const loggerMiddleware = t.middleware(
       path,
       req: ctx.req,
     })
-    const rawInput = await getRawInput()
+    const rawInput = redactLogInput(await getRawInput())
 
     const result = await next({
       ctx: { logger },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `loggerMiddleware` in `apps/studio/src/server/trpc.ts` logs raw procedure input on every tRPC call. Because this middleware is applied to all procedures via `baseProcedure`, sensitive values such as OTP tokens from `auth.email.verifyOtp` are written to application logs in plaintext. Anyone with log access could harvest a valid OTP within its expiry window and complete sign-in as the corresponding user.

## Solution

Added a `redactLogInput` utility that recursively replaces known-sensitive object keys (case-insensitive) with `[REDACTED]` before logging. The tRPC logger middleware now passes redacted input to both success and error log entries.

Sensitive keys covered: `token`, `otp`, `password`, `apiKey`, `secret`, `authorization`, `accessToken`, `refreshToken`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Prevent OTP tokens and other sensitive procedure input from being written to application logs

## Before & After Screenshots

N/A — logging-only security fix with no UI changes.

## Tests

**Manual Verification Steps**:

- [ ] Trigger an email OTP sign-in flow (request OTP, then submit OTP)
- [ ] Inspect application logs for the `auth.email.verifyOtp` procedure call
- [ ] Confirm the log entry includes the email but shows `token: "[REDACTED]"` instead of the plaintext OTP

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d929f2cd-08cc-4445-9a6c-76d77f1c2806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d929f2cd-08cc-4445-9a6c-76d77f1c2806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

