### PR TITLE
docs(ai-workflow): define canonical Linear/Figma ticket fields

### DIFF
--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,0 +1,107 @@
+# AI-assisted workflow — canonical inputs
+
+This doc defines the **canonical contract** between humans, Linear, Figma, and any AI agent that triages or implements work in this repo. Triggers (webhooks, MCP fetches) read these fields; if they're missing or malformed, the agent must stop and ask rather than guess.
+
+If you change a field name or label here, you must also update the corresponding skill / webhook handler. Treat this doc as the source of truth.
+
+## Linear ticket fields
+
+Every ticket that an agent may pick up **must** carry the following:
+
+| Field             | Required for                | Notes                                                            |
+| ----------------- | --------------------------- | ---------------------------------------------------------------- |
+| `Title`           | all                         | Imperative, scoped. No "investigate X" titles for bugs.          |
+| `Description`     | all                         | Markdown. Sections below.                                        |
+| `Area` label      | all                         | One of: `area:studio`, `area:components`, `area:infra`, `area:db`. Drives which `CLAUDE.md` files the agent loads. |
+| `Type` label      | all                         | One of: `bug`, `feature`, `chore`, `design-iteration`.           |
+| `Risk` label      | feature, chore              | One of: `risk:low`, `risk:medium`, `risk:high`. Bugs are graded by the agent. |
+| `Trigger` label   | agent-eligible tickets only | `ai:triage` (let agent triage), `ai:implement` (let agent ship a PR). Absence = agent must not act. |
+| Figma frame URL   | features, design-iteration  | Paste the frame URL in the description. Frame must be named, not "Frame 47". |
+| Repro steps       | bugs                        | Numbered list in description.                                    |
+| Expected / actual | bugs                        | Two sub-headings in description.                                 |
+
+Anything else (priority, cycle, assignee) is for humans; agents ignore it.
+
+### Description template — bug
+
+```markdown
+## Repro
+1. ...
+2. ...
+
+## Expected
+...
+
+## Actual
+...
+
+## Environment
+- Browser / OS / role
+```
+
+### Description template — feature
+
+```markdown
+## Goal
+One sentence. What outcome the user gets.
+
+## Design
+- Figma frame: https://figma.com/...
+- Target location: `apps/studio/src/.../Foo.tsx` (or "new component in packages/components/src/templates/...")
+
+## Constraints
+- Must use existing design tokens
+- ...
+
+## Out of scope
+- ...
+```
+
+### Description template — design-iteration
+
+Used when a designer wants the agent to update an already-implemented component to match a new Figma frame.
+
+```markdown
+## Component
+`apps/studio/src/components/Foo/Bar.tsx`
+
+## Target frame
+https://figma.com/...
+
+## Changes from current
+- Header padding: 12 → 16
+- Primary CTA: solid → ghost
+```
+
+## Figma conventions
+
+For an agent to read a frame reliably:
+
+- **Frame names must be human-readable.** `Dashboard / Empty state` is fine; `Frame 47` is not — the agent will refuse.
+- **Components used in the frame must exist in our design library** or be flagged as "new primitive — needs eng review" in the description.
+- **Spacing/sizing should reference tokens** when present. If a value is hardcoded, the agent will ask before using a magic number.
+
+## GitHub PR conventions
+
+When the agent opens a PR, it must:
+
+1. Link the originating Linear ticket in the PR body (first line: `Closes ENG-123`).
+2. Tag the PR with `ai-authored` (label).
+3. Add a risk tier label (`risk:low` / `risk:medium` / `risk:high`) determined by the `pr-review` skill.
+4. Use a stacked branch via Graphite when the change spans more than one concern (see [CONTRIBUTING.md](../CONTRIBUTING.md#stacked-prs-with-graphite)).
+5. Include a **Root cause** section (bugs) or **Approach** section (features) in the PR body.
+
+## Slack / notifications
+
+- Bug PRs → `#isomer-eng-reviews` channel
+- Design iterations → `#isomer-design-reviews` channel, with the Chromatic preview link inline
+- Incident diagnoses → the incident channel for the firing monitor (see runbooks)
+
+## When the agent must stop and ask
+
+- A required field above is missing or malformed.
+- The ticket is labelled `risk:high` but the agent only has `ai:triage` permission (it can investigate but not open an implementing PR).
+- The area label points to a directory without a `CLAUDE.md` covering its conventions.
+- The Figma frame references a component not present in `packages/components/src/`.
+
+Stopping looks like: post a Linear comment listing what's missing, mark the ticket back to the human in the triage column. Never guess.


### PR DESCRIPTION
## Problem

Agent-triggered work (bug triage, feature implementation, code review) needs a stable contract for the inputs it reads from Linear and Figma. Without an agreed schema for required ticket fields, frame names, and labels, agent runs will silently produce poor work whenever a ticket is malformed.

No linked issue — part of the L2 → L3 foundation.

## Solution

Adds `docs/ai-workflow.md` defining the canonical Linear/Figma contract:

- Required Linear fields per ticket type (bug / feature / chore / design-iteration) with label conventions (`area:*`, `risk:*`, `ai:triage`, `ai:implement`)
- Description templates for bug, feature, and design-iteration tickets
- Figma frame naming + component referencing rules
- GitHub PR conventions for agent-authored PRs (link to Linear, risk label, stacked-branch requirement)
- The list of states where the agent must stop and ask instead of guessing

**Breaking Changes**

- [ ] Yes — this PR contains breaking changes
- [x] No — this PR is backwards compatible

**Improvements**:

- New `docs/ai-workflow.md` as the source of truth for any future skill / webhook that reads ticket data
- Skills introduced later in this stack (triage, bugfix, feature-plan, feature-implement, pr-review) read this file at run time

Doc-only; reverting has no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

