### PR TITLE
feat(skills): add pr-review skill that grades risk and flags coverage gaps

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pr-review
+description: Grade a pull request against the project risk taxonomy, flag hot-path touches, surface missing tests/stories, and post a structured review comment. Does not approve or merge.
+---
+
+# Instructions
+
+This skill grades the current pull request. It is read-only with respect to merge state — it never approves, never requests changes, never closes. It posts one annotated comment.
+
+If the request is to "review this PR" with full sign-off authority (typical human-engineer ask), prefer the `review-pr` skill instead. This skill is for **automation**: a structured grade that humans + CI consume.
+
+## Inputs
+
+- The current branch's diff against `main`.
+- `docs/risk-taxonomy.md` — file-glob → risk tier mapping. **Read this at run time, not from memory.**
+- `docs/ai-workflow.md` — canonical Linear/Figma fields and PR conventions.
+- All `CLAUDE.md` files under directories touched by the diff.
+
+## Procedure
+
+1. **Resolve the diff.** Use `git diff --name-only main...HEAD` to list changed files. If on `main`, abort.
+2. **Load the taxonomy.** Read `docs/risk-taxonomy.md`. Build the glob → tier table from the file as-is — do not hardcode.
+3. **Tier each file.** Match top-down; first match wins for that file. The PR tier is the max across all files.
+4. **Hot-path scan.** Cross-reference the "Hot paths to flag" section. Note any matches.
+5. **Convention scan.** For each touched directory with a `CLAUDE.md`, read it and look for diff content that violates a documented "Anti-pattern" or rule. Cite the file:line.
+6. **Coverage scan.**
+   - Touched `apps/studio/src/server/modules/**` without a corresponding `__tests__/` change → flag missing test.
+   - Touched `packages/components/src/templates/**/components/**` without a `*.stories.tsx` change → flag missing story.
+   - New tRPC procedure without an input schema in `apps/studio/src/schemas/` → flag.
+7. **Auto-approve eligibility.** If tier is `risk:low` AND every condition in the taxonomy's "Auto-approve caveats" holds, mark eligible. Otherwise mark not eligible with the failing condition.
+8. **Post the annotation.** Format below. Use `gh pr comment` to post to the current PR.
+
+## Output format
+
+The PR comment must be exactly this shape:
+
+```markdown
+## 🤖 PR review automation
+
+**Risk tier:** `risk:<low|medium|high>`
+**Auto-approve eligible:** yes | no — <one-line reason>
+
+### Hot paths touched
+- `<path>` — <why hot>
+(or: "None.")
+
+### Convention checks
+- ✅ <rule> — <file>
+- ⚠️  <rule violated> — <file:line>
+(or: "All checked rules pass.")
+
+### Coverage
+- Server module changed without test: <list>
+- Component changed without story: <list>
+- New procedure without schema: <list>
+(omit sections that don't apply)
+
+### Suggested reviewers
+<area owner from CODEOWNERS, or @-mention based on label>
+```
+
+## Hard rules
+
+- **Never approve, never request changes, never merge.** This skill comments only.
+- **Never bypass the taxonomy.** If the taxonomy says `risk:high`, the comment says `risk:high` — even if the diff "looks small".
+- **Read the taxonomy and CLAUDE.md files at run time.** Do not cache assumptions about file contents; the team updates them frequently.
+- **Cite file:line for every convention violation.** Vague comments are worse than no comments.
+- **Do not summarise the diff.** That's the PR description's job. This comment is grading only.
+
+## Failure modes
+
+- Diff has 0 files → exit silently. No comment.
+- `risk-taxonomy.md` missing → post a comment saying so and skip grading.
+- Convention scan throws → post a partial comment with what was completed and flag the failure for a human.
+
+## Anti-patterns the agent must refuse
+
+- Bypassing the risk taxonomy because "this change is obviously fine".
+- Approving a PR via this skill — wrong tool, use `review-pr`.
+- Adding speculative concerns not grounded in the diff or a documented rule.
+- Long prose explanations — keep each bullet under one line.


### PR DESCRIPTION
## Problem

Reviewers can't reliably tell at a glance whether an opened PR is low, medium, or high risk, what hot paths it touches, or whether it's missing required artefacts (tests for server modules, Storybook stories for components). Without a structured, automated annotation, PRs queue up against human attention bandwidth.

No linked issue — part of the L2 → L3 foundation. Builds on `docs/risk-taxonomy.md` (PR #2274).

## Solution

Adds `.claude/skills/pr-review/SKILL.md` — a skill that an agent invokes on an opened PR to post a structured grade comment. The skill:

- Reads `docs/risk-taxonomy.md` at run time (so taxonomy updates need no skill change)
- Tiers each touched file by matching globs top-down; PR tier = max
- Flags hot-path touches by cross-referencing the taxonomy's hot-path list
- Reads every `CLAUDE.md` under directories the diff touches and cites `file:line` for any documented anti-pattern violation
- Coverage scan: server module without test, component without story, new procedure without input schema
- Auto-approve eligibility: only `risk:low` + every caveat condition; otherwise marks the failing condition

The skill is **read-only with respect to merge state** — it posts one annotated comment and never approves, requests changes, or merges. Sign-off remains human.

**Breaking Changes**

- [ ] Yes — this PR contains breaking changes
- [x] No — this PR is backwards compatible

**Features**:

- New `pr-review` skill for agent-driven PR annotation

**Improvements**:

- Defined output format so the comment is consistent across runs and machine-readable for downstream automation
- Hard rules in the skill prevent it from approving or summarising the diff (separation from `review-pr` skill which is for full human-style sign-off)

This PR adds the skill file only. Wiring it into a GitHub Action that runs on `pull_request` is intentionally deferred — that requires an `AI_REVIEW_ENABLED` repo variable and agent credentials, and should land in its own PR with explicit infra approval.

Doc-only; reverting deletes the skill file with no runtime impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

