### PR TITLE
chore: add pnpm catalog convention to isomer-conventions skill

### DIFF
--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -57,5 +57,9 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 ### Testing
 - [Structure tests as Arrange / Act / Assert](conventions/tests-arrange-act-assert.md) — best practice: mark AAA phases (collapse adjacent markers when trivial), one Act per test
 
+### Dependencies
+
+- [Reference catalog packages via "catalog:" not direct version strings](conventions/pnpm-catalog-references.md) — smell: direct version strings in package.json for packages defined in pnpm-workspace.yaml catalog
+
 <!-- Each line: [Title](conventions/slug.md) — short hook (smell/best practice).
      Group under a category heading; create the heading if it's new. -->

--- a/.claude/skills/isomer-conventions/conventions/pnpm-catalog-references.md
+++ b/.claude/skills/isomer-conventions/conventions/pnpm-catalog-references.md
@@ -1,0 +1,61 @@
+---
+title: Reference catalog packages via "catalog:" not direct version strings
+category: Dependencies
+type: smell
+---
+
+## Pattern
+
+Any package declared in `pnpm-workspace.yaml` under `catalog:` or `catalogs:`
+must be referenced in `package.json` files using `"catalog:"`,
+`"catalog:XXX"`, or `"workspace:*"` — never a direct version string.
+
+## Why
+
+Direct version strings (`"^1.0.0"`) in individual `package.json` files bypass
+the single-source-of-truth in `pnpm-workspace.yaml`, allowing version drift
+between packages in the monorepo. When the catalog version is bumped, files
+with pinned versions silently diverge, causing hard-to-diagnose mismatches.
+
+## Bad
+
+```json
+// apps/studio/package.json
+{
+  "dependencies": {
+    "zod": "^4.0.0",
+    "react": "^18.3.1"
+  }
+}
+```
+
+Both `zod` and `react` are defined in `pnpm-workspace.yaml` — the version
+should not be duplicated in `package.json`.
+
+## Good
+
+```json
+// apps/studio/package.json
+{
+  "dependencies": {
+    "zod": "catalog:",
+    "react": "catalog:react",
+    "@isomer/some-internal-pkg": "workspace:*"
+  }
+}
+```
+
+## How to detect
+
+1. Extract all package names from `catalog:` and every `catalogs:` entry in
+   `pnpm-workspace.yaml`.
+2. Search all `package.json` files (excluding `node_modules`) for dependency
+   values that are plain version strings (start with a digit, `^`, `~`, or are
+   a range) for packages in that set.
+
+```bash
+find . -name "package.json" -not -path "*/node_modules/*"
+```
+
+Then inspect `dependencies`, `devDependencies`, `peerDependencies`, and
+`optionalDependencies` in each file.


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Packages declared in `pnpm-workspace.yaml` catalogs were not consistently enforced across `package.json` files, allowing direct version strings (`"^1.0.0"`) to drift from the catalog source of truth.

## Solution

<!-- How did you solve the problem? -->

Adds a new convention entry to the `isomer-conventions` Claude skill so it catches this pattern during code review.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Added `conventions/pnpm-catalog-references.md` — documents the rule that any package defined in `pnpm-workspace.yaml` under `catalog:` or `catalogs:` must be referenced in `package.json` using `"catalog:"`, `"catalog:XXX"`, or `"workspace:*"`, never a bare version string
- Added a **Dependencies** section to the `isomer-conventions` skill catalog pointing to the new entry

## Before & After Screenshots

N/A — tooling/config change only.

## Tests

No production code changes — no manual verification steps required.

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none