### PR TITLE
feat(agent-runner): scaffold Cloudflare Worker for Linear ↔ Anthropic webhooks

### DIFF
--- a/apps/agent-runner/README.md
+++ b/apps/agent-runner/README.md
@@ -1,0 +1,90 @@
+# @isomer/agent-runner
+
+Cloudflare Worker that brokers between Linear, Anthropic Managed Agents, and GitHub for the L3 AI-adoption pipeline. **Stateless** — no database, no in-memory state across requests. Source of truth lives in Linear (ticket labels, comments) and Anthropic (session metadata).
+
+## Status
+
+PR-1: Worker shell only. Verifies signatures and acks, but does no real dispatch yet — the `LINEAR_AGENT_TRIGGER` env flag short-circuits with 204 when off (the default). Follow-up PRs wire the Anthropic Managed Agents client, the Linear label state machine, and the pick resolver.
+
+## Endpoints
+
+| Path              | Caller                   | What it does today                                            |
+| ----------------- | ------------------------ | ------------------------------------------------------------- |
+| `POST /linear`    | Linear webhooks          | Verify HMAC + timestamp window, parse, log intent, 204 / 202. |
+| `POST /anthropic` | Anthropic Managed Agents | Verify HMAC + timestamp window, parse, log intent, 204 / 202. |
+
+## Local development
+
+```bash
+pnpm --filter @isomer/agent-runner dev
+```
+
+`wrangler dev` runs the Worker on `http://localhost:8787`. Configure secrets in a `.dev.vars` file (gitignored):
+
+```
+LINEAR_WEBHOOK_SECRET=dev-secret
+ANTHROPIC_WEBHOOK_SECRET=dev-secret
+ANTHROPIC_API_KEY=sk-ant-...
+LINEAR_API_TOKEN=lin_api_...
+```
+
+Use [webhook.site](https://webhook.site) or `ngrok` to receive real Linear webhooks locally, then replay them against `localhost:8787` with `curl -X POST -H "linear-signature: ..." --data-binary @payload.json http://localhost:8787/linear`.
+
+## Tests
+
+```bash
+pnpm --filter @isomer/agent-runner test:unit
+```
+
+The HMAC verifier has full coverage — every other piece is either a stateless parser or a stub for a follow-up PR.
+
+## Deploy
+
+```bash
+pnpm --filter @isomer/agent-runner deploy
+```
+
+The Worker deploys to Cloudflare under the `isomer-agent-runner` name. Production secrets are set per-env via:
+
+```bash
+wrangler secret put LINEAR_WEBHOOK_SECRET
+wrangler secret put ANTHROPIC_WEBHOOK_SECRET
+wrangler secret put ANTHROPIC_API_KEY
+wrangler secret put LINEAR_API_TOKEN
+```
+
+## Trigger lifecycle (planned, not in this PR)
+
+Designed for stateless operation — every webhook handler reads state from Linear or Anthropic at request time and writes state back to Linear via labels and comments.
+
+```
+Linear ticket gets `ai:implement` label
+  → POST /linear
+  → Worker validates fields, checks for existing `agent:running` label (skip if present)
+  → Worker calls Anthropic POST /v1/sessions
+       metadata: { linearIssueId }
+       webhook: this Worker's /anthropic URL
+  → Worker writes `agent:running` label to the Linear ticket
+
+Anthropic session goes idle (e.g. feature-plan finished)
+  → POST /anthropic { type: session.status_idle }
+  → Worker swaps Linear label: agent:running → agent:idle
+
+Human comments `pick: B` on the Linear ticket
+  → POST /linear (comment.create)
+  → Worker queries Anthropic for the session by metadata.linearIssueId
+  → Worker POSTs user.custom_tool_result with the pick
+  → Worker swaps Linear label: agent:idle → agent:running
+
+Anthropic session completes
+  → POST /anthropic { type: session.completed }
+  → Worker clears all agent:* labels from the Linear ticket
+```
+
+If the Worker crashes, the next webhook recovers — no state is lost because there's no Worker-side state.
+
+## Rollback
+
+`LINEAR_AGENT_TRIGGER=false` (the default) is the master kill-switch — handlers short-circuit before any outbound work. Flip via `wrangler secret put` or directly in `wrangler.toml [vars]` + redeploy.
+
+Full rollback: `wrangler delete` removes the Worker. Linear and Anthropic are independent — no cleanup required there.

--- a/apps/agent-runner/package.json
+++ b/apps/agent-runner/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@isomer/agent-runner",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "clean": "git clean -xdf .cache .turbo .wrangler node_modules",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "format": "oxfmt --check . --ignore-path ../../.gitignore",
+    "format:fix": "oxfmt --write . --ignore-path ../../.gitignore",
+    "lint": "oxlint --type-aware .",
+    "lint:fix": "oxlint --type-aware --fix .",
+    "test": "run-s test:*",
+    "test-ci:unit": "vitest run -- --coverage",
+    "test:unit": "vitest run",
+    "test:watch": "vitest watch",
+    "typecheck": "tsgo"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260601.0",
+    "@isomer/oxlint-config": "workspace:*",
+    "@isomer/tsconfig": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "@vitest/coverage-istanbul": "catalog:vitest",
+    "npm-run-all2": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:vitest",
+    "wrangler": "^4.45.0",
+    "zod": "catalog:"
+  }
+}

