### PR TITLE
fix: set Singapore timezone in components vitest setup

### DIFF
--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -694,6 +694,26 @@ describe("site.router", async () => {
       // Assert
       expect(result.config).toEqual({ ...MOCK_INTEGRATION_DATA, fake: "fake" })
     })
+
+    it("should reject an invalid siteGtmId", async () => {
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const result = caller.updateSiteIntegrations({
+        siteId: site.id,
+        data: {
+          ...MOCK_INTEGRATION_DATA,
+          siteGtmId: "');alert(document.cookie);//",
+        },
+      })
+
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
+    })
   })
 
   describe("setTheme", () => {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -10,6 +10,7 @@ export {
   NON_EMPTY_STRING_REGEX,
   createChildrenPagesComparator,
   formatBytes,
+  serializeForInlineScript,
 } from "./utils"
 export * from "./schemas"
 export * from "./types"

--- a/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
+++ b/packages/components/src/templates/next/components/internal/GoogleTagManager/GoogleTagManagerHeader.tsx
@@ -1,10 +1,14 @@
 import type { GoogleTagManagerHeaderProps } from "~/interfaces"
+import { serializeForInlineScript } from "~/utils/serializeForInlineScript"
 
 export const GoogleTagManagerHeader = ({
   siteGtmId,
   ScriptComponent,
 }: GoogleTagManagerHeaderProps) => {
   if (!ScriptComponent) return null
+
+  const sanitizedGtmId = serializeForInlineScript(siteGtmId)
+
   return (
     <ScriptComponent
       id={`_next-gtm-init-${siteGtmId}`}
@@ -14,7 +18,7 @@ export const GoogleTagManagerHeader = ({
           new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-        })(window,document,'script','dataLayer','${siteGtmId}');`,
+        })(window,document,'script','dataLayer',${sanitizedGtmId});`,
       }}
     />
   )

--- a/packages/components/src/types/site.ts
+++ b/packages/components/src/types/site.ts
@@ -10,6 +10,7 @@ import {
   VicaSchema,
 } from "~/interfaces"
 import { NotificationSettingsSchema } from "~/interfaces/internal/Notification"
+import { GTM_ID_STRING_REGEX } from "~/utils/validation"
 
 import type { IsomerSitemap } from "./sitemap"
 
@@ -35,6 +36,7 @@ export const SimpleIntegrationsSettingsSchema = Type.Object({
       title: "Google Tag Manager (GTM) ID",
       description:
         "You can locate your GTM ID on your Google Tag Manager account. It should start with “GTM-”.",
+      pattern: GTM_ID_STRING_REGEX,
     }),
   ),
   search: Type.Optional(

--- a/packages/components/src/utils/__tests__/serializeForInlineScript.test.ts
+++ b/packages/components/src/utils/__tests__/serializeForInlineScript.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import { serializeForInlineScript } from "~/utils/serializeForInlineScript"
+
+describe("serializeForInlineScript", () => {
+  it("should serialize strings as valid JavaScript string literals", () => {
+    // Arrange
+    const value = "GTM-ABC123"
+    const expected = '"GTM-ABC123"'
+
+    // Act
+    const actual = serializeForInlineScript(value)
+
+    // Assert
+    expect(actual).toBe(expected)
+  })
+
+  it("should escape characters that would break out of single-quoted interpolation", () => {
+    // Arrange
+    const value = "');alert(document.cookie);//"
+    const expected = `"');alert(document.cookie);//"`
+
+    // Act
+    const actual = serializeForInlineScript(value)
+
+    // Assert
+    expect(actual).toBe(expected)
+  })
+
+  it("should escape angle brackets to prevent closing the script element", () => {
+    // Arrange
+    const value = "</script><script>alert(1)</script>"
+    const expected = '"\\u003c/script>\\u003cscript>alert(1)\\u003c/script>"'
+
+    // Act
+    const actual = serializeForInlineScript(value)
+
+    // Assert
+    expect(actual).toBe(expected)
+  })
+
+  it("should serialize objects for JSON-LD script tags", () => {
+    // Arrange
+    const value = {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "Isomer",
+    }
+    const expected =
+      '{"@context":"https://schema.org","@type":"WebSite","name":"Isomer"}'
+
+    // Act
+    const actual = serializeForInlineScript(value)
+
+    // Assert
+    expect(actual).toBe(expected)
+  })
+})

--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   AUDIO_EMBED_URL_PATTERN,
+  GTM_ID_STRING_REGEX,
   isValidAudioEmbedUrl,
   LINK_HREF_PATTERN,
   MAPS_EMBED_URL_PATTERN,
@@ -270,6 +271,30 @@ describe("validation", () => {
       testCases.forEach((testCase) => {
         const result = new RegExp(VIDEO_EMBED_URL_PATTERN).test(testCase)
         expect(result).toBe(false)
+      })
+    })
+  })
+
+  describe("GTM_ID_STRING_REGEX", () => {
+    it("should allow valid Google Tag Manager container IDs", () => {
+      const testCases = ["GTM-ABC123", "GTM-1234567", "GTM-ABCDEFGHIJ"]
+
+      testCases.forEach((testCase) => {
+        expect(new RegExp(GTM_ID_STRING_REGEX).test(testCase)).toBe(true)
+      })
+    })
+
+    it("should reject invalid or malicious GTM IDs", () => {
+      const testCases = [
+        "gtm-abc123",
+        "GTM-",
+        "');alert(document.cookie);//",
+        "GTM-ABC<script>",
+        "",
+      ]
+
+      testCases.forEach((testCase) => {
+        expect(new RegExp(GTM_ID_STRING_REGEX).test(testCase)).toBe(false)
       })
     })
   })

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -15,6 +15,7 @@ export { isPhoneNumber, sanitizePhoneNumber } from "./isPhoneNumber"
 export { isUrl } from "./isUrl"
 export { isExternalUrl } from "./isExternalUrl"
 export { safeJsonParse } from "./safeJsonParse"
