### PR TITLE
fix(studio): wait for asset readback before setting image form value

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageControl.tsx
@@ -56,7 +56,7 @@ function JsonFormsImageControl({
           siteId={siteId}
           resourceId={(pageId ?? linkId) ? String(pageId ?? linkId) : undefined}
           setHref={(src) => handleChange(path, src)}
-          shouldFetchResource={false}
+          shouldFetchResource={true}
         />
       )}
       {!!errors && (


### PR DESCRIPTION
## Summary
- Flips `shouldFetchResource` to `true` in `JsonFormsImageControl` so the form field is only populated once the uploaded asset is actually reachable from `NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME`.
- Previously the control wrote the raw S3 path to the form immediately after upload, which can briefly 404 in any downstream preview that fetches via the assets domain.
- Behavior on failure: `useAssetUpload` retries with exponential backoff (~63s worst case); if it never resolves, the field is left empty and the user can re-upload.

## Test plan
- [ ] Upload an image via a JSON Forms image control in the page editor; confirm the form value is set only after the skeleton clears.
- [ ] Confirm the uploaded image renders in preview without a transient broken state.
- [ ] Sanity check that `NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME` is set in the relevant environments — if unset, the readback fetch would hit the studio origin and 404, hanging uploads for the full backoff window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)