### PR TITLE
feat(components): add EgazetteAlgoliaSearch renderer

### DIFF
--- a/packages/components/src/interfaces/internal/EgazetteAlgoliaSearchInputBox.ts
+++ b/packages/components/src/interfaces/internal/EgazetteAlgoliaSearchInputBox.ts
@@ -1,29 +1,8 @@
 import type { Static } from "@sinclair/typebox"
 import { Type } from "@sinclair/typebox"
 
-const EgazetteAlgoliaSubCategorySchema = Type.Object({
-  value: Type.String({
-    title: "Sub-category value as stored in Algolia",
-  }),
-  displayLabel: Type.String({
-    title: "Sub-category label shown in the UI",
-  }),
-})
-
-const EgazetteAlgoliaCategorySchema = Type.Object({
-  value: Type.String({
-    title: "Category value as stored in Algolia",
-  }),
-  displayLabel: Type.String({
-    title: "Category label shown in the UI",
-  }),
-  subCategories: Type.Optional(
-    Type.Array(EgazetteAlgoliaSubCategorySchema, {
-      title: "Sub-categories under this category",
-    }),
-  ),
-})
-
+// The category/sub-category taxonomy is fixed and hard-coded in the renderer
+// (see EgazetteAlgoliaSearch/categories.ts), so it is not part of this config.
 export const EgazetteAlgoliaSearchSchema = Type.Object({
   type: Type.Literal("egazette-algolia", {
     default: "egazette-algolia",
@@ -43,19 +22,8 @@ export const EgazetteAlgoliaSearchSchema = Type.Object({
     title: "Algolia index name",
     readOnly: true,
   }),
-  categories: Type.Array(EgazetteAlgoliaCategorySchema, {
-    title: "Category taxonomy",
-    description:
-      "Ordered list of categories shown in the left filter rail. Each category may carry its own sub-categories.",
-  }),
 })
 
 export type EgazetteAlgoliaSearchProps = Static<
   typeof EgazetteAlgoliaSearchSchema
->
-export type EgazetteAlgoliaCategory = Static<
-  typeof EgazetteAlgoliaCategorySchema
->
-export type EgazetteAlgoliaSubCategory = Static<
-  typeof EgazetteAlgoliaSubCategorySchema
 >

--- a/packages/components/src/interfaces/internal/__tests__/EgazetteAlgoliaSearchInputBox.test.ts
+++ b/packages/components/src/interfaces/internal/__tests__/EgazetteAlgoliaSearchInputBox.test.ts
@@ -1,0 +1,62 @@
+import { FormatRegistry } from "@sinclair/typebox"
+import { Value } from "@sinclair/typebox/value"
+import { describe, expect, it } from "vitest"
+
+// "hidden" (and friends) are UI-only annotations consumed by Studio's form
+// renderer, not data formats — accept any value, as Studio's validator does.
+FormatRegistry.Set("hidden", () => true)
+import { SimpleIntegrationsSettingsSchema } from "~/types/site"
+
+import { EgazetteAlgoliaSearchSchema } from "../EgazetteAlgoliaSearchInputBox"
+
+// The category taxonomy is hard-coded in the renderer, not configured here,
+// so the config is just the Algolia connection details.
+const VALID_CONFIG = {
+  type: "egazette-algolia",
+  appId: "1V7DZGZJKK",
+  searchApiKey: "bbc5751b3f9b7fdfc08c99712adfa397",
+  indexName: "staging_ogp_egazettes_index",
+}
+
+describe("EgazetteAlgoliaSearchSchema", () => {
+  it("accepts a valid config", () => {
+    expect(Value.Check(EgazetteAlgoliaSearchSchema, VALID_CONFIG)).toBe(true)
+  })
+
+  it.each(["appId", "searchApiKey", "indexName"] as const)(
+    "rejects a config missing %s",
+    (key) => {
+      const { [key]: _omitted, ...rest } = VALID_CONFIG
+      expect(Value.Check(EgazetteAlgoliaSearchSchema, rest)).toBe(false)
+    },
+  )
+
+  it("rejects a config with the wrong type discriminator", () => {
+    const config = { ...VALID_CONFIG, type: "searchSG" }
+    expect(Value.Check(EgazetteAlgoliaSearchSchema, config)).toBe(false)
+  })
+})
+
+describe("site.search union", () => {
+  it("accepts the egazette-algolia variant", () => {
+    expect(
+      Value.Check(SimpleIntegrationsSettingsSchema, { search: VALID_CONFIG }),
+    ).toBe(true)
+  })
+
+  it("still accepts the searchSG variant", () => {
+    expect(
+      Value.Check(SimpleIntegrationsSettingsSchema, {
+        search: { type: "searchSG", clientId: "some-client-id" },
+      }),
+    ).toBe(true)
+  })
+
+  it("still accepts the localSearch variant", () => {
+    expect(
+      Value.Check(SimpleIntegrationsSettingsSchema, {
+        search: { type: "localSearch", searchUrl: "/search" },
+      }),
+    ).toBe(true)
+  })
+})

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -22,8 +22,6 @@ export { LocalSearchSchema, type LocalSearchProps } from "./LocalSearchInputBox"
 export {
   EgazetteAlgoliaSearchSchema,
   type EgazetteAlgoliaSearchProps,
-  type EgazetteAlgoliaCategory,
-  type EgazetteAlgoliaSubCategory,
 } from "./EgazetteAlgoliaSearchInputBox"
 export type { MastheadProps } from "./Masthead"
 export {

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/EgazetteAlgoliaSearch.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/EgazetteAlgoliaSearch.tsx
@@ -1,0 +1,107 @@
+"use client"
+
+import type { EgazetteAlgoliaSearchProps } from "~/interfaces/internal/EgazetteAlgoliaSearchInputBox"
+import { liteClient as algoliasearch } from "algoliasearch/lite"
+import { useMemo } from "react"
+import { InstantSearch } from "react-instantsearch"
+
+import { createEgazetteRouting } from "./routing"
+import { CategoryRefinementList } from "./widgets/CategoryRefinementList"
+import { ClearRefinements } from "./widgets/ClearRefinements"
+import { CurrentRefinements } from "./widgets/CurrentRefinements"
+import { Hits } from "./widgets/Hits"
+import { Pagination } from "./widgets/Pagination"
+import { RangeInput } from "./widgets/RangeInput"
+import { SearchBox } from "./widgets/SearchBox"
+import { SortedByLabel } from "./widgets/SortedByLabel"
+import { Stats } from "./widgets/Stats"
+import { SubCategoryRefinementList } from "./widgets/SubCategoryRefinementList"
+
+interface EgazetteAlgoliaSearchClientProps {
+  config: EgazetteAlgoliaSearchProps
+}
+
+const SectionHeading = ({ children }: { children: React.ReactNode }) => (
+  <h3 className="prose-headline-base-semibold text-base-content">{children}</h3>
+)
+
+const Divider = () => <hr className="border-t border-base-divider-medium" />
+
+export const EgazetteAlgoliaSearch = ({
+  config,
+}: EgazetteAlgoliaSearchClientProps) => {
+  const searchClient = useMemo(
+    () => algoliasearch(config.appId, config.searchApiKey),
+    [config.appId, config.searchApiKey],
+  )
+
+  const routing = useMemo(
+    () => createEgazetteRouting(config.indexName),
+    [config.indexName],
+  )
+
+  return (
+    <InstantSearch
+      indexName={config.indexName}
+      searchClient={searchClient}
+      routing={routing}
+      future={{ preserveSharedStateOnUnmount: true }}
+    >
+      <section className="mx-auto flex w-full max-w-screen-xl flex-col gap-8 px-6 py-10 lg:flex-row">
+        <aside className="flex w-full flex-col gap-4 lg:w-72 lg:flex-shrink-0">
+          <SectionHeading>Search</SectionHeading>
+          <SearchBox />
+
+          <SectionHeading>Filter by</SectionHeading>
+          <Divider />
+
+          <div className="flex flex-col gap-3">
+            <h4 className="prose-headline-base-medium text-base-content">
+              Category
+            </h4>
+            <CategoryRefinementList />
+          </div>
+          <Divider />
+
+          <SubCategoryRefinementList />
+
+          <div className="flex flex-col gap-3">
+            <h4 className="prose-headline-base-medium text-base-content">
+              Year
+            </h4>
+            {/* No explicit bound: useRange derives min/max from the index's
+                publishYear facet stats, matching the reference implementation. */}
+            <RangeInput attribute="publishYear" minLabel="From" maxLabel="To" />
+          </div>
+          <Divider />
+
+          <div className="flex flex-col gap-3">
+            <h4 className="prose-headline-base-medium text-base-content">
+              Month
+            </h4>
+            {/* No explicit bound: useRange derives min/max from the index's
+                publishMonth facet stats, matching the reference implementation. */}
+            <RangeInput
+              attribute="publishMonth"
+              minLabel="From"
+              maxLabel="To"
+            />
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex flex-col gap-4">
+              <Stats />
+              <CurrentRefinements />
+              <ClearRefinements />
+            </div>
+            <SortedByLabel />
+          </div>
+          <Hits />
+          <Pagination />
+        </div>
+      </section>
+    </InstantSearch>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/EgazetteAlgoliaSearch.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/EgazetteAlgoliaSearch.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { EgazetteAlgoliaSearchProps } from "~/interfaces/internal/EgazetteAlgoliaSearchInputBox"
-import { liteClient as algoliasearch } from "algoliasearch/lite"
+import algoliasearch from "algoliasearch/lite"
 import { useMemo } from "react"
 import { InstantSearch } from "react-instantsearch"
 

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/categories.ts
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/categories.ts
@@ -1,0 +1,97 @@
+export interface EgazetteSubCategory {
+  /** Value as stored in Algolia (the `subCategory` facet). */
+  value: string
+  /** Label shown in the UI. */
+  displayLabel: string
+}
+
+export interface EgazetteCategory {
+  /** Value as stored in Algolia (the `category` facet). */
+  value: string
+  /** Label shown in the UI. */
+  displayLabel: string
+  subCategories?: EgazetteSubCategory[]
+}
+
+// The egazette taxonomy is fixed and owned by the publishing pipeline in
+// isomer-egazette, so it is hard-coded here rather than configured per-site.
+// Order is significant — it mirrors the declared order of the legacy Jekyll
+// `algolia-search.js` arrays, and `displayLabel` reflects its
+// CATEGORY_INTERNAL_MAPPING (e.g. "Legislative Supplements" displays as
+// "Legislation Supplements", "Bankruptcy Act Notice" as "Notices (Bankruptcy Act)").
+export const EGAZETTE_CATEGORIES: EgazetteCategory[] = [
+  {
+    value: "Government Gazette",
+    displayLabel: "Government Gazette",
+    subCategories: [
+      { value: "Advertisements", displayLabel: "Advertisements" },
+      { value: "Appointments", displayLabel: "Appointments" },
+      { value: "Audited Reports", displayLabel: "Audited Reports" },
+      { value: "Cessation of Service", displayLabel: "Cessation of Service" },
+      { value: "Corrigendum", displayLabel: "Corrigendum" },
+      { value: "Death", displayLabel: "Death" },
+      { value: "Dismissals", displayLabel: "Dismissals" },
+      { value: "Leave", displayLabel: "Leave" },
+      {
+        value: "Bankruptcy Act Notice",
+        displayLabel: "Notices (Bankruptcy Act)",
+      },
+      {
+        value: "Companies Act Notice",
+        displayLabel: "Notices (Companies Act)",
+      },
+      {
+        value: "Notices under the Constitution",
+        displayLabel: "Notices (Constitution)",
+      },
+      {
+        value: "Notices under other Acts",
+        displayLabel: "Notices (other Acts)",
+      },
+      { value: "Revocation", displayLabel: "Revocation" },
+      { value: "Tenders", displayLabel: "Tenders" },
+      {
+        value: "Termination of Service",
+        displayLabel: "Termination of Service",
+      },
+      { value: "Vacation of Service", displayLabel: "Vacation of Service" },
+      { value: "Others", displayLabel: "Others" },
+    ],
+  },
+  {
+    value: "Legislative Supplements",
+    displayLabel: "Legislation Supplements",
+    subCategories: [
+      { value: "Bills Supplement", displayLabel: "Bills Supplement" },
+      { value: "Acts Supplement", displayLabel: "Acts Supplement" },
+      {
+        value: "Subsidiary Legislation Supplement",
+        displayLabel: "Subsidiary Legislation Supplement",
+      },
+      { value: "Revised Acts", displayLabel: "Revised Acts" },
+      {
+        value: "Revised Subsidiary Legislation",
+        displayLabel: "Revised Subsidiary Legislation",
+      },
+    ],
+  },
+  {
+    value: "Other Supplements",
+    displayLabel: "Other Supplements",
+    subCategories: [
+      {
+        value: "Government Gazette Supplement",
+        displayLabel: "Government Gazette Supplement",
+      },
+      {
+        value: "Industrial Relations Supplement",
+        displayLabel: "Industrial Relations Supplement",
+      },
+      {
+        value: "Trade Marks Supplement",
+        displayLabel: "Trade Marks Supplement",
+      },
+      { value: "Treaties Supplement", displayLabel: "Treaties Supplement" },
+    ],
+  },
+]

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/index.ts
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/index.ts
@@ -1,0 +1,1 @@
+export { EgazetteAlgoliaSearch } from "./EgazetteAlgoliaSearch"

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/routing.ts
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/routing.ts
@@ -1,0 +1,72 @@
+interface IndexUiState {
+  query?: string
+  refinementList?: Record<string, string[]>
+  range?: Record<string, string>
+}
+
+interface EgazetteRouteState {
+  q?: string
+  category?: string | string[]
+  subCategory?: string | string[]
+  minYear?: string
+  maxYear?: string
+  minMonth?: string
+  maxMonth?: string
+}
+
+// The history router serializes a single-element array as a bare `category=X`
+// param, which parses back as a string — coerce so single-value deep links work.
+const toArray = (value: string | string[] | undefined) =>
+  value === undefined || Array.isArray(value) ? value : [value]
+
+const splitRange = (range: string | undefined) => {
+  if (!range) return [undefined, undefined] as const
+  const [min, max] = range.split(":")
+  return [min || undefined, max || undefined] as const
+}
+
+const joinRange = (min: string | undefined, max: string | undefined) =>
+  min || max ? `${min ?? ""}:${max ?? ""}` : ""
+
+// Round-trips the egazette search UI state through URL params so searches are shareable —
+// matches the param shape (q, category, subCategory, minYear/maxYear, minMonth/maxMonth)
+// used by the legacy Jekyll template.
+export const createEgazetteRouting = (indexName: string) => ({
+  stateMapping: {
+    stateToRoute(uiState: Record<string, IndexUiState>): EgazetteRouteState {
+      const indexUiState = uiState[indexName] ?? {}
+      const [minYear, maxYear] = splitRange(indexUiState.range?.publishYear)
+      const [minMonth, maxMonth] = splitRange(indexUiState.range?.publishMonth)
+      return {
+        q: indexUiState.query,
+        category: indexUiState.refinementList?.category,
+        subCategory: indexUiState.refinementList?.subCategory,
+        minYear,
+        maxYear,
+        minMonth,
+        maxMonth,
+      }
+    },
+    routeToState(routeState: EgazetteRouteState): Record<string, IndexUiState> {
+      const refinementList: Record<string, string[]> = {}
+      const category = toArray(routeState.category)
+      if (category) refinementList.category = category
+      const subCategory = toArray(routeState.subCategory)
+      if (subCategory) refinementList.subCategory = subCategory
+
+      const range: Record<string, string> = {}
+      const yearRange = joinRange(routeState.minYear, routeState.maxYear)
+      if (yearRange) range.publishYear = yearRange
+      const monthRange = joinRange(routeState.minMonth, routeState.maxMonth)
+      if (monthRange) range.publishMonth = monthRange
+
+      return {
+        [indexName]: {
+          query: routeState.q,
+          refinementList,
+          range,
+        },
+      }
+    },
+  },
+})

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/CategoryRefinementList.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/CategoryRefinementList.tsx
@@ -1,0 +1,45 @@
+import { useRefinementList } from "react-instantsearch"
+
+import {
+  Checkbox,
+  CheckboxGroup,
+} from "../../../../components/internal/Checkbox"
+import { EGAZETTE_CATEGORIES } from "../categories"
+
+export const CategoryRefinementList = () => {
+  const { items, refine } = useRefinementList({
+    attribute: "category",
+    limit: 50,
+  })
+
+  // Match the Jekyll behavior: always render every category in declared order,
+  // even when Algolia returns zero hits for it. Empty rows stay clickable.
+  const itemsByValue = new Map(items.map((item) => [item.value, item]))
+  const rows = EGAZETTE_CATEGORIES.map(({ value, displayLabel }) => {
+    const match = itemsByValue.get(value)
+    return {
+      value,
+      label: displayLabel,
+      isRefined: match?.isRefined ?? false,
+    }
+  })
+
+  const selectedValues = rows
+    .filter((row) => row.isRefined)
+    .map((row) => row.value)
+
+  return (
+    <CheckboxGroup className="gap-2" value={selectedValues}>
+      {rows.map((row) => (
+        <Checkbox
+          key={row.value}
+          className="w-fit cursor-pointer"
+          value={row.value}
+          onChange={() => refine(row.value)}
+        >
+          {row.label}
+        </Checkbox>
+      ))}
+    </CheckboxGroup>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/ClearRefinements.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/ClearRefinements.tsx
@@ -1,0 +1,18 @@
+import { useClearRefinements } from "react-instantsearch"
+import { Button } from "~/templates/next/components/internal/Button"
+
+export const ClearRefinements = () => {
+  const { refine, canRefine } = useClearRefinements()
+
+  if (!canRefine) return null
+
+  return (
+    <Button
+      variant="unstyled"
+      onClick={() => refine()}
+      className="prose-headline-base-medium self-start p-0 text-link underline underline-offset-2 hover:text-link-hover"
+    >
+      Clear refinements
+    </Button>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/CurrentRefinements.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/CurrentRefinements.tsx
@@ -1,0 +1,55 @@
+import { useMemo } from "react"
+import { BiX } from "react-icons/bi"
+import { useCurrentRefinements } from "react-instantsearch"
+import { Button } from "~/templates/next/components/internal/Button"
+
+import { EGAZETTE_CATEGORIES } from "../categories"
+
+export const CurrentRefinements = () => {
+  // Year/month are surfaced through the range inputs; don't duplicate them as
+  // removable chips here. "query" stays excluded to match the default behavior.
+  const { items, refine } = useCurrentRefinements({
+    excludedAttributes: ["query", "publishYear", "publishMonth"],
+  })
+
+  // Built once from a static constant rather than on every render.
+  const labelLookup = useMemo(() => {
+    const lookup = new Map<string, string>()
+    EGAZETTE_CATEGORIES.forEach((category) => {
+      lookup.set(category.value, category.displayLabel)
+      category.subCategories?.forEach((sub) => {
+        lookup.set(sub.value, sub.displayLabel)
+      })
+    })
+    return lookup
+  }, [])
+
+  if (items.length === 0) return null
+
+  return (
+    <ul className="flex flex-wrap gap-2">
+      {items.flatMap((group) =>
+        group.refinements.map((refinement) => {
+          const display =
+            labelLookup.get(String(refinement.value)) ?? refinement.label
+          return (
+            <li
+              key={`${group.attribute}-${refinement.value}`}
+              className="prose-body-sm inline-flex items-center gap-1 rounded-full border border-base-content-strong bg-white px-3 py-1 text-base-content transition-colors hover:bg-base-canvas-backdrop/50"
+            >
+              {display}
+              <Button
+                variant="unstyled"
+                onPress={() => refine(refinement)}
+                className="inline-flex h-auto min-h-0 items-center gap-0 rounded-full p-0 transition-colors active:bg-base-canvas-backdrop/80"
+              >
+                <BiX aria-hidden className="h-4 w-4" />
+                <span className="sr-only">Remove filter</span>
+              </Button>
+            </li>
+          )
+        }),
+      )}
+    </ul>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Hits.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Hits.tsx
@@ -1,0 +1,73 @@
+import { BiFile } from "react-icons/bi"
+import { Highlight, Snippet, useHits } from "react-instantsearch"
+import { Link } from "~/templates/next/components/internal/Link"
+import { getFormattedDate } from "~/utils/getFormattedDate"
+
+interface EgazetteHit {
+  fileUrl: string
+  title: string
+  category: string
+  subCategory?: string
+  notificationNum?: string
+  publishTimestamp: number
+  text?: string
+}
+
+const formatDate = (timestamp: number) => {
+  if (!Number.isFinite(timestamp)) return ""
+  return getFormattedDate(new Date(timestamp).toISOString())
+}
+
+export const Hits = () => {
+  const { items } = useHits<EgazetteHit>()
+
+  if (items.length === 0) return null
+
+  return (
+    <ul className="flex flex-col divide-y divide-base-divider-medium">
+      {items.map((hit) => (
+        <li key={hit.objectID} className="flex flex-col gap-2 py-5">
+          <h5 className="prose-headline-lg-semibold text-base-content-strong">
+            <Link
+              href={hit.fileUrl}
+              isExternal
+              className="flex items-start gap-2 text-link hover:text-link-hover"
+            >
+              <BiFile
+                aria-hidden
+                className="mt-0.5 size-6 shrink-0 text-base-content"
+              />
+              <span className="underline underline-offset-2">
+                <Highlight attribute="title" hit={hit} />
+              </span>
+            </Link>
+          </h5>
+          <div className="flex flex-col gap-2 pl-8">
+            <p className="prose-body-base text-base-content">
+              Category: <Highlight attribute="category" hit={hit} />
+              {hit.subCategory && (
+                <>
+                  , Sub-Category:{" "}
+                  <Highlight attribute="subCategory" hit={hit} />
+                </>
+              )}
+            </p>
+            {hit.notificationNum && (
+              <p className="prose-body-base text-base-content">
+                Number: <Highlight attribute="notificationNum" hit={hit} />
+              </p>
+            )}
+            <p className="prose-body-base text-base-content">
+              Date of publication: {formatDate(hit.publishTimestamp)}
+            </p>
+            {hit.text && (
+              <p className="prose-body-base text-base-content">
+                Content: <Snippet attribute="text" hit={hit} />
+              </p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Pagination.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Pagination.tsx
@@ -1,0 +1,23 @@
+import { usePagination } from "react-instantsearch"
+
+import { PaginationControls } from "../../../../components/internal/PaginationControls"
+
+export const Pagination = () => {
+  const { currentRefinement, nbPages, refine } = usePagination()
+
+  if (nbPages <= 1) return null
+
+  // PaginationControls derives its page count as ceil(totalItems / itemsPerPage)
+  // and is 1-indexed; react-instantsearch pages are 0-indexed. Treating each
+  // Algolia page as a single "item" makes the rendered page count exactly nbPages.
+  return (
+    <div className="flex w-full justify-center lg:justify-end">
+      <PaginationControls
+        totalItems={nbPages}
+        itemsPerPage={1}
+        currPage={currentRefinement + 1}
+        setCurrPage={(page) => refine(page - 1)}
+      />
+    </div>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/RangeInput.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/RangeInput.tsx
@@ -1,0 +1,160 @@
+import { useEffect, useState } from "react"
+import { useRange } from "react-instantsearch"
+import { tv } from "~/lib/tv"
+
+interface RangeInputProps {
+  attribute: string
+  minLabel: string
+  maxLabel: string
+  /** Inclusive lower bound each value must satisfy. */
+  bound?: { min?: number; max?: number }
+}
+
+const inputStyles = tv({
+  base: "h-10 w-full rounded border bg-white px-2",
+  variants: {
+    hasError: {
+      true: "border-utility-feedback-alert",
+      false: "border-base-content-strong",
+    },
+  },
+})
+
+const toInputValue = (value: number | undefined) =>
+  value === undefined || !Number.isFinite(value) ? "" : String(value)
+
+const validate = (
+  minNum: number | undefined,
+  maxNum: number | undefined,
+  bound: { min?: number; max?: number } | undefined,
+): string | undefined => {
+  const checkBound = (value: number | undefined, label: string) => {
+    if (value === undefined) return undefined
+    if (bound?.min !== undefined && value < bound.min)
+      return `${label} must be ${bound.min} or later`
+    if (bound?.max !== undefined && value > bound.max)
+      return `${label} must be ${bound.max} or earlier`
+    return undefined
+  }
+
+  return (
+    checkBound(minNum, "From") ??
+    checkBound(maxNum, "To") ??
+    (minNum !== undefined && maxNum !== undefined && minNum > maxNum
+      ? `"From" cannot be later than "To"`
+      : undefined)
+  )
+}
+
+export const RangeInput = ({
+  attribute,
+  minLabel,
+  maxLabel,
+  bound,
+}: RangeInputProps) => {
+  // `bound` is optional: when omitted, useRange derives min/max from the
+  // attribute's facet stats. Pass explicit bounds only to refine an attribute
+  // that lacks facet stats, or to clamp refinements to [min, max] at the
+  // connector level.
+  const { start, range, refine, canRefine } = useRange({
+    attribute,
+    min: bound?.min,
+    max: bound?.max,
+  })
+  const [minRaw, maxRaw] = start
+
+  const [min, setMin] = useState(toInputValue(minRaw))
+  const [max, setMax] = useState(toInputValue(maxRaw))
+  const [error, setError] = useState<string>()
+
+  // Keep the inputs in sync when the active refinement changes outside of this
+  // form (URL hydration on deep-links, "Clear refinements", browser back/forward).
+  // Without this the inputs would show stale values that no longer match the
+  // applied filters. `minRaw`/`maxRaw` are stable primitives, so the effect only
+  // fires when the refinement actually changes.
+  useEffect(() => {
+    setMin(toInputValue(minRaw))
+    setMax(toInputValue(maxRaw))
+    // An external refinement change (e.g. "Clear refinements") makes any prior
+    // validation error stale, so reset it alongside the inputs.
+    setError(undefined)
+  }, [minRaw, maxRaw])
+
+  const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const minNum = min === "" ? undefined : Number(min)
+    const maxNum = max === "" ? undefined : Number(max)
+    if (
+      (minNum !== undefined && Number.isNaN(minNum)) ||
+      (maxNum !== undefined && Number.isNaN(maxNum))
+    ) {
+      setError("Please enter a valid number")
+      return
+    }
+    const validationError = validate(minNum, maxNum, bound)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+    setError(undefined)
+    refine([minNum, maxNum])
+  }
+
+  const inputClassName = inputStyles({ hasError: error !== undefined })
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-1">
+      <div className="flex items-end gap-2">
+        <label className="flex flex-1 flex-col gap-1">
+          <span className="prose-body-sm text-base-content">{minLabel}</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={bound?.min}
+            max={bound?.max}
+            placeholder={
+              range.min !== undefined ? String(range.min) : undefined
+            }
+            value={min}
+            onChange={(event) => setMin(event.target.value)}
+            disabled={!canRefine}
+            aria-invalid={error !== undefined}
+            className={inputClassName}
+          />
+        </label>
+        <label className="flex flex-1 flex-col gap-1">
+          <span className="prose-body-sm text-base-content">{maxLabel}</span>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={bound?.min}
+            max={bound?.max}
+            placeholder={
+              range.max !== undefined ? String(range.max) : undefined
+            }
+            value={max}
+            onChange={(event) => setMax(event.target.value)}
+            disabled={!canRefine}
+            aria-invalid={error !== undefined}
+            className={inputClassName}
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={!canRefine}
+          className="prose-headline-base-medium h-10 rounded border border-base-content-strong bg-white px-3 text-base-content disabled:opacity-50"
+        >
+          Go
+        </button>
+      </div>
+      {error ? (
+        <span
+          role="alert"
+          className="prose-body-sm text-utility-feedback-alert"
+        >
+          {error}
+        </span>
+      ) : null}
+    </form>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SearchBox.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SearchBox.tsx
@@ -1,0 +1,53 @@
+import type { UseSearchBoxProps } from "react-instantsearch"
+import { useEffect, useRef, useState } from "react"
+import { BiSearch } from "react-icons/bi"
+import { useSearchBox } from "react-instantsearch"
+
+const DEBOUNCE_MS = 250
+
+// Disable the connector's default debounce — we manage it locally so the input stays in sync.
+// Must be a stable reference: useSearchBox re-registers the widget when its props change
+// identity, which loops into "Too many re-renders" on any refinement change.
+const queryHook: NonNullable<UseSearchBoxProps["queryHook"]> = (
+  newQuery,
+  search,
+) => search(newQuery)
+
+export const SearchBox = () => {
+  const { query, refine } = useSearchBox({ queryHook })
+  const [value, setValue] = useState(query)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => {
+    setValue(query)
+  }, [query])
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return (
+    <label className="relative flex w-full items-center">
+      <BiSearch
+        aria-hidden
+        className="pointer-events-none absolute left-3 h-5 w-5 text-base-content-medium"
+      />
+      <span className="sr-only">Search</span>
+      <input
+        type="search"
+        autoFocus
+        placeholder="Start typing to search"
+        value={value}
+        onChange={(event) => {
+          const next = event.target.value
+          setValue(next)
+          if (timerRef.current) clearTimeout(timerRef.current)
+          timerRef.current = setTimeout(() => refine(next), DEBOUNCE_MS)
+        }}
+        className="prose-body-base h-12 w-full rounded border border-base-content-strong bg-white pl-10 pr-3 text-base-content placeholder:text-base-content-medium focus:outline-none focus:ring-2 focus:ring-utility-highlight"
+      />
+    </label>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SortedByLabel.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SortedByLabel.tsx
@@ -1,0 +1,12 @@
+import { useSearchBox } from "react-instantsearch"
+
+export const SortedByLabel = () => {
+  const { query } = useSearchBox()
+  const isQuerying = query.trim() !== ""
+
+  return (
+    <p className="prose-body-sm text-base-content">
+      {isQuerying ? "Sorted by relevancy" : "Sorted by most recent"}
+    </p>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Stats.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Stats.tsx
@@ -1,0 +1,20 @@
+import { useStats } from "react-instantsearch"
+
+const MAX_REPORTED = 1000
+
+export const Stats = () => {
+  const { nbHits, query } = useStats()
+
+  let content: string
+  if (nbHits === 0) {
+    content = query ? `No results found for ${query}` : "No results found"
+  } else if (nbHits === 1) {
+    content = "1 result found"
+  } else if (nbHits > MAX_REPORTED) {
+    content = "More than 1000 results found"
+  } else {
+    content = `${nbHits} results found`
+  }
+
+  return <p className="prose-body-base text-base-content">{content}</p>
+}

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SubCategoryRefinementList.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SubCategoryRefinementList.tsx
@@ -1,0 +1,76 @@
+import { useCurrentRefinements, useRefinementList } from "react-instantsearch"
+
+import {
+  Checkbox,
+  CheckboxGroup,
+} from "../../../../components/internal/Checkbox"
+import { EGAZETTE_CATEGORIES } from "../categories"
+
+export const SubCategoryRefinementList = () => {
+  const { items: refinementItems, refine } = useRefinementList({
+    attribute: "subCategory",
+    limit: 200,
+  })
+  const { items: currentRefinements } = useCurrentRefinements()
+
+  const selectedCategoryValues = new Set(
+    currentRefinements
+      .find((entry) => entry.attribute === "category")
+      ?.refinements.map((refinement) => String(refinement.value)) ?? [],
+  )
+
+  // Match the Jekyll behavior: hide the sub-category section entirely (heading
+  // and trailing divider included) until a category is picked.
+  if (selectedCategoryValues.size === 0) return null
+
+  const availableSubCategories = EGAZETTE_CATEGORIES.flatMap((category) =>
+    selectedCategoryValues.has(category.value)
+      ? (category.subCategories ?? [])
+      : [],
+  )
+
+  const refinementByValue = new Map(
+    refinementItems.map((item) => [item.value, item]),
+  )
+
+  const rows = availableSubCategories.map(({ value, displayLabel }) => {
+    const match = refinementByValue.get(value)
+    return {
+      value,
+      label: displayLabel,
+      count: match?.count ?? 0,
+      isRefined: match?.isRefined ?? false,
+    }
+  })
+
+  const selectedValues = rows
+    .filter((row) => row.isRefined)
+    .map((row) => row.value)
+
+  return (
+    <>
+      <div className="flex flex-col gap-3">
+        <h4 className="prose-headline-base-medium text-base-content">
+          Sub-category
+        </h4>
+        <CheckboxGroup className="gap-2" value={selectedValues}>
+          {rows.map((row) => {
+            const isDisabled = row.count === 0 && !row.isRefined
+            return (
+              <Checkbox
+                key={row.value}
+                className="w-fit cursor-pointer"
+                value={row.value}
+                isDisabled={isDisabled}
+                onChange={() => refine(row.value)}
+              >
+                {row.label}
+              </Checkbox>
+            )
+          })}
+        </CheckboxGroup>
+      </div>
+      <hr className="border-t border-base-divider-medium" />
+    </>
+  )
+}

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -1,4 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/react-vite"
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite"
+import { useEffect } from "react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import {
   SEARCHSG_TEST_CLIENT_ID,
   withSearchSgSetup,
@@ -44,5 +46,114 @@ export const SearchSG: Story = {
       permalink: "/search",
       lastModified: "2024-05-02T14:12:57.160Z",
     },
+  },
+}
+
+// Staging Algolia credentials reused from the legacy Jekyll egazette template — safe to commit
+// because these are public search-only keys that ship in the browser bundle today.
+const EGAZETTE_STAGING_CONFIG = {
+  type: "egazette-algolia" as const,
+  appId: "1V7DZGZJKK",
+  searchApiKey: "bbc5751b3f9b7fdfc08c99712adfa397",
+  indexName: "staging_ogp_egazettes_index",
+}
+
+const EGAZETTE_ARGS: Story["args"] = {
+  layout: "search",
+  site: generateSiteConfig({
+    siteName: "Singapore Government e-Gazette",
+    search: EGAZETTE_STAGING_CONFIG,
+  }),
+  meta: {
+    description: "Search the Singapore Government e-Gazette",
+  },
+  page: {
+    title: "Search the e-Gazette",
+    permalink: "/search",
+    lastModified: "2026-01-15T00:00:00.000Z",
+  },
+}
+
+export const EgazetteAlgolia: Story = {
+  args: EGAZETTE_ARGS,
+}
+
+// The stories below hit the live staging Algolia index, so hit counts and
+// results vary between runs — skip Chromatic snapshots to avoid flakiness.
+const liveAlgoliaParameters = {
+  chromatic: { disableSnapshot: true },
+}
+
+export const EgazetteAlgoliaWithCategorySelected: Story = {
+  args: EGAZETTE_ARGS,
+  parameters: liveAlgoliaParameters,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      canvas.getByRole("checkbox", { name: /^Government Gazette/ }),
+    )
+    // Sub-category section appears only once a category is selected, in the
+    // order declared by the taxonomy, with zero-count rows dimmed + disabled.
+    await expect(
+      await canvas.findByRole("checkbox", { name: /^Advertisements/ }),
+    ).toBeInTheDocument()
+  },
+}
+
+export const EgazetteAlgoliaWithYearRange: Story = {
+  args: EGAZETTE_ARGS,
+  parameters: liveAlgoliaParameters,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Range inputs stay disabled until the first Algolia response arrives.
+    const yearFromInput = canvas.getAllByLabelText("From")[0]
+    if (!yearFromInput) throw new Error("Year range input not found")
+    await waitFor(() => expect(yearFromInput).toBeEnabled(), { timeout: 10000 })
+    await userEvent.type(yearFromInput, "2024")
+    const goButton = canvas.getAllByRole("button", { name: "Go" })[0]
+    if (!goButton) throw new Error("Year range submit button not found")
+    await userEvent.click(goButton)
+  },
+}
+
+// Seeds the URL with egazette deep-link params before <InstantSearch> mounts,
+// then restores the original URL on unmount so other stories are unaffected.
+const withDeepLinkParams = (search: string): Decorator => {
+  return (StoryComponent) => {
+    const original = `${window.location.pathname}${window.location.search}`
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}${search}`,
+    )
+    // oxlint-disable-next-line rules-of-hooks -- decorators render as components
+    useEffect(() => {
+      return () => window.history.replaceState(null, "", original)
+    }, [original])
+    return <StoryComponent />
+  }
+}
+
+export const EgazetteAlgoliaWithDeepLink: Story = {
+  args: EGAZETTE_ARGS,
+  parameters: liveAlgoliaParameters,
+  decorators: [
+    withDeepLinkParams("?q=tender&category=Government%20Gazette&minYear=2024"),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // URL params hydrate the initial UI state on mount.
+    await expect(canvas.getByRole("searchbox")).toHaveValue("tender")
+    // isRefined on the checkbox only reflects once the first Algolia response lands
+    await waitFor(
+      () =>
+        expect(
+          canvas.getByRole("checkbox", { name: /^Government Gazette/ }),
+        ).toBeChecked(),
+      { timeout: 10000 },
+    )
+    await expect(
+      await canvas.findByRole("checkbox", { name: /^Advertisements/ }),
+    ).toBeInTheDocument()
   },
 }

--- a/packages/components/src/templates/next/layouts/Search/Search.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.tsx
@@ -1,6 +1,7 @@
 import { type SearchPageSchemaType } from "~/types"
 
 import { Skeleton } from "../Skeleton"
+import { EgazetteAlgoliaSearch } from "./EgazetteAlgoliaSearch"
 import { SearchSG } from "./SearchSG"
 
 export const SearchLayout = ({ site, page, layout }: SearchPageSchemaType) => {
@@ -12,6 +13,10 @@ export const SearchLayout = ({ site, page, layout }: SearchPageSchemaType) => {
       {/* SearchSG-powered search */}
       {site.search?.type === "searchSG" && clientId && (
         <SearchSG clientId={clientId} />
+      )}
+      {/* Algolia-powered egazette search */}
+      {site.search?.type === "egazette-algolia" && (
+        <EgazetteAlgoliaSearch config={site.search} />
       )}
     </Skeleton>
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,9 @@ catalogs:
     react-icons:
       specifier: ^5.2.0
       version: 5.6.0
+    react-instantsearch:
+      specifier: ^7.35.0
+      version: 7.36.0
     react-markdown:
       specifier: ^10.1.0
       version: 10.1.0
@@ -1167,6 +1170,9 @@ importers:
       '@sinclair/typebox':
         specifier: 'catalog:'
         version: 0.33.22
+      algoliasearch:
+        specifier: 'catalog:'
+        version: 4.27.0
       date-fns:
         specifier: 'catalog:'
         version: 4.4.0
@@ -1191,6 +1197,9 @@ importers:
       react-icons:
         specifier: 'catalog:'
         version: 5.6.0(react@18.3.1)
+      react-instantsearch:
+        specifier: 'catalog:'
+        version: 7.36.0(algoliasearch@4.27.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: 'catalog:'
         version: 2.6.1
@@ -1913,6 +1922,9 @@ packages:
 
   '@algolia/client-search@4.27.0':
     resolution: {integrity: sha512-qmX/f67ay0eZ4V5Io8fWWOcUVo/gqre2yei1PnmEhQU2Gul6ushg25QnNrfu4BODiRrw1rwYveZaLCiHvcUxrQ==}
+
+  '@algolia/events@4.0.1':
+    resolution: {integrity: sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==}
 
   '@algolia/logger-common@4.27.0':
     resolution: {integrity: sha512-pIrmQRXtDV+zTMVXKtKCosC2rWhn0F0TdUeb9etA6RiAz6jY6bY6f0+JX7YekDK09SnmZMLIyUa7Jci+Ied9bw==}
@@ -5781,6 +5793,9 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@swc/helpers@0.5.18':
+    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
+
   '@swc/helpers@0.5.20':
     resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
 
@@ -6143,6 +6158,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/dom-speech-recognition@0.0.1':
+    resolution: {integrity: sha512-udCxb8DvjcDKfk1WTBzDsxFbLgYxmQGKrE/ricoMqHRNjSlSUCcamVTA5lIQqzY10mY5qCY0QDwBfFEwhfoDPw==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -6161,8 +6179,14 @@ packages:
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
+  '@types/google.maps@3.65.2':
+    resolution: {integrity: sha512-e52bmOhGCQSNabFpL48iQlwJybq6rfns8NUVJ20MR7CdPlHQ2RmSCnPbJfrUYJfogrE4OiHQTZ4LXpop+eer1w==}
+
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/hogan.js@3.0.5':
+    resolution: {integrity: sha512-/uRaY3HGPWyLqOyhgvW9Aa43BNnLZrNeQxl2p8wqId4UHMfPKolSB+U7BlZyO1ng7MkLnyEAItsBzCG0SDhqrA==}
 
   '@types/html-minifier-terser@6.1.0':
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
@@ -6218,6 +6242,9 @@ packages:
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
 
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
@@ -6509,6 +6536,9 @@ packages:
   '@zag-js/focus-visible@0.31.1':
     resolution: {integrity: sha512-dbLksz7FEwyFoANbpIlNnd3bVm0clQSUsnP8yUVQucStZPsuWjCrhL2jlAbGNrTrahX96ntUMXHb/sM68TibFg==}
 
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -6578,6 +6608,11 @@ packages:
 
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  algoliasearch-helper@3.29.1:
+    resolution: {integrity: sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 6'
 
   algoliasearch@4.27.0:
     resolution: {integrity: sha512-C88C5grLa5VOCp9eYZJt+q99ik7yNdm92l7Q9+4XK0Md8kL05Lg8l2v9ZVX0uMW3mH9pAFxMMXlLOvqNumA4lw==}
@@ -8348,12 +8383,19 @@ packages:
   hmac-drbg@1.0.1:
     resolution: {integrity: sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==}
 
+  hogan.js@3.0.2:
+    resolution: {integrity: sha512-RqGs4wavGYJWE07t35JQccByczmNUXQT0E12ZYV1VKYu5UiAU9lsos/yBAcf840+zrUQQxgVduCR5/B8nNtibg==}
+    hasBin: true
+
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
   hono@4.12.23:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
+
+  htm@3.1.1:
+    resolution: {integrity: sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -8485,6 +8527,14 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  instantsearch-ui-components@0.31.0:
+    resolution: {integrity: sha512-mdbxlzsCQKs4IygXEibO29LrA8uFtToBKQyHUHeQiHvPWOdZWxhBZ1ZE1C6GjmKnOBZWDnVAn/rwhNKTYhCFKw==}
+
+  instantsearch.js@4.102.0:
+    resolution: {integrity: sha512-Ury18PgLVyQ7NFlWLJI/DvPGaM+tMW+AntjsEADA/2ZJ1MS+iX/END2ojLcHSWfp2oeHWAs6fG8x/hbcgm2g5Q==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 6'
 
   inter-ui@3.19.3:
     resolution: {integrity: sha512-5FG9fjuYOXocIfjzcCBhICL5cpvwEetseL3FU6tP3d6Bn7g8wODhB+I9RNGRTizCT7CUG4GOK54OPxqq3msQgg==}
@@ -9049,6 +9099,15 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  markdown-to-jsx@7.7.17:
+    resolution: {integrity: sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      react: '>= 0.14.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -9246,6 +9305,10 @@ packages:
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
+  mkdirp@0.3.0:
+    resolution: {integrity: sha512-OHsdUcVAQ6pOtg5JYWpCBo9W/GySVuwvP9hueRMW7UqshC0tbfzLv8wjySTPm3tfUZ/21CE9E1pJagOA91Pxew==}
+    deprecated: Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)
+
   mkdirp@3.0.1:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
@@ -9412,6 +9475,10 @@ packages:
   non-error@0.1.0:
     resolution: {integrity: sha512-TMB1uHiGsHRGv1uYclfhivcnf0/PdFp2pNqRxXjncaAsjYMoisaQJI+SSZCqRq+VliwRTC8tsMQfmrWjDMhkPQ==}
     engines: {node: '>=20'}
+
+  nopt@1.0.10:
+    resolution: {integrity: sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==}
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -10132,6 +10199,9 @@ packages:
   pprof-format@2.2.1:
     resolution: {integrity: sha512-p4tVN7iK19ccDqQv8heyobzUmbHyds4N2FI6aBMcXz6y99MglTWDxIyhFkNaLeEXs6IFUEzT0zya0icbSLLY0g==}
 
+  preact@10.29.2:
+    resolution: {integrity: sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -10396,6 +10466,19 @@ packages:
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
+
+  react-instantsearch-core@7.36.0:
+    resolution: {integrity: sha512-fabUeh82h6j6ph6SNa6m7aJxLRUWldncO+nR2RgZ6tb9J5sDKNGHepQWptSorLQM3TRWJQWzMCUf5FHxe5YWag==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 6'
+      react: '>= 16.8.0 < 20'
+
+  react-instantsearch@7.36.0:
+    resolution: {integrity: sha512-yvD5Edgm8aGl37vbSnF2xa2eQsaOsKJ9wlY4LkcPwx2p4eBj2JHv32YH1esnhhmguzuyTAmh8xEfg6Qbf+YyZg==}
+    peerDependencies:
+      algoliasearch: '>= 3.1 < 6'
+      react: '>= 16.8.0 < 20'
+      react-dom: '>= 16.8.0 < 20'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -10762,6 +10845,9 @@ packages:
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
     engines: {node: '>= 10.13.0'}
+
+  search-insights@2.17.3:
+    resolution: {integrity: sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==}
 
   secure-json-parse@4.1.0:
     resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
@@ -11993,6 +12079,8 @@ snapshots:
       '@algolia/client-common': 4.27.0
       '@algolia/requester-common': 4.27.0
       '@algolia/transporter': 4.27.0
+
+  '@algolia/events@4.0.1': {}
 
   '@algolia/logger-common@4.27.0': {}
 
@@ -16461,6 +16549,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@swc/helpers@0.5.18':
+    dependencies:
+      tslib: 2.8.1
+
   '@swc/helpers@0.5.20':
     dependencies:
       tslib: 2.8.1
@@ -16808,6 +16900,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/dom-speech-recognition@0.0.1': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -16832,9 +16926,13 @@ snapshots:
       '@types/minimatch': 6.0.0
       '@types/node': 25.9.3
 
+  '@types/google.maps@3.65.2': {}
+
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/hogan.js@3.0.5': {}
 
   '@types/html-minifier-terser@6.1.0': {}
 
@@ -16892,6 +16990,8 @@ snapshots:
       pg-types: 2.2.0
 
   '@types/prop-types@15.7.15': {}
+
+  '@types/qs@6.15.1': {}
 
   '@types/react-dom@18.3.7(@types/react@18.3.28)':
     dependencies:
@@ -17255,6 +17355,8 @@ snapshots:
     dependencies:
       '@zag-js/dom-query': 0.31.1
 
+  abbrev@1.1.1: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -17323,6 +17425,11 @@ snapshots:
       fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
+
+  algoliasearch-helper@3.29.1(algoliasearch@4.27.0):
+    dependencies:
+      '@algolia/events': 4.0.1
+      algoliasearch: 4.27.0
 
   algoliasearch@4.27.0:
     dependencies:
@@ -19362,11 +19469,18 @@ snapshots:
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
 
+  hogan.js@3.0.2:
+    dependencies:
+      mkdirp: 0.3.0
+      nopt: 1.0.10
+
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
 
   hono@4.12.23: {}
+
+  htm@3.1.1: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
     dependencies:
@@ -19493,6 +19607,31 @@ snapshots:
   ini@2.0.0: {}
 
   inline-style-parser@0.2.7: {}
+
+  instantsearch-ui-components@0.31.0(react@18.3.1):
+    dependencies:
+      '@swc/helpers': 0.5.18
+      markdown-to-jsx: 7.7.17(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+
+  instantsearch.js@4.102.0(algoliasearch@4.27.0):
+    dependencies:
+      '@algolia/events': 4.0.1
+      '@swc/helpers': 0.5.18
+      '@types/dom-speech-recognition': 0.0.1
+      '@types/google.maps': 3.65.2
+      '@types/hogan.js': 3.0.5
+      '@types/qs': 6.15.1
+      algoliasearch: 4.27.0
+      algoliasearch-helper: 3.29.1(algoliasearch@4.27.0)
+      hogan.js: 3.0.2
+      htm: 3.1.1
+      instantsearch-ui-components: 0.31.0(react@18.3.1)
+      preact: 10.29.2
+      qs: 6.15.0
+      react: 18.3.1
+      search-insights: 2.17.3
 
   inter-ui@3.19.3: {}
 
@@ -19972,6 +20111,10 @@ snapshots:
     dependencies:
       semver: 7.8.2
 
+  markdown-to-jsx@7.7.17(react@18.3.1):
+    optionalDependencies:
+      react: 18.3.1
+
   math-intrinsics@1.1.0: {}
 
   md5.js@1.3.5:
@@ -20276,6 +20419,8 @@ snapshots:
 
   mkdirp-classic@0.5.3: {}
 
+  mkdirp@0.3.0: {}
+
   mkdirp@3.0.1: {}
 
   mockdate@3.0.5: {}
@@ -20470,6 +20615,10 @@ snapshots:
   node-releases@2.0.36: {}
 
   non-error@0.1.0: {}
+
+  nopt@1.0.10:
+    dependencies:
+      abbrev: 1.1.1
 
   normalize-path@3.0.0: {}
 
@@ -21341,6 +21490,8 @@ snapshots:
   pprof-format@2.2.1:
     optional: true
 
+  preact@10.29.2: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
@@ -21693,6 +21844,25 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       warning: 4.0.3
+
+  react-instantsearch-core@7.36.0(algoliasearch@4.27.0)(react@18.3.1):
+    dependencies:
+      '@swc/helpers': 0.5.18
+      algoliasearch: 4.27.0
+      algoliasearch-helper: 3.29.1(algoliasearch@4.27.0)
+      instantsearch.js: 4.102.0(algoliasearch@4.27.0)
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  react-instantsearch@7.36.0(algoliasearch@4.27.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@swc/helpers': 0.5.18
+      algoliasearch: 4.27.0
+      instantsearch-ui-components: 0.31.0(react@18.3.1)
+      instantsearch.js: 4.102.0(algoliasearch@4.27.0)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-instantsearch-core: 7.36.0(algoliasearch@4.27.0)(react@18.3.1)
 
   react-is@16.13.1: {}
 
@@ -22139,6 +22309,8 @@ snapshots:
       ajv: 8.20.0
       ajv-formats: 2.1.1(ajv@8.20.0)
       ajv-keywords: 5.1.0(ajv@8.20.0)
+
+  search-insights@2.17.3: {}
 
   secure-json-parse@4.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,8 +55,11 @@ patchedDependencies:
   next@16.2.6: patches/next@16.2.6.patch
 
 catalog:
+  # v4 is pinned deliberately: the legacy egazette integration uses the v4 client API
+  # (algoliasearch(appId, key).initIndex(name), index.saveObjects, index.deleteBy).
+  # v5 changed the client API — do not "upgrade" this without reviewing egazette compatibility.
+  algoliasearch: ^4.24.0
   ajv: ^8.20.0
-  algoliasearch: ^5.53.0
   autoprefixer: ^10.4.21
   axios: ^1.17.0
   bootstrap-icons: ^1.13.1


### PR DESCRIPTION
## Problem

The downstack PR widened `site.search` to accept the `"egazette-algolia"` variant but did not render anything for it. This PR ports the legacy Jekyll `egazette-search` layout (`isomerpages-template/next-gen/_layouts/egazette-search.html` + `algolia-search.js`) into `packages/components` so the egazette site can publish its Algolia-powered search page from Isomer Next.

Closes ISOM-2297

## Solution

### Where the renderer mounts

The existing `SearchLayout` (`templates/next/layouts/Search/Search.tsx`) already branches on `site.search.type` to pick a renderer. It gains a third arm:

```tsx
{site.search?.type === "egazette-algolia" && (
  <EgazetteAlgoliaSearch config={site.search} />
)}
```

No new top-level page layout, no change to `ISOMER_PAGE_LAYOUTS`, no change to `renderLayout.tsx` — the extensibility seam already existed.

### Client island

`templates/next/layouts/Search/EgazetteAlgoliaSearch/` is a `"use client"` subtree owning the Algolia search client, the `<InstantSearch>` provider, and the URL state mapping:

- `EgazetteAlgoliaSearch.tsx` — composes the widget tree (left-rail filters, right-pane results)
- `routing.ts` — `stateMapping` that round-trips `q`, `category`, `subCategory`, `minYear/maxYear`, `minMonth/maxMonth` through URL params, matching the Jekyll URL shape so deep links survive the port
- `widgets/` — one file per widget, each wrapping a `react-instantsearch` hook

### Behavioral parity with the Jekyll JS

Faithfully reproduced from `assets/js/algolia-search.js`:

- **Hardcoded category order** (`CategoryRefinementList`) — every configured category renders in declared order even when Algolia returns zero hits, preserving the "show empty rows in fixed order" affordance.
- **Sub-category visibility** (`SubCategoryRefinementList`) — hidden until a category is selected; sub-categories filtered to those under the selected categories; zero-count rows dimmed + disabled (matches `algolia-search-item-disabled`).
- **Display-label remap** — categories/sub-categories show `displayLabel` from the schema instead of the Algolia-stored value, replacing the old `CATEGORY_INTERNAL_MAPPING` constant. `CurrentRefinements` also remaps chip labels.
- **Debounced query** — 250 ms `setTimeout` on `SearchBox`, matching the Jekyll `queryHook`.
- **Stats templates** — "More than 1000 results", "N results found", "1 result found", "No results found for {query}".
- **Sort-by label** — flips between "Sorted by most recent" (empty query) and "Sorted by relevancy" (any text).
- **Hit template** — title linked to `hit.fileUrl` (PDF, opens in new tab), highlighted category/sub-category/notificationNum, en-SG formatted `publishTimestamp`, snippet of `text`.
- **Pagination** — first/last + padding 2.

### Storybook

`Search.stories.tsx` gets a new `EgazetteAlgolia` story pointing at the same staging Algolia keys the Jekyll JS uses today (`1V7DZGZJKK` / `staging_ogp_egazettes_index`) with the full egazette taxonomy fixture, so the live behavior can be exercised in Storybook against a real index.

**Breaking Changes**

- [ ] Yes
- [x] No — only activates when `site.search.type === "egazette-algolia"`, a value no production site currently emits

**Features**:

- `EgazetteAlgoliaSearch` renderer wired into `SearchLayout` for the new variant
- URL state syncing so refinements + query + ranges are bookmarkable

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

No renderer for `site.search.type === "egazette-algolia"`.

**AFTER**:

`SearchLayout` renders the left-rail filter UI + right-pane Algolia results. See the new Storybook story `Next/Layouts/Search/Egazette Algolia` against the staging index.

## Tests

- [x] `pnpm --filter @opengovsg/isomer-components typecheck` — clean
- [x] `pnpm --filter @opengovsg/isomer-components lint` — 0 new warnings on changed files
- [x] `pnpm --filter @opengovsg/isomer-components test:unit` — 313/313 pass
- [x] `pnpm --filter @opengovsg/isomer-components build` — publishable tarball produced

**Manual Verification Steps**:

- [ ] Open Storybook story `Next/Layouts/Search/Egazette Algolia` — type a query (debounces ~250 ms), toggle a category (sub-category section appears with zero-counts dimmed), apply a year range, click a hit (PDF opens in new tab)
- [ ] Refresh with `?q=foo&category[]=Government%20Gazette&minYear=2024` — state hydrates from the URL
- [ ] Existing `SearchSG` story still renders unchanged (no regression)

