### PR TITLE
fix: resolve dompurify hook leak

### DIFF
--- a/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
+++ b/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
@@ -35,6 +35,11 @@ export const Iframe = ({
   shouldLazyLoad = true,
 }: IframeProps) => {
   const sanitizedIframe = getSanitizedIframeWithTitle(content, title)
+
+  if (!sanitizedIframe) {
+    return null
+  }
+
   sanitizedIframe.setAttribute("loading", shouldLazyLoad ? "lazy" : "eager")
 
   const iframeUrl = sanitizedIframe.getAttribute("src")

--- a/packages/components/src/utils/__tests__/getSanitizedIframeWithTitle.test.ts
+++ b/packages/components/src/utils/__tests__/getSanitizedIframeWithTitle.test.ts
@@ -1,0 +1,42 @@
+import DOMPurify from "isomorphic-dompurify"
+import { describe, expect, it } from "vitest"
+
+import { getSanitizedIframeWithTitle } from "../getSanitizedIframeWithTitle"
+
+describe("getSanitizedIframeWithTitle", () => {
+  it("sanitizes iframe and sets accessibility attributes", () => {
+    const iframe = getSanitizedIframeWithTitle(
+      '<iframe src="https://example.com" onload="alert(1)"></iframe>',
+      "My embed",
+    )
+
+    expect(iframe.tagName).toBe("IFRAME")
+    expect(iframe.getAttribute("src")).toBe("https://example.com")
+    expect(iframe.getAttribute("onload")).toBeNull()
+    expect(iframe.getAttribute("title")).toBe("My embed")
+    expect(iframe.getAttribute("height")).toBe("100%")
+    expect(iframe.getAttribute("width")).toBe("100%")
+    expect(iframe.getAttribute("class")).toBe(
+      "absolute top-0 left-0 bottom-0 right-0",
+    )
+  })
+
+  it("does not leak hooks across multiple calls", () => {
+    for (let i = 0; i < 10; i++) {
+      getSanitizedIframeWithTitle(
+        `<iframe src="https://example.com/${i}"></iframe>`,
+        `Title ${i}`,
+      )
+    }
+
+    const unrelated = DOMPurify.sanitize(
+      '<iframe src="https://other.com"></iframe>',
+      {
+        ALLOWED_TAGS: ["iframe"],
+        RETURN_DOM_FRAGMENT: true,
+      },
+    ).firstChild as HTMLIFrameElement
+
+    expect(unrelated.getAttribute("title")).toBeNull()
+  })
+})

--- a/packages/components/src/utils/__tests__/getSanitizedIframeWithTitle.test.ts
+++ b/packages/components/src/utils/__tests__/getSanitizedIframeWithTitle.test.ts
@@ -10,15 +10,33 @@ describe("getSanitizedIframeWithTitle", () => {
       "My embed",
     )
 
-    expect(iframe.tagName).toBe("IFRAME")
-    expect(iframe.getAttribute("src")).toBe("https://example.com")
-    expect(iframe.getAttribute("onload")).toBeNull()
-    expect(iframe.getAttribute("title")).toBe("My embed")
-    expect(iframe.getAttribute("height")).toBe("100%")
-    expect(iframe.getAttribute("width")).toBe("100%")
-    expect(iframe.getAttribute("class")).toBe(
+    expect(iframe).not.toBeNull()
+    expect(iframe?.tagName).toBe("IFRAME")
+    expect(iframe?.getAttribute("src")).toBe("https://example.com")
+    expect(iframe?.getAttribute("onload")).toBeNull()
+    expect(iframe?.getAttribute("title")).toBe("My embed")
+    expect(iframe?.getAttribute("height")).toBe("100%")
+    expect(iframe?.getAttribute("width")).toBe("100%")
+    expect(iframe?.getAttribute("class")).toBe(
       "absolute top-0 left-0 bottom-0 right-0",
     )
+  })
+
+  it("handles leading whitespace before the iframe", () => {
+    const iframe = getSanitizedIframeWithTitle(
+      '\n  <iframe src="https://example.com"></iframe>',
+      "Whitespace embed",
+    )
+
+    expect(iframe).not.toBeNull()
+    expect(iframe?.tagName).toBe("IFRAME")
+    expect(iframe?.getAttribute("src")).toBe("https://example.com")
+    expect(iframe?.getAttribute("title")).toBe("Whitespace embed")
+  })
+
+  it("returns null when sanitized content does not include an iframe", () => {
+    expect(getSanitizedIframeWithTitle("", "Empty embed")).toBeNull()
+    expect(getSanitizedIframeWithTitle("plain text", "Text embed")).toBeNull()
   })
 
   it("does not leak hooks across multiple calls", () => {

--- a/packages/components/src/utils/getSanitizedIframeWithTitle.ts
+++ b/packages/components/src/utils/getSanitizedIframeWithTitle.ts
@@ -1,33 +1,46 @@
 import DOMPurify from "isomorphic-dompurify"
 
-// Sanitize iframe embeds to remove any potentially harmful attributes
-// and to insert the iframe title for accessibility
-export const getSanitizedIframeWithTitle = (content: string, title: string) => {
-  const iframe = DOMPurify.sanitize(content, {
-    ALLOWED_TAGS: ["iframe"],
-    ALLOWED_ATTR: [
-      "src",
-      "title",
-      "width",
-      "height",
-      "class",
+const IFRAME_ALLOWED_ATTRIBUTES = [
+  "src",
+  "title",
+  "width",
+  "height",
+  "class",
+  "frameborder",
+  "allow",
+  "allowfullscreen",
+  "referrerpolicy",
+  "id",
+  "scrolling",
+  "loading",
+  "align",
+]
 
-      "frameborder",
-      "allow",
-      "allowfullscreen",
-      "referrerpolicy",
-      "id",
-      "scrolling",
-      "loading",
-      "align",
-    ],
+const IFRAME_LAYOUT_ATTRIBUTES = {
+  height: "100%",
+  width: "100%",
+  class: "absolute top-0 left-0 bottom-0 right-0",
+} as const
+
+// Sanitize iframe embeds to remove any potentially harmful attributes
+// and to insert the minimal accessibility
+export const getSanitizedIframeWithTitle = (content: string, title: string) => {
+  const sanitizedFragment = DOMPurify.sanitize(content, {
+    ALLOWED_TAGS: ["iframe"],
+    ALLOWED_ATTR: IFRAME_ALLOWED_ATTRIBUTES,
     RETURN_DOM_FRAGMENT: true,
-  }).firstChild as HTMLIFrameElement
+  })
+
+  const iframe = sanitizedFragment.querySelector<HTMLIFrameElement>("iframe")
+
+  if (!iframe) {
+    return null
+  }
 
   iframe.setAttribute("title", title)
-  iframe.setAttribute("height", "100%")
-  iframe.setAttribute("width", "100%")
-  iframe.setAttribute("class", "absolute top-0 left-0 bottom-0 right-0")
+  iframe.setAttribute("height", IFRAME_LAYOUT_ATTRIBUTES.height)
+  iframe.setAttribute("width", IFRAME_LAYOUT_ATTRIBUTES.width)
+  iframe.setAttribute("class", IFRAME_LAYOUT_ATTRIBUTES.class)
 
   return iframe
 }

--- a/packages/components/src/utils/getSanitizedIframeWithTitle.ts
+++ b/packages/components/src/utils/getSanitizedIframeWithTitle.ts
@@ -3,21 +3,7 @@ import DOMPurify from "isomorphic-dompurify"
 // Sanitize iframe embeds to remove any potentially harmful attributes
 // and to insert the iframe title for accessibility
 export const getSanitizedIframeWithTitle = (content: string, title: string) => {
-  DOMPurify.addHook("beforeSanitizeElements", (curr) => {
-    const el = curr as Element
-
-    if (el.tagName !== "IFRAME") {
-      return el
-    }
-
-    // Add title attribute to iframe elements for accessibility
-    el.setAttribute("title", title)
-    el.setAttribute("height", "100%")
-    el.setAttribute("width", "100%")
-    el.setAttribute("class", "absolute top-0 left-0 bottom-0 right-0")
-  })
-
-  return DOMPurify.sanitize(content, {
+  const iframe = DOMPurify.sanitize(content, {
     ALLOWED_TAGS: ["iframe"],
     ALLOWED_ATTR: [
       "src",
@@ -37,4 +23,11 @@ export const getSanitizedIframeWithTitle = (content: string, title: string) => {
     ],
     RETURN_DOM_FRAGMENT: true,
   }).firstChild as HTMLIFrameElement
+
+  iframe.setAttribute("title", title)
+  iframe.setAttribute("height", "100%")
+  iframe.setAttribute("width", "100%")
+  iframe.setAttribute("class", "absolute top-0 left-0 bottom-0 right-0")
+
+  return iframe
 }


### PR DESCRIPTION
## Problem

`getSanitizedIframeWithTitle.ts` registers a global `beforeSanitizeElements` hook on the shared `isomorphic-dompurify` singleton on every invocation. Because `Iframe.tsx` calls this utility on every render and hooks are never removed, it causes an unbounded memory leak and performance degradation during SSR.

Closes https://github.com/opengovsg/isomer/issues/2230

## Solution

Removed the global DOMPurify hook mechanism entirely. Instead, the function now mutates attributes (title, height, width, class) directly onto the returned HTMLIFrameElement fragment after sanitization completes. This ensures side-effect-free, localized attribute assignment, mirroring the existing post-sanitization pattern used for the loading attribute in Iframe.tsx.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed a linear memory leak and unintended global side-effects caused by unremoved DOMPurify hooks during server-side rendering.

## Tests

**Manual Verification Steps**:

- [ ] Run unit tests to verify both standard HTML sanitization logic and the regression test confirming that global hooks no longer leak into separate, unrelated DOMPurify operations.
