### PR TITLE
[DO NOT MERGE] feat: migrate redirects from infra to database table

### DIFF
--- a/apps/studio/prisma/scripts/README.md
+++ b/apps/studio/prisma/scripts/README.md
@@ -30,10 +30,11 @@
 1. This script imports rows from a `domainName,source,target` CSV (e.g. `redirects.production.csv` in isomer-next-infra) into the `Redirect` table
 2. Domains are matched against `Site.config.url`; rows for unmatched domains are skipped and reported
 3. Rows with wildcards (`*`) or query parameters (`?`) in the source or target are ignored — these are infra publishing features with no equivalent in the `Redirect` table
-4. Rows are validated with `createRedirectSchema` (same as the Studio publish flow); invalid rows are skipped and reported
+4. Rows are validated with a deliberately lenient subset of `createRedirectSchema` — this is a migration of legacy redirects, so it preserves as many existing rules as possible rather than enforcing Studio's stricter rules (reserved prefixes, source character whitelist, lowercasing, self-redirect rejection) on data that predates them. Only rows that would corrupt the published output (control chars, backslashes, `..`, non-path/`https` destinations) are skipped and reported; Studio's full validation still applies to anything created or edited through the UI afterwards
 5. Internal destinations that resolve to a live page (or a folder/collection with a published index page) are converted to the `[resource:siteId:resourceId]` reference format, matching how Studio stores internal destinations so the redirect follows the page if its permalink later changes. External `https://` URLs are stored verbatim; an internal path with no matching live page is kept as a literal path and surfaced for review
 6. Edit the `csvPath` at the end of the script. It runs as a dry run by default — review the reported summary, then set `dryRun` to `false` to write
 7. The import is idempotent: re-running updates destinations in place via the `(siteId, source)` unique constraint
+8. A real (non-dry-run) import also writes the rows it migrated to `output/migrated-redirects.csv` (a `domainName,source,target` CSV, with each target set to the Location the published redirect should emit). Feed this file to the verification script below to check exactly the migrated redirects
 
 ## Verify redirects against the live site
 
@@ -41,7 +42,7 @@ Run this **after** the imported redirects have been published, to confirm each l
 
 1. It reads the same `domainName,source,target` CSV used for the import, then for each row requests `https://<domain>/<source>` (with a browser `User-Agent` so the WAF doesn't block the probe) and checks the response is a `301`. The `Location` is also compared against the CSV target and a mismatch is reported as a softer finding. Wildcard / query-parameter rows are skipped, since they aren't imported
 2. Edit the props at the end of the script:
-   - `csvPath` — path to the same CSV used for the import
+   - `csvPath` — path to the CSV to verify; prefer `output/migrated-redirects.csv` written by the import (exactly the migrated rows, targets set to the expected Location). The original infra CSV also works but reports un-migrated domains as failures
    - `domainFilter` — verify a single domain (bare hostname), or leave empty for every domain in the CSV
    - `sampleSize` — per-domain cap for a quick check, or `0` to probe every redirect
    - `concurrency`, `timeoutMs`, `expectedStatus` — request tuning (defaults: 10, 10s, 301)

--- a/apps/studio/prisma/scripts/README.md
+++ b/apps/studio/prisma/scripts/README.md
@@ -31,5 +31,6 @@
 2. Domains are matched against `Site.config.url`; rows for unmatched domains are skipped and reported
 3. Rows with wildcards (`*`) or query parameters (`?`) in the source or target are ignored — these are infra publishing features with no equivalent in the `Redirect` table
 4. Rows are validated with `createRedirectSchema` (same as the Studio publish flow); invalid rows are skipped and reported
-5. Edit the `csvPath` at the end of the script. It runs as a dry run by default — review the reported summary, then set `dryRun` to `false` to write
-6. The import is idempotent: re-running updates destinations in place via the `(siteId, source)` unique constraint
+5. Internal destinations that resolve to a live page (or a folder/collection with a published index page) are converted to the `[resource:siteId:resourceId]` reference format, matching how Studio stores internal destinations so the redirect follows the page if its permalink later changes. External `https://` URLs are stored verbatim; an internal path with no matching live page is kept as a literal path and surfaced for review
+6. Edit the `csvPath` at the end of the script. It runs as a dry run by default — review the reported summary, then set `dryRun` to `false` to write
+7. The import is idempotent: re-running updates destinations in place via the `(siteId, source)` unique constraint

--- a/apps/studio/prisma/scripts/README.md
+++ b/apps/studio/prisma/scripts/README.md
@@ -34,3 +34,18 @@
 5. Internal destinations that resolve to a live page (or a folder/collection with a published index page) are converted to the `[resource:siteId:resourceId]` reference format, matching how Studio stores internal destinations so the redirect follows the page if its permalink later changes. External `https://` URLs are stored verbatim; an internal path with no matching live page is kept as a literal path and surfaced for review
 6. Edit the `csvPath` at the end of the script. It runs as a dry run by default — review the reported summary, then set `dryRun` to `false` to write
 7. The import is idempotent: re-running updates destinations in place via the `(siteId, source)` unique constraint
+
+## Verify redirects against the live site
+
+Run this **after** the imported redirects have been published, to confirm each legacy rule actually returns a 301 from CloudFront. Run it against staging first. This script needs no database — it reads the original CSV directly.
+
+1. It reads the same `domainName,source,target` CSV used for the import, then for each row requests `https://<domain>/<source>` (with a browser `User-Agent` so the WAF doesn't block the probe) and checks the response is a `301`. The `Location` is also compared against the CSV target and a mismatch is reported as a softer finding. Wildcard / query-parameter rows are skipped, since they aren't imported
+2. Edit the props at the end of the script:
+   - `csvPath` — path to the same CSV used for the import
+   - `domainFilter` — verify a single domain (bare hostname), or leave empty for every domain in the CSV
+   - `sampleSize` — per-domain cap for a quick check, or `0` to probe every redirect
+   - `concurrency`, `timeoutMs`, `expectedStatus` — request tuning (defaults: 10, 10s, 301)
+3. It runs as a dry run by default — this only counts how many redirects would be probed per domain. Set `dryRun` to `false` to make the requests
+4. Results are summarised by outcome (OK / wrong status / wrong location / error); any failures are also written to `output/redirect-verification-failures.csv` for review
+
+> Note: the CSV includes domains that may not be on Studio yet (not imported); without the database the script can't filter those out, so they will show up as failures. Use `domainFilter` to verify migrated sites one at a time.

--- a/apps/studio/prisma/scripts/README.md
+++ b/apps/studio/prisma/scripts/README.md
@@ -24,3 +24,12 @@
 
 1. This script updates all users of a site to have a specific `RoleType`
 2. Edit the `siteId` and `role` at the end of the script
+
+## Import redirects from CSV
+
+1. This script imports rows from a `domainName,source,target` CSV (e.g. `redirects.production.csv` in isomer-next-infra) into the `Redirect` table
+2. Domains are matched against `Site.config.url`; rows for unmatched domains are skipped and reported
+3. Rows with wildcards (`*`) or query parameters (`?`) in the source or target are ignored — these are infra publishing features with no equivalent in the `Redirect` table
+4. Rows are validated with `createRedirectSchema` (same as the Studio publish flow); invalid rows are skipped and reported
+5. Edit the `csvPath` at the end of the script. It runs as a dry run by default — review the reported summary, then set `dryRun` to `false` to write
+6. The import is idempotent: re-running updates destinations in place via the `(siteId, source)` unique constraint

--- a/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
@@ -174,6 +174,54 @@ describe("importRedirectsFromCsv", () => {
     expect(summary.unresolvedDestinations).toHaveLength(1)
   })
 
+  it("writes the migrated rows to migratedCsvPath with the expected Location as target", async () => {
+    // Arrange — one external, one reference (live page), one literal (no page)
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const user = await setupUser({ email: "import-migrated@open.gov.sg" })
+    await setupPageResource({
+      siteId,
+      resourceType: ResourceType.Page,
+      permalink: "new-page",
+      parentId: null,
+      state: ResourceState.Published,
+      userId: user.id,
+    })
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/ext,https://example.gov.sg/page",
+      "www.alpha.gov.sg,/old-page,/New-Page",
+      "www.alpha.gov.sg,/gone,/missing-page",
+    ])
+    const migratedCsvPath = path.join(tmpDir, "migrated.csv")
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: false, migratedCsvPath })
+
+    // Assert — header plus a row per migrated redirect; the reference target is
+    // the resolved (lowercased) permalink, not the [resource:...] reference
+    const lines = fs.readFileSync(migratedCsvPath, "utf8").trim().split(/\r?\n/)
+    expect(lines[0]).toBe("domainName,source,target")
+    expect(lines.slice(1).sort()).toEqual(
+      [
+        "www.alpha.gov.sg,/ext,https://example.gov.sg/page",
+        "www.alpha.gov.sg,/old-page,/new-page",
+        "www.alpha.gov.sg,/gone,/missing-page",
+      ].sort(),
+    )
+  })
+
+  it("does not write a migrated CSV on a dry run", async () => {
+    // Arrange
+    await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv(["www.alpha.gov.sg,/old-page,/new-page"])
+    const migratedCsvPath = path.join(tmpDir, "should-not-exist.csv")
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: true, migratedCsvPath })
+
+    // Assert
+    expect(fs.existsSync(migratedCsvPath)).toBe(false)
+  })
+
   it("skips rows for domains with no matching site and reports them", async () => {
     // Arrange
     const siteId = await setupSiteWithUrl("www.alpha.gov.sg")

--- a/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
@@ -354,6 +354,41 @@ describe("importRedirectsFromCsv", () => {
     ])
   })
 
