### PR TITLE
fix(build): handle CloudFront PreconditionFailed race condition gracefully

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -218,4 +218,43 @@ echo "ETag: $ETag"
 
 jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
 jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
-aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag
+
+# Temporarily disable set -e so we can inspect the exit code and error message before deciding
+# whether to fail or warn. Re-enabled immediately after the command.
+set +e
+UPDATE_DISTRIBUTION_OUTPUT=$(aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag 2>&1)
+UPDATE_DISTRIBUTION_EXIT_CODE=$?
+set -e
+
+if [ $UPDATE_DISTRIBUTION_EXIT_CODE -ne 0 ]; then
+  # PreconditionFailed means the ETag we read no longer matches the distribution's current ETag,
+  # i.e. someone updated the distribution between our get-distribution and update-distribution calls.
+  # This can happen legitimately when two builds run concurrently for the same site and the other
+  # build won the race. In that case it's safe to skip our update — but only if the distribution
+  # already points to a build that is at least as new as ours. If the current origin path is older
+  # or unrecognised (e.g. a manual or IaC change), we still want to fail loudly so the operator
+  # knows our build's content is not being served.
+  if echo "$UPDATE_DISTRIBUTION_OUTPUT" | grep -q "PreconditionFailed"; then
+    # Re-fetch the distribution to see what origin path won the race.
+    CURRENT_ORIGIN_PATH=$(aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID \
+      | jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath')
+    echo "PreconditionFailed: current origin path is $CURRENT_ORIGIN_PATH"
+
+    # Extract the build number from the current origin path (format: /<site>/<build>/latest).
+    CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed "s|/$SITE_NAME/||; s|/latest||")
+
+    # Only skip if the winning update already points to a newer-or-equal build for this site.
+    # A non-numeric result means the path is in an unexpected format (manual change, wrong site,
+    # etc.) and we should not silently accept it.
+    if [[ "$CURRENT_BUILD_NUMBER" =~ ^[0-9]+$ ]] && [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
+      echo "Warning: CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). Concurrent build won the race — skipping update."
+    else
+      echo "Error: PreconditionFailed but current origin path ($CURRENT_ORIGIN_PATH) does not point to a newer build. A non-build update may have occurred. Manual inspection required."
+      exit 1
+    fi
+  else
+    # Any other AWS error should still fail the build.
+    echo "$UPDATE_DISTRIBUTION_OUTPUT"
+    exit $UPDATE_DISTRIBUTION_EXIT_CODE
+  fi
+fi

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -241,7 +241,10 @@ if [ $UPDATE_DISTRIBUTION_EXIT_CODE -ne 0 ]; then
     echo "PreconditionFailed: current origin path is $CURRENT_ORIGIN_PATH"
 
     # Extract the build number from the current origin path (format: /<site>/<build>/latest).
-    CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed "s|/$SITE_NAME/||; s|/latest||")
+    # The anchored pattern returns an empty string for any path that does not strictly match
+    # /<site>/<digits>/latest (e.g. a path missing /latest, or from a different site), which
+    # causes the numeric check below to fail and the build to exit loudly as intended.
+    CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed -n "s|^/$SITE_NAME/\([0-9]\+\)/latest$|\1|p")
 
     # Only skip if the winning update already points to a newer-or-equal build for this site.
     # A non-numeric result means the path is in an unexpected format (manual change, wrong site,

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -224,44 +224,29 @@ echo "ETag: $ETag"
 jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
 jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
 
-# Temporarily disable set -e so we can inspect the exit code and error message before deciding
-# whether to fail or warn. Re-enabled immediately after the command.
+# Disable errexit so we can handle PreconditionFailed without aborting.
 set +e
 UPDATE_DISTRIBUTION_OUTPUT=$(aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag 2>&1)
 UPDATE_DISTRIBUTION_EXIT_CODE=$?
 set -e
 
 if [ $UPDATE_DISTRIBUTION_EXIT_CODE -ne 0 ]; then
