### PR TITLE
fix: prevent unauthorized cross-site SearchSG config access via clientId injection

### DIFF
--- a/apps/studio/src/server/modules/searchsg/__tests__/searchsg.service.test.ts
+++ b/apps/studio/src/server/modules/searchsg/__tests__/searchsg.service.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { mockWretch } = vi.hoisted(() => ({
+  mockWretch: vi.fn(),
+}))
+
+vi.mock("wretch", () => ({ default: mockWretch }))
+
+vi.mock("~/env.mjs", () => ({
+  env: {
+    NEXT_PUBLIC_APP_ENV: "production",
+    SEARCHSG_API_KEY: "test-api-key",
+  },
+}))
+
+import { updateSearchSGConfig } from "../searchsg.service"
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000"
+const PROPS = { name: "test-site", _kind: "name" } as const
+const URL = "https://example.gov.sg"
+
+describe("updateSearchSGConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    // Throw on the auth call to prevent actual HTTP requests while still
+    // allowing us to assert whether wretch was invoked at all
+    mockWretch.mockReturnValue({
+      auth: vi.fn().mockReturnThis(),
+      headers: vi.fn().mockReturnThis(),
+      post: vi.fn().mockReturnThis(),
+      json: vi.fn().mockRejectedValue(new Error("no network in tests")),
+    })
+  })
+
+  describe("clientId validation", () => {
+    it("should not call the SearchSG API for a clientId containing path traversal sequences", async () => {
+      // Arrange
+      const clientId = "../../other-client-id"
+
+      // Act
+      await updateSearchSGConfig(PROPS, clientId, URL)
+
+      // Assert
+      expect(mockWretch).not.toHaveBeenCalled()
+    })
+
+    it("should not call the SearchSG API for a plain string clientId", async () => {
+      // Arrange
+      const clientId = "not-a-uuid"
+
+      // Act
+      await updateSearchSGConfig(PROPS, clientId, URL)
+
+      // Assert
+      expect(mockWretch).not.toHaveBeenCalled()
+    })
+
+    it("should not call the SearchSG API for an empty clientId", async () => {
+      // Arrange
+      const clientId = ""
+
+      // Act
+      await updateSearchSGConfig(PROPS, clientId, URL)
+
+      // Assert
+      expect(mockWretch).not.toHaveBeenCalled()
+    })
+
+    it("should call the SearchSG API for a valid UUID clientId", async () => {
+      // Act
+      await updateSearchSGConfig(PROPS, VALID_UUID, URL).catch(() => {})
+
+      // Assert
+      expect(mockWretch).toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/studio/src/server/modules/searchsg/searchsg.service.ts
+++ b/apps/studio/src/server/modules/searchsg/searchsg.service.ts
@@ -1,3 +1,4 @@
+import { z } from "zod"
 import wretch from "wretch"
 import { env } from "~/env.mjs"
 import { createBaseLogger } from "~/lib/logger"
@@ -90,11 +91,23 @@ const requestSearchSGClient = async () => {
     })
 }
 
+export const isValidSearchSGClientId = (clientId: string): boolean =>
+  z.string().uuid().safeParse(clientId).success
+
 export const updateSearchSGConfig = async (
   props: UpdateSearchSGConfigProps,
   searchsgClientId: string,
   url: string,
 ) => {
+  // Reject non-UUID clientIds to prevent path traversal attacks
+  if (!isValidSearchSGClientId(searchsgClientId)) {
+    logger.error(
+      { searchsgClientId },
+      `[ERROR] Invalid SearchSG client ID format - aborting to prevent path traversal`,
+    )
+    return
+  }
+
   // Only update SearchSG in production and staging environments since SearchSG does not have non-prod env
   // This is to avoid accidentally updating a production site in a non-prod environment
   if (!["production", "staging"].includes(env.NEXT_PUBLIC_APP_ENV)) {

--- a/apps/studio/src/server/modules/searchsg/searchsg.service.ts
+++ b/apps/studio/src/server/modules/searchsg/searchsg.service.ts
@@ -1,5 +1,5 @@
-import { z } from "zod"
 import wretch from "wretch"
+import { z } from "zod"
 import { env } from "~/env.mjs"
 import { createBaseLogger } from "~/lib/logger"
 

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -41,6 +41,7 @@ const createCaller = createCallerFactory(siteRouter)
 
 const MOCK_SITE_NAME = "isobad"
 const MOCK_LOGO_URL = "https://isobad.com/logo.png"
+const MOCK_SEARCHSG_CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000"
 const MOCK_ISOMER_THEME = {
   colors: {
     brand: {
@@ -525,7 +526,7 @@ describe("site.router", async () => {
       const mockSearch = {
         search: {
           type: "searchSG",
-          clientId: "i-love-searchsg",
+          clientId: MOCK_SEARCHSG_CLIENT_ID,
         },
       } as const
       const searchSpy = vi.spyOn(searchSgService, "updateSearchSGConfig")
@@ -571,6 +572,78 @@ describe("site.router", async () => {
         theme: "isomer-next",
         ...mockSearch,
       })
+    })
+    it("should not allow a site admin to change the searchSG clientId", async () => {
+      // Arrange
+      const existingClientId = MOCK_SEARCHSG_CLIENT_ID
+      const { site } = await setupSite()
+      await db
+        .updateTable("Site")
+        .set({
+          config: {
+            ...site.config,
+            search: { type: "searchSG", clientId: existingClientId },
+          },
+        })
+        .where("id", "=", site.id)
+        .execute()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act - submit with a different clientId
+      const result = await caller.updateSiteConfig({
+        siteName: MOCK_SITE_NAME,
+        logoUrl: MOCK_LOGO_URL,
+        url: "https://www.isomer.gov.sg",
+        theme: "isomer-next",
+        siteId: site.id,
+        search: { type: "searchSG", clientId: "../../other-client-id" },
+      })
+
+      // Assert - the stored clientId should be the original DB value
+      expect(result.search).toEqual({
+        type: "searchSG",
+        clientId: existingClientId,
+      })
+    })
+    it("should call updateSearchSGConfig with the DB clientId, not the user-supplied one", async () => {
+      // Arrange
+      const existingClientId = MOCK_SEARCHSG_CLIENT_ID
+      const searchSpy = vi.spyOn(searchSgService, "updateSearchSGConfig")
+      const { site } = await setupSite()
+      await db
+        .updateTable("Site")
+        .set({
+          config: {
+            ...site.config,
+            search: { type: "searchSG", clientId: existingClientId },
+          },
+        })
+        .where("id", "=", site.id)
+        .execute()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act - submit with a different clientId and changed siteName to trigger searchsg update
+      const result = await caller.updateSiteConfig({
+        siteName: MOCK_SITE_NAME,
+        logoUrl: MOCK_LOGO_URL,
+        url: "https://www.isomer.gov.sg",
+        theme: "isomer-next",
+        siteId: site.id,
+        search: { type: "searchSG", clientId: "../../other-client-id" },
+      })
+
+      // Assert - updateSearchSGConfig is called with the preserved DB clientId
+      expect(searchSpy).toHaveBeenCalledWith(
+        { name: MOCK_SITE_NAME, _kind: "name" },
+        existingClientId,
+        result.url,
+      )
     })
   })
 
@@ -810,7 +883,7 @@ describe("site.router", async () => {
     it("should update searchsg if the user is a site admin", async () => {
       // Arrange
       const mockSearchSg = {
-        search: { type: "searchSG", clientId: "mock-client-id" },
+        search: { type: "searchSG", clientId: MOCK_SEARCHSG_CLIENT_ID },
       } as const
       const { site } = await setupSite()
       const spy = vi.spyOn(searchSgService, "updateSearchSGConfig")

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -131,9 +131,15 @@ export const siteRouter = router({
       const { config } = site
 
       const updatedConfig = await db.transaction().execute(async (tx) => {
+        // Preserve the existing clientId from DB - only admins can update it via setSiteConfigByAdmin
+        const searchConfig =
+          rest.search?.type === "searchSG" && config.search?.type === "searchSG"
+            ? { ...rest.search, clientId: config.search.clientId }
+            : rest.search
+
         const updatedSite = await tx
           .updateTable("Site")
-          .set({ name: siteName, config: jsonb({ ...rest, siteName }) })
+          .set({ name: siteName, config: jsonb({ ...rest, siteName, search: searchConfig }) })
           .where("id", "=", siteId)
           .returningAll()
           .executeTakeFirstOrThrow()
@@ -159,6 +165,7 @@ export const siteRouter = router({
         (config.search?.type !== "searchSG" ||
           config.siteName !== updatedConfig.siteName)
       )
+        // IMPORTANT: clientId must always come from the DB, not user input (path traversal risk)
         void updateSearchSGConfig(
           { name: siteName, _kind: "name" },
           updatedConfig.search.clientId,
@@ -295,6 +302,7 @@ export const siteRouter = router({
         oldTheme.colors.brand.canvas.inverse !==
           theme.colors.brand.canvas.inverse
       ) {
+        // IMPORTANT: clientId must always come from the DB, not user input (path traversal risk)
         void updateSearchSGConfig(
           { colour: theme.colors.brand.canvas.inverse, _kind: "colour" },
           site.config.search.clientId,

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -139,7 +139,10 @@ export const siteRouter = router({
 
         const updatedSite = await tx
           .updateTable("Site")
-          .set({ name: siteName, config: jsonb({ ...rest, siteName, search: searchConfig }) })
+          .set({
+            name: siteName,
+            config: jsonb({ ...rest, siteName, search: searchConfig }),
+          })
           .where("id", "=", siteId)
           .returningAll()
           .executeTakeFirstOrThrow()


### PR DESCRIPTION
## Problem

A site admin of site A could submit an arbitrary `clientId` in `updateSiteConfig` — including the `clientId` belonging to site B. Because `clientId` was used directly as a URL path segment in SearchSG admin API calls (`client.get(\`/\${searchsgClientId}\`)`), this caused Isomer's platform admin credentials to issue authenticated requests against site B's SearchSG application, allowing the attacker to read or overwrite another government site's search configuration (domain, siteName, theme) without authorization.

The attack has two components:
1. **IDOR** — a site admin can reference any `clientId`, not just their own site's
2. **Path traversal** — the `clientId` is unsanitized in the URL path, so values like `../../other-id` also work against the SearchSG API

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- **`updateSiteConfig` — preserve `clientId` from DB (fixes IDOR)**: When a site admin submits a config update, `search.clientId` is now always sourced from the existing DB value and cannot be overwritten by user input. Only `setSiteConfigByAdmin` (restricted to Isomer Core/Migrator admins) can set the `clientId`, ensuring a site admin can only ever operate on their own site's SearchSG application.
- **`updateSearchSGConfig` — UUID validation as defence-in-depth (fixes path traversal)**: Added a UUID format check via Zod before `clientId` is used in any URL path. Non-UUID values (including path traversal sequences) are rejected with an error log and early return before any HTTP call is made.
- **Inline comments**: Added `IMPORTANT` comments on both `updateSearchSGConfig` call sites in `site.router.ts` to make the invariant (clientId must always come from the DB) explicit for future maintainers.

**Tests**:

- New unit tests for `updateSearchSGConfig` asserting that invalid clientIds (path traversal, plain strings, empty) never invoke the HTTP client, while a valid UUID does.
- New integration tests in `site.router.test.ts` asserting that `updateSiteConfig` preserves the DB `clientId` regardless of the user-supplied value, and that `updateSearchSGConfig` is called with the DB value.

## Before & After Screenshots

N/A — backend security fix, no UI changes.

## Tests

**Manual Verification Steps**:

- [ ] As a site admin (non-Isomer admin), attempt to update the site config with a modified `search.clientId` (e.g. another site's clientId or a path traversal string) via API. Confirm the stored `clientId` in the DB remains unchanged after the update.
- [ ] Confirm that site search continues to function correctly after a normal site config update (e.g. agency name change).
- [ ] Confirm that an Isomer Core admin can still set/update the `clientId` via the `/sites/XX/admin` route (`setSiteConfigByAdmin`).

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None