--- a/apps/agent-runner/src/env.ts
+++ b/apps/agent-runner/src/env.ts
@@ -1,0 +1,17 @@
+import { z } from "zod"
+
+const envSchema = z.object({
+  LINEAR_AGENT_TRIGGER: z
+    .enum(["true", "false"])
+    .transform((v) => v === "true"),
+  MAX_PAYLOAD_AGE_SECONDS: z.coerce.number().int().positive(),
+
+  LINEAR_WEBHOOK_SECRET: z.string().min(1).optional(),
+  ANTHROPIC_WEBHOOK_SECRET: z.string().min(1).optional(),
+  ANTHROPIC_API_KEY: z.string().min(1).optional(),
+  LINEAR_API_TOKEN: z.string().min(1).optional(),
+})
+
+export type Env = z.infer<typeof envSchema>
+
+export const parseEnv = (raw: unknown): Env => envSchema.parse(raw)

--- a/apps/agent-runner/src/handlers/anthropic.ts
+++ b/apps/agent-runner/src/handlers/anthropic.ts
@@ -1,0 +1,84 @@
+import { z } from "zod"
+
+import type { Env } from "../env"
+import { isWithinTimestampWindow, verifyHmacSha256 } from "../lib/hmac"
+
+const SIGNATURE_HEADER = "x-anthropic-signature"
+const TIMESTAMP_HEADER = "x-anthropic-timestamp"
+
+const anthropicWebhookSchema = z
+  .object({
+    type: z.string(),
+    session_id: z.string(),
+    timestamp: z.string().datetime().optional(),
+  })
+  .passthrough()
+
+export const handleAnthropicWebhook = async (
+  request: Request,
+  env: Env,
+): Promise<Response> => {
+  const rawBody = await request.text()
+  const signatureHex = request.headers.get(SIGNATURE_HEADER) ?? ""
+
+  if (!env.ANTHROPIC_WEBHOOK_SECRET) {
+    console.error(
+      "anthropic webhook received but ANTHROPIC_WEBHOOK_SECRET is unset",
+    )
+    return new Response("server not configured", { status: 503 })
+  }
+
+  const valid = await verifyHmacSha256({
+    rawBody,
+    signatureHex,
+    secret: env.ANTHROPIC_WEBHOOK_SECRET,
+  })
+  if (!valid) {
+    console.warn("anthropic webhook signature invalid")
+    return new Response("bad signature", { status: 401 })
+  }
+
+  const headerTimestamp = request.headers.get(TIMESTAMP_HEADER)
+  if (headerTimestamp !== null) {
+    const ts = Number.parseInt(headerTimestamp, 10)
+    if (
+      !Number.isFinite(ts) ||
+      !isWithinTimestampWindow({
+        timestampMs: ts * 1000,
+        nowMs: Date.now(),
+        maxAgeSeconds: env.MAX_PAYLOAD_AGE_SECONDS,
+      })
+    ) {
+      console.warn("anthropic webhook timestamp outside window", {
+        headerTimestamp,
+      })
+      return new Response("stale", { status: 401 })
+    }
+  }
+
+  const parsed = anthropicWebhookSchema.safeParse(JSON.parse(rawBody))
+  if (!parsed.success) {
+    console.warn("anthropic webhook payload failed schema validation", {
+      issues: parsed.error.issues,
+    })
+    return new Response("bad payload", { status: 400 })
+  }
+
+  if (!env.LINEAR_AGENT_TRIGGER) {
+    console.info("anthropic webhook accepted but trigger disabled", {
+      type: parsed.data.type,
+      sessionId: parsed.data.session_id,
+    })
+    return new Response(null, { status: 204 })
+  }
+
+  // TODO(stack 3.5 follow-up): route based on parsed.data.type
+  //   - session.status_idle → swap Linear label agent:running → agent:idle
+  //   - session.completed   → clear agent:* labels, optionally post summary
+  //   - session.failed      → clear labels, post failure comment with audit link
+  console.info("anthropic webhook would dispatch (trigger enabled)", {
+    type: parsed.data.type,
+    sessionId: parsed.data.session_id,
+  })
+  return new Response(null, { status: 202 })
+}