-  # PreconditionFailed means the ETag we read no longer matches the distribution's current ETag,
-  # i.e. someone updated the distribution between our get-distribution and update-distribution calls.
-  # This can happen legitimately when two builds run concurrently for the same site and the other
-  # build won the race. In that case it's safe to skip our update — but only if the distribution
-  # already points to a build that is at least as new as ours. If the current origin path is older
-  # or unrecognised (e.g. a manual or IaC change), we still want to fail loudly so the operator
-  # knows our build's content is not being served.
-  if echo "$UPDATE_DISTRIBUTION_OUTPUT" | grep -q "PreconditionFailed"; then
-    # Re-fetch the distribution to see what origin path won the race.
+  # Concurrent publishes race on the CloudFront ETag. If we lose, only skip our update
+  # when the distribution already points at this site's build >= ours.
+  if [[ "$UPDATE_DISTRIBUTION_OUTPUT" == *PreconditionFailed* ]]; then
     CURRENT_ORIGIN_PATH=$(aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID \
       | jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath')
     echo "PreconditionFailed: current origin path is $CURRENT_ORIGIN_PATH"
 
-    # Extract the build number from the current origin path (format: /<site>/<build>/latest).
-    # The anchored pattern returns an empty string for any path that does not strictly match
-    # /<site>/<digits>/latest (e.g. a path missing /latest, or from a different site), which
-    # causes the numeric check below to fail and the build to exit loudly as intended.
     CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed -n "s|^/$SITE_NAME/\([0-9]\+\)/latest$|\1|p")
 
