### PR TITLE
fix(studio): sanitize SVG uploads server-side to prevent stored XSS

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -132,6 +132,7 @@
     "isomorphic-dompurify": "catalog:",
     "jose": "catalog:",
     "jotai": "catalog:",
+    "jsdom": "catalog:",
     "kysely": "catalog:",
     "lodash-es": "catalog:",
     "nanoid": "catalog:",

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/constants.ts
@@ -3,6 +3,8 @@ import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "@opengovsg/isomer-components"
 export const ONE_MB_IN_BYTES = 1000000
 
 export const MAX_IMG_FILE_SIZE_BYTES = 5 * ONE_MB_IN_BYTES
+// Lower than MAX_IMG_FILE_SIZE_BYTES: SVGs are sanitized server-side (CPU/memory cost per request)
+export const MAX_SVG_FILE_SIZE_BYTES = 1 * ONE_MB_IN_BYTES
 
 export const ACCEPTED_IMAGE_TYPES_MESSAGE = Object.keys(
   IMAGE_ACCEPTED_MIME_TYPE_MAPPING,

--- a/apps/studio/src/hooks/useUploadAssetMutation.ts
+++ b/apps/studio/src/hooks/useUploadAssetMutation.ts
@@ -40,6 +40,14 @@ export const useUploadAssetMutation = ({
             resourceId,
             fileName: effectiveName,
             content,
+            tags: scheduledAt
+              ? [
+                  {
+                    key: "scheduledAt",
+                    value: scheduledAt.getTime().toString(),
+                  },
+                ]
+              : undefined,
           })
           return { path: `/${fileKey}` }
         }

