### PR TITLE
fix: prevent duplicate heading IDs across prose blocks breaking TOC links

### DIFF
--- a/packages/components/src/utils/__tests__/getTransformedPageContent.test.ts
+++ b/packages/components/src/utils/__tests__/getTransformedPageContent.test.ts
@@ -89,7 +89,7 @@ describe("getTransformedPageContent", () => {
     }
   })
 
-  it("generates unique IDs for identical headings in different prose blocks", () => {
+  it("generates unique IDs for identical headings in 2 prose blocks", () => {
     // Arrange
     const proseBlock: IsomerComponent = {
       type: "prose",
@@ -115,6 +115,71 @@ describe("getTransformedPageContent", () => {
     })
 
     expect(ids[0]).toBe(getDigestFromText(seed)) // preserve legacy seed for the first heading
+    expect(ids[1]).toBe(getDigestFromText(`${seed}_1`))
+    expect(ids[0]).not.toBe(ids[1])
+  })
+
+  it("generates unique IDs for identical headings in 3+ prose blocks", () => {
+    // Arrange
+    const proseBlock: IsomerComponent = {
+      type: "prose",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Introduction" }],
+        },
+      ],
+    }
+    const seed = `${JSON.stringify(proseBlock.content[0])}_0`
+    const content: IsomerComponent[] = [proseBlock, proseBlock, proseBlock]
+
+    // Act
+    const transformed = getTransformedPageContent(content)
+
+    // Assert
+    const ids = transformed.map((block) => {
+      if (block.type !== "prose" || !block.content) return undefined
+      const node = block.content[0]
+      return node?.type === "heading" ? node.attrs.id : undefined
+    })
+
+    expect(ids[0]).toBe(getDigestFromText(seed))
+    expect(ids[1]).toBe(getDigestFromText(`${seed}_1`))
+    expect(ids[2]).toBe(getDigestFromText(`${seed}_2`))
+    expect(new Set(ids).size).toBe(3)
+  })
+
+  it("preserves componentIndex in seed when heading is not first in prose block", () => {
+    // Arrange
+    const proseBlock: IsomerComponent = {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Intro paragraph" }],
+        },
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Introduction" }],
+        },
+      ],
+    }
+    const seed = `${JSON.stringify(proseBlock.content[1])}_1`
+    const content: IsomerComponent[] = [proseBlock, proseBlock]
+
+    // Act
+    const transformed = getTransformedPageContent(content)
+
+    // Assert
+    const ids = transformed.map((block) => {
+      if (block.type !== "prose" || !block.content) return undefined
+      const node = block.content[1]
+      return node?.type === "heading" ? node.attrs.id : undefined
+    })
+
+    expect(ids[0]).toBe(getDigestFromText(seed))
     expect(ids[1]).toBe(getDigestFromText(`${seed}_1`))
     expect(ids[0]).not.toBe(ids[1])
   })

--- a/packages/components/src/utils/__tests__/getTransformedPageContent.test.ts
+++ b/packages/components/src/utils/__tests__/getTransformedPageContent.test.ts
@@ -1,5 +1,6 @@
 import type { IsomerComponent } from "~/types"
 import { describe, expect, it } from "vitest"
+import { getDigestFromText } from "~/utils/getDigestFromText"
 import { getTransformedPageContent } from "~/utils/getTransformedPageContent"
 
 describe("getTransformedPageContent", () => {
@@ -100,6 +101,7 @@ describe("getTransformedPageContent", () => {
         },
       ],
     }
+    const seed = `${JSON.stringify(proseBlock.content[0])}_0`
     const content: IsomerComponent[] = [proseBlock, proseBlock]
 
     // Act
@@ -108,12 +110,12 @@ describe("getTransformedPageContent", () => {
     // Assert
     const ids = transformed.map((block) => {
       if (block.type !== "prose" || !block.content) return undefined
-      const heading = block.content[0]
-      return heading?.type === "heading" ? heading.attrs.id : undefined
+      const node = block.content[0]
+      return node?.type === "heading" ? node.attrs.id : undefined
     })
 
-    expect(ids[0]).toMatch(idPattern)
-    expect(ids[1]).toMatch(idPattern)
+    expect(ids[0]).toBe(getDigestFromText(seed)) // preserve legacy seed for the first heading
+    expect(ids[1]).toBe(getDigestFromText(`${seed}_1`))
     expect(ids[0]).not.toBe(ids[1])
   })
 

--- a/packages/components/src/utils/__tests__/getTransformedPageContent.test.ts
+++ b/packages/components/src/utils/__tests__/getTransformedPageContent.test.ts
@@ -88,6 +88,35 @@ describe("getTransformedPageContent", () => {
     }
   })
 
