### PR TITLE
fix: allow dependabot[bot] to trigger Claude review workflow

### DIFF
--- a/.github/workflows/claude_review_dependabot.yml
+++ b/.github/workflows/claude_review_dependabot.yml
@@ -23,6 +23,7 @@ jobs:
         uses: anthropics/claude-code-action@64de744025ca9e24df2b88204b4f1e968f39f009 # v1.0.139
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: 'dependabot[bot]'
 
           claude_args: |
             --model claude-sonnet-4-6


### PR DESCRIPTION
## Problem

The Claude review workflow for Dependabot PRs was failing with: _\"Workflow initiated by non-human actor: dependabot (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.\"_

This meant automated dependency upgrade PRs opened by Dependabot never received a Claude review.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Added `allowed_bots: 'dependabot[bot]'` to the `claude-code-action` step in `.github/workflows/claude_review_dependabot.yml`, permitting the action to run when triggered by the Dependabot bot.

## Before & After Screenshots

N/A — CI/CD config change only.

## Tests

No manual verification steps required — this is a CI/CD config-only change with no production code impact.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None