### PR TITLE
fix(studio): inline gazette file-id icon + dash placeholder for empty notification no.

### DIFF
--- a/apps/studio/src/features/gazettes/components/GazetteTable/FileIdCell.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteTable/FileIdCell.tsx
@@ -1,5 +1,6 @@
-import { HStack, Text } from "@chakra-ui/react"
+import { Icon, Text } from "@chakra-ui/react"
 import { Link } from "@opengovsg/design-system-react"
+import { BiLinkExternal } from "react-icons/bi"
 import { trpc } from "~/utils/trpc"
 
 interface FileIdCellProps {
@@ -34,23 +35,27 @@ export const FileIdCell = ({
 
   if (fileKey) {
     return (
-      <HStack spacing="0.25rem" align="center">
-        <Link
-          href="#"
-          onClick={handleClick}
-          isExternal
-          textStyle="body-2"
-          color="interaction.links.default"
-          textDecoration="underline"
-          p="0"
-          aria-disabled={isPending}
-          opacity={isPending ? 0.5 : 1}
-          pointerEvents={isPending ? "none" : "auto"}
-          wordBreak="break-all"
-        >
-          {fileId}
-        </Link>
-      </HStack>
+      <Link
+        href="#"
+        onClick={handleClick}
+        textStyle="body-2"
+        color="interaction.links.default"
+        textDecoration="underline"
+        p="0"
+        aria-disabled={isPending}
+        opacity={isPending ? 0.5 : 1}
+        pointerEvents={isPending ? "none" : "auto"}
+        wordBreak="break-all"
+      >
+        {fileId}
+        <Icon
+          as={BiLinkExternal}
+          display="inline-block"
+          verticalAlign="text-bottom"
+          ml="0.25rem"
+          aria-hidden
+        />
+      </Link>
     )
   }
 

--- a/apps/studio/src/features/gazettes/components/GazetteTable/FileIdCell.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteTable/FileIdCell.tsx
@@ -45,14 +45,18 @@ export const FileIdCell = ({
         aria-disabled={isPending}
         opacity={isPending ? 0.5 : 1}
         pointerEvents={isPending ? "none" : "auto"}
-        wordBreak="break-all"
+        display="inline-flex"
+        alignItems="baseline"
+        gap="0.25rem"
       >
-        {fileId}
+        <Text as="span" wordBreak="break-all">
+          {fileId}
+        </Text>
         <Icon
           as={BiLinkExternal}
-          display="inline-block"
-          verticalAlign="text-bottom"
-          ml="0.25rem"
+          flexShrink={0}
+          position="relative"
+          top="0.125rem"
           aria-hidden
         />
       </Link>

--- a/apps/studio/src/features/gazettes/components/GazetteTable/GazetteTable.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteTable/GazetteTable.tsx
@@ -29,7 +29,7 @@ const getColumns = (siteId: number) => [
     header: () => <TableHeader>Notification No.</TableHeader>,
     cell: ({ getValue }) => (
       <Text textStyle="body-2" color="base.content.strong">
-        {getValue() ?? "-"}
+        {getValue() || "-"}
       </Text>
     ),
   }),

--- a/apps/studio/src/pages/sites/[siteId]/gazettes/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/gazettes/index.tsx
@@ -61,10 +61,10 @@ const GazettesPage: NextPageWithLayout = () => {
             Gazettes are not enabled for this account
           </Text>
           <Text textStyle="body-2" color="base.content.medium">
-            Please contact
+            Please contact{" "}
             <Link variant="inline" href={ISOMER_SUPPORT_LINK}>
               support
-            </Link>
+            </Link>{" "}
             if you believe this is incorrect.
           </Text>
         </VStack>

--- a/apps/studio/src/stories/Page/GazettesPage.stories.tsx
+++ b/apps/studio/src/stories/Page/GazettesPage.stories.tsx
@@ -1,15 +1,40 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
+import {
+  createGazetteContent,
+  createGazetteItem,
+  gazetteHandlers,
+} from "tests/msw/handlers/gazette"
+import { pageHandlers } from "tests/msw/handlers/page"
+import { userHandlers } from "tests/msw/handlers/user"
+import { governmentGazetteSubcategories } from "~/features/gazettes/constants"
 import GazettesPage from "~/pages/sites/[siteId]/gazettes"
 
 import { ADMIN_HANDLERS } from "../handlers"
+import { createEgazetteInfoGbParameters } from "../utils/growthbook"
+
+// Must precede ADMIN_HANDLERS' isIsomerAdmin.default() (returns false), since
+// MSW resolves to the first matching handler. The page redirects away unless
+// the user is a Toppan user or an Isomer admin.
+const baseHandlers = [
+  userHandlers.isIsomerAdmin.admin(),
+  ...ADMIN_HANDLERS,
+  gazetteHandlers.collectionTags.default(),
+  pageHandlers.countWithoutRoot.default(),
+]
 
 const meta: Meta<typeof GazettesPage> = {
   title: "Pages/eGazette/Gazettes Page",
   component: GazettesPage,
   parameters: {
     getLayout: GazettesPage.getLayout,
+    growthbook: [
+      createEgazetteInfoGbParameters({
+        siteId: "1",
+        gazettesCollectionId: "1",
+      }),
+    ],
     msw: {
-      handlers: [...ADMIN_HANDLERS],
+      handlers: [...baseHandlers, gazetteHandlers.list.default()],
     },
     nextjs: {
       router: {
@@ -27,4 +52,83 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {},
+}
+
+export const NotConfigured: Story = {
+  parameters: {
+    growthbook: [],
+  },
+}
+
+// Empty notification number should show a dash, not look like an error.
+export const EmptyNotificationNumber: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...baseHandlers,
+        gazetteHandlers.list.withItems([
+          createGazetteItem({
+            id: "201",
+            title: "Notice with no notification number assigned",
+            content: createGazetteContent({
+              ref: "/gazettes/26gg0001.pdf",
+              category: "Government Gazette",
+              description: "",
+              tagged: [governmentGazetteSubcategories.NOTICES_UNDER_OTHER_ACTS],
+            }),
+          }),
+        ]),
+      ],
+    },
+  },
+}
+
+// Long single-token file IDs must wrap inside the File ID column instead of
+// spilling into Publish time. Pre-fix, the Link had no word-break and was
+// wrapped in an HStack that grew past its cell.
+export const OverflowingFileId: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...baseHandlers,
+        gazetteHandlers.list.withItems([
+          createGazetteItem({
+            id: "202",
+            title:
+              "Government Gazette Extraordinary Supplement - Section 64 Notice",
+            content: createGazetteContent({
+              ref: "/gazettes/26gg-government-gazette-extraordinary-supplement-section-64-revised-statutes-2024-09-12.pdf",
+              category: "Government Gazette",
+              description: "2145",
+              tagged: [governmentGazetteSubcategories.NOTICES_UNDER_OTHER_ACTS],
+            }),
+          }),
+        ]),
+      ],
+    },
+  },
+}
+
+// When the file ID wraps onto multiple lines, the external-link icon should
+// stay inline with the last fragment of text — not orphan onto its own line.
+export const InlineExternalLinkIcon: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...baseHandlers,
+        gazetteHandlers.list.withItems([
+          createGazetteItem({
+            id: "203",
+            title: "Bills Supplement - Companies (Amendment) Bill 2024",
+            content: createGazetteContent({
+              ref: "/gazettes/26gg-bills-supplement-companies-amendment.pdf",
+              category: "Legislation Supplements",
+              description: "2199",
+              tagged: ["Bills Supplement"],
+            }),
+          }),
+        ]),
+      ],
+    },
+  },
 }