--- a/apps/agent-runner/src/handlers/linear.ts
+++ b/apps/agent-runner/src/handlers/linear.ts
@@ -1,0 +1,88 @@
+import { z } from "zod"
+
+import type { Env } from "../env"
+import { isWithinTimestampWindow, verifyHmacSha256 } from "../lib/hmac"
+
+const SIGNATURE_HEADER = "linear-signature"
+const TIMESTAMP_HEADER = "linear-delivery-timestamp"
+
+const linearWebhookSchema = z
+  .object({
+    action: z.string(),
+    type: z.string(),
+    webhookTimestamp: z.number(),
+    data: z
+      .object({
+        id: z.string(),
+      })
+      .passthrough(),
+  })
+  .passthrough()
+
+export const handleLinearWebhook = async (
+  request: Request,
+  env: Env,
+): Promise<Response> => {
+  const rawBody = await request.text()
+  const signatureHex = request.headers.get(SIGNATURE_HEADER) ?? ""
+
+  if (!env.LINEAR_WEBHOOK_SECRET) {
+    console.error("linear webhook received but LINEAR_WEBHOOK_SECRET is unset")
+    return new Response("server not configured", { status: 503 })
+  }
+
+  const valid = await verifyHmacSha256({
+    rawBody,
+    signatureHex,
+    secret: env.LINEAR_WEBHOOK_SECRET,
+  })
+  if (!valid) {
+    console.warn("linear webhook signature invalid")
+    return new Response("bad signature", { status: 401 })
+  }
+
+  const headerTimestamp = request.headers.get(TIMESTAMP_HEADER)
+  if (headerTimestamp !== null) {
+    const ts = Number.parseInt(headerTimestamp, 10)
+    if (
+      !Number.isFinite(ts) ||
+      !isWithinTimestampWindow({
+        timestampMs: ts,
+        nowMs: Date.now(),
+        maxAgeSeconds: env.MAX_PAYLOAD_AGE_SECONDS,
+      })
+    ) {
+      console.warn("linear webhook timestamp outside window", {
+        headerTimestamp,
+      })
+      return new Response("stale", { status: 401 })
+    }
+  }
+
+  const parsed = linearWebhookSchema.safeParse(JSON.parse(rawBody))
+  if (!parsed.success) {
+    console.warn("linear webhook payload failed schema validation", {
+      issues: parsed.error.issues,
+    })
+    return new Response("bad payload", { status: 400 })
+  }
+
+  if (!env.LINEAR_AGENT_TRIGGER) {
+    console.info("linear webhook accepted but trigger disabled", {
+      action: parsed.data.action,
+      type: parsed.data.type,
+      id: parsed.data.data.id,
+    })
+    return new Response(null, { status: 204 })
+  }
+
+  // TODO(stack 3.4 follow-up): route based on parsed.data.type
+  //   - Issue + action=update with newly-added ai:implement label → start session
+  //   - Comment + body matching /pick:\s*[ABC]/ → resume idle session
+  console.info("linear webhook would dispatch (trigger enabled)", {
+    action: parsed.data.action,
+    type: parsed.data.type,
+    id: parsed.data.data.id,
+  })
+  return new Response(null, { status: 202 })
+}

--- a/apps/agent-runner/src/index.ts
+++ b/apps/agent-runner/src/index.ts
@@ -1,0 +1,24 @@
+import { parseEnv } from "./env"
+import { handleAnthropicWebhook } from "./handlers/anthropic"
+import { handleLinearWebhook } from "./handlers/linear"
+
+export default {
+  async fetch(request: Request, rawEnv: unknown): Promise<Response> {
+    const url = new URL(request.url)
+
+    if (request.method !== "POST") {
+      return new Response("method not allowed", { status: 405 })
+    }
+
+    const env = parseEnv(rawEnv)
+
+    switch (url.pathname) {
+      case "/linear":
+        return handleLinearWebhook(request, env)
+      case "/anthropic":
+        return handleAnthropicWebhook(request, env)
+      default:
+        return new Response("not found", { status: 404 })
+    }
+  },
+} satisfies ExportedHandler<unknown>

