### PR TITLE
fix(docker): fix pnpm 11.x global bin path and turbo lockfile parse error

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -37,9 +37,9 @@ RUN apk add --no-cache libc6-compat
 
 # Set working directory
 WORKDIR /app
-# pnpm global bin is under PNPM_HOME (not on PATH by default); npm's -g used /usr/local/bin.
+# pnpm global bin is under PNPM_HOME/bin (not on PATH by default); npm's -g used /usr/local/bin.
 ENV PNPM_HOME="/pnpm"
-ENV PATH="$PNPM_HOME:$PATH"
+ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable && corepack install -g pnpm@11.5.1
 # fixed version to prevent supply chain attacks (to ensure it's same version as pnpm-workspace.yaml)
 RUN pnpm add -g turbo@2.9.6

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -42,7 +42,7 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME/bin:$PATH"
 RUN corepack enable && corepack install -g pnpm@11.5.1
 # fixed version to prevent supply chain attacks (to ensure it's same version as pnpm-workspace.yaml)
-RUN pnpm add -g turbo@2.9.6
+RUN pnpm add -g turbo@2.9.16
 COPY . .
 
 # Generate a partial monorepo with a pruned lockfile for a target workspace.


### PR DESCRIPTION
## Problem

Docker builds were failing in two sequential steps:

1. `pnpm add -g turbo@2.9.6` failed with: \`The configured global bin directory "/pnpm/bin" is not in PATH\`
2. After fixing (1), `turbo prune isomer-studio --docker` failed with: \`Could not resolve workspaces — patchedDependencies.next@16.2.6: invalid type: string, expected struct PatchFile\`

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Fixed Docker build failure: pnpm 11.x places global binaries at `$PNPM_HOME/bin` (not `$PNPM_HOME`), so updated `PATH` accordingly
- Fixed Docker build failure: turbo 2.9.6 cannot parse the current pnpm lockfile's `patchedDependencies` format; bumped pinned turbo version in Dockerfile from `2.9.6` to `2.9.16` to match the workspace catalog

## Before & After Screenshots

N/A — CI/CD pipeline fix only.

## Tests

No manual verification steps required — this is a CI/CD config fix with no production code changes.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A