### PR TITLE
docs: foundation for L2 → L3 AI adoption (CLAUDE.md, skills, workflow docs)

### DIFF
--- a/.claude/skills/bugfix/SKILL.md
+++ b/.claude/skills/bugfix/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: bugfix
+description: Implement the minimal fix for an already-triaged bug, run the full test suite, and open a stacked PR via Graphite. Requires the `triage` skill to have run first.
+---
+
+# Instructions
+
+This skill ships the fix. It assumes the `triage` skill has already produced:
+
+- A failing test on the current branch.
+- A root-cause comment on the Linear ticket.
+- An "allow-list status: yes" determination per `docs/bug-automation-allowlist.md`.
+
+If any of those is missing, abort and run `triage` first. Do not freelance a fix without a failing test.
+
+## Procedure
+
+### 1. Verify prerequisites
+
+- Current branch has a failing test commit at HEAD.
+- Linear ticket has the triage summary comment.
+- The bug category is on the allow-list. Re-read `docs/bug-automation-allowlist.md` and confirm the category. If the category changed since `triage` ran, abort.
+
+### 2. Pick the minimal fix
+
+Constraints:
+
+- **Source code change ≤ 100 LOC.** Tests don't count.
+- Replace > delete. If the fix would remove more than 20 LOC of existing logic, you are not bug-fixing — you are refactoring. Abort.
+- One module. The fix touches one server module *or* one feature *or* one component.
+- No schema migrations.
+- No new dependencies.
+
+If you can't fit the fix inside these limits, stop. Post a Linear comment listing what's needed and hand back to a human.
+
+### 3. Apply the fix
+
+- Make the change on the current (triage) branch — same branch as the failing test, so the fix and the test land together.
+- Reuse existing helpers and utilities. Do not introduce new abstractions for a single bug fix.
+- Respect the area's `CLAUDE.md` (read it before editing). Cite the rule you're following in the PR body if non-obvious.
+- Add no comments unless the *why* of the fix would surprise a future reader (see project convention).
+
+### 4. Run the full local suite
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test:unit     # from apps/studio if the change is there
+```
+
+If any check fails:
+
+- If the failure is caused by your fix: iterate within the LOC budget.
+- If the failure is unrelated and pre-existing on `main`: stop and report. Do not push.
+
+The previously-failing test must now pass — confirm in the output before continuing.
+
+### 5. Commit and open the PR
+
+```bash
+gt create -m "fix(<area>): <one-line summary>"
+gt submit --draft
+```
+
+The PR body must contain:
+
+```markdown
+## Root cause
+<paste from triage>
+
+## Fix
+<one or two sentences — what changed, why this is the minimal fix>
+
+## Allow-list category
+<category from docs/bug-automation-allowlist.md>
+
+## Closes
+<Linear ticket ID>
+
+## Verification
+- Failing test from triage now passes: <path>
+- Full unit suite passes locally
+- typecheck + lint pass
+```
+
+Apply labels:
+
+- `ai-authored`
+- `risk:<tier>` per `docs/risk-taxonomy.md`
+- The originating `area:*` label from the Linear ticket
+
+### 6. Post to Linear
+
+Update the ticket with:
+
+```markdown
+## Bugfix PR opened
+
+PR: <url>
+Risk tier: <risk:low|medium>
+```
+
+## Hard rules
+
+- **No fix without a passing-from-failing test in the same PR.**
+- **Never push directly to main.** Always via `gt submit --draft`.
+- **Refuse to exceed 100 LOC source change.** Escalate instead.
+- **Never delete existing tests** to make CI pass. If a test is wrong, that's a separate PR.
+- **Never edit `prisma/`, `src/server/trpc.ts`, `src/server/modules/auth`, or any path in `risk:high`.** Allow-list excludes these.
+
+## Anti-patterns the agent must refuse
+
+- Adding a "defensive" check unrelated to the failing test.
+- Refactoring the file while fixing the bug ("while I was here").
+- Combining two bugs into one PR.
+- Disabling a flaky test to make CI green.
+- Inventing a feature flag to gate the fix.

--- a/.claude/skills/feature-implement/SKILL.md
+++ b/.claude/skills/feature-implement/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: feature-implement
+description: Implement a feature ticket. Hard guardrails — Storybook (FE) or tRPC test (BE) required, area conventions enforced via CLAUDE.md, stacked PRs via Graphite. Picks up from `feature-plan` or one-shot when eligible.
+---
+
+# Instructions
+
+This skill ships feature code. It enters from one of two paths:
+
+- **One-shot path**: the ticket qualifies under `docs/oneshot-vs-plan-threshold.md` and there is no `feature-plan` comment.
+- **Plan-first path**: a human replied `pick: A|B|C` to a `feature-plan` comment on the ticket.
+
+If you find yourself in this skill without one of those preconditions, abort and run `feature-plan`.
+
+## Inputs
+
+- The Linear ticket and (if applicable) the picked approach.
+- The Figma frame URL when relevant.
+- `docs/ai-workflow.md`, `docs/risk-taxonomy.md`, `docs/oneshot-vs-plan-threshold.md`.
+- All `CLAUDE.md` files in directories the change will touch — **read these before editing**.
+
+## Procedure
+
+### 1. Validate entry conditions
+
+- Linear ticket has the canonical fields.
+- Either: ticket is one-shot eligible per `docs/oneshot-vs-plan-threshold.md`, **or** there's a `pick:` reply on a `feature-plan` comment.
+- The picked approach (if plan-first) is still implementable on top of current `main`. If `main` moved in a way that invalidates the plan, re-run `feature-plan`.
+
+### 2. Read the area conventions
+
+For every directory you intend to edit, read its `CLAUDE.md`. Quote the relevant rules in your internal scratchpad. Plan the implementation against those rules — do not edit first and reconcile after.
+
+Particular files to re-read every time:
+
+- `apps/studio/src/server/CLAUDE.md` if touching the server
+- `apps/studio/src/features/CLAUDE.md` if touching a feature
+- `packages/components/CLAUDE.md` if touching the published-site renderer
+- `apps/studio/prisma/CLAUDE.md` if touching the schema
+
+### 3. Stack the work
+
+A feature lands as a Graphite stack of small PRs, not one big PR. Default split:
+
+1. **Schema / interface PR.** Type, Zod schema, JSON schema additions. Backward compatible.
+2. **Server PR.** New procedure, service, tests. Wires the new behaviour but is unreachable from the UI.
+3. **Client PR.** Hooks, components, page wiring. The user-visible change.
+4. **Story / Chromatic PR.** Storybook stories for FE work.
+
+If the change is one-shot eligible and trivially small (e.g. a single component update for design-iteration), one PR is OK.
+
+For each PR in the stack:
+
+```bash
+gt create -m "<conventional commit message scoped to that PR>"
+```
+
+### 4. Implement against the rules
+
+While writing:
+
+- Reuse existing helpers and primitives. Adding a new abstraction needs a justification one of: existing approach is fundamentally broken, three callers already exist, the convention doc calls for it.
+- No new dependencies without explicit ticket approval.
+- No new feature flags without explicit ticket approval.
+- Follow the area `CLAUDE.md` literally. If a rule there is wrong, the right move is to update that file in a separate PR, not to silently violate it.
+- Add no comments except where the *why* of the code is non-obvious. Don't narrate the code.
+
+### 5. Required artefacts per area
+
+**Frontend (`apps/studio/src/features/**`, `apps/studio/src/components/**`, `packages/components/src/templates/**`):**
+
+- A Storybook story covering empty, populated, and (where applicable) error states.
+- A component test if the component has interactive logic.
+
+**Backend (`apps/studio/src/server/modules/**`):**
+
+- A tRPC integration test using `createCallerFactory` — at least happy path + one permission-denied path.
+- An audit log call for every state mutation.
+- A rate limit `.meta()` for any procedure that triggers external side effects.
+
+**Schema (`apps/studio/src/schemas/**`, `packages/components/src/schemas/**`):**
+
+- User-facing `message` strings on every constraint.
+- A unit test for any schema with conditional rules.
+
+These are guardrails, not suggestions. A PR without the required artefact must not be opened.
+
+### 6. Verify locally
+
+For each PR in the stack, before `gt submit`:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm test:unit       # from apps/studio
+```
+
+For FE-only changes, also build Storybook to make sure stories render:
+
+```bash
+pnpm storybook       # from the relevant workspace, verify visually
+```
+
+If anything fails, fix on the current branch — do not move up the stack with red CI.
+
+### 7. Submit the stack
+
+```bash
+gt submit --stack --draft
+```
+
+For each PR:
+
+- Body must follow the template below.
+- Labels: `ai-authored`, `risk:<tier>` per `docs/risk-taxonomy.md`, `area:<name>` from the Linear ticket.
+- Link the Linear ticket on the bottom PR (`Closes ENG-123`).
+- The middle PRs reference the bottom one ("part of stack starting at #N").
+
+PR body template:
+
+```markdown
+## Goal
+<one sentence from the ticket>
+
+## Approach
+<which approach from feature-plan, or "one-shot" with the reason>
+
+## What this PR does
+<this PR's slice only — not the whole feature>
+
+## Stack
+- PR #N (this one) — <slice>
+- PR #N+1 — <slice>
+- ...
+
+## Verification
+- [ ] typecheck / lint / unit pass
+- [ ] Storybook story added (FE)
+- [ ] tRPC integration test added (BE)
+- [ ] Chromatic preview link (FE, after CI builds)
+
+## Closes
+<ticket id on the bottom PR only>
+```
+
+### 8. Post back to Linear
+
+Update the ticket:
+
+```markdown
+## Feature PRs opened
+
+Stack:
+- PR #N — <slice>
+- PR #N+1 — <slice>
+
+Risk: <tier>
+Awaiting: <review or design sign-off>
+```
+
+If this is a `design-iteration` and Chromatic is wired up, attach the preview link.
+
+## Hard rules
+
+- **Required artefacts are not optional.** No PR without the corresponding test / story.
+- **Stack, don't bundle.** A feature touching three layers ships as three PRs.
+- **Read every relevant `CLAUDE.md` before editing.** Don't reconstruct conventions from memory.
+- **No new dependencies, no new feature flags** without explicit ticket approval.
+- **Never amend or force-push the bottom of the stack** after later PRs land in review.
+- **Stop and re-plan** if the diff balloons past the planned LOC estimate by 2×.
+
+## Anti-patterns the agent must refuse
+
+- Combining FE + BE + schema changes into one PR.
+- Skipping the Storybook story because "the change is obvious".
+- Mocking the database in BE integration tests.
+- Adding `// TODO` markers without an attached follow-up ticket.
+- Editing `CLAUDE.md` to make a rule fit your implementation choice.
+- Squashing the stack into one branch before submitting.

--- a/.claude/skills/feature-plan/SKILL.md
+++ b/.claude/skills/feature-plan/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: feature-plan
+description: Produce 2-3 implementation approaches with trade-offs for a scoped feature ticket. Stops and waits for a human to pick. Does not write code.
+---
+
+# Instructions
+
+This skill turns a feature ticket into a small set of distinct approaches with clear trade-offs, then **stops and waits** for a human to pick. It does not write code. If the ticket is one-shot eligible per `docs/oneshot-vs-plan-threshold.md`, the `feature-implement` skill runs directly instead — this skill is not invoked.
+
+The output is a Linear comment a human can scan in 60 seconds and pick from.
+
+## Inputs
+
+- A Linear ticket ID and its content.
+- A Figma frame URL (for design work).
+- The repo at HEAD of `main`.
+- `docs/ai-workflow.md` for ticket field validation.
+- `docs/oneshot-vs-plan-threshold.md` to confirm plan-first is correct.
+- `CLAUDE.md` files in directories the feature will touch.
+
+## Procedure
+
+### 1. Validate the ticket
+
+Read the ticket. Verify the canonical fields per `docs/ai-workflow.md`:
+
+- `area:*` label, `feature` or `design-iteration` type label
+- `Goal`, `Design`, `Constraints`, `Out of scope` sections in the description
+- Figma frame URL with a human-readable frame name
+
+If anything is missing, post a Linear comment listing what's missing and stop.
+
+### 2. Confirm plan-first
+
+Re-check the one-shot thresholds in `docs/oneshot-vs-plan-threshold.md`. If the ticket qualifies for one-shot, abort and hand off to `feature-implement`.
+
+### 3. Generate 2-3 distinct approaches
+
+Each approach must:
+
+- Solve the goal stated in the ticket.
+- Be **materially different** from the others. Two approaches that differ only in variable naming or file location are one approach.
+- Be implementable in the codebase as it stands today — no "we'd need to introduce X first".
+- Have at least one *real* drawback. If you can't name a drawback, you haven't thought hard enough.
+
+Distinctness checklist — approaches should vary on at least one of:
+
+- Data model shape (e.g. HashMap vs array vs joined table)
+- Where the logic lives (server module vs client hook vs shared utility)
+- Compatibility surface (new endpoint vs extending an existing one)
+- User-visible behaviour (sync vs async, optimistic vs pessimistic)
+
+If only one approach is genuinely viable, post that finding to the ticket and stop — don't fabricate a second.
+
+### 4. Score each approach
+
+For each approach, populate:
+
+- **Sketch**: ≤ 5 bullets describing the implementation, with file paths.
+- **LOC estimate**: rough order of magnitude (50, 200, 500). Include tests and stories.
+- **Risk tier**: per `docs/risk-taxonomy.md`.
+- **Pros**: 2–4 bullets. Reuses existing patterns, fewer files, easier to roll back.
+- **Cons**: 2–4 bullets. The real ones, including future maintenance.
+- **Reversibility**: easy / medium / hard. Hard = "needs a migration to undo".
+
+### 5. Post to Linear and stop
+
+Format:
+
+```markdown
+## 🤖 Feature plan — <ticket-id>
+
+**Goal recap:** <one sentence from the ticket>
+**Plan-first because:** <which trigger from oneshot-vs-plan-threshold.md fired>
+
+---
+
+### Approach A — <name>
+- **Sketch:** ...
+- **LOC estimate:** ~N
+- **Risk:** risk:<tier>
+- **Reversibility:** ...
+- **Pros:** ...
+- **Cons:** ...
+
+### Approach B — <name>
+... (same shape)
+
+### Approach C — <name>
+... (same shape, if applicable)
+
+---
+
+**Agent recommendation:** Approach <A|B|C> — <one sentence why>.
+**Waiting for:** human picks an approach by replying with `pick: A|B|C`.
+```
+
+After posting, **stop**. Do not write code. Do not open a PR. Do not infer the choice.
+
+## Picking is the human's job
+
+If the comment thread receives a reply matching `pick: A`, `pick: B`, or `pick: C`, the `feature-implement` skill picks up with that selection. Anything else (questions, "what about X?", "combine A and B") is a request for the agent to rerun with new constraints — re-do step 3 from the new context.
+
+## Hard rules
+
+- **Never write code in this skill.** The deliverable is a Linear comment.
+- **Never pick the approach yourself.** The recommendation is a suggestion; the choice is human.
+- **No more than 3 approaches.** More than 3 is decision fatigue, not optionality.
+- **No fabricated alternatives.** If only one approach makes sense, say so.
+- **Cite file paths in every sketch.** Vague "add a service" is not a plan.
+
+## Anti-patterns the agent must refuse
+
+- Bundling all three approaches into one synthesis ("approach A but with B's data model").
+- Treating "use TypeScript" or "add tests" as a differentiator.
+- Skipping the cons because the recommended approach "is obviously right".
+- Proceeding to implement after posting, before a human picks.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: pr-review
+description: Grade a pull request against the project risk taxonomy, flag hot-path touches, surface missing tests/stories, and post a structured review comment. Does not approve or merge.
+---
+
+# Instructions
+
+This skill grades the current pull request. It is read-only with respect to merge state — it never approves, never requests changes, never closes. It posts one annotated comment.
+
+If the request is to "review this PR" with full sign-off authority (typical human-engineer ask), prefer the `review-pr` skill instead. This skill is for **automation**: a structured grade that humans + CI consume.
+
+## Inputs
+
+- The current branch's diff against `main`.
+- `docs/risk-taxonomy.md` — file-glob → risk tier mapping. **Read this at run time, not from memory.**
+- `docs/ai-workflow.md` — canonical Linear/Figma fields and PR conventions.
+- All `CLAUDE.md` files under directories touched by the diff.
+
+## Procedure
+
+1. **Resolve the diff.** Use `git diff --name-only main...HEAD` to list changed files. If on `main`, abort.
+2. **Load the taxonomy.** Read `docs/risk-taxonomy.md`. Build the glob → tier table from the file as-is — do not hardcode.
+3. **Tier each file.** Match top-down; first match wins for that file. The PR tier is the max across all files.
+4. **Hot-path scan.** Cross-reference the "Hot paths to flag" section. Note any matches.
+5. **Convention scan.** For each touched directory with a `CLAUDE.md`, read it and look for diff content that violates a documented "Anti-pattern" or rule. Cite the file:line.
+6. **Coverage scan.**
+   - Touched `apps/studio/src/server/modules/**` without a corresponding `__tests__/` change → flag missing test.
+   - Touched `packages/components/src/templates/**/components/**` without a `*.stories.tsx` change → flag missing story.
+   - New tRPC procedure without an input schema in `apps/studio/src/schemas/` → flag.
+7. **Auto-approve eligibility.** If tier is `risk:low` AND every condition in the taxonomy's "Auto-approve caveats" holds, mark eligible. Otherwise mark not eligible with the failing condition.
+8. **Post the annotation.** Format below. Use `gh pr comment` to post to the current PR.
+
+## Output format
+
+The PR comment must be exactly this shape:
+
+```markdown
+## 🤖 PR review automation
+
+**Risk tier:** `risk:<low|medium|high>`
+**Auto-approve eligible:** yes | no — <one-line reason>
+
+### Hot paths touched
+- `<path>` — <why hot>
+(or: "None.")
+
+### Convention checks
+- ✅ <rule> — <file>
+- ⚠️  <rule violated> — <file:line>
+(or: "All checked rules pass.")
+
+### Coverage
+- Server module changed without test: <list>
+- Component changed without story: <list>
+- New procedure without schema: <list>
+(omit sections that don't apply)
+
+### Suggested reviewers
+<area owner from CODEOWNERS, or @-mention based on label>
+```
+
+## Hard rules
+
+- **Never approve, never request changes, never merge.** This skill comments only.
+- **Never bypass the taxonomy.** If the taxonomy says `risk:high`, the comment says `risk:high` — even if the diff "looks small".
+- **Read the taxonomy and CLAUDE.md files at run time.** Do not cache assumptions about file contents; the team updates them frequently.
+- **Cite file:line for every convention violation.** Vague comments are worse than no comments.
+- **Do not summarise the diff.** That's the PR description's job. This comment is grading only.
+
+## Failure modes
+
+- Diff has 0 files → exit silently. No comment.
+- `risk-taxonomy.md` missing → post a comment saying so and skip grading.
+- Convention scan throws → post a partial comment with what was completed and flag the failure for a human.
+
+## Anti-patterns the agent must refuse
+
+- Bypassing the risk taxonomy because "this change is obviously fine".
+- Approving a PR via this skill — wrong tool, use `review-pr`.
+- Adding speculative concerns not grounded in the diff or a documented rule.
+- Long prose explanations — keep each bullet under one line.

--- a/.claude/skills/triage/SKILL.md
+++ b/.claude/skills/triage/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: triage
+description: Triage a bug from a Linear ticket — reproduce, locate suspect code, write a failing test. Stops before fixing. Use as the first step of any bug-driven agent run.
+---
+
+# Instructions
+
+This skill triages a bug. It does **not** fix it. The output is a failing test + a root-cause writeup posted to the Linear ticket. If the bug is in the allow-list at `docs/bug-automation-allowlist.md`, the `bugfix` skill picks up from here; otherwise a human takes over.
+
+## Inputs
+
+- A Linear ticket ID (or a ticket payload from the agent runner).
+- The repo at HEAD of `main`.
+- `docs/ai-workflow.md` for canonical Linear field validation.
+
+## Procedure
+
+### 1. Validate the ticket
+
+Read the ticket. Verify the canonical fields per `docs/ai-workflow.md`:
+
+- `area:*` label present
+- `bug` type label present
+- Description contains `## Repro`, `## Expected`, `## Actual`
+
+If any field is missing, post a Linear comment listing what's missing and stop. Do not guess.
+
+### 2. Reproduce
+
+Pick the most direct repro environment:
+
+- For UI bugs: spin up `pnpm dev` and follow the repro steps. Use the dev tools to capture the failing state.
+- For server bugs: write a Vitest test that exercises the failing path using the `createCallerFactory` from `~/server/trpc`.
+- For DB bugs: use `pnpm services:setup` to get a real Postgres, then write the failing test against it.
+
+If you can't reproduce in 3 attempts:
+
+- Post a Linear comment listing what you tried (commands, inputs, environment).
+- Ask the reporter for the missing detail (likely environment / role / data shape).
+- Stop. Do not invent a repro.
+
+### 3. Locate the suspect
+
+Start from the user-visible symptom and walk **outward**:
+
+1. Find the React component / tRPC procedure that the user is interacting with.
+2. Trace its call chain into the service layer.
+3. Identify the smallest code unit (often a function) where expected and actual diverge.
+
+Cite file:line for every step in your trace — the engineer reviewer needs to retrace it.
+
+### 4. Write the failing test
+
+The failing test is the deliverable. It must:
+
+- Live next to the suspect code (`__tests__/` for server, alongside the file for components).
+- Fail **only** because of this bug. If you have to fix two things to make it pass, you've conflated bugs — split the ticket.
+- Assert the user-visible expected behaviour, not the internal mechanism.
+- Be deterministic. Flaky tests in this slot are a hard failure.
+
+Commit the failing test on a new branch via `gt create -m "test(<area>): failing test for <ticket-id>"`. The test is committed *failing*; CI on the draft PR will show red. That's intentional.
+
+### 5. Write the root-cause summary
+
+Post a Linear comment on the ticket with:
+
+```markdown
+## Triage — <ticket-id>
+
+**Repro**: <one line>
+**Suspect**: <file:line>
+**Root cause**: <one sentence>
+**Failing test**: <branch + path>
+**Allow-list status**: yes (category: <name>) | no — <reason>
+
+**Trace**:
+- <step 1, with file:line>
+- <step 2>
+- ...
+```
+
+### 6. Hand off
+
+- If allow-list status is **yes**: invoke the `bugfix` skill on the same branch.
+- If **no**: convert the branch to a draft PR, link the Linear ticket, label `risk:<tier>` per `docs/risk-taxonomy.md`, and post to the channel from `docs/ai-workflow.md`.
+
+## Hard rules
+
+- **Never fix in this skill.** If you find yourself editing source code, stop — that's the `bugfix` skill's job.
+- **Never invent a repro.** If you can't reproduce, escalate to the reporter.
+- **Failing test before anything else.** No PR without a failing test on the branch.
+- **One bug per branch.** If repro surfaces a second bug, file a separate Linear ticket and continue with the original.
+- **Cite file:line for every claim** in the trace.
+
+## Anti-patterns the agent must refuse
+
+- Posting a "probably caused by X" comment without a failing test.
+- Combining triage + fix in one commit.
+- Skipping the canonical field check because the ticket "looks fine".
+- Writing a test that asserts internal implementation details rather than user-visible behaviour.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,40 @@ If you're submitting a pull request, some points to note:
 3. Write [semantic commit messages](https://www.conventionalcommits.org/en/v1.0.0/). See past [PRs](https://github.com/opengovsg/isomer/pulls) for examples.
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you do not have permission to do that, you may request the second reviewer to merge it for you.
 
+## Stacked PRs with Graphite
+
+We use [Graphite](https://graphite.dev) to break large changes into a stack of small, individually-reviewable PRs. Each PR in a stack should be scoped to a single concern and revertable on its own.
+
+### Why stack
+
+- One concern per PR keeps reviews fast and reverts safe.
+- Reviewers can approve earlier PRs while later ones evolve.
+- AI-generated changes are easier to audit when split by area.
+
+### Authoring a stack
+
+```bash
+gt create -m "feat: add foo router"      # branch + commit
+# edit files for the next PR in the stack
+gt create -m "feat: wire foo router to client"
+gt log short                             # see the stack
+gt submit --stack                        # push & open PRs for the whole stack
+```
+
+Rules of thumb:
+
+- **One concern per branch.** If a branch touches two unrelated areas, split it: `gt split` or `gt absorb`.
+- **Each PR must be revertable without breaking the ones below it.** New code paths land behind feature flags / config when the rest of the stack is not yet merged.
+- **Restack after rebases.** `gt sync` pulls in `main` and restacks. Resolve conflicts bottom-up.
+- **Never force-push the trunk.** `gt submit` force-pushes feature branches in the stack; this is expected.
+
+### When *not* to stack
+
+- One-line hotfixes and dependency bumps go straight to `main` via a single PR.
+- Migrations that change schema in a non-backward-compatible way must land alone (see [Database migrations](./README.md#running-database-migrations)).
+
+If you don't have access to Graphite yet, see the invite link in [README.md](./README.md#extra-tools).
+
 ## Contributor License Agreement
 
 Code contributions to this project must be accompanied by a Contributor License Agreement. You (or your employer) retain the copyright to your contribution; this simply gives us permission to use and redistribute your contributions as part of the project.

--- a/apps/studio/prisma/CLAUDE.md
+++ b/apps/studio/prisma/CLAUDE.md
@@ -1,0 +1,101 @@
+# Prisma + migrations (`apps/studio/prisma`)
+
+The Prisma schema is the source of truth for the database. Migrations apply atomically against production via the `migrate:<env>` flow in the root `README.md`. Mistakes here are expensive — a bad migration can lock tables, drop data, or block deploys.
+
+## Layout
+
+```
+prisma/
+├── schema.prisma           # The schema. Generator targets: prisma-client-js, prisma-json-types-generator, prisma-kysely.
+├── migrations/             # Prisma-managed migrations (timestamp-prefixed folders).
+│   └── <ts>_<name>/migration.sql
+├── custom/                 # Hand-authored SQL applied via the custom migration mechanism.
+│   ├── install.ts          # Roller that splices custom SQL into the next migration.
+│   └── migration.sql       # Accumulated custom statements awaiting the next dev migration.
+├── generated/              # Kysely + Prisma JSON types (generated). Do not edit.
+├── scripts/                # Ad-hoc data scripts (run manually, not by migrate).
+├── seed.ts                 # Seed data for local dev.
+└── types.ts                # JSON column TS types — referenced from schema via `prisma-json-types-generator`.
+```
+
+## Generators — what runs at `pnpm generate`
+
+| Generator                     | Output                                       | Why                                           |
+| ----------------------------- | -------------------------------------------- | --------------------------------------------- |
+| `prisma-client-js`            | `node_modules/.prisma/client`                | Default Prisma client used by legacy queries. |
+| `prisma-json-types-generator` | Types for `Json` columns                     | Reads from `prisma/types.ts`.                 |
+| `prisma-kysely`               | `prisma/generated/generatedTypes.ts` + enums | Kysely DB types — preferred for new queries.  |
+
+After any schema change, run `pnpm generate` and commit the regenerated `prisma/generated/` files.
+
+## Workflow — adding a new migration
+
+1. Edit `schema.prisma`.
+2. From `apps/studio/`: `pnpm migrate:dev`. Name the migration descriptively (`add_<table>_<reason>`).
+3. Inspect the generated `migration.sql` — Prisma sometimes generates destructive operations (drops, renames) when a non-destructive one would do.
+4. Run `pnpm generate` to refresh the Kysely + JSON types.
+5. Commit:
+   - `prisma/schema.prisma`
+   - `prisma/migrations/<ts>_<name>/migration.sql`
+   - `prisma/generated/*`
+6. Update `apps/studio/prisma/types.ts` if you added/changed a JSON column.
+
+## Custom migrations
+
+The `custom/` folder lets you ship hand-written SQL (triggers, partial indexes, RLS) that Prisma's introspection cannot express. Statements in `custom/migration.sql` get merged into the next Prisma migration by `custom/install.ts`.
+
+Use this for:
+
+- Triggers and stored procedures.
+- Partial / expression indexes that Prisma can't express.
+- Data backfills attached to a schema change.
+
+Do **not** use this to bypass Prisma's tracked migration history. Every change must still land in a tracked migration folder.
+
+## Rules
+
+### Backward-compatible by default
+
+- Migrations run before the new app code is deployed. The old code must still work against the new schema during the window.
+- New required columns: add as nullable, backfill, then tighten in a follow-up migration.
+- Column renames: add new, dual-write, drop old — three migrations, not one.
+- Type changes: add a new column with the new type, migrate data, swap in code, drop old.
+
+### One migration per PR
+
+- A PR that touches the schema should land its migration alone, or as the only schema-change PR in a Graphite stack.
+- Migrations that change schema in a non-backward-compatible way **must not** be stacked with app code changes that depend on them — they ship in their own PR and merge first.
+
+### No destructive ops without explicit approval
+
+- `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, `TRUNCATE` require an explicit approving reviewer in the PR description.
+- The agent must refuse to ship a destructive migration without a human picking the approach.
+
+### Indexes
+
+- New indexes on large tables should use `CREATE INDEX CONCURRENTLY` via a custom migration. Prisma's default `CREATE INDEX` will lock writes.
+- An index that supports a new query path lands in the same PR as the query.
+
+### JSON columns
+
+- The TS type for each JSON column lives in `prisma/types.ts` and is picked up by `prisma-json-types-generator`. Update both together.
+
+## Seeding
+
+- `prisma/seed.ts` is for local dev only — it must be idempotent (re-running should produce the same state).
+- Tests use their own setup, not the seed file.
+
+## Scripts (`prisma/scripts/`)
+
+- One-off data scripts (rename a column, normalise a value across rows) live here.
+- Each script must be idempotent and dry-runnable.
+- Scripts are **not** run by `migrate:<env>` — they're executed manually and recorded in the PR description.
+
+## Anti-patterns the agent should refuse
+
+- Combining a schema change with un-related app code in one migration PR.
+- A `DROP COLUMN` / `DROP TABLE` in the same migration that adds its replacement.
+- New required columns without a backfill + two-phase rollout.
+- Editing files under `prisma/generated/` by hand.
+- Skipping `pnpm generate` after a schema change.
+- A non-idempotent script in `prisma/scripts/`.

--- a/apps/studio/src/components/CLAUDE.md
+++ b/apps/studio/src/components/CLAUDE.md
@@ -1,0 +1,59 @@
+# Studio components (`apps/studio/src/components`)
+
+Components in this folder are **app-wide UI used by more than one feature**. If a component is used by exactly one feature, it belongs under `features/<area>/components/` instead — see `apps/studio/src/features/CLAUDE.md`.
+
+This folder is _not_ the design system. Reusable, framework-agnostic primitives belong in `packages/components/` — see `packages/components/CLAUDE.md`.
+
+## What goes where
+
+| Location                                      | What                                                                               |
+| --------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `apps/studio/src/components/`                 | Studio-app UI shared across features (sidebar, navbar, error boundary, providers). |
+| `apps/studio/src/features/<area>/components/` | UI used by exactly one feature.                                                    |
+| `packages/components/src/`                    | UI rendered on the **published Isomer sites** — see that folder's CLAUDE.md.       |
+
+If you are not sure: start in the feature folder. Lift up only when a second feature needs it.
+
+## Styling
+
+- Chakra UI is the component framework. Use Chakra primitives (`Box`, `Stack`, `Button`, etc.) and the OGP theme exported from `~/theme`.
+- Tailwind is available for utility classes — prefer Chakra for layout and tokens, Tailwind for one-off utility styling.
+- Hardcoded hex colours / pixel values are an anti-pattern. Use theme tokens.
+
+## Component conventions
+
+- One component per file. File name matches the export (`Foo.tsx` exports `Foo`).
+- Folder-per-component when a component has sub-files (`Foo/index.tsx` + `Foo/FooHeader.tsx` + `Foo/types.ts`).
+- Props interface lives next to the component as `interface FooProps` — exported only if consumed externally.
+- Avoid default exports for components; named exports compose better with codemods and tooling.
+
+## Server/client boundaries
+
+- These are React 18 client components by default (Next.js Pages Router).
+- Don't fetch data in `components/`. Components receive data via props or via shared hooks. Data fetching lives in feature components or pages.
+- Side effects (analytics, intercom, etc.) belong in a provider under `AppProviders/` or in `instrumentation.ts`.
+
+## A11y baseline
+
+- Every interactive element must be keyboard reachable and have an accessible name.
+- Use Chakra's `aria-*` props rather than rolling your own.
+- Modals: use Chakra `Modal` (focus trap + escape handler built in). Don't reimplement.
+- Images: pass meaningful `alt` text. Decorative images: `alt=""`.
+
+## Testing
+
+- Tests co-located with the component (`Foo.test.tsx` next to `Foo.tsx`).
+- Test behaviour, not snapshots. No snapshot-only tests.
+
+## Storybook
+
+- Shared components used in more than two places should have a story.
+- Story file: `Foo.stories.tsx` next to the component, or under `apps/studio/src/stories/` if the component takes a lot of mock setup.
+
+## Anti-patterns the agent should refuse
+
+- Hardcoded colours / spacings instead of theme tokens.
+- Default-exported components.
+- Direct `fetch` or tRPC calls from inside a shared component (push data through props).
+- Reimplementing Chakra primitives instead of using them.
+- Placing single-feature UI in this folder.

--- a/apps/studio/src/features/CLAUDE.md
+++ b/apps/studio/src/features/CLAUDE.md
@@ -1,0 +1,68 @@
+# Features (`apps/studio/src/features`)
+
+Each top-level folder under `features/` is a vertical slice of one user-facing area: dashboard, editing-experience, gazettes, permissions, settings, sign-in, users, etc.
+
+A feature owns its own UI, hooks, atoms, schemas, and tests. Server logic for the same domain lives separately under `server/modules/<area>/` — see `apps/studio/src/server/CLAUDE.md`.
+
+## Layout
+
+Typical feature shape:
+
+```
+features/<area>/
+├── components/         # React components scoped to this feature
+├── hooks/              # Custom hooks scoped to this feature
+├── atoms.ts            # Jotai atoms for local UI state
+├── schema.ts           # Feature-internal Zod schemas (if not shared)
+├── constants.ts        # Feature-internal constants
+├── data/               # Static data, fixtures, lookup tables (when present)
+├── utils/              # Feature-internal helpers
+└── __tests__/          # Vitest tests
+```
+
+Not every feature needs every folder. Add a folder when you have more than one file of that kind.
+
+## Rules
+
+### Feature isolation
+
+- A feature **must not import from another feature's internals.** If two features need the same code, lift it into `apps/studio/src/components/`, `apps/studio/src/hooks/`, `apps/studio/src/lib/`, or `apps/studio/src/utils/` as appropriate.
+- A feature **may** import from `~/components`, `~/hooks`, `~/lib`, `~/schemas`, `~/utils`, and `~/server` types — these are the shared surface.
+
+### State
+
+- Local UI state → `useState` or a feature-scoped Jotai atom in `atoms.ts`.
+- Server state → tRPC + React Query. Do not duplicate server state into Jotai.
+- Shared cross-feature state belongs in a top-level atoms file, not in a feature.
+
+### Data fetching
+
+- Use the tRPC client (`api.<router>.<procedure>.useQuery` / `useMutation`). Never call `fetch` against our own backend.
+- Loading and error states are required for every query — surface them with the shared `Suspense` / `ErrorBoundary` wrappers in `~/components/`.
+
+### Forms
+
+- Validation schemas live in `~/schemas/` if shared with the server router, or in a feature-local `schema.ts` if not.
+- Use the existing form-builder primitives in `editing-experience/components/form-builder/` for editor-style forms; use Chakra `FormControl` + `react-hook-form` for everything else.
+
+### Tests
+
+- Co-located in `__tests__/` per feature.
+- Unit tests for pure functions and hooks. Component tests via `@testing-library/react`.
+- For flows that span features (e.g. "create page → publish"), put the test under `apps/studio/tests/e2e/` instead.
+
+## Adding a new feature — checklist
+
+1. Create `features/<area>/` with `components/` as the minimum.
+2. Wire the entry point from `pages/` (Next.js page) — keep the page file a thin shell that mounts the feature component.
+3. If the feature talks to a new server domain, add the router under `server/modules/<area>/` in the same stack of PRs.
+4. Tests: at least one happy-path component test.
+5. If the feature requires a Linear `area:` label other than `area:studio`, document the mapping in `docs/ai-workflow.md`.
+
+## Anti-patterns the agent should refuse
+
+- Cross-feature imports (`features/foo` importing from `features/bar/...`).
+- Pages doing real work instead of delegating to a feature component.
+- Direct `fetch` calls to Studio's own API instead of tRPC.
+- Mirroring tRPC query data into a Jotai atom.
+- Adding shared UI primitives inside a feature folder.

--- a/apps/studio/src/schemas/CLAUDE.md
+++ b/apps/studio/src/schemas/CLAUDE.md
@@ -1,0 +1,64 @@
+# Zod schemas (`apps/studio/src/schemas`)
+
+This folder is the single source of truth for **input schemas shared between the tRPC server and any client that calls it.** Server routers and client forms import from here so the types stay in lockstep.
+
+## What lives here
+
+- One file per domain area (`page.ts`, `resource.ts`, `site.ts`, `user.ts`, …).
+- Shared primitives in `common.ts` (e.g. permalink generators, common string constraints).
+- Pagination and webhook schemas (`pagination.ts`, `webhook.ts`).
+- The `auth/` subfolder for login and Singpass flows.
+- Tests under `__tests__/`.
+
+## What does _not_ belong here
+
+- **Feature-internal schemas used by exactly one component** — put them in `features/<area>/schema.ts`.
+- **Database row shapes** — those come from Prisma's generated types under `~prisma/generated/`.
+- **Component / template content schemas for published sites** — those live in `packages/components/src/schemas/`.
+
+## Conventions
+
+### Naming
+
+- Schemas: `<action><Entity>Schema` — e.g. `createPageSchema`, `updatePageMetaSchema`, `publishPageSchema`.
+- Inferred types: `type X = z.infer<typeof xSchema>` exported next to the schema.
+- Constants used by multiple schemas (e.g. `MAX_TITLE_LENGTH`) live in the same file and are exported.
+
+### Composition
+
+- Compose with `.extend()` and `.merge()` rather than redeclaring fields.
+- Reuse `basePageSchema`, `baseResourceSchema`, etc. for common identifier shapes.
+- Pull permalink, slug, URL constraints from `common.ts` — do not redefine character classes inline.
+
+### Error messages
+
+- Every `.min()` / `.max()` / `.regex()` must have a user-facing `message`. Generic Zod messages ("Required") leak through to forms.
+- Messages should be sentence case, no trailing period, and address the user ("Enter a title for this page", not "Title is required").
+
+### Server-only schemas
+
+- Some schemas are server-internal (e.g. `scheduledPublishServerSchema`). Suffix them with `ServerSchema` to make the boundary obvious — the client should never import these.
+
+### JSON content validation
+
+- For block/JSON content validated against an external schema (`@opengovsg/isomer-components`), compile the JSON Schema with `ajv` at module load and export the compiled validator. Do not recompile per request.
+
+## Testing
+
+- Unit tests under `__tests__/` covering boundary cases for any schema with non-trivial rules (regex, conditional refinement, transforms).
+- For schemas that depend on Prisma enums (`ResourceState`, `ResourceType`), import the enum so the schema fails type-check if the enum changes.
+
+## Adding a new schema — checklist
+
+1. Decide if it's shared (this folder) or feature-internal (`features/<area>/schema.ts`).
+2. Reuse `common.ts` primitives where possible.
+3. Export the inferred type alongside the schema.
+4. Add user-facing `message` to every validator.
+5. Add the schema to `__tests__/` if it has any conditional rules.
+
+## Anti-patterns the agent should refuse
+
+- Declaring inline `z.object(...)` schemas inside a router file when more than one caller needs the shape.
+- Schemas without `message` strings on constraints.
+- Hand-written types that duplicate `z.infer` output.
+- Importing a `*ServerSchema` from client code.

--- a/apps/studio/src/server/CLAUDE.md
+++ b/apps/studio/src/server/CLAUDE.md
@@ -1,0 +1,91 @@
+# Server conventions (`apps/studio/src/server`)
+
+This is the tRPC server for Studio. Read this before adding endpoints, middleware, or services.
+
+## Layout
+
+```
+server/
+├── context.ts              # Per-request context: session, prisma, req, res, gb (GrowthBook)
+├── trpc.ts                 # tRPC init + middlewares + base procedures
+├── webhooks.ts             # Non-tRPC webhook routes
+├── cron/                   # Scheduled jobs (pg-boss workers)
+└── modules/
+    └── <area>/
+        ├── <area>.router.ts    # tRPC router — endpoints only, no business logic
+        ├── <area>.service.ts   # Pure functions — business logic + DB queries
+        ├── <area>.select.ts    # Reusable Kysely select projections (optional)
+        ├── <area>.types.ts     # Shared module-internal types (optional)
+        └── __tests__/          # Vitest unit + integration tests
+```
+
+A module is a vertical slice of one domain (page, resource, auth, audit, permissions). New cross-module behaviour should compose existing services, not reach into another module's router.
+
+## Procedure types — pick the right base
+
+All four are exported from `~/server/trpc`:
+
+| Procedure            | Use for                                                                       |
+| -------------------- | ----------------------------------------------------------------------------- |
+| `publicProcedure`    | Endpoints that intentionally allow unauthenticated callers (very rare).       |
+| `protectedProcedure` | The default. Requires a valid session, non-deleted user, and email whitelist. |
+| `webhookProcedure`   | Server-to-server callers using `x-api-key` (e.g. CodeBuild).                  |
+
+Never write your own auth middleware in a router. If you need a new auth shape, add a middleware in `trpc.ts` and a new exported base procedure.
+
+## Required patterns
+
+### Input validation lives in `~/schemas/`
+
+- Define the Zod schema in `apps/studio/src/schemas/<area>.ts` and import it in the router.
+- Routers should not declare ad-hoc inline schemas. If a schema is router-internal and tiny, keep it inline; otherwise lift it.
+
+### Permission checks belong in the service
+
+- Routers wire input → service. The service performs the permission check (`bulkValidateUserPermissionsForResources` and friends) **before** mutating.
+- Do not gate purely on the existence of a session — that only proves the caller is logged in, not authorised for the resource.
+
+### Audit-log every state change
+
+- Mutations that change resource state must call `logResourceEvent` (or the appropriate `AuditLogEvent`) inside the same transaction as the write.
+- Reads are not audited unless they expose sensitive data.
+
+### Rate limiting via meta
+
+- Attach rate limits with `.meta({ rateLimitOptions: ... })` on the procedure. The `rateLimitMiddleware` in `trpc.ts` reads this.
+- Anything user-input-triggered that hits an external service (email, S3, Singpass) must have a rate limit.
+
+### Errors
+
+- Throw `TRPCError` with a `code` from the tRPC set. Pick the right code — never use `INTERNAL_SERVER_ERROR` for validation issues.
+- Caught errors that leak request data must be logged with `ctx.logger` and re-thrown as a generic `INTERNAL_SERVER_ERROR` — never echo back database errors or stack traces.
+
+## Database access
+
+- Kysely (`db`) is the default. Prefer it for new queries.
+- Prisma (`ctx.prisma`) is used for legacy queries and where Kysely lacks parity.
+- Mix in one router only when necessary, and prefer one transaction owner per mutation.
+- Migrations and schema live under `apps/studio/prisma/` — see `apps/studio/prisma/CLAUDE.md`.
+
+## Testing
+
+- Co-located under `__tests__/` in each module.
+- Integration tests against a real Postgres via `pnpm services:setup` — do not mock the DB. (The doc rationale: mocked tests have masked broken migrations in past incidents.)
+- Use the `createCallerFactory` exported from `trpc.ts` to call the router as a real authed user in tests.
+
+## Adding a new module — checklist
+
+1. Create `modules/<area>/` with the four files above.
+2. Add the router to `modules/_app.ts`.
+3. Define input schemas under `~/schemas/<area>.ts`.
+4. Add at least one happy-path and one permission-denied test.
+5. If the module mutates resources, wire `logResourceEvent` into every mutation.
+6. Update this file if the module introduces a convention not covered here.
+
+## Anti-patterns the agent should refuse
+
+- Adding business logic inside a router callback.
+- Validating input in the service instead of with a Zod schema.
+- Calling another module's service to bypass that module's permission checks.
+- Returning raw Prisma errors or `error.message` to the client.
+- Adding a new `protectedProcedure`-equivalent middleware ad hoc in a router file.

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -1,0 +1,107 @@
+# AI-assisted workflow — canonical inputs
+
+This doc defines the **canonical contract** between humans, Linear, Figma, and any AI agent that triages or implements work in this repo. Triggers (webhooks, MCP fetches) read these fields; if they're missing or malformed, the agent must stop and ask rather than guess.
+
+If you change a field name or label here, you must also update the corresponding skill / webhook handler. Treat this doc as the source of truth.
+
+## Linear ticket fields
+
+Every ticket that an agent may pick up **must** carry the following:
+
+| Field             | Required for                | Notes                                                            |
+| ----------------- | --------------------------- | ---------------------------------------------------------------- |
+| `Title`           | all                         | Imperative, scoped. No "investigate X" titles for bugs.          |
+| `Description`     | all                         | Markdown. Sections below.                                        |
+| `Area` label      | all                         | One of: `area:studio`, `area:components`, `area:infra`, `area:db`. Drives which `CLAUDE.md` files the agent loads. |
+| `Type` label      | all                         | One of: `bug`, `feature`, `chore`, `design-iteration`.           |
+| `Risk` label      | feature, chore              | One of: `risk:low`, `risk:medium`, `risk:high`. Bugs are graded by the agent. |
+| `Trigger` label   | agent-eligible tickets only | `ai:triage` (let agent triage), `ai:implement` (let agent ship a PR). Absence = agent must not act. |
+| Figma frame URL   | features, design-iteration  | Paste the frame URL in the description. Frame must be named, not "Frame 47". |
+| Repro steps       | bugs                        | Numbered list in description.                                    |
+| Expected / actual | bugs                        | Two sub-headings in description.                                 |
+
+Anything else (priority, cycle, assignee) is for humans; agents ignore it.
+
+### Description template — bug
+
+```markdown
+## Repro
+1. ...
+2. ...
+
+## Expected
+...
+
+## Actual
+...
+
+## Environment
+- Browser / OS / role
+```
+
+### Description template — feature
+
+```markdown
+## Goal
+One sentence. What outcome the user gets.
+
+## Design
+- Figma frame: https://figma.com/...
+- Target location: `apps/studio/src/.../Foo.tsx` (or "new component in packages/components/src/templates/...")
+
+## Constraints
+- Must use existing design tokens
+- ...
+
+## Out of scope
+- ...
+```
+
+### Description template — design-iteration
+
+Used when a designer wants the agent to update an already-implemented component to match a new Figma frame.
+
+```markdown
+## Component
+`apps/studio/src/components/Foo/Bar.tsx`
+
+## Target frame
+https://figma.com/...
+
+## Changes from current
+- Header padding: 12 → 16
+- Primary CTA: solid → ghost
+```
+
+## Figma conventions
+
+For an agent to read a frame reliably:
+
+- **Frame names must be human-readable.** `Dashboard / Empty state` is fine; `Frame 47` is not — the agent will refuse.
+- **Components used in the frame must exist in our design library** or be flagged as "new primitive — needs eng review" in the description.
+- **Spacing/sizing should reference tokens** when present. If a value is hardcoded, the agent will ask before using a magic number.
+
+## GitHub PR conventions
+
+When the agent opens a PR, it must:
+
+1. Link the originating Linear ticket in the PR body (first line: `Closes ENG-123`).
+2. Tag the PR with `ai-authored` (label).
+3. Add a risk tier label (`risk:low` / `risk:medium` / `risk:high`) determined by the `pr-review` skill.
+4. Use a stacked branch via Graphite when the change spans more than one concern (see [CONTRIBUTING.md](../CONTRIBUTING.md#stacked-prs-with-graphite)).
+5. Include a **Root cause** section (bugs) or **Approach** section (features) in the PR body.
+
+## Slack / notifications
+
+- Bug PRs → `#isomer-eng-reviews` channel
+- Design iterations → `#isomer-design-reviews` channel, with the Chromatic preview link inline
+- Incident diagnoses → the incident channel for the firing monitor (see runbooks)
+
+## When the agent must stop and ask
+
+- A required field above is missing or malformed.
+- The ticket is labelled `risk:high` but the agent only has `ai:triage` permission (it can investigate but not open an implementing PR).
+- The area label points to a directory without a `CLAUDE.md` covering its conventions.
+- The Figma frame references a component not present in `packages/components/src/`.
+
+Stopping looks like: post a Linear comment listing what's missing, mark the ticket back to the human in the triage column. Never guess.

--- a/docs/bug-automation-allowlist.md
+++ b/docs/bug-automation-allowlist.md
@@ -1,0 +1,66 @@
+# Bug automation allow-list
+
+This doc enumerates the categories of bugs that the `triage` + `bugfix` skills are allowed to ship a PR for **without a human in the loop on plan selection**. Everything else: the agent can triage and post findings, but a human picks the approach.
+
+The allow-list expands over time. New categories are added only after the team has reviewed a sample of agent-shipped PRs in that category and agrees the fix pattern is reliable.
+
+## Currently allow-listed
+
+A bug is allow-listed only when *every* line below is true.
+
+1. **The fix is local.** Changes touch at most one module under `apps/studio/src/server/modules/` *or* one feature under `apps/studio/src/features/` *or* one component under `apps/studio/src/components/` or `packages/components/src/templates/next/components/`.
+2. **The bug has a deterministic repro.** The triage skill produced a failing test that reliably reproduces the bug without flakes.
+3. **The category is one of the following.**
+
+### Allowed categories
+
+| Category                      | What it looks like                                                                                          |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| **Null/undefined guard**      | A crash on a missing optional field. Fix: add the guard, return early or fall back to a documented default. |
+| **Off-by-one**                | Pagination, slicing, index arithmetic that's one step wrong. Fix: adjust the constant + add the boundary test. |
+| **UI regression**             | Visual or behavioural drift in a single component caused by a recent change. Fix: revert the drift in that component. |
+| **Date/time formatting**      | Wrong format token, wrong timezone for display-only code (not storage). Fix: adjust the format string + test. |
+| **Copy / string fix**         | Wrong wording, typo, missing translation. Fix: edit the string in `~/constants/` or i18n file.              |
+| **Validation message**        | A Zod schema rejects valid input or accepts invalid input with a documented intended boundary. Fix: tighten the constraint + add a schema test. |
+| **Dead import / unused code** | A linter-flagged dead path. Fix: remove + verify nothing else depends.                                       |
+| **Type narrowing fix**        | A TS error caused by missing narrowing, where the runtime is already correct. Fix: add the narrowing + cast assertion test. |
+
+## Not allow-listed (agent triages only)
+
+These categories produce a Linear comment + a failing test in a draft PR — but the agent stops and waits for a human to pick the approach:
+
+- Authentication and session lifecycle (`server/modules/auth/**`)
+- Permission and authorization (`server/modules/permissions/**`)
+- Audit logging changes
+- Rate limiting changes
+- Anything that requires a database migration
+- Anything in `server/trpc.ts`, `server/context.ts`, `server/webhooks.ts`
+- Race conditions and concurrency
+- Memory leaks
+- Performance regressions where the fix changes algorithmic complexity
+- Anything that touches `apps/studio/src/env.mjs` or feature flags
+- Cross-module fixes (more than one module's service involved)
+- Anything labelled `risk:high` per `docs/risk-taxonomy.md`
+
+## Hard limits regardless of category
+
+The agent must refuse to ship even an allow-listed fix when:
+
+- The minimal fix would exceed **100 LOC of source-code change** (tests don't count).
+- The fix requires deleting or replacing more than 20 LOC of existing logic (replace > delete heuristic — large rewrites are not bug fixes).
+- The diff touches a file under `risk:high` globs.
+- The originating Linear ticket lacks the canonical fields per `docs/ai-workflow.md`.
+- The failing test cannot be written before the fix (no test-first → no automation).
+
+When refused, post the diagnosis as a Linear comment and stop.
+
+## Evolution
+
+To propose a new category for the allow-list:
+
+1. Collect ≥5 examples of recent merged PRs in the proposed category.
+2. Verify each PR fits the allow-list rules above (local, deterministic, bounded LOC).
+3. Open a PR adding the category to this file with the examples linked in the PR body.
+4. The PR needs sign-off from two engineers active on Isomer.
+
+Removing a category needs only one engineer's call — if the agent ships a regression, narrow the allow-list immediately.

--- a/docs/oneshot-vs-plan-threshold.md
+++ b/docs/oneshot-vs-plan-threshold.md
@@ -1,0 +1,56 @@
+# One-shot vs plan-first thresholds
+
+When the agent picks up a feature ticket, it must choose between:
+
+- **One-shot**: skip the plan step and implement directly.
+- **Plan-first**: propose 2–3 approaches with trade-offs, stop, wait for a human to pick before implementing.
+
+This doc defines when each applies. The `feature-plan` and `feature-implement` skills read this file at run time.
+
+## One-shot eligibility — *all* conditions must hold
+
+1. **Type label:** `feature` or `design-iteration`.
+2. **Risk:** `risk:low` per `docs/risk-taxonomy.md` (computed from the *expected diff*, not the diff after writing).
+3. **Surface:**
+   - Frontend-only changes, or
+   - A new tRPC procedure that is a CRUD wrapper around an existing model with no new permission shape.
+4. **Size budget:**
+   - **FE-only:** ≤ 200 LOC of source code (tests, stories, types not counted).
+   - **BE-only:** ≤ 150 LOC of source code, single module under `server/modules/<area>/`.
+   - **FE + BE:** **not one-shot.** Always plan-first.
+5. **No new dependencies.** Adding a package is never one-shot.
+6. **No new feature flags.** Gating new behaviour requires a plan.
+7. **No schema changes.** Migrations are always plan-first.
+8. **A single Figma frame** (design-iteration) or a clearly bounded ticket goal (feature). Multiple frames → plan-first.
+
+If any condition fails, the agent must run `feature-plan` first.
+
+## Plan-first triggers — any one is enough
+
+- The ticket is `risk:medium` or `risk:high`.
+- The change crosses Studio and `packages/components` (the contract boundary — see `packages/components/CLAUDE.md`).
+- The change introduces a new database table, column, or index.
+- The change introduces a new tRPC router or a new module under `server/modules/`.
+- The change introduces a new shared component in `apps/studio/src/components/` or `packages/components/src/`.
+- The change adds a new permission shape, new auth flow, or new audit event.
+- The change requires data backfill.
+- The change estimated diff exceeds the one-shot LOC budget.
+- The ticket is ambiguous about user-visible behaviour and the agent has more than one reasonable interpretation.
+
+## How the agent decides
+
+At the start of every feature run:
+
+1. Read the Linear ticket. Validate canonical fields per `docs/ai-workflow.md`.
+2. List the files the change will likely touch. Compute the max risk tier across them.
+3. Apply the eligibility checks above.
+4. **One-shot eligible:** start `feature-implement` directly.
+5. **Plan-first:** run `feature-plan`. Post approaches to the ticket. Stop until a human picks.
+
+If the agent starts one-shot and the diff exceeds the budget while writing, it must **stop, throw away the in-progress diff, and re-enter plan-first**. Do not silently land an over-budget one-shot.
+
+## Why the LOC budgets exist
+
+These numbers come from the L3 doc's design constraint: at L3 the human is shot-caller + sense-check. The smaller the diff, the smaller the sense-check. 200 LOC is roughly the upper end of "review-in-one-sitting". Above that, the right intervention is to split the work into smaller PRs, not to push a single bigger one through.
+
+The budgets evolve. If the team finds 200 LOC is too generous (regressions slip through) or too tight (too many obvious things get held up), edit this file. Skills read it at run time, so no code change is needed.

--- a/docs/risk-taxonomy.md
+++ b/docs/risk-taxonomy.md
@@ -1,0 +1,87 @@
+# PR risk taxonomy
+
+This doc maps file-glob heuristics → risk tier. It is the source of truth for the `pr-review` skill, the auto-approve gate, and any future code-review automation.
+
+Tiers are conservative on purpose: if multiple globs match a single PR, the **highest** tier wins.
+
+## Tiers
+
+| Tier         | Meaning                                                                                       | Auto-approve? |
+| ------------ | --------------------------------------------------------------------------------------------- | ------------- |
+| `risk:low`   | Cosmetic, docs, deps, copy. Cannot break runtime behaviour or change data.                    | Yes, with caveats below. |
+| `risk:medium`| Adds or changes app behaviour but in a contained area. Requires human approve.                | No.           |
+| `risk:high`  | Touches security, auth, billing, migrations, infra, or cross-cutting code. Requires human approve + a tagged reviewer. | No.           |
+
+## File-glob → tier
+
+Match top-down — the first matching glob wins for that file. The PR's tier is the max across its files.
+
+### `risk:high`
+
+- `apps/studio/prisma/migrations/**`
+- `apps/studio/prisma/schema.prisma`
+- `apps/studio/src/server/modules/auth/**`
+- `apps/studio/src/server/modules/permissions/**`
+- `apps/studio/src/server/modules/audit/**`
+- `apps/studio/src/server/modules/rate-limit/**`
+- `apps/studio/src/server/trpc.ts`
+- `apps/studio/src/server/context.ts`
+- `apps/studio/src/server/webhooks.ts`
+- `apps/studio/src/lib/growthbook*` (feature flag definitions)
+- `apps/studio/src/env.mjs`
+- `.github/workflows/**`
+- `tooling/**` (shared configs)
+- `**/seed.ts`
+- `infrastructure/**` (if/when added)
+
+### `risk:medium`
+
+- `apps/studio/src/server/modules/**` (all other modules)
+- `apps/studio/src/pages/api/**`
+- `apps/studio/src/features/**`
+- `apps/studio/src/schemas/**`
+- `apps/studio/src/hooks/**`
+- `apps/studio/src/lib/**`
+- `apps/studio/src/utils/**`
+- `apps/studio/src/components/**`
+- `packages/components/src/templates/**`
+- `packages/components/src/schemas/**`
+- `packages/components/src/engine/**`
+- `packages/pgboss/**`, `packages/redis/**`, `packages/logging/**`, `packages/validators/**`
+
+### `risk:low`
+
+- `**/*.md`, `**/*.mdx`
+- `docs/**`
+- `**/CLAUDE.md`
+- `**/*.stories.tsx`, `**/stories/**`
+- `**/__tests__/**`, `**/*.test.ts`, `**/*.test.tsx`, `**/*.spec.ts`
+- `package.json` for dependency-only diffs from Dependabot or Renovate (no script changes)
+- `pnpm-lock.yaml` paired with a dep-only `package.json` change
+- `apps/studio/src/constants/**` for copy / strings only (no logic)
+- `**/i18n/**`, `**/locales/**`
+
+## Auto-approve caveats
+
+`risk:low` is *eligible* for auto-approve. It is auto-approved only when **all** of the following hold:
+
+1. The author is on the explicit allow-list (initially: Dependabot, Renovate, and the agent's GitHub identity).
+2. The PR touches no file outside the `risk:low` globs.
+3. CI is green (lint, typecheck, build, tests).
+4. The PR carries the `ai-authored` label or comes from a known bot.
+5. The PR does not change `package.json` scripts, `engines`, `pnpm.overrides`, or workspace dependencies.
+
+If any condition fails, the PR is downgraded to "human review required" and the agent leaves an annotation explaining why.
+
+## Hot paths to flag (any tier)
+
+Even within `risk:medium`, the following sub-paths are "hot" and should be called out by the `pr-review` skill with a banner:
+
+- `apps/studio/src/server/modules/page/page.service.ts` — publish + scheduled publish flow
+- `apps/studio/src/server/modules/resource/**` — resource graph mutations
+- `apps/studio/src/features/editing-experience/**` — the editor core; any change risks publisher data loss
+- `packages/components/src/schemas/**` — published-site JSON Schema; backward compatibility required
+
+## Evolution
+
+This file evolves with the codebase. When you add a new high-risk area (new auth integration, new payment path, new infra-as-code), add it to `risk:high` in the same PR. The `pr-review` skill reads this file at run time; no code change is needed to expand coverage.

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -1,0 +1,121 @@
+# `@opengovsg/isomer-components`
+
+This package renders **published Isomer sites**. It is published to npm and consumed by Studio at build time. The boundary between Studio and this package is the most important contract in the repo — get it wrong and you ship a regression to every published site.
+
+## What this package owns
+
+- React templates and layouts for published sites (`src/templates/`).
+- Block components for content (`src/templates/<variant>/components/`).
+- The JSON Schema describing valid page content (`src/schemas/`).
+- Interfaces and types consumed by Studio (`src/interfaces/`, `src/types/`).
+- Pure utilities for rendering (`src/utils/`).
+- The Storybook for visual documentation (`src/stories/`).
+
+## The Components ↔ Studio contract
+
+This is the rule the agent must never bend:
+
+> **Studio drives content. `packages/components` renders content. Communication is by typed interfaces and the JSON Schema — nothing else.**
+
+Concretely:
+
+| Boundary            | What flows                                                                 |
+| ------------------- | -------------------------------------------------------------------------- |
+| Studio → Components | Content blocks validated against `schemas/`, layout props from interfaces. |
+| Components → Studio | Exported types (`IsomerSchema`, etc.), constants, and the schema itself.   |
+
+Things that violate the contract:
+
+- A component that reads `window.location` or Studio-specific URLs.
+- A component that calls back into Studio's API.
+- A component that branches behaviour on a Studio-internal feature flag.
+- Studio importing a private (un-exported) symbol from `packages/components/src/`.
+
+If you need new data on the rendering side, add it to the **schema and interfaces first**, ship that PR, then update Studio to produce the new shape in a follow-up PR. The schema PR must remain backward-compatible (new fields are optional) so Studio doesn't break in between.
+
+## No UI logic in JSONForms components
+
+JSONForms components in this package render schema-driven editor UI inside Studio. They must stay **dumb renderers** of the schema:
+
+- No branching on which Studio screen they're embedded in.
+- No fetching data from the network.
+- No state that lives outside the form value passed in.
+- No imports from `apps/studio/src/`.
+
+If a JSONForms component needs Studio-only behaviour, that behaviour belongs in Studio — wrap the component there.
+
+## Layout
+
+```
+src/
+├── templates/
+│   ├── classic/        # Legacy template — frozen, no new features
+│   └── next/           # Current template — new components land here
+│       ├── components/
+│       │   ├── complex/    # Composed multi-part blocks
+│       │   ├── internal/   # Used by other components, not exported as blocks
+│       │   └── native/     # Atomic blocks (Paragraph, Heading, Image, …)
+│       ├── layouts/        # Page-shape templates (Article, Collection, Homepage, …)
+│       ├── render/         # Block-to-component dispatch
+│       ├── context/        # React context providers used by render
+│       └── types/
+├── schemas/            # JSON Schema describing valid content
+├── interfaces/         # TS interfaces shared with consumers
+├── engine/             # JSON Schema engine + AJV setup
+├── presets/            # Pre-configured renderers
+├── stories/            # Storybook
+└── utils/              # Pure helpers (URL parsing, formatting)
+```
+
+## Adding a new block
+
+1. Decide: `native` (atomic), `complex` (composed), or `internal` (helper).
+2. Add the component under `src/templates/next/components/<bucket>/<Name>/`.
+3. Add the schema entry under `src/schemas/` — must be backward compatible.
+4. Add a Storybook story under `src/stories/` covering the new variants.
+5. Export from `src/index.ts` (or the relevant sub-index) so Studio can consume it.
+6. Bump the package version and update Studio in a follow-up PR.
+
+## Conventions
+
+### Pure rendering
+
+- Components in templates are **server-renderable**: no `useState`, no `useEffect`, no browser-only APIs at the top level. Push interactivity into nested client components when unavoidable.
+- No network calls. All data is passed in via props.
+
+### Styling
+
+- Tailwind classes drive styling. Tokens come from the Isomer theme (`tooling/template/styles/`).
+- Hardcoded hex / px values are an anti-pattern.
+- The classic template is **frozen** — bug fixes only, never new features.
+
+### Types
+
+- Components consume interfaces from `src/interfaces/`. Don't redeclare prop types inline if the prop matches a published interface.
+- Export new public types from `src/index.ts`. Anything not exported is considered private and may break without notice.
+
+### Schema changes
+
+- Adding a field: must be optional (`?:`) for backward compatibility.
+- Removing a field: minor or major version bump, requires Studio migration first.
+- Changing the type of a field: never. Add a new field, deprecate the old, remove later.
+
+## Storybook
+
+- Every public component must have a story.
+- Stories must cover empty, populated, long-content, and error states where applicable.
+- The Storybook is published — treat it as documentation.
+
+## Tests
+
+- Visual + behavioural tests via Storybook.
+- Unit tests (`.spec.ts`) for utilities and engine code.
+- Snapshot tests are discouraged except for the JSON Schema itself.
+
+## Anti-patterns the agent should refuse
+
+- A template component importing from `apps/studio/src/`.
+- A JSONForms component fetching data or holding non-form state.
+- A breaking schema change without a Studio migration PR landing first.
+- New work on the `classic` template.
+- Adding a new block without a Storybook story.


### PR DESCRIPTION
## Problem

Isomer is at L2 of [AI adoption](https://www.notion.so/opengov/Levels-of-AI-adoption-Isomer-36877dbba7888083b6bef8043b409dac) — we have shared skills in `SKILLS.md` but their triggers are manual, so engineers context-switch to invoke them. Reaching L3 (unsupervised execution within bounded scope) is blocked on five cross-cutting prerequisites called out in the doc:

- Per-subfolder `CLAUDE.md` files so agents pick up area-specific conventions automatically
- Graphite-based stacked PR convention documented so AI-generated changes land as small, reviewable PRs
- A canonical Linear/Figma input contract so triggers have a stable schema
- Codified review standards and risk taxonomy so PR review can be automated for low-risk changes
- Codified skill procedures for triage, bugfix, feature-plan, feature-implement, and pr-review

This PR delivers all of the above. It does not include the infrastructure that *triggers* the skills (Linear webhooks, GitHub Actions runners, MCP server configs, IAM roles) — those land in their own PRs once secrets are provisioned.

No linked issue — internal AI adoption initiative.

## Solution

Doc + skill-only foundation. No source code, no runtime behaviour changes. Every file is purely additive and revertable on its own by deletion.

**Per-folder `CLAUDE.md`** — codifies conventions for the six highest-traffic areas:

- `apps/studio/src/server/CLAUDE.md` — tRPC procedure choice (`protectedProcedure` / `publicProcedure` / `webhookProcedure`), audit logging on mutations, rate limit via `.meta()`, Kysely-over-Prisma preference, integration tests against real Postgres (no mocks, with rationale)
- `apps/studio/src/features/CLAUDE.md` — feature isolation rule (no cross-feature imports), server state via tRPC/React Query (never duplicated into Jotai), where shared code is lifted
- `apps/studio/src/components/CLAUDE.md` — three UI tiers (app-wide vs feature-local vs published-site), Chakra primitives + OGP theme tokens, no hardcoded hex/px values, a11y baseline
- `apps/studio/src/schemas/CLAUDE.md` — `<action><Entity>Schema` naming, `.extend()` composition, mandatory user-facing `message` strings on validators, `*ServerSchema` server-only suffix
- `packages/components/CLAUDE.md` — the Studio ↔ Components contract (Studio drives content, components render content, communication only via typed interfaces + JSON Schema), no-UI-logic-in-JSONForms rule, frozen `classic` template, backward-compatible schema-change rules
- `apps/studio/prisma/CLAUDE.md` — backward-compatible migrations as default, two-phase column renames, destructive op (`DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, `TRUNCATE`) refusal without explicit reviewer, `CREATE INDEX CONCURRENTLY` on large tables, idempotent seed and scripts

**Workflow + automation docs under `docs/`:**

- `ai-workflow.md` — canonical Linear ticket fields and label conventions (`area:*`, `risk:*`, `ai:triage`, `ai:implement`), description templates for bug/feature/design-iteration, Figma frame naming rules, when the agent must stop and ask
- `risk-taxonomy.md` — three risk tiers (`risk:low` / `risk:medium` / `risk:high`), file-glob → tier mapping, max-across-files rule, auto-approve caveats (low tier alone is not enough — must be Dependabot/Renovate/agent + no `package.json` script changes + CI green), explicit hot paths within medium tier
- `bug-automation-allowlist.md` — eight bug categories safe for full automation (null guard, off-by-one, UI regression, date formatting, copy, validation message, dead import, type narrowing), explicit not-allow-listed list (auth, permissions, audit, rate limit, migrations, `trpc.ts`, race conditions, etc.), hard limit ≤100 LOC source change, replace > delete heuristic
- `oneshot-vs-plan-threshold.md` — one-shot eligibility (all conditions must hold: low risk, FE-only ≤200 LOC or BE-only-CRUD ≤150 LOC, no new deps/flags/migrations) vs plan-first triggers (any one is enough)

**Skill files under `.claude/skills/`** — markdown procedures, no automation wiring:

- `pr-review/SKILL.md` — grades risk against `risk-taxonomy.md` at run time, flags hot paths, scans for missing tests/stories/schemas, posts one structured comment. Never approves, never requests changes, never merges. Read-only on merge state.
- `triage/SKILL.md` — validates canonical Linear fields, reproduces (refusing to invent one after 3 failed attempts), walks from symptom to suspect citing `file:line`, writes a deterministic failing test, hands off to `bugfix` if allow-listed
- `bugfix/SKILL.md` — verifies triage prerequisites, enforces ≤100 LOC source change + replace-greater-than-delete + single module, reads area `CLAUDE.md` before editing, runs full local suite, opens stacked draft PR via `gt`
- `feature-plan/SKILL.md` — generates 2–3 materially different approaches with file-path sketches, LOC estimates, risk tiers, reversibility, and real pros/cons; recommends but does not pick; stops and waits for `pick: A|B|C` Linear reply
- `feature-implement/SKILL.md` — enters from one-shot eligibility or a `pick:` reply, reads relevant `CLAUDE.md` files before editing, splits into a 4-PR Graphite stack (schema → server → client → stories), enforces required artefacts (Storybook stories for FE, tRPC integration tests for BE), re-plans if diff balloons past 2× estimate

**`CONTRIBUTING.md`** gains a Stacked PRs with Graphite section covering rationale, `gt create` / `gt submit` flow, rules of thumb (one concern per branch, independently revertable, restack after rebases), and when not to stack.

**Breaking Changes**

- [ ] Yes — this PR contains breaking changes
- [x] No — this PR is backwards compatible

**Features**:

- Five new skills (`pr-review`, `triage`, `bugfix`, `feature-plan`, `feature-implement`) that future infrastructure can trigger; the skills themselves are read at run time so updates need no infra change

**Improvements**:

- Six per-folder `CLAUDE.md` files so agent + human edits in those areas follow existing module conventions on the first pass
- Four workflow/automation docs codifying the team's risk thresholds, bug allow-list, and one-shot vs plan-first decision rules
- Graphite stacked PR convention documented in `CONTRIBUTING.md`

## Tests

Doc + skill-only PR; no runtime code paths added. Verification:

- [x] `pnpm format` passes on the full repo
- [x] `pnpm install` succeeds with no lockfile changes (no dependency changes)
- [x] No source code modified (every file is a new addition under `docs/`, `.claude/skills/`, or `**/CLAUDE.md`, plus a `CONTRIBUTING.md` edit)

## What's deferred and why

Out of scope for this PR (each needs external infra or a team decision):

- GitHub Action invoking `pr-review` on opened PRs (needs `AI_REVIEW_ENABLED` repo variable + agent credentials)
- Linear webhook → agent runner (needs Linear webhook secret + hosted runner + agent identity for `gt`)
- Figma + Linear MCP fetching (needs MCP server config + Figma token)
- Chromatic post-deploy step (needs Chromatic project token + workflow)
- Datadog MCP for incident triage (org has not allowed it yet per the source doc)

## History

This consolidates the previously-stacked PRs #2265–#2272 and #2274–#2281 into a single PR. Each of those PRs was independently revertable docs, but a 16-PR stack for pure documentation was reviewer-unfriendly; this single PR makes the same content easier to read end-to-end. The originals will be closed with a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