--- a/apps/agent-runner/src/lib/hmac.test.ts
+++ b/apps/agent-runner/src/lib/hmac.test.ts
@@ -1,0 +1,126 @@
+import { createHmac } from "node:crypto"
+import { describe, expect, it } from "vitest"
+
+import { isWithinTimestampWindow, verifyHmacSha256 } from "./hmac"
+
+const sign = (body: string, secret: string): string =>
+  createHmac("sha256", secret).update(body).digest("hex")
+
+describe("verifyHmacSha256", () => {
+  const secret = "test-shared-secret"
+  const body = '{"action":"update","data":{"id":"ENG-123"}}'
+
+  it("returns true for a valid signature", async () => {
+    const signatureHex = sign(body, secret)
+    const result = await verifyHmacSha256({
+      rawBody: body,
+      signatureHex,
+      secret,
+    })
+    expect(result).toBe(true)
+  })
+
+  it("returns false for a signature signed with a different secret", async () => {
+    const signatureHex = sign(body, "wrong-secret")
+    const result = await verifyHmacSha256({
+      rawBody: body,
+      signatureHex,
+      secret,
+    })
+    expect(result).toBe(false)
+  })
+
+  it("returns false when the body has been tampered with", async () => {
+    const signatureHex = sign(body, secret)
+    const result = await verifyHmacSha256({
+      rawBody: body + " ",
+      signatureHex,
+      secret,
+    })
+    expect(result).toBe(false)
+  })
+
+  it("returns false for malformed hex", async () => {
+    const result = await verifyHmacSha256({
+      rawBody: body,
+      signatureHex: "not-hex",
+      secret,
+    })
+    expect(result).toBe(false)
+  })
+
+  it("returns false for an empty signature", async () => {
+    const result = await verifyHmacSha256({
+      rawBody: body,
+      signatureHex: "",
+      secret,
+    })
+    expect(result).toBe(false)
+  })
+
+  it("returns false for an odd-length hex string", async () => {
+    const result = await verifyHmacSha256({
+      rawBody: body,
+      signatureHex: "abc",
+      secret,
+    })
+    expect(result).toBe(false)
+  })
+
+  it("returns false for a signature with the right length but wrong content", async () => {
+    const validSig = sign(body, secret)
+    // Flip the last char
+    const last = validSig.slice(-1) === "0" ? "1" : "0"
+    const tampered = validSig.slice(0, -1) + last
+    const result = await verifyHmacSha256({
+      rawBody: body,
+      signatureHex: tampered,
+      secret,
+    })
+    expect(result).toBe(false)
+  })
+})
+
+describe("isWithinTimestampWindow", () => {
+  const now = 1_700_000_000_000
+
+  it("accepts a timestamp inside the window", () => {
+    expect(
+      isWithinTimestampWindow({
+        timestampMs: now - 60_000,
+        nowMs: now,
+        maxAgeSeconds: 300,
+      }),
+    ).toBe(true)
+  })
+
+  it("rejects a timestamp older than the window", () => {
+    expect(
+      isWithinTimestampWindow({
+        timestampMs: now - 301_000,
+        nowMs: now,
+        maxAgeSeconds: 300,
+      }),
+    ).toBe(false)
+  })
+
+  it("rejects a timestamp far in the future (skew protection)", () => {
+    expect(
+      isWithinTimestampWindow({
+        timestampMs: now + 3_600_000,
+        nowMs: now,
+        maxAgeSeconds: 300,
+      }),
+    ).toBe(false)
+  })
+
+  it("accepts a timestamp exactly at the boundary", () => {
+    expect(
+      isWithinTimestampWindow({
+        timestampMs: now - 300_000,
+        nowMs: now,
+        maxAgeSeconds: 300,
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/agent-runner/src/lib/hmac.ts
+++ b/apps/agent-runner/src/lib/hmac.ts
@@ -1,0 +1,66 @@
+const encoder = new TextEncoder()
+
+const importKey = (secret: string): Promise<CryptoKey> =>
+  crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  )
+
+const hexToBytes = (hex: string): Uint8Array | null => {
+  if (hex.length === 0 || hex.length % 2 !== 0) return null
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+    if (Number.isNaN(byte)) return null
+    bytes[i] = byte
+  }
+  return bytes
+}
+
+const timingSafeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  if (a.byteLength !== b.byteLength) return false
+  let diff = 0
+  for (let i = 0; i < a.byteLength; i++) {
+    diff |= (a[i] ?? 0) ^ (b[i] ?? 0)
+  }
+  return diff === 0
+}
+
+export interface HmacVerifyInput {
+  rawBody: string
+  signatureHex: string
+  secret: string
+}
+
+export const verifyHmacSha256 = async ({
+  rawBody,
+  signatureHex,
+  secret,
+}: HmacVerifyInput): Promise<boolean> => {
+  const given = hexToBytes(signatureHex)
+  if (!given) return false
+
+  const key = await importKey(secret)
+  const expected = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, encoder.encode(rawBody)),
+  )
+  return timingSafeEqual(expected, given)
+}
+
+export interface TimestampWindowInput {
+  timestampMs: number
+  nowMs: number
+  maxAgeSeconds: number
+}
+
+export const isWithinTimestampWindow = ({
+  timestampMs,
+  nowMs,
+  maxAgeSeconds,
+}: TimestampWindowInput): boolean => {
+  const ageMs = Math.abs(nowMs - timestampMs)
+  return ageMs <= maxAgeSeconds * 1000
+}

--- a/apps/agent-runner/tsconfig.json
+++ b/apps/agent-runner/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@isomer/tsconfig/base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "outDir": ".cache/tsc"
+  },
+  "include": ["src/**/*.ts", "vitest.config.ts"],
+  "exclude": ["node_modules", ".wrangler", ".cache"]
+}

