### PR TITLE
fix: remove .tiff from IMAGE_ACCEPTED_MIME_TYPE_MAPPING

### DIFF
--- a/packages/components/src/constants/image.ts
+++ b/packages/components/src/constants/image.ts
@@ -4,7 +4,6 @@ export const IMAGE_ACCEPTED_MIME_TYPE_MAPPING: Record<string, string> = {
   ".png": "image/png",
   ".gif": "image/gif",
   ".svg": "image/svg+xml",
-  ".tiff": "image/tiff",
   ".bmp": "image/bmp",
   ".webp": "image/webp",
   ".avif": "image/avif",


### PR DESCRIPTION
Removes `.tiff` (`image/tiff`) from `IMAGE_ACCEPTED_MIME_TYPE_MAPPING`. TIFF is not renderable in `<img>` tags by Chrome, Firefox, or Edge, so allowing uploads produced broken images on published sites for most visitors.

Fixes #2393

Generated with [Claude Code](https://claude.ai/code)