### PR TITLE
fix: sync index page blob content when renaming a folder

### DIFF
--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -775,9 +775,9 @@ describe("folder.router", async () => {
       expect(updatedBlob.content).toMatchObject({
         content: blob.content.content,
       })
-      // audit log: folder ResourceUpdate + index page ResourceUpdate
+      // audit log: folder ResourceUpdate + index page ResourceUpdate + folder Publish
       const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(2)
+      expect(auditLogs).toHaveLength(3)
       expect(
         auditLogs.some(
           (log) =>
@@ -839,9 +839,9 @@ describe("folder.router", async () => {
       expect(newPublishedBlob.content).toMatchObject({
         content: blob.content.content,
       })
-      // audit log: folder ResourceUpdate + index page Publish
+      // audit log: folder ResourceUpdate + index page Publish + folder Publish
       const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
-      expect(auditLogs).toHaveLength(2)
+      expect(auditLogs).toHaveLength(3)
       expect(
         auditLogs.some((log) => log.eventType === AuditLogEvent.Publish),
       ).toBe(true)

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -17,6 +17,7 @@ import {
 import { createCallerFactory } from "~/server/trpc"
 
 import { AuditLogEvent, db, ResourceState, ResourceType } from "../../database"
+import { getIndexPageSummary } from "../../page/page.service"
 import { folderRouter } from "../folder.router"
 
 const createCaller = createCallerFactory(folderRouter)
@@ -767,7 +768,7 @@ describe("folder.router", async () => {
       expect(updatedBlob.content).toMatchObject({
         page: {
           title: newTitle,
-          contentPageHeader: { summary: `Pages in ${newTitle}` },
+          contentPageHeader: { summary: getIndexPageSummary(newTitle) },
         },
       })
       // existing content blocks are preserved (not overwritten by a fresh template)
@@ -820,7 +821,7 @@ describe("folder.router", async () => {
       expect(newPublishedBlob.content).toMatchObject({
         page: {
           title: newTitle,
-          contentPageHeader: { summary: `Pages in ${newTitle}` },
+          contentPageHeader: { summary: getIndexPageSummary(newTitle) },
         },
       })
       // original content blocks are preserved

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -775,6 +775,17 @@ describe("folder.router", async () => {
       expect(updatedBlob.content).toMatchObject({
         content: blob.content.content,
       })
+      // audit log: folder ResourceUpdate + index page ResourceUpdate
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(2)
+      expect(
+        auditLogs.some(
+          (log) =>
+            log.eventType === AuditLogEvent.ResourceUpdate &&
+            (log.delta as { after: { blob?: unknown } }).after?.blob !==
+              undefined,
+        ),
+      ).toBe(true)
     })
 
     it("should create a new published version with updated title when index page has no draft", async () => {
@@ -828,6 +839,12 @@ describe("folder.router", async () => {
       expect(newPublishedBlob.content).toMatchObject({
         content: blob.content.content,
       })
+      // audit log: folder ResourceUpdate + index page Publish
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(2)
+      expect(
+        auditLogs.some((log) => log.eventType === AuditLogEvent.Publish),
+      ).toBe(true)
     })
   })
 

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -775,6 +775,59 @@ describe("folder.router", async () => {
         content: blob.content.content,
       })
     })
+
+    it("should create a new published version with updated title when index page has no draft", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder({ title: "Old Title" })
+      const { blob, page: indexPage } = await setupPageResource({
+        resourceType: ResourceType.IndexPage,
+        siteId: site.id,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const newTitle = "New Folder Name"
+
+      // Act
+      await caller.editFolder({
+        siteId: String(site.id),
+        resourceId: folder.id,
+        title: newTitle,
+        permalink: folder.permalink,
+      })
+
+      // Assert: a new Version should have been created
+      const updatedIndexPage = await db
+        .selectFrom("Resource")
+        .where("id", "=", indexPage.id)
+        .select(["publishedVersionId", "draftBlobId"])
+        .executeTakeFirstOrThrow()
+
+      expect(updatedIndexPage.draftBlobId).toBeNull()
+      expect(updatedIndexPage.publishedVersionId).not.toEqual(
+        indexPage.publishedVersionId,
+      )
+
+      // The new published version's blob should have the updated title/summary
+      const newPublishedBlob = await db
+        .selectFrom("Version")
+        .innerJoin("Blob", "Blob.id", "Version.blobId")
+        .where("Version.id", "=", updatedIndexPage.publishedVersionId!)
+        .select("Blob.content")
+        .executeTakeFirstOrThrow()
+
+      expect(newPublishedBlob.content).toMatchObject({
+        page: {
+          title: newTitle,
+          contentPageHeader: { summary: `Pages in ${newTitle}` },
+        },
+      })
+      // original content blocks are preserved
+      expect(newPublishedBlob.content).toMatchObject({
+        content: blob.content.content,
+      })
+    })
   })
 
   describe("getIndexpage", () => {

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -736,6 +736,40 @@ describe("folder.router", async () => {
       expect(auditLogs?.userId).toEqual(session.userId)
       expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
+
+    it("should update the index page blob content to reflect the new folder title", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder({ title: "Old Title" })
+      const { blob } = await setupPageResource({
+        resourceType: ResourceType.IndexPage,
+        siteId: site.id,
+        parentId: folder.id,
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const newTitle = "New Folder Name"
+
+      // Act
+      await caller.editFolder({
+        siteId: String(site.id),
+        resourceId: folder.id,
+        title: newTitle,
+        permalink: folder.permalink,
+      })
+
+      // Assert
+      const updatedBlob = await db
+        .selectFrom("Blob")
+        .where("id", "=", blob.id)
+        .select("content")
+        .executeTakeFirstOrThrow()
+
+      expect(updatedBlob.content).toMatchObject({
+        page: {
+          title: newTitle,
+          contentPageHeader: { summary: `Pages in ${newTitle}` },
+        },
+      })
+    })
   })
 
   describe("getIndexpage", () => {

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -737,7 +737,7 @@ describe("folder.router", async () => {
       expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
     })
 
-    it("should update the index page blob content to reflect the new folder title", async () => {
+    it("should update only title/summary in the index page blob, preserving other content", async () => {
       // Arrange
       const { site, folder } = await setupFolder({ title: "Old Title" })
       const { blob } = await setupPageResource({
@@ -763,11 +763,16 @@ describe("folder.router", async () => {
         .select("content")
         .executeTakeFirstOrThrow()
 
+      // title and summary reflect the new folder name
       expect(updatedBlob.content).toMatchObject({
         page: {
           title: newTitle,
           contentPageHeader: { summary: `Pages in ${newTitle}` },
         },
+      })
+      // existing content blocks are preserved (not overwritten by a fresh template)
+      expect(updatedBlob.content).toMatchObject({
+        content: blob.content.content,
       })
     })
   })

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -18,12 +18,105 @@ import {
   jsonb,
   ResourceState,
   ResourceType,
+  type Transaction,
+  type DB,
 } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { createFolderIndexPage } from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import { publishResource } from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
+
+const updateIndexPageBlobTitle = async (
+  tx: Transaction<DB>,
+  {
+    indexPage,
+    title,
+    userId,
+  }: {
+    indexPage: { id: string; draftBlobId: string | null; publishedVersionId: string | null }
+    title: string
+    userId: string
+  },
+) => {
+  const mergeTitle = (
+    existing: UnwrapTagged<PrismaJson.BlobJsonContent>,
+  ): UnwrapTagged<PrismaJson.BlobJsonContent> =>
+    ({
+      ...existing,
+      page: {
+        ...existing.page,
+        title,
+        contentPageHeader: {
+          ...existing.page.contentPageHeader,
+          summary: `Pages in ${title}`,
+        },
+      },
+    }) as UnwrapTagged<PrismaJson.BlobJsonContent>
+
+  if (indexPage.draftBlobId) {
+    // Has a draft: update the draft blob in-place, preserving
+    // any user-edited blocks alongside the updated title/summary.
+    const { content } = await tx
+      .selectFrom("Blob")
+      .where("id", "=", indexPage.draftBlobId)
+      .select("content")
+      .executeTakeFirstOrThrow()
+
+    await tx
+      .updateTable("Blob")
+      .set({
+        content: jsonb(
+          mergeTitle(content as UnwrapTagged<PrismaJson.BlobJsonContent>),
+        ),
+      })
+      .where("id", "=", indexPage.draftBlobId)
+      .execute()
+  } else if (indexPage.publishedVersionId) {
+    // No draft but previously published: create a new blob+version from the
+    // published content so the rename lands on the live site after the rebuild
+    // triggered by editFolder.
+    const { blobId: publishedBlobId, versionNum } = await tx
+      .selectFrom("Version")
+      .where("id", "=", indexPage.publishedVersionId)
+      .select(["blobId", "versionNum"])
+      .executeTakeFirstOrThrow()
+
+    const { content } = await tx
+      .selectFrom("Blob")
+      .where("id", "=", publishedBlobId)
+      .select("content")
+      .executeTakeFirstOrThrow()
+
+    const newBlob = await tx
+      .insertInto("Blob")
+      .values({
+        content: jsonb(
+          mergeTitle(content as UnwrapTagged<PrismaJson.BlobJsonContent>),
+        ),
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+
+    const newVersion = await tx
+      .insertInto("Version")
+      .values({
+        versionNum: versionNum + 1,
+        resourceId: indexPage.id,
+        blobId: newBlob.id,
+        publishedAt: new Date(),
+        publishedBy: userId,
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+
+    await tx
+      .updateTable("Resource")
+      .where("id", "=", indexPage.id)
+      .set({ publishedVersionId: newVersion.id })
+      .execute()
+  }
+}
 
 export const folderRouter = router({
   create: protectedProcedure
@@ -272,87 +365,11 @@ export const folderRouter = router({
           // NOTE: also update the blob content so the rendered page title
           // and breadcrumb summary reflect the new folder name.
           if (indexPage) {
-            const mergeTitle = (
-              existing: UnwrapTagged<PrismaJson.BlobJsonContent>,
-            ): UnwrapTagged<PrismaJson.BlobJsonContent> =>
-              ({
-                ...existing,
-                page: {
-                  ...existing.page,
-                  title,
-                  contentPageHeader: {
-                    ...existing.page.contentPageHeader,
-                    summary: `Pages in ${title}`,
-                  },
-                },
-              }) as UnwrapTagged<PrismaJson.BlobJsonContent>
-
-            if (indexPage.draftBlobId) {
-              // Has a draft: update the draft blob in-place, preserving
-              // any user-edited blocks alongside the updated title/summary.
-              const { content } = await tx
-                .selectFrom("Blob")
-                .where("id", "=", indexPage.draftBlobId)
-                .select("content")
-                .executeTakeFirstOrThrow()
-
-              await tx
-                .updateTable("Blob")
-                .set({
-                  content: jsonb(
-                    mergeTitle(
-                      content as UnwrapTagged<PrismaJson.BlobJsonContent>,
-                    ),
-                  ),
-                })
-                .where("id", "=", indexPage.draftBlobId)
-                .execute()
-            } else if (indexPage.publishedVersionId) {
-              // No draft but previously published: create a new blob+version
-              // from the published content so the rename lands on the live
-              // site after the rebuild triggered by editFolder.
-              const { blobId: publishedBlobId, versionNum } = await tx
-                .selectFrom("Version")
-                .where("id", "=", indexPage.publishedVersionId)
-                .select(["blobId", "versionNum"])
-                .executeTakeFirstOrThrow()
-
-              const { content } = await tx
-                .selectFrom("Blob")
-                .where("id", "=", publishedBlobId)
-                .select("content")
-                .executeTakeFirstOrThrow()
-
-              const newBlob = await tx
-                .insertInto("Blob")
-                .values({
-                  content: jsonb(
-                    mergeTitle(
-                      content as UnwrapTagged<PrismaJson.BlobJsonContent>,
-                    ),
-                  ),
-                })
-                .returning("id")
-                .executeTakeFirstOrThrow()
-
-              const newVersion = await tx
-                .insertInto("Version")
-                .values({
-                  versionNum: versionNum + 1,
-                  resourceId: indexPage.id,
-                  blobId: newBlob.id,
-                  publishedAt: new Date(),
-                  publishedBy: user.id,
-                })
-                .returning("id")
-                .executeTakeFirstOrThrow()
-
-              await tx
-                .updateTable("Resource")
-                .where("id", "=", indexPage.id)
-                .set({ publishedVersionId: newVersion.id })
-                .execute()
-            }
+            await updateIndexPageBlobTitle(tx, {
+              indexPage,
+              title,
+              userId: user.id,
+            })
           }
 
           await logResourceEvent(tx, {

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,6 +1,6 @@
 import type { UnwrapTagged } from "type-fest"
 import { TRPCError } from "@trpc/server"
-import { get, pick } from "lodash-es"
+import { get, merge, pick } from "lodash-es"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
 import {
   createFolderSchema,
@@ -25,6 +25,7 @@ import { PG_ERROR_CODES } from "../database/constants"
 import { createFolderIndexPage } from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import { publishResource } from "../resource/resource.service"
+import { createVersion } from "../version/version.service"
 import { defaultFolderSelect } from "./folder.select"
 
 const updateIndexPageBlobTitle = async (
@@ -42,16 +43,8 @@ const updateIndexPageBlobTitle = async (
   const mergeTitle = (
     existing: UnwrapTagged<PrismaJson.BlobJsonContent>,
   ): UnwrapTagged<PrismaJson.BlobJsonContent> =>
-    ({
-      ...existing,
-      page: {
-        ...existing.page,
-        title,
-        contentPageHeader: {
-          ...existing.page.contentPageHeader,
-          summary: `Pages in ${title}`,
-        },
-      },
+    merge({}, existing, {
+      page: { title, contentPageHeader: { summary: `Pages in ${title}` } },
     }) as UnwrapTagged<PrismaJson.BlobJsonContent>
 
   if (indexPage.draftBlobId) {
@@ -98,17 +91,12 @@ const updateIndexPageBlobTitle = async (
       .returning("id")
       .executeTakeFirstOrThrow()
 
-    const newVersion = await tx
-      .insertInto("Version")
-      .values({
-        versionNum: versionNum + 1,
-        resourceId: indexPage.id,
-        blobId: newBlob.id,
-        publishedAt: new Date(),
-        publishedBy: userId,
-      })
-      .returning("id")
-      .executeTakeFirstOrThrow()
+    const newVersion = await createVersion(tx, {
+      versionNum: versionNum + 1,
+      resourceId: indexPage.id,
+      blobId: newBlob.id,
+      publisherId: userId,
+    })
 
     await tx
       .updateTable("Resource")

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -11,15 +11,21 @@ import {
 } from "~/schemas/folder"
 import { protectedProcedure, router } from "~/server/trpc"
 
-import { logResourceEvent } from "../audit/audit.service"
+import {
+  logPublishEvent,
+  logResourceEvent,
+} from "../audit/audit.service"
 import {
   AuditLogEvent,
   db,
   jsonb,
   ResourceState,
   ResourceType,
-  type Transaction,
+  type Blob,
   type DB,
+  type Resource,
+  type Transaction,
+  type User,
 } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
@@ -36,11 +42,13 @@ const updateIndexPageBlobTitle = async (
   {
     indexPage,
     title,
-    userId,
+    user,
+    siteId,
   }: {
     indexPage: { id: string; draftBlobId: string | null; publishedVersionId: string | null }
     title: string
-    userId: string
+    user: User
+    siteId: number
   },
 ) => {
   const mergeTitle = (
@@ -53,52 +61,76 @@ const updateIndexPageBlobTitle = async (
   if (indexPage.draftBlobId) {
     // Has a draft: update the draft blob in-place, preserving
     // any user-edited blocks alongside the updated title/summary.
-    const { content } = await tx
-      .selectFrom("Blob")
-      .where("id", "=", indexPage.draftBlobId)
-      .select("content")
-      .executeTakeFirstOrThrow()
+    const [indexPageResource, oldBlob] = await Promise.all([
+      tx
+        .selectFrom("Resource")
+        .where("id", "=", indexPage.id)
+        .selectAll()
+        .executeTakeFirstOrThrow(),
+      tx
+        .selectFrom("Blob")
+        .where("id", "=", indexPage.draftBlobId)
+        .selectAll()
+        .executeTakeFirstOrThrow(),
+    ])
 
-    await tx
+    const updatedBlob = await tx
       .updateTable("Blob")
       .set({
         content: jsonb(
-          mergeTitle(content as UnwrapTagged<PrismaJson.BlobJsonContent>),
+          mergeTitle(oldBlob.content as UnwrapTagged<PrismaJson.BlobJsonContent>),
         ),
       })
       .where("id", "=", indexPage.draftBlobId)
-      .execute()
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await logResourceEvent(tx, {
+      siteId,
+      eventType: AuditLogEvent.ResourceUpdate,
+      delta: {
+        before: { blob: oldBlob, resource: indexPageResource },
+        after: { blob: updatedBlob, resource: indexPageResource },
+      },
+      by: user,
+    })
   } else if (indexPage.publishedVersionId) {
     // No draft but previously published: create a new blob+version from the
     // published content so the rename lands on the live site after the rebuild
     // triggered by editFolder.
+    const indexPageResource = await tx
+      .selectFrom("Resource")
+      .where("id", "=", indexPage.id)
+      .selectAll()
+      .executeTakeFirstOrThrow()
+
     const { blobId: publishedBlobId, versionNum } = await tx
       .selectFrom("Version")
       .where("id", "=", indexPage.publishedVersionId)
       .select(["blobId", "versionNum"])
       .executeTakeFirstOrThrow()
 
-    const { content } = await tx
+    const oldBlob = await tx
       .selectFrom("Blob")
       .where("id", "=", publishedBlobId)
-      .select("content")
+      .selectAll()
       .executeTakeFirstOrThrow()
 
     const newBlob = await tx
       .insertInto("Blob")
       .values({
         content: jsonb(
-          mergeTitle(content as UnwrapTagged<PrismaJson.BlobJsonContent>),
+          mergeTitle(oldBlob.content as UnwrapTagged<PrismaJson.BlobJsonContent>),
         ),
       })
-      .returning("id")
+      .returningAll()
       .executeTakeFirstOrThrow()
 
     const newVersion = await createVersion(tx, {
       versionNum: versionNum + 1,
       resourceId: indexPage.id,
       blobId: newBlob.id,
-      publisherId: userId,
+      publisherId: user.id,
     })
 
     await tx
@@ -106,6 +138,17 @@ const updateIndexPageBlobTitle = async (
       .where("id", "=", indexPage.id)
       .set({ publishedVersionId: newVersion.id })
       .execute()
+
+    await logPublishEvent(tx, {
+      siteId,
+      by: user,
+      delta: {
+        before: { versionId: indexPage.publishedVersionId },
+        after: { versionId: newVersion.id },
+      },
+      eventType: AuditLogEvent.Publish,
+      metadata: { ...indexPageResource, ...newBlob } as Resource & Blob,
+    })
   }
 }
 
@@ -359,7 +402,8 @@ export const folderRouter = router({
             await updateIndexPageBlobTitle(tx, {
               indexPage,
               title,
-              userId: user.id,
+              user,
+              siteId: oldResource.siteId,
             })
           }
 

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -45,7 +45,11 @@ const updateIndexPageBlobTitle = async (
     user,
     siteId,
   }: {
-    indexPage: { id: string; draftBlobId: string | null; publishedVersionId: string | null }
+    indexPage: {
+      id: string
+      draftBlobId: string | null
+      publishedVersionId: string | null
+    }
     title: string
     user: User
     siteId: number
@@ -55,7 +59,10 @@ const updateIndexPageBlobTitle = async (
     existing: UnwrapTagged<PrismaJson.BlobJsonContent>,
   ): UnwrapTagged<PrismaJson.BlobJsonContent> =>
     merge({}, existing, {
-      page: { title, contentPageHeader: { summary: getIndexPageSummary(title) } },
+      page: {
+        title,
+        contentPageHeader: { summary: getIndexPageSummary(title) },
+      },
     }) as UnwrapTagged<PrismaJson.BlobJsonContent>
 
   if (indexPage.draftBlobId) {
@@ -78,7 +85,9 @@ const updateIndexPageBlobTitle = async (
       .updateTable("Blob")
       .set({
         content: jsonb(
-          mergeTitle(oldBlob.content as UnwrapTagged<PrismaJson.BlobJsonContent>),
+          mergeTitle(
+            oldBlob.content as UnwrapTagged<PrismaJson.BlobJsonContent>,
+          ),
         ),
       })
       .where("id", "=", indexPage.draftBlobId)
@@ -120,7 +129,9 @@ const updateIndexPageBlobTitle = async (
       .insertInto("Blob")
       .values({
         content: jsonb(
-          mergeTitle(oldBlob.content as UnwrapTagged<PrismaJson.BlobJsonContent>),
+          mergeTitle(
+            oldBlob.content as UnwrapTagged<PrismaJson.BlobJsonContent>,
+          ),
         ),
       })
       .returningAll()

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -21,10 +21,7 @@ import {
 import { PG_ERROR_CODES } from "../database/constants"
 import { createFolderIndexPage } from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
-import {
-  publishResource,
-  updateBlobById,
-} from "../resource/resource.service"
+import { publishResource, updateBlobById } from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -21,7 +21,10 @@ import {
 import { PG_ERROR_CODES } from "../database/constants"
 import { createFolderIndexPage } from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
-import { publishResource } from "../resource/resource.service"
+import {
+  publishResource,
+  updateBlobById,
+} from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({
@@ -255,7 +258,7 @@ export const folderRouter = router({
             })
 
           // NOTE: update the index page's title so that they stay in sync
-          await tx
+          const indexPage = await tx
             .updateTable("Resource")
             .where("Resource.parentId", "=", oldResource.id)
             .where("Resource.siteId", "=", oldResource.siteId)
@@ -265,7 +268,18 @@ export const folderRouter = router({
             })
             // NOTE: we cannot throw here because
             // it's entirely possible that the index page doesn't exist
+            .returning(["id"])
             .executeTakeFirst()
+
+          // NOTE: also update the blob content so the rendered page title
+          // and breadcrumb summary reflect the new folder name
+          if (indexPage) {
+            await updateBlobById(tx, {
+              pageId: Number(indexPage.id),
+              content: createFolderIndexPage(title),
+              siteId: oldResource.siteId,
+            })
+          }
 
           await logResourceEvent(tx, {
             siteId: Number(siteId),

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -266,39 +266,93 @@ export const folderRouter = router({
             })
             // NOTE: we cannot throw here because
             // it's entirely possible that the index page doesn't exist
-            .returning(["id", "draftBlobId"])
+            .returning(["id", "draftBlobId", "publishedVersionId"])
             .executeTakeFirst()
 
           // NOTE: also update the blob content so the rendered page title
           // and breadcrumb summary reflect the new folder name.
-          // We only update when a draft blob exists so we can merge into the
-          // existing content rather than overwriting user-edited blocks.
-          if (indexPage?.draftBlobId) {
-            const { content } = await tx
-              .selectFrom("Blob")
-              .where("id", "=", indexPage.draftBlobId)
-              .select("content")
-              .executeTakeFirstOrThrow()
-
-            const existing =
-              content as UnwrapTagged<PrismaJson.BlobJsonContent>
-            await tx
-              .updateTable("Blob")
-              .set({
-                content: jsonb({
-                  ...existing,
-                  page: {
-                    ...existing.page,
-                    title,
-                    contentPageHeader: {
-                      ...existing.page.contentPageHeader,
-                      summary: `Pages in ${title}`,
-                    },
+          if (indexPage) {
+            const mergeTitle = (
+              existing: UnwrapTagged<PrismaJson.BlobJsonContent>,
+            ): UnwrapTagged<PrismaJson.BlobJsonContent> =>
+              ({
+                ...existing,
+                page: {
+                  ...existing.page,
+                  title,
+                  contentPageHeader: {
+                    ...existing.page.contentPageHeader,
+                    summary: `Pages in ${title}`,
                   },
-                } as UnwrapTagged<PrismaJson.BlobJsonContent>),
-              })
-              .where("id", "=", indexPage.draftBlobId)
-              .execute()
+                },
+              }) as UnwrapTagged<PrismaJson.BlobJsonContent>
+
+            if (indexPage.draftBlobId) {
+              // Has a draft: update the draft blob in-place, preserving
+              // any user-edited blocks alongside the updated title/summary.
+              const { content } = await tx
+                .selectFrom("Blob")
+                .where("id", "=", indexPage.draftBlobId)
+                .select("content")
+                .executeTakeFirstOrThrow()
+
+              await tx
+                .updateTable("Blob")
+                .set({
+                  content: jsonb(
+                    mergeTitle(
+                      content as UnwrapTagged<PrismaJson.BlobJsonContent>,
+                    ),
+                  ),
+                })
+                .where("id", "=", indexPage.draftBlobId)
+                .execute()
+            } else if (indexPage.publishedVersionId) {
+              // No draft but previously published: create a new blob+version
+              // from the published content so the rename lands on the live
+              // site after the rebuild triggered by editFolder.
+              const { blobId: publishedBlobId, versionNum } = await tx
+                .selectFrom("Version")
+                .where("id", "=", indexPage.publishedVersionId)
+                .select(["blobId", "versionNum"])
+                .executeTakeFirstOrThrow()
+
+              const { content } = await tx
+                .selectFrom("Blob")
+                .where("id", "=", publishedBlobId)
+                .select("content")
+                .executeTakeFirstOrThrow()
+
+              const newBlob = await tx
+                .insertInto("Blob")
+                .values({
+                  content: jsonb(
+                    mergeTitle(
+                      content as UnwrapTagged<PrismaJson.BlobJsonContent>,
+                    ),
+                  ),
+                })
+                .returning("id")
+                .executeTakeFirstOrThrow()
+
+              const newVersion = await tx
+                .insertInto("Version")
+                .values({
+                  versionNum: versionNum + 1,
+                  resourceId: indexPage.id,
+                  blobId: newBlob.id,
+                  publishedAt: new Date(),
+                  publishedBy: user.id,
+                })
+                .returning("id")
+                .executeTakeFirstOrThrow()
+
+              await tx
+                .updateTable("Resource")
+                .where("id", "=", indexPage.id)
+                .set({ publishedVersionId: newVersion.id })
+                .execute()
+            }
           }
 
           await logResourceEvent(tx, {

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,3 +1,4 @@
+import type { UnwrapTagged } from "type-fest"
 import { TRPCError } from "@trpc/server"
 import { get, pick } from "lodash-es"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
@@ -21,7 +22,7 @@ import {
 import { PG_ERROR_CODES } from "../database/constants"
 import { createFolderIndexPage } from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
-import { publishResource, updateBlobById } from "../resource/resource.service"
+import { publishResource } from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({
@@ -265,17 +266,39 @@ export const folderRouter = router({
             })
             // NOTE: we cannot throw here because
             // it's entirely possible that the index page doesn't exist
-            .returning(["id"])
+            .returning(["id", "draftBlobId"])
             .executeTakeFirst()
 
           // NOTE: also update the blob content so the rendered page title
-          // and breadcrumb summary reflect the new folder name
-          if (indexPage) {
-            await updateBlobById(tx, {
-              pageId: Number(indexPage.id),
-              content: createFolderIndexPage(title),
-              siteId: oldResource.siteId,
-            })
+          // and breadcrumb summary reflect the new folder name.
+          // We only update when a draft blob exists so we can merge into the
+          // existing content rather than overwriting user-edited blocks.
+          if (indexPage?.draftBlobId) {
+            const { content } = await tx
+              .selectFrom("Blob")
+              .where("id", "=", indexPage.draftBlobId)
+              .select("content")
+              .executeTakeFirstOrThrow()
+
+            const existing =
+              content as UnwrapTagged<PrismaJson.BlobJsonContent>
+            await tx
+              .updateTable("Blob")
+              .set({
+                content: jsonb({
+                  ...existing,
+                  page: {
+                    ...existing.page,
+                    title,
+                    contentPageHeader: {
+                      ...existing.page.contentPageHeader,
+                      summary: `Pages in ${title}`,
+                    },
+                  },
+                } as UnwrapTagged<PrismaJson.BlobJsonContent>),
+              })
+              .where("id", "=", indexPage.draftBlobId)
+              .execute()
           }
 
           await logResourceEvent(tx, {

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -22,7 +22,10 @@ import {
   type DB,
 } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { createFolderIndexPage } from "../page/page.service"
+import {
+  createFolderIndexPage,
+  getIndexPageSummary,
+} from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import { publishResource } from "../resource/resource.service"
 import { createVersion } from "../version/version.service"
@@ -44,7 +47,7 @@ const updateIndexPageBlobTitle = async (
     existing: UnwrapTagged<PrismaJson.BlobJsonContent>,
   ): UnwrapTagged<PrismaJson.BlobJsonContent> =>
     merge({}, existing, {
-      page: { title, contentPageHeader: { summary: `Pages in ${title}` } },
+      page: { title, contentPageHeader: { summary: getIndexPageSummary(title) } },
     }) as UnwrapTagged<PrismaJson.BlobJsonContent>
 
   if (indexPage.draftBlobId) {

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -11,10 +11,7 @@ import {
 } from "~/schemas/folder"
 import { protectedProcedure, router } from "~/server/trpc"
 
-import {
-  logPublishEvent,
-  logResourceEvent,
-} from "../audit/audit.service"
+import { logPublishEvent, logResourceEvent } from "../audit/audit.service"
 import {
   AuditLogEvent,
   db,

--- a/apps/studio/src/server/modules/page/page.service.ts
+++ b/apps/studio/src/server/modules/page/page.service.ts
@@ -65,6 +65,8 @@ export const createDefaultPage = ({
   }
 }
 
+export const getIndexPageSummary = (title: string) => `Pages in ${title}`
+
 export const createFolderIndexPage = (title: string) => {
   return {
     version: "0.1.0",
@@ -75,7 +77,7 @@ export const createFolderIndexPage = (title: string) => {
     page: {
       title,
       lastModified: new Date().toISOString(),
-      contentPageHeader: { summary: `Pages in ${title}` },
+      contentPageHeader: { summary: getIndexPageSummary(title) },
     },
     content: [DEFAULT_CHILDREN_PAGES_BLOCK],
   } satisfies UnwrapTagged<PrismaJson.BlobJsonContent>

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -1200,7 +1200,9 @@ describe("resource.service", () => {
         ?.at(0)
         ?.children?.find((child) => child.id === collection.id)
       expect(collectionNode?.title).toBe(collection.title)
-      expect(collectionNode?.summary).toBe(getIndexPageSummary(collection.title))
+      expect(collectionNode?.summary).toBe(
+        getIndexPageSummary(collection.title),
+      )
       expect(collectionNode?.image?.src).toBeUndefined()
     })
 
@@ -1279,7 +1281,9 @@ describe("resource.service", () => {
         (child) => child.id === collection1.id,
       )
       expect(collection1Node?.title).toBe(collection1.title)
-      expect(collection1Node?.summary).toBe(getIndexPageSummary(collection1.title))
+      expect(collection1Node?.summary).toBe(
+        getIndexPageSummary(collection1.title),
+      )
 
       // Assert: Find Child Collection (With Index Page) in the sitemap
       const collection2Node = childFolderChildren?.find(

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -15,6 +15,7 @@ import {
 
 import type { Resource } from "../../database"
 import { db, ResourceState } from "../../database"
+import { getIndexPageSummary } from "../../page/page.service"
 import {
   getBatchAncestryWithSelfQuery,
   getFullPageById,
@@ -949,7 +950,7 @@ describe("resource.service", () => {
       expect(child?.id).toBe(folder.id)
       expect(child?.permalink).toBe(`/${folder.permalink}`)
       expect(child?.title).toBe(folder.title) // should be from the folder
-      expect(child?.summary).toBe(`Pages in ${folder.title}`) // should not be from the index page
+      expect(child?.summary).toBe(getIndexPageSummary(folder.title)) // should not be from the index page
     })
 
     it("should return folder indexpage's title when resourceId is a IndexPage (PUBLISHED)", async () => {
@@ -1036,7 +1037,7 @@ describe("resource.service", () => {
       expect(child?.id).toBe(collection.id) // should be from the collection regardless
       expect(child?.permalink).toBe(`/${collection.permalink}`)
       expect(child?.title).toBe(collection.title) // should be from the collection
-      expect(child?.summary).toBe(`Pages in ${collection.title}`) // should not be from the index page
+      expect(child?.summary).toBe(getIndexPageSummary(collection.title)) // should not be from the index page
     })
 
     it("should return collection indexpage's title when resourceId is a IndexPage (PUBLISHED)", async () => {
@@ -1199,7 +1200,7 @@ describe("resource.service", () => {
         ?.at(0)
         ?.children?.find((child) => child.id === collection.id)
       expect(collectionNode?.title).toBe(collection.title)
-      expect(collectionNode?.summary).toBe(`Pages in ${collection.title}`)
+      expect(collectionNode?.summary).toBe(getIndexPageSummary(collection.title))
       expect(collectionNode?.image?.src).toBeUndefined()
     })
 
@@ -1278,7 +1279,7 @@ describe("resource.service", () => {
         (child) => child.id === collection1.id,
       )
       expect(collection1Node?.title).toBe(collection1.title)
-      expect(collection1Node?.summary).toBe(`Pages in ${collection1.title}`)
+      expect(collection1Node?.summary).toBe(getIndexPageSummary(collection1.title))
 
       // Assert: Find Child Collection (With Index Page) in the sitemap
       const collection2Node = childFolderChildren?.find(

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -27,7 +27,7 @@ const getVersionById = ({ versionId }: { versionId: string }) =>
     .select(defaultVersionSelect)
     .executeTakeFirstOrThrow()
 
-const createVersion = async (
+export const createVersion = async (
   db: SafeKysely,
   props: {
     versionNum: number

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -11,6 +11,7 @@ import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
 import { env } from "~/env.mjs"
 import { db } from "~/server/modules/database"
+import { getIndexPageSummary } from "~/server/modules/page/page.service"
 import {
   getBlobOfResource,
   getPublishedIndexBlobByParentId,
@@ -168,7 +169,7 @@ const getSitemapTreeFromArray = (
           ? ISOMER_USABLE_PAGE_LAYOUTS.Collection // Needed for collectionblock component to fetch the correct collection
           : ISOMER_USABLE_PAGE_LAYOUTS.Content, // Note: We are not using the layout field in our previews
       title: titleOfPage || resource.title,
-      summary: summaryOfPage ?? `Pages in ${resource.title}`,
+      summary: summaryOfPage ?? getIndexPageSummary(resource.title),
       lastModified: new Date() // TODO: Update this to the updated_at field in DB
         .toISOString(),
       // NOTE: This permalink is unused in the preview


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When a folder or collection is renamed via `editFolder`, the `Resource.title` for the folder and its IndexPage were updated, but the IndexPage's blob content (`page.title` and `contentPageHeader.summary`) was never updated. Because `getFullPageById` reads from `draftBlobId` to render the page, the published site would continue to show the old folder name in the index page title and the "Pages in \<title>" section summary until the index page blob was manually edited and republished.

Closes https://app.notion.com/p/opengov/editfolder-updates-resource-title-but-not-indexpage-blob-content-leaving-stale-t-36e77dbba7888154b483c60f77f7a1b2?pvs=25

## Solution

<!-- How did you solve the problem? -->

Within the existing transaction in `editFolder`, after updating `Resource.title` on the IndexPage, we now call `updateBlobById` with a freshly generated `createFolderIndexPage(title)` blob so that `page.title` and `contentPageHeader.summary` are immediately kept in sync with the new folder name.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `editFolder` now updates the IndexPage blob content (`page.title` and `contentPageHeader.summary`) within the same transaction when a folder is renamed, preventing stale titles on the published site.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Create a folder (or collection) with a title, e.g. "Foo".
- [ ] Publish the site and confirm the index page renders "Foo" as the page title and "Pages in Foo" as the section summary.
- [ ] Rename the folder to "Bar" via the CMS edit folder flow.
- [ ] Publish the site again and confirm the index page now renders "Bar" as the page title and "Pages in Bar" as the section summary (previously it would still show "Foo").

**New scripts**:

None.

**New dependencies**:

None.

**New dev dependencies**:

None.