### PR TITLE
fix: wrap CodeBuildJobs INSERT + superseded-build UPDATE in a transaction

### DIFF
--- a/apps/studio/src/server/modules/aws/utils.ts
+++ b/apps/studio/src/server/modules/aws/utils.ts
@@ -71,14 +71,10 @@ export const addCodeBuildAndMarkSupersededBuild = async ({
           tx
             .selectFrom("CodeBuildJobs")
             .select("buildId")
-            .where(
-              "supersededByBuildId",
-              "=",
-              buildChanges.stoppedBuild.id,
-            )
+            .where("supersededByBuildId", "=", buildChanges.stoppedBuild.id)
             .unionAll(
               tx.selectNoFrom((eb) => [
-                eb.val(buildChanges.stoppedBuild!.id).as("buildId"),
+                eb.val(buildChanges.stoppedBuild.id).as("buildId"),
               ]),
             ),
         )

--- a/apps/studio/src/server/modules/aws/utils.ts
+++ b/apps/studio/src/server/modules/aws/utils.ts
@@ -9,6 +9,7 @@ import { TRPCError } from "@trpc/server"
 
 import type { Logger } from "@isomer/logging"
 
+import type { SafeKysely } from "../database/types"
 import type {
   BuildChanges,
   RequiresNewBuild,
@@ -59,26 +60,11 @@ export const addCodeBuildAndMarkSupersededBuild = async ({
       .execute()
     // If a new build was started, mark the stopped build (if any) as being superseded by the new build
     if (buildChanges.isNewBuildNeeded && buildChanges.stoppedBuild?.id) {
-      await tx
-        .updateTable("CodeBuildJobs")
-        .set({
-          supersededByBuildId: buildChanges.startedBuild.id,
-          status: "STOPPED",
-        })
-        .where(
-          "buildId",
-          "in",
-          tx
-            .selectFrom("CodeBuildJobs")
-            .select("buildId")
-            .where("supersededByBuildId", "=", buildChanges.stoppedBuild.id)
-            .unionAll(
-              tx.selectNoFrom((eb) => [
-                eb.val(buildChanges.stoppedBuild.id).as("buildId"),
-              ]),
-            ),
-        )
-        .execute()
+      await updateStoppedBuild({
+        startedBuildId: buildChanges.startedBuild.id,
+        stoppedBuildId: buildChanges.stoppedBuild.id,
+        trx: tx,
+      })
     }
   })
 }
@@ -93,22 +79,24 @@ export const addCodeBuildAndMarkSupersededBuild = async ({
 export const updateStoppedBuild = async ({
   startedBuildId,
   stoppedBuildId,
+  trx = db,
 }: {
   startedBuildId: string
   stoppedBuildId: string
+  trx?: SafeKysely
 }) => {
-  await db
+  await trx
     .updateTable("CodeBuildJobs")
     .set({ supersededByBuildId: startedBuildId, status: "STOPPED" })
     .where(
       "buildId",
       "in",
-      db
+      trx
         .selectFrom("CodeBuildJobs")
         .select("buildId")
         .where("supersededByBuildId", "=", stoppedBuildId)
         .unionAll(
-          db.selectNoFrom((eb) => [eb.val(stoppedBuildId).as("buildId")]),
+          trx.selectNoFrom((eb) => [eb.val(stoppedBuildId).as("buildId")]),
         ),
     )
     .execute()

--- a/apps/studio/src/server/modules/aws/utils.ts
+++ b/apps/studio/src/server/modules/aws/utils.ts
@@ -42,27 +42,49 @@ export const addCodeBuildAndMarkSupersededBuild = async ({
     buildStartTime = buildChanges.latestRunningBuild.startTime
   }
 
-  // Insert a new row into CodeBuildJobs to link the resourceId, userId, siteId to the build
-  await db
-    .insertInto("CodeBuildJobs")
-    .values(
-      resourceWithUserIds.map(({ resourceId, userId }) => ({
-        siteId,
-        userId,
-        buildId: buildIdToLink,
-        startedAt: buildStartTime,
-        resourceId,
-        isScheduled,
-      })),
-    )
-    .execute()
-  // If a new build was started, mark the stopped build (if any) as being superseded by the new build
-  if (buildChanges.isNewBuildNeeded && buildChanges.stoppedBuild?.id) {
-    await updateStoppedBuild({
-      startedBuildId: buildChanges.startedBuild.id,
-      stoppedBuildId: buildChanges.stoppedBuild.id,
-    })
-  }
+  await db.transaction().execute(async (tx) => {
+    // Insert a new row into CodeBuildJobs to link the resourceId, userId, siteId to the build
+    await tx
+      .insertInto("CodeBuildJobs")
+      .values(
+        resourceWithUserIds.map(({ resourceId, userId }) => ({
+          siteId,
+          userId,
+          buildId: buildIdToLink,
+          startedAt: buildStartTime,
+          resourceId,
+          isScheduled,
+        })),
+      )
+      .execute()
+    // If a new build was started, mark the stopped build (if any) as being superseded by the new build
+    if (buildChanges.isNewBuildNeeded && buildChanges.stoppedBuild?.id) {
+      await tx
+        .updateTable("CodeBuildJobs")
+        .set({
+          supersededByBuildId: buildChanges.startedBuild.id,
+          status: "STOPPED",
+        })
+        .where(
+          "buildId",
+          "in",
+          tx
+            .selectFrom("CodeBuildJobs")
+            .select("buildId")
+            .where(
+              "supersededByBuildId",
+              "=",
+              buildChanges.stoppedBuild.id,
+            )
+            .unionAll(
+              tx.selectNoFrom((eb) => [
+                eb.val(buildChanges.stoppedBuild!.id).as("buildId"),
+              ]),
+            ),
+        )
+        .execute()
+    }
+  })
 }
 
 /**


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

In \`addCodeBuildAndMarkSupersededBuild\`, the \`insertInto("CodeBuildJobs")\` and the subsequent \`updateStoppedBuild\` call were two separate, non-atomic database operations. If the UPDATE failed after the INSERT succeeded (e.g. a transient DB connection error), the stopped build's \`CodeBuildJobs\` rows would retain \`supersededByBuildId = null\`. When the new build later completed, \`sendEmails\` queries \`supersededByBuildId = newBuildId\` to find related jobs — so those rows would be invisible to the query and affected users would never receive publish success/failure email notifications.

Closes https://app.notion.com/p/opengov/non-atomic-insert-update-in-addcodebuildandmarksupersededbuild-causes-orphaned-r-36e77dbba788810bb10ffd27572f4807

## Solution

<!-- How did you solve the problem? -->

Wrap both DB writes in a single \`db.transaction().execute()\` block so they commit or roll back together. The \`updateStoppedBuild\` logic is inlined inside the transaction using the transaction's \`tx\` connection (the standalone \`updateStoppedBuild\` export is preserved for existing unit tests).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Fixed non-atomic INSERT + UPDATE in \`addCodeBuildAndMarkSupersededBuild\` that could leave \`supersededByBuildId\` as \`null\`, causing orphaned \`CodeBuildJobs\` rows and missed publish email notifications for users whose resources were in a stopped build.

## Before & After Screenshots

**BEFORE**:

<!-- N/A — server-side logic change -->

**AFTER**:

<!-- N/A — server-side logic change -->

## Tests

**Manual Verification Steps**:

- [ ] Trigger a publish that causes a running build to be stopped and superseded (requires 2 running non-recent builds in the CodeBuild project). Confirm that after the new build completes, all users who had resources in the stopped build receive the expected email notification.
- [ ] Trigger a normal publish (no stopped build). Confirm the new \`CodeBuildJobs\` rows are inserted and the build completes with email notifications sent as expected.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A