+  it("generates unique IDs for identical headings in different prose blocks", () => {
+    // Arrange
+    const proseBlock: IsomerComponent = {
+      type: "prose",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 2 },
+          content: [{ type: "text", text: "Introduction" }],
+        },
+      ],
+    }
+    const content: IsomerComponent[] = [proseBlock, proseBlock]
+
+    // Act
+    const transformed = getTransformedPageContent(content)
+
+    // Assert
+    const ids = transformed.map((block) => {
+      if (block.type !== "prose" || !block.content) return undefined
+      const heading = block.content[0]
+      return heading?.type === "heading" ? heading.attrs.id : undefined
+    })
+
+    expect(ids[0]).toMatch(idPattern)
+    expect(ids[1]).toMatch(idPattern)
+    expect(ids[0]).not.toBe(ids[1])
+  })
+
   it("adds ids to supported structured blocks", () => {
     // Arrange
     const content: IsomerComponent[] = [

--- a/packages/components/src/utils/getTransformedPageContent.ts
+++ b/packages/components/src/utils/getTransformedPageContent.ts
@@ -19,7 +19,7 @@ export const getTransformedPageContent = (
           ) {
             // generate a unique hash to auto-generate anchor links
             const anchorId = getDigestFromText(
-              `${JSON.stringify(component)}_${componentIndex}`,
+              `${JSON.stringify(component)}_${index}_${componentIndex}`,
             )
             const newAttrs = {
               ...component.attrs,

--- a/packages/components/src/utils/getTransformedPageContent.ts
+++ b/packages/components/src/utils/getTransformedPageContent.ts
@@ -20,7 +20,8 @@ export const getTransformedPageContent = (
             component.attrs.id === undefined
           ) {
             // generate a unique hash to auto-generate anchor links
-            // for backwards compatibility, use the same seed format for headings, but with an added index suffix only if there are multiple headings with the same content
+            // for backwards compatibility, use the seed format for headings,
+            // add index suffix only if for multiple headings with the same content
             const seed = `${JSON.stringify(component)}_${componentIndex}`
             let anchorId = getDigestFromText(seed)
             if (usedHeadingIds.has(anchorId)) {

--- a/packages/components/src/utils/getTransformedPageContent.ts
+++ b/packages/components/src/utils/getTransformedPageContent.ts
@@ -7,6 +7,8 @@ import { getDigestFromText } from "./getDigestFromText"
 export const getTransformedPageContent = (
   content: IsomerComponent[],
 ): IsomerComponent[] => {
+  const usedHeadingIds = new Set<string>()
+
   return content.map((block, index) => {
     if (block.type === "prose" && block.content) {
       return {
@@ -18,9 +20,14 @@ export const getTransformedPageContent = (
             component.attrs.id === undefined
           ) {
             // generate a unique hash to auto-generate anchor links
-            const anchorId = getDigestFromText(
-              `${JSON.stringify(component)}_${index}_${componentIndex}`,
-            )
+            // for backwards compatibility, use the same seed format for headings, but with an added collision count suffix only if there are multiple headings with the same content
+            const seed = `${JSON.stringify(component)}_${componentIndex}`
+            let anchorId = getDigestFromText(seed)
+            if (usedHeadingIds.has(anchorId)) {
+              anchorId = getDigestFromText(`${seed}_${index}`)
+            }
+            usedHeadingIds.add(anchorId)
+
             const newAttrs = {
               ...component.attrs,
               id: anchorId,

--- a/packages/components/src/utils/getTransformedPageContent.ts
+++ b/packages/components/src/utils/getTransformedPageContent.ts
@@ -20,7 +20,7 @@ export const getTransformedPageContent = (
             component.attrs.id === undefined
           ) {
             // generate a unique hash to auto-generate anchor links
-            // for backwards compatibility, use the same seed format for headings, but with an added collision count suffix only if there are multiple headings with the same content
+            // for backwards compatibility, use the same seed format for headings, but with an added index suffix only if there are multiple headings with the same content
             const seed = `${JSON.stringify(component)}_${componentIndex}`
             let anchorId = getDigestFromText(seed)
             if (usedHeadingIds.has(anchorId)) {


### PR DESCRIPTION
## Problem

Closes #1952

Level-2 prose headings get auto-generated ID whose MD5 hash input can be the same, if different prose blocks have identical headings. This causes duplicate HTML ID and ToC links to jump only to the first matching heading.

## Solution

* Include the outer block `index` in the hash input, similar to how `infocards`, `infocols`, etc. generate their IDs.
* For backwards compatibility, only duplicated prose block with identical headings (2nd block onwards) will have `index` appended to hash input to ensure old links still work


**Breaking Changes**

- [x] Yes - this PR contains breaking changes
  - Auto-generated heading IDs change, so old external/bookmarked anchor links (`#<hash>`) may break. On-page TOC links are unaffected as they regenerate alongside the IDs on each build (mitigated in solution above).
- [ ] No - this PR is backwards compatible

**Features**:

- NIL

**Improvements**:

- NIL

**Bug Fixes**:

- Fix duplicate auto-generated heading IDs across prose blocks that broke TOC anchor links and produced invalid HTML.

## Before & After Screenshots

**BEFORE**:

NIL

**AFTER**:

NIL

## Tests

**Manual Verification Steps**:

- [ ] Create a page with two prose blocks, each starting with an identical level-2 heading (e.g. "Introduction").
- [ ] Confirm both headings render with distinct `id` attributes.
- [ ] Click each TOC entry and confirm it scrolls to its own heading (not just the first).
- [ ] Run the unit test `pnpm test:unit -- src/utils/__tests__/getTransformedPageContent.test.ts`

**New scripts**:

NIL

**New dependencies**:

NIL

**New dev dependencies**:

NIL
