### PR TITLE
test(e2e): user module — admin can invite a collaborator as Editor

### DIFF
--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -51,6 +51,7 @@ const inviteCollaborator = async (
   // The form debounces email + runs a whitelist check before enabling Send.
   await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
   await sendBtn.click()
+  await expect(page.getByText(/Sent invite to/)).toBeVisible({ timeout: 10_000 })
 }
 
 // Polls the DB for the active permission role granted to an invitee on the

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -1,12 +1,75 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Page } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
+import { type RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
 import { getSeedSiteId } from "../fixtures/seed"
 
 const UNIQUE_INVITEE = () =>
   `e2e-invitee-${crypto.randomUUID().slice(0, 8)}@open.gov.sg`
+
+// Non-gov.sg domain — i.e. a "vendor" collaborator. Vendors can only be added
+// as Editor/Publisher (never Admin) and only if their email is whitelisted.
+const UNIQUE_VENDOR = () =>
+  `e2e-vendor-${crypto.randomUUID().slice(0, 8)}@vendor.example.com`
+
+// Whitelist a vendor email so the whitelist gate isn't the blocker. A future
+// expiry marks it as a (temporary) vendor entry rather than a permanent admin
+// one; isEmailWhitelisted treats both as valid.
+const whitelistVendor = async (email: string) => {
+  const expiry = new Date()
+  expiry.setDate(expiry.getDate() + 90)
+  await db
+    .insertInto("Whitelist")
+    .values({ email: email.toLowerCase(), expiry })
+    .onConflict((oc) =>
+      oc
+        .column("email")
+        .doUpdateSet((eb) => ({ expiry: eb.ref("excluded.expiry") })),
+    )
+    .execute()
+}
+
+const openInviteModal = async (page: Page) => {
+  await page.goto(`/sites/${getSeedSiteId()}/users`)
+  await page.getByRole("button", { name: "Add new user" }).click()
+}
+
+// Drives the modal happy path: fill email, pick role, wait for the whitelist
+// check to enable Send, then submit.
+const inviteCollaborator = async (
+  page: Page,
+  { email, role }: { email: string; role: keyof typeof RoleType },
+) => {
+  await openInviteModal(page)
+  await page.getByLabel("Email address").fill(email)
+  // RoleBoxes are clickable cards; their accessible name is "<Role> role".
+  await page.getByRole("button", { name: new RegExp(`^${role}`) }).click()
+
+  const sendBtn = page.getByRole("button", { name: "Send invite" })
+  // The form debounces email + runs a whitelist check before enabling Send.
+  await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
+  await sendBtn.click()
+}
+
+// Polls the DB for the active permission role granted to an invitee on the
+// seed site.
+const expectGrantedRole = (email: string) =>
+  expect.poll(
+    async () => {
+      const row = await db
+        .selectFrom("User as u")
+        .innerJoin("ResourcePermission as rp", "rp.userId", "u.id")
+        .where("u.email", "=", email)
+        .where("rp.siteId", "=", getSeedSiteId())
+        .where("rp.deletedAt", "is", null)
+        .select(["rp.role"])
+        .executeTakeFirst()
+      return row?.role ?? null
+    },
+    { timeout: 10_000 },
+  )
 
 test.use({ storageState: storageStateFor("admin") })
 
@@ -27,43 +90,72 @@ test.afterEach(async () => {
     .where("email", "like", "e2e-invitee-%@open.gov.sg")
     .select(["id"])
     .execute()
-  if (invitees.length === 0) return
-  const ids = invitees.map((u) => u.id)
-  await db.deleteFrom("ResourcePermission").where("userId", "in", ids).execute()
-  await db.deleteFrom("User").where("id", "in", ids).execute()
+  if (invitees.length > 0) {
+    const ids = invitees.map((u) => u.id)
+    await db
+      .deleteFrom("ResourcePermission")
+      .where("userId", "in", ids)
+      .execute()
+    await db.deleteFrom("User").where("id", "in", ids).execute()
+  }
+  // Remove any vendor whitelist entries created by the negative-case tests.
+  await db
+    .deleteFrom("Whitelist")
+    .where("email", "like", "e2e-vendor-%@vendor.example.com")
+    .execute()
 })
 
 test("admin can invite a new collaborator as Editor", async ({ page }) => {
   const inviteeEmail = UNIQUE_INVITEE()
-  await page.goto(`/sites/${getSeedSiteId()}/users`)
+  await inviteCollaborator(page, { email: inviteeEmail, role: "Editor" })
+  await expectGrantedRole(inviteeEmail).toBe("Editor")
+})
 
-  await page.getByRole("button", { name: "Add new user" }).click()
+test("admin can invite a new collaborator as Publisher", async ({ page }) => {
+  const inviteeEmail = UNIQUE_INVITEE()
+  await inviteCollaborator(page, { email: inviteeEmail, role: "Publisher" })
+  await expectGrantedRole(inviteeEmail).toBe("Publisher")
+})
 
-  // Modal opens; fill email + pick Editor role + send.
-  await page.getByLabel("Email address").fill(inviteeEmail)
-  // RoleBoxes are clickable cards labeled by role name.
-  await page.getByRole("button", { name: /^Editor/ }).click()
+test("admin can invite a new collaborator as Admin", async ({ page }) => {
+  // A gov.sg invitee is whitelisted by the `.gov.sg` suffix and eligible for
+  // the Admin role.
+  const inviteeEmail = UNIQUE_INVITEE()
+  await inviteCollaborator(page, { email: inviteeEmail, role: "Admin" })
+  await expectGrantedRole(inviteeEmail).toBe("Admin")
+})
 
-  const sendBtn = page.getByRole("button", { name: "Send invite" })
-  // The form debounces email + runs a whitelist check before enabling Send.
-  await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
-  await sendBtn.click()
+test("admin cannot invite a vendor collaborator as Admin", async ({ page }) => {
+  const vendorEmail = UNIQUE_VENDOR()
+  // Whitelist the vendor so the whitelist gate is satisfied — this isolates the
+  // role restriction: a vendor still cannot be made Admin.
+  await whitelistVendor(vendorEmail)
+  await openInviteModal(page)
 
-  // Verify in DB: invitee user exists with an active permission on the seed site.
-  await expect
-    .poll(
-      async () => {
-        const row = await db
-          .selectFrom("User as u")
-          .innerJoin("ResourcePermission as rp", "rp.userId", "u.id")
-          .where("u.email", "=", inviteeEmail)
-          .where("rp.siteId", "=", getSeedSiteId())
-          .where("rp.deletedAt", "is", null)
-          .select(["rp.role"])
-          .executeTakeFirst()
-        return row?.role ?? null
-      },
-      { timeout: 10_000 },
-    )
-    .toBe("Editor")
+  // Select Admin while the email is empty (allowed), then enter a vendor email.
+  await page.getByRole("button", { name: /^Admin/ }).click()
+  await page.getByLabel("Email address").fill(vendorEmail)
+
+  // The Admin choice is rejected: the role box disables, the explanatory error
+  // shows, and Send stays blocked.
+  await expect(page.getByRole("button", { name: /^Admin/ })).toBeDisabled()
+  await expect(
+    page.getByText("Non-gov.sg emails cannot be added as admin"),
+  ).toBeVisible()
+  await expect(page.getByRole("button", { name: "Send invite" })).toBeDisabled()
+})
+
+test("admin cannot invite a non-whitelisted vendor collaborator", async ({
+  page,
+}) => {
+  const vendorEmail = UNIQUE_VENDOR()
+  await openInviteModal(page)
+  await page.getByLabel("Email address").fill(vendorEmail)
+
+  // Default role is Editor, so the Admin restriction isn't in play — the sole
+  // blocker is the missing whitelist entry.
+  await expect(
+    page.getByText("There are non-gov.sg domains that need to be whitelisted"),
+  ).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole("button", { name: "Send invite" })).toBeDisabled()
 })

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -51,7 +51,9 @@ const inviteCollaborator = async (
   // The form debounces email + runs a whitelist check before enabling Send.
   await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
   await sendBtn.click()
-  await expect(page.getByText(/Sent invite to/)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/Sent invite to/)).toBeVisible({
+    timeout: 10_000,
+  })
 }
 
 // Polls the DB for the active permission role granted to an invitee on the
