### PR TITLE
fix(studio): prevent page type from being changed to RootPage via updateSettings

### DIFF
--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2240,6 +2240,33 @@ describe("page.router", async () => {
       expect(result).toMatchObject(expectedSettings)
     })
 
+    it("should not allow changing a page type to RootPage", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.updateSettings({
+        siteId: site.id,
+        pageId: Number(page.id),
+        type: "RootPage",
+        title: "Attempted RootPage",
+      })
+
+      // Assert: type should remain unchanged
+      const actualResource = await db
+        .selectFrom("Resource")
+        .where("id", "=", page.id)
+        .select(["Resource.type"])
+        .executeTakeFirstOrThrow()
+      expect(actualResource.type).toBe("Page")
+    })
+
     it("should throw 409 if permalink is not unique", async () => {
       // Arrange
       const reusedPermalink = "this-is-not-unique"

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -762,7 +762,10 @@ export const pageRouter = router({
   updateSettings: protectedProcedure
     .input(pageSettingsSchema)
     .mutation(
-      async ({ ctx, input: { pageId, siteId, title, ...settings } }) => {
+      async ({
+        ctx,
+        input: { pageId, siteId, title, type: _pageType, ...settings },
+      }) => {
         await bulkValidateUserPermissionsForResources({
           siteId,
           action: "update",


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

A VAPT finding (low severity) identified that any page could be escalated to `RootPage` type by calling `page.updateSettings` with `type: \"RootPage\"` in the request payload. Because the handler spread the full input `settings` (which included the `type` field) directly into the Kysely `.set()` call, an authenticated user with edit permissions could mutate the `type` column of any page resource.

## Solution

<!-- How did you solve the problem? -->

Destructure `type` out of the `settings` spread in the `updateSettings` handler so it is never passed to the database update. The resource type is now immutable via this endpoint — only `title` and `permalink` (where applicable) are written.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- `page.router.ts` — exclude `type` from the `.set()` payload in `updateSettings` so a caller cannot change a resource's type to `RootPage` (or any other type).
- `page.router.test.ts` — add regression test asserting that calling `updateSettings` with `type: \"RootPage\"` on a regular `Page` resource leaves its type unchanged.

## Before & After Screenshots

**BEFORE**:

<!-- N/A — server-side only change -->

**AFTER**:

<!-- N/A — server-side only change -->

## Tests

**Manual Verification Steps**:

- [ ] As an admin user, open any regular page in Studio and capture its `pageId` and `siteId` from the network tab.
- [ ] Using a tool such as Postman or browser DevTools, call the `page.updateSettings` tRPC mutation with `type: "RootPage"` and the captured IDs.
- [ ] Verify the response `type` field is **not** `RootPage` and matches the original page type.
- [ ] Confirm no `RootPage`-type duplicates appear in the site's resource list.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A