### PR TITLE
fix: add rate limiting to invite-sending tRPC procedures

### DIFF
--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -53,6 +53,8 @@ export const userRouter = router({
   create: protectedProcedure
     .input(createUserInputSchema)
     .output(createUserOutputSchema)
+    // Arbitrary limit to prevent invite email abuse; tune if legitimate usage is blocked
+    .meta({ rateLimitOptions: { max: 10, windowMs: 60 * 1000 } })
     .mutation(async ({ ctx, input: { siteId, users } }) => {
       await validatePermissionsForManagingUsers({
         siteId,
@@ -342,6 +344,8 @@ export const userRouter = router({
   resendInvite: protectedProcedure
     .input(resendInviteInputSchema)
     .output(resendInviteOutputSchema)
+    // Arbitrary limit to prevent invite email abuse; tune if legitimate usage is blocked
+    .meta({ rateLimitOptions: { max: 10, windowMs: 60 * 1000 } })
     .mutation(async ({ ctx, input: { siteId, userId } }) => {
       await validatePermissionsForManagingUsers({
         siteId,


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The `user.create` and `user.resendInvite` tRPC procedures sent invitation emails without any rate limiting. An authenticated site manager could repeatedly call `resendInvite` against any pending user to flood their inbox, or call `create` with up to 100 email addresses per request to spray invitations without throttling. The platform's `rateLimitMiddleware` only activates when a procedure sets `.meta({ rateLimitOptions: {} })`, which neither procedure did.

## Solution

<!-- How did you solve the problem? -->

Added `.meta({ rateLimitOptions: { max: 10, windowMs: 60 * 1000 } })` to both `user.create` and `user.resendInvite`. This hooks into the existing `rateLimitMiddleware` (used by OTP login) and caps each procedure at 10 requests per minute per IP. The limit is intentionally conservative to block abuse; it can be tuned upward if legitimate usage is affected.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Rate-limit `user.create` to 10 requests/minute per IP to prevent invitation email spraying
- Rate-limit `user.resendInvite` to 10 requests/minute per IP to prevent repeated invite flooding

## Before & After Screenshots

N/A — server-side only change.

## Tests

**Manual Verification Steps**:

- [ ] As a site manager, attempt to call resend invite more than 10 times within a minute for a pending user and confirm a `TOO_MANY_REQUESTS` error is returned with a retry-after message
- [ ] As a site manager, confirm that inviting users (up to the batch limit) works normally within the first 10 requests per minute
- [ ] Verify that after the rate limit window (1 minute) resets, invite operations succeed again

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None