### PR TITLE
test(e2e): resource module — admin can create a folder via the wizard

### DIFF
--- a/apps/studio/tests/e2e/resource/create-folder.test.ts
+++ b/apps/studio/tests/e2e/resource/create-folder.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "@playwright/test"
+import crypto from "crypto"
+import { db } from "~/server/modules/database"
+
+import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
+import { getSeedSiteId } from "../fixtures/seed"
+
+const UNIQUE_TITLE = () => `E2E Test Folder ${crypto.randomUUID().slice(0, 8)}`
+
+test.use({ storageState: storageStateFor("admin") })
+
+test.beforeEach(async () => {
+  // Welcome-modal workaround (see settings tests for rationale).
+  await db
+    .updateTable("User")
+    .set({ name: "test-e2e", phone: "82345678" })
+    .where("email", "=", TEST_EMAILS.admin)
+    .execute()
+})
+
+test.afterEach(async () => {
+  // Clean up any folders created during the test. permalink uniqueness is
+  // enforced per-site, so re-runs collide unless we delete.
+  await db
+    .deleteFrom("Resource")
+    .where("siteId", "=", getSeedSiteId())
+    .where("title", "like", "E2E Test Folder %")
+    .execute()
+})
+
+test("admin can create a folder via the Create new wizard", async ({
+  page,
+}) => {
+  const title = UNIQUE_TITLE()
+  await page.goto(`/sites/${getSeedSiteId()}`)
+
+  await page.getByRole("button", { name: "Create new..." }).click()
+  await page.getByRole("menuitem", { name: "Folder" }).click()
+
+  await page.getByLabel("Folder name").fill(title)
+  await page.getByRole("button", { name: "Create Folder" }).click()
+
+  // Unlike create-page, the folder mutation does not navigate — it closes
+  // the modal and shows a success toast. Wait for the toast as the signal.
+  await expect(page.getByText("Folder created!")).toBeVisible()
+
+  // Verify in DB: folder Resource row exists with type Folder.
+  const created = await db
+    .selectFrom("Resource")
+    .where("siteId", "=", getSeedSiteId())
+    .where("title", "=", title)
+    .select(["id", "type"])
+    .executeTakeFirst()
+  expect(created).toBeTruthy()
+  expect(created?.type).toBe("Folder")
+})


### PR DESCRIPTION
## Problem

`folder.router.create` has integration coverage, but the UI flow — Dashboard → Create new... → Folder → CreateFolderModal → title + URL → submit — has no end-to-end test. Unlike the page modal, CreateFolderModal does not navigate on success: it relies on a toast + query invalidation, which is exactly the kind of subtle UX detail an e2e test guards.

Stacked on top of #2324 (page module).

## Solution

One new test at `apps/studio/tests/e2e/resource/create-folder.test.ts`:

- **admin can create a folder via the Create new wizard** — opens the menu, fills "Folder name", clicks "Create Folder", waits for the **`Folder created!`** toast (the modal closes but does not navigate, unlike CreatePageModal), then verifies the Resource row in the DB with `type = 'Folder'`. Unique titles + afterEach cleanup keep re-runs idempotent.

The permission gate test is intentionally omitted — `<Can do="create" on={{ parentId: null }}>` wraps the entire "Create new..." menu, so the same gate already proved in #2324 (page module) covers Folder, Page, and Collection menu items uniformly.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- E2E coverage for folder creation from the site dashboard.

## Tests

**Manual Verification Steps**:

- [ ] `cd apps/studio && pnpm dev:e2e` — expect `10 passed, 4 skipped`. The new test appears in the Playwright output.

## Stays in integration tests

- Folder permalink validation
- Move/delete on folders
- Cross-folder hierarchy validation

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds an end-to-end test for the folder-creation wizard flow (`Dashboard → Create new… → Folder → modal → submit`), complementing the existing page-creation tests in `apps/studio/tests/e2e/page/create-page.test.ts`.

- A single test verifies the full UI flow: menu click → label fill → submit → `Folder created!` toast → DB row with `type = 'Folder'`.
- `beforeEach` sets up the welcome-modal workaround via direct DB write; `afterEach` cleans up by title pattern to keep re-runs idempotent.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — this PR adds a single new e2e test file with no changes to production code.

The change is limited to one new test file that follows established patterns from the existing create-page test. The DB cleanup in afterEach correctly scopes deletion by siteId and a title prefix that cannot collide with seed-folder titles created by other test helpers. No production code is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/tests/e2e/resource/create-folder.test.ts | New e2e test for folder creation via the wizard; mirrors create-page pattern, DB cleanup, and toast-based success signal. No functional issues. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test (Playwright)
    participant B as Browser / UI
    participant API as Studio API
    participant DB as Database

    T->>DB: beforeEach — set user name+phone (dismiss welcome modal)
    T->>B: "page.goto /sites/{siteId}"
    T->>B: click "Create new..."
    T->>B: click "Folder" menu item
    T->>B: fill "Folder name"
    T->>B: click "Create Folder"
    B->>API: folder.create mutation
    API->>DB: "INSERT Resource (type=Folder)"
    API-->>B: success response
    B-->>T: toast "Folder created!" visible
    T->>DB: "SELECT Resource WHERE title = title"
    T->>T: "assert type = "Folder""
    T->>DB: afterEach — DELETE Resource WHERE title LIKE "E2E Test Folder %"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test (Playwright)
    participant B as Browser / UI
    participant API as Studio API
    participant DB as Database

    T->>DB: beforeEach — set user name+phone (dismiss welcome modal)
    T->>B: "page.goto /sites/{siteId}"
    T->>B: click "Create new..."
    T->>B: click "Folder" menu item
    T->>B: fill "Folder name"
    T->>B: click "Create Folder"
    B->>API: folder.create mutation
    API->>DB: "INSERT Resource (type=Folder)"
    API-->>B: success response
    B-->>T: toast "Folder created!" visible
    T->>DB: "SELECT Resource WHERE title = title"
    T->>T: "assert type = "Folder""
    T->>DB: afterEach — DELETE Resource WHERE title LIKE "E2E Test Folder %"
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(e2e): resource module — admin can c..."](https://github.com/opengovsg/isomer/commit/3785d73d118266ae77c0a37d21e24e0369a82501) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746773)</sub>

<!-- /greptile_comment -->