### PR TITLE
fix: restore rawInput log key name to fix Datadog monitors

### DIFF
--- a/apps/studio/src/server/trpc.ts
+++ b/apps/studio/src/server/trpc.ts
@@ -62,7 +62,7 @@ const loggerMiddleware = t.middleware(
       path,
       req: ctx.req,
     })
-    const redactedInput = redactLogInput(await getRawInput())
+    const rawInput = redactLogInput(await getRawInput())
 
     const result = await next({
       ctx: { logger },
@@ -72,7 +72,7 @@ const loggerMiddleware = t.middleware(
 
     if (result.ok) {
       logger.info(
-        { durationInMs, redactedInput, userId: ctx.session?.userId },
+        { durationInMs, rawInput, userId: ctx.session?.userId },
         `[${type}]: ${path} - ${durationInMs}ms - OK`,
       )
     } else {
@@ -80,7 +80,7 @@ const loggerMiddleware = t.middleware(
         {
           durationInMs,
           err: result.error,
-          redactedInput,
+          rawInput,
           userId: ctx.session?.userId,
         },
         `[${type}]: ${path} - ${durationInMs}ms - ${result.error.code} ${result.error.message} - ERROR`,


### PR DESCRIPTION
## Problem

Partial revert/fix of https://github.com/opengovsg/isomer/pull/2227.

PR #2227 introduced `redactLogInput()` to strip PII (e.g. email addresses) from tRPC logs sent to Datadog. As part of that change, the log key was also renamed from `rawInput` to `redactedInput` to reflect that the value is now redacted. However, Datadog monitors were configured against the original `rawInput` key, so renaming it silently broke those monitors.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Reverts the log key name from `redactedInput` back to `rawInput` in `loggerMiddleware` so that existing Datadog monitors continue to match on the correct field.
- The `redactLogInput()` call is preserved, so PII redaction still works — only the variable/key name changes back.

## Before & After Screenshots

N/A — logging infrastructure change only.

## Tests

**Manual Verification Steps**:

- [ ] Trigger a tRPC request (e.g. log in and navigate to any page in Studio) and confirm a log entry appears in Datadog with the field named `rawInput` (not `redactedInput`).
- [ ] Confirm that sensitive values such as email addresses are still redacted in the `rawInput` field value in Datadog.
- [ ] Confirm that existing Datadog monitors/alerts that query on `rawInput` are no longer broken/alerting due to a missing field.