### PR TITLE
chore: remove markdown-to-jsx ignore rule from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -115,8 +115,6 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "chakra-react-select"
         update-types: ["version-update:semver-major"]
-      # markdown-to-jsx is only used in the unmaintained classic template; skip all updates
-      - dependency-name: "markdown-to-jsx"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
## Problem

The `markdown-to-jsx` package was ignored in Dependabot's config because it was only used in the unmaintained classic template. Since the classic codebase has been removed, this ignore rule is no longer needed.

## Solution

- [x] No - this PR is backwards compatible

**Improvements**:

- Removed the `markdown-to-jsx` ignore entry from `.github/dependabot.yml` so Dependabot can track it if it ever re-enters the dependency graph.

## Before & After Screenshots

N/A — CI/CD config change only.

## Tests

No production code changes. No manual verification steps required.

**New scripts**: N/A

**New dependencies**: N/A

**New dev dependencies**: N/A