-    # Only skip if the winning update already points to a newer-or-equal build for this site.
-    # A non-numeric result means the path is in an unexpected format (manual change, wrong site,
-    # etc.) and we should not silently accept it.
-    if [[ "$CURRENT_BUILD_NUMBER" =~ ^[0-9]+$ ]] && [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
-      echo "Warning: CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). Concurrent build won the race — skipping update."
+    if [ -n "$CURRENT_BUILD_NUMBER" ] && [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
+      echo "Warning: CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). Concurrent build won the race, skipping update."
     else
-      echo "Error: PreconditionFailed but current origin path ($CURRENT_ORIGIN_PATH) does not point to a newer build. A non-build update may have occurred. Manual inspection required."
+      echo "Error: PreconditionFailed but current origin path ($CURRENT_ORIGIN_PATH) does not point to a newer build."
       exit 1
     fi
   else
-    # Any other AWS error should still fail the build.
     echo "$UPDATE_DISTRIBUTION_OUTPUT"
     exit $UPDATE_DISTRIBUTION_EXIT_CODE
   fi

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -223,4 +223,43 @@ echo "ETag: $ETag"
 
 jq '.Distribution.DistributionConfig' distribution.json >distribution-new.json
 jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\"" distribution-new.json >distribution-config.json
-aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag
+
+# Temporarily disable set -e so we can inspect the exit code and error message before deciding
+# whether to fail or warn. Re-enabled immediately after the command.
+set +e
+UPDATE_DISTRIBUTION_OUTPUT=$(aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag 2>&1)
+UPDATE_DISTRIBUTION_EXIT_CODE=$?
+set -e
+
+if [ $UPDATE_DISTRIBUTION_EXIT_CODE -ne 0 ]; then
+  # PreconditionFailed means the ETag we read no longer matches the distribution's current ETag,
+  # i.e. someone updated the distribution between our get-distribution and update-distribution calls.
+  # This can happen legitimately when two builds run concurrently for the same site and the other
+  # build won the race. In that case it's safe to skip our update — but only if the distribution
+  # already points to a build that is at least as new as ours. If the current origin path is older
+  # or unrecognised (e.g. a manual or IaC change), we still want to fail loudly so the operator
+  # knows our build's content is not being served.
+  if echo "$UPDATE_DISTRIBUTION_OUTPUT" | grep -q "PreconditionFailed"; then
+    # Re-fetch the distribution to see what origin path won the race.
+    CURRENT_ORIGIN_PATH=$(aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID \
+      | jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath')
+    echo "PreconditionFailed: current origin path is $CURRENT_ORIGIN_PATH"
+
+    # Extract the build number from the current origin path (format: /<site>/<build>/latest).
+    CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed "s|/$SITE_NAME/||; s|/latest||")
+
+    # Only skip if the winning update already points to a newer-or-equal build for this site.
+    # A non-numeric result means the path is in an unexpected format (manual change, wrong site,
+    # etc.) and we should not silently accept it.
+    if [[ "$CURRENT_BUILD_NUMBER" =~ ^[0-9]+$ ]] && [ "$CURRENT_BUILD_NUMBER" -ge "$CODEBUILD_BUILD_NUMBER" ]; then
+      echo "Warning: CloudFront already points to build $CURRENT_BUILD_NUMBER (>= ours: $CODEBUILD_BUILD_NUMBER). Concurrent build won the race — skipping update."
+    else
+      echo "Error: PreconditionFailed but current origin path ($CURRENT_ORIGIN_PATH) does not point to a newer build. A non-build update may have occurred. Manual inspection required."
+      exit 1
+    fi
+  else
+    # Any other AWS error should still fail the build.
+    echo "$UPDATE_DISTRIBUTION_OUTPUT"
+    exit $UPDATE_DISTRIBUTION_EXIT_CODE
+  fi
+fi

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -216,7 +216,7 @@ calculate_duration $start_time
 # Update CloudFront origin path
 echo "Updating CloudFront origin path..."
 echo "CloudFront distribution ID: $CLOUDFRONT_DISTRIBUTION_ID"
-aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID >distribution.json
+aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" >distribution.json
 
 ETag=$(cat distribution.json | jq -r '.ETag')
 echo "ETag: $ETag"
@@ -226,15 +226,15 @@ jq ".Origins.Items[0].OriginPath = \"/$SITE_NAME/$CODEBUILD_BUILD_NUMBER/latest\
 
 # Disable errexit so we can handle PreconditionFailed without aborting.
 set +e
-UPDATE_DISTRIBUTION_OUTPUT=$(aws cloudfront update-distribution --id $CLOUDFRONT_DISTRIBUTION_ID --distribution-config file://distribution-config.json --if-match $ETag 2>&1)
+UPDATE_DISTRIBUTION_OUTPUT=$(aws cloudfront update-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" --distribution-config file://distribution-config.json --if-match "$ETag" 2>&1)
 UPDATE_DISTRIBUTION_EXIT_CODE=$?
 set -e
 
-if [ $UPDATE_DISTRIBUTION_EXIT_CODE -ne 0 ]; then
+if [ "$UPDATE_DISTRIBUTION_EXIT_CODE" -ne 0 ]; then
   # Concurrent publishes race on the CloudFront ETag. If we lose, only skip our update
   # when the distribution already points at this site's build >= ours.
   if [[ "$UPDATE_DISTRIBUTION_OUTPUT" == *PreconditionFailed* ]]; then
-    CURRENT_ORIGIN_PATH=$(aws cloudfront get-distribution --id $CLOUDFRONT_DISTRIBUTION_ID \
+    CURRENT_ORIGIN_PATH=$(aws cloudfront get-distribution --id "$CLOUDFRONT_DISTRIBUTION_ID" \
       | jq -r '.Distribution.DistributionConfig.Origins.Items[0].OriginPath')
     echo "PreconditionFailed: current origin path is $CURRENT_ORIGIN_PATH"
 

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -246,7 +246,10 @@ if [ $UPDATE_DISTRIBUTION_EXIT_CODE -ne 0 ]; then
     echo "PreconditionFailed: current origin path is $CURRENT_ORIGIN_PATH"
 
     # Extract the build number from the current origin path (format: /<site>/<build>/latest).
-    CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed "s|/$SITE_NAME/||; s|/latest||")
+    # The anchored pattern returns an empty string for any path that does not strictly match
+    # /<site>/<digits>/latest (e.g. a path missing /latest, or from a different site), which
+    # causes the numeric check below to fail and the build to exit loudly as intended.
+    CURRENT_BUILD_NUMBER=$(echo "$CURRENT_ORIGIN_PATH" | sed -n "s|^/$SITE_NAME/\([0-9]\+\)/latest$|\1|p")
 
     # Only skip if the winning update already points to a newer-or-equal build for this site.
     # A non-numeric result means the path is in an unexpected format (manual change, wrong site,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +29 | -2 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When two CodeBuild jobs run concurrently for the same site, the second job fails with a `PreconditionFailed` error when calling `UpdateDistribution` because the first job already updated the CloudFront distribution, changing its ETag. This causes the CodeBuild job to fail even though the site is already pointing to a valid (newer) build.

## Solution

<!-- How did you solve the problem? -->

Instead of immediately failing on `PreconditionFailed`, the script now re-fetches the distribution to inspect the current origin path. If the current origin path already points to a build number >= the current build's number, it means a concurrent build legitimately won the race — a warning is logged and the build continues. If the origin path is older, unrecognised, or in an unexpected format (indicating a manual or IaC change rather than a race), the build still fails loudly so the operator knows the new content is not being served.

> [!WARNING]
> to test on staging first before merging 

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Prevent spurious CodeBuild failures caused by a `PreconditionFailed` race condition when updating the CloudFront origin path

## Before & After Screenshots

N/A — CodeBuild/infrastructure change only.

## Tests

**Manual Verification Steps**:

- [ ] Trigger two concurrent CodeBuild jobs for the same site and confirm that both jobs complete successfully, with only a warning logged by the job that lost the race
- [ ] Confirm the CloudFront distribution's origin path reflects the newer build number after both jobs finish
- [ ] Trigger a single CodeBuild job and confirm it still successfully updates the CloudFront origin path as before

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds graceful handling of the `PreconditionFailed` error that occurs when two concurrent CodeBuild jobs for the same site race to call `UpdateDistribution`. Instead of immediately aborting, the script now re-fetches the current CloudFront origin path and only silently continues if a build with an equal or higher build number already won; any other state (older build, unexpected path format, manual IaC change) still fails loudly.

- The `sed` pattern used to extract the current build number is properly anchored (`^/$SITE_NAME/\([0-9]\+\)/latest$`) and uses `-n … p`, so paths lacking the `/latest` suffix, paths for a different site, or arbitrary manual paths return an empty string and trigger the `exit 1` branch.
- `set +e` / `set -e` is scoped tightly around the single `update-distribution` call; all subsequent commands (including the second `get-distribution`) run with errexit restored, so transient AWS failures in the re-check path abort the build rather than silently succeed.
- A minor quoting improvement on `$CLOUDFRONT_DISTRIBUTION_ID` is included as a bonus fix.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

- The change is safe to merge. The race-condition guard is narrowly scoped, all failure paths still abort the build, and the previously flagged unanchored `sed` issue is correctly resolved with a fully anchored pattern.
- The new error-handling block is short and the logic is straightforward: capture exit code, check for the specific AWS error string, re-fetch the origin path, extract the build number with a properly anchored sed pattern, and compare numerically. Every unexpected case (different error, unexpected path format, older build number) still causes `exit 1`. The `set -e` restoration before the second AWS call means transient re-check failures abort rather than silently pass. No pre-existing functionality is changed.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publisher.sh | Adds graceful PreconditionFailed handling for concurrent CloudFront UpdateDistribution calls; uses a properly anchored sed pattern to distinguish a legitimate concurrent-build race from a manual/IaC origin change, and fails loudly for the latter. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[aws cloudfront update-distribution] -->|exit 0| B[Success — done]
    A -->|exit non-zero| C{PreconditionFailed?}
    C -->|No| D[Print error\nexit with original code]
    C -->|Yes| E[Re-fetch distribution\nget current OriginPath]
    E --> F{OriginPath matches\n/SITE_NAME/digits/latest?}
    F -->|No match / unexpected format| G[Error: manual/IaC change\nexit 1]
    F -->|Matches| H{CURRENT_BUILD_NUMBER\n>= CODEBUILD_BUILD_NUMBER?}
    H -->|No — older build won| G
    H -->|Yes — newer or equal build won| I[Warning logged\nContinue — race lost gracefully]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(build): quote shell variables in Clo..."](https://github.com/opengovsg/isomer/commit/f090b0b3956963f8dbee207f30a59899fb68661e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746847)</sub>

<!-- /greptile_comment -->