### PR TITLE
fix: use timing-safe webhook api key comparison

### DIFF
--- a/apps/studio/src/schemas/__tests__/webhook.test.ts
+++ b/apps/studio/src/schemas/__tests__/webhook.test.ts
@@ -10,6 +10,13 @@ import { WEBHOOK_X_API_KEY_HEADER } from "~/server/trpc"
 
 import type { codeBuildWebhookSchema } from "../webhook"
 
+const { WEBHOOK_API_KEY, INVALID_WEBHOOK_API_KEY_WITH_EXPECTED_LENGTH } =
+  vi.hoisted(() => ({
+    WEBHOOK_API_KEY: "00000000-0000-4000-8000-000000000000",
+    INVALID_WEBHOOK_API_KEY_WITH_EXPECTED_LENGTH:
+      "11111111-1111-4111-8111-111111111111",
+  }))
+
 vi.mock("~/env.mjs", async () => {
   // Import the real module first to get all default values
   const actual = await vi.importActual<{ env: typeof env }>("~/env.mjs")
@@ -17,7 +24,7 @@ vi.mock("~/env.mjs", async () => {
     env: {
       ...actual.env,
       // override some env variables for testing
-      STUDIO_SSM_WEBHOOK_API_KEY: "test-webhook-api-key",
+      STUDIO_SSM_WEBHOOK_API_KEY: WEBHOOK_API_KEY,
       GROWTHBOOK_CLIENT_KEY: "test-growthbook-client-key",
     },
   }
@@ -31,7 +38,7 @@ vi.mock("~/features/mail/service", () => ({
 
 const createMockRequest = ({
   arn,
-  apiKey = "test-webhook-api-key",
+  apiKey = WEBHOOK_API_KEY,
 }: {
   arn: string
   apiKey?: string | null
@@ -89,6 +96,26 @@ describe("webhook", () => {
       const { req, res } = createMockRequest({
         arn: "build/test-id",
         apiKey: "wrong-api-key",
+      })
+
+      // Act
+      await handler(req, res)
+
+      // Assert
+      expect(res.statusCode).toBe(401)
+    })
+    it("providing an incorrect API key with the expected length causes a 401", async () => {
+      // Arrange
+      const user = await setupUser(createTestUser())
+      await setupCodeBuildJob({
+        userId: user.id,
+        arn: "build/test-id",
+        startedAt: new Date(),
+        isScheduled: true,
+      })
+      const { req, res } = createMockRequest({
+        arn: "build/test-id",
+        apiKey: INVALID_WEBHOOK_API_KEY_WITH_EXPECTED_LENGTH,
       })
 
       // Act

--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -9,6 +9,7 @@
  */
 
 import { initTRPC, TRPCError } from "@trpc/server"
+import { timingSafeEqual } from "node:crypto"
 import superjson from "superjson"
 import { ZodError } from "zod"
 import { APP_VERSION_HEADER_KEY } from "~/constants/version"
@@ -179,6 +180,17 @@ const authMiddleware = t.middleware(async ({ next, ctx }) => {
 
 export const WEBHOOK_X_API_KEY_HEADER = "x-api-key"
 
+const isValidWebhookApiKey = (
+  apiKey: string | string[] | undefined,
+  expectedApiKey: string,
+): boolean => {
+  return (
+    typeof apiKey === "string" &&
+    apiKey.length === expectedApiKey.length &&
+    timingSafeEqual(Buffer.from(apiKey), Buffer.from(expectedApiKey))
+  )
+}
+
 const webhookMiddleware = t.middleware(async ({ next, ctx }) => {
   const apiKey = ctx.req.headers[WEBHOOK_X_API_KEY_HEADER]
   // Ensure that the API key is set in the env
@@ -189,7 +201,7 @@ const webhookMiddleware = t.middleware(async ({ next, ctx }) => {
     })
   }
   // Ensure that the API key is valid and matches
-  if (!apiKey || apiKey !== env.STUDIO_SSM_WEBHOOK_API_KEY) {
+  if (!isValidWebhookApiKey(apiKey, env.STUDIO_SSM_WEBHOOK_API_KEY)) {
     throw new TRPCError({
       code: "UNAUTHORIZED",
       message: "Invalid Webhook API key provided",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The webhook middleware compares the inbound `x-api-key` header against `STUDIO_SSM_WEBHOOK_API_KEY` using normal string equality. This can short-circuit on the first differing byte, which is a known timing side-channel pattern for secret comparisons.

Closes #2232
Closes #2233

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Replaces the webhook API key string equality check with `crypto.timingSafeEqual`.
- Rejects missing, repeated, or length-mismatched API key headers before comparing equal-length buffers.
- Adds regression coverage for an incorrect API key with the expected length.

## Before & After Screenshots

N/A, backend-only change.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Send a webhook request with the configured `x-api-key` and verify it succeeds.
- [ ] Send a webhook request with a missing `x-api-key` and verify it returns 401.
- [ ] Send a webhook request with an incorrect same-length `x-api-key` and verify it returns 401.

**New scripts**:

N/A

**New dependencies**:

N/A

**New dev dependencies**:

N/A