--- a/apps/agent-runner/vitest.config.ts
+++ b/apps/agent-runner/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+})

--- a/apps/agent-runner/wrangler.toml
+++ b/apps/agent-runner/wrangler.toml
@@ -1,0 +1,21 @@
+name = "isomer-agent-runner"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat_v2"]
+
+# Secrets configured via `wrangler secret put`, not committed.
+# Required secrets (none populated in this PR — handlers no-op when missing):
+#   LINEAR_WEBHOOK_SECRET      — HMAC shared secret with Linear
+#   ANTHROPIC_WEBHOOK_SECRET   — HMAC shared secret with Anthropic Managed Agents
+#   ANTHROPIC_API_KEY          — for outbound calls to platform.claude.com
+#   LINEAR_API_TOKEN           — Linear service-account token for ticket/comment reads
+#
+# Non-secret config goes under [vars]:
+
+[vars]
+LINEAR_AGENT_TRIGGER = "false" # master kill-switch; nothing fires until "true"
+MAX_PAYLOAD_AGE_SECONDS = "300" # reject webhooks older than 5 min (replay window)
+
+[observability]
+enabled = true
+head_sampling_rate = 1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -662,6 +662,42 @@ importers:
         specifier: 'catalog:'
         version: 2.9.14
 
+  apps/agent-runner:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260601.0
+        version: 4.20260602.1
+      '@isomer/oxlint-config':
+        specifier: workspace:*
+        version: link:../../tooling/oxlint
+      '@isomer/tsconfig':
+        specifier: workspace:*
+        version: link:../../tooling/typescript
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.0
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260513.1
+      '@vitest/coverage-istanbul':
+        specifier: catalog:vitest
+        version: 4.1.8(vitest@4.1.8)
+      npm-run-all2:
+        specifier: 'catalog:'
+        version: 8.0.4
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-istanbul@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3))(vite@8.0.15(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.22.3)(yaml@2.8.3))
+      wrangler:
+        specifier: ^4.45.0
+        version: 4.96.0(@cloudflare/workers-types@4.20260602.1)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   apps/studio:
     dependencies:
       '@atlaskit/pragmatic-drag-and-drop':
