### PR TITLE
feat(footer): add subscription CTA section for mailing lists

### DIFF
--- a/packages/components/src/interfaces/internal/Footer.ts
+++ b/packages/components/src/interfaces/internal/Footer.ts
@@ -31,38 +31,32 @@ const FooterItemSchema = Type.Object({
   }),
 })
 
-const SubscriptionCtaSchema = Type.Object(
-  {
-    title: Type.String({
-      title: "Title",
-      description: "A short heading for the CTA",
-      maxLength: 100,
+const SubscriptionCtaSchema = Type.Object({
+  title: Type.String({
+    title: "Title",
+    description: "A short heading for the CTA",
+    maxLength: 100,
+  }),
+  description: Type.Optional(
+    Type.String({
+      title: "Description",
+      description: "A brief message to encourage subscription",
+      maxLength: 200,
     }),
-    description: Type.Optional(
-      Type.String({
-        title: "Description",
-        description: "A brief message to encourage subscription",
-        maxLength: 200,
-      }),
-    ),
-    buttonLabel: Type.String({
-      title: "Button label",
-      description: "The text displayed on the CTA button",
-      maxLength: 30,
-      default: "Subscribe",
-    }),
-    buttonUrl: Type.String({
-      title: "Button link",
-      description: "The URL the button links to (e.g., FormSG or mailing list)",
-      format: "link",
-      pattern: LINK_HREF_PATTERN,
-    }),
-  },
-  {
-    $id: "SubscriptionCta",
-    title: "Subscription CTA",
-  },
-)
+  ),
+  buttonLabel: Type.String({
+    title: "Button label",
+    description: "The text displayed on the CTA button",
+    maxLength: 30,
+    default: "Subscribe",
+  }),
+  buttonUrl: Type.String({
+    title: "Button link",
+    description: "The URL the button links to (e.g., FormSG or mailing list)",
+    format: "link",
+    pattern: LINK_HREF_PATTERN,
+  }),
+})
 
 export type SubscriptionCta = Static<typeof SubscriptionCtaSchema>
 
@@ -129,17 +123,43 @@ export const FooterSchema = Type.Object(
       pattern: LINK_HREF_PATTERN,
     }),
     subscriptionCta: Type.Optional(
-      Type.Ref(SubscriptionCtaSchema, {
-        title: "Mailing list subscription",
-        description:
-          "Add a CTA section for users to subscribe to your mailing list",
-      }),
+      Type.Object(
+        {
+          title: Type.String({
+            title: "Title",
+            description: "A short heading for the CTA",
+            maxLength: 100,
+          }),
+          description: Type.Optional(
+            Type.String({
+              title: "Description",
+              description: "A brief message to encourage subscription",
+              maxLength: 200,
+            }),
+          ),
+          buttonLabel: Type.String({
+            title: "Button label",
+            description: "The text displayed on the CTA button",
+            maxLength: 30,
+            default: "Subscribe",
+          }),
+          buttonUrl: Type.String({
+            title: "Button link",
+            description:
+              "The URL the button links to (e.g., FormSG or mailing list)",
+            format: "link",
+            pattern: LINK_HREF_PATTERN,
+          }),
+        },
+        {
+          title: "Mailing list subscription",
+          description:
+            "Add a CTA section for users to subscribe to your mailing list",
+        },
+      ),
     ),
   },
   {
-    $defs: {
-      SubscriptionCta: SubscriptionCtaSchema,
-    },
     groups: [
       {
         label: "Contact and feedback form",

--- a/packages/components/src/interfaces/internal/Footer.ts
+++ b/packages/components/src/interfaces/internal/Footer.ts
@@ -31,6 +31,41 @@ const FooterItemSchema = Type.Object({
   }),
 })
 
+const SubscriptionCtaSchema = Type.Object(
+  {
+    title: Type.String({
+      title: "Title",
+      description: "A short heading for the CTA",
+      maxLength: 100,
+    }),
+    description: Type.Optional(
+      Type.String({
+        title: "Description",
+        description: "A brief message to encourage subscription",
+        maxLength: 200,
+      }),
+    ),
+    buttonLabel: Type.String({
+      title: "Button label",
+      description: "The text displayed on the CTA button",
+      maxLength: 30,
+      default: "Subscribe",
+    }),
+    buttonUrl: Type.String({
+      title: "Button link",
+      description: "The URL the button links to (e.g., FormSG or mailing list)",
+      format: "link",
+      pattern: LINK_HREF_PATTERN,
+    }),
+  },
+  {
+    $id: "SubscriptionCta",
+    title: "Subscription CTA",
+  },
+)
+
+export type SubscriptionCta = Static<typeof SubscriptionCtaSchema>
+
 export const FooterSchema = Type.Object(
   {
     siteNavItems: Type.Array(FooterItemSchema, {
@@ -93,8 +128,18 @@ export const FooterSchema = Type.Object(
       format: "link",
       pattern: LINK_HREF_PATTERN,
     }),
+    subscriptionCta: Type.Optional(
+      Type.Ref(SubscriptionCtaSchema, {
+        title: "Mailing list subscription",
+        description:
+          "Add a CTA section for users to subscribe to your mailing list",
+      }),
+    ),
   },
   {
+    $defs: {
+      SubscriptionCta: SubscriptionCtaSchema,
+    },
     groups: [
       {
         label: "Contact and feedback form",
@@ -103,6 +148,10 @@ export const FooterSchema = Type.Object(
       {
         label: "Legal pages",
         fields: ["privacyStatementLink", "termsOfUseLink"],
+      },
+      {
+        label: "Mailing list",
+        fields: ["subscriptionCta"],
       },
     ],
   },

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -14,7 +14,12 @@ export {
   ContentPageHeaderSchema,
   type ContentPageHeaderProps,
 } from "./ContentPageHeader"
-export { FooterSchema, type FooterSchemaType, type FooterProps } from "./Footer"
+export {
+  FooterSchema,
+  type FooterSchemaType,
+  type FooterProps,
+  type SubscriptionCta,
+} from "./Footer"
 export { HardBreakSchema, type HardBreakProps } from "./HardBreak"
 export type { HeaderProps } from "./Header"
 export type { LinkProps } from "./Link"

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx
@@ -311,3 +311,103 @@ export const NoCustomItems: Story = {
     termsOfUseLink: "/",
   },
 }
+
+export const WithSubscriptionCta: Story = {
+  args: {
+    siteName: "Enterprise Singapore",
+    isGovernment: true,
+    lastUpdated: "11 Mar 2024",
+    siteNavItems: [
+      {
+        title: "About us",
+        url: "/",
+      },
+      {
+        title: "Our partners",
+        url: "/",
+      },
+      {
+        title: "Grants and programmes",
+        url: "/",
+      },
+      {
+        title: "Contact us",
+        url: "/",
+      },
+    ],
+    customNavItems: [
+      {
+        title: "Careers",
+        url: "/",
+      },
+      {
+        title: "Events calendar",
+        url: "/",
+      },
+    ],
+    socialMediaLinks: [
+      {
+        type: "facebook",
+        url: "https://www.facebook.com",
+      },
+      {
+        type: "instagram",
+        url: "https://www.instagram.com",
+      },
+      {
+        type: "linkedin",
+        url: "https://www.linkedin.com",
+      },
+    ],
+    contactUsLink: "/",
+    feedbackFormLink: "https://www.google.com",
+    privacyStatementLink: "/",
+    termsOfUseLink: "/",
+    subscriptionCta: {
+      title: "Subscribe to our mailing list",
+      description: "Get the latest updates on grants, programmes, and events.",
+      buttonLabel: "Subscribe",
+      buttonUrl: "https://form.gov.sg/example",
+    },
+  },
+}
+
+export const WithSubscriptionCtaNoDescription: Story = {
+  args: {
+    siteName: "Ministry of Health",
+    isGovernment: true,
+    lastUpdated: "11 Mar 2024",
+    siteNavItems: [
+      {
+        title: "About us",
+        url: "/",
+      },
+      {
+        title: "Services",
+        url: "/",
+      },
+      {
+        title: "Resources",
+        url: "/",
+      },
+    ],
+    socialMediaLinks: [
+      {
+        type: "facebook",
+        url: "https://www.facebook.com",
+      },
+      {
+        type: "twitter",
+        url: "https://www.twitter.com",
+      },
+    ],
+    contactUsLink: "/",
+    privacyStatementLink: "/",
+    termsOfUseLink: "/",
+    subscriptionCta: {
+      title: "Stay informed with health updates",
+      buttonLabel: "Sign up",
+      buttonUrl: "https://form.gov.sg/health-updates",
+    },
+  },
+}

--- a/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
+++ b/packages/components/src/templates/next/components/internal/Footer/Footer.tsx
@@ -3,6 +3,7 @@ import type { FooterProps } from "~/interfaces"
 import type {
   FooterItem as FooterItemType,
   SocialMediaType,
+  SubscriptionCta,
 } from "~/interfaces/internal/Footer"
 import { BiLinkExternal } from "react-icons/bi"
 import {
@@ -30,6 +31,7 @@ import { isExternalUrl } from "~/utils/isExternalUrl"
 import { focusVisibleHighlight } from "~/utils/tailwind"
 
 import { Link } from "../Link"
+import { LinkButton } from "../LinkButton"
 import { ClientCopyrightYear } from "./ClientCopyrightYear"
 
 const SocialMediaTypeToIconMap: Record<SocialMediaType, IconType> = {
@@ -218,6 +220,45 @@ const ReachUsSection = ({
   )
 }
 
+const SubscriptionCtaSection = ({
+  subscriptionCta,
+  site,
+}: {
+  subscriptionCta: SubscriptionCta
+  site: FooterProps["site"]
+}) => {
+  const buttonUrl =
+    getReferenceLinkHref(
+      subscriptionCta.buttonUrl,
+      site.siteMapArray,
+      site.assetsBaseUrl,
+    ) ?? subscriptionCta.buttonUrl
+
+  return (
+    <div className="flex flex-col gap-4 border-t border-base-divider-inverse pt-6 lg:flex-row lg:items-center lg:justify-between lg:gap-8 lg:border-b lg:border-t-0 lg:pb-8 lg:pt-0">
+      <div className="flex flex-col gap-1">
+        <h3 className="prose-headline-base-medium text-base-content-inverse">
+          {subscriptionCta.title}
+        </h3>
+        {subscriptionCta.description && (
+          <p className="prose-body-sm text-base-content-inverse-subtle">
+            {subscriptionCta.description}
+          </p>
+        )}
+      </div>
+      <LinkButton
+        href={buttonUrl}
+        variant="outline"
+        colorScheme="inverse"
+        size="sm"
+        className="w-fit flex-shrink-0"
+      >
+        {subscriptionCta.buttonLabel}
+      </LinkButton>
+    </div>
+  )
+}
+
 const LegalSection = ({
   site,
   agencyName,
@@ -337,6 +378,7 @@ const FooterMobile = ({
   feedbackFormLink,
   privacyStatementLink,
   termsOfUseLink,
+  subscriptionCta,
 }: FooterProps) => {
   return (
     <div className="flex flex-col gap-8 px-6 py-11 md:px-10 lg:hidden lg:py-16">
@@ -352,6 +394,9 @@ const FooterMobile = ({
         feedbackFormLink={feedbackFormLink}
         site={site}
       />
+      {subscriptionCta && (
+        <SubscriptionCtaSection subscriptionCta={subscriptionCta} site={site} />
+      )}
       <div className="flex flex-col gap-9">
         <LegalSection
           agencyName={agencyName}
@@ -381,11 +426,18 @@ const FooterDesktop = ({
   feedbackFormLink,
   privacyStatementLink,
   termsOfUseLink,
+  subscriptionCta,
 }: FooterProps) => {
   return (
     <div className="hidden px-10 py-14 lg:block">
       <div className="mx-auto flex max-w-[72.5rem] flex-col gap-6">
         <SiteNameSection siteName={siteName} />
+        {subscriptionCta && (
+          <SubscriptionCtaSection
+            subscriptionCta={subscriptionCta}
+            site={site}
+          />
+        )}
         <div className="grid-cols-[1fr_min-content] grid-rows-[1fr_min-content] gap-x-10 gap-y-14 lg:grid">
           <div>
             <NavSection


### PR DESCRIPTION
## Summary
- Adds an optional `subscriptionCta` field to the footer schema that allows agencies to add a CTA section for mailing list subscriptions
- The CTA includes a title, optional description, and a button linking to a signup form (e.g., FormSG)
- Positioned prominently below the site name on desktop (with bottom border separator) and after the reach-us section on mobile
- Uses the existing `LinkButton` component with inverse outline styling to match the footer's dark theme

## Changes
- `packages/components/src/interfaces/internal/Footer.ts` - Added `SubscriptionCtaSchema` and `subscriptionCta` optional field to `FooterSchema`
- `packages/components/src/templates/next/components/internal/Footer/Footer.tsx` - Added `SubscriptionCtaSection` component and integrated into both mobile and desktop layouts
- `packages/components/src/templates/next/components/internal/Footer/Footer.stories.tsx` - Added `WithSubscriptionCta` and `WithSubscriptionCtaNoDescription` stories

## Test plan
- [ ] Run Storybook and verify the new `WithSubscriptionCta` story renders correctly on both mobile and desktop viewports
- [ ] Verify the `WithSubscriptionCtaNoDescription` variant (title-only, no description) renders correctly
- [ ] Verify existing footer stories still render correctly (backward compatible since field is optional)
- [ ] Verify external link button shows external link icon

## Related
Slack thread: https://opengovproducts.slack.com/archives/C06R4DX966P/p1780909544976769?thread_ts=1780909341.472019&cid=C06R4DX966P

https://claude.ai/code/session_01XnDz2Pj5hZKzLwncw2LZuF

---
_Generated by [Claude Code](https://claude.ai/code/session_01XnDz2Pj5hZKzLwncw2LZuF)_