+export { serializeForInlineScript } from "./serializeForInlineScript"
 export {
   fetchDgsFileDownloadUrl,
   fetchDgsMetadata,
@@ -33,6 +34,7 @@ export {
   MAPS_EMBED_URL_REGEXES,
   VIDEO_EMBED_URL_REGEXES,
   NON_EMPTY_STRING_REGEX,
+  GTM_ID_STRING_REGEX,
 } from "./validation"
 
 export { createChildrenPagesComparator } from "./createChildrenPagesComparator"

--- a/packages/components/src/utils/serializeForInlineScript.ts
+++ b/packages/components/src/utils/serializeForInlineScript.ts
@@ -1,0 +1,11 @@
+/**
+ * Serializes a value for safe embedding in inline `<script>` content.
+ *
+ * Uses JSON.stringify for proper JS escaping, then replaces `<` so user-controlled
+ * data cannot close the surrounding script element (e.g. via `</script>`).
+ *
+ * DOMPurify is not suitable here — it sanitizes HTML markup, not JavaScript
+ * literals inside script bodies.
+ */
+export const serializeForInlineScript = (value: unknown): string =>
+  JSON.stringify(value).replace(/</g, "\\u003c")

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -213,3 +213,14 @@ export const NON_EMPTY_STRING_REGEX = "^(?=.*\\S)"
 // ❌ "d_ab c" (contains space)
 // ❌ "d_ab_c" (contains underscore after prefix)
 export const DGS_ID_STRING_REGEX = "^d_[a-zA-Z0-9]+$"
+
+// Matches Google Tag Manager container IDs that start with "GTM-" followed by 6 to 7 uppercase letters or digits.
+// Examples:
+// ✅ "GTM-ABC123"
+// ✅ "GTM-1234567"
+// ❌ "gtm-abc123" (lowercase)
+// ❌ "GTM-" (missing container ID)
+// ❌ "');alert(document.cookie);//" (XSS payload)
+// NOTE: Official documentation does not specify allowed length,
+// so we use ^GTM-[A-Z0-9]+$ (one or more chars) for future proofing.
+export const GTM_ID_STRING_REGEX = "^GTM-[A-Z0-9]+$"

--- a/packages/components/vitest.config.ts
+++ b/packages/components/vitest.config.ts
@@ -4,6 +4,7 @@ import { configDefaults, defineConfig } from "vitest/config"
 export default defineConfig({
   test: {
     globals: true,
+    setupFiles: ["./vitest.setup.ts"],
     exclude: [...configDefaults.exclude, "**/playwright/**", "tests/load/**"],
     alias: {
       "~/": fileURLToPath(new URL("./src/", import.meta.url)),

--- a/packages/components/vitest.setup.ts
+++ b/packages/components/vitest.setup.ts
@@ -1,0 +1,2 @@
+// Match CI and production (Singapore) for timezone-sensitive tests.
+process.env.TZ = "Asia/Singapore"

--- a/tooling/template/app/layout.tsx
+++ b/tooling/template/app/layout.tsx
@@ -5,6 +5,7 @@ import sitemap from "@/sitemap.json"
 import {
   RenderApplicationHeadScripts,
   RenderApplicationScripts,
+  serializeForInlineScript,
 } from "@opengovsg/isomer-components"
 import { Inter } from "next/font/google"
 import Script from "next/script"
@@ -70,7 +71,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
+            __html: serializeForInlineScript(jsonLd),
           }}
         />
       </body>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `getParsedDate` ISO 8601 unit test assumes the runtime timezone is `Asia/Singapore`. CI sets `TZ` in the workflow, but local and cloud agent runs without that variable fail with a date mismatch.

## Solution

Add a Vitest setup file that sets `process.env.TZ = "Asia/Singapore"` for the components package, matching CI and production behavior.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Components unit tests no longer fail when `TZ` is unset in the environment.

## Tests

- `cd packages/components && pnpm test:unit` (with `TZ` unset)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60d5db4c-dd49-44f6-b254-be5279be246b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60d5db4c-dd49-44f6-b254-be5279be246b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

