### PR TITLE
fix(studio): align CSP with Intercom Messenger requirements

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -16,6 +16,7 @@ TODO: Removing this CSP first
 */
 
 // TODO: Stricten the CSP for images
+// Intercom CSP: https://www.intercom.com/help/en/articles/3894-using-intercom-with-content-security-policy
 const ContentSecurityPolicy = `
   default-src 'none';
   base-uri 'self';
@@ -39,6 +40,7 @@ const ContentSecurityPolicy = `
     'self'
     https://intercom-sheets.com
     https://www.intercom-reporting.com
+    https://www.youtube.com
     https://fast.wistia.net
     https://www.google.com
     https://www.googletagmanager.com
@@ -59,10 +61,9 @@ const ContentSecurityPolicy = `
     'self'
     'unsafe-eval'
     https://*.wogaa.sg
+    https://app.intercom.io
+    https://widget.intercom.io
     https://js.intercomcdn.com
-    https://downloads.intercomcdn.com
-    https://downloads.intercomcdn.eu
-    https://downloads.au.intercomcdn.com
     https://embed-cdn.spotifycdn.com
     https://open.spotify.com
     https://js-cdn.music.apple.com


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The Studio app Content Security Policy was missing required Intercom `script-src` entries from [Intercom's CSP documentation](https://www.intercom.com/help/en/articles/3894-using-intercom-with-content-security-policy). Without `https://app.intercom.io` and `https://widget.intercom.io`, the Messenger bootstrap script can be blocked (a common console error: refused to load script from `widget.intercom.io`).

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Add `https://app.intercom.io` and `https://widget.intercom.io` to `script-src` per Intercom's required allowlist
- Remove `downloads.intercomcdn.com` regional hosts from `script-src` (they belong under `media-src`, which already lists them)
- Add `https://www.youtube.com` to `frame-src` for embedded content shown inside the Messenger (Intercom's `child-src` / CSPv3 `frame-src` guidance)
- Link to Intercom's CSP doc in `next.config.mjs` for future maintenance

Other Intercom directives (`connect-src`, `font-src`, `form-action`, `media-src`, `worker-src`, `style-src` with `'unsafe-inline'`) were already present.

## Before & After Screenshots

**BEFORE**:

N/A — CSP header change only.

**AFTER**:

N/A — verify via browser devtools (no CSP violations for Intercom domains).

## Tests

**Manual Verification Steps**:

- [ ] Deploy or run Studio with `NEXT_PUBLIC_INTERCOM_APP_ID` set and log in
- [ ] Open browser DevTools → Console and confirm there are no CSP violations mentioning `widget.intercom.io`, `app.intercom.io`, or other `*.intercom*` hosts
- [ ] Confirm the Intercom Messenger launcher appears and opens a conversation
- [ ] Optionally send a test message to confirm `connect-src` / WebSocket connectivity works

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50f71acc-0ed1-434f-a529-ef0da42eb173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50f71acc-0ed1-434f-a529-ef0da42eb173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

