### PR TITLE
fix(ci): add missing review-pr skill and update actions/checkout to v6.0.2

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: review-pr
+description: Review the current pull request as a senior engineer — security, correctness, maintainability — and post a structured review comment to the PR. Does not approve or merge.
+---
+
+# Instructions
+
+Review the current pull request with the eye of a senior engineer doing a thorough code review. Post one structured comment to the PR via `gh pr comment`. Never approve, request changes via the GitHub review API, or merge.
+
+## Inputs
+
+- The current branch's diff against `main`.
+- All `CLAUDE.md` files under directories touched by the diff.
+- `docs/risk-taxonomy.md` if it exists — use it to gauge risk tier.
+
+## Procedure
+
+1. **Get the diff.** Run `git diff origin/main...HEAD` to see all changes. If on `main` or the diff is empty, post a comment saying there is nothing to review and exit.
+2. **Read context.** For each directory touched by the diff, read any `CLAUDE.md` present.
+3. **Review across four lenses:**
+   - **Correctness** — bugs, off-by-ones, unhandled edge cases, incorrect logic.
+   - **Security** — injection risks, unvalidated inputs at system boundaries, exposed secrets, broken auth/authz.
+   - **Maintainability** — naming clarity, unnecessary complexity, missing or misleading comments, test coverage gaps.
+   - **Conventions** — violations of rules documented in `CLAUDE.md` files in the touched directories.
+4. **Post the review comment** using `gh pr comment --body "..."` on the current PR number (derive from `gh pr view --json number -q .number`).
+
+## Output format
+
+```markdown
+## 🔍 Code Review
+
+### Summary
+<1–3 sentence overall assessment>
+
+### Findings
+
+| Severity | Location | Finding |
+|----------|----------|---------|
+| 🔴 Critical | `path/to/file.ts:42` | <description> |
+| 🟡 Warning  | `path/to/file.ts:88` | <description> |
+| 🔵 Nit      | `path/to/file.ts:12` | <description> |
+
+*(omit table entirely if no findings)*
+
+### Positive observations
+- <what was done well — omit section if nothing notable>
+
+### Suggested follow-ups
+- <optional improvements beyond the scope of this PR — omit if none>
+```
+
+Severity guide:
+- 🔴 Critical — correctness bug, security vulnerability, or convention violation that must be fixed before merge.
+- 🟡 Warning — likely problem or significant maintainability concern; strongly recommended to fix.
+- 🔵 Nit — minor style or clarity issue; author's discretion.
+
+## Hard rules
+
+- **Never approve, never request changes via the GitHub review API, never merge.**
+- **Cite `file:line` for every finding.** Vague findings are worse than no findings.
+- **Do not summarise the diff.** The PR description does that. Focus on what could go wrong.
+- **Only flag things grounded in the diff or a `CLAUDE.md` rule.** No speculative concerns.
+- **Keep each finding under two lines.**

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
## Problem

Two issues in the Claude Code GitHub Actions setup:

1. `@claude /review-pr` on PRs produced `num_turns: 0` (Claude exited immediately without doing anything) — the `review-pr` skill did not exist. The existing `pr-review` skill itself references `review-pr` as the intended human sign-off variant, so the skill was always meant to exist but was never created.

2. `actions/checkout` in `claude.yml` was pinned to `v4` (Node.js 20), while every other workflow in the repo already uses `v6.0.2`. Node.js 20 runners are deprecated on GitHub Actions as of June 16, 2026.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Created `.claude/skills/review-pr/SKILL.md` — a senior-engineer-style code review skill that posts a structured finding table to the PR. This is what `@claude /review-pr` now invokes.
- Updated `actions/checkout` in `.github/workflows/claude.yml` from `v4` (SHA `34e114876b`) to `v6.0.2` (SHA `de0fac2e45`), consistent with all other workflows.

## Before & After Screenshots

N/A — CI config and skill definition only.

## Tests

No manual verification steps required — CI/CD config and skill definition changes with no production code impact.

**New scripts**: N/A

**New dependencies**: N/A

**New dev dependencies**: N/A