### PR TITLE
fix(studio): add max length validation to folder edit schema

### DIFF
--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -39,7 +39,12 @@ const baseFolderSchema = z.object({
 
 export const baseEditFolderSchema = baseFolderSchema.extend({
   permalink: permalinkSchema,
-  title: z.string().min(1, { message: "Enter a title for this folder" }),
+  title: z
+    .string()
+    .min(1, { message: "Enter a title for this folder" })
+    .max(MAX_FOLDER_TITLE_LENGTH, {
+      message: `Folder title should be shorter than ${MAX_FOLDER_TITLE_LENGTH} characters.`,
+    }),
 })
 
 export const editFolderSchema = baseEditFolderSchema.superRefine(


### PR DESCRIPTION
## Problem

The `editFolder` tRPC route validates input with `baseEditFolderSchema`, but its `title` field only enforced a minimum length. Unlike `createFolderSchema`, there was no maximum length constraint on the server. A caller could bypass the UI's `maxLength` guard and submit arbitrarily long folder titles, allowing oversized payloads to be stored and processed.

## Solution

Add a `.max(MAX_FOLDER_TITLE_LENGTH)` constraint to the `title` field in `baseEditFolderSchema`, reusing the existing `MAX_FOLDER_TITLE_LENGTH` constant (250 characters) already applied to folder creation and the folder settings modal UI.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Add server-side max length validation to `baseEditFolderSchema.title` in `apps/studio/src/schemas/folder.ts`, closing a validation gap on the `editFolder` route.

## Before & After Screenshots

**BEFORE**:

N/A — server-side validation gap only; the folder settings UI already enforced the 250-character limit client-side.

**AFTER**:

N/A

## Tests

**Manual Verification Steps**:

- [ ] Log in to Studio and open an existing site's dashboard.
- [ ] Open folder settings for any folder and confirm a title up to 250 characters can still be saved successfully.
- [ ] Attempt to save a folder title longer than 250 characters (e.g. via browser devtools by removing the `maxLength` attribute on the title input) and confirm the request is rejected with the message "Folder title should be shorter than 250 characters."
- [ ] Create a new folder with a title under 250 characters and confirm creation still works as before.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Made with [Cursor](https://cursor.com)