### PR TITLE
chore: add isomer-conventions skill for code smells

### DIFF
--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: isomer-conventions
+description: Repository-specific code smells and blessed conventions for the Isomer Next monorepo. Use when writing or reviewing code in this repo (tRPC routers, Kysely/Prisma access, zod schemas, React components, tests) to catch deviations from team conventions, and when the user wants to record a new code smell or best practice ("remember this convention", "add a code smell", "we always/never do X here").
+---
+
+# Isomer conventions
+
+A growable catalog of repo-specific code smells (patterns to avoid) and best
+practices (the blessed way). Each entry lives in its own file under
+`conventions/`; the [Catalog](#catalog) below indexes them. The catalog starts
+empty and grows as the team discovers conventions during review.
+
+## Applying conventions
+
+When writing or reviewing code in this repo:
+
+1. Skim the [Catalog](#catalog) and load any entry whose hook looks relevant to
+   the diff/file at hand. Don't load all of them — only what's relevant.
+2. For each relevant entry, check the code against it.
+3. Flag violations as `path:line` — name the convention, show the blessed
+   pattern, and (for smells) why it matters. Cite the entry file.
+4. When writing new code, follow the matching best-practice entries by default.
+
+If the catalog is empty or nothing matches, fall back to general good judgment —
+do not invent repo conventions that aren't recorded here.
+
+## Adding a new entry
+
+Triggered when the user says things like "remember this", "add a code smell",
+"we always/never do X here", or describes a convention while reviewing code.
+
+1. **Check for an existing entry first.** If one covers the same ground, update
+   it instead of creating a duplicate.
+2. Create `conventions/<kebab-slug>.md` following
+   [conventions/TEMPLATE.md](conventions/TEMPLATE.md). Keep it short — a smell,
+   why, a Bad/Good pair, and how to detect it. Ground examples in real
+   `path:line` from the repo when possible.
+3. Add a one-line pointer to the [Catalog](#catalog) below, grouped under its
+   category (create the category heading if it's new).
+4. Confirm what you saved in one line.
+
+Keep SKILL.md lean: detail lives in the entry files, never inline here.
+
+## Catalog
+
+### React
+
+- [Prefer a new component over overloading props](conventions/react-new-component-over-prop-overload.md) — smell: flag soup / single-caller props bending one component into two jobs
+- [Build forms with useZodForm, not per-field useState](conventions/react-forms-usezodform-over-usestate.md) — best practice: forms use the zod-wired useForm wrapper, schema reused from ~/schemas
+
+### Audit logging
+- [Audit deltas must log real DB rows, not hand-built objects](conventions/audit-log-real-db-rows.md) — best practice: log before/after as rows re-read from the DB inside the same tx, so deltas are accurate
+
+### Readability
+- [Document every regex, and keep the comment correct](conventions/document-regex-with-verified-comments.md) — best practice: comment what + why a regex matches, and verify the comment is accurate
+
+<!-- Each line: [Title](conventions/slug.md) — short hook (smell/best practice).
+     Group under a category heading; create the heading if it's new. -->

--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -54,5 +54,8 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 ### Readability
 - [Document every regex, and keep the comment correct](conventions/document-regex-with-verified-comments.md) — best practice: comment what + why a regex matches, and verify the comment is accurate
 
+### Testing
+- [Structure tests as Arrange / Act / Assert](conventions/tests-arrange-act-assert.md) — best practice: mark AAA phases (collapse adjacent markers when trivial), one Act per test
+
 <!-- Each line: [Title](conventions/slug.md) — short hook (smell/best practice).
      Group under a category heading; create the heading if it's new. -->

--- a/.claude/skills/isomer-conventions/conventions/TEMPLATE.md
+++ b/.claude/skills/isomer-conventions/conventions/TEMPLATE.md
@@ -1,0 +1,32 @@
+---
+title: <short imperative title, e.g. "Check permissions before DB access">
+category: <e.g. tRPC, Database, Schemas, React, Testing, Types, Imports>
+type: smell | best-practice
+---
+
+## Pattern
+
+<One or two sentences describing the smell to avoid, or the practice to follow.>
+
+## Why
+
+<Why it matters here — the concrete consequence (bug class, perf, security,
+maintainability). Keep it to a few lines.>
+
+## Bad
+
+```ts
+// the anti-pattern
+```
+
+## Good
+
+```ts
+// the blessed pattern
+```
+
+## How to detect
+
+<What to grep for / what a reviewer should look at to spot a violation. Cite a
+real `path:line` example in the repo if one exists. Link related entries with
+[text](other-slug.md).>

--- a/.claude/skills/isomer-conventions/conventions/audit-log-real-db-rows.md
+++ b/.claude/skills/isomer-conventions/conventions/audit-log-real-db-rows.md
@@ -1,0 +1,81 @@
+---
+title: Audit deltas must log real DB rows, not hand-built objects
+category: Audit logging
+type: best-practice
+---
+
+## Pattern
+
+Mutations to auditable entities must write an audit log. The before/after
+`delta` must be populated with the **actual rows read from the database** —
+`before` fetched before the mutation, `after` re-fetched after it — not an
+object you assembled or mutated in memory from the input payload.
+
+This applies to every typed logger in `audit.service.ts`, not just Resource:
+`logResourceEvent` (Resource create/update/delete, schedule publish),
+`logUserEvent`, `logPermissionEvent`, `logConfigEvent`, `logPublishEvent`,
+`logAuthEvent`. Resource is the worked example below.
+
+Log inside the **same transaction** as the mutation, so `before`/`after`
+reflect exactly what the database committed and the write can't succeed without
+its audit entry.
+
+## Why
+
+The audit log's whole value is an accurate diff. A hand-built `after` (e.g.
+`{ ...before, ...input }`) silently diverges from what the DB actually stored —
+column defaults, triggers, coercion, transforms, and computed values are all
+missed, so the delta lies. The classic failure is mutating the fetched row in
+place and logging it as both sides: `before` and `after` point at the same
+object and the delta collapses to nothing. Re-reading real rows is the only way
+the delta records the true state transition.
+
+## Bad
+
+```ts
+const resource = await tx
+  .selectFrom("Resource").where("id", "=", id).selectAll()
+  .executeTakeFirstOrThrow()
+
+resource.title = input.title // mutated in place
+await tx.updateTable("Resource").set({ title: input.title }).where("id", "=", id).execute()
+
+await logResourceEvent(tx, {
+  siteId, by: user, eventType: AuditLogEvent.ResourceUpdate,
+  delta: { before: resource, after: resource }, // same object → empty delta
+})
+```
+
+## Good
+
+```ts
+const before = await tx
+  .selectFrom("Resource").where("id", "=", id).select(defaultResourceSelect)
+  .executeTakeFirstOrThrow()
+
+await tx.updateTable("Resource").set({ title: input.title }).where("id", "=", id).execute()
+
+const after = await tx
+  .selectFrom("Resource").where("id", "=", id).select(defaultResourceSelect)
+  .executeTakeFirstOrThrow()
+
+await logResourceEvent(tx, {
+  siteId, by: user, eventType: AuditLogEvent.ResourceUpdate,
+  delta: { before, after }, // two real DB rows
+})
+```
+
+Creates log `{ before: null, after: <created row> }`; deletes log
+`{ before: <row>, after: null }` (capture `before` before deleting). When only
+part of a `FullResource` changed (e.g. the blob but not the resource row), the
+unchanged half may reuse its fetched row — it's still a real DB row. See the
+move handler `resource.router.ts:356` for the fetch → mutate → re-fetch → log
+idiom, and `gazette.router.ts` for create/delete.
+
+## How to detect
+
+Look for `logResourceEvent`/`log*Event` calls where `delta.after` is built by
+spreading input over `before` (`{ ...before, ...input }`), where `before` and
+`after` are the same variable, or where the logged object was mutated in place
+rather than re-read. Confirm the log call sits inside the mutation's
+`db.transaction().execute(async (tx) => ...)`.

--- a/.claude/skills/isomer-conventions/conventions/document-regex-with-verified-comments.md
+++ b/.claude/skills/isomer-conventions/conventions/document-regex-with-verified-comments.md
@@ -1,0 +1,48 @@
+---
+title: Document every regex, and keep the comment correct
+category: Readability
+type: best-practice
+---
+
+## Pattern
+
+Every non-trivial regex gets a comment that says (a) **what** it matches in
+plain language and (b) **why** that pattern is needed here — the edge case,
+spec, or input quirk that drove it. Crucially, **verify the comment actually
+describes the regex**: a wrong or stale comment is worse than none, because
+reviewers trust it instead of re-reading the pattern.
+
+## Why
+
+Regex is write-once, read-never: the author understands it for about a day,
+then nobody does. The comment is the only affordance for the next reader and for
+reviewers who won't mentally execute the pattern. The "why" matters as much as
+the "what" — without it, someone later "simplifies" the regex and silently
+breaks the edge case it was guarding. And an inaccurate comment actively
+misleads, so correctness of the comment is part of the convention, not optional.
+
+## Bad
+
+```ts
+// validate slug
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+```
+
+The comment restates the variable name and explains nothing — not what counts as
+valid, nor why (e.g. why no leading/trailing/double hyphens).
+
+## Good
+
+```ts
+// Permalink slug: lowercase alphanumerics in hyphen-separated groups.
+// No leading/trailing/consecutive hyphens — those break URL routing and
+// collide with our auto-generated parent paths.
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+```
+
+## How to detect
+
+Flag any regex literal or `new RegExp(...)` with no comment, or with a comment
+that only repeats the variable name. When reviewing a documented regex, read the
+pattern against its comment and call out mismatches (e.g. comment says "digits
+only" but the class is `\w`). Treat a stale comment as a fixable, not a nit.

--- a/.claude/skills/isomer-conventions/conventions/react-forms-usezodform-over-usestate.md
+++ b/.claude/skills/isomer-conventions/conventions/react-forms-usezodform-over-usestate.md
@@ -1,0 +1,79 @@
+---
+title: Build forms with useZodForm, not per-field useState
+category: React
+type: best-practice
+---
+
+## Pattern
+
+Build forms with the project's `useZodForm` hook
+(`apps/studio/src/lib/form.ts:6`) — a thin wrapper over react-hook-form's
+`useForm` wired to a zod schema via `zodResolver`. Do not manage form field
+values, validation, and error state with a pile of `useState` calls.
+
+Reuse the schema from `apps/studio/src/schemas/` — ideally the same schema the
+tRPC procedure validates with (`.input()`), so client and server agree.
+
+## Why
+
+`useState`-per-field reimplements what react-hook-form already gives for free:
+validation, error messages, dirty/touched tracking, and submit handling. It
+drifts out of sync with the server's zod schema, re-renders the whole form on
+every keystroke, and scatters validation logic across handlers. `useZodForm`
+derives the input/output types straight from the schema, so the form, the
+mutation input, and the server stay type-aligned.
+
+## Bad
+
+```tsx
+// Hand-rolled form state — validation and types drift from the schema
+const [title, setTitle] = useState("")
+const [permalink, setPermalink] = useState("")
+const [errors, setErrors] = useState<Record<string, string>>({})
+
+const onSubmit = () => {
+  const next: Record<string, string> = {}
+  if (!title) next.title = "Enter a title"
+  // ...manual validation, easy to diverge from the server schema
+  setErrors(next)
+}
+```
+
+## Good
+
+```tsx
+const { register, control, handleSubmit, formState: { errors } } = useZodForm({
+  schema: basePageSettingsSchema.omit({ pageId: true, siteId: true }),
+  defaultValues: { title: originalTitle, permalink: "" },
+})
+
+<form onSubmit={handleSubmit((data) => mutate(data))}>
+  <FormControl isInvalid={!!errors.title}>
+    <FormLabel isRequired>Title</FormLabel>
+    <Input {...register("title")} />
+    <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+  </FormControl>
+</form>
+```
+
+Wire nested fields with `FormProvider` + `useFormContext` in children, and use
+`Controller` for non-native inputs (DatePicker, SingleSelect). Surface errors
+via `FormControl isInvalid` + `FormErrorMessage`. See
+`features/dashboard/components/PageSettingsModal.tsx` and
+`features/editing-experience/components/PublishingModal/` for the full idiom.
+
+## Not a smell
+
+`useState` for **UI-only state that isn't part of the schema** is fine — e.g. a
+display-only `File` object backing an upload widget, an open/closed toggle, a
+hover state. Form *data* flows through react-hook-form (`register` / `control` /
+`setValue`); local state just drives presentation. See
+`features/gazettes/components/GazetteModal/GazetteFormFields.tsx:62` for a
+sanctioned mix.
+
+## How to detect
+
+Look for components rendering inputs with multiple `useState` values plus
+`onChange` handlers and manual `if (!value) ...` validation, instead of
+`useZodForm` + `register`/`Controller`. Check that the schema is imported from
+`~/schemas/` rather than redefined inline.

--- a/.claude/skills/isomer-conventions/conventions/react-new-component-over-prop-overload.md
+++ b/.claude/skills/isomer-conventions/conventions/react-new-component-over-prop-overload.md
@@ -1,0 +1,102 @@
+---
+title: Prefer a new component over overloading props
+category: React
+type: smell
+---
+
+## Pattern
+
+When a new use case needs a component to behave differently, prefer creating a
+new component over piling more props onto the existing one. Adding flags and
+single-purpose props to bend a component into a second job makes it a "component
+in a trenchcoat" — really N components fused into one.
+
+## Why
+
+Overloaded components accrete conditional branches, become hard to read, and
+couple unrelated callers: a change for one use case risks breaking the others.
+Each prop multiplies the states to reason about and test. Splitting keeps each
+component's intent clear and its blast radius small.
+
+## Signals (what fires this smell)
+
+- **Flag soup** — booleans piling up (`isCompact`, `hideThumbnail`,
+  `showOwner`), each toggling some bit of layout/behaviour.
+- **Single-caller props** — a prop that exists only to serve one usage site
+  (e.g. `draggable` used only by the dashboard). Strong sign the component is
+  straddling two distinct jobs.
+- **All-or-nothing slot / render-prop** — a `renderX` or slot prop that each
+  consumer either fully supplies or fully omits, and the supplied versions
+  share nothing with each other. The component isn't being *configured*; it's
+  hosting N different body implementations behind one seam — N components fused
+  into a wrapper. Slots are the blessed fix *until they become the disguise*.
+
+## Not a smell
+
+- **Design-system primitives** (`Button`, `Input`, and similar low-level
+  reusable building blocks) legitimately expose many configuration props.
+  Don't flag these.
+- **Shells with real shared machinery.** Before condemning a slot/render-prop,
+  apply the litmus test: *when the slot is supplied, what's left in the
+  component?* If it still owns substantial shared behaviour (drag-and-drop
+  reorder, add/remove plumbing, data wiring, layout chrome), the slot is
+  legitimate composition — splitting would duplicate that machinery. If only a
+  thin wrapper remains, it should have been separate components.
+
+## Yellow flags (call these out as fixables, non-blocking)
+
+Some cases pass the litmus test but still carry warning signs. Don't wave them
+through silently — surface them as *fixables*, not blockers:
+
+- **Single-caller slots on a shared shell** (e.g. `listItemIcon`,
+  `listItemSubtitle` supplied by only one of N consumers). Fine while the shell
+  shares real chrome, but say so: if a third divergent consumer appears, push
+  that decoration into the consumer via the existing render-prop seam rather
+  than growing more optional slots.
+- **A prop every consumer passes the same value for** isn't a configuration
+  point — bake it into the component default and drop the prop.
+
+## Bad
+
+```tsx
+// FileCard grew a flag per new context
+<FileCard
+  file={file}
+  isCompact
+  hideThumbnail
+  showOwner={false}
+  variant="search-result"
+  onSelect={...}    // only the picker uses this
+  draggable={false} // only the dashboard uses this
+/>
+```
+
+## Good
+
+```tsx
+// Each use case is its own named component; shared parts are extracted
+<SearchResultCard file={file} onSelect={...} />
+<DashboardFileCard file={file} draggable />
+// both compose a shared <FileCardShell> and/or useFileMeta() for common bits
+```
+
+## The fix
+
+The principle is: **a genuinely new use case → a new component**. The mechanism
+is the author's call — common options:
+
+- Extract shared behaviour into a `useX()` hook so the new component reuses
+  logic without inheriting props.
+- Favour composition (children/slots, a shared shell component) over adding
+  configuration props.
+- Split into intent-named components (`SearchResultCard`, `DashboardFileCard`)
+  rather than one configurable mega-component.
+
+## How to detect
+
+Scan component props for accumulating booleans and for props consumed by only
+one caller. Look for `if (variant === ...)` / ternaries that swap whole layouts.
+For slots and `renderX` props, check how each consumer uses them: if every
+consumer either fully supplies or fully omits the slot (all-or-nothing) and the
+supplied versions share nothing, apply the litmus test above. Flag props that
+all consumers pass the same value for.

--- a/.claude/skills/isomer-conventions/conventions/tests-arrange-act-assert.md
+++ b/.claude/skills/isomer-conventions/conventions/tests-arrange-act-assert.md
@@ -1,0 +1,58 @@
+---
+title: Structure tests as Arrange / Act / Assert
+category: Testing
+type: best-practice
+---
+
+## Pattern
+
+Structure each test body in three phases, marked with comments:
+
+- `// Arrange` — set up inputs, fixtures, mocks
+- `// Act` — invoke the thing under test, capturing its result
+- `// Assert` — `expect(...)` on the result
+
+Match the repo's existing convention (used across the test suite): collapse
+adjacent markers when a phase is empty or trivially one line —
+`// Arrange / Act` when there's no setup, or `// Arrange / Act / Assert` for a
+single-expression test.
+
+## Why
+
+AAA gives every test the same skeleton, so a reader instantly sees what's being
+set up, what's exercised, and what's checked — without reverse-engineering it.
+It also surfaces smells: multiple Act blocks mean the test is doing too much and
+should be split; a giant Arrange hints at a missing helper or an over-coupled
+unit. It's already the house style here, so deviating just adds inconsistency.
+
+## Bad
+
+```ts
+it("replaces whitespace with hyphens", () => {
+  expect(toFileId("Gazette Notice 2026.pdf")).toBe("Gazette-Notice-2026.pdf")
+  const other = toFileId("a b")        // a second act buried among asserts
+  expect(other).toBe("a-b")
+})
+```
+
+## Good
+
+```ts
+it("replaces whitespace with hyphens", () => {
+  // Arrange / Act
+  const result = toFileId("Gazette Notice 2026.pdf")
+
+  // Assert
+  expect(result).toBe("Gazette-Notice-2026.pdf")
+  expect(result).toMatch(FILE_ID_REGEX)
+})
+```
+
+See `apps/studio/src/features/gazettes/utils/__tests__/toFileId.test.ts` for the
+established style.
+
+## How to detect
+
+Flag test bodies with no AAA markers, or ones that interleave `expect(...)` with
+fresh calls to the unit under test (a sign of multiple Act phases — split into
+separate `it` blocks). One assertion target per test where practical.


### PR DESCRIPTION
## Problem

We have no shared, repo-specific record of code smells and blessed conventions. Patterns get re-explained in review, and AFK agents have no convention catalog to check against.

## Solution

Adds an `isomer-conventions` Claude Code skill under `.claude/skills/` — a **growable** catalog of code smells (anti-patterns) and best practices specific to this repo.

**Improvements**:

- `SKILL.md` documents two flows: *applying* conventions during review/authoring (flag deviations as `path:line` with the blessed pattern), and *adding* a new entry. It indexes entries; it intentionally stays lean.
- Detail lives in one file per convention under `conventions/` (mirrors the index + per-entry pattern), with a `TEMPLATE.md` for consistency. Categories are created on the fly as entries land.
- Designed to grow over time — engineers add entries by asking their agent ("code smell: ...", "best practice: ...") or by hand from the template, then PR as normal.

Seed conventions:

- **React** — prefer a new component over overloading props (flag soup / single-caller props)
- **React** — build forms with `useZodForm` + a `~/schemas` zod schema, not per-field `useState`
- **Audit logging** — populate before/after deltas with real DB rows re-read inside the same `tx`, never hand-built objects
- **Readability** — document every regex with a verified what/why comment

Each entry cites the real repo idiom (e.g. `useZodForm` at `apps/studio/src/lib/form.ts`, the move handler's fetch → mutate → re-fetch → log pattern) and carves out sanctioned exceptions so the smells don't misfire.

## Tests

No production code changes — this adds documentation/tooling only (a project skill), so there are no manual verification steps.