### PR TITLE
ci(e2e): post a PR comment with the test-results artifact link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,11 @@ jobs:
     needs: optimize_ci
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
+    # pull-requests: write is needed to upsert a comment with the artifact URL
+    # after the test run; contents: read is the existing checkout default.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup
@@ -256,8 +261,37 @@ jobs:
 
       - name: Upload test results
         if: ${{ !cancelled() }}
+        id: upload-test-results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: test results
+          # Unique per run so that re-runs from the same PR don't collide.
+          name: e2e-test-results-${{ github.run_id }}
           path: apps/studio/tests/e2e/test-results
           retention-days: 7
+          if-no-files-found: warn
+
+      # On PR runs, post (or replace) a comment with a clickable link to the
+      # artifact zip so reviewers can play the per-test video.webm files
+      # without having to navigate to the workflow run UI.
+      - name: Find existing video-link comment
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
+        id: find-video-comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- e2e-video-link -->"
+
+      - name: Upsert PR comment with e2e video artifact link
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.upload-test-results.outputs.artifact-url != '' }}
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          comment-id: ${{ steps.find-video-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            <!-- e2e-video-link -->
+            🎥 **E2E test videos** — [Download artifact](${{ steps.upload-test-results.outputs.artifact-url }})
+
+            Each test has its own directory under the zip; play `video.webm` to watch the run.
+            Workflow: [run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) — artifact expires in 7 days.


### PR DESCRIPTION
## Problem

Playwright is already configured with `video: "on"` (`apps/studio/playwright.config.ts:25`), so every e2e test produces a `video.webm` under `apps/studio/tests/e2e/test-results/<test>/`. CI already uploads that directory as an artifact. But the artifact link only surfaces if you navigate to the workflow run UI, scroll to the summary, and download the zip — not part of any reviewer's normal flow.

Stacked on top of #2326 (user module).

## Solution

Add two steps after the existing "Upload test results" step in `.github/workflows/ci.yml`:

1. **find-comment** (peter-evans/find-comment v3.1.0) — looks for an existing PR comment from `github-actions[bot]` containing the marker `<!-- e2e-video-link -->`.
2. **create-or-update-comment** (peter-evans/create-or-update-comment v4) — replaces that comment in place, or creates one if none exists, with a link to the artifact URL emitted by `actions/upload-artifact@v7`'s `artifact-url` output. The comment also links back to the workflow run.

Additional changes in the same step:

- The artifact is renamed `e2e-test-results-${{ github.run_id }}` (was `test results`) so re-runs against the same PR get distinct artifact names without collision.
- `pull-requests: write` added at job scope only — the rest of the workflow stays on the default `contents: read`.
- Third-party actions pinned by SHA + version comment, matching the existing convention in this workflow.

**Effect on a PR**:

- First run posts the comment.
- Subsequent pushes find the existing comment and replace its body in place (no thread spam).
- Old artifacts expire after 7 days; the link in the comment will 404 after that, which is fine — by then the PR is either merged or has fresher CI.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- PR-thread comment with a one-click link to the e2e test video artifact.
- Comment is deduped across re-runs.

**Improvements**:

- Renamed artifact for uniqueness across runs.
- Job-scoped `pull-requests: write` permission (doesn't widen the rest of the workflow).

## Tests

**Manual Verification Steps**:

- [ ] After this PR merges, push any commit to a feature branch with an open PR. The "End-to-end tests" job runs.
- [ ] When the job finishes, a single PR comment appears: `🎥 E2E test videos — Download artifact`.
- [ ] Click the link → downloads the artifact zip. Unzip → each test directory contains `video.webm`.
- [ ] Push another commit to the same PR. After the next CI run, the comment is **replaced in place** (same comment ID, no second comment thread).

**New dependencies**:

- `peter-evans/find-comment@v3.1.0` (action only, no npm install)
- `peter-evans/create-or-update-comment@v4` (action only)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds two CI steps to the `end-to-end-tests` job that post (or replace) a PR comment containing a direct download link to the uploaded Playwright test-results artifact, so reviewers can access test videos without navigating the workflow run UI.

- Artifact renamed to `e2e-test-results-${{ github.run_id }}` and `if-no-files-found: warn` added; `find-comment` then `create-or-update-comment` are appended, both guarded by `!cancelled() && github.event_name == 'pull_request'`, so they are no-ops on push-to-main runs.
- `pull-requests: write` is scoped to the job level only, matching the pattern already used in `components-bundle-size`; SHA-pinned with version comments consistent with the rest of the workflow.
- The `upsert` step is correctly guarded by `artifact-url != ''`, so no comment is posted when the upload produces nothing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — changes are confined to the CI workflow and do not affect application code or deployed artefacts.

The logic is straightforward: two new steps gated by `github.event_name == 'pull_request'` and a non-empty artifact URL, both using SHA-pinned actions. No application code is touched, existing test execution is unchanged, and the permission addition is job-scoped.

No files require special attention beyond `.github/workflows/ci.yml`, which is the only changed file.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds pull-requests:write permission at job scope and two new steps (find-comment + create-or-update-comment) to post/deduplicate a PR comment containing the e2e artifact download link; also renames the artifact to include run_id and sets if-no-files-found:warn. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as GitHub Actions Runner
    participant UA as upload-artifact@v7
    participant FC as find-comment@v3
    participant CC as create-or-update-comment@v4
    participant GH as GitHub API (PR)

    CI->>UA: Upload test-results (id: upload-test-results)
    UA-->>CI: artifact-url output

    alt "github.event_name == 'pull_request'"
        CI->>FC: Find comment by author + marker
        FC->>GH: List PR comments
        GH-->>FC: comment-id (or empty)
        FC-->>CI: comment-id output

        alt "artifact-url != ''"
            CI->>CC: Upsert comment (comment-id or new)
            CC->>GH: Create or replace comment body
        else "artifact-url == ''"
            CI-->>CI: Skip upsert step
        end
    else push to main/staging/production
        CI-->>CI: Skip find + upsert steps
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as GitHub Actions Runner
    participant UA as upload-artifact@v7
    participant FC as find-comment@v3
    participant CC as create-or-update-comment@v4
    participant GH as GitHub API (PR)

    CI->>UA: Upload test-results (id: upload-test-results)
    UA-->>CI: artifact-url output

    alt "github.event_name == 'pull_request'"
        CI->>FC: Find comment by author + marker
        FC->>GH: List PR comments
        GH-->>FC: comment-id (or empty)
        FC-->>CI: comment-id output

        alt "artifact-url != ''"
            CI->>CC: Upsert comment (comment-id or new)
            CC->>GH: Create or replace comment body
        else "artifact-url == ''"
            CI-->>CI: Skip upsert step
        end
    else push to main/staging/production
        CI-->>CI: Skip find + upsert steps
    end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["ci(e2e): post a PR comment with the test..."](https://github.com/opengovsg/isomer/commit/4b36a62bed78eb759f508fceb8dfada232374651) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746770)</sub>

<!-- /greptile_comment -->