### PR TITLE
fix: handle URL error for searchsg config

### DIFF
--- a/apps/studio/src/server/modules/searchsg/__tests__/searchsg.service.test.ts
+++ b/apps/studio/src/server/modules/searchsg/__tests__/searchsg.service.test.ts
@@ -74,4 +74,19 @@ describe("updateSearchSGConfig", () => {
       expect(mockWretch).toHaveBeenCalled()
     })
   })
+
+  describe("URL validation", () => {
+    it.each(["www.example.com", "example.com", "not a url", ""])(
+      "should resolve without rejecting and skip SearchSG config fetch for invalid URL %j",
+      async (invalidUrl) => {
+        // Act
+        await updateSearchSGConfig(PROPS, VALID_UUID, invalidUrl).catch(
+          () => {},
+        )
+
+        // Assert
+        expect(mockWretch).not.toHaveBeenCalled()
+      },
+    )
+  })
 })

--- a/apps/studio/src/server/modules/searchsg/searchsg.service.ts
+++ b/apps/studio/src/server/modules/searchsg/searchsg.service.ts
@@ -118,8 +118,17 @@ export const updateSearchSGConfig = async (
     return
   }
 
+  let actualUrl: URL
+  try {
+    actualUrl = new URL(url)
+  } catch (error) {
+    logger.error(
+      { error, url, ...props },
+      `[ERROR] Invalid URL format for SearchSG config update`,
+    )
+    return
+  }
   const client = await requestSearchSGClient()
-  const actualUrl = new URL(url)
   logger.info(
     { ...props, searchsgClientId, url: actualUrl.host },
     `[INFO] Updating searchsg config for ${url} with searchsg client id: ${searchsgClientId}`,

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -173,6 +173,8 @@ export const siteRouter = router({
           { name: siteName, _kind: "name" },
           updatedConfig.search.clientId,
           updatedConfig.url,
+        ).catch((error) =>
+          ctx.logger.error({ error }, "[ERROR] updateSearchSGConfig failed"),
         )
 
       return updatedConfig
@@ -324,6 +326,8 @@ export const siteRouter = router({
           { colour: theme.colors.brand.canvas.inverse, _kind: "colour" },
           site.config.search.clientId,
           site.config.url,
+        ).catch((error) =>
+          ctx.logger.error({ error }, "[ERROR] updateSearchSGConfig failed"),
         )
       }
 


### PR DESCRIPTION
## Problem

`updateSearchSGConfig` called `new URL(url)` without error handling, causing unhandled promise rejections when an invalid URL (e.g. `www.example.com`, empty string) was passed.

Closes #1956 

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Features**:

- NIL

**Improvements**:

- NIL

**Bug Fixes**:

- Wrapped `new URL(url)` in a `try/catch` — logs the error and returns early on invalid URLs.
- Added `.catch()` handlers on both `updateSearchSGConfig()` call sites in `site.router.ts` to prevent unhandled rejections from bubbling up.
- Added unit tests for invalid URL inputs.

## Before & After Screenshots

**BEFORE**:

- NIL

**AFTER**:

- NIL

## Tests

**Manual Verification Steps**:

- [ ] Set the site URL to an invalid value (e.g. `www.example.com`) and save. Confirm no 500 error and no unhandled rejection in server logs.
- [ ] Set a valid URL (e.g. `https://example.gov.sg`) and save. Confirm the SearchSG config update proceeds normally.
- [ ] Run unit tests: `pnpm test:unit -- src/server/modules/searchsg/__tests__/searchsg.service.test.ts`

**New scripts**:

- NIL

**New dependencies**:

- NIL

**New dev dependencies**:

- NIL
