### PR TITLE
fix: add id-token write permission to Dependabot Claude review workflow

### DIFF
--- a/.github/workflows/claude_review_dependabot.yml
+++ b/.github/workflows/claude_review_dependabot.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   pull-requests: write # needed to write the review comment
+  id-token: write # needed to fetch OIDC token for Claude Code Action
 
 jobs:
   review:


### PR DESCRIPTION
## Problem

The `claude_review_dependabot` workflow was failing with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

The `anthropics/claude-code-action` uses OIDC for authentication but the workflow's `permissions` block was missing the required `id-token: write` grant.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Added `id-token: write` to the workflow permissions so the Claude Code Action can successfully fetch an OIDC token and run.

## Before & After Screenshots

N/A — CI workflow fix.

## Tests

No production code changes. The fix can be verified by triggering a new Dependabot PR and confirming the `Claude Review (Dependabot)` workflow completes without the OIDC token error.

**New scripts**: N/A

**New dependencies**: N/A

**New dev dependencies**: N/A