### PR TITLE
fix: prevent pnpm test from hanging on vitest watch

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -42,7 +42,7 @@
     "start": "next start",
     "storybook": "storybook dev -p 6007",
     "teardown": "docker compose down",
-    "test": "run-s test:*",
+    "test": "run-s test:e2e test:load:build test:unit",
     "test-ci:e2e": "dotenv -e .env.test start-server-and-test start http://127.0.0.1:3000 test:e2e",
     "test-ci:unit": "dotenv -e .env.test vitest run --coverage",
     "test-dev": "start-server-and-test dev http://127.0.0.1:3000 test",

--- a/packages/pgboss/package.json
+++ b/packages/pgboss/package.json
@@ -16,7 +16,9 @@
     "lint:fix": "oxlint --type-aware --fix .",
     "services:setup": "docker compose -f \"docker-compose.yml\" up -d --wait",
     "setup:test": "run-s --print-label services:setup db:sleep",
-    "test": "run-s test:*",
+    "test": "pnpm test:unit",
+    "test-ci:unit": "dotenv -e .env.test pnpm exec vitest run",
+    "test:unit": "dotenv -e .env.test pnpm exec vitest run",
     "test:watch": "dotenv -e .env.test pnpm exec vitest watch",
     "typecheck": "tsgo"
   },


### PR DESCRIPTION
Fixes #2385

`run-s test:*` expands via `npm-run-all2` glob and matches `test:watch` (`vitest watch`), so `pnpm test` hangs forever.

- `packages/pgboss`: drop `run-s` and call the one-shot `test:unit` directly; add `test-ci:unit` to match the turbo.json task.
- `apps/studio`: keep `run-s` but list the one-shot scripts explicitly so `test:watch` is excluded.

Generated with [Claude Code](https://claude.ai/code)