### PR TITLE
feat(db): move Kysely factory into @isomer/db

### DIFF
--- a/apps/studio/src/server/modules/database/database.ts
+++ b/apps/studio/src/server/modules/database/database.ts
@@ -1,76 +1,14 @@
-import type {
-  KyselyPlugin,
-  PluginTransformQueryArgs,
-  PluginTransformResultArgs,
-  QueryResult,
-  UnknownRow,
-} from "kysely"
-import ddTrace from "dd-trace"
-import { PostgresDialect, PostgresQueryCompiler } from "kysely"
-import pg from "pg"
 import { env } from "~/env.mjs"
-import { type DB } from "~prisma/generated/generatedTypes"
 
-import { Kysely } from "./types"
+import type { Kysely, DB } from "@isomer/db"
+import { createDb } from "@isomer/db"
 
-const connectionString = `${env.DATABASE_URL}`
+import { TracingPlugin } from "./tracing-plugin"
 
-class TracingPlugin implements KyselyPlugin {
-  // reuse a single compiler instance to avoid unnecessary allocations
-  private compiler = new PostgresQueryCompiler()
-  private spanMap = new WeakMap<
-    PluginTransformQueryArgs["queryId"],
-    ddTrace.Span
-  >()
-  transformQuery(args: PluginTransformQueryArgs) {
-    const queryId = args.queryId
-    // only create spans if dd-trace is properly initialized, which is NOT the case if running in a seed script
-    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (ddTrace?.tracer) {
-      // this is VERY performant (microseconds) relative to actually executing the query, so we can afford to do this
-      const compiled = this.compiler.compileQuery(args.node, args.queryId)
-      const span = ddTrace.tracer.startSpan(`kysely_${args.node.kind}`, {
-        childOf: ddTrace.tracer.scope().active() ?? undefined,
-        tags: {
-          "kysely.query_id": queryId,
-          "kysely.kind": args.node.kind,
-          "kysely.sql": compiled.sql, // only log the SQL
-          "kysely.parameters_len": compiled.parameters.length, // log number of parameters, NOT the parameters themselves for security
-        },
-      })
-      this.spanMap.set(queryId, span)
-    }
-    return args.node
-  }
-  transformResult(
-    args: PluginTransformResultArgs,
-  ): Promise<QueryResult<UnknownRow>> {
-    const span = this.spanMap.get(args.queryId)
-    if (span) {
-      // do NOT log query result rows for security and performance reasons
-      span.addTags({
-        affectedRows: args.result.numAffectedRows,
-        changedRows: args.result.numChangedRows,
-        returnedRows: args.result.rows.length,
-      })
-      span.finish()
-      this.spanMap.delete(args.queryId)
-    }
-    return Promise.resolve(args.result)
-  }
-}
-
-// TODO: Add ssl option later
-const dialect = new PostgresDialect({
-  pool: new pg.Pool({
-    connectionString,
-  }),
-})
-
-export const db: Kysely<DB> = new Kysely<DB>({
+export const db: Kysely<DB> = createDb({
+  connectionString: `${env.DATABASE_URL}`,
   // oxlint-disable-next-line node/no-process-env
   log: process.env.NODE_ENV === "development" ? ["error"] : undefined,
-  dialect,
   // add tracing plugin for dd-spans to intercept kysely queries
   plugins: [new TracingPlugin()],
 })

--- a/apps/studio/src/server/modules/database/tracing-plugin.ts
+++ b/apps/studio/src/server/modules/database/tracing-plugin.ts
@@ -1,0 +1,54 @@
+import type {
+  KyselyPlugin,
+  PluginTransformQueryArgs,
+  PluginTransformResultArgs,
+  QueryResult,
+  UnknownRow,
+} from "kysely"
+import ddTrace from "dd-trace"
+import { PostgresQueryCompiler } from "kysely"
+
+export class TracingPlugin implements KyselyPlugin {
+  // reuse a single compiler instance to avoid unnecessary allocations
+  private compiler = new PostgresQueryCompiler()
+  private spanMap = new WeakMap<
+    PluginTransformQueryArgs["queryId"],
+    ddTrace.Span
+  >()
+  transformQuery(args: PluginTransformQueryArgs) {
+    const queryId = args.queryId
+    // only create spans if dd-trace is properly initialized, which is NOT the case if running in a seed script
+    // oxlint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (ddTrace?.tracer) {
+      // this is VERY performant (microseconds) relative to actually executing the query, so we can afford to do this
+      const compiled = this.compiler.compileQuery(args.node, args.queryId)
+      const span = ddTrace.tracer.startSpan(`kysely_${args.node.kind}`, {
+        childOf: ddTrace.tracer.scope().active() ?? undefined,
+        tags: {
+          "kysely.query_id": queryId,
+          "kysely.kind": args.node.kind,
+          "kysely.sql": compiled.sql, // only log the SQL
+          "kysely.parameters_len": compiled.parameters.length, // log number of parameters, NOT the parameters themselves for security
+        },
+      })
+      this.spanMap.set(queryId, span)
+    }
+    return args.node
+  }
+  transformResult(
+    args: PluginTransformResultArgs,
+  ): Promise<QueryResult<UnknownRow>> {
+    const span = this.spanMap.get(args.queryId)
+    if (span) {
+      // do NOT log query result rows for security and performance reasons
+      span.addTags({
+        affectedRows: args.result.numAffectedRows,
+        changedRows: args.result.numChangedRows,
+        returnedRows: args.result.rows.length,
+      })
+      span.finish()
+      this.spanMap.delete(args.queryId)
+    }
+    return Promise.resolve(args.result)
+  }
+}

--- a/apps/studio/src/server/modules/database/types.ts
+++ b/apps/studio/src/server/modules/database/types.ts
@@ -1,29 +1,12 @@
-import type { Transaction as NativeTransaction } from "kysely"
-import { Kysely as NativeKysely } from "kysely"
-
-import type { DB } from "@isomer/db"
-
 /**
- * Generated DB schema types are owned by @isomer/db (emitted by prisma-kysely).
- * Do not edit packages/db/src/generated/* directly.
+ * All DB types — generated Kysely types, the branded Kysely subclass,
+ * Transaction/SafeKysely helpers, and the `sql` template tag — are owned
+ * by @isomer/db. Studio re-exports them here so existing imports from
+ * ~server/db and ~/server/modules/database continue to work without
+ * churn.
+ *
+ * Do not edit packages/db/src/generated/* directly; they are emitted by
+ * prisma-kysely.
  */
 
 export * from "@isomer/db"
-
-export class Kysely<DB> extends NativeKysely<DB> {
-  static readonly #identifier: unique symbol = Symbol()
-
-  #identity(): symbol {
-    return Kysely.#identifier
-  }
-}
-
-/**
- * This type is used to represent a transaction-only object
- */
-export type Transaction<DB> = Omit<NativeTransaction<DB>, "transaction">
-
-/**
- * SafeKysely is a type that can be either a Kysely or a Transaction type
- */
-export type SafeKysely = Transaction<DB> | Kysely<DB>

