### PR TITLE
feat: render egazette-specific banner on IMDA gazette collection page

### DIFF
--- a/apps/studio/src/features/dashboard/components/GazetteCollectionBanner/GazetteCollectionBanner.tsx
+++ b/apps/studio/src/features/dashboard/components/GazetteCollectionBanner/GazetteCollectionBanner.tsx
@@ -1,0 +1,7 @@
+import { Infobox } from "@opengovsg/design-system-react"
+
+export const GazetteCollectionBanner = (): JSX.Element => (
+  <Infobox variant="info" size="sm" w="100%">
+    This is a customised view for Government Gazettes.
+  </Infobox>
+)

--- a/apps/studio/src/features/dashboard/components/GazetteCollectionBanner/index.ts
+++ b/apps/studio/src/features/dashboard/components/GazetteCollectionBanner/index.ts
@@ -1,0 +1,1 @@
+export { GazetteCollectionBanner } from "./GazetteCollectionBanner"

--- a/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
@@ -13,10 +13,12 @@ import {
 } from "~/features/dashboard/components/DashboardLayout"
 import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
+import { GazetteCollectionBanner } from "~/features/dashboard/components/GazetteCollectionBanner"
 import { IndexpageRow } from "~/features/dashboard/components/IndexpageRow/IndexpageRow"
 import { PageSettingsModal } from "~/features/dashboard/components/PageSettingsModal"
 import { CreateCollectionPageModal } from "~/features/editing-experience/components/CreateCollectionPageModal"
 import { MoveResourceModal } from "~/features/editing-experience/components/MoveResourceModal"
+import { useEgazetteInfo } from "~/hooks/useEgazetteInfo"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { SiteEditorLayout } from "~/templates/layouts/SiteEditorLayout"
@@ -37,6 +39,11 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
   } = useDisclosure()
   const { siteId, collectionId } = useQueryParse(collectionPageSchema)
   const setFolderSettingsModalState = useSetAtom(folderSettingsModalAtom)
+  const egazetteInfo = useEgazetteInfo()
+  const isEgazetteCollection =
+    egazetteInfo.isConfigured &&
+    egazetteInfo.siteId === String(siteId) &&
+    egazetteInfo.gazettesCollectionId === String(collectionId)
 
   const [resource] = trpc.resource.getParentOf.useSuspenseQuery({
     siteId: Number(siteId),
@@ -76,7 +83,11 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
           </>
         }
       >
-        <CollectionBanner />
+        {isEgazetteCollection ? (
+          <GazetteCollectionBanner />
+        ) : (
+          <CollectionBanner />
+        )}
         <IndexpageRow
           type="collection"
           siteId={siteId}

--- a/apps/studio/src/stories/Page/CollectionPage.stories.tsx
+++ b/apps/studio/src/stories/Page/CollectionPage.stories.tsx
@@ -9,7 +9,10 @@ import { sitesHandlers } from "tests/msw/handlers/sites"
 import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import CollectionPage from "~/pages/sites/[siteId]/collections/[collectionId]"
 
-import { createBannerGbParameters } from "../utils/growthbook"
+import {
+  createBannerGbParameters,
+  createEgazetteInfoGbParameters,
+} from "../utils/growthbook"
 
 const meta: Meta<typeof CollectionPage> = {
   title: "Pages/Collection Management/Collection Page",
@@ -80,6 +83,17 @@ export const WithBanner: Story = {
         variant: "info",
         message:
           "This is a test banner that is very long. This is a test banner that is very long. This is a test banner that is very long. This is a test banner that is very long. This is a test banner that is very long.",
+      }),
+    ],
+  },
+}
+
+export const GazetteCollection: Story = {
+  parameters: {
+    growthbook: [
+      createEgazetteInfoGbParameters({
+        siteId: "1",
+        gazettesCollectionId: "1",
       }),
     ],
   },

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -3,6 +3,7 @@ import { GrowthBook } from "@growthbook/growthbook"
 import {
   BANNER_FEATURE_KEY,
   CATEGORY_DROPDOWN_FEATURE_KEY,
+  EGAZETTE_INFO_FEATURE_KEY,
   IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
   IS_REDIRECTIONS_ENABLED_FEATURE_KEY,
   IS_SINGPASS_ENABLED_FEATURE_KEY,
@@ -45,4 +46,14 @@ export const createRedirectionsEnabledGbParameters = (isEnabled: boolean) => {
 
 export const createAntiScamBannerEnabledGbParameters = (isEnabled: boolean) => {
   return [IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY, isEnabled]
+}
+
+export const createEgazetteInfoGbParameters = ({
+  siteId,
+  gazettesCollectionId,
+}: {
+  siteId: string
+  gazettesCollectionId: string
+}) => {
+  return [EGAZETTE_INFO_FEATURE_KEY, { siteId, gazettesCollectionId }]
 }


### PR DESCRIPTION
## Goal
Show IMDA users a distinct banner on the eGazette collection page so they know this collection is a customised view.

## Approach
Approach A from the [feature plan](https://linear.app/ogp/issue/ISOM-2293/test-imda-frontend-for-egazette) on ISOM-2293: gate a new dedicated `GazetteCollectionBanner` in the page via the existing `useEgazetteInfo` hook (GrowthBook). Default `CollectionBanner` code path is untouched.

## What this PR does
- Adds `apps/studio/src/features/dashboard/components/GazetteCollectionBanner/` — a thin `Infobox variant="info"` banner matching the Figma frame.
- In `apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx`, derives `isEgazetteCollection` from `useEgazetteInfo()` and renders the new banner when the configured egazette site+collection matches; otherwise renders the existing banner.
- Adds `createEgazetteInfoGbParameters` helper in `apps/studio/src/stories/utils/growthbook.ts` mirroring the existing GrowthBook story helpers.
- Adds a `GazetteCollection` story to `CollectionPage.stories.tsx` to exercise the page-level branching.

## Stack
Single PR — Approach A is FE-only with no schema or server change, so the default Graphite split (schema → server → client → stories) collapses to one slice per `feature-implement` step 3.

## Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new warnings/errors; pre-existing warnings in unrelated stories files)
- [x] `pnpm test:unit` passes (1063 passed, 41 skipped)
- [x] `pnpm build-storybook` succeeds with the new story
- [x] Storybook story added (`Pages/Collection Management/Collection Page → GazetteCollection`)
- [ ] tRPC integration test — N/A (no server changes)
- [ ] Chromatic preview link — will populate after CI builds

## Notes
- Base branch is `docs/ai-adoption-l3-foundation` (not `main`) because this PR is exercising the L3 workflow that branch introduces. Once that lands in `main`, this can be rebased.
- Risk tier: **medium** (touches `apps/studio/src/features/**` per `docs/risk-taxonomy.md`); blast radius is contained — only the egazette collection page renders the new branch.
- Labels (`ai-authored`, `risk:medium`, `area:studio`) are not yet defined on the repo. They will be added once the docs branch lands.

## Closes
ISOM-2293