--- a/apps/studio/src/hooks/useUploadAssetMutation.ts
+++ b/apps/studio/src/hooks/useUploadAssetMutation.ts
@@ -26,15 +26,29 @@ export const useUploadAssetMutation = ({
 }: UploadAssetMutationParams) => {
   const { mutateAsync: getPresignedPutUrl } =
     trpc.asset.getPresignedPutUrl.useMutation()
+  const { mutateAsync: uploadSvg } = trpc.asset.uploadSvg.useMutation()
 
   return useMutation<UploadAssetMutationOutput, void, UploadAssetMutationInput>(
     {
       mutationFn: async ({ file, fileName, scheduledAt }) => {
+        const effectiveName = fileName ?? file.name
+
+        if (effectiveName.toLowerCase().endsWith(".svg")) {
+          const content = await file.text()
+          const { fileKey } = await uploadSvg({
+            siteId,
+            resourceId,
+            fileName: effectiveName,
+            content,
+          })
+          return { path: `/${fileKey}` }
+        }
+
         const { fileKey, presignedPutUrl, contentType, contentDisposition } =
           await getPresignedPutUrl({
             siteId,
             resourceId,
-            fileName: fileName ?? file.name,
+            fileName: effectiveName,
             tags: scheduledAt
               ? [
                   {

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -259,23 +259,11 @@ export const getBlob = async (bucketName: string, key: string) => {
   }
 }
 
-export const putObjectDirect = async ({
-  Bucket,
-  Key,
-  Body,
-  ContentType,
-  ContentDisposition,
-}: Pick<
-  PutObjectCommandInput,
-  "Bucket" | "Key" | "Body" | "ContentType" | "ContentDisposition"
->): Promise<void> => {
-  await storage.send(
-    new PutObjectCommand({
-      Bucket,
-      Key,
-      Body,
-      ContentType,
-      ContentDisposition,
-    }),
-  )
+export const putObjectDirect = async (
+  props: Pick<
+    PutObjectCommandInput,
+    "Bucket" | "Key" | "Body" | "ContentType" | "ContentDisposition"
+  >,
+): Promise<void> => {
+  await storage.send(new PutObjectCommand(props))
 }

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -262,7 +262,7 @@ export const getBlob = async (bucketName: string, key: string) => {
 export const putObjectDirect = async (
   props: Pick<
     PutObjectCommandInput,
-    "Bucket" | "Key" | "Body" | "ContentType" | "ContentDisposition"
+    "Bucket" | "Key" | "Body" | "ContentType" | "ContentDisposition" | "Tagging"
   >,
 ): Promise<void> => {
   await storage.send(new PutObjectCommand(props))

--- a/apps/studio/src/lib/s3.ts
+++ b/apps/studio/src/lib/s3.ts
@@ -258,3 +258,24 @@ export const getBlob = async (bucketName: string, key: string) => {
     throw err
   }
 }
+
+export const putObjectDirect = async ({
+  Bucket,
+  Key,
+  Body,
+  ContentType,
+  ContentDisposition,
+}: Pick<
+  PutObjectCommandInput,
+  "Bucket" | "Key" | "Body" | "ContentType" | "ContentDisposition"
+>): Promise<void> => {
+  await storage.send(
+    new PutObjectCommand({
+      Bucket,
+      Key,
+      Body,
+      ContentType,
+      ContentDisposition,
+    }),
+  )
+}

--- a/apps/studio/src/schemas/__tests__/asset.test.ts
+++ b/apps/studio/src/schemas/__tests__/asset.test.ts
@@ -12,16 +12,26 @@ describe("getPresignedPutUrlSchema", () => {
 
   describe("fileName validation", () => {
     describe("file extension validation", () => {
-      // Test all allowed image extensions
-      Object.keys(IMAGE_ACCEPTED_MIME_TYPE_MAPPING).forEach((extension) => {
-        it(`should accept valid image extension: ${extension}`, () => {
-          const fileName = `test-image${extension}`
-          const result = getPresignedPutUrlSchema.safeParse({
-            ...validBaseData,
-            fileName,
+      // Test all allowed image extensions except .svg (handled by uploadSvg endpoint)
+      Object.keys(IMAGE_ACCEPTED_MIME_TYPE_MAPPING)
+        .filter((ext) => ext !== ".svg")
+        .forEach((extension) => {
+          it(`should accept valid image extension: ${extension}`, () => {
+            const fileName = `test-image${extension}`
+            const result = getPresignedPutUrlSchema.safeParse({
+              ...validBaseData,
+              fileName,
+            })
+            expect(result.success).toBe(true)
           })
-          expect(result.success).toBe(true)
         })
+
+      it("should reject .svg files (use uploadSvg endpoint instead)", () => {
+        const result = getPresignedPutUrlSchema.safeParse({
+          ...validBaseData,
+          fileName: "test-image.svg",
+        })
+        expect(result.success).toBe(false)
       })
 
       // Test all allowed file extensions

--- a/apps/studio/src/schemas/asset.ts
+++ b/apps/studio/src/schemas/asset.ts
@@ -1,12 +1,19 @@
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "@opengovsg/isomer-components"
 import { z } from "zod"
-import { FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
+import {
+  FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING,
+  MAX_SVG_FILE_SIZE_BYTES,
+} from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 
 // Combine allowed extensions from existing constants
 const ALLOWED_EXTENSIONS = [
   ...Object.keys(IMAGE_ACCEPTED_MIME_TYPE_MAPPING),
   ...Object.keys(FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING),
 ]
+
+const fileNameStartingCharRefine = (s: string) => /^[a-zA-Z0-9\-_]/.test(s)
+const fileNameStartingCharMessage =
+  "File name must start with a letter, number, hyphen, or underscore"
 
 export const getPresignedPutUrlSchema = z.object({
   siteId: z.number().min(1),
@@ -23,16 +30,9 @@ export const getPresignedPutUrlSchema = z.object({
     .string({
       error: "Missing file name",
     })
-    .refine(
-      (s) => {
-        const allowedStartingChars = new RegExp(/^[a-zA-Z0-9-_]/)
-        return allowedStartingChars.test(s)
-      },
-      {
-        message:
-          "File name must start with a letter, number, hyphen, or underscore",
-      },
-    )
+    .refine(fileNameStartingCharRefine, {
+      message: fileNameStartingCharMessage,
+    })
     // Check if extension is in allowed list (whitelist approach)
     // To ensure we don't allow any other file types that can have security implications
     .refine(
@@ -46,12 +46,37 @@ export const getPresignedPutUrlSchema = z.object({
         const extension = fileName
           .toLowerCase()
           .substring(fileName.lastIndexOf("."))
+
+        // SVGs must go through the dedicated uploadSvg endpoint which
+        // sanitizes the content server-side before uploading to S3.
+        // The presigned PUT path never sees the file bytes, so it cannot
+        // validate or strip embedded scripts/event handlers.
+        if (extension === ".svg") return false
+
         return ALLOWED_EXTENSIONS.includes(extension)
       },
       {
         message: "File type not allowed. Please upload a supported file type.",
       },
     ),
+})
+
+export const uploadSvgSchema = z.object({
+  siteId: z.number().min(1),
+  fileName: z
+    .string()
+    .refine(fileNameStartingCharRefine, {
+      message: fileNameStartingCharMessage,
+    })
+    .refine((s) => s.toLowerCase().endsWith(".svg"), {
+      message: "Only .svg files are allowed",
+    })
+    .max(255),
+  content: z.string().max(MAX_SVG_FILE_SIZE_BYTES, {
+    message: `SVG file size must not exceed ${MAX_SVG_FILE_SIZE_BYTES / 1_000_000} MB`,
+  }),
+  resourceId: z.string().optional(),
+  tags: z.array(z.object({ key: z.string(), value: z.string() })).optional(),
 })
 
 export const deleteAssetsSchema = z.object({

--- a/apps/studio/src/schemas/asset.ts
+++ b/apps/studio/src/schemas/asset.ts
@@ -72,6 +72,10 @@ export const uploadSvgSchema = z.object({
       message: "Only .svg files are allowed",
     })
     .max(255),
+  // z.string().max() counts UTF-16 code units (JS string length), not bytes.
+  // Multi-byte characters can exceed the intended byte budget, but the difference
+  // is bounded: worst case is 3× (4-byte UTF-8 chars are 2 code units). Acceptable
+  // as a rough upper bound; use Buffer.byteLength for an exact byte check if needed.
   content: z.string().max(MAX_SVG_FILE_SIZE_BYTES, {
     message: `SVG file size must not exceed ${MAX_SVG_FILE_SIZE_BYTES / 1_000_000} MB`,
   }),

--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -20,23 +20,6 @@ import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import { assetRouter } from "../asset.router"
 
-// isomorphic-dompurify's DOMPurify.window is undefined in the Node test
-// environment because dompurify v3 no longer exposes `.window` on the instance.
-// Provide a jsdom-backed shim so sanitizeSvg can call DOMPurify.window.DOMParser.
-vi.mock("isomorphic-dompurify", async () => {
-  const { JSDOM: JSDOMCtor } = await import("jsdom")
-  const { default: createPurify } = await import("dompurify")
-  const win = new JSDOMCtor("<!DOCTYPE html>").window
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const purify = createPurify(win as any)
-  return {
-    default: {
-      window: win,
-      sanitize: purify.sanitize.bind(purify),
-    },
-  }
-})
-
 // Mock the S3 client to prevent credential loading issues in CI
 // Workaround as we do not really want to set up a full integration test here with S3
 vi.mock("~/lib/s3", () => ({
@@ -219,6 +202,29 @@ describe("asset.router", async () => {
           /^inline; filename\*=UTF-8''.+/,
         ),
       })
+    })
+
+    it("should throw BAD_REQUEST when called with .svg filename", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.getPresignedPutUrl({
+        siteId: site.id,
+        resourceId: page.id,
+        fileName: "test.svg",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
     })
   })
 
@@ -614,29 +620,6 @@ describe("asset.router", async () => {
         fileKey: expect.stringContaining(".svg"),
       })
       expect(putObjectDirect).toHaveBeenCalledTimes(1)
-    })
-
-    it("should throw BAD_REQUEST when getPresignedPutUrl is called with .svg filename", async () => {
-      // Arrange
-      const { site, page } = await setupPageResource({
-        resourceType: ResourceType.Page,
-      })
-      await setupEditorPermissions({
-        siteId: site.id,
-        userId: session.userId,
-      })
-
-      // Act
-      const result = caller.getPresignedPutUrl({
-        siteId: site.id,
-        resourceId: page.id,
-        fileName: "test.svg",
-      })
-
-      // Assert
-      await expect(result).rejects.toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
-      )
     })
 
     it("should reject fileName not ending in .svg", async () => {

--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -502,7 +502,7 @@ describe("asset.router", async () => {
 
     it("should throw 404 if site does not exist", async () => {
       // Arrange
-      const { site, page } = await setupPageResource({
+      const { site } = await setupPageResource({
         resourceType: ResourceType.Page,
       })
 

--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -14,11 +14,28 @@ import {
   setUpWhitelist,
 } from "tests/integration/helpers/seed"
 import { vi } from "vitest"
-import { deleteFile, generateSignedPutUrl } from "~/lib/s3"
+import { deleteFile, generateSignedPutUrl, putObjectDirect } from "~/lib/s3"
 import { createCallerFactory } from "~/server/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import { assetRouter } from "../asset.router"
+
+// isomorphic-dompurify's DOMPurify.window is undefined in the Node test
+// environment because dompurify v3 no longer exposes `.window` on the instance.
+// Provide a jsdom-backed shim so sanitizeSvg can call DOMPurify.window.DOMParser.
+vi.mock("isomorphic-dompurify", async () => {
+  const { JSDOM: JSDOMCtor } = await import("jsdom")
+  const { default: createPurify } = await import("dompurify")
+  const win = new JSDOMCtor("<!DOCTYPE html>").window
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const purify = createPurify(win as any)
+  return {
+    default: {
+      window: win,
+      sanitize: purify.sanitize.bind(purify),
+    },
+  }
+})
 
 // Mock the S3 client to prevent credential loading issues in CI
 // Workaround as we do not really want to set up a full integration test here with S3
@@ -31,6 +48,7 @@ vi.mock("~/lib/s3", () => ({
     .mockResolvedValue("https://example.com/signed-url"),
   markFileAsDeleted: vi.fn().mockResolvedValue(undefined),
   deleteFile: vi.fn().mockResolvedValue(undefined),
+  putObjectDirect: vi.fn().mockResolvedValue(undefined),
 }))
 
 const createCaller = createCallerFactory(assetRouter)
@@ -52,6 +70,7 @@ describe("asset.router", async () => {
     vi.mocked(generateSignedPutUrl).mockResolvedValue(
       "https://example.com/signed-url",
     )
+    vi.mocked(putObjectDirect).mockResolvedValue(undefined)
   })
 
   describe("getPresignedPutUrl", () => {
@@ -456,6 +475,191 @@ describe("asset.router", async () => {
         }),
       )
       expect(deleteFile).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("uploadSvg", () => {
+    const VALID_SVG =
+      '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
+
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.uploadSvg({
+        siteId: 1,
+        fileName: "test.svg",
+        content: VALID_SVG,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 404 if site does not exist", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+
+      // Act
+      const result = caller.uploadSvg({
+        siteId: site.id + 1,
+        fileName: "test.svg",
+        content: VALID_SVG,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "The requested resource does not exist",
+        }),
+      )
+    })
+
+    it("should throw 403 if user does not have permission", async () => {
+      // Arrange
+      const { site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+
+      // Act
+      const result = caller.uploadSvg({
+        siteId: site.id,
+        fileName: "test.svg",
+        content: VALID_SVG,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should return BAD_REQUEST for invalid SVG content", async () => {
+      // Arrange
+      const { site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.uploadSvg({
+        siteId: site.id,
+        fileName: "test.svg",
+        content: "not valid svg",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
+    })
+
+    it("should return BAD_REQUEST for SVG with entity bomb", async () => {
+      // Arrange
+      const { site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+      const entityBomb = `<!DOCTYPE svg [<!ENTITY lol "lol">]><svg xmlns="http://www.w3.org/2000/svg"/>`
+
+      // Act
+      const result = caller.uploadSvg({
+        siteId: site.id,
+        fileName: "test.svg",
+        content: entityBomb,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
+    })
+
+    it("should return fileKey on successful SVG upload", async () => {
+      // Arrange
+      const { site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.uploadSvg({
+        siteId: site.id,
+        fileName: "test.svg",
+        content: VALID_SVG,
+      })
+
+      // Assert
+      await expect(result).resolves.toMatchObject({
+        fileKey: expect.stringContaining(".svg"),
+      })
+      expect(putObjectDirect).toHaveBeenCalledTimes(1)
+    })
+
+    it("should throw BAD_REQUEST when getPresignedPutUrl is called with .svg filename", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.getPresignedPutUrl({
+        siteId: site.id,
+        resourceId: page.id,
+        fileName: "test.svg",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
+    })
+
+    it("should reject fileName not ending in .svg", async () => {
+      // Arrange
+      const { site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.uploadSvg({
+        siteId: site.id,
+        fileName: "test.png",
+        content: VALID_SVG,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "BAD_REQUEST" }),
+      )
     })
   })
 })

--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -223,7 +223,7 @@ describe("asset.router", async () => {
 
       // Assert
       await expect(result).rejects.toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        expect.objectContaining({ code: "BAD_REQUEST" }),
       )
     })
   })
@@ -508,7 +508,7 @@ describe("asset.router", async () => {
 
     it("should throw 404 if site does not exist", async () => {
       // Arrange
-      const { site } = await setupPageResource({
+      const { site, page } = await setupPageResource({
         resourceType: ResourceType.Page,
       })
 
@@ -517,6 +517,7 @@ describe("asset.router", async () => {
         siteId: site.id + 1,
         fileName: "test.svg",
         content: VALID_SVG,
+        resourceId: page.id,
       })
 
       // Assert
@@ -553,7 +554,7 @@ describe("asset.router", async () => {
 
     it("should return BAD_REQUEST for invalid SVG content", async () => {
       // Arrange
-      const { site } = await setupPageResource({
+      const { site, page } = await setupPageResource({
         resourceType: ResourceType.Page,
       })
       await setupEditorPermissions({
@@ -566,17 +567,18 @@ describe("asset.router", async () => {
         siteId: site.id,
         fileName: "test.svg",
         content: "not valid svg",
+        resourceId: page.id,
       })
 
       // Assert
       await expect(result).rejects.toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        expect.objectContaining({ code: "BAD_REQUEST" }),
       )
     })
 
     it("should return BAD_REQUEST for SVG with entity bomb", async () => {
       // Arrange
-      const { site } = await setupPageResource({
+      const { site, page } = await setupPageResource({
         resourceType: ResourceType.Page,
       })
       await setupEditorPermissions({
@@ -590,17 +592,18 @@ describe("asset.router", async () => {
         siteId: site.id,
         fileName: "test.svg",
         content: entityBomb,
+        resourceId: page.id,
       })
 
       // Assert
       await expect(result).rejects.toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        expect.objectContaining({ code: "BAD_REQUEST" }),
       )
     })
 
     it("should return fileKey on successful SVG upload", async () => {
       // Arrange
-      const { site } = await setupPageResource({
+      const { site, page } = await setupPageResource({
         resourceType: ResourceType.Page,
       })
       await setupEditorPermissions({
@@ -613,6 +616,7 @@ describe("asset.router", async () => {
         siteId: site.id,
         fileName: "test.svg",
         content: VALID_SVG,
+        resourceId: page.id,
       })
 
       // Assert
@@ -624,7 +628,7 @@ describe("asset.router", async () => {
 
     it("should reject fileName not ending in .svg", async () => {
       // Arrange
-      const { site } = await setupPageResource({
+      const { site, page } = await setupPageResource({
         resourceType: ResourceType.Page,
       })
       await setupEditorPermissions({
@@ -637,11 +641,12 @@ describe("asset.router", async () => {
         siteId: site.id,
         fileName: "test.png",
         content: VALID_SVG,
+        resourceId: page.id,
       })
 
       // Assert
       await expect(result).rejects.toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        expect.objectContaining({ code: "BAD_REQUEST" }),
       )
     })
   })

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -1,10 +1,29 @@
-import { describe, expect, it } from "vitest"
+import { TRPCError } from "@trpc/server"
+import { describe, expect, it, vi } from "vitest"
+
+// isomorphic-dompurify's DOMPurify.window is undefined in the Node test
+// environment because dompurify v3 no longer exposes `.window` on the instance.
+// Provide a jsdom-backed shim so sanitizeSvg can call DOMPurify.window.DOMParser.
+vi.mock("isomorphic-dompurify", async () => {
+  const { JSDOM: JSDOMCtor } = await import("jsdom")
+  const { default: createPurify } = await import("dompurify")
+  const win = new JSDOMCtor("<!DOCTYPE html>").window
+  // oxlint-disable-next-line typescript/no-explicit-any
+  const purify = createPurify(win as any)
+  return {
+    default: {
+      window: win,
+      sanitize: purify.sanitize.bind(purify),
+    },
+  }
+})
 
 import {
   doAllFileKeysBelongToSite,
   getContentDispositionForKey,
   getContentTypeFromKey,
   getFileKey,
+  sanitizeSvg,
 } from "../asset.service"
 
 describe("asset.service", () => {
@@ -273,6 +292,198 @@ describe("asset.service", () => {
           fileKeys: ["2/uuid/file.png"],
         }),
       ).toBe(true)
+    })
+  })
+
+  describe("sanitizeSvg", () => {
+    it("should return sanitized content for a valid SVG", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).toBeTruthy()
+      expect(result.length).toBeGreaterThan(0)
+    })
+
+    it("should strip <script> tag from SVG without throwing", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("<script")
+    })
+
+    it("should strip onload attribute from SVG without throwing", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><rect/></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("onload")
+    })
+
+    it("should throw BAD_REQUEST when root element is not svg (HTML document)", () => {
+      // Arrange
+      const input = "<!DOCTYPE html><html><body></body></html>"
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
+    })
+
+    it("should throw BAD_REQUEST for XML entity declaration", () => {
+      // Arrange
+      const input =
+        '<!ENTITY xxe "test"><svg xmlns="http://www.w3.org/2000/svg"/>'
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
+    })
+
+    it("should throw BAD_REQUEST for billion-laughs XML entity bomb", () => {
+      // Arrange
+      // Billion-laughs: exponential entity expansion that exhausts server memory
+      // at parse time. Must be caught by the <!ENTITY regex BEFORE DOMParser runs —
+      // DOMPurify operates on the already-parsed DOM and cannot prevent this.
+      const input = `<!DOCTYPE svg [
+        <!ENTITY lol "lol">
+        <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+        <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+      ]>
+      <svg xmlns="http://www.w3.org/2000/svg">&lol3;</svg>`
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
+    })
+
+    it("should throw BAD_REQUEST for non-XML binary/random string", () => {
+      // Arrange
+      const input = "not an svg at all, just random text"
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
+    })
+
+    it("should throw BAD_REQUEST for empty string", () => {
+      // Arrange
+      const input = ""
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
+    })
+
+    it("should strip foreignObject tag from SVG", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>evil</div></foreignObject></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("foreignObject")
+    })
+
+    it("should strip use tag from SVG", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><use href="http://evil.com/evil.svg#xss"/></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("<use")
+    })
+
+    it("should strip onclick attribute from SVG", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="alert(1)"/></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("onclick")
+    })
+
+    it("should strip onerror attribute from SVG", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><image onerror="alert(1)"/></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("onerror")
+    })
+
+    it("should strip onmouseover attribute from SVG", () => {
+      // Arrange
+      const input =
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect onmouseover="alert(1)"/></svg>'
+
+      // Act
+      const result = sanitizeSvg(input)
+
+      // Assert
+      expect(result).not.toContain("onmouseover")
+    })
+
+    it("should throw BAD_REQUEST for valid XML that is not SVG", () => {
+      // Arrange
+      const input = '<root xmlns="http://example.com"><child/></root>'
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
+    })
+
+    it("should throw BAD_REQUEST for malformed XML", () => {
+      // Arrange
+      const input = '<svg xmlns="http://www.w3.org/2000/svg"><unclosed>'
+
+      // Act & Assert
+      expect(() => sanitizeSvg(input)).toThrow(
+        expect.objectContaining({
+          code: "BAD_REQUEST",
+        } satisfies Partial<TRPCError>),
+      )
     })
   })
 })

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -326,16 +326,18 @@ describe("asset.service", () => {
       expect(result).toContain('height="10"')
     })
 
-    it("should strip onload attribute from SVG without throwing", () => {
+    it("should strip onload attribute from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><rect/></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><rect width="10" height="10"/></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("onload")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
     it("should throw BAD_REQUEST when root element is not svg (HTML document)", () => {
@@ -407,64 +409,74 @@ describe("asset.service", () => {
       )
     })
 
-    it("should strip foreignObject tag from SVG", () => {
+    it("should strip foreignObject tag from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg"><foreignObject><div>evil</div></foreignObject></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/><foreignObject><div>evil</div></foreignObject></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("foreignObject")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
-    it("should strip use tag from SVG", () => {
+    it("should strip use tag from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg"><use href="http://evil.com/evil.svg#xss"/></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/><use href="http://evil.com/evil.svg#xss"/></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("<use")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
-    it("should strip onclick attribute from SVG", () => {
+    it("should strip onclick attribute from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg"><rect onclick="alert(1)"/></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" onclick="alert(1)"/></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("onclick")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
-    it("should strip onerror attribute from SVG", () => {
+    it("should strip onerror attribute from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg"><image onerror="alert(1)"/></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/><image onerror="alert(1)"/></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("onerror")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
-    it("should strip onmouseover attribute from SVG", () => {
+    it("should strip onmouseover attribute from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg"><rect onmouseover="alert(1)"/></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10" onmouseover="alert(1)"/></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("onmouseover")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
     it("should throw BAD_REQUEST for valid XML that is not SVG", () => {

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -305,11 +305,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert — DOMPurify normalises self-closing tags to explicit close tags
-      // but must not drop or alter any attributes on safe elements
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
-      expect(result).not.toContain("<script")
-      expect(result).not.toContain("onload")
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should strip <script> tag from SVG without touching other content", () => {

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -327,7 +327,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Root element is not a valid SVG element",
+        }),
       )
     })
 
@@ -338,7 +341,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "SVG contains disallowed XML entities",
+        }),
       )
     })
 
@@ -356,7 +362,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "SVG contains disallowed XML entities",
+        }),
       )
     })
 
@@ -366,7 +375,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "SVG failed to parse as valid XML",
+        }),
       )
     })
 
@@ -376,7 +388,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "SVG failed to parse as valid XML",
+        }),
       )
     })
 
@@ -456,7 +471,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Root element is not a valid SVG element",
+        }),
       )
     })
 
@@ -466,7 +484,10 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        new TRPCError({ code: "BAD_REQUEST" }),
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "SVG failed to parse as valid XML",
+        }),
       )
     })
   })

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -319,9 +319,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("<script")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should strip onload attribute from SVG without touching other content", () => {
@@ -333,9 +333,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("onload")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should throw BAD_REQUEST when root element is not svg (HTML document)", () => {
@@ -416,9 +416,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("foreignObject")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should strip use tag from SVG without touching other content", () => {
@@ -430,9 +430,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("<use")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should strip onclick attribute from SVG without touching other content", () => {
@@ -444,9 +444,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("onclick")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should strip onerror attribute from SVG without touching other content", () => {
@@ -458,9 +458,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("onerror")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect><image></image></svg>',
+      )
     })
 
     it("should strip onmouseover attribute from SVG without touching other content", () => {
@@ -472,9 +472,9 @@ describe("asset.service", () => {
       const result = sanitizeSvg(input)
 
       // Assert
-      expect(result).not.toContain("onmouseover")
-      expect(result).toContain('width="10"')
-      expect(result).toContain('height="10"')
+      expect(result).toEqual(
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"></rect></svg>',
+      )
     })
 
     it("should throw BAD_REQUEST for valid XML that is not SVG", () => {

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -1,22 +1,5 @@
 import { TRPCError } from "@trpc/server"
-import { describe, expect, it, vi } from "vitest"
-
-// isomorphic-dompurify's DOMPurify.window is undefined in the Node test
-// environment because dompurify v3 no longer exposes `.window` on the instance.
-// Provide a jsdom-backed shim so sanitizeSvg can call DOMPurify.window.DOMParser.
-vi.mock("isomorphic-dompurify", async () => {
-  const { JSDOM: JSDOMCtor } = await import("jsdom")
-  const { default: createPurify } = await import("dompurify")
-  const win = new JSDOMCtor("<!DOCTYPE html>").window
-  // oxlint-disable-next-line typescript/no-explicit-any
-  const purify = createPurify(win as any)
-  return {
-    default: {
-      window: win,
-      sanitize: purify.sanitize.bind(purify),
-    },
-  }
-})
+import { describe, expect, it } from "vitest"
 
 import {
   doAllFileKeysBelongToSite,
@@ -344,9 +327,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
 
@@ -357,9 +338,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
 
@@ -377,9 +356,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
 
@@ -389,9 +366,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
 
@@ -401,9 +376,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
 
@@ -483,9 +456,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
 
@@ -495,9 +466,7 @@ describe("asset.service", () => {
 
       // Act & Assert
       expect(() => sanitizeSvg(input)).toThrow(
-        expect.objectContaining({
-          code: "BAD_REQUEST",
-        } satisfies Partial<TRPCError>),
+        new TRPCError({ code: "BAD_REQUEST" }),
       )
     })
   })

--- a/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts
@@ -296,7 +296,7 @@ describe("asset.service", () => {
   })
 
   describe("sanitizeSvg", () => {
-    it("should return sanitized content for a valid SVG", () => {
+    it("should return sanitized content for a valid SVG without altering safe elements or attributes", () => {
       // Arrange
       const input =
         '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>'
@@ -304,21 +304,26 @@ describe("asset.service", () => {
       // Act
       const result = sanitizeSvg(input)
 
-      // Assert
-      expect(result).toBeTruthy()
-      expect(result.length).toBeGreaterThan(0)
+      // Assert — DOMPurify normalises self-closing tags to explicit close tags
+      // but must not drop or alter any attributes on safe elements
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
+      expect(result).not.toContain("<script")
+      expect(result).not.toContain("onload")
     })
 
-    it("should strip <script> tag from SVG without throwing", () => {
+    it("should strip <script> tag from SVG without touching other content", () => {
       // Arrange
       const input =
-        '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+        '<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/><script>alert(1)</script></svg>'
 
       // Act
       const result = sanitizeSvg(input)
 
       // Assert
       expect(result).not.toContain("<script")
+      expect(result).toContain('width="10"')
+      expect(result).toContain('height="10"')
     })
 
     it("should strip onload attribute from SVG without throwing", () => {

--- a/apps/studio/src/server/modules/asset/asset.router.ts
+++ b/apps/studio/src/server/modules/asset/asset.router.ts
@@ -3,6 +3,7 @@ import {
   deleteAssetsSchema,
   getPresignedGetUrlSchema,
   getPresignedPutUrlSchema,
+  uploadSvgSchema,
 } from "~/schemas/asset"
 import { protectedProcedure, router } from "~/server/trpc"
 
@@ -12,6 +13,8 @@ import {
   getPresignedGetUrl,
   getPresignedPutUrl,
   markFileAsDeleted,
+  putFileDirect,
+  sanitizeSvg,
   validateUserPermissionsForAsset,
 } from "./asset.service"
 
@@ -130,4 +133,38 @@ export const assetRouter = router({
         }
       })
     }),
+
+  uploadSvg: protectedProcedure
+    .input(uploadSvgSchema)
+    // Arbitrary: 10 SVG uploads per user per minute. SVG sanitization is
+    // CPU-intensive relative to presigned URL issuance, so a tighter limit
+    // applies here. Adjust freely based on observed usage patterns.
+    .meta({ rateLimitOptions: { max: 10, windowMs: 60_000 } })
+    .mutation(
+      async ({ ctx, input: { siteId, fileName, content, resourceId } }) => {
+        await validateUserPermissionsForAsset({
+          siteId,
+          resourceId,
+          action: "create",
+          userId: ctx.user.id,
+        })
+
+        const fileKey = getFileKey({ siteId, fileName })
+        const sanitized = sanitizeSvg(content)
+
+        await putFileDirect({ key: fileKey, body: sanitized })
+
+        ctx.logger.info(
+          {
+            userId: ctx.session?.userId,
+            siteId,
+            fileName,
+            fileKey,
+          },
+          `Uploaded sanitized SVG ${fileKey} for site ${siteId}`,
+        )
+
+        return { fileKey }
+      },
+    ),
 })

--- a/apps/studio/src/server/modules/asset/asset.router.ts
+++ b/apps/studio/src/server/modules/asset/asset.router.ts
@@ -141,7 +141,10 @@ export const assetRouter = router({
     // applies here. Adjust freely based on observed usage patterns.
     .meta({ rateLimitOptions: { max: 10, windowMs: 60_000 } })
     .mutation(
-      async ({ ctx, input: { siteId, fileName, content, resourceId } }) => {
+      async ({
+        ctx,
+        input: { siteId, fileName, content, resourceId, tags },
+      }) => {
         await validateUserPermissionsForAsset({
           siteId,
           resourceId,
@@ -152,7 +155,7 @@ export const assetRouter = router({
         const fileKey = getFileKey({ siteId, fileName })
         const sanitized = sanitizeSvg(content)
 
-        await putFileDirect({ key: fileKey, body: sanitized })
+        await putFileDirect({ key: fileKey, body: sanitized, tags })
 
         ctx.logger.info(
           {

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -6,6 +6,8 @@ import { randomUUID } from "crypto"
 import filenamify from "filenamify"
 import DOMPurify from "isomorphic-dompurify"
 import { JSDOM } from "jsdom"
+
+const { DOMParser } = new JSDOM("").window
 import { env } from "~/env.mjs"
 import { FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import {
@@ -173,7 +175,6 @@ export const sanitizeSvg = (content: string): string => {
     })
   }
 
-  const { DOMParser } = new JSDOM("").window
   const doc = new DOMParser().parseFromString(content, "image/svg+xml")
 
   if (doc.getElementsByTagName("parsererror").length > 0) {

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -5,6 +5,7 @@ import { TRPCError } from "@trpc/server"
 import { randomUUID } from "crypto"
 import filenamify from "filenamify"
 import DOMPurify from "isomorphic-dompurify"
+import { JSDOM } from "jsdom"
 import { env } from "~/env.mjs"
 import { FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import {
@@ -172,10 +173,8 @@ export const sanitizeSvg = (content: string): string => {
     })
   }
 
-  const doc = new DOMPurify.window.DOMParser().parseFromString(
-    content,
-    "image/svg+xml",
-  )
+  const { DOMParser } = new JSDOM("").window
+  const doc = new DOMParser().parseFromString(content, "image/svg+xml")
 
   if (doc.getElementsByTagName("parsererror").length > 0) {
     throw new TRPCError({
@@ -195,18 +194,14 @@ export const sanitizeSvg = (content: string): string => {
     })
   }
 
+  // Allowlist SVG/filter elements, then explicitly block tags and attributes that
+  // enable stored XSS: <script> executes JS, <foreignObject> embeds arbitrary HTML,
+  // <use> can load external resources via href, and event attributes fire on interaction.
   const sanitized = DOMPurify.sanitize(content, {
     USE_PROFILES: { svg: true, svgFilters: true },
     FORBID_TAGS: ["script", "foreignObject", "use"],
     FORBID_ATTR: ["onload", "onclick", "onerror", "onmouseover"],
   })
-
-  if (sanitized.length < 10) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "SVG content was stripped during sanitization",
-    })
-  }
 
   return sanitized
 }

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -4,12 +4,14 @@ import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import { randomUUID } from "crypto"
 import filenamify from "filenamify"
+import DOMPurify from "isomorphic-dompurify"
 import { env } from "~/env.mjs"
 import { FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import {
   deleteFile,
   generateSignedGetUrl,
   generateSignedPutUrl,
+  putObjectDirect,
 } from "~/lib/s3"
 
 import type { AssetPermissionsProps } from "../permissions/permissions.type"
@@ -156,5 +158,73 @@ export const getPresignedGetUrl = async ({
   return generateSignedGetUrl({
     Bucket: NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
     Key: key,
+  })
+}
+
+export const sanitizeSvg = (content: string): string => {
+  // Must run BEFORE parsing. Entity expansion (e.g. billion-laughs) happens
+  // inside DOMParser.parseFromString — DOMPurify only sees the resulting DOM
+  // and cannot intercept it. No sanitization library operates at this layer.
+  if (/<!ENTITY/i.test(content)) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "SVG contains disallowed XML entities",
+    })
+  }
+
+  const doc = new DOMPurify.window.DOMParser().parseFromString(
+    content,
+    "image/svg+xml",
+  )
+
+  if (doc.getElementsByTagName("parsererror").length > 0) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "SVG failed to parse as valid XML",
+    })
+  }
+
+  const root = doc.documentElement
+  if (
+    root.localName !== "svg" ||
+    root.namespaceURI !== "http://www.w3.org/2000/svg"
+  ) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Root element is not a valid SVG element",
+    })
+  }
+
+  const sanitized = DOMPurify.sanitize(content, {
+    USE_PROFILES: { svg: true, svgFilters: true },
+    FORBID_TAGS: ["script", "foreignObject", "use"],
+    FORBID_ATTR: ["onload", "onclick", "onerror", "onmouseover"],
+  })
+
+  if (sanitized.length < 10) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "SVG content was stripped during sanitization",
+    })
+  }
+
+  return sanitized
+}
+
+export const putFileDirect = async ({
+  key,
+  body,
+}: {
+  key: string
+  body: string
+}): Promise<void> => {
+  const contentType = getContentTypeFromKey(key)
+  const contentDisposition = getContentDispositionForKey(key)
+  await putObjectDirect({
+    Bucket: NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
+    Key: key,
+    Body: body,
+    ContentType: contentType,
+    ContentDisposition: contentDisposition,
   })
 }

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -195,9 +195,10 @@ export const sanitizeSvg = (content: string): string => {
     })
   }
 
-  // Allowlist SVG/filter elements, then explicitly block tags and attributes that
-  // enable stored XSS: <script> executes JS, <foreignObject> embeds arbitrary HTML,
-  // <use> can load external resources via href, and event attributes fire on interaction.
+  // DOMPurify's svg+svgFilters profile is the actual security boundary — it strips
+  // all on* event handlers and dangerous elements by default. The explicit lists
+  // below are defense-in-depth for the highest-risk items; do not treat them as
+  // exhaustive. Adding an entry here does not replace the profile's coverage.
   const sanitized = DOMPurify.sanitize(content, {
     USE_PROFILES: { svg: true, svgFilters: true },
     FORBID_TAGS: ["script", "foreignObject", "use"],
@@ -210,17 +211,21 @@ export const sanitizeSvg = (content: string): string => {
 export const putFileDirect = async ({
   key,
   body,
+  tags,
 }: {
   key: string
   body: string
+  tags?: { key: string; value: string }[]
 }): Promise<void> => {
   const contentType = getContentTypeFromKey(key)
   const contentDisposition = getContentDispositionForKey(key)
+  const stringifiedTags = tags && generateTagsQueryString(tags)
   await putObjectDirect({
     Bucket: NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
     Key: key,
     Body: body,
     ContentType: contentType,
     ContentDisposition: contentDisposition,
+    Tagging: tags ? stringifiedTags : undefined,
   })
 }

--- a/apps/studio/src/server/modules/asset/asset.service.ts
+++ b/apps/studio/src/server/modules/asset/asset.service.ts
@@ -10,6 +10,7 @@ import { JSDOM } from "jsdom"
 const { DOMParser } = new JSDOM("").window
 import { env } from "~/env.mjs"
 import { FILE_UPLOAD_ACCEPTED_MIME_TYPE_MAPPING } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
+import { createBaseLogger } from "~/lib/logger"
 import {
   deleteFile,
   generateSignedGetUrl,
@@ -22,6 +23,8 @@ import { db } from "../database"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 
 const { NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME } = env
+
+const logger = createBaseLogger({ path: "asset.service" })
 
 // Server-side allowlist: extension (lowercase, e.g. ".jpg") -> MIME (used for signed upload metadata)
 const EXTENSION_TO_MIME: Record<string, string> = {
@@ -169,6 +172,7 @@ export const sanitizeSvg = (content: string): string => {
   // inside DOMParser.parseFromString — DOMPurify only sees the resulting DOM
   // and cannot intercept it. No sanitization library operates at this layer.
   if (/<!ENTITY/i.test(content)) {
+    logger.error("SVG rejected: contains disallowed XML entities")
     throw new TRPCError({
       code: "BAD_REQUEST",
       message: "SVG contains disallowed XML entities",
@@ -178,6 +182,7 @@ export const sanitizeSvg = (content: string): string => {
   const doc = new DOMParser().parseFromString(content, "image/svg+xml")
 
   if (doc.getElementsByTagName("parsererror").length > 0) {
+    logger.error("SVG rejected: failed to parse as valid XML")
     throw new TRPCError({
       code: "BAD_REQUEST",
       message: "SVG failed to parse as valid XML",
@@ -189,6 +194,10 @@ export const sanitizeSvg = (content: string): string => {
     root.localName !== "svg" ||
     root.namespaceURI !== "http://www.w3.org/2000/svg"
   ) {
+    logger.error(
+      { localName: root.localName, namespaceURI: root.namespaceURI },
+      "SVG rejected: root element is not a valid SVG element",
+    )
     throw new TRPCError({
       code: "BAD_REQUEST",
       message: "Root element is not a valid SVG element",

--- a/apps/studio/src/types/shims.d.ts
+++ b/apps/studio/src/types/shims.d.ts
@@ -1,3 +1,12 @@
 declare module "*.css"
 declare module "*.scss"
 declare module "@fontsource/ibm-plex-mono"
+
+// jsdom does not ship its own TypeScript declarations.
+// This minimal stub covers the subset used in asset.service.ts.
+declare module "jsdom" {
+  export class JSDOM {
+    constructor(html: string, options?: Record<string, unknown>)
+    readonly window: Window & typeof globalThis
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -901,6 +901,9 @@ importers:
       jotai:
         specifier: 'catalog:'
         version: 2.20.0(@babel/core@7.29.0)(@babel/template@7.29.7)(@types/react@18.3.28)(react@18.3.1)
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1(@noble/hashes@2.2.0)
       kysely:
         specifier: 'catalog:'
         version: 0.28.17


### PR DESCRIPTION
## Problem

SVG files uploaded via the presigned PUT URL flow were never inspected server-side — the server issued a signed URL and the browser PUT the bytes directly to S3, bypassing any content validation. Because S3 served these assets with \`inline\` content-disposition, a malicious SVG containing embedded \`<script>\` tags or event-handler attributes would execute in the browser when accessed via the direct CloudFront URL (stored XSS).

Security context: [SVG with inline content disposition enables stored XSS via direct CloudFront URL](https://app.notion.com/p/opengov/svg-with-inline-content-disposition-enables-stored-xss-via-direct-cloudfront-url-36e77dbba788818ca928ed92624420ef)

Closes [insert issue #]

## Solution

SVG uploads are now routed through a dedicated \`uploadSvg\` tRPC endpoint that reads and sanitizes content server-side before writing to S3. The presigned PUT URL path explicitly blocks \`.svg\` files so this inspection cannot be bypassed.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Added \`sanitizeSvg\` service function that:
  - Rejects content containing \`<!ENTITY\` declarations before parsing, preventing XML entity-expansion (billion-laughs) DoS attacks
  - Uses JSDOM's \`DOMParser\` to parse the content and rejects anything that produces a parse error or whose root element is not a valid \`<svg>\` with the correct namespace
  - Runs DOMPurify (via \`isomorphic-dompurify\`) with \`svg\` + \`svgFilters\` profiles, explicitly forbidding \`<script>\`, \`<foreignObject>\`, \`<use>\` tags and \`onload\`, \`onclick\`, \`onerror\`, \`onmouseover\` attributes as defense-in-depth (the svg profile is the actual security boundary)
- Added \`putFileDirect\` service helper that writes the sanitized SVG body directly to S3 (bypassing presigned URLs) with correct \`Content-Type\`, \`Content-Disposition\`, and S3 \`Tagging\` headers (including \`scheduledAt\` when provided)
- Added \`putObjectDirect\` S3 helper for direct \`PutObjectCommand\` calls (now accepts \`Tagging\`)
- Added \`uploadSvg\` tRPC mutation (rate-limited to 10 requests/min per user given CPU cost of sanitization)
- Blocked \`.svg\` in \`getPresignedPutUrlSchema\` so SVGs can no longer reach S3 via the unsigned presigned-PUT path
- Added \`uploadSvgSchema\` with a 1 MB size cap (lower than the regular image limit) to bound sanitization cost; note the cap uses string length (UTF-16 code units) as a conservative upper bound
- Client-side \`useUploadAssetMutation\` now detects \`.svg\` files and routes them to \`uploadSvg\` instead of the presigned PUT flow, forwarding \`scheduledAt\` as an S3 tag to match the presigned path behaviour

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Upload a valid \`.svg\` file in the Studio image uploader and confirm it appears correctly in the editor
- [ ] Attempt to upload an SVG containing \`<script>alert(1)</script>\` — confirm the upload either fails with a validation error or the script tag is absent when the asset is later rendered
- [ ] Attempt to upload an SVG containing \`onload="alert(1)"\` — confirm the attribute is stripped or the upload is rejected
- [ ] Attempt to upload a non-SVG file (e.g. \`.png\`) via the normal image uploader and confirm it still works via the presigned PUT URL flow
- [ ] Confirm that accessing a freshly uploaded SVG via its direct CloudFront URL does not trigger a script execution

**New dependencies**:

- \`isomorphic-dompurify\` : server-side DOMPurify wrapper used to sanitize SVG content before S3 upload
- \`jsdom\` : provides JSDOM's \`DOMParser\` for server-side SVG parsing (used directly to avoid relying on a browser environment)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes a stored-XSS vector where SVG files uploaded via the presigned PUT URL path reached S3 uninspected and were served with `inline` content-disposition, allowing embedded `<script>` tags or event handlers to execute in browsers visiting the direct CloudFront URL.

- SVG uploads are now routed through a dedicated `uploadSvg` tRPC endpoint that performs an entity-bomb regex check, XML parse validation, SVG root/namespace verification, and DOMPurify sanitization (SVG+svgFilters profile) before writing to S3 via `putObjectDirect`; the presigned PUT path explicitly blocks `.svg` files so the unsigned path cannot be used as a bypass.
- The client-side `useUploadAssetMutation` hook detects `.svg` filenames and routes them to `uploadSvg` instead of the presigned flow, forwarding `scheduledAt` as an S3 tag to preserve scheduling behaviour.
- Test coverage is thorough: entity bombs, `<script>` injection, event-handler attributes, `foreignObject`/`use` stripping, malformed XML, wrong root elements, and auth/permission checks are all exercised.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the core sanitization chain is sound and well-tested, with only minor style and UX polish remaining.

The security mechanism is layered correctly — entity check, XML parse, namespace validation, and DOMPurify allowlist all run in the right order, and the presigned-PUT bypass path is explicitly closed. Tests cover the critical attack vectors. The three findings are non-blocking: an import ordering oddity in asset.service.ts, a potentially incorrect comment and widened type in the jsdom shim, and the absence of a client-side size guard before file.text() that causes unnecessary memory allocation on oversized files before the server rejects them.

apps/studio/src/types/shims.d.ts (the jsdom module stub may conflict with bundled types) and apps/studio/src/server/modules/asset/asset.service.ts (import ordering).
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/asset/asset.service.ts | Adds sanitizeSvg (entity-bomb guard → XML parse → SVG root check → DOMPurify SVG profile) and putFileDirect; minor style issue with import ordering around the JSDOM DOMParser extraction. |
| apps/studio/src/server/modules/asset/asset.router.ts | Adds uploadSvg tRPC mutation with rate limiting (10/min), permission validation, sanitizeSvg call, and direct S3 write; implementation is correct and well-structured. |
| apps/studio/src/schemas/asset.ts | Blocks .svg from getPresignedPutUrlSchema; adds uploadSvgSchema with fileName + .svg extension check and 1 MB character-count cap (acknowledged approximation in comments). |
| apps/studio/src/hooks/useUploadAssetMutation.ts | Routes .svg files to uploadSvg endpoint; no client-side size guard before file.text(), so oversized SVGs are fully buffered before the server rejects them. |
| apps/studio/src/types/shims.d.ts | Adds a jsdom module stub, but the comment claiming jsdom ships no TypeScript types is inaccurate for v29.1.1; the stub widens the window type which could mask type errors. |
| apps/studio/src/lib/s3.ts | Adds putObjectDirect helper wrapping PutObjectCommand; straightforward and consistent with existing S3 helpers. |
| apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts | Good coverage for uploadSvg: auth, 404, 403, invalid content, entity bomb, success, and wrong extension cases all tested. |
| apps/studio/src/server/modules/asset/__tests__/asset.service.test.ts | Thorough unit tests for sanitizeSvg covering script stripping, event-handler attribute removal, foreignObject/use tag removal, entity bombs, malformed XML, wrong root element, and empty input. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant tRPC as tRPC (asset.router)
    participant Service as asset.service
    participant S3

    Note over Browser,S3: SVG upload path (new)
    Browser->>tRPC: "uploadSvg({ siteId, fileName, content, tags })"
    tRPC->>Service: validateUserPermissionsForAsset()
    tRPC->>Service: sanitizeSvg(content)
    Service->>Service: "/<!ENTITY/i check (entity-bomb guard)"
    Service->>Service: "DOMParser.parseFromString() -> check parsererror"
    Service->>Service: Verify root element is svg + correct namespace
    Service->>Service: DOMPurify.sanitize() with svg+svgFilters profile
    Service-->>tRPC: sanitized SVG string
    tRPC->>Service: "putFileDirect({ key, body, tags })"
    Service->>S3: PutObjectCommand (Content-Type, Content-Disposition, Tagging)
    S3-->>Service: OK
    tRPC-->>Browser: "{ fileKey }"

    Note over Browser,S3: Non-SVG upload path (unchanged)
    Browser->>tRPC: "getPresignedPutUrl({ siteId, fileName })"
    Note over tRPC: .svg extension -> BAD_REQUEST (blocked)
    tRPC-->>Browser: "{ presignedPutUrl, contentType }"
    Browser->>S3: PUT file bytes directly to presigned URL
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant tRPC as tRPC (asset.router)
    participant Service as asset.service
    participant S3

    Note over Browser,S3: SVG upload path (new)
    Browser->>tRPC: "uploadSvg({ siteId, fileName, content, tags })"
    tRPC->>Service: validateUserPermissionsForAsset()
    tRPC->>Service: sanitizeSvg(content)
    Service->>Service: "/<!ENTITY/i check (entity-bomb guard)"
    Service->>Service: "DOMParser.parseFromString() -> check parsererror"
    Service->>Service: Verify root element is svg + correct namespace
    Service->>Service: DOMPurify.sanitize() with svg+svgFilters profile
    Service-->>tRPC: sanitized SVG string
    tRPC->>Service: "putFileDirect({ key, body, tags })"
    Service->>S3: PutObjectCommand (Content-Type, Content-Disposition, Tagging)
    S3-->>Service: OK
    tRPC-->>Browser: "{ fileKey }"

    Note over Browser,S3: Non-SVG upload path (unchanged)
    Browser->>tRPC: "getPresignedPutUrl({ siteId, fileName })"
    Note over tRPC: .svg extension -> BAD_REQUEST (blocked)
    tRPC-->>Browser: "{ presignedPutUrl, contentType }"
    Browser->>S3: PUT file bytes directly to presigned URL
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fasset%2Fasset.service.ts%3A10-11%0A**%60const%60%20declaration%20splits%20import%20block**%0A%0A%60const%20%7B%20DOMParser%20%7D%20%3D%20new%20JSDOM%28%22%22%29.window%60%20is%20sandwiched%20between%20two%20groups%20of%20%60import%60%20statements.%20TypeScript%20hoists%20imports%2C%20so%20this%20compiles%20correctly%2C%20but%20it%20violates%20the%20universal%20convention%20that%20all%20%60import%60%20declarations%20appear%20before%20any%20executable%20statements.%20Most%20lint%20rules%20%28e.g.%2C%20%60import%2Ffirst%60%29%20would%20flag%20this.%20Moving%20the%20%60const%60%20to%20after%20the%20last%20import%20keeps%20the%20module%20initialisation%20order%20clear%20and%20avoids%20confusing%20tooling.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fstudio%2Fsrc%2Ftypes%2Fshims.d.ts%3A5-12%0A**Incorrect%20comment%20%E2%80%94%20jsdom%20v22%2B%20ships%20bundled%20TypeScript%20declarations**%0A%0AThe%20comment%20%22jsdom%20does%20not%20ship%20its%20own%20TypeScript%20declarations%22%20is%20inaccurate%20for%20jsdom%20v29.1.1%20%28used%20here%29.%20jsdom%20migrated%20to%20TypeScript%20internally%20around%20v22%20and%20now%20ships%20bundled%20types.%20The%20%60window%60%20type%20in%20the%20real%20declarations%20is%20%60DOMWindow%60%2C%20not%20%60Window%20%26%20typeof%20globalThis%60.%20This%20stub%20is%20a%20module%20augmentation%20that%20widens%20the%20type%2C%20which%20can%20mask%20real%20type%20errors%20%28e.g.%2C%20accessing%20properties%20on%20%60window%60%20that%20exist%20on%20%60Window%60%20but%20not%20on%20jsdom's%20%60DOMWindow%60%29.%0A%0A%60%60%60suggestion%0A%2F%2F%20jsdom%20v22%2B%20ships%20bundled%20TypeScript%20declarations%3B%20no%20stub%20is%20needed%20for%20the%0A%2F%2F%20JSDOM%20class%20itself.%20If%20the%20compiler%20still%20cannot%20resolve%20the%20type%2C%20install%0A%2F%2F%20%40types%2Fjsdom%20or%20rely%20on%20the%20types%20bundled%20with%20the%20jsdom%20package%20directly.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fstudio%2Fsrc%2Fhooks%2FuseUploadAssetMutation.ts%3A36-53%0A**File%20fully%20buffered%20in%20memory%20before%20server-side%20size%20check**%0A%0A%60file.text%28%29%60%20reads%20the%20entire%20file%20into%20memory%20before%20the%20tRPC%20schema%20rejects%20oversized%20content.%20If%20a%20user%20selects%20a%20multi-megabyte%20SVG%20%28or%20something%20mis-named%20%60.svg%60%29%2C%20the%20client%20allocates%20the%20full%20buffer%2C%20makes%20the%20network%20round-trip%2C%20and%20only%20then%20sees%20the%20%60BAD_REQUEST%60.%20A%20guard%20like%20%60if%20%28file.size%20%3E%20MAX_SVG_FILE_SIZE_BYTES%29%60%20before%20the%20%60await%20file.text%28%29%60%20call%20would%20give%20immediate%20feedback%20and%20avoid%20the%20wasted%20allocation.%20The%20%60MAX_SVG_FILE_SIZE_BYTES%60%20constant%20is%20already%20exported%20from%20%60constants.ts%60%20so%20no%20new%20value%20needs%20importing.%0A%0A&repo=opengovsg%2Fisomer&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fasset%2Fasset.service.ts%3A10-11%0A**%60const%60%20declaration%20splits%20import%20block**%0A%0A%60const%20%7B%20DOMParser%20%7D%20%3D%20new%20JSDOM%28%22%22%29.window%60%20is%20sandwiched%20between%20two%20groups%20of%20%60import%60%20statements.%20TypeScript%20hoists%20imports%2C%20so%20this%20compiles%20correctly%2C%20but%20it%20violates%20the%20universal%20convention%20that%20all%20%60import%60%20declarations%20appear%20before%20any%20executable%20statements.%20Most%20lint%20rules%20%28e.g.%2C%20%60import%2Ffirst%60%29%20would%20flag%20this.%20Moving%20the%20%60const%60%20to%20after%20the%20last%20import%20keeps%20the%20module%20initialisation%20order%20clear%20and%20avoids%20confusing%20tooling.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fstudio%2Fsrc%2Ftypes%2Fshims.d.ts%3A5-12%0A**Incorrect%20comment%20%E2%80%94%20jsdom%20v22%2B%20ships%20bundled%20TypeScript%20declarations**%0A%0AThe%20comment%20%22jsdom%20does%20not%20ship%20its%20own%20TypeScript%20declarations%22%20is%20inaccurate%20for%20jsdom%20v29.1.1%20%28used%20here%29.%20jsdom%20migrated%20to%20TypeScript%20internally%20around%20v22%20and%20now%20ships%20bundled%20types.%20The%20%60window%60%20type%20in%20the%20real%20declarations%20is%20%60DOMWindow%60%2C%20not%20%60Window%20%26%20typeof%20globalThis%60.%20This%20stub%20is%20a%20module%20augmentation%20that%20widens%20the%20type%2C%20which%20can%20mask%20real%20type%20errors%20%28e.g.%2C%20accessing%20properties%20on%20%60window%60%20that%20exist%20on%20%60Window%60%20but%20not%20on%20jsdom's%20%60DOMWindow%60%29.%0A%0A%60%60%60suggestion%0A%2F%2F%20jsdom%20v22%2B%20ships%20bundled%20TypeScript%20declarations%3B%20no%20stub%20is%20needed%20for%20the%0A%2F%2F%20JSDOM%20class%20itself.%20If%20the%20compiler%20still%20cannot%20resolve%20the%20type%2C%20install%0A%2F%2F%20%40types%2Fjsdom%20or%20rely%20on%20the%20types%20bundled%20with%20the%20jsdom%20package%20directly.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fstudio%2Fsrc%2Fhooks%2FuseUploadAssetMutation.ts%3A36-53%0A**File%20fully%20buffered%20in%20memory%20before%20server-side%20size%20check**%0A%0A%60file.text%28%29%60%20reads%20the%20entire%20file%20into%20memory%20before%20the%20tRPC%20schema%20rejects%20oversized%20content.%20If%20a%20user%20selects%20a%20multi-megabyte%20SVG%20%28or%20something%20mis-named%20%60.svg%60%29%2C%20the%20client%20allocates%20the%20full%20buffer%2C%20makes%20the%20network%20round-trip%2C%20and%20only%20then%20sees%20the%20%60BAD_REQUEST%60.%20A%20guard%20like%20%60if%20%28file.size%20%3E%20MAX_SVG_FILE_SIZE_BYTES%29%60%20before%20the%20%60await%20file.text%28%29%60%20call%20would%20give%20immediate%20feedback%20and%20avoid%20the%20wasted%20allocation.%20The%20%60MAX_SVG_FILE_SIZE_BYTES%60%20constant%20is%20already%20exported%20from%20%60constants.ts%60%20so%20no%20new%20value%20needs%20importing.%0A%0A&pr=2293&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fimplement-pasted-feature%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fimplement-pasted-feature%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fasset%2Fasset.service.ts%3A10-11%0A**%60const%60%20declaration%20splits%20import%20block**%0A%0A%60const%20%7B%20DOMParser%20%7D%20%3D%20new%20JSDOM%28%22%22%29.window%60%20is%20sandwiched%20between%20two%20groups%20of%20%60import%60%20statements.%20TypeScript%20hoists%20imports%2C%20so%20this%20compiles%20correctly%2C%20but%20it%20violates%20the%20universal%20convention%20that%20all%20%60import%60%20declarations%20appear%20before%20any%20executable%20statements.%20Most%20lint%20rules%20%28e.g.%2C%20%60import%2Ffirst%60%29%20would%20flag%20this.%20Moving%20the%20%60const%60%20to%20after%20the%20last%20import%20keeps%20the%20module%20initialisation%20order%20clear%20and%20avoids%20confusing%20tooling.%0A%0A%23%23%23%20Issue%202%20of%203%0Aapps%2Fstudio%2Fsrc%2Ftypes%2Fshims.d.ts%3A5-12%0A**Incorrect%20comment%20%E2%80%94%20jsdom%20v22%2B%20ships%20bundled%20TypeScript%20declarations**%0A%0AThe%20comment%20%22jsdom%20does%20not%20ship%20its%20own%20TypeScript%20declarations%22%20is%20inaccurate%20for%20jsdom%20v29.1.1%20%28used%20here%29.%20jsdom%20migrated%20to%20TypeScript%20internally%20around%20v22%20and%20now%20ships%20bundled%20types.%20The%20%60window%60%20type%20in%20the%20real%20declarations%20is%20%60DOMWindow%60%2C%20not%20%60Window%20%26%20typeof%20globalThis%60.%20This%20stub%20is%20a%20module%20augmentation%20that%20widens%20the%20type%2C%20which%20can%20mask%20real%20type%20errors%20%28e.g.%2C%20accessing%20properties%20on%20%60window%60%20that%20exist%20on%20%60Window%60%20but%20not%20on%20jsdom's%20%60DOMWindow%60%29.%0A%0A%60%60%60suggestion%0A%2F%2F%20jsdom%20v22%2B%20ships%20bundled%20TypeScript%20declarations%3B%20no%20stub%20is%20needed%20for%20the%0A%2F%2F%20JSDOM%20class%20itself.%20If%20the%20compiler%20still%20cannot%20resolve%20the%20type%2C%20install%0A%2F%2F%20%40types%2Fjsdom%20or%20rely%20on%20the%20types%20bundled%20with%20the%20jsdom%20package%20directly.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aapps%2Fstudio%2Fsrc%2Fhooks%2FuseUploadAssetMutation.ts%3A36-53%0A**File%20fully%20buffered%20in%20memory%20before%20server-side%20size%20check**%0A%0A%60file.text%28%29%60%20reads%20the%20entire%20file%20into%20memory%20before%20the%20tRPC%20schema%20rejects%20oversized%20content.%20If%20a%20user%20selects%20a%20multi-megabyte%20SVG%20%28or%20something%20mis-named%20%60.svg%60%29%2C%20the%20client%20allocates%20the%20full%20buffer%2C%20makes%20the%20network%20round-trip%2C%20and%20only%20then%20sees%20the%20%60BAD_REQUEST%60.%20A%20guard%20like%20%60if%20%28file.size%20%3E%20MAX_SVG_FILE_SIZE_BYTES%29%60%20before%20the%20%60await%20file.text%28%29%60%20call%20would%20give%20immediate%20feedback%20and%20avoid%20the%20wasted%20allocation.%20The%20%60MAX_SVG_FILE_SIZE_BYTES%60%20constant%20is%20already%20exported%20from%20%60constants.ts%60%20so%20no%20new%20value%20needs%20importing.%0A%0A&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
apps/studio/src/server/modules/asset/asset.service.ts:10-11
**`const` declaration splits import block**

`const { DOMParser } = new JSDOM("").window` is sandwiched between two groups of `import` statements. TypeScript hoists imports, so this compiles correctly, but it violates the universal convention that all `import` declarations appear before any executable statements. Most lint rules (e.g., `import/first`) would flag this. Moving the `const` to after the last import keeps the module initialisation order clear and avoids confusing tooling.

### Issue 2 of 3
apps/studio/src/types/shims.d.ts:5-12
**Incorrect comment — jsdom v22+ ships bundled TypeScript declarations**

The comment "jsdom does not ship its own TypeScript declarations" is inaccurate for jsdom v29.1.1 (used here). jsdom migrated to TypeScript internally around v22 and now ships bundled types. The `window` type in the real declarations is `DOMWindow`, not `Window & typeof globalThis`. This stub is a module augmentation that widens the type, which can mask real type errors (e.g., accessing properties on `window` that exist on `Window` but not on jsdom's `DOMWindow`).

```suggestion
// jsdom v22+ ships bundled TypeScript declarations; no stub is needed for the
// JSDOM class itself. If the compiler still cannot resolve the type, install
// @types/jsdom or rely on the types bundled with the jsdom package directly.
```

### Issue 3 of 3
apps/studio/src/hooks/useUploadAssetMutation.ts:36-53
**File fully buffered in memory before server-side size check**

`file.text()` reads the entire file into memory before the tRPC schema rejects oversized content. If a user selects a multi-megabyte SVG (or something mis-named `.svg`), the client allocates the full buffer, makes the network round-trip, and only then sees the `BAD_REQUEST`. A guard like `if (file.size > MAX_SVG_FILE_SIZE_BYTES)` before the `await file.text()` call would give immediate feedback and avoid the wasted allocation. The `MAX_SVG_FILE_SIZE_BYTES` constant is already exported from `constants.ts` so no new value needs importing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): add logger.error calls in s..."](https://github.com/opengovsg/isomer/commit/2cc3def1976fc342260e055ca9e2b7ff756ea272) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746809)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->