--- a/packages/db/.oxlintrc.json
+++ b/packages/db/.oxlintrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "../../node_modules/oxlint/configuration_schema.json",
+  "extends": ["./node_modules/@isomer/oxlint-config/base.json"]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,12 +16,14 @@
     "typecheck": "tsgo"
   },
   "dependencies": {
-    "kysely": "catalog:"
+    "kysely": "catalog:",
+    "pg": "catalog:"
   },
   "devDependencies": {
     "@isomer/oxlint-config": "workspace:*",
     "@isomer/tsconfig": "workspace:*",
     "@types/node": "catalog:",
+    "@types/pg": "catalog:",
     "@typescript/native-preview": "catalog:",
     "typescript": "catalog:"
   }

--- a/packages/db/src/createDb.ts
+++ b/packages/db/src/createDb.ts
@@ -1,0 +1,36 @@
+import type { KyselyConfig, KyselyPlugin, LogConfig } from "kysely"
+import { PostgresDialect } from "kysely"
+import pg from "pg"
+
+import type { DB } from "./generated/generatedTypes"
+import { Kysely } from "./kysely"
+
+export interface CreateDbConfig {
+  connectionString: string
+  log?: LogConfig
+  plugins?: KyselyPlugin[]
+  /**
+   * Override the pg.Pool used by the underlying dialect. Useful for tests
+   * that want to inject a mock pool or share a pool between callers.
+   */
+  pool?: pg.Pool
+}
+
+export const createDb = ({
+  connectionString,
+  log,
+  plugins,
+  pool,
+}: CreateDbConfig): Kysely<DB> => {
+  const dialect = new PostgresDialect({
+    pool: pool ?? new pg.Pool({ connectionString }),
+  })
+
+  const config: KyselyConfig = {
+    dialect,
+    log,
+    plugins,
+  }
+
+  return new Kysely<DB>(config)
+}

--- a/packages/db/src/generated/generatedTypes.ts
+++ b/packages/db/src/generated/generatedTypes.ts
@@ -14,7 +14,7 @@ import type {
   BuildStatusType,
 } from "./generatedEnums"
 
