### PR TITLE
fix: reduce permalink length to 250 characters

### DIFF
--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -4,7 +4,9 @@ import { generateBasePermalinkSchema } from "./common"
 import { offsetPaginationSchema } from "./pagination"
 
 export const MAX_FOLDER_TITLE_LENGTH = 250
-export const MAX_FOLDER_PERMALINK_LENGTH = 500
+// NOTE: 250 characters is the hard limit, and we want to be consistent with
+// page permalink length limit
+export const MAX_FOLDER_PERMALINK_LENGTH = 250
 
 const permalinkSchema = generateBasePermalinkSchema("folder")
   .min(1, { message: "Enter a URL for this folder" })

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -16,7 +16,9 @@ export const NEW_PAGE_LAYOUT_VALUES = [
 ] as const satisfies readonly PrismaJson.BlobJsonContent["layout"][]
 
 export const MAX_TITLE_LENGTH = 250
-export const MAX_PAGE_URL_LENGTH = 500
+// NOTE: 250 characters is the hard limit as file names have a max limit of 255
+// characters, and the file name includes ".json" suffix
+export const MAX_PAGE_URL_LENGTH = 250
 
 const pageTitleSchema = z
   .string({


### PR DESCRIPTION
## Problem

Pages and folders currently allow permalinks of up to 500 characters. However, published pages are stored as files named after their permalink with a `.json` suffix, and file names have a hard limit of 255 characters. A permalink longer than ~250 characters would therefore produce a file name that exceeds the file system limit and break publishing for that page.

## Solution

Reduce the maximum permalink length for both pages and folders from 500 to 250 characters:

- `MAX_PAGE_URL_LENGTH` (apps/studio/src/schemas/page.ts): 500 → 250, since the page file name is the permalink plus a `.json` suffix and must stay within the 255-character file name limit
- `MAX_FOLDER_PERMALINK_LENGTH` (apps/studio/src/schemas/folder.ts): 500 → 250, to stay consistent with the page permalink limit (this is also re-used by collections via `apps/studio/src/schemas/collection.ts`)

These constants drive both the server-side Zod validation and the client-side `maxLength`/characters-left counters in the page, folder, and collection create/settings modals, so the new limit is enforced consistently across Studio.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

Note: any existing page or folder with a permalink longer than 250 characters will fail validation the next time its settings are saved. No data migration is performed by this PR.

**Bug Fixes**:

- Prevent users from creating page, folder, or collection permalinks longer than 250 characters, which would result in file names exceeding the 255-character file name limit

## Before & After Screenshots

**BEFORE**:

The permalink input in the create/settings modals accepts up to 500 characters.

**AFTER**:

The permalink input in the create/settings modals accepts up to 250 characters, with the characters-left counter reflecting the new limit.

## Tests

**Manual Verification Steps**:

- [ ] Log in to Studio and navigate to any site
- [ ] Create a new page and confirm the page URL field stops accepting input at 250 characters, with the "characters left" counter starting from 250
- [ ] Create a new folder and confirm the folder URL field is similarly capped at 250 characters
- [ ] Create a new collection and confirm the collection URL field is similarly capped at 250 characters
- [ ] Open an existing page's settings, attempt to set a permalink of exactly 250 characters, and confirm it saves successfully
- [ ] Confirm that a page created with a long (~250 character) permalink can still be published successfully