--- a/apps/studio/tests/msw/handlers/gazette.ts
+++ b/apps/studio/tests/msw/handlers/gazette.ts
@@ -1,0 +1,139 @@
+import type { RouterOutput } from "~/utils/trpc"
+import {
+  GAZETTE_SUBCATEGORY_LABEL,
+  governmentGazetteSubcategories,
+} from "~/features/gazettes/constants"
+import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+
+import { MOCK_STORY_DATE } from "../constants"
+import { trpcMsw } from "../mockTrpc"
+
+interface GazetteContentInputs {
+  ref: string
+  category: string
+  description?: string
+  tagged: string[]
+}
+
+export const createGazetteContent = ({
+  ref,
+  category,
+  description,
+  tagged,
+}: GazetteContentInputs) =>
+  ({
+    layout: "link",
+    page: {
+      ref,
+      date: "12/09/2024",
+      category,
+      description,
+      tagged,
+    },
+    content: [],
+    version: "0.1.0",
+  }) as unknown as PrismaJson.BlobJsonContent
+
+type GazetteItem = RouterOutput["gazette"]["list"][number]
+
+export const createGazetteItem = (
+  overrides: Partial<GazetteItem>,
+): GazetteItem => ({
+  id: "101",
+  title: "Limited Liability Partnerships Act 2005 - Section 64",
+  permalink: "limited-liability-partnerships-act-2005-section-64",
+  siteId: 1,
+  parentId: "1",
+  publishedVersionId: "101",
+  draftBlobId: null,
+  type: ResourceType.CollectionLink,
+  state: ResourceState.Published,
+  createdAt: MOCK_STORY_DATE,
+  updatedAt: MOCK_STORY_DATE,
+  scheduledAt: MOCK_STORY_DATE,
+  scheduledBy: null,
+  publishedAt: MOCK_STORY_DATE,
+  fileSize: 123456,
+  content: createGazetteContent({
+    ref: "/gazettes/26gg5734.pdf",
+    category: "Government Gazette",
+    description: "2145",
+    tagged: [governmentGazetteSubcategories.NOTICES_UNDER_OTHER_ACTS],
+  }),
+  ...overrides,
+})
+
+export const DEFAULT_GAZETTE_ITEMS: RouterOutput["gazette"]["list"] = [
+  {
+    id: "101",
+    title: "Limited Liability Partnerships Act 2005 - Section 64",
+    permalink: "limited-liability-partnerships-act-2005-section-64",
+    siteId: 1,
+    parentId: "1",
+    publishedVersionId: null,
+    draftBlobId: "101",
+    type: ResourceType.CollectionLink,
+    state: ResourceState.Draft,
+    createdAt: MOCK_STORY_DATE,
+    updatedAt: MOCK_STORY_DATE,
+    scheduledAt: new Date("2024-09-13T09:00:00.000Z"),
+    scheduledBy: "cljcnahpn0000xlwynuea40lv",
+    publishedAt: null,
+    fileSize: 123456,
+    content: createGazetteContent({
+      ref: "/gazettes/26gg5734.pdf",
+      category: "Government Gazette",
+      description: "2145",
+      tagged: [governmentGazetteSubcategories.NOTICES_UNDER_OTHER_ACTS],
+    }),
+  },
+  {
+    id: "102",
+    title: "Appointment of Commissioner of Inland Revenue",
+    permalink: "appointment-of-commissioner-of-inland-revenue",
+    siteId: 1,
+    parentId: "1",
+    publishedVersionId: "102",
+    draftBlobId: null,
+    type: ResourceType.CollectionLink,
+    state: ResourceState.Published,
+    createdAt: MOCK_STORY_DATE,
+    updatedAt: MOCK_STORY_DATE,
+    scheduledAt: MOCK_STORY_DATE,
+    scheduledBy: null,
+    publishedAt: MOCK_STORY_DATE,
+    fileSize: 654321,
+    content: createGazetteContent({
+      ref: "/gazettes/26gg5701.pdf",
+      category: "Government Gazette",
+      description: "2101",
+      tagged: [governmentGazetteSubcategories.APPOINTMENTS],
+    }),
+  },
+]
+
+const GAZETTE_TAG_CATEGORIES = [
+  {
+    label: GAZETTE_SUBCATEGORY_LABEL,
+    id: "0e02b2c3-58cc-4372-a567-f47ac10b3d47",
+    options: Object.values(governmentGazetteSubcategories).map(
+      (label, index) => ({
+        label,
+        id: `6ba7b810-9dad-11d1-80b4-00c04fd430${String(index).padStart(2, "0")}`,
+      }),
+    ),
+  },
+]
+
+export const gazetteHandlers = {
+  list: {
+    default: () => trpcMsw.gazette.list.query(() => DEFAULT_GAZETTE_ITEMS),
+    empty: () => trpcMsw.gazette.list.query(() => []),
+    withItems: (items: RouterOutput["gazette"]["list"]) =>
+      trpcMsw.gazette.list.query(() => items),
+  },
+  collectionTags: {
+    default: () =>
+      trpcMsw.collection.getCollectionTags.query(() => GAZETTE_TAG_CATEGORIES),
+  },
+}