@@ -83,22 +85,25 @@ test.beforeEach(async () => {
     .execute()
 })
 
-test.afterEach(async () => {
-  // Hard-delete any e2e invitee users + their permissions so re-runs are clean.
-  // ResourcePermission has FK to User so delete permissions first.
-  const invitees = await db
+// Hard-delete e2e users matching `emailPattern` + their permissions so re-runs
+// are clean. ResourcePermission has FK to User so delete permissions first.
+const deleteUsersByEmail = async (emailPattern: string) => {
+  const users = await db
     .selectFrom("User")
-    .where("email", "like", "e2e-invitee-%@open.gov.sg")
+    .where("email", "like", emailPattern)
     .select(["id"])
     .execute()
-  if (invitees.length > 0) {
-    const ids = invitees.map((u) => u.id)
-    await db
-      .deleteFrom("ResourcePermission")
-      .where("userId", "in", ids)
-      .execute()
-    await db.deleteFrom("User").where("id", "in", ids).execute()
-  }
+  if (users.length === 0) return
+  const ids = users.map((u) => u.id)
+  await db.deleteFrom("ResourcePermission").where("userId", "in", ids).execute()
+  await db.deleteFrom("User").where("id", "in", ids).execute()
+}
+
+test.afterEach(async () => {
+  await deleteUsersByEmail("e2e-invitee-%@open.gov.sg")
+  // Symmetric cleanup for vendor users, in case a positive vendor-invite test
+  // is added later that creates User rows.
+  await deleteUsersByEmail("e2e-vendor-%@vendor.example.com")
   // Remove any vendor whitelist entries created by the negative-case tests.
   await db
     .deleteFrom("Whitelist")

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test"
+import crypto from "crypto"
+import { db } from "~/server/modules/database"
+
+import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
+import { getSeedSiteId } from "../fixtures/seed"
+
+const UNIQUE_INVITEE = () =>
+  `e2e-invitee-${crypto.randomUUID().slice(0, 8)}@open.gov.sg`
+
+test.use({ storageState: storageStateFor("admin") })
+
+test.beforeEach(async () => {
+  // Welcome-modal workaround (see settings tests for rationale).
+  await db
+    .updateTable("User")
+    .set({ name: "test-e2e", phone: "82345678" })
+    .where("email", "=", TEST_EMAILS.admin)
+    .execute()
+})
+
+test.afterEach(async () => {
+  // Hard-delete any e2e invitee users + their permissions so re-runs are clean.
+  // ResourcePermission has FK to User so delete permissions first.
+  const invitees = await db
+    .selectFrom("User")
+    .where("email", "like", "e2e-invitee-%@open.gov.sg")
+    .select(["id"])
+    .execute()
+  if (invitees.length === 0) return
+  const ids = invitees.map((u) => u.id)
+  await db.deleteFrom("ResourcePermission").where("userId", "in", ids).execute()
+  await db.deleteFrom("User").where("id", "in", ids).execute()
+})
+
+test("admin can invite a new collaborator as Editor", async ({ page }) => {
+  const inviteeEmail = UNIQUE_INVITEE()
+  await page.goto(`/sites/${getSeedSiteId()}/users`)
+
+  await page.getByRole("button", { name: "Add new user" }).click()
+
+  // Modal opens; fill email + pick Editor role + send.
+  await page.getByLabel("Email address").fill(inviteeEmail)
+  // RoleBoxes are clickable cards labeled by role name.
+  await page.getByRole("button", { name: /^Editor/ }).click()
+
+  const sendBtn = page.getByRole("button", { name: "Send invite" })
+  // The form debounces email + runs a whitelist check before enabling Send.
+  await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
+  await sendBtn.click()
+
+  // Verify in DB: invitee user exists with an active permission on the seed site.
+  await expect
+    .poll(
+      async () => {
+        const row = await db
+          .selectFrom("User as u")
+          .innerJoin("ResourcePermission as rp", "rp.userId", "u.id")
+          .where("u.email", "=", inviteeEmail)
+          .where("rp.siteId", "=", getSeedSiteId())
+          .where("rp.deletedAt", "is", null)
+          .select(["rp.role"])
+          .executeTakeFirst()
+        return row?.role ?? null
+      },
+      { timeout: 10_000 },
+    )
+    .toBe("Editor")
+})


### PR DESCRIPTION
## Problem

`user.router.create` (collaborator invite) has integration coverage, but the UI is non-trivial: AddUserModal involves email field with debounced whitelist lookup, three RoleBoxes for role selection, and a Send invite button that's gated by debouncedEmail === email, whitelist success, valid role, and the singpass-enabled feature flag. None of that gate logic is exercised by integration tests.

Stacked on top of #2325 (resource module).

## Solution

One new test at `apps/studio/tests/e2e/user/invite-user.test.ts`:

- **admin can invite a new collaborator as Editor** — opens `/sites/1/users`, clicks "Add new user", fills a unique `e2e-invitee-*@open.gov.sg` email, picks the Editor RoleBox, waits for the Send invite button to enable (the form runs an async whitelist check + 250ms debounce), submits, and uses `expect.poll` to verify the new User row + ResourcePermission appear in the DB. afterEach hard-deletes any `e2e-invitee-*@open.gov.sg` users + their permissions (FK-aware: permissions first, then users).

**Caveats / follow-ups noted in the commit message**:

- Permission gate (publisher/editor can't see "Add new user") is left to a follow-up. The button is `Tooltip`-disabled via `canManageUsers` rather than `<Can>`-wrapped, so the assertion shape (button present-but-disabled) differs from the page/resource modules' (button absent).
- The flow depends on `is-singpass-enabled` GrowthBook flag falling back to `true` (`src/lib/growthbook.ts:18`). If that fallback ever flips to false, this test starts seeing a disabled Send invite button.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- E2E coverage for inviting a collaborator from the Users tab.

## Tests

**Manual Verification Steps**:

- [ ] `cd apps/studio && pnpm dev:e2e` — expect `11 passed, 4 skipped`. The new test should appear; verify no e2e-invitee rows persist in the DB after the suite finishes (afterEach should have cleaned).

## Stays in integration tests

- Non-gov.sg email + Admin role rejection
- Whitelist-domain logic
- Self-deletion / cross-site delete guards
- updateDetails, resendInvite, list pagination, isomer-admin filtering

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a new E2E test file covering the `AddUserModal` collaborator-invite flow for the Users tab. The previous comment threads about missing vendor `User` cleanup and fast-fail toast anchoring have both been addressed: `deleteUsersByEmail` is now a shared helper called symmetrically for both invitee and vendor patterns, and `inviteCollaborator` waits for the "Sent invite to" toast before returning.

- Five tests are added: three positive (Editor, Publisher, Admin invite with a gov.sg email) and two negative (vendor-as-Admin rejection, non-whitelisted vendor). The `afterEach` hard-deletes matching `User` + `ResourcePermission` rows and Whitelist entries, with FK order respected.
- The `inviteCollaborator` helper drives the modal happy path: fill email → pick role → poll `toBeEnabled` with a 10-second timeout to absorb the 300 ms debounce + whitelist round-trip → click Send → await success toast, then `expectGrantedRole` polls the DB for final consistency.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change adding E2E coverage for a UI flow that was previously exercised only by integration tests; no production code is touched.

All five new tests are scoped to the e2e directory, the cleanup is correct (FK-aware deletion, symmetric patterns), the modal's async debounce/whitelist gate is handled robustly, and the two prior review findings are resolved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/tests/e2e/user/invite-user.test.ts | New E2E test covering admin invite flow for Editor, Publisher, Admin roles, plus two negative cases (vendor-as-admin rejection, non-whitelisted vendor). Teardown is FK-aware and symmetric for both invitee and vendor patterns. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant T as Test
    participant P as Playwright (Browser)
    participant UI as AddUserModal
    participant API as tRPC API
    participant DB as Database

    T->>P: goto /sites/1/users
    P->>UI: click "Add new user"
    T->>P: fill Email address
    T->>P: click RoleBox (Editor/Publisher/Admin)
    Note over UI: 300ms debounce fires
    UI->>API: whitelist.isEmailWhitelisted
    API-->>UI: "whitelisted = true (gov.sg) / check result"
    UI-->>P: Send invite button enables
    T->>P: expect(sendBtn).toBeEnabled()
    T->>P: click "Send invite"
    P->>API: user.create mutation
    API->>DB: INSERT User + ResourcePermission
    API-->>P: createdUsers
    UI-->>P: toast "Sent invite to …"
    T->>P: expect(toast).toBeVisible()
    T->>DB: poll expectGrantedRole (10s)
    DB-->>T: "role = "Editor""
    Note over T: afterEach: deleteUsersByEmail + Whitelist cleanup
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant T as Test
    participant P as Playwright (Browser)
    participant UI as AddUserModal
    participant API as tRPC API
    participant DB as Database

    T->>P: goto /sites/1/users
    P->>UI: click "Add new user"
    T->>P: fill Email address
    T->>P: click RoleBox (Editor/Publisher/Admin)
    Note over UI: 300ms debounce fires
    UI->>API: whitelist.isEmailWhitelisted
    API-->>UI: "whitelisted = true (gov.sg) / check result"
    UI-->>P: Send invite button enables
    T->>P: expect(sendBtn).toBeEnabled()
    T->>P: click "Send invite"
    P->>API: user.create mutation
    API->>DB: INSERT User + ResourcePermission
    API-->>P: createdUsers
    UI-->>P: toast "Sent invite to …"
    T->>P: expect(toast).toBeVisible()
    T->>DB: poll expectGrantedRole (10s)
    DB-->>T: "role = "Editor""
    Note over T: afterEach: deleteUsersByEmail + Whitelist cleanup
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["test(e2e): symmetric vendor-user cleanup..."](https://github.com/opengovsg/isomer/commit/677091598080bd68176a2b5d7401f39f09ed52b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746772)</sub>

<!-- /greptile_comment -->