@@ -2729,6 +2765,56 @@ packages:
   '@chevrotain/utils@10.5.0':
     resolution: {integrity: sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260529.1':
+    resolution: {integrity: sha512-gxh5sXw0CsBxNCNj8uJnrAxqFM7+R8SZI9WIqYMKz6uaPxgg+eTcBDTxjKczMs6bS21FkTEF6ohIzB5+UvxwKw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260529.1':
+    resolution: {integrity: sha512-B8xOwqd8ok8oaWBPhrpmNVSYou6AejFrYf3VzsJF6pg6TEA2tYbdThAGXgtLPQ8d1RD7GXYjVth2dSMg9napDA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260529.1':
+    resolution: {integrity: sha512-M1EKzsfoKmmno7MNPkuIc8iOdHLhFnE7ltEYaGGEoOj1MTJfMBK/JkIrhdkzc/06wpyPZPiBfBBmUppbeaMqUg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260529.1':
+    resolution: {integrity: sha512-Mn/Qpl1FAHDLtPthw6ti5gsHRj582jJdtK4OMUlW1CN0v+pmmxaav3KSqq7CS6a+5W0o2e8o9fKnjVilBxVVmQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260529.1':
+    resolution: {integrity: sha512-78xgJJeXxkKYumWdKGH1pybUsEjTreSvbJqirW9cth7ZGonqdv5pzAVt+WWcbu0OFcSHrtQFX6zWioPNFp0/xQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260602.1':
+    resolution: {integrity: sha512-0VssYYXHUn4VR1BaV+GXfhFpI53P2f6AIi17qyA9lQFyTs/u5ZF6IDPda2enDTIPFz/02872RM8CYVlXvRKtUA==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@csstools/cascade-layer-name-parser@3.0.0':
     resolution: {integrity: sha512-/3iksyevwRfSJx5yH0RkcrcYXwuhMQx3Juqf40t97PeEy2/Mz2TItZ/z/216qpe4GgOyFBP8MKIwVvytzHmfIQ==}
     engines: {node: '>=20.19.0'}
@@ -3185,6 +3271,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
@@ -3199,6 +3291,12 @@ packages:
 
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -3221,6 +3319,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.27.7':
     resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
@@ -3235,6 +3339,12 @@ packages:
 
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -3257,6 +3367,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
@@ -3271,6 +3387,12 @@ packages:
 
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -3293,6 +3415,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
@@ -3307,6 +3435,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -3329,6 +3463,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
@@ -3343,6 +3483,12 @@ packages:
 
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -3365,6 +3511,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
@@ -3379,6 +3531,12 @@ packages:
 
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -3401,6 +3559,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
@@ -3415,6 +3579,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -3437,6 +3607,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
@@ -3451,6 +3627,12 @@ packages:
 
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -3473,6 +3655,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.7':
     resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
@@ -3487,6 +3675,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -3509,6 +3703,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
@@ -3523,6 +3723,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -3545,6 +3751,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.27.7':
     resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
@@ -3559,6 +3771,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -3581,6 +3799,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
@@ -3595,6 +3819,12 @@ packages:
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -3617,6 +3847,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
@@ -3631,6 +3867,12 @@ packages:
 
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -4144,6 +4386,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
@@ -5145,6 +5390,15 @@ packages:
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
   '@prisma/client@5.22.0':
     resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
     engines: {node: '>=16.13'}
@@ -5556,6 +5810,10 @@ packages:
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
 
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
   '@smithy/core@3.24.3':
     resolution: {integrity: sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==}
     engines: {node: '>=18.0.0'}
@@ -5591,6 +5849,9 @@ packages:
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@speed-highlight/core@1.2.15':
+    resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6865,6 +7126,9 @@ packages:
   bl@5.1.0:
     resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
@@ -7808,6 +8072,9 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
@@ -7835,6 +8102,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -9305,6 +9577,11 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  miniflare@4.20260529.0:
+    resolution: {integrity: sha512-4pj7WZQR/uYqVMa0cpAmmPBKEb0JegSocuystaXCubY455iqWdPUqgVD9R6N28oneWyPiUyAu5N8QpLbK+MU/Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
 
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
@@ -11266,6 +11543,10 @@ packages:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -11622,9 +11903,16 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
+  undici@7.24.8:
+    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -12024,6 +12312,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260529.1:
+    resolution: {integrity: sha512-G1rurOKEdzCtFE0yUPR9J9mUnPzMU8NdsD7NKM1/oMyCr1j3VEtWJzc5VbhgFQHNBVWrHzCL0JgVPuBirRW31g==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.96.0:
+    resolution: {integrity: sha512-8WuiMutalyfBB74wwRyy4VKKJEHjQuEnwcvdUav1M5AfQ8VaTYY5ZQnzvVZPOVXap40k5Mntz1LY3SPWpPukTg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260529.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -12111,6 +12414,12 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zeed-dom@0.15.1:
     resolution: {integrity: sha512-dtZ0aQSFyZmoJS0m06/xBN1SazUBPL5HpzlAcs/KcRW0rzadYw12deQBjeMhGKMMeGEp7bA9vmikMLaO4exBcg==}
@@ -13476,6 +13785,35 @@ snapshots:
 
   '@chevrotain/utils@10.5.0': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260529.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260529.1
+
+  '@cloudflare/workerd-darwin-64@1.20260529.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260529.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260529.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260529.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260529.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260602.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@csstools/cascade-layer-name-parser@3.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
@@ -13985,6 +14323,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -13992,6 +14333,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
@@ -14003,6 +14347,9 @@ snapshots:
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
     optional: true
 
@@ -14010,6 +14357,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
@@ -14021,6 +14371,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
@@ -14028,6 +14381,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
@@ -14039,6 +14395,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
@@ -14046,6 +14405,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -14057,6 +14419,9 @@ snapshots:
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
@@ -14064,6 +14429,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
@@ -14075,6 +14443,9 @@ snapshots:
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
@@ -14082,6 +14453,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
@@ -14093,6 +14467,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
@@ -14100,6 +14477,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -14111,6 +14491,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
@@ -14118,6 +14501,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
@@ -14129,6 +14515,9 @@ snapshots:
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
@@ -14136,6 +14525,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
@@ -14147,6 +14539,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
@@ -14154,6 +14549,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
@@ -14165,6 +14563,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
@@ -14172,6 +14573,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
@@ -14183,6 +14587,9 @@ snapshots:
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
@@ -14190,6 +14597,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
@@ -14201,6 +14611,9 @@ snapshots:
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
@@ -14208,6 +14621,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -14407,8 +14823,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -14676,6 +15091,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -15352,6 +15772,18 @@ snapshots:
 
   '@popperjs/core@2.11.8': {}
 
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
   '@prisma/client@5.22.0(prisma@5.22.0)':
     optionalDependencies:
       prisma: 5.22.0
@@ -15744,6 +16176,8 @@ snapshots:
 
   '@sindresorhus/is@5.6.0': {}
 
+  '@sindresorhus/is@7.2.0': {}
+
   '@smithy/core@3.24.3':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -15791,6 +16225,8 @@ snapshots:
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
+
+  '@speed-highlight/core@1.2.15': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -16720,7 +17156,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-istanbul@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3))(vite@8.0.15(@types/node@25.9.0)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.99.0)(terser@5.46.1)(tsx@4.22.3)(yaml@2.8.3))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-istanbul@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3))(vite@8.0.15(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.6.1)(sass@1.99.0)(terser@5.46.1)(tsx@4.22.3)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -17261,6 +17697,8 @@ snapshots:
       buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  blake3-wasm@2.1.5: {}
 
   bluebird@3.7.2: {}
 
@@ -18290,6 +18728,8 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
+  error-stack-parser-es@1.0.5: {}
+
   error-stack-parser@2.1.4:
     dependencies:
       stackframe: 1.3.4
@@ -18341,6 +18781,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -19989,6 +20458,18 @@ snapshots:
   mimic-response@4.0.0: {}
 
   min-indent@1.0.1: {}
+
+  miniflare@4.20260529.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260529.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   minimalistic-assert@1.0.1: {}
 
@@ -22011,7 +22492,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -22340,6 +22820,8 @@ snapshots:
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
+
+  supports-color@10.2.2: {}
 
   supports-color@5.5.0:
     dependencies:
@@ -22726,7 +23208,13 @@ snapshots:
 
   undici-types@7.24.6: {}
 
+  undici@7.24.8: {}
+
   undici@7.25.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -23224,6 +23712,31 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260529.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260529.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260529.1
+      '@cloudflare/workerd-linux-64': 1.20260529.1
+      '@cloudflare/workerd-linux-arm64': 1.20260529.1
+      '@cloudflare/workerd-windows-64': 1.20260529.1
+
+  wrangler@4.96.0(@cloudflare/workers-types@4.20260602.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260529.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260529.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260529.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260602.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -23288,6 +23801,19 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.15
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zeed-dom@0.15.1:
     dependencies:


### PR DESCRIPTION
## Problem

PR #2283 ships the doc + skill foundation for the L2 → L3 AI adoption initiative. The next gap is **infrastructure to actually trigger the skills**: when a Linear ticket gets the `ai:implement` label, something needs to receive that webhook, start an Anthropic Managed Agents session, and orchestrate the lifecycle through to a merged PR.

This PR is the first scaffold of that infrastructure — a stateless Cloudflare Worker. It does not run any agent yet; it acks webhooks and logs intent. Follow-up PRs wire the Anthropic Managed Agents client and the Linear label state machine.

Internal AI adoption initiative — no linked issue.

## Solution

**Stateless Worker** under a new workspace `apps/agent-runner/`. Source of truth lives in Linear (ticket labels, comments) and Anthropic (session metadata) — the Worker carries no state across requests, has no database, and can be redeployed or destroyed without losing in-flight runs.

Two endpoints:

| Path                  | Caller                   | Behaviour today                                                  |
| --------------------- | ------------------------ | ---------------------------------------------------------------- |
| `POST /linear`        | Linear webhooks          | Verify HMAC + timestamp window, schema-validate, log, ack.       |
| `POST /anthropic`     | Anthropic Managed Agents | Verify HMAC + timestamp window, schema-validate, log, ack.       |

Why Cloudflare Worker: zero-ops, native Web Crypto for HMAC, sub-50ms cold start, scale-to-zero billing. The L3 doc's per-runner overhead is ~$0.02/run (vs ~$0.12 on GH Actions); the Worker contributes effectively nothing on top of that. Most importantly: the runner stack is **deployable, debuggable, and rollback-able independent of Studio**. A bug here cannot break the editor.

Why no database: any state the dispatcher would store (active session, plan/pick state, idle/running) lives equally well in two existing systems. Linear gets `agent:running` / `agent:idle` labels on the ticket. Anthropic Managed Agents holds the session by ID and exposes `metadata.linearIssueId` for lookup. A stateless dispatcher querying both at handler time avoids a fourth source of truth and keeps the Worker thin.

Why beta-product (Managed Agents): see the research spike notes in chat history. Sandbox capabilities, vault-based secrets, pause/resume via `session.status_idle`, and per-token economics check out. Beta status is the main caveat — acceptable for internal automation; rollback path is the `LINEAR_AGENT_TRIGGER` kill-switch documented in the Worker's README.

**Breaking Changes**

- [ ] Yes — this PR contains breaking changes
- [x] No — this PR is backwards compatible

**Features**:

- New `apps/agent-runner` workspace with `wrangler.toml` and Cloudflare Worker entry
- HMAC-SHA-256 verification using Web Crypto API with timing-safe equality and configurable timestamp window
- Two webhook handlers (Linear, Anthropic) with Zod-validated payloads
- Master kill-switch via `LINEAR_AGENT_TRIGGER` env (default `false`) — handlers short-circuit with 204 until the flag flips

**Improvements**:

- README documents the planned lifecycle (label-driven state machine) and rollback path
- 11 unit tests for the HMAC verifier covering valid / invalid / malformed / boundary cases — the only non-glue logic in this PR

## Tests

The new workspace passes the standard quality suite:

- [x] `pnpm --filter @isomer/agent-runner test:unit` — 11/11 pass
- [x] `pnpm --filter @isomer/agent-runner typecheck` — clean
- [x] `pnpm --filter @isomer/agent-runner lint` — 0 warnings, 0 errors
- [x] `pnpm --filter @isomer/agent-runner format` — clean
- [x] `pnpm install` — lockfile updates only for the new workspace deps

**Manual Verification Steps** (for the next deployer once secrets are wired in a follow-up PR):

- [ ] `pnpm --filter @isomer/agent-runner dev` boots `wrangler dev` on `localhost:8787`
- [ ] `curl -X POST localhost:8787/linear` returns 503 (`LINEAR_WEBHOOK_SECRET` unset by default — expected)
- [ ] With a `.dev.vars` populated, the same call with a valid HMAC returns 204 (flag off) or 202 (flag on)
- [ ] A call with a wrong-signature header returns 401
- [ ] A call with `linear-delivery-timestamp` older than 5 min returns 401

No production code paths affected. Studio, packages, and tooling are untouched. Reverting deletes the new workspace; nothing else changes.

**New scripts**:

- `apps/agent-runner` exposes `dev`, `deploy`, `format`, `format:fix`, `lint`, `lint:fix`, `test`, `test:unit`, `test-ci:unit`, `test:watch`, `typecheck`, `clean` — matches the convention from `packages/validators`.

**New dependencies**:

- `wrangler` (^4.45.0) — Cloudflare Workers CLI, dev-only
- `@cloudflare/workers-types` (^4.20260601.0) — types for the Worker runtime, dev-only

No production dependencies. The Worker bundles itself via `wrangler` at deploy time and ships only what `src/` imports — no Node runtime needed.

## Rollback

- **Soft rollback**: set `LINEAR_AGENT_TRIGGER=false` (or never set it true). Handlers ack but do nothing.
- **Hard rollback**: `wrangler delete` removes the Worker entirely. Linear and Anthropic are independent — no cleanup required.
- **Revert this PR**: deletes the new workspace. Lockfile reverts cleanly. No other workspace depends on `@isomer/agent-runner`.

## What's deferred

- **Anthropic Managed Agents client** — outbound calls to start sessions and send resume events
- **Linear API client** — read ticket fields, write `agent:running` / `agent:idle` labels, post comments
- **Pick resolver** — regex-match `pick: A|B|C` on comment payloads, look up session via Anthropic metadata, send `user.custom_tool_result`
- **Empirical wall-clock spike** — verify Managed Agents can run a 30-min session before relying on it for `feature-implement`
- **CI deployment** — GitHub Actions workflow to deploy on merge to `main`

Each lands in its own PR on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
