### PR TITLE
fix: match logout events by email in audit log query

### DIFF
--- a/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
@@ -33,7 +33,7 @@ const insertAuditLog = async ({
   ipAddress?: string | null
   createdAt?: Date
 }) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
   const values: any = {
     eventType,
     userId,
@@ -1048,7 +1048,7 @@ describe("getAuditLogQuery", () => {
       const buildQuery = () =>
         getAuditLogQuery({
           siteId,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // oxlint-disable-next-line @typescript-eslint/no-explicit-any
           type: "unknown" as any,
           monthYear: TEST_MONTH,
         })

--- a/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
@@ -16,6 +16,41 @@ const MONTH_START = startOfMonth(TEST_DATE)
 const MONTH_END = endOfMonth(TEST_DATE)
 const MID_MONTH = new Date("2026-01-15T12:00:00.000Z")
 
+interface UsersQueryRow {
+  Email: string
+  '"Last login"': Date | null
+  Role: string
+  '"Date added"': Date
+}
+
+interface EventsQueryRow {
+  '"Date and time"': Date
+  '"Event type"': AuditLogEvent
+  '"Account creation date"': Date | null
+  '"Last login date"': Date | null
+  Description: unknown
+  Delta: unknown
+  Email: string | null
+  Metadata: unknown
+  Name: string | null
+}
+
+const getUsersRows = async (params: { siteId: number; monthYear: string }) => {
+  const result = await getAuditLogQuery({
+    ...params,
+    type: "users",
+  }).execute()
+  return result as unknown as UsersQueryRow[]
+}
+
+const getEventsRows = async (params: { siteId: number; monthYear: string }) => {
+  const result = await getAuditLogQuery({
+    ...params,
+    type: "events",
+  }).execute()
+  return result as unknown as EventsQueryRow[]
+}
+
 const insertAuditLog = async ({
   eventType,
   userId,
@@ -33,8 +68,7 @@ const insertAuditLog = async ({
   ipAddress?: string | null
   createdAt?: Date
 }) => {
-  // oxlint-disable-next-line @typescript-eslint/no-explicit-any
-  const values: any = {
+  const baseValues = {
     eventType,
     userId,
     siteId,
@@ -42,14 +76,16 @@ const insertAuditLog = async ({
     metadata: jsonb(metadata),
     ipAddress,
   }
-  if (createdAt !== undefined) {
-    values.createdAt = createdAt
-  }
-  return db
-    .insertInto("AuditLog")
-    .values(values)
-    .returningAll()
-    .executeTakeFirstOrThrow()
+  const values =
+    createdAt !== undefined ? { ...baseValues, createdAt } : baseValues
+  return (
+    db
+      .insertInto("AuditLog")
+      // oxlint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument
+      .values(values as any)
+      .returningAll()
+      .executeTakeFirstOrThrow()
+  )
 }
 
 // Group A: pure unit tests — no DB required
@@ -165,11 +201,7 @@ describe("getAuditLogQuery", () => {
   describe("users query", () => {
     it("returns users with non-deleted permission with expected columns", async () => {
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "users",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getUsersRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -186,11 +218,7 @@ describe("getAuditLogQuery", () => {
       await setupAdminPermissions({ userId: ogpUser.id, siteId })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "users",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getUsersRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const emails = rows.map((r) => r.Email)
@@ -208,11 +236,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "users",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getUsersRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows.map((r) => r.Email)).not.toContain("deleted@agency.gov.sg")
@@ -228,11 +252,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "users",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getUsersRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows.map((r) => r.Email)).not.toContain("other@agency.gov.sg")
@@ -247,11 +267,7 @@ describe("getAuditLogQuery", () => {
       await setupAdminPermissions({ userId: oldUser.id, siteId })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "users",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getUsersRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows.map((r) => r.Email)).toContain("old@agency.gov.sg")
@@ -273,11 +289,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe('"My Page" (Page 5) created')
@@ -297,11 +309,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe('"T" (Page 5) updated')
@@ -321,11 +329,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe('"T" (Page 5) updated')
@@ -342,11 +346,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe('"T" (Page 5) deleted')
@@ -364,11 +364,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe(
@@ -387,11 +383,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe("Publish")
@@ -408,11 +400,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe("Navbar has been updated")
@@ -429,11 +417,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe("Footer has been updated")
@@ -450,11 +434,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe("Site configuration has been updated")
@@ -472,11 +452,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe(
@@ -499,11 +475,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows[0]!.Description).toBe(
@@ -525,11 +497,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const row = rows.find((r) => r['"Event type"'] === AuditLogEvent.Login)
@@ -550,11 +518,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const row = rows.find((r) => r['"Event type"'] === AuditLogEvent.Logout)
@@ -577,11 +541,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -599,11 +559,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -621,11 +577,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(0)
@@ -649,11 +601,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(0)
@@ -673,11 +621,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -698,11 +642,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(0)
@@ -729,11 +669,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const loginRow = rows.find(
@@ -757,11 +693,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -781,11 +713,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(0)
@@ -805,11 +733,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const logoutRow = rows.find(
@@ -837,11 +761,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const logoutRow = rows.find(
@@ -863,11 +783,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const logoutRow = rows.find(
@@ -890,11 +806,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -911,11 +823,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(1)
@@ -932,11 +840,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(0)
@@ -953,11 +857,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(0)
@@ -991,11 +891,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       expect(rows).toHaveLength(3)
@@ -1027,11 +923,7 @@ describe("getAuditLogQuery", () => {
       })
 
       // Act
-      const rows = await getAuditLogQuery({
-        siteId,
-        type: "events",
-        monthYear: TEST_MONTH,
-      }).execute()
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const loginRow = rows.find(
@@ -1059,12 +951,7 @@ describe("getAuditLogQuery", () => {
 
     it("malformed monthYear throws a database error (Invalid Date → invalid timestamp)", async () => {
       // Act
-      const execute = () =>
-        getAuditLogQuery({
-          siteId,
-          type: "events",
-          monthYear: "garbage",
-        }).execute()
+      const execute = () => getEventsRows({ siteId, monthYear: "garbage" })
 
       // Assert
       await expect(execute()).rejects.toThrow()

--- a/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
@@ -1,0 +1,1073 @@
+import { addMilliseconds, endOfMonth, parse, startOfMonth } from "date-fns"
+import { AuditLogEvent, db, jsonb } from "~/server/modules/database"
+
+import { resetTables } from "../../../tests/integration/helpers/db"
+import {
+  setupAdminPermissions,
+  setupEditorPermissions,
+  setupSite,
+  setupUser,
+} from "../../../tests/integration/helpers/seed"
+import { getAuditLogQuery, getStringifiedValue } from "../getAuditLogs"
+
+const TEST_MONTH = "2026-01"
+const TEST_DATE = parse(TEST_MONTH, "yyyy-MM", new Date())
+const MONTH_START = startOfMonth(TEST_DATE)
+const MONTH_END = endOfMonth(TEST_DATE)
+const MID_MONTH = new Date("2026-01-15T12:00:00.000Z")
+
+const insertAuditLog = async ({
+  eventType,
+  userId,
+  siteId = null,
+  delta,
+  metadata = {},
+  ipAddress = null,
+  createdAt,
+}: {
+  eventType: AuditLogEvent
+  userId: string
+  siteId?: number | null
+  delta: object
+  metadata?: object
+  ipAddress?: string | null
+  createdAt?: Date
+}) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const values: any = {
+    eventType,
+    userId,
+    siteId,
+    delta: jsonb(delta),
+    metadata: jsonb(metadata),
+    ipAddress,
+  }
+  if (createdAt !== undefined) {
+    values.createdAt = createdAt
+  }
+  return db
+    .insertInto("AuditLog")
+    .values(values)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+// Group A: pure unit tests — no DB required
+describe("getStringifiedValue", () => {
+  it("returns empty string for null", () => {
+    // Act
+    const result = getStringifiedValue(null)
+
+    // Assert
+    expect(result).toBe("")
+  })
+
+  it("returns empty string for undefined", () => {
+    // Act
+    const result = getStringifiedValue(undefined)
+
+    // Assert
+    expect(result).toBe("")
+  })
+
+  it("returns ISO string for Date", () => {
+    // Arrange
+    const date = new Date("2025-01-15T10:00:00.000Z")
+
+    // Act
+    const result = getStringifiedValue(date)
+
+    // Assert
+    expect(result).toBe("2025-01-15T10:00:00.000Z")
+  })
+
+  it("returns the string as-is", () => {
+    // Act
+    const result = getStringifiedValue("hello")
+
+    // Assert
+    expect(result).toBe("hello")
+  })
+
+  it("returns empty string for empty string (not confused with null)", () => {
+    // Act
+    const result = getStringifiedValue("")
+
+    // Assert
+    expect(result).toBe("")
+  })
+
+  it("returns '0' for zero (falsy number is not dropped)", () => {
+    // Act
+    const result = getStringifiedValue(0)
+
+    // Assert
+    expect(result).toBe("0")
+  })
+
+  it("returns 'false' for boolean false", () => {
+    // Act
+    const result = getStringifiedValue(false)
+
+    // Assert
+    expect(result).toBe("false")
+  })
+
+  it("returns JSON-stringified object", () => {
+    // Act
+    const result = getStringifiedValue({ a: 1 })
+
+    // Assert
+    expect(result).toBe('{"a":1}')
+  })
+
+  it("returns JSON-stringified array", () => {
+    // Act
+    const result = getStringifiedValue([1, 2])
+
+    // Assert
+    expect(result).toBe("[1,2]")
+  })
+
+  it("returns JSON-stringified nested delta shape", () => {
+    // Arrange
+    const delta = { before: { email: "a@b.com" }, after: null }
+
+    // Act
+    const result = getStringifiedValue(delta)
+
+    // Assert
+    expect(result).toBe('{"before":{"email":"a@b.com"},"after":null}')
+  })
+})
+
+// Groups B–G: integration tests requiring a real DB
+describe("getAuditLogQuery", () => {
+  let siteId: number
+  let user: Awaited<ReturnType<typeof setupUser>>
+
+  beforeEach(async () => {
+    await resetTables(
+      "AuditLog",
+      "ResourcePermission",
+      "User",
+      "Site",
+      "Navbar",
+      "Footer",
+    )
+    const { site } = await setupSite()
+    siteId = site.id
+    user = await setupUser({ email: "user@agency.gov.sg" })
+    await setupAdminPermissions({ userId: user.id, siteId })
+  })
+
+  // Group B: users query
+  describe("users query", () => {
+    it("returns users with non-deleted permission with expected columns", async () => {
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "users",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+      const row = rows[0]!
+      expect(row.Email).toBe(user.email)
+      expect(row.Role).toBe("Admin")
+      expect('"Last login"' in row).toBe(true)
+      expect('"Date added"' in row).toBe(true)
+    })
+
+    it("excludes @open.gov.sg emails", async () => {
+      // Arrange
+      const ogpUser = await setupUser({ email: "admin@open.gov.sg" })
+      await setupAdminPermissions({ userId: ogpUser.id, siteId })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "users",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const emails = rows.map((r) => r.Email)
+      expect(emails).not.toContain("admin@open.gov.sg")
+      expect(emails).toContain(user.email)
+    })
+
+    it("excludes soft-deleted permissions", async () => {
+      // Arrange
+      const deletedUser = await setupUser({ email: "deleted@agency.gov.sg" })
+      await setupEditorPermissions({
+        userId: deletedUser.id,
+        siteId,
+        isDeleted: true,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "users",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows.map((r) => r.Email)).not.toContain("deleted@agency.gov.sg")
+    })
+
+    it("excludes users permissioned on a different site", async () => {
+      // Arrange
+      const otherUser = await setupUser({ email: "other@agency.gov.sg" })
+      const { site: otherSite } = await setupSite()
+      await setupAdminPermissions({
+        userId: otherUser.id,
+        siteId: otherSite.id,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "users",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows.map((r) => r.Email)).not.toContain("other@agency.gov.sg")
+    })
+
+    it("ignores monthYear — users with lastLoginAt outside the month still appear", async () => {
+      // Arrange
+      const oldUser = await setupUser({
+        email: "old@agency.gov.sg",
+        lastLoginAt: new Date("2020-01-01"),
+      })
+      await setupAdminPermissions({ userId: oldUser.id, siteId })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "users",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows.map((r) => r.Email)).toContain("old@agency.gov.sg")
+    })
+  })
+
+  // Group C: events description rendering
+  describe("events query — description rendering", () => {
+    it("ResourceCreate: correct description", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.ResourceCreate,
+        userId: user.id,
+        siteId,
+        delta: {
+          after: { resource: { title: "My Page", type: "Page", id: 5 } },
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe('"My Page" (Page 5) created')
+    })
+
+    it("ResourceUpdate ordinary: uses resource path from before", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.ResourceUpdate,
+        userId: user.id,
+        siteId,
+        delta: {
+          before: { resource: { title: "T", type: "Page", id: 5 } },
+          after: { resource: { title: "T2", type: "Page", id: 5 } },
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe('"T" (Page 5) updated')
+    })
+
+    it("ResourceUpdate special path: uses top-level title from before when present", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.ResourceUpdate,
+        userId: user.id,
+        siteId,
+        delta: {
+          before: { title: "T", type: "Page", id: 5 },
+          after: { title: "T2", type: "Page", id: 5 },
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe('"T" (Page 5) updated')
+    })
+
+    it("ResourceDelete: correct description", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.ResourceDelete,
+        userId: user.id,
+        siteId,
+        delta: { before: { title: "T", type: "Page", id: 5 } },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe('"T" (Page 5) deleted')
+    })
+
+    it("Publish ordinary: correct description with version number", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.Publish,
+        userId: user.id,
+        siteId,
+        delta: { before: { something: true }, after: { versionNum: 3 } },
+        metadata: { title: "T", type: "Page", id: 5 },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe(
+        '"T" (Page 5) published to Version No. 3',
+      )
+    })
+
+    it("Publish special path: both before and after null returns 'Publish'", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.Publish,
+        userId: user.id,
+        siteId,
+        delta: { before: null, after: null },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe("Publish")
+    })
+
+    it("NavbarUpdate: correct description", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe("Navbar has been updated")
+    })
+
+    it("FooterUpdate: correct description", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.FooterUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe("Footer has been updated")
+    })
+
+    it("SiteConfigUpdate: correct description", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.SiteConfigUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe("Site configuration has been updated")
+    })
+
+    it("PermissionCreate: resolves target user email via left join", async () => {
+      // Arrange
+      const targetUser = await setupUser({ email: "target@agency.gov.sg" })
+      await insertAuditLog({
+        eventType: AuditLogEvent.PermissionCreate,
+        userId: user.id,
+        siteId,
+        delta: { after: { userId: targetUser.id, role: "Admin" } },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe(
+        "Permission (Admin) granted to target@agency.gov.sg",
+      )
+    })
+
+    it("PermissionDelete: resolves target user email via left join", async () => {
+      // Arrange
+      const targetUser = await setupUser({ email: "target@agency.gov.sg" })
+      await insertAuditLog({
+        eventType: AuditLogEvent.PermissionDelete,
+        userId: user.id,
+        siteId,
+        delta: {
+          before: { userId: targetUser.id, role: "Editor" },
+          after: { userId: targetUser.id },
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows[0]!.Description).toBe(
+        "Permission (Editor) revoked from target@agency.gov.sg",
+      )
+    })
+
+    it("Login: extracts email and IP from identifier field", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.Login,
+        userId: user.id,
+        siteId: null,
+        delta: {
+          before: { identifier: "user@agency.gov.sg|203.0.113.1" },
+          after: null,
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const row = rows.find((r) => r['"Event type"'] === AuditLogEvent.Login)
+      expect(row!.Description).toBe(
+        "Login attempt by user@agency.gov.sg from IP address 203.0.113.1",
+      )
+    })
+
+    it("Logout: extracts email from delta.before and IP from ipAddress column", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: user.id,
+        siteId: null,
+        delta: { before: { email: "user@agency.gov.sg" }, after: null },
+        ipAddress: "1.2.3.4",
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const row = rows.find((r) => r['"Event type"'] === AuditLogEvent.Logout)
+      expect(row!.Description).toBe(
+        "Logout attempt by user@agency.gov.sg from IP address 1.2.3.4",
+      )
+    })
+  })
+
+  // Group D: events filtering / inclusion logic
+  describe("events filtering / inclusion", () => {
+    it("displayable event with al.siteId matching is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+    })
+
+    it("displayable event with delta.after.siteId matching but different al.siteId is included", async () => {
+      // Arrange
+      const { site: otherSite } = await setupSite()
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId: otherSite.id,
+        delta: { after: { siteId } },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+    })
+
+    it("displayable event matching neither al.siteId nor delta.after.siteId is excluded", async () => {
+      // Arrange
+      const { site: otherSite } = await setupSite()
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId: otherSite.id,
+        delta: {},
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(0)
+    })
+
+    it.each([
+      AuditLogEvent.UserCreate,
+      AuditLogEvent.UserUpdate,
+      AuditLogEvent.UserDelete,
+      AuditLogEvent.PermissionUpdate,
+      AuditLogEvent.SchedulePublish,
+      AuditLogEvent.CancelSchedulePublish,
+    ])("excluded event type %s is not returned", async (eventType) => {
+      // Arrange
+      await insertAuditLog({
+        eventType,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(0)
+    })
+
+    it("Login by a site user email is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.Login,
+        userId: user.id,
+        siteId: null,
+        delta: {
+          before: { identifier: `${user.email}|1.2.3.4` },
+          after: null,
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+    })
+
+    it("Login by email with no site association is excluded", async () => {
+      // Arrange
+      const nonSiteUser = await setupUser({ email: "nonsite@agency.gov.sg" })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Login,
+        userId: nonSiteUser.id,
+        siteId: null,
+        delta: {
+          before: { identifier: "nonsite@agency.gov.sg|1.2.3.4" },
+          after: null,
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(0)
+    })
+
+    it("Login by user with in-month PermissionCreate is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.PermissionCreate,
+        userId: user.id,
+        siteId,
+        delta: { after: { userId: user.id, role: "Admin" } },
+        createdAt: MID_MONTH,
+      })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Login,
+        userId: user.id,
+        siteId: null,
+        delta: {
+          before: { identifier: `${user.email}|1.2.3.4` },
+          after: null,
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const loginRow = rows.find(
+        (r) => r['"Event type"'] === AuditLogEvent.Login,
+      )
+      expect(loginRow).toBeDefined()
+    })
+  })
+
+  // Group E: Logout regression tests — validates the fix on this branch
+  describe("logout regression tests", () => {
+    it("regression: Logout by a site user with delta.before.email is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: user.id,
+        siteId: null,
+        delta: { before: { email: user.email }, after: null },
+        ipAddress: "1.2.3.4",
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+      expect(rows[0]!['"Event type"']).toBe(AuditLogEvent.Logout)
+    })
+
+    it("Logout by non-site email is excluded", async () => {
+      // Arrange
+      const nonSiteUser = await setupUser({ email: "nonsite@agency.gov.sg" })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: nonSiteUser.id,
+        siteId: null,
+        delta: { before: { email: "nonsite@agency.gov.sg" }, after: null },
+        ipAddress: "1.2.3.4",
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(0)
+    })
+
+    it("Logout by @open.gov.sg email is excluded", async () => {
+      // Arrange
+      const ogpUser = await setupUser({ email: "admin@open.gov.sg" })
+      await setupAdminPermissions({ userId: ogpUser.id, siteId })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: ogpUser.id,
+        siteId: null,
+        delta: { before: { email: "admin@open.gov.sg" }, after: null },
+        ipAddress: "1.2.3.4",
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const logoutRow = rows.find(
+        (r) => r['"Event type"'] === AuditLogEvent.Logout,
+      )
+      expect(logoutRow).toBeUndefined()
+    })
+
+    it("Logout by user with in-month PermissionCreate is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.PermissionCreate,
+        userId: user.id,
+        siteId,
+        delta: { after: { userId: user.id, role: "Admin" } },
+        createdAt: MID_MONTH,
+      })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: user.id,
+        siteId: null,
+        delta: { before: { email: user.email }, after: null },
+        ipAddress: "1.2.3.4",
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const logoutRow = rows.find(
+        (r) => r['"Event type"'] === AuditLogEvent.Logout,
+      )
+      expect(logoutRow).toBeDefined()
+    })
+
+    it("Logout with null delta.before.email is excluded without crashing", async () => {
+      // Arrange
+      const nonSiteUser = await setupUser({ email: "ghost@agency.gov.sg" })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: nonSiteUser.id,
+        siteId: null,
+        delta: { before: null, after: null },
+        ipAddress: "1.2.3.4",
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const logoutRow = rows.find(
+        (r) => r['"Event type"'] === AuditLogEvent.Logout,
+      )
+      expect(logoutRow).toBeUndefined()
+    })
+  })
+
+  // Group F: date-range scoping
+  describe("date-range scoping", () => {
+    it("event at exactly startOfMonth is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MONTH_START,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+    })
+
+    it("event at exactly endOfMonth is included", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: MONTH_END,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(1)
+    })
+
+    it("event one millisecond before startOfMonth is excluded", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: addMilliseconds(MONTH_START, -1),
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(0)
+    })
+
+    it("event one millisecond into next month is excluded", async () => {
+      // Arrange
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: addMilliseconds(MONTH_END, 1),
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(0)
+    })
+
+    it("results are ordered by createdAt asc", async () => {
+      // Arrange
+      const t1 = new Date("2026-01-10T00:00:00.000Z")
+      const t2 = new Date("2026-01-20T00:00:00.000Z")
+      const t3 = new Date("2026-01-15T00:00:00.000Z")
+      await insertAuditLog({
+        eventType: AuditLogEvent.NavbarUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: t1,
+      })
+      await insertAuditLog({
+        eventType: AuditLogEvent.FooterUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: t2,
+      })
+      await insertAuditLog({
+        eventType: AuditLogEvent.SiteConfigUpdate,
+        userId: user.id,
+        siteId,
+        delta: {},
+        createdAt: t3,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      expect(rows).toHaveLength(3)
+      expect(rows[0]!['"Date and time"']).toEqual(t1)
+      expect(rows[1]!['"Date and time"']).toEqual(t3)
+      expect(rows[2]!['"Date and time"']).toEqual(t2)
+    })
+
+    it("PermissionCreate from a prior month does not widen Login allow-list for current month", async () => {
+      // Arrange
+      const priorUser = await setupUser({ email: "prior@agency.gov.sg" })
+      const priorMid = new Date("2025-12-15T12:00:00.000Z")
+      await insertAuditLog({
+        eventType: AuditLogEvent.PermissionCreate,
+        userId: user.id,
+        siteId,
+        delta: { after: { userId: priorUser.id, role: "Editor" } },
+        createdAt: priorMid,
+      })
+      await insertAuditLog({
+        eventType: AuditLogEvent.Login,
+        userId: priorUser.id,
+        siteId: null,
+        delta: {
+          before: { identifier: "prior@agency.gov.sg|1.2.3.4" },
+          after: null,
+        },
+        createdAt: MID_MONTH,
+      })
+
+      // Act
+      const rows = await getAuditLogQuery({
+        siteId,
+        type: "events",
+        monthYear: TEST_MONTH,
+      }).execute()
+
+      // Assert
+      const loginRow = rows.find(
+        (r) => r['"Event type"'] === AuditLogEvent.Login,
+      )
+      expect(loginRow).toBeUndefined()
+    })
+  })
+
+  // Group G: invalid / edge-case input
+  describe("invalid / edge-case input", () => {
+    it("throws for unknown type", () => {
+      // Act
+      const buildQuery = () =>
+        getAuditLogQuery({
+          siteId,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          type: "unknown" as any,
+          monthYear: TEST_MONTH,
+        })
+
+      // Assert
+      expect(buildQuery).toThrow("Unknown type: unknown")
+    })
+
+    it("malformed monthYear throws a database error (Invalid Date → invalid timestamp)", async () => {
+      // Act
+      const execute = () =>
+        getAuditLogQuery({
+          siteId,
+          type: "events",
+          monthYear: "garbage",
+        }).execute()
+
+      // Assert
+      await expect(execute()).rejects.toThrow()
+    })
+  })
+})

--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -159,7 +159,7 @@ const AUDIT_LOGS_EVENTS_QUERIES: Record<
   Logout: sql<string>`CONCAT('Logout attempt by ', al.delta -> 'before' ->> 'email', ' from IP address ', al."ipAddress")`,
 }
 
-const getAuditLogQuery = ({
+export const getAuditLogQuery = ({
   siteId,
   type,
   monthYear,
@@ -213,7 +213,7 @@ const getAuditLogQuery = ({
         .with("emailsFromUsers", (eb) =>
           eb
             .selectFrom("User")
-            .select("User.email")
+            .select(["User.email", "User.id"])
             .where("User.email", "not like", "%@open.gov.sg")
             .where("User.id", "in", (fb) =>
               fb
@@ -325,7 +325,7 @@ const getAuditLogQuery = ({
             ]),
             eb.and([
               eb("al.eventType", "=", AuditLogEvent.Logout),
-              eb("al.userId", "in", (fb) =>
+              eb(sql<string>`al.delta -> 'before' ->> 'email'`, "in", (fb) =>
                 fb
                   .selectFrom("emailsFromUsers")
                   .select("emailsFromUsers.email")
@@ -348,7 +348,7 @@ const getAuditLogQuery = ({
   }
 }
 
-const getStringifiedValue = (value: unknown) => {
+export const getStringifiedValue = (value: unknown) => {
   if (value === null || value === undefined) {
     return ""
   }
@@ -417,4 +417,6 @@ const getAuditLogsForSite = async () => {
   console.log('All audit logs saved in "output" folder')
 }
 
-await getAuditLogsForSite()
+// Only run when executed directly, not when imported by tests
+const isMain = process.argv[1] === fileURLToPath(import.meta.url)
+if (isMain) await getAuditLogsForSite()

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -4,7 +4,7 @@ import { configDefaults, defineConfig } from "vitest/config"
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    dir: "src",
+    include: ["src/**/*.test.{ts,tsx}", "prisma/scripts/**/*.test.ts"],
     retry: 0,
     globals: true,
     exclude: [...configDefaults.exclude, "**/tests/e2e/**", "tests/load/**"],


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Logout audit log events were silently dropped from monthly CSV exports because the filter compared `al.userId` (a cuid string) against a set of user email addresses — a comparison that can never match, so all logout rows were excluded.

Closes https://app.notion.com/p/opengov/logout-events-for-current-site-users-silently-omitted-userid-compared-against-em-36e77dbba78881ee9903d8e8ceb54443

Closes https://app.notion.com/p/opengov/logout-filter-compares-userid-to-email-strings-dropping-all-logout-events-for-cu-36e77dbba78881e0bb9cf6460b060f50

## Solution

<!-- How did you solve the problem? -->

Changed the logout filter in `getAuditLogQuery` to extract the email from `al.delta -> 'before' ->> 'email'` and match it against the `emailsFromUsers` CTE, which is the correct field written by the logout event handler.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Extended `vitest.config.ts` include pattern to cover `prisma/scripts/` so script-level tests are picked up by the test runner.
- Exported `getAuditLogQuery` and `getStringifiedValue` from the script and guarded the top-level `await getAuditLogsForSite()` call behind an ESM main check so the module can be safely imported by tests without executing.

**Bug Fixes**:

- `getAuditLogQuery` events query: logout events for site users are now correctly included in audit log exports instead of being silently dropped.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Added `apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts` with 53 tests (10 pure unit, 43 integration) covering:
- `getStringifiedValue`: all value types including falsy edge cases
- Users query: column presence, OGP exclusion, soft-delete exclusion, cross-site isolation, date-range ignorance
- Events query descriptions: all 13 event types including both `ResourceUpdate` and `Publish` special paths
- Events filtering: siteId matching, `delta.after.siteId` fallback, excluded event types, Login inclusion/exclusion
- Logout regression (the core fix): site-user logout included, non-site excluded, OGP excluded, null email safe
- Date-range scoping: inclusive boundaries, out-of-range exclusion, `asc` ordering, CTE date scoping
- Edge cases: unknown type throws, malformed `monthYear` throws