### PR TITLE
refactor(studio): migrate ~prisma/generated/* imports to @isomer/db

### DIFF
--- a/apps/studio/src/components/AppNavbar.tsx
+++ b/apps/studio/src/components/AppNavbar.tsx
@@ -5,7 +5,8 @@ import NextLink from "next/link"
 import { BiLinkExternal } from "react-icons/bi"
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { AvatarMenu } from "./AvatarMenu"
 

--- a/apps/studio/src/components/AuthWrappers/PermissionsBoundary.tsx
+++ b/apps/studio/src/components/AuthWrappers/PermissionsBoundary.tsx
@@ -1,10 +1,11 @@
 import type { ReactNode } from "react"
-import type { ResourceType } from "~prisma/generated/generatedEnums"
 import { PermissionsErrorBoundary } from "~/features/dashboard/PermissionsErrorPage"
 import { Can, PermissionsProvider } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
 import { DefaultLayout } from "~/templates/layouts/DefaultLayout"
+
+import type { ResourceType } from "@isomer/db"
 
 interface ErrorProps {
   title: string

--- a/apps/studio/src/components/CmsSidebar/CmsContainerWrapper.tsx
+++ b/apps/studio/src/components/CmsSidebar/CmsContainerWrapper.tsx
@@ -7,7 +7,8 @@ import { BiCog, BiFolder, BiGroup, BiHelpCircle, BiStar } from "react-icons/bi"
 import { CmsContainer, CmsSidebar } from "~/components/CmsSidebar"
 import { SearchableHeader } from "~/components/SearchableHeader"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { OpenSidebarIcon } from "../Svg/OpenSidebarIcon"
 

--- a/apps/studio/src/components/PageEditor/ComponentSelector.tsx
+++ b/apps/studio/src/components/PageEditor/ComponentSelector.tsx
@@ -8,7 +8,8 @@ import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { TYPE_TO_ICON } from "~/features/editing-experience/constants"
 import { IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { type DrawerState } from "~/types/editorDrawer"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { UsageTooltipProps } from "./UsageTooltip"
 import {

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -4,7 +4,8 @@ import { Box, Flex, Skeleton, Text, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { Suspense, useMemo } from "react"
 import { useSearchQuery } from "~/hooks/useSearchQuery"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import {
   LoadingResourceItemsResults,

--- a/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
@@ -2,7 +2,8 @@ import type { ResourceItemContent } from "~/schemas/resource"
 import { useCallback, useMemo } from "react"
 import { isAllowedToHaveChildren } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { lastResourceItemInAncestryStack } from "./utils"
 

--- a/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
+++ b/apps/studio/src/components/Searchbar/SearchModalBodyContentStates.tsx
@@ -4,7 +4,8 @@ import type { SearchResultResource } from "~/server/modules/resource/resource.ty
 import { ModalBody as ChakraModalBody, Text, VStack } from "@chakra-ui/react"
 import { useResourceLocalViewHistory } from "~/hooks/useResourceLocalViewHistory"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { SearchResultProps } from "./SearchResult"
 import { NoSearchResultSvgr } from "../Svg/NoSearchResultSvgr"

--- a/apps/studio/src/constants/resources.ts
+++ b/apps/studio/src/constants/resources.ts
@@ -1,4 +1,4 @@
-import { ResourceType } from "~prisma/generated/generatedEnums"
+import { ResourceType } from "@isomer/db"
 
 // only show user-viewable resources (excluding root page, folder meta etc.)
 export const USER_VIEWABLE_RESOURCE_TYPES: ResourceType[] = [

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -1,10 +1,11 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { Dispatch, PropsWithChildren, SetStateAction } from "react"
 import type { ModifiedAsset } from "~/types/assets"
-import type { ResourceType } from "~prisma/generated/generatedEnums"
 import { createContext, useCallback, useContext, useState } from "react"
 import { flushSync } from "react-dom"
 import { type DrawerState } from "~/types/editorDrawer"
+
+import type { ResourceType } from "@isomer/db"
 
 interface DrawerContextType extends Pick<
   EditorDrawerProviderProps,

--- a/apps/studio/src/features/dashboard/atoms.ts
+++ b/apps/studio/src/features/dashboard/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type {
   DeleteResourceModalState,

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -13,7 +13,8 @@ import { Datatable } from "~/components/Datatable/Datatable"
 import { EmptyTablePlaceholder } from "~/components/Datatable/EmptyTablePlaceholder"
 import { useTablePagination } from "~/hooks/useTablePagination"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { CollectionTableData, CollectionTableSortOptions } from "./types"
 import { TitleCell } from "../ResourceTable/TitleCell"

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -9,7 +9,8 @@ import {
 } from "react-icons/bi"
 import { MenuItem } from "~/components/Menu"
 import { moveResourceAtom } from "~/features/editing-experience/atoms"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { CollectionTableData } from "./types"
 import { deleteResourceModalAtom, pageSettingsModalAtom } from "../../atoms"

--- a/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DeleteResourceModal/DeleteResourceModal.tsx
@@ -20,7 +20,8 @@ import { useState } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { isAllowedToHaveChildren } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { DeleteResourceModalState } from "../../types"
 import {

--- a/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebar.tsx
+++ b/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebar.tsx
@@ -1,5 +1,6 @@
 import { Flex } from "@chakra-ui/react"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { DirectorySidebarContent } from "./DirectorySidebarContent"
 

--- a/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebarContent.tsx
+++ b/apps/studio/src/features/dashboard/components/DirectorySidebar/DirectorySidebarContent.tsx
@@ -4,7 +4,8 @@ import { useEffect, useMemo, useState } from "react"
 import { getResourceSubpath } from "~/utils/resource"
 import { getIcon } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { RowEntry } from "./RowEntry"
 import { useIsActive } from "./useIsActive"

--- a/apps/studio/src/features/dashboard/components/DirectorySidebar/useIsActive.ts
+++ b/apps/studio/src/features/dashboard/components/DirectorySidebar/useIsActive.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const siteSchema = z.object({
   folderId: z.string().optional(),

--- a/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
@@ -12,7 +12,8 @@ import { useEffect } from "react"
 import { BiChevronRight, BiSolidCircle } from "react-icons/bi"
 import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { trpc } from "~/utils/trpc"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 import type { IndexpageRowProps } from "./types"
 import { getIndexPageIcon, getIndexPageSubtitle } from "./utils"

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -38,7 +38,8 @@ import {
   MAX_TITLE_LENGTH,
 } from "~/schemas/page"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { generateResourceUrl } from "../../editing-experience/components/utils"
 

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -10,7 +10,8 @@ import {
 import { MenuItem } from "~/components/Menu"
 import { moveResourceAtom } from "~/features/editing-experience/atoms"
 import { Can } from "~/features/permissions"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { ResourceTableData } from "./types"
 import {

--- a/apps/studio/src/features/dashboard/components/RootpageRow/RootpageRow.tsx
+++ b/apps/studio/src/features/dashboard/components/RootpageRow/RootpageRow.tsx
@@ -3,7 +3,8 @@ import { Badge, BadgeLeftIcon } from "@opengovsg/design-system-react"
 import Link from "next/link"
 import { BiChevronRight, BiHomeAlt, BiSolidCircle } from "react-icons/bi"
 import { trpc } from "~/utils/trpc"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 interface RootpageRowProps {
   siteId: number

--- a/apps/studio/src/features/dashboard/types.ts
+++ b/apps/studio/src/features/dashboard/types.ts
@@ -1,4 +1,4 @@
-import type { ResourceType } from "~prisma/generated/generatedEnums"
+import type { ResourceType } from "@isomer/db"
 
 export interface DeleteResourceModalState {
   title: string

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/CreateCollectionPageWizardContext.tsx
@@ -11,7 +11,8 @@ import { useZodForm } from "~/lib/form"
 import { createCollectionPageFormSchema } from "~/schemas/page"
 import { getResourceSubpath } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 export enum CreateCollectionPageFlowStates {
   Type = "type",

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/DetailsScreen.tsx
@@ -23,7 +23,8 @@ import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 import { MAX_PAGE_URL_LENGTH, MAX_TITLE_LENGTH } from "~/schemas/page"
 import { AppGrid } from "~/templates/AppGrid"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { generateResourceUrl } from "../utils"
 import { useCreateCollectionPageWizard } from "./CreateCollectionPageWizardContext"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/PreviewLayout.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/PreviewLayout.tsx
@@ -4,7 +4,8 @@ import { format } from "date-fns"
 import { Suspense, useMemo } from "react"
 import collectionSitemap from "~/features/editing-experience/data/collectionSitemap.json"
 import { useSiteThemeCssVars } from "~/features/preview/hooks/useSiteThemeCssVars"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { PreviewIframe } from "../preview/PreviewIframe"
 import PreviewWithCustomSitemap from "../preview/PreviewWithCustomSitemap"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/TypeOptionsInput.tsx
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/TypeOptionsInput.tsx
@@ -12,7 +12,8 @@ import {
 import { Badge } from "@opengovsg/design-system-react"
 import { forwardRef, useMemo } from "react"
 import { getIcon } from "~/utils/resources"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { CollectionItemType } from "./constants"
 import { COLLECTION_ITEM_TYPES } from "./constants"

--- a/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/constants.ts
+++ b/apps/studio/src/features/editing-experience/components/CreateCollectionPageModal/constants.ts
@@ -1,4 +1,4 @@
-import { ResourceType } from "~prisma/generated/generatedEnums"
+import { ResourceType } from "@isomer/db"
 
 export const COLLECTION_ITEM_TYPES = [
   ResourceType.CollectionPage,

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -14,7 +14,8 @@ import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { pageSchema } from "../../schema"
 import {

--- a/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
@@ -12,7 +12,7 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+import { ResourceType } from "@isomer/db"
 
 import { pageSchema } from "../../schema"
 import {

--- a/apps/studio/src/features/editing-experience/components/Drawer/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/LinkEditorDrawer.tsx
@@ -12,7 +12,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { ajv } from "~/utils/ajv"
 import { safeJsonParse } from "~/utils/safeJsonParse"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { ActivateRawJsonEditorMode } from "../ActivateRawJsonEditorMode"
 import { ErrorProvider, useBuilderErrors } from "../form-builder/ErrorProvider"

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -38,7 +38,8 @@ import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsMana
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole, ResourceType } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole, ResourceType } from "@isomer/db"
 
 import { TYPE_TO_ICON } from "../../constants"
 import { pageSchema } from "../../schema"

--- a/apps/studio/src/features/editing-experience/components/Drawer/SiderailOrderingEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/SiderailOrderingEditorStateDrawer.tsx
@@ -13,7 +13,8 @@ import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { getIcon } from "~/utils/resources"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { pageSchema } from "../../schema"
 import { BaseBlock, BaseBlockDragHandle } from "../Block/BaseBlock"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
@@ -28,7 +28,7 @@ import {
 } from "react-icons/bi"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+import { IsomerAdminRole } from "@isomer/db"
 
 import { DrawerHeader } from "../../../Drawer/DrawerHeader"
 import { AddItemButton } from "../../components/AddItemButton"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -6,7 +6,7 @@ import { get } from "lodash-es"
 import { useMemo, useState } from "react"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+import { IsomerAdminRole } from "@isomer/db"
 
 import { DeleteConfirmModal } from "./DeleteConfirmModal"
 import { TagDraggableButton } from "./DraggableTagButton"

--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -4,7 +4,8 @@ import { useMemo } from "react"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { editLinkSchema } from "~/pages/sites/[siteId]/links/[linkId]"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import PreviewWithCustomSitemap from "./PreviewWithCustomSitemap"
 import { ViewportContainer } from "./ViewportContainer"

--- a/apps/studio/src/features/mail/templates/__tests__/templates.test.ts
+++ b/apps/studio/src/features/mail/templates/__tests__/templates.test.ts
@@ -1,7 +1,8 @@
 import type { Resource } from "~/server/modules/database"
 import { ISOMER_SUPPORT_EMAIL, ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { env } from "~/env.mjs"
-import { ResourceType, RoleType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType, RoleType } from "@isomer/db"
 
 import {
   accountDeactivationTemplate,

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -5,7 +5,8 @@ import { env } from "~/env.mjs"
 import { formatScheduledAtDate } from "~/lib/dates"
 import { MAX_DAYS_FROM_LAST_LOGIN } from "~/server/modules/user/constants"
 import { getStudioResourceUrl } from "~/utils/resources"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 import type {
   AccountDeactivationEmailTemplateData,

--- a/apps/studio/src/features/mail/templates/types.ts
+++ b/apps/studio/src/features/mail/templates/types.ts
@@ -1,6 +1,7 @@
 import type { Resource } from "~/server/modules/database"
 import type { BulkSendAccountDeactivationWarningEmailsProps } from "~/server/modules/user/types"
-import type { RoleType } from "~prisma/generated/generatedEnums"
+
+import type { RoleType } from "@isomer/db"
 
 export interface BaseEmailTemplateData {
   recipientEmail: string

--- a/apps/studio/src/features/me/api/isUserOnboarded.ts
+++ b/apps/studio/src/features/me/api/isUserOnboarded.ts
@@ -1,4 +1,4 @@
-import type { User } from "~prisma/generated/generatedTypes"
+import type { User } from "@isomer/db"
 
 export type isUserOnboardedProps = Pick<User, "name" | "phone">
 

--- a/apps/studio/src/features/permissions/PermissionsContext.tsx
+++ b/apps/studio/src/features/permissions/PermissionsContext.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react"
 import type { ResourceAbility } from "~/server/modules/permissions/permissions.type"
-import type { RoleType } from "~prisma/generated/generatedEnums"
+import type { RoleType } from "@isomer/db"
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
 import { AbilityProvider, Can, useAbility } from "@casl/react"
 import { buildPermissionsForResource } from "~/server/modules/permissions/permissions.util"

--- a/apps/studio/src/features/users/atoms.ts
+++ b/apps/studio/src/features/users/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 import type {
   AddUserModalState,

--- a/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
@@ -28,7 +28,8 @@ import { useZodForm } from "~/lib/form"
 import { createUserInputSchema } from "~/schemas/user"
 import { isGovEmail } from "~/utils/email"
 import { trpc } from "~/utils/trpc"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 import { addUserModalAtom, DEFAULT_ADD_USER_MODAL_STATE } from "../../atoms"
 import { SingpassConditionalTooltip } from "../SingpassConditionalTooltip"

--- a/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
@@ -23,7 +23,8 @@ import { useZodForm } from "~/lib/form"
 import { updateUserInputSchema } from "~/schemas/user"
 import { isGovEmail } from "~/utils/email"
 import { trpc } from "~/utils/trpc"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 import {
   DEFAULT_UPDATE_USER_MODAL_STATE,

--- a/apps/studio/src/features/users/components/UserPermissionModal/RoleBox.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/RoleBox.tsx
@@ -1,7 +1,8 @@
-import type { RoleType } from "~prisma/generated/generatedEnums"
 import { Icon, Text, VStack } from "@chakra-ui/react"
 import { dataAttr } from "@chakra-ui/utils"
 import { Button } from "@opengovsg/design-system-react"
+
+import type { RoleType } from "@isomer/db"
 
 import { ROLES_ICONS, ROLES_LABELS } from "./constants"
 import {

--- a/apps/studio/src/features/users/components/UserPermissionModal/constants.ts
+++ b/apps/studio/src/features/users/components/UserPermissionModal/constants.ts
@@ -1,6 +1,7 @@
 import type { IconType } from "react-icons/lib"
 import { BiCheckShield, BiPencil, BiRocket } from "react-icons/bi"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 // TODO: move this to a official isomer.gov.sg once we migrate that to Isomer Next
 export const ISOMER_GUIDE_URL =

--- a/apps/studio/src/features/users/types.ts
+++ b/apps/studio/src/features/users/types.ts
@@ -1,4 +1,4 @@
-import type { RoleType } from "~prisma/generated/generatedEnums"
+import type { RoleType } from "@isomer/db"
 
 export interface UpdateUserModalState {
   siteId: number

--- a/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
+++ b/apps/studio/src/hooks/useIsUserIsomerAdmin.ts
@@ -1,5 +1,6 @@
-import type { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 import { trpc } from "~/utils/trpc"
+
+import type { IsomerAdminRole } from "@isomer/db"
 
 interface UseIsUserIsomerAdminProps {
   roles: IsomerAdminRole[]

--- a/apps/studio/src/hooks/useSearchQuery.ts
+++ b/apps/studio/src/hooks/useSearchQuery.ts
@@ -1,8 +1,9 @@
 import type { SearchResultResource } from "~/server/modules/resource/resource.types"
-import type { ResourceType } from "~prisma/generated/generatedEnums"
 import { useDebounce } from "@uidotdev/usehooks"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { trpc } from "~/utils/trpc"
+
+import type { ResourceType } from "@isomer/db"
 
 interface UseSearchQueryProps {
   siteId: string

--- a/apps/studio/src/pages/godmode/create-site.tsx
+++ b/apps/studio/src/pages/godmode/create-site.tsx
@@ -26,7 +26,8 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { createSiteSchema } from "~/schemas/site"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 const GodModeCreateSitePage: NextPageWithLayout = () => {
   const toast = useToast()

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -12,7 +12,8 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 interface GodmodeLink {
   href: string

--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -21,7 +21,8 @@ import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 const GodModePublishingPage: NextPageWithLayout = () => {
   const toast = useToast()

--- a/apps/studio/src/pages/godmode/whitelist.tsx
+++ b/apps/studio/src/pages/godmode/whitelist.tsx
@@ -16,7 +16,8 @@ import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 const GodModeWhitelistPage: NextPageWithLayout = () => {
   const toast = useToast()

--- a/apps/studio/src/pages/sites/[siteId]/admin.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/admin.tsx
@@ -28,7 +28,8 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { setSiteConfigByAdminSchema } from "~/schemas/site"
 import { SiteBasicLayout } from "~/templates/layouts/SiteBasicLayout"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole, ResourceType } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole, ResourceType } from "@isomer/db"
 
 const siteAdminSchema = z.object({
   siteId: z.coerce.number(),

--- a/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
@@ -24,7 +24,8 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { SiteEditorLayout } from "~/templates/layouts/SiteEditorLayout"
 import { getCollectionHref } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const collectionPageSchema = z.object({
   siteId: z.coerce.number(),

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -23,7 +23,8 @@ import { type NextPageWithLayout } from "~/lib/types"
 import { SiteEditorLayout } from "~/templates/layouts/SiteEditorLayout"
 import { getFolderHref } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const folderPageSchema = z.object({
   siteId: z.string(),

--- a/apps/studio/src/pages/sites/[siteId]/gazettes/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/gazettes/index.tsx
@@ -19,7 +19,8 @@ import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { SiteMinimalLayout } from "~/templates/layouts/SiteMinimalLayout"
-import { IsomerAdminRole, ResourceType } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole, ResourceType } from "@isomer/db"
 
 export const gazettePageSchema = z.object({
   siteId: z.coerce.number(),

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -17,7 +17,8 @@ import { Can } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { SiteEditorLayout } from "~/templates/layouts/SiteEditorLayout"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 export const sitePageSchema = z.object({
   siteId: z.coerce.number(),

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -9,7 +9,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { useResourceLocalViewHistory } from "~/hooks/useResourceLocalViewHistory"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const EditPage: NextPageWithLayout = () => {
   const { pageId, siteId } = useQueryParse(pageSchema)

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/settings.tsx
@@ -17,7 +17,8 @@ import { updatePageMetaSchema } from "~/schemas/page"
 import { PageEditingLayout } from "~/templates/layouts/PageEditingLayout"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const SUCCESS_TOAST_ID = "save-page-settings-success"
 

--- a/apps/studio/src/pages/sites/[siteId]/settings/agency.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/agency.tsx
@@ -26,7 +26,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const validateFn = ajv.compile<AgencySettings>(AgencySettingsSchema)
 

--- a/apps/studio/src/pages/sites/[siteId]/settings/colours.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/colours.tsx
@@ -28,7 +28,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { siteThemeValidator } from "~/schemas/site"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const ColoursSettingsPage: NextPageWithLayout = () => {
   const { siteId: rawSiteId } = useQueryParse(siteSchema)

--- a/apps/studio/src/pages/sites/[siteId]/settings/footer.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/footer.tsx
@@ -21,7 +21,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const FooterSettingsPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteSchema)

--- a/apps/studio/src/pages/sites/[siteId]/settings/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/index.tsx
@@ -6,7 +6,8 @@ import { PermissionsBoundary } from "~/components/AuthWrappers"
 import { FullscreenSpinner } from "~/components/FullscreenSpinner"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { SiteBasicLayout } from "~/templates/layouts/SiteBasicLayout"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const siteSettingsSchema = z.object({
   siteId: z.coerce.number(),

--- a/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
@@ -36,7 +36,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 export const DEFAULT_SIMPLE_INTEGRATION_SETTINGS = Value.Parse(
   SimpleIntegrationsSettingsSchema,

--- a/apps/studio/src/pages/sites/[siteId]/settings/logo.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/logo.tsx
@@ -28,7 +28,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { logoSettingsValidator } from "~/schemas/site"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const LogoSettingsPage: NextPageWithLayout = () => {
   const { siteId: rawSiteId } = useQueryParse(siteSchema)

--- a/apps/studio/src/pages/sites/[siteId]/settings/navbar.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/navbar.tsx
@@ -22,7 +22,8 @@ import { useNavigationEffect } from "~/hooks/useNavigationEffect"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const NavbarSettingsPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteSchema)

--- a/apps/studio/src/pages/sites/[siteId]/settings/notification.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/notification.tsx
@@ -32,7 +32,8 @@ import { useQueryParse } from "~/hooks/useQueryParse"
 import { notificationValidator } from "~/schemas/site"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { trpc } from "~/utils/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const validateFn = notificationValidator
 

--- a/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
@@ -8,7 +8,8 @@ import { siteSchema } from "~/features/editing-experience/schema"
 import { useIsRedirectionsEnabled } from "~/hooks/useIsRedirectionsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const RedirectsSettingsPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteSchema)

--- a/apps/studio/src/pages/sites/[siteId]/users.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/users.tsx
@@ -14,7 +14,8 @@ import { CollaboratorsDescription } from "~/features/users/components/Collaborat
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { type NextPageWithLayout } from "~/lib/types"
 import { SiteBasicLayout } from "~/templates/layouts/SiteBasicLayout"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 const siteUsersSchema = z.object({
   siteId: z.coerce.number(),

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -3,7 +3,8 @@ import { schema } from "@opengovsg/isomer-components"
 import { z } from "zod"
 import { ajv } from "~/utils/ajv"
 import { safeJsonParse } from "~/utils/safeJsonParse"
-import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceState, ResourceType } from "@isomer/db"
 
 import { generateBasePermalinkSchema } from "./common"
 

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { SearchResultResource } from "../server/modules/resource/resource.types"
 import {

--- a/apps/studio/src/schemas/user.ts
+++ b/apps/studio/src/schemas/user.ts
@@ -1,6 +1,7 @@
 import { createEmailSchema } from "@opengovsg/starter-kitty-validators/email"
 import { z } from "zod"
-import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole, RoleType } from "@isomer/db"
 
 import { offsetPaginationSchema } from "./pagination"
 

--- a/apps/studio/src/schemas/webhook.ts
+++ b/apps/studio/src/schemas/webhook.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
-import { BuildStatusType } from "~prisma/generated/generatedEnums"
+
+import { BuildStatusType } from "@isomer/db"
 
 /**
  * Extract the build ID from the ARN string. When eventbridge sends the ARN,

--- a/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
+++ b/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
@@ -1,4 +1,3 @@
-import type { User } from "~prisma/generated/selectableTypes"
 import { addMinutes } from "date-fns"
 import MockDate from "mockdate"
 import { resetTables } from "tests/integration/helpers/db"
@@ -6,8 +5,10 @@ import { applyAuthedSession } from "tests/integration/helpers/iron-session"
 import { setupPageResource, setupUser } from "tests/integration/helpers/seed"
 import * as s3Lib from "~/lib/s3"
 import * as gazetteService from "~/server/modules/gazette/gazette.service"
-import { ResourceType } from "~prisma/generated/generatedEnums"
 import { db } from "~server/db"
+
+import type { User } from "@isomer/db"
+import { ResourceType } from "@isomer/db"
 
 import { schedulePushDocumentJobHandler } from "../schedulePushDocumentJob"
 

--- a/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
+++ b/apps/studio/src/server/modules/asset/__tests__/asset.router.test.ts
@@ -16,7 +16,8 @@ import {
 import { vi } from "vitest"
 import { deleteFile, generateSignedPutUrl, putObjectDirect } from "~/lib/s3"
 import { createCallerFactory } from "~/server/trpc"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { assetRouter } from "../asset.router"
 

--- a/apps/studio/src/server/modules/auth/auth.router.ts
+++ b/apps/studio/src/server/modules/auth/auth.router.ts
@@ -1,7 +1,8 @@
 import { TRPCError } from "@trpc/server"
 import { publicProcedure, router } from "~/server/trpc"
 import getIP from "~/utils/getClientIp"
-import { AuditLogEvent } from "~prisma/generated/generatedEnums"
+
+import { AuditLogEvent } from "@isomer/db"
 
 import { logAuthEvent } from "../audit/audit.service"
 import { db } from "../database"

--- a/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
+++ b/apps/studio/src/server/modules/auth/singpass/singpass.router.ts
@@ -7,7 +7,8 @@ import {
   singpassLoginSchema,
 } from "~/schemas/auth/singpass"
 import { publicProcedure, router } from "~/server/trpc"
-import { AuditLogEvent } from "~prisma/generated/generatedEnums"
+
+import { AuditLogEvent } from "@isomer/db"
 
 import { logUserEvent } from "../../audit/audit.service"
 import { recordUserLogin } from "../auth.service"

--- a/apps/studio/src/server/modules/folder/folder.select.ts
+++ b/apps/studio/src/server/modules/folder/folder.select.ts
@@ -1,5 +1,6 @@
 import type { SelectExpression } from "kysely"
-import type { DB } from "~prisma/generated/generatedTypes"
+
+import type { DB } from "@isomer/db"
 
 export const defaultFolderSelect = [
   "id",

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -20,11 +20,8 @@ import { env } from "~/env.mjs"
 import * as mailService from "~/features/mail/service"
 import * as s3Lib from "~/lib/s3"
 import { createCallerFactory } from "~/server/trpc"
-import {
-  AuditLogEvent,
-  IsomerAdminRole,
-  ResourceType,
-} from "~prisma/generated/generatedEnums"
+
+import { AuditLogEvent, IsomerAdminRole, ResourceType } from "@isomer/db"
 
 import { db } from "../../database"
 import { gazetteRouter } from "../gazette.router"

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.service.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.service.test.ts
@@ -3,7 +3,8 @@ import { resetTables } from "tests/integration/helpers/db"
 import { setupIsomerAdmin, setupUser } from "tests/integration/helpers/seed"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import * as s3Lib from "~/lib/s3"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import {
   assertGazetteAccess,

--- a/apps/studio/src/server/modules/gazette/gazette.service.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.service.ts
@@ -11,8 +11,9 @@ import {
   generateSignedGetUrl,
   generateSignedPutUrl,
 } from "~/lib/s3"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
-import { type DB } from "~prisma/generated/generatedTypes"
+
+import { IsomerAdminRole } from "@isomer/db"
+import { type DB } from "@isomer/db"
 
 import {
   generateTagsQueryString,

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -23,11 +23,8 @@ import {
   setupUser,
 } from "tests/integration/helpers/seed"
 import { createCallerFactory } from "~/server/trpc"
-import {
-  AuditLogEvent,
-  ResourceState,
-  ResourceType,
-} from "~prisma/generated/generatedEnums"
+
+import { AuditLogEvent, ResourceState, ResourceType } from "@isomer/db"
 
 import type { User } from "../../database"
 import { assertAuditLogRows } from "../../audit/__tests__/utils"

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -39,11 +39,8 @@ import { scheduledPublishServerSchema } from "~/schemas/schedule"
 import { protectedProcedure, router } from "~/server/trpc"
 import { ajv } from "~/utils/ajv"
 import { safeJsonParse } from "~/utils/safeJsonParse"
-import {
-  AuditLogEvent,
-  ResourceState,
-  ResourceType,
-} from "~prisma/generated/generatedEnums"
+
+import { AuditLogEvent, ResourceState, ResourceType } from "@isomer/db"
 
 import { logResourceEvent } from "../audit/audit.service"
 import { alertPublishWhenSingpassDisabled } from "../auth/email/email.service"

--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -12,7 +12,8 @@ import {
   setupUser,
 } from "tests/integration/helpers/seed"
 import { describe, expect, it } from "vitest"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import type { ResourceAbility } from "../permissions.type"
 import { db, ResourceType, RoleType } from "../../database"

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -1,8 +1,9 @@
-import type { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
 import { TRPCError } from "@trpc/server"
 import { get, partition } from "lodash-es"
-import { AuditLogEvent, RoleType } from "~prisma/generated/generatedEnums"
+
+import type { IsomerAdminRole } from "@isomer/db"
+import { AuditLogEvent, RoleType } from "@isomer/db"
 
 import type {
   BulkPermissionsProps,

--- a/apps/studio/src/server/modules/permissions/permissions.util.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.util.ts
@@ -1,6 +1,7 @@
 import type { UserManagementAbility } from "~/server/modules/permissions/permissions.type"
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 import type { ResourceAbility } from "./permissions.type"
 import { ALL_ACTIONS, CRUD_ACTIONS } from "./permissions.type"

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -27,7 +27,8 @@ import {
   searchWithResourceIdsSchema,
 } from "~/schemas/resource"
 import { protectedProcedure, router } from "~/server/trpc"
-import { AuditLogEvent } from "~prisma/generated/generatedEnums"
+
+import { AuditLogEvent } from "@isomer/db"
 
 import type { PermissionsProps } from "../permissions/permissions.type"
 import { logResourceEvent } from "../audit/audit.service"

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -14,10 +14,10 @@ import {
   isCollectionItem,
   overwriteCollectionChildrenForCollectionBlock,
 } from "~/utils/sitemap"
-import { AuditLogEvent } from "~prisma/generated/generatedEnums"
-import { type DB } from "~prisma/generated/generatedTypes"
 
 import type { Logger } from "@isomer/logging"
+import { AuditLogEvent } from "@isomer/db"
+import { type DB } from "@isomer/db"
 
 import type {
   Footer,

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -19,7 +19,8 @@ import {
 } from "tests/integration/helpers/seed"
 import * as searchSgService from "~/server/modules/searchsg/searchsg.service"
 import { createCallerFactory } from "~/server/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import type { User } from "../../database"
 import { AuditLogEvent, db, jsonb, ResourceType } from "../../database"

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -21,7 +21,8 @@ import {
 } from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
 import { safeJsonParse } from "~/utils/safeJsonParse"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { logConfigEvent, logPublishEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"

--- a/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/inactiveUsers.service.test.ts
@@ -14,7 +14,8 @@ import {
 } from "~/features/mail/service"
 import { db } from "~/server/modules/database"
 import { RoleType } from "~/server/modules/database/types"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { MAX_DAYS_FROM_LAST_LOGIN } from "../constants"
 

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -22,7 +22,8 @@ import {
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { db, jsonb, RoleType } from "~/server/modules/database"
 import { createCallerFactory } from "~/server/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { userRouter } from "../user.router"
 import { isomerAdminsCount, setupIsomerAdmins } from "./utils"

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -9,7 +9,8 @@ import {
 } from "tests/integration/helpers/seed"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 import { db } from "~/server/modules/database"
-import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RoleType } from "@isomer/db"
 
 import { createUserWithPermission, isUserDeleted } from "../user.service"
 

--- a/apps/studio/src/server/modules/user/__tests__/utils.ts
+++ b/apps/studio/src/server/modules/user/__tests__/utils.ts
@@ -2,8 +2,9 @@ import {
   setupAdminPermissions,
   setupUser,
 } from "tests/integration/helpers/seed"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 import { db } from "~server/db"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 const ISOMER_ADMIN_TEST_EMAILS = [
   "admin1@open.gov.sg",

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -1,10 +1,11 @@
 import type { AdminType } from "~/schemas/user"
-import type { ResourcePermission, User } from "~prisma/generated/generatedTypes"
 import { createId } from "@paralleldrive/cuid2"
 import { TRPCError } from "@trpc/server"
 import isEmail from "validator/lib/isEmail"
 import { isGovEmail } from "~/utils/email"
-import { AuditLogEvent } from "~prisma/generated/generatedEnums"
+
+import type { ResourcePermission, User } from "@isomer/db"
+import { AuditLogEvent } from "@isomer/db"
 
 import type { DB, Transaction } from "../database"
 import { logPermissionEvent, logUserEvent } from "../audit/audit.service"

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -1,7 +1,8 @@
 import type { SelectExpression } from "kysely"
 import { TRPCError } from "@trpc/server"
-import { ResourceState } from "~prisma/generated/generatedEnums"
-import { type DB } from "~prisma/generated/generatedTypes"
+
+import { ResourceState } from "@isomer/db"
+import { type DB } from "@isomer/db"
 
 import type { SafeKysely, Transaction } from "../database"
 import { db } from "../database"

--- a/apps/studio/src/server/modules/whitelist/__tests__/whitelist.router.test.ts
+++ b/apps/studio/src/server/modules/whitelist/__tests__/whitelist.router.test.ts
@@ -15,7 +15,8 @@ import {
   setUpWhitelist,
 } from "tests/integration/helpers/seed"
 import { createCallerFactory } from "~/server/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import type { User } from "../../database"
 import { db } from "../../database"

--- a/apps/studio/src/server/modules/whitelist/whitelist.router.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.router.ts
@@ -3,7 +3,8 @@ import {
   isEmailWhitelistedOutputSchema,
   whitelistEmailsInputSchema,
 } from "~/schemas/whitelist"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+
+import { IsomerAdminRole } from "@isomer/db"
 
 import { protectedProcedure, router } from "../../trpc"
 import {

--- a/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditArticlePage.stories.tsx
@@ -9,7 +9,8 @@ import {
   createBannerGbParameters,
   createDropdownGbParameters,
 } from "~/stories/utils/growthbook"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -8,7 +8,8 @@ import { userHandlers } from "tests/msw/handlers/user"
 import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
@@ -10,7 +10,8 @@ import {
   createBannerGbParameters,
   createDropdownGbParameters,
 } from "~/stories/utils/growthbook"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -6,7 +6,8 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),

--- a/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditHomePage.stories.tsx
@@ -9,7 +9,8 @@ import {
   createAntiScamBannerEnabledGbParameters,
   createBannerGbParameters,
 } from "~/stories/utils/growthbook"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),

--- a/apps/studio/src/stories/Page/EditPage/EditIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditIndexPage.stories.tsx
@@ -7,7 +7,8 @@ import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
-import { ResourceState } from "~prisma/generated/generatedEnums"
+
+import { ResourceState } from "@isomer/db"
 
 const COMMON_HANDLERS = [
   meHandlers.me(),

--- a/apps/studio/src/utils/resource.ts
+++ b/apps/studio/src/utils/resource.ts
@@ -1,4 +1,4 @@
-import { ResourceType } from "~prisma/generated/generatedEnums"
+import { ResourceType } from "@isomer/db"
 
 // Gets the Studio URL subpath for a given resource type
 export const getResourceSubpath = (resourceType: ResourceType) => {

--- a/apps/studio/src/utils/resources.ts
+++ b/apps/studio/src/utils/resources.ts
@@ -10,7 +10,8 @@ import {
   BiSort,
 } from "react-icons/bi"
 import { env } from "~/env.mjs"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 export const isAllowedToHaveChildren = (
   resourceType: ResourceType,

--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -6,7 +6,6 @@ import type {
   IsomerSitemap,
   LinkRefPageProps,
 } from "@opengovsg/isomer-components"
-import type { Resource } from "~prisma/generated/selectableTypes"
 import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
 import { env } from "~/env.mjs"
@@ -15,7 +14,9 @@ import {
   getBlobOfResource,
   getPublishedIndexBlobByParentId,
 } from "~/server/modules/resource/resource.service"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import type { Resource } from "@isomer/db"
+import { ResourceType } from "@isomer/db"
 
 type ResourceDto = Omit<
   Resource,

--- a/apps/studio/tests/integration/helpers/seed/index.ts
+++ b/apps/studio/tests/integration/helpers/seed/index.ts
@@ -4,13 +4,14 @@ import { nanoid } from "nanoid"
 import { INDEX_PAGE_PERMALINK } from "src/constants/sitemap"
 import { MOCK_STORY_DATE } from "tests/msw/constants"
 import { buildIdFromArn } from "~/schemas/webhook"
+import { db, jsonb } from "~server/db"
+
 import {
   IsomerAdminRole,
   ResourceState,
   ResourceType,
   RoleType,
-} from "~prisma/generated/generatedEnums"
-import { db, jsonb } from "~server/db"
+} from "@isomer/db"
 
 interface SetupPermissionsProps {
   userId?: string

--- a/apps/studio/tests/msw/handlers/collection.ts
+++ b/apps/studio/tests/msw/handlers/collection.ts
@@ -1,4 +1,4 @@
-import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+import { ResourceState, ResourceType } from "@isomer/db"
 
 import { MOCK_STORY_DATE } from "../constants"
 import { trpcMsw } from "../mockTrpc"

--- a/apps/studio/tests/msw/handlers/gazette.ts
+++ b/apps/studio/tests/msw/handlers/gazette.ts
@@ -3,7 +3,7 @@ import {
   GAZETTE_SUBCATEGORY_LABEL,
   governmentGazetteSubcategories,
 } from "~/features/gazettes/constants"
-import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+import { ResourceState, ResourceType } from "@isomer/db"
 
 import { MOCK_STORY_DATE } from "../constants"
 import { trpcMsw } from "../mockTrpc"

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -2,7 +2,8 @@ import type { DelayMode } from "msw"
 import type { getPageById } from "~/server/modules/resource/resource.service"
 import type { RouterOutput } from "~/utils/trpc"
 import { delay } from "msw"
-import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import { trpcMsw } from "../mockTrpc"
 

--- a/apps/studio/tests/msw/handlers/user.ts
+++ b/apps/studio/tests/msw/handlers/user.ts
@@ -1,4 +1,4 @@
-import { RoleType } from "~prisma/generated/generatedEnums"
+import { RoleType } from "@isomer/db"
 
 import { trpcMsw } from "../mockTrpc"
 

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -21,7 +21,6 @@
       "~prisma/generated/prisma/*": [
         "../../packages/db/prisma/generated/prisma/*"
       ],
-      "~prisma/generated/*": ["../../packages/db/src/generated/*"],
       "~server/db/*": ["./src/server/modules/database/*"],
       "~server/db": ["./src/server/modules/database/index"],
       "tests/*": ["./tests/*"],


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

PR #2287 relocated the generated Kysely types/enums into `@isomer/db` but kept a `~prisma/generated/*` tsconfig path alias in `apps/studio` as a compatibility shim, so studio's ~115 type-only imports kept resolving without touching 100+ files in that PR. This PR is the mechanical cleanup that removes the shim, making `@isomer/db` the single, explicit import source for DB types in studio.

Part of the `@isomer/db` extraction effort (follow-up to #2284–#2287).

Closes N/A (internal refactor)

## Solution

<!-- How did you solve the problem? -->

- Rewrote every `~prisma/generated/generatedEnums`, `~prisma/generated/generatedTypes`, and `~prisma/generated/selectableTypes` import across 109 studio files to import from `@isomer/db` (which already re-exports the `DB` type, `Model` namespace, every enum, the selectable types, and `sql`).
- Dropped the `~prisma/generated/*` alias from `apps/studio/tsconfig.json`. The unrelated `~prisma/generated/prisma/*` alias (the Prisma 7 runtime client path) is intentionally left in place.

**Behavioural note (no runtime change):** two files (`features/me/api/isUserOnboarded.ts`, `server/modules/user/user.service.ts`) previously imported `User`/`ResourcePermission` from `generatedTypes` (the insertable shape) and now resolve to the `Selectable<T>` shape. Both only use those types for property-key indexing (`User["email"]`, `ResourcePermission["role"]`, etc.), which is identical between the two shapes — so the rewrite is a pure no-op at runtime.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- `@isomer/db` is now the single, explicit import source for generated DB types in studio; the cross-package `~prisma/generated/*` alias shim is gone.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- No UI change. -->

**AFTER**:

<!-- No UI change. -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

- [ ] `pnpm --filter isomer-studio typecheck` passes
- [ ] `pnpm --filter isomer-studio lint` reports no new errors
- [ ] `pnpm --filter isomer-studio test:unit` passes with no new failures
- [ ] `pnpm --filter isomer-studio build` succeeds
- [ ] Sanity: `grep -rn "~prisma/generated/[^p]" apps/studio` returns no matches (the `[^p]` keeps the still-aliased `prisma/` client path out)

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