### PR DESCRIPTION
## Summary

Closes the three in-progress items from the [eGazettes deletion dogfooding notes](https://www.notion.so/opengov/Dogfooding-eGazettes-deletion-36677dbba7888002868bd4e66e08fdde):

- **File ID column overflow & external-link icon dropping to a new line** (`FileIdCell.tsx`): OGP's `Link isExternal` renders its icon in a way that wraps below the file name when the text breaks via `wordBreak: break-all`, and the surrounding `HStack` flex container was also contributing to the link escaping its fixed-width column. Replaced with an explicit inline `<Icon as={BiLinkExternal}>` that flows in the same text run as the file ID (so it stays beside the last visible character), and dropped the now-redundant `HStack` wrapper.
- **Empty notification number rendered blank** (`GazetteTable.tsx`): the `Notification No.` cell already had a `?? "-"` fallback, but the underlying value (`page.description`) can be an empty string when the field is cleared, which `??` doesn't catch. Switched to `|| "-"` so empty strings also fall back to a dash.

## Test plan

- [ ] On `/sites/33/gazettes`, file names with long, unbreakable strings stay inside the **File ID** column and the new-tab icon sits inline with the last line of the file name (no longer drops to its own row).
- [ ] A gazette whose notification number was left blank now shows `-` in the **Notification No.** column instead of an empty cell.
- [ ] Clicking the file-id link still opens the presigned URL in a new tab and does not bubble up to open the row modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)