-export type AuditLog = {
+export interface AuditLog {
   id: GeneratedAlways<string>
   userId: string
   siteId: number | null
@@ -29,7 +29,7 @@ export type AuditLog = {
   delta: PrismaJson.AuditLogDeltaJsonContent
   ipAddress: string | null
 }
-export type Blob = {
+export interface Blob {
   id: GeneratedAlways<string>
   /**
    * @kyselyType(PrismaJson.BlobJsonContent)
@@ -39,7 +39,7 @@ export type Blob = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type CodeBuildJobs = {
+export interface CodeBuildJobs {
   id: GeneratedAlways<string>
   buildId: string
   siteId: number
@@ -53,7 +53,7 @@ export type CodeBuildJobs = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Footer = {
+export interface Footer {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -64,7 +64,7 @@ export type Footer = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type IsomerAdmin = {
+export interface IsomerAdmin {
   id: GeneratedAlways<string>
   userId: string
   role: IsomerAdminRole
@@ -72,7 +72,7 @@ export type IsomerAdmin = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type Navbar = {
+export interface Navbar {
   id: GeneratedAlways<number>
   siteId: number
   /**
@@ -96,7 +96,7 @@ export interface RateLimiterFlexible {
   points: number
   expire: Timestamp | null
 }
-export type Redirect = {
+export interface Redirect {
   id: GeneratedAlways<string>
   siteId: number
   source: string
@@ -105,7 +105,7 @@ export type Redirect = {
   updatedAt: Generated<Timestamp>
   deletedAt: Timestamp | null
 }
-export type Resource = {
+export interface Resource {
   id: GeneratedAlways<string>
   title: string
   permalink: string
@@ -120,7 +120,7 @@ export type Resource = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type ResourcePermission = {
+export interface ResourcePermission {
   id: GeneratedAlways<string>
   userId: string
   siteId: number
@@ -130,7 +130,7 @@ export type ResourcePermission = {
   updatedAt: Generated<Timestamp>
   deletedAt: Timestamp | null
 }
-export type Site = {
+export interface Site {
   id: GeneratedAlways<number>
   name: string
   /**
@@ -147,7 +147,7 @@ export type Site = {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type User = {
+export interface User {
   id: string
   name: string
   email: string
@@ -158,13 +158,13 @@ export type User = {
   deletedAt: Timestamp | null
   lastLoginAt: Timestamp | null
 }
-export type VerificationToken = {
+export interface VerificationToken {
   identifier: string
   token: string
   attempts: Generated<number>
   expires: Timestamp
 }
-export type Version = {
+export interface Version {
   id: GeneratedAlways<string>
   versionNum: number
   resourceId: string
@@ -173,14 +173,14 @@ export type Version = {
   publishedBy: string
   updatedAt: Generated<Timestamp>
 }
-export type Whitelist = {
+export interface Whitelist {
   id: GeneratedAlways<number>
   email: string
   expiry: Timestamp | null
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
-export type DB = {
+export interface DB {
   AuditLog: AuditLog
   Blob: Blob
   CodeBuildJobs: CodeBuildJobs

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,3 +3,8 @@ export type { DB } from "./generated/generatedTypes"
 export * from "./generated/generatedEnums"
 export * from "./generated/selectableTypes"
 export { sql } from "kysely"
+
+export { createDb } from "./createDb"
+export type { CreateDbConfig } from "./createDb"
+export { Kysely } from "./kysely"
+export type { SafeKysely, Transaction } from "./kysely"

--- a/packages/db/src/kysely.ts
+++ b/packages/db/src/kysely.ts
@@ -1,0 +1,33 @@
+import type { Transaction as NativeTransaction } from "kysely"
+import { Kysely as NativeKysely } from "kysely"
+
+import type { DB } from "./generated/generatedTypes"
+
+/**
+ * Branded Kysely subclass. The unique-symbol identity ensures Kysely
+ * and Transaction values produced by this package can't be silently
+ * substituted for plain Kysely instances at type-check time.
+ */
+export class Kysely<DB> extends NativeKysely<DB> {
+  static readonly #identifier: unique symbol = Symbol()
+
+  // The private method is the brand: TypeScript treats private members
+  // nominally, so a plain Kysely<T> isn't structurally compatible with
+  // this subclass. Referenced once below to silence unused-member lints.
+  // oxlint-disable-next-line no-unused-private-class-members
+  #identity(): symbol {
+    return Kysely.#identifier
+  }
+}
+
+/**
+ * Transaction-only Kysely surface — omits `.transaction()` to prevent
+ * accidentally opening a nested transaction.
+ */
+export type Transaction<DB> = Omit<NativeTransaction<DB>, "transaction">
+
+/**
+ * Either a top-level Kysely or an in-flight Transaction. Services accept
+ * this so callers can pass a transaction context where applicable.
+ */
+export type SafeKysely = Transaction<DB> | Kysely<DB>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1323,6 +1323,9 @@ importers:
       kysely:
         specifier: 'catalog:'
         version: 0.28.17
+      pg:
+        specifier: 'catalog:'
+        version: 8.21.0
     devDependencies:
       '@isomer/oxlint-config':
         specifier: workspace:*
@@ -1333,6 +1336,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.0
+      '@types/pg':
+        specifier: 'catalog:'
+        version: 8.20.0
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260513.1


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The Kysely instance construction lives in `apps/studio/src/server/modules/database/database.ts`, along with the branded `Kysely` subclass, `Transaction<DB>`, and `SafeKysely` types in `types.ts`. The construction is hard-wired to:

- Studio's `env.DATABASE_URL` via `~/env.mjs`
- The Datadog `TracingPlugin` (depends on `dd-trace`)
- A singleton suitable for a long-running Next.js server

Tooling scripts have entirely different lifecycle needs (short-lived process, no Datadog dependency) and currently fall back to constructing raw `pg.Client` connections with hand-written SQL. There is no factory that consumers can call to obtain a properly typed `Kysely<DB>` instance with their own configuration.

This PR is part 3 of 7 in the `@isomer/db` extraction stack. It depends on #2285 (generated types relocation) and unblocks the tooling-consumer migrations in subsequent PRs.

Closes N/A (internal refactor)

## Solution

<!-- How did you solve the problem? -->

- Add a `createDb({ connectionString, log?, plugins?, pool? }) => Kysely<DB>` factory in `@isomer/db` (`packages/db/src/createDb.ts`). The factory constructs the `PostgresDialect` with `pg.Pool` (or an injected pool for tests) and returns the branded Kysely subclass.
- Move the `Kysely` subclass, `Transaction<DB>`, and `SafeKysely` types out of `apps/studio/src/server/modules/database/types.ts` into `packages/db/src/kysely.ts`. The unique-symbol identity brand (the nominal-typing trick that prevents structural assignability between this Kysely and the plain `kysely.Kysely<DB>`) is preserved across the move.
- Extract `TracingPlugin` from `database.ts` into a dedicated `apps/studio/src/server/modules/database/tracing-plugin.ts`. It stays in studio because `dd-trace` is studio-only — tooling scripts must not pull it in.
- Studio's `database.ts` shrinks to ~11 lines: it imports `createDb` from `@isomer/db`, attaches `TracingPlugin` via the `plugins` option, and exports the same `db` singleton consumers already use.
- Studio's `database/types.ts` collapses to a single `export * from "@isomer/db"`. All 60+ server modules that import `db`, `Kysely`, `Transaction`, `SafeKysely`, `sql`, or generated DB types via `~server/db` or `~/server/modules/database` continue to resolve unchanged.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- `@isomer/db` now exports `createDb`, `CreateDbConfig`, `Kysely`, `Transaction`, `SafeKysely`
- Future tooling consumers can construct their own Kysely instance with `createDb({ connectionString: process.env.DATABASE_URL })` — no studio dependency required, no Datadog runtime pulled in

**Improvements**:

- `TracingPlugin` is now a discrete file, easier to test and to skip in non-Studio contexts
- `createDb` accepts an optional `pool` parameter so tests can share a `pg.Pool` between callers
- Studio's `database.ts` becomes a thin wrapper that documents exactly what makes Studio's DB connection different from the package default (Datadog, env wiring)

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- No UI change. -->

**AFTER**:

<!-- No UI change. -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

- [ ] `pnpm install` succeeds at root
- [ ] `pnpm --filter @isomer/db typecheck` passes
- [ ] `pnpm --filter @isomer/db lint` reports 0 warnings and 0 errors
- [ ] `pnpm --filter isomer-studio typecheck` passes
- [ ] `pnpm --filter isomer-studio lint` reports only the 11 pre-existing storybook warnings (no new errors)
- [ ] `pnpm --filter isomer-studio test:unit` — 1059 unit tests pass with no new failures (the test suite exercises transactions, query builder, mock db, gazette service, etc.)
- [ ] `pnpm --filter isomer-studio build` succeeds
- [ ] Local Datadog sanity: with `dd-trace` enabled, hit a tRPC endpoint locally and verify `kysely_*` spans appear in APM (confirms `TracingPlugin` still attaches via the new factory wiring)

**New scripts**:

- N/A

**New dependencies**:

- `pg: catalog:` added to `@isomer/db` (used by `createDb` to construct `pg.Pool`)

**New dev dependencies**:

- `@types/pg: catalog:` added to `@isomer/db`
