### PR TITLE
fix: prevent open redirect via localSearch searchUrl

### DIFF
--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -694,6 +694,71 @@ describe("site.router", async () => {
       // Assert
       expect(result.config).toEqual({ ...MOCK_INTEGRATION_DATA, fake: "fake" })
     })
+
+    it("should throw 400 if downgrading search integration from searchSG to localSearch", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      // Set the site config to have searchSG integration
+      await db
+        .updateTable("Site")
+        .set({
+          config: jsonb({
+            ...MOCK_INTEGRATION_DATA,
+            search: { type: "searchSG", clientId: "mock-client-id" },
+          }),
+        })
+        .where("id", "=", site.id)
+        .execute()
+
+      // Act
+      const result = caller.updateSiteIntegrations({
+        siteId: site.id,
+        data: {
+          ...MOCK_INTEGRATION_DATA,
+          search: { type: "localSearch", searchUrl: "/search" },
+        },
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message:
+            "Cannot downgrade search integration from SearchSG to local search",
+        }),
+      )
+    })
+
+    it("should throw 400 if localSearch searchUrl is not a relative path", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act — searchUrl must match pattern "^/" (enforced by LocalSearchSchema);
+      // an absolute URL would enable open redirect via the form action.
+      const result = caller.updateSiteIntegrations({
+        siteId: site.id,
+        data: {
+          ...MOCK_INTEGRATION_DATA,
+          search: {
+            type: "localSearch",
+            searchUrl: "https://attacker.com",
+          },
+        },
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
+    })
   })
 
   describe("setTheme", () => {

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -754,10 +754,9 @@ describe("site.router", async () => {
         },
       })
 
-      // Assert
-      await expect(result).rejects.toThrowError(
-        new TRPCError({ code: "BAD_REQUEST" }),
-      )
+      // Assert — validation is enforced by LocalSearchSchema's pattern "^/" via AJV;
+      // tRPC surfaces this as a Zod custom validation failure, not a plain TRPCError.
+      await expect(result).rejects.toThrow("Invalid integration settings")
     })
   })
 

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -188,6 +188,20 @@ export const siteRouter = router({
           .selectAll()
           .executeTakeFirstOrThrow()
 
+        // SearchSG is a vetted external search integration; localSearch exposes
+        // a searchUrl field that could be used for open redirect. Prevent
+        // a site admin from switching back to localSearch once SearchSG is set.
+        if (
+          site.config.search?.type === "searchSG" &&
+          data.search?.type === "localSearch"
+        ) {
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Cannot downgrade search integration from SearchSG to local search",
+          })
+        }
+
         const updatedSite = await tx
           .updateTable("Site")
           .set({ config: jsonb(data) })

--- a/packages/components/src/interfaces/internal/LocalSearchInputBox.ts
+++ b/packages/components/src/interfaces/internal/LocalSearchInputBox.ts
@@ -3,12 +3,13 @@ import { Type } from "@sinclair/typebox"
 
 export const LocalSearchSchema = Type.Object({
   type: Type.Literal("localSearch", { default: "localSearch" }),
-  // FIXME: This should be fixed to /search
   searchUrl: Type.String({
     title: "Search URL",
     description:
       "The URL to which the search query will be sent. This should point to a local search endpoint.",
     format: "hidden",
+    // Relative paths only — prevents open redirect if a site admin sets this to an external URL
+    pattern: "^/",
   }),
 })
 


### PR DESCRIPTION
## Problem

A site admin could call the \`updateSiteIntegrations\` tRPC endpoint with \`search: { type: \"localSearch\", searchUrl: \"https://attacker.com\" }\`, causing every visitor's search form submission to be sent to an attacker-controlled server. Additionally, a site admin on SearchSG could downgrade to localSearch, reintroducing this surface.

Closes <!-- insert issue # if applicable -->

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add `pattern: "^/"` to `LocalSearchSchema.searchUrl` so AJV rejects any non-relative URL at the tRPC input validation layer, using the schema as the single source of truth
- Block downgrade from `searchSG` to `localSearch` in `updateSiteIntegrations` — once a site is on SearchSG, a site admin cannot switch back to localSearch, preventing reintroduction of the open-redirect surface

## Before & After Screenshots

N/A — server-side validation change, no UI impact.

## Tests

**Manual Verification Steps**:

- [ ] As a site admin, attempt to call `updateSiteIntegrations` with `search: { type: "localSearch", searchUrl: "https://attacker.com" }` and confirm a 400 error is returned
- [ ] As a site admin on a site already configured with SearchSG, attempt to switch to localSearch and confirm a 400 error is returned with the message "Cannot downgrade search integration from SearchSG to local search"
- [ ] As a site admin, set `searchUrl` to a valid relative path (e.g. `/search`) and confirm the update succeeds

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None