+  it("bumps updatedAt when a re-run changes a destination in place", async () => {
+    // Arrange — Kysely bypasses Prisma's @updatedAt, so the conflict update
+    // must set it explicitly or it stays frozen at the original insert time
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const firstCsvPath = writeCsv(["www.alpha.gov.sg,/old-page,/first"])
+    await importRedirectsFromCsv({ csvPath: firstCsvPath, dryRun: false })
+    const [before] = await db
+      .selectFrom("Redirect")
+      .select(["updatedAt"])
+      .where("siteId", "=", siteId)
+      .execute()
+    const secondCsvPath = writeCsv(["www.alpha.gov.sg,/old-page,/second"])
+
+    // Act
+    await importRedirectsFromCsv({ csvPath: secondCsvPath, dryRun: false })
+
+    // Assert
+    const [after] = await db
+      .selectFrom("Redirect")
+      .select(["updatedAt"])
+      .where("siteId", "=", siteId)
+      .execute()
+    expect(after?.updatedAt.getTime()).toBeGreaterThan(
+      before?.updatedAt.getTime() ?? 0,
+    )
+  })
+
+  it("throws a clear error when csvPath is empty", async () => {
+    // Act
+    const run = () => importRedirectsFromCsv({ csvPath: "", dryRun: true })
+
+    // Assert
+    await expect(run()).rejects.toThrow("csvPath is empty")
+  })
+
   it("writes nothing in dry-run mode but still reports the summary", async () => {
     // Arrange
     const siteId = await setupSiteWithUrl("www.alpha.gov.sg")

--- a/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
@@ -1,0 +1,250 @@
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { db, jsonb } from "~/server/modules/database"
+
+import { resetTables } from "../../../tests/integration/helpers/db"
+import { setupSite } from "../../../tests/integration/helpers/seed"
+import { importRedirectsFromCsv } from "../importRedirectsFromCsv"
+
+let tmpDir: string
+let csvCounter = 0
+
+beforeAll(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "import-redirects-test-"))
+})
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+const writeCsv = (
+  rows: string[],
+  { header = "domainName,source,target" }: { header?: string } = {},
+) => {
+  csvCounter += 1
+  const csvPath = path.join(tmpDir, `redirects-${csvCounter}.csv`)
+  fs.writeFileSync(csvPath, [header, ...rows].join("\n"))
+  return csvPath
+}
+
+// setupSite seeds config.url as "" - point it at a domain so the import
+// script's domain matching can find the site
+const setupSiteWithUrl = async (url: string) => {
+  const { site } = await setupSite()
+  await db
+    .updateTable("Site")
+    .set({ config: jsonb({ ...site.config, url }) })
+    .where("id", "=", site.id)
+    .execute()
+  return site.id
+}
+
+const getRedirects = (siteId: number) =>
+  db
+    .selectFrom("Redirect")
+    .select(["source", "destination", "deletedAt"])
+    .where("siteId", "=", siteId)
+    .orderBy("source")
+    .execute()
+
+describe("importRedirectsFromCsv", () => {
+  beforeEach(async () => {
+    await resetTables("Redirect", "Navbar", "Footer", "Site")
+  })
+
+  it("imports rows for the site whose config.url matches the CSV domain", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/old-page,/new-page",
+      "www.alpha.gov.sg,/external,https://example.gov.sg/page",
+    ])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      {
+        source: "/external",
+        destination: "https://example.gov.sg/page",
+        deletedAt: null,
+      },
+      { source: "/old-page", destination: "/new-page", deletedAt: null },
+    ])
+    expect(summary.sitesMatched).toBe(1)
+    expect(summary.importedCount).toBe(2)
+  })
+
+  it("skips rows for domains with no matching site and reports them", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/old-page,/new-page",
+      "www.unknown.gov.sg,/a,/b",
+      "www.unknown.gov.sg,/c,/d",
+    ])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toHaveLength(1)
+    expect(summary.unmatchedDomains.get("www.unknown.gov.sg")).toBe(2)
+  })
+
+  it("matches domains ignoring case, scheme and trailing path", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("https://WWW.Alpha.gov.sg/")
+    const csvPath = writeCsv(["www.alpha.gov.sg,/old-page,/new-page"])
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toHaveLength(1)
+  })
+
+  it("ignores rows with wildcards in source or target", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/old-section/*,/new-section",
+      "www.alpha.gov.sg,/old-page,/new-section/*",
+      "www.alpha.gov.sg,/kept,/destination",
+    ])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects.map((row) => row.source)).toEqual(["/kept"])
+    expect(summary.wildcardRowCount).toBe(2)
+  })
+
+  it("ignores rows with query parameters in source or target", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/old-page?lang=en,/new-page",
+      "www.alpha.gov.sg,/news,/articles/?page=1",
+      "www.alpha.gov.sg,/kept,/destination",
+    ])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects.map((row) => row.source)).toEqual(["/kept"])
+    expect(summary.queryParamRowCount).toBe(2)
+  })
+
+  it("skips rows that fail redirect validation and reports the reason", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/empty-destination,",
+      "www.alpha.gov.sg,/insecure,http://example.com",
+      "www.alpha.gov.sg,/mail,mailto:hello@example.gov.sg",
+      "www.alpha.gov.sg,/kept,/destination",
+    ])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects.map((row) => row.source)).toEqual(["/kept"])
+    expect(summary.invalidRows).toHaveLength(3)
+    expect(summary.invalidRows[0]?.reason).toContain(
+      "Destination must start with '/' or 'https://'",
+    )
+  })
+
+  it("normalises sources the same way as the publish flow", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv(["www.alpha.gov.sg,//old//page/,/new-page"])
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects.map((row) => row.source)).toEqual(["/old/page"])
+  })
+
+  it("keeps the first destination when two sources normalise to the same value", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      "www.alpha.gov.sg,/old-page,/first",
+      "www.alpha.gov.sg,/old-page/,/second",
+    ])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toHaveLength(1)
+    expect(redirects[0]?.destination).toBe("/first")
+    expect(summary.duplicateRows).toHaveLength(1)
+  })
+
+  it("is idempotent: re-running updates destinations in place and revives soft-deleted rows", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const firstCsvPath = writeCsv(["www.alpha.gov.sg,/old-page,/first"])
+    await importRedirectsFromCsv({ csvPath: firstCsvPath, dryRun: false })
+    await db
+      .updateTable("Redirect")
+      .set({ deletedAt: new Date() })
+      .where("siteId", "=", siteId)
+      .execute()
+    const secondCsvPath = writeCsv(["www.alpha.gov.sg,/old-page,/second"])
+
+    // Act
+    await importRedirectsFromCsv({ csvPath: secondCsvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      { source: "/old-page", destination: "/second", deletedAt: null },
+    ])
+  })
+
+  it("writes nothing in dry-run mode but still reports the summary", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv(["www.alpha.gov.sg,/old-page,/new-page"])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: true })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toHaveLength(0)
+    expect(summary.sitesMatched).toBe(1)
+    expect(summary.importedCount).toBe(1)
+  })
+
+  it("throws on an unexpected CSV header", async () => {
+    // Arrange
+    const csvPath = writeCsv(["www.alpha.gov.sg,/a,/b"], {
+      header: "domain,from,to",
+    })
+
+    // Act
+    const run = () => importRedirectsFromCsv({ csvPath, dryRun: true })
+
+    // Assert
+    await expect(run()).rejects.toThrow("Unexpected CSV header: domain,from,to")
+  })
+})

--- a/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
@@ -1,10 +1,20 @@
 import fs from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { db, jsonb } from "~/server/modules/database"
+import {
+  db,
+  jsonb,
+  ResourceState,
+  ResourceType,
+} from "~/server/modules/database"
 
 import { resetTables } from "../../../tests/integration/helpers/db"
-import { setupSite } from "../../../tests/integration/helpers/seed"
+import {
+  setupFolder,
+  setupPageResource,
+  setupSite,
+  setupUser,
+} from "../../../tests/integration/helpers/seed"
 import { importRedirectsFromCsv } from "../importRedirectsFromCsv"
 
 let tmpDir: string
@@ -50,7 +60,16 @@ const getRedirects = (siteId: number) =>
 
 describe("importRedirectsFromCsv", () => {
   beforeEach(async () => {
-    await resetTables("Redirect", "Navbar", "Footer", "Site")
+    await resetTables(
+      "Redirect",
+      "Blob",
+      "Version",
+      "Resource",
+      "Navbar",
+      "Footer",
+      "Site",
+      "User",
+    )
   })
 
   it("imports rows for the site whose config.url matches the CSV domain", async () => {
@@ -76,6 +95,83 @@ describe("importRedirectsFromCsv", () => {
     ])
     expect(summary.sitesMatched).toBe(1)
     expect(summary.importedCount).toBe(2)
+  })
+
+  it("converts an internal destination to a page reference when a live page exists at that path", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const user = await setupUser({ email: "import-page@open.gov.sg" })
+    const { page } = await setupPageResource({
+      siteId,
+      resourceType: ResourceType.Page,
+      permalink: "new-page",
+      parentId: null,
+      state: ResourceState.Published,
+      userId: user.id,
+    })
+    const csvPath = writeCsv(["www.alpha.gov.sg,/old-page,/new-page"])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert — the permalink is stored as a [resource:...] reference so the
+    // redirect follows the page if its permalink later changes
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      {
+        source: "/old-page",
+        destination: `[resource:${siteId}:${page.id}]`,
+        deletedAt: null,
+      },
+    ])
+    expect(summary.referenceCount).toBe(1)
+  })
+
+  it("converts a folder destination to the folder's reference when its index page is published", async () => {
+    // Arrange — a folder is served by its published index page; the reference
+    // must point at the folder (its index page id never appears in the build)
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const user = await setupUser({ email: "import-folder@open.gov.sg" })
+    const { folder } = await setupFolder({ siteId, permalink: "info" })
+    await setupPageResource({
+      siteId,
+      resourceType: ResourceType.IndexPage,
+      permalink: "_index",
+      parentId: folder.id,
+      state: ResourceState.Published,
+      userId: user.id,
+    })
+    const csvPath = writeCsv(["www.alpha.gov.sg,/old,/info"])
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      {
+        source: "/old",
+        destination: `[resource:${siteId}:${folder.id}]`,
+        deletedAt: null,
+      },
+    ])
+  })
+
+  it("keeps an internal destination as a literal path when no live page exists at it", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv(["www.alpha.gov.sg,/old-page,/missing-page"])
+
+    // Act
+    const summary = await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert — an unresolved internal path stays literal and is surfaced for review
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      { source: "/old-page", destination: "/missing-page", deletedAt: null },
+    ])
+    expect(summary.referenceCount).toBe(0)
+    expect(summary.unresolvedDestinations).toHaveLength(1)
   })
 
   it("skips rows for domains with no matching site and reports them", async () => {

--- a/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts
@@ -96,6 +96,44 @@ describe("importRedirectsFromCsv", () => {
     expect(summary.unmatchedDomains.get("www.unknown.gov.sg")).toBe(2)
   })
 
+  it("parses quoted fields containing commas per standard CSV quoting", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv([
+      'www.alpha.gov.sg,/old-page,"https://example.gov.sg/a,b"',
+    ])
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      {
+        source: "/old-page",
+        destination: "https://example.gov.sg/a,b",
+        deletedAt: null,
+      },
+    ])
+  })
+
+  it("tolerates a UTF-8 BOM and whitespace around fields", async () => {
+    // Arrange
+    const siteId = await setupSiteWithUrl("www.alpha.gov.sg")
+    const csvPath = writeCsv(["www.alpha.gov.sg, /old-page , /new-page "], {
+      header: "\uFEFFdomainName,source,target",
+    })
+
+    // Act
+    await importRedirectsFromCsv({ csvPath, dryRun: false })
+
+    // Assert
+    const redirects = await getRedirects(siteId)
+    expect(redirects).toEqual([
+      { source: "/old-page", destination: "/new-page", deletedAt: null },
+    ])
+  })
+
   it("matches domains ignoring case, scheme and trailing path", async () => {
     // Arrange
     const siteId = await setupSiteWithUrl("https://WWW.Alpha.gov.sg/")

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -1,13 +1,21 @@
 import fs from "node:fs"
+import path, { dirname } from "node:path"
 import { fileURLToPath } from "node:url"
 import Papa from "papaparse"
 import { z } from "zod"
 import { db, ResourceType } from "~/server/modules/database"
 
-// Inline copy of createRedirectSchema from ~/schemas/redirect on the
-// feat/redirects-management-backend branch, so this script can land off main
-// without depending on that branch. Once the redirects backend merges, drop
-// this block and import the schema instead so the two cannot drift.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// A deliberately lenient subset of the validation in ~/schemas/redirect. This
+// is a migration of legacy redirects from infra, so the goal is to preserve as
+// many existing rules as possible rather than retroactively enforce Studio's
+// stricter rules (reserved-prefix rejection, the source character whitelist,
+// lowercasing, self-redirect rejection, etc.) on data that predates them. Those
+// rules apply going forward — anything created or edited through Studio is still
+// validated by createRedirectSchema. We only reject what would corrupt the
+// published rules outright (control chars, backslashes, "..", non-path/https
+// destinations).
 const MAX_REDIRECT_PATH_LENGTH = 2000
 
 // Matches ASCII control characters (0x00-0x1f, 0x7f) and backslashes.
@@ -68,6 +76,12 @@ interface ImportRedirectsFromCsvProps {
   // isomer-next-infra/src/publishing/redirects.production.csv
   csvPath: string
   dryRun: boolean
+  // When set, a real (non-dry-run) import writes the rows it migrated to this
+  // path as a `domainName,source,target` CSV that verifyRedirectsLive.ts can
+  // read directly — so verification covers exactly the migrated redirects (and
+  // not unmatched domains or skipped rows). Omitted by tests, so no file is
+  // written there.
+  migratedCsvPath?: string
 }
 
 // Rows are inserted in chunks so a 38k-row import doesn't build one giant
@@ -179,6 +193,7 @@ const buildPermalinkToResourceId = async (siteId: number) => {
 export const importRedirectsFromCsv = async ({
   csvPath,
   dryRun,
+  migratedCsvPath,
 }: ImportRedirectsFromCsvProps) => {
   // Surface a clear message instead of an opaque ENOENT when csvPath is unset.
   if (!csvPath) {
@@ -206,9 +221,12 @@ export const importRedirectsFromCsv = async ({
 
   const sites = await db.selectFrom("Site").select(["id", "config"]).execute()
   const siteIdByDomain = new Map<string, number>()
+  const domainBySiteId = new Map<number, string>()
   for (const site of sites) {
     if (site.config.url) {
-      siteIdByDomain.set(normaliseDomain(site.config.url), site.id)
+      const domain = normaliseDomain(site.config.url)
+      siteIdByDomain.set(domain, site.id)
+      domainBySiteId.set(site.id, domain)
     }
   }
 
@@ -254,8 +272,9 @@ export const importRedirectsFromCsv = async ({
       return
     }
 
-    // Validate with the same rules as the Studio publish flow so imported
-    // rows are normalised exactly like redirects created through Studio
+    // Apply the lenient migration validation (see the schema block above) and
+    // normalise the source. This is intentionally weaker than Studio's
+    // createRedirectSchema so legacy redirects are preserved.
     const parsed = createRedirectSchema.safeParse({
       source,
       destination: target,
@@ -298,20 +317,31 @@ export const importRedirectsFromCsv = async ({
     source: string
     destination: string
   }[] = []
+  // The migrated rows, in `domainName,source,target` form for verification. The
+  // target is the Location the published redirect will emit: for a converted
+  // reference that's the resolved permalink, otherwise the destination as stored.
+  const migratedEntries: {
+    domainName: string
+    source: string
+    target: string
+  }[] = []
   let referenceCount = 0
   for (const [siteId, siteRedirects] of redirectsBySite) {
     const permalinkToResourceId = await buildPermalinkToResourceId(siteId)
+    const domainName = domainBySiteId.get(siteId) ?? ""
     for (const [source, destination] of siteRedirects) {
       if (destination.startsWith("https://")) {
         rowsToInsert.push({ siteId, source, destination })
+        migratedEntries.push({ domainName, source, target: destination })
         continue
       }
-      const resourceId = permalinkToResourceId.get(
-        normalizeRedirectSource(destination),
-      )
+      const normalisedDestination = normalizeRedirectSource(destination)
+      const resourceId = permalinkToResourceId.get(normalisedDestination)
       if (resourceId === undefined) {
         unresolvedDestinations.push({ siteId, source, destination })
         rowsToInsert.push({ siteId, source, destination })
+        // Kept as a literal path, so the published Location is that path as-is.
+        migratedEntries.push({ domainName, source, target: destination })
         continue
       }
       referenceCount += 1
@@ -319,6 +349,13 @@ export const importRedirectsFromCsv = async ({
         siteId,
         source,
         destination: toReferenceLink(siteId, resourceId),
+      })
+      // The reference resolves to this permalink at publish time, so that's the
+      // Location verification should expect.
+      migratedEntries.push({
+        domainName,
+        source,
+        target: normalisedDestination,
       })
     }
   }
@@ -392,6 +429,27 @@ export const importRedirectsFromCsv = async ({
   })
 
   console.log("Import complete")
+
+  // Write the migrated rows so verifyRedirectsLive.ts can probe exactly what was
+  // migrated. Same `domainName,source,target` header the verifier expects.
+  if (migratedCsvPath) {
+    fs.mkdirSync(path.dirname(migratedCsvPath), { recursive: true })
+    fs.writeFileSync(
+      migratedCsvPath,
+      Papa.unparse({
+        fields: ["domainName", "source", "target"],
+        data: migratedEntries.map((entry) => [
+          entry.domainName,
+          entry.source,
+          entry.target,
+        ]),
+      }),
+    )
+    console.log(
+      `Wrote ${migratedEntries.length} migrated entries to ${migratedCsvPath} (feed this to verifyRedirectsLive.ts)`,
+    )
+  }
+
   return summary
 }
 
@@ -401,9 +459,15 @@ if (isMain) {
   // NOTE: Update the CSV path and set dryRun to false before executing!
   const csvPath = ""
   const dryRun = true
+  // A real import writes the migrated rows here for verifyRedirectsLive.ts.
+  const migratedCsvPath = path.join(
+    __dirname,
+    "output",
+    "migrated-redirects.csv",
+  )
 
   try {
-    await importRedirectsFromCsv({ csvPath, dryRun })
+    await importRedirectsFromCsv({ csvPath, dryRun, migratedCsvPath })
   } finally {
     // Always release the connection pool, even when the import throws, so
     // the process does not hang on an open DB connection

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -1,0 +1,242 @@
+import fs from "node:fs"
+import { fileURLToPath } from "node:url"
+import { z } from "zod"
+import { db } from "~/server/modules/database"
+
+// Inline copy of createRedirectSchema from ~/schemas/redirect on the
+// feat/redirects-management-backend branch, so this script can land off main
+// without depending on that branch. Once the redirects backend merges, drop
+// this block and import the schema instead so the two cannot drift.
+const MAX_REDIRECT_PATH_LENGTH = 2000
+
+// Matches ASCII control characters (0x00-0x1f, 0x7f) and backslashes.
+// These are never valid in a URL path and can corrupt the generated
+// redirect rules on the published site.
+const INVALID_PATH_CHARS_REGEX = /[\x00-\x1f\x7f\\]/
+
+// Strips slashes from both ends of a path so "/foo/", "foo" and "foo//"
+// all normalise to the same inner segments before validation.
+const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
+
+const sourceSchema = z
+  .string()
+  .min(1, { message: "Source path is required" })
+  .max(MAX_REDIRECT_PATH_LENGTH, { message: "Source path is too long" })
+  .refine((value) => !INVALID_PATH_CHARS_REGEX.test(value), {
+    message: "Source must not contain control characters or backslashes",
+  })
+  .refine((value) => trimSlashes(value).length > 0, {
+    message: "Source path cannot consist only of slashes",
+  })
+  .refine((value) => !trimSlashes(value).split("/").includes(".."), {
+    message: "Source must not contain '..' path segments",
+  })
+  // Normalise to a single leading slash with no trailing slash, collapsing
+  // runs of slashes so equivalent inputs map to the same source. This keeps
+  // the (siteId, source) unique constraint meaningful.
+  .transform((value) => `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`)
+
+const destinationSchema = z
+  .string()
+  .min(1, { message: "Destination is required" })
+  .max(MAX_REDIRECT_PATH_LENGTH, { message: "Destination is too long" })
+  // Destinations must be a path on the same site ("/...") or an external
+  // https URL — anything else (http://, javascript:, ...) is rejected.
+  .refine((value) => value.startsWith("/") || value.startsWith("https://"), {
+    message: "Destination must start with '/' or 'https://'",
+  })
+
+const createRedirectSchema = z.object({
+  source: sourceSchema,
+  destination: destinationSchema,
+})
+
+interface ImportRedirectsFromCsvProps {
+  // CSV with a `domainName,source,target` header, e.g.
+  // isomer-next-infra/src/publishing/redirects.production.csv
+  csvPath: string
+  dryRun: boolean
+}
+
+// Rows are inserted in chunks so a 38k-row import doesn't build one giant
+// INSERT statement; the whole import still runs in a single transaction.
+const INSERT_CHUNK_SIZE = 1000
+
+// Reduces a site URL or CSV domain to a bare lowercase hostname so the two
+// can be compared: strips an optional scheme, then anything from the first
+// "/" onwards. `Site.config.url` is stored as a bare domain today, but this
+// keeps the match working if a value ever includes a scheme or trailing slash.
+const normaliseDomain = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/.*$/, "")
+
+export const importRedirectsFromCsv = async ({
+  csvPath,
+  dryRun,
+}: ImportRedirectsFromCsvProps) => {
+  const [header = "", ...dataLines] = fs
+    .readFileSync(csvPath, "utf8")
+    .split("\n")
+    .map((line) => line.replace(/\r$/, ""))
+    .filter((line) => line.length > 0)
+
+  if (header !== "domainName,source,target") {
+    throw new Error(`Unexpected CSV header: ${header}`)
+  }
+
+  const sites = await db.selectFrom("Site").select(["id", "config"]).execute()
+  const siteIdByDomain = new Map<string, number>()
+  for (const site of sites) {
+    if (site.config.url) {
+      siteIdByDomain.set(normaliseDomain(site.config.url), site.id)
+    }
+  }
+
+  const unmatchedDomains = new Map<string, number>()
+  const invalidRows: { lineNumber: number; line: string; reason: string }[] = []
+  const duplicateRows: { lineNumber: number; line: string }[] = []
+  const redirectsBySite = new Map<number, Map<string, string>>()
+  let wildcardRowCount = 0
+  let queryParamRowCount = 0
+
+  dataLines.forEach((line, index) => {
+    // CSV header line is 1, so the first data line is 2
+    const lineNumber = index + 2
+    const parts = line.split(",")
+    if (parts.length !== 3) {
+      invalidRows.push({
+        lineNumber,
+        line,
+        reason: `Expected 3 comma-separated fields, got ${parts.length}`,
+      })
+      return
+    }
+    const [domainName = "", source = "", target = ""] = parts
+
+    // Wildcard rules and query-parameter matching are infra publishing
+    // features with no equivalent in the Redirect table's exact-match
+    // semantics - skip them rather than import rules that behave differently
+    if (source.includes("*") || target.includes("*")) {
+      wildcardRowCount += 1
+      return
+    }
+    if (source.includes("?") || target.includes("?")) {
+      queryParamRowCount += 1
+      return
+    }
+
+    const siteId = siteIdByDomain.get(normaliseDomain(domainName))
+    if (siteId === undefined) {
+      const domain = normaliseDomain(domainName)
+      unmatchedDomains.set(domain, (unmatchedDomains.get(domain) ?? 0) + 1)
+      return
+    }
+
+    // Validate with the same rules as the Studio publish flow so imported
+    // rows are normalised exactly like redirects created through Studio
+    const parsed = createRedirectSchema.safeParse({
+      source,
+      destination: target,
+    })
+    if (!parsed.success) {
+      invalidRows.push({
+        lineNumber,
+        line,
+        reason: parsed.error.issues.map((issue) => issue.message).join("; "),
+      })
+      return
+    }
+
+    // Distinct CSV sources can normalise to the same value (e.g. "/foo" and
+    // "/foo/"). Keep the first occurrence so the import is deterministic, and
+    // surface the dropped row for manual review.
+    const siteRedirects =
+      redirectsBySite.get(siteId) ?? new Map<string, string>()
+    redirectsBySite.set(siteId, siteRedirects)
+    if (siteRedirects.has(parsed.data.source)) {
+      duplicateRows.push({ lineNumber, line })
+      return
+    }
+    siteRedirects.set(parsed.data.source, parsed.data.destination)
+  })
+
+  const rowsToInsert = [...redirectsBySite.entries()].flatMap(
+    ([siteId, siteRedirects]) =>
+      [...siteRedirects.entries()].map(([source, destination]) => ({
+        siteId,
+        source,
+        destination,
+      })),
+  )
+
+  console.log(`Sites matched: ${redirectsBySite.size}`)
+  console.log(`Redirects to import: ${rowsToInsert.length}`)
+  console.log(`Wildcard rows ignored: ${wildcardRowCount}`)
+  console.log(`Query-parameter rows ignored: ${queryParamRowCount}`)
+  for (const [domain, count] of unmatchedDomains) {
+    console.warn(
+      `Unmatched domain (no site with this config.url): ${domain} (${count} rows skipped)`,
+    )
+  }
+  for (const { lineNumber, line, reason } of invalidRows) {
+    console.warn(`Invalid row at line ${lineNumber} (${reason}): ${line}`)
+  }
+  for (const { lineNumber, line } of duplicateRows) {
+    console.warn(
+      `Duplicate source after normalisation at line ${lineNumber} (kept first occurrence): ${line}`,
+    )
+  }
+
+  const summary = {
+    sitesMatched: redirectsBySite.size,
+    importedCount: rowsToInsert.length,
+    wildcardRowCount,
+    queryParamRowCount,
+    unmatchedDomains,
+    invalidRows,
+    duplicateRows,
+  }
+
+  if (dryRun) {
+    console.log("Dry run - no rows written. Set dryRun to false to import.")
+    return summary
+  }
+
+  await db.transaction().execute(async (tx) => {
+    for (let i = 0; i < rowsToInsert.length; i += INSERT_CHUNK_SIZE) {
+      await tx
+        .insertInto("Redirect")
+        .values(rowsToInsert.slice(i, i + INSERT_CHUNK_SIZE))
+        // Re-running the import updates destinations in place and revives
+        // soft-deleted rows, mirroring the publish flow - the script is
+        // idempotent
+        .onConflict((oc) =>
+          oc.columns(["siteId", "source"]).doUpdateSet((eb) => ({
+            destination: eb.ref("excluded.destination"),
+            deletedAt: null,
+          })),
+        )
+        .execute()
+      console.log(
+        `Inserted ${Math.min(i + INSERT_CHUNK_SIZE, rowsToInsert.length)}/${rowsToInsert.length} redirects`,
+      )
+    }
+  })
+
+  console.log("Import complete")
+  return summary
+}
+
+// Only run when executed directly, not when imported by tests
+const isMain = process.argv[1] === fileURLToPath(import.meta.url)
+if (isMain) {
+  // NOTE: Update the CSV path and set dryRun to false before executing!
+  const csvPath = ""
+  const dryRun = true
+
+  await importRedirectsFromCsv({ csvPath, dryRun })
+  await db.destroy()
+}

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -117,9 +117,13 @@ const buildPermalinkToResourceId = async (siteId: number) => {
   )
 
   const cache = new Map<string, string>()
-  const fullPermalinkOf = (id: string): string => {
+  // Guards against a parentId cycle in corrupt data (A -> B -> A), which would
+  // otherwise recurse until the call stack overflows.
+  const fullPermalinkOf = (id: string, visited = new Set<string>()): string => {
     const cached = cache.get(id)
     if (cached !== undefined) return cached
+    if (visited.has(id)) return "/"
+    visited.add(id)
     const resource = byId.get(id)
     if (!resource) return "/"
     const segment =
@@ -130,7 +134,7 @@ const buildPermalinkToResourceId = async (siteId: number) => {
     if (resource.parentId === null) {
       result = segment === "" ? "/" : `/${segment}`
     } else {
-      const parentPath = fullPermalinkOf(String(resource.parentId))
+      const parentPath = fullPermalinkOf(String(resource.parentId), visited)
       result =
         segment === ""
           ? parentPath
@@ -163,6 +167,12 @@ export const importRedirectsFromCsv = async ({
   csvPath,
   dryRun,
 }: ImportRedirectsFromCsvProps) => {
+  // Surface a clear message instead of an opaque ENOENT when csvPath is unset.
+  if (!csvPath) {
+    throw new Error(
+      "csvPath is empty - set the csvPath variable at the bottom of the script before running.",
+    )
+  }
   // Papa handles standard CSV quoting (fields containing commas) and CRLF
   // line endings; the BOM is stripped up front so spreadsheet-exported files
   // don't fail the header check below.
@@ -351,10 +361,14 @@ export const importRedirectsFromCsv = async ({
         // Re-running the import updates destinations in place and revives
         // soft-deleted rows, mirroring the publish flow - the script is
         // idempotent
+        // Kysely bypasses Prisma's client-side `@updatedAt`, so set updatedAt
+        // explicitly on conflict - otherwise it stays frozen at the original
+        // insert time when a re-run changes a destination
         .onConflict((oc) =>
           oc.columns(["siteId", "source"]).doUpdateSet((eb) => ({
             destination: eb.ref("excluded.destination"),
             deletedAt: null,
+            updatedAt: new Date(),
           })),
         )
         .execute()

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -24,6 +24,13 @@ const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
 const normalizeRedirectPath = (value: string) =>
   `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`
 
+// Page permalinks are lowercase-only, so an internal destination is compared
+// against the live-permalink map in lowercase too — otherwise a mixed-case CSV
+// target (e.g. "/About-Us") would miss the "/about-us" key and fall back to a
+// literal path instead of resolving to a [resource:...] reference.
+const normalizeRedirectSource = (value: string) =>
+  normalizeRedirectPath(value).toLowerCase()
+
 const sourceSchema = z
   .string()
   .min(1, { message: "Source path is required" })
@@ -85,6 +92,11 @@ const toReferenceLink = (siteId: number, resourceId: number) =>
 
 const INDEX_PAGE_PERMALINK = "_index"
 
+// An empty permalink (the root) or an "_index" segment contributes no path
+// segment to a full permalink.
+const isIndexOrRoot = (permalink: string) =>
+  permalink === "" || permalink === INDEX_PAGE_PERMALINK
+
 // Maps every live, addressable full permalink on a site to the resource id a
 // redirect destination should reference, mirroring how Studio stores internal
 // destinations: a published page references itself; a Folder/Collection
@@ -126,10 +138,7 @@ const buildPermalinkToResourceId = async (siteId: number) => {
     visited.add(id)
     const resource = byId.get(id)
     if (!resource) return "/"
-    const segment =
-      resource.permalink === "" || resource.permalink === INDEX_PAGE_PERMALINK
-        ? ""
-        : resource.permalink
+    const segment = isIndexOrRoot(resource.permalink) ? "" : resource.permalink
     let result: string
     if (resource.parentId === null) {
       result = segment === "" ? "/" : `/${segment}`
@@ -157,7 +166,11 @@ const buildPermalinkToResourceId = async (siteId: number) => {
         resource.type === ResourceType.Collection) &&
       publishedContainerIds.has(id)
     if (isLivePage || isLiveContainer) {
-      permalinkToResourceId.set(fullPermalinkOf(id), Number(resource.id))
+      // Lowercase the key so the lowercased destination lookup below matches.
+      permalinkToResourceId.set(
+        fullPermalinkOf(id).toLowerCase(),
+        Number(resource.id),
+      )
     }
   }
   return permalinkToResourceId
@@ -294,7 +307,7 @@ export const importRedirectsFromCsv = async ({
         continue
       }
       const resourceId = permalinkToResourceId.get(
-        normalizeRedirectPath(destination),
+        normalizeRedirectSource(destination),
       )
       if (resourceId === undefined) {
         unresolvedDestinations.push({ siteId, source, destination })

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -82,6 +82,15 @@ interface ImportRedirectsFromCsvProps {
   // not unmatched domains or skipped rows). Omitted by tests, so no file is
   // written there.
   migratedCsvPath?: string
+  // When set, only migrate redirects for these domains (bare hostnames or full
+  // URLs — normalised the same way as Site.config.url). Rows for other domains
+  // are left untouched in the remaining CSV.
+  domainFilter?: string[]
+  // When set (and not a dry-run), writes the original CSV rows that were NOT
+  // successfully migrated here — rows for out-of-filter domains, wildcards,
+  // invalid rows, unmatched domains, and duplicates are all preserved so you
+  // can re-run on leftovers or archive what was skipped.
+  remainingCsvPath?: string
 }
 
 // Rows are inserted in chunks so a 38k-row import doesn't build one giant
@@ -194,6 +203,8 @@ export const importRedirectsFromCsv = async ({
   csvPath,
   dryRun,
   migratedCsvPath,
+  domainFilter,
+  remainingCsvPath,
 }: ImportRedirectsFromCsvProps) => {
   // Surface a clear message instead of an opaque ENOENT when csvPath is unset.
   if (!csvPath) {
@@ -230,10 +241,19 @@ export const importRedirectsFromCsv = async ({
     }
   }
 
+  // Pre-normalise the domain filter for O(1) lookup.
+  const filterSet =
+    domainFilter && domainFilter.length > 0
+      ? new Set(domainFilter.map(normaliseDomain))
+      : null
+
   const unmatchedDomains = new Map<string, number>()
   const invalidRows: { lineNumber: number; line: string; reason: string }[] = []
   const duplicateRows: { lineNumber: number; line: string }[] = []
   const redirectsBySite = new Map<number, Map<string, string>>()
+  // Tracks which dataRow indices were queued for migration so the remaining CSV
+  // can exclude exactly those rows (and only those rows).
+  const migratedIndices = new Set<number>()
   let wildcardRowCount = 0
   let queryParamRowCount = 0
 
@@ -265,10 +285,20 @@ export const importRedirectsFromCsv = async ({
       return
     }
 
-    const siteId = siteIdByDomain.get(normaliseDomain(domainName))
+    const normalisedDomain = normaliseDomain(domainName)
+
+    // Silently skip rows outside the domain filter — they are not counted as
+    // unmatched and are preserved in the remaining CSV.
+    if (filterSet && !filterSet.has(normalisedDomain)) {
+      return
+    }
+
+    const siteId = siteIdByDomain.get(normalisedDomain)
     if (siteId === undefined) {
-      const domain = normaliseDomain(domainName)
-      unmatchedDomains.set(domain, (unmatchedDomains.get(domain) ?? 0) + 1)
+      unmatchedDomains.set(
+        normalisedDomain,
+        (unmatchedDomains.get(normalisedDomain) ?? 0) + 1,
+      )
       return
     }
 
@@ -299,6 +329,7 @@ export const importRedirectsFromCsv = async ({
       return
     }
     siteRedirects.set(parsed.data.source, parsed.data.destination)
+    migratedIndices.add(index)
   })
 
   // Resolve destinations to the stored form. An internal path that resolves to
@@ -450,6 +481,24 @@ export const importRedirectsFromCsv = async ({
     )
   }
 
+  // Write the original rows that were not migrated so the caller can re-run on
+  // leftovers or archive what was skipped (wildcards, invalid rows, unmatched
+  // domains, duplicates, and rows outside the domain filter).
+  if (remainingCsvPath) {
+    const remainingRows = dataRows.filter((_, i) => !migratedIndices.has(i))
+    fs.mkdirSync(path.dirname(remainingCsvPath), { recursive: true })
+    fs.writeFileSync(
+      remainingCsvPath,
+      Papa.unparse({
+        fields: ["domainName", "source", "target"],
+        data: remainingRows,
+      }),
+    )
+    console.log(
+      `Wrote ${remainingRows.length} remaining rows to ${remainingCsvPath}`,
+    )
+  }
+
   return summary
 }
 
@@ -459,15 +508,30 @@ if (isMain) {
   // NOTE: Update the CSV path and set dryRun to false before executing!
   const csvPath = ""
   const dryRun = true
+  // Optional: restrict migration to specific domains (bare hostnames).
+  // Leave as undefined to migrate all matched domains.
+  const domainFilter: string[] | undefined = undefined
   // A real import writes the migrated rows here for verifyRedirectsLive.ts.
   const migratedCsvPath = path.join(
     __dirname,
     "output",
     "migrated-redirects.csv",
   )
+  // The original CSV minus migrated rows — re-run on this to process leftovers.
+  const remainingCsvPath = path.join(
+    __dirname,
+    "output",
+    "remaining-redirects.csv",
+  )
 
   try {
-    await importRedirectsFromCsv({ csvPath, dryRun, migratedCsvPath })
+    await importRedirectsFromCsv({
+      csvPath,
+      dryRun,
+      domainFilter,
+      migratedCsvPath,
+      remainingCsvPath,
+    })
   } finally {
     // Always release the connection pool, even when the import throws, so
     // the process does not hang on an open DB connection

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -2,7 +2,7 @@ import fs from "node:fs"
 import { fileURLToPath } from "node:url"
 import Papa from "papaparse"
 import { z } from "zod"
-import { db } from "~/server/modules/database"
+import { db, ResourceType } from "~/server/modules/database"
 
 // Inline copy of createRedirectSchema from ~/schemas/redirect on the
 // feat/redirects-management-backend branch, so this script can land off main
@@ -19,6 +19,11 @@ const INVALID_PATH_CHARS_REGEX = /[\x00-\x1f\x7f\\]/
 // all normalise to the same inner segments before validation.
 const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
 
+// Normalises a path to a single leading slash, no trailing slash, collapsed
+// runs of slashes — so "/foo/", "foo" and "foo//" all map to "/foo".
+const normalizeRedirectPath = (value: string) =>
+  `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`
+
 const sourceSchema = z
   .string()
   .min(1, { message: "Source path is required" })
@@ -32,10 +37,9 @@ const sourceSchema = z
   .refine((value) => !trimSlashes(value).split("/").includes(".."), {
     message: "Source must not contain '..' path segments",
   })
-  // Normalise to a single leading slash with no trailing slash, collapsing
-  // runs of slashes so equivalent inputs map to the same source. This keeps
-  // the (siteId, source) unique constraint meaningful.
-  .transform((value) => `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`)
+  // Normalise so equivalent inputs map to the same source, keeping the
+  // (siteId, source) unique constraint meaningful.
+  .transform(normalizeRedirectPath)
 
 const destinationSchema = z
   .string()
@@ -73,6 +77,87 @@ const normaliseDomain = (value: string) =>
     .toLowerCase()
     .replace(/^https?:\/\//, "")
     .replace(/\/.*$/, "")
+
+// The form internal destinations are stored in (matches Studio / the publish
+// resolver), so the redirect follows the page if its permalink later changes.
+const toReferenceLink = (siteId: number, resourceId: number) =>
+  `[resource:${siteId}:${resourceId}]`
+
+const INDEX_PAGE_PERMALINK = "_index"
+
+// Maps every live, addressable full permalink on a site to the resource id a
+// redirect destination should reference, mirroring how Studio stores internal
+// destinations: a published page references itself; a Folder/Collection
+// references the container (its index page id never appears in the built site)
+// and is addressable only when its index page is published. The full permalink
+// of each resource is built by walking the parent chain in memory; root (empty
+// permalink) and "_index" segments contribute no path segment.
+const buildPermalinkToResourceId = async (siteId: number) => {
+  const resources = await db
+    .selectFrom("Resource")
+    .where("siteId", "=", siteId)
+    .select(["id", "permalink", "parentId", "type", "publishedVersionId"])
+    .execute()
+
+  const byId = new Map(
+    resources.map((resource) => [String(resource.id), resource]),
+  )
+
+  // Container ids that have a published index page child (so the container is
+  // live and addressable at its own URL).
+  const publishedContainerIds = new Set(
+    resources
+      .filter(
+        (resource) =>
+          resource.type === ResourceType.IndexPage &&
+          resource.publishedVersionId !== null &&
+          resource.parentId !== null,
+      )
+      .map((resource) => String(resource.parentId)),
+  )
+
+  const cache = new Map<string, string>()
+  const fullPermalinkOf = (id: string): string => {
+    const cached = cache.get(id)
+    if (cached !== undefined) return cached
+    const resource = byId.get(id)
+    if (!resource) return "/"
+    const segment =
+      resource.permalink === "" || resource.permalink === INDEX_PAGE_PERMALINK
+        ? ""
+        : resource.permalink
+    let result: string
+    if (resource.parentId === null) {
+      result = segment === "" ? "/" : `/${segment}`
+    } else {
+      const parentPath = fullPermalinkOf(String(resource.parentId))
+      result =
+        segment === ""
+          ? parentPath
+          : `${parentPath === "/" ? "" : parentPath}/${segment}`
+    }
+    cache.set(id, result)
+    return result
+  }
+
+  const permalinkToResourceId = new Map<string, number>()
+  for (const resource of resources) {
+    const id = String(resource.id)
+    const isLivePage =
+      (resource.type === ResourceType.Page ||
+        resource.type === ResourceType.CollectionPage ||
+        resource.type === ResourceType.RootPage) &&
+      resource.publishedVersionId !== null
+    const isLiveContainer =
+      (resource.type === ResourceType.Folder ||
+        resource.type === ResourceType.Collection) &&
+      publishedContainerIds.has(id)
+    if (isLivePage || isLiveContainer) {
+      permalinkToResourceId.set(fullPermalinkOf(id), Number(resource.id))
+    }
+  }
+  return permalinkToResourceId
+}
 
 export const importRedirectsFromCsv = async ({
   csvPath,
@@ -174,17 +259,52 @@ export const importRedirectsFromCsv = async ({
     siteRedirects.set(parsed.data.source, parsed.data.destination)
   })
 
-  const rowsToInsert = [...redirectsBySite.entries()].flatMap(
-    ([siteId, siteRedirects]) =>
-      [...siteRedirects.entries()].map(([source, destination]) => ({
+  // Resolve destinations to the stored form. An internal path that resolves to
+  // a live page/folder becomes a [resource:...] reference so the redirect
+  // follows the page if its permalink later changes; an external https URL is
+  // stored verbatim. An internal path with no matching live page is kept as a
+  // literal path (it still redirects, it just won't track future moves) and
+  // surfaced for review.
+  const rowsToInsert: {
+    siteId: number
+    source: string
+    destination: string
+  }[] = []
+  const unresolvedDestinations: {
+    siteId: number
+    source: string
+    destination: string
+  }[] = []
+  let referenceCount = 0
+  for (const [siteId, siteRedirects] of redirectsBySite) {
+    const permalinkToResourceId = await buildPermalinkToResourceId(siteId)
+    for (const [source, destination] of siteRedirects) {
+      if (destination.startsWith("https://")) {
+        rowsToInsert.push({ siteId, source, destination })
+        continue
+      }
+      const resourceId = permalinkToResourceId.get(
+        normalizeRedirectPath(destination),
+      )
+      if (resourceId === undefined) {
+        unresolvedDestinations.push({ siteId, source, destination })
+        rowsToInsert.push({ siteId, source, destination })
+        continue
+      }
+      referenceCount += 1
+      rowsToInsert.push({
         siteId,
         source,
-        destination,
-      })),
-  )
+        destination: toReferenceLink(siteId, resourceId),
+      })
+    }
+  }
 
   console.log(`Sites matched: ${redirectsBySite.size}`)
   console.log(`Redirects to import: ${rowsToInsert.length}`)
+  console.log(
+    `Internal destinations converted to references: ${referenceCount}`,
+  )
   console.log(`Wildcard rows ignored: ${wildcardRowCount}`)
   console.log(`Query-parameter rows ignored: ${queryParamRowCount}`)
   for (const [domain, count] of unmatchedDomains) {
@@ -200,15 +320,22 @@ export const importRedirectsFromCsv = async ({
       `Duplicate source after normalisation at line ${lineNumber} (kept first occurrence): ${line}`,
     )
   }
+  for (const { siteId, source, destination } of unresolvedDestinations) {
+    console.warn(
+      `Internal destination kept as a literal path (no live page at it): site ${siteId} ${source} -> ${destination}`,
+    )
+  }
 
   const summary = {
     sitesMatched: redirectsBySite.size,
     importedCount: rowsToInsert.length,
+    referenceCount,
     wildcardRowCount,
     queryParamRowCount,
     unmatchedDomains,
     invalidRows,
     duplicateRows,
+    unresolvedDestinations,
   }
 
   if (dryRun) {

--- a/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
+++ b/apps/studio/prisma/scripts/importRedirectsFromCsv.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs"
 import { fileURLToPath } from "node:url"
+import Papa from "papaparse"
 import { z } from "zod"
 import { db } from "~/server/modules/database"
 
@@ -77,14 +78,22 @@ export const importRedirectsFromCsv = async ({
   csvPath,
   dryRun,
 }: ImportRedirectsFromCsvProps) => {
-  const [header = "", ...dataLines] = fs
-    .readFileSync(csvPath, "utf8")
-    .split("\n")
-    .map((line) => line.replace(/\r$/, ""))
-    .filter((line) => line.length > 0)
+  // Papa handles standard CSV quoting (fields containing commas) and CRLF
+  // line endings; the BOM is stripped up front so spreadsheet-exported files
+  // don't fail the header check below.
+  const { data: rows, errors: parseErrors } = Papa.parse<string[]>(
+    fs.readFileSync(csvPath, "utf8").replace(/^\uFEFF/, ""),
+    { skipEmptyLines: true },
+  )
+  for (const error of parseErrors) {
+    console.warn(`CSV parse warning at row ${error.row}: ${error.message}`)
+  }
 
-  if (header !== "domainName,source,target") {
-    throw new Error(`Unexpected CSV header: ${header}`)
+  const [header = [], ...dataRows] = rows
+  if (
+    header.map((field) => field.trim()).join(",") !== "domainName,source,target"
+  ) {
+    throw new Error(`Unexpected CSV header: ${header.join(",")}`)
   }
 
   const sites = await db.selectFrom("Site").select(["id", "config"]).execute()
@@ -102,19 +111,21 @@ export const importRedirectsFromCsv = async ({
   let wildcardRowCount = 0
   let queryParamRowCount = 0
 
-  dataLines.forEach((line, index) => {
+  dataRows.forEach((row, index) => {
     // CSV header line is 1, so the first data line is 2
     const lineNumber = index + 2
-    const parts = line.split(",")
-    if (parts.length !== 3) {
+    const line = row.join(",")
+    if (row.length !== 3) {
       invalidRows.push({
         lineNumber,
         line,
-        reason: `Expected 3 comma-separated fields, got ${parts.length}`,
+        reason: `Expected 3 comma-separated fields, got ${row.length}`,
       })
       return
     }
-    const [domainName = "", source = "", target = ""] = parts
+    const [domainName = "", source = "", target = ""] = row.map((field) =>
+      field.trim(),
+    )
 
     // Wildcard rules and query-parameter matching are infra publishing
     // features with no equivalent in the Redirect table's exact-match
@@ -237,6 +248,11 @@ if (isMain) {
   const csvPath = ""
   const dryRun = true
 
-  await importRedirectsFromCsv({ csvPath, dryRun })
-  await db.destroy()
+  try {
+    await importRedirectsFromCsv({ csvPath, dryRun })
+  } finally {
+    // Always release the connection pool, even when the import throws, so
+    // the process does not hang on an open DB connection
+    await db.destroy()
+  }
 }

--- a/apps/studio/prisma/scripts/verifyRedirectsLive.ts
+++ b/apps/studio/prisma/scripts/verifyRedirectsLive.ts
@@ -1,0 +1,285 @@
+import fs from "node:fs"
+import path, { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import Papa from "papaparse"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+// A browser-like User-Agent so the WAF in front of the published sites doesn't
+// block the probe as an automated client (a default fetch/curl agent gets 403s).
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+interface VerifyRedirectsLiveProps {
+  // The same CSV used for the import (`domainName,source,target` header), e.g.
+  // isomer-next-infra/src/publishing/redirects.production.csv. The CSV is the
+  // source of truth: we verify the original legacy redirects still work live.
+  csvPath: string
+  // Only verify this domain (bare hostname, e.g. "www.isomer.gov.sg"). Leave
+  // empty to verify every domain in the CSV.
+  domainFilter: string
+  // Per-domain cap on how many redirects to probe (0 = all). A small sample
+  // gives a quick signal; 0 exhaustively checks every redirect.
+  sampleSize: number
+  // Number of concurrent HTTP requests against the live site.
+  concurrency: number
+  // The status code a working redirect should return (CloudFront issues 301).
+  expectedStatus: number
+  // Per-request timeout in milliseconds.
+  timeoutMs: number
+  // When true, only report how many redirects would be probed per domain
+  // without making any HTTP request.
+  dryRun: boolean
+}
+
+// Reduces a domain to a bare lowercase hostname, mirroring
+// importRedirectsFromCsv.ts so the two agree on what a site's domain is.
+const normaliseDomain = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/\/.*$/, "")
+
+const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
+
+type Outcome = "ok" | "wrong-status" | "wrong-location" | "error"
+
+interface Probe {
+  domain: string
+  source: string
+  expectedTarget: string
+}
+
+interface Result extends Probe {
+  outcome: Outcome
+  status: number | null
+  location: string | null
+  detail: string
+}
+
+// Resolves a (possibly relative) Location against the request URL and strips a
+// single trailing slash, so "/foo" and "/foo/" — and absolute vs relative forms
+// of the same target — compare equal.
+const canonicalUrl = (value: string, base: string) => {
+  try {
+    const url = new URL(value, base)
+    url.pathname = url.pathname.replace(/\/+$/, "") || "/"
+    return url.href
+  } catch {
+    return value
+  }
+}
+
+const probeOne = async (
+  probe: Probe,
+  { expectedStatus, timeoutMs }: VerifyRedirectsLiveProps,
+): Promise<Result> => {
+  const requestUrl = `https://${probe.domain}/${trimSlashes(probe.source)}`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const res = await fetch(requestUrl, {
+      method: "GET",
+      redirect: "manual",
+      headers: { "user-agent": USER_AGENT },
+      signal: controller.signal,
+    })
+    const location = res.headers.get("location")
+    const base = { ...probe, status: res.status, location }
+    if (res.status !== expectedStatus) {
+      return {
+        ...base,
+        outcome: "wrong-status",
+        detail: `expected ${expectedStatus}, got ${res.status}`,
+      }
+    }
+    // The 301 fired (the thing we're verifying). Flag a mismatched Location as a
+    // softer finding — at migration time it should still match the CSV target.
+    if (
+      location === null ||
+      canonicalUrl(location, requestUrl) !==
+        canonicalUrl(probe.expectedTarget, requestUrl)
+    ) {
+      return {
+        ...base,
+        outcome: "wrong-location",
+        detail: `expected Location "${probe.expectedTarget}", got "${location ?? "(none)"}"`,
+      }
+    }
+    return { ...base, outcome: "ok", detail: "" }
+  } catch (error) {
+    return {
+      ...probe,
+      outcome: "error",
+      status: null,
+      location: null,
+      detail: error instanceof Error ? error.message : String(error),
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// Worker-pool: each worker pulls from the shared queue until it is empty,
+// mirroring uploadRedirects.ts so we don't open thousands of sockets at once.
+const runWithConcurrency = async (
+  probes: Probe[],
+  props: VerifyRedirectsLiveProps,
+): Promise<Result[]> => {
+  const queue = probes.slice()
+  const results: Result[] = []
+  let done = 0
+  const worker = async () => {
+    while (queue.length > 0) {
+      const probe = queue.shift()
+      if (!probe) break
+      results.push(await probeOne(probe, props))
+      done += 1
+      if (done % 500 === 0) {
+        console.log(`Probed ${done}/${probes.length}`)
+      }
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(props.concurrency, probes.length) }, worker),
+  )
+  return results
+}
+
+export const verifyRedirectsLive = async (props: VerifyRedirectsLiveProps) => {
+  const { csvPath, domainFilter, sampleSize, dryRun } = props
+
+  if (!csvPath) {
+    throw new Error(
+      "csvPath is empty - set the csvPath variable at the bottom of the script before running.",
+    )
+  }
+
+  // Papa handles standard CSV quoting and CRLF; the BOM is stripped up front so
+  // spreadsheet-exported files don't fail the header check (mirrors the import).
+  const { data: rows, errors: parseErrors } = Papa.parse<string[]>(
+    fs.readFileSync(csvPath, "utf8").replace(/^\uFEFF/, ""),
+    { skipEmptyLines: true },
+  )
+  for (const error of parseErrors) {
+    console.warn(`CSV parse warning at row ${error.row}: ${error.message}`)
+  }
+
+  const [header = [], ...dataRows] = rows
+  if (
+    header.map((field) => field.trim()).join(",") !== "domainName,source,target"
+  ) {
+    throw new Error(`Unexpected CSV header: ${header.join(",")}`)
+  }
+
+  const target = domainFilter ? normaliseDomain(domainFilter) : null
+  const byDomain = new Map<string, Probe[]>()
+  for (const row of dataRows) {
+    if (row.length !== 3) continue
+    const [domainName = "", source = "", csvTarget = ""] = row.map((field) =>
+      field.trim(),
+    )
+    // Wildcard / query-parameter rows are not imported, so they won't redirect
+    // — skip them to avoid false failures (mirrors the import).
+    if (
+      source.includes("*") ||
+      csvTarget.includes("*") ||
+      source.includes("?") ||
+      csvTarget.includes("?")
+    ) {
+      continue
+    }
+    const domain = normaliseDomain(domainName)
+    if (!domain || !trimSlashes(source)) continue
+    if (target && domain !== target) continue
+    const list = byDomain.get(domain) ?? []
+    byDomain.set(domain, list)
+    list.push({ domain, source, expectedTarget: csvTarget })
+  }
+
+  const probes: Probe[] = []
+  for (const [domain, list] of byDomain) {
+    const sliced = sampleSize > 0 ? list.slice(0, sampleSize) : list
+    probes.push(...sliced)
+    console.log(
+      `${domain}: ${list.length} redirect(s)` +
+        (sampleSize > 0 ? `, probing ${sliced.length}` : ""),
+    )
+  }
+
+  console.log(`Total redirects to verify: ${probes.length}`)
+  if (dryRun) {
+    console.log("Dry run - no requests made. Set dryRun to false to probe.")
+    return { probes, results: [] as Result[] }
+  }
+
+  const results = await runWithConcurrency(probes, props)
+  const failures = results.filter((r) => r.outcome !== "ok")
+
+  const byOutcome = (outcome: Outcome) =>
+    results.filter((r) => r.outcome === outcome).length
+  console.log(`\nVerified ${results.length} redirect(s):`)
+  console.log(`  OK:             ${byOutcome("ok")}`)
+  console.log(`  Wrong status:   ${byOutcome("wrong-status")}`)
+  console.log(`  Wrong location: ${byOutcome("wrong-location")}`)
+  console.log(`  Errors:         ${byOutcome("error")}`)
+
+  for (const f of failures) {
+    console.warn(
+      `[${f.outcome}] ${f.domain}/${trimSlashes(f.source)} -> ${f.detail}`,
+    )
+  }
+
+  if (failures.length > 0) {
+    const outputDir = path.join(__dirname, "output")
+    if (!fs.existsSync(outputDir)) fs.mkdirSync(outputDir)
+    const outputPath = path.join(
+      outputDir,
+      "redirect-verification-failures.csv",
+    )
+    fs.writeFileSync(
+      outputPath,
+      Papa.unparse({
+        fields: [
+          "domain",
+          "source",
+          "expectedTarget",
+          "outcome",
+          "status",
+          "location",
+          "detail",
+        ],
+        data: failures.map((f) => [
+          f.domain,
+          f.source,
+          f.expectedTarget,
+          f.outcome,
+          f.status ?? "",
+          f.location ?? "",
+          f.detail,
+        ]),
+      }),
+    )
+    console.log(`\nFailures written to ${outputPath}`)
+  }
+
+  return { probes, results }
+}
+
+// Only run when executed directly, not when imported by tests
+const isMain = process.argv[1] === fileURLToPath(import.meta.url)
+if (isMain) {
+  // NOTE: set csvPath, run against staging first, then set dryRun to false.
+  const props: VerifyRedirectsLiveProps = {
+    csvPath: "",
+    domainFilter: "",
+    sampleSize: 0,
+    concurrency: 10,
+    expectedStatus: 301,
+    timeoutMs: 10_000,
+    dryRun: true,
+  }
+
+  await verifyRedirectsLive(props)
+}

--- a/apps/studio/prisma/scripts/verifyRedirectsLive.ts
+++ b/apps/studio/prisma/scripts/verifyRedirectsLive.ts
@@ -11,9 +11,11 @@ const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
 interface VerifyRedirectsLiveProps {
-  // The same CSV used for the import (`domainName,source,target` header), e.g.
-  // isomer-next-infra/src/publishing/redirects.production.csv. The CSV is the
-  // source of truth: we verify the original legacy redirects still work live.
+  // A `domainName,source,target` CSV. Prefer the `migrated-redirects.csv` that a
+  // real import writes (under prisma/scripts/output) — it contains exactly the
+  // rows that were migrated, with the target set to the Location the published
+  // redirect should emit, so there are no unmatched-domain false failures. The
+  // original infra CSV also works, but will report un-migrated domains as errors.
   csvPath: string
   // Only verify this domain (bare hostname, e.g. "www.isomer.gov.sg"). Leave
   // empty to verify every domain in the CSV.


### PR DESCRIPTION
> [!CAUTION]
> **DO NOT MERGE — this PR will never be merged.** It exists only to review and record the one-off script used to migrate redirects from isomer-next-infra into the Studio database. The script is executed manually against the target environment as part of the redirects migration, and this PR will be closed once the migration is complete. Because the branch never merges, the script carries an inline copy of `createRedirectSchema` (from `feat/redirects-management-backend`) instead of importing it.

## Problem

Redirects for Isomer Next sites currently live as static rules in `redirects.production.csv` inside the isomer-next-infra repository. With redirects management moving into Studio (backed by the new `Redirect` table), the existing CSV rules need to be migrated into the database so sites keep their redirects once the new feature takes over.

There is currently no tooling to perform this migration.

Fixes ISOM-2274.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Adds `apps/studio/prisma/scripts/importRedirectsFromCsv.ts`, a one-off data script that imports rows from a `domainName,source,target` CSV into the `Redirect` table:
  - Maps each CSV domain to a site by matching against `Site.config.url` (comparison ignores case, scheme, and trailing path). Rows for domains with no matching site are skipped and reported with counts.
  - Ignores rows containing wildcards (`*`) or query parameters (`?`) in the source or target, since these are infra publishing features with no equivalent in the `Redirect` table's exact-match semantics.
  - Validates and normalises every row with the same rules as the Studio publish flow (inline copy of `createRedirectSchema`), so imported sources are normalised identically to redirects created through Studio. Invalid rows (e.g. empty, `http://`, or `mailto:` destinations) are skipped and reported with reasons.
  - Keeps the first occurrence when two CSV sources normalise to the same value, and reports the dropped duplicates.
  - Is idempotent: inserts use `ON CONFLICT (siteId, source)` to update destinations in place and revive soft-deleted rows, mirroring the publish flow. Inserts run in chunks of 1,000 inside a single transaction.
  - Runs as a dry run by default, printing a full summary (sites matched, rows to import, ignored/invalid/unmatched rows) without writing.
- Adds 11 integration tests (`prisma/scripts/__tests__/importRedirectsFromCsv.test.ts`) covering domain matching, wildcard/query-parameter/invalid row handling, source normalisation, duplicate handling, idempotency and soft-delete revival, dry-run behaviour, and header validation.
- Documents the script in `prisma/scripts/README.md`.

## Before & After Screenshots

N/A — this PR adds a manually-run data script with no UI changes.

## Tests

- Run `pnpm test:unit prisma/scripts/__tests__/importRedirectsFromCsv.test.ts` from `apps/studio` (requires `pnpm setup:test` for the test database). All 11 tests pass.

**Manual Verification Steps** (this doubles as the migration runbook):

- [ ] From `apps/studio`, follow `prisma/scripts/README.md` to tunnel to the target environment and set `DATABASE_URL`
- [ ] Set `csvPath` at the bottom of the script to the path of `redirects.production.csv` from isomer-next-infra and leave `dryRun = true`
- [ ] Run `source .env && pnpm exec tsx prisma/scripts/importRedirectsFromCsv.ts` and review the summary: sites matched, rows to import, and the reported unmatched domains, wildcard/query-parameter rows, and invalid rows
- [ ] Confirm the unmatched domains are expected (sites not yet on Studio) before proceeding
- [ ] Set `dryRun = false` and re-run the script with another engineer pairing (production requirement per `prisma/scripts/README.md`)
- [ ] Spot-check a few imported rows in the `Redirect` table: sources have a single leading slash and no trailing slash, destinations are unchanged
- [ ] Re-run the script once more and confirm the row count is unchanged (idempotency)
- [ ] Close this PR once the migration is complete

**New scripts**:

- `prisma/scripts/importRedirectsFromCsv.ts` : imports redirect rules from the isomer-next-infra `redirects.production.csv` into the `Redirect` table; dry-run by default, idempotent on re-run

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds two new one-off scripts and their tests for a data migration that moves static redirect rules from the infra CSV into the `Redirect` database table. The import script is idempotent, dry-run-by-default, and resolves internal destinations to `[resource:...]` references; the companion verification script probes the live CloudFront distribution to confirm each migrated redirect returns a 301.

- `importRedirectsFromCsv.ts` — parses and validates the CSV with an intentionally lenient schema subset, bulk-inserts in 1 000-row chunks inside a single transaction, and writes a `migrated-redirects.csv` for the verifier.
- `verifyRedirectsLive.ts` — reads the same CSV, fires concurrent HTTP probes with abort-signal timeout, and reports wrong-status / wrong-location failures to a CSV.
- 16 integration tests cover domain matching, wildcard/query-param skipping, invalid-row reporting, source normalisation, duplicate handling, idempotency, soft-delete revival, dry-run correctness, `updatedAt` advancement, empty-path guard, and header validation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to proceed — the script is a manually-executed, dry-run-by-default migration with no schema changes, and an idempotent ON CONFLICT path ensures re-runs are harmless.

The migration logic is well-guarded: every code path that previously caused concern (stale updatedAt, parentId cycles, empty csvPath) has been addressed. The single gap is that destinationSchema omits the control-char, backslash, and '..' guards the inline comment says are intended — a real-CSV destination with those characters would be stored verbatim — but the mandatory dry-run review step provides a practical safety net before any write occurs.

apps/studio/prisma/scripts/importRedirectsFromCsv.ts — destinationSchema is missing the control-char, backslash, and '..' guards present on sourceSchema.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/prisma/scripts/importRedirectsFromCsv.ts | New one-off migration script: parses a domain/source/target CSV, resolves internal destinations to [resource:...] references, and bulk-inserts via ON CONFLICT; addressed feedback on updatedAt, cycle guard, and empty-csvPath guard from prior rounds. |
| apps/studio/prisma/scripts/__tests__/importRedirectsFromCsv.test.ts | 16 integration tests covering domain matching, wildcard/query-param/invalid rows, source normalisation, duplicate handling, idempotency, soft-delete revival, dry-run, updatedAt bump, empty-csvPath guard, and header validation. |
| apps/studio/prisma/scripts/verifyRedirectsLive.ts | New verification script: reads the same CSV, probes each redirect over HTTP with a concurrency pool, compares status + Location, and writes failures to a CSV. No database access needed. |
| apps/studio/prisma/scripts/README.md | README extended with runbook steps for import and verification, including dry-run → review → real-run flow and pointers to the migrated-redirects output file. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[redirects.production.csv] --> B[importRedirectsFromCsv.ts]
    B --> C{Parse & validate rows}
    C -->|wildcard / query-param| D[Skip — log wildcardRowCount / queryParamRowCount]
    C -->|no matching Site.config.url| E[Skip — log unmatchedDomains]
    C -->|fails lenient schema| F[Skip — log invalidRows]
    C -->|duplicate after normalisation| G[Skip — log duplicateRows]
    C -->|valid| H[buildPermalinkToResourceId]
    H --> I{Destination type}
    I -->|https:// external| J[Store verbatim]
    I -->|internal path — live page/folder found| K[Store as resource:siteId:id reference]
    I -->|internal path — no live page| L[Store as literal path — log unresolvedDestinations]
    J & K & L --> M{dryRun?}
    M -->|yes| N[Print summary — no DB writes]
    M -->|no| O[INSERT in 1k-row chunks — ON CONFLICT doUpdateSet + updatedAt]
    O --> P[Write migrated-redirects.csv]
    P --> Q[verifyRedirectsLive.ts]
    Q --> R[Probe each redirect over HTTP]
    R --> S{301 + correct Location?}
    S -->|yes| T[OK]
    S -->|wrong status or location| U[Write redirect-verification-failures.csv]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[redirects.production.csv] --> B[importRedirectsFromCsv.ts]
    B --> C{Parse & validate rows}
    C -->|wildcard / query-param| D[Skip — log wildcardRowCount / queryParamRowCount]
    C -->|no matching Site.config.url| E[Skip — log unmatchedDomains]
    C -->|fails lenient schema| F[Skip — log invalidRows]
    C -->|duplicate after normalisation| G[Skip — log duplicateRows]
    C -->|valid| H[buildPermalinkToResourceId]
    H --> I{Destination type}
    I -->|https:// external| J[Store verbatim]
    I -->|internal path — live page/folder found| K[Store as resource:siteId:id reference]
    I -->|internal path — no live page| L[Store as literal path — log unresolvedDestinations]
    J & K & L --> M{dryRun?}
    M -->|yes| N[Print summary — no DB writes]
    M -->|no| O[INSERT in 1k-row chunks — ON CONFLICT doUpdateSet + updatedAt]
    O --> P[Write migrated-redirects.csv]
    P --> Q[verifyRedirectsLive.ts]
    Q --> R[Probe each redirect over HTTP]
    R --> S{301 + correct Location?}
    S -->|yes| T[OK]
    S -->|wrong status or location| U[Write redirect-verification-failures.csv]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["feat(redirect): write migrated rows to C..."](https://github.com/opengovsg/isomer/commit/f02f1a9bc92772e29edd9aa08fd85ad232568a33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746724)</sub>

**Context used:**

- Context used - apps/studio/prisma/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=511e297b-11a8-4965-aa9a-a7db76a58b1c))

<!-- /greptile_comment -->