### PR TITLE
fix: show edit settings and move options for collection items in resource table

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -93,7 +93,9 @@ export const ResourceTableMenu = ({
           ) : (
             <>
               {/* TODO: Open edit modal depending on resource  */}
-              {type === ResourceType.Page && (
+              {(type === ResourceType.Page ||
+                type === ResourceType.CollectionPage ||
+                type === ResourceType.CollectionLink) && (
                 <MenuItem
                   onClick={() =>
                     setPageSettingsModalState({
@@ -118,7 +120,10 @@ export const ResourceTableMenu = ({
                   Edit folder settings
                 </MenuItem>
               )}
-              {(type === ResourceType.Page || type === ResourceType.Folder) && (
+              {(type === ResourceType.Page ||
+                type === ResourceType.CollectionPage ||
+                type === ResourceType.CollectionLink ||
+                type === ResourceType.Folder) && (
                 // TODO: we need to change the resourceid next time when we implement root level permissions
                 <Can do="move" on={{ parentId }}>
                   <MenuItem


### PR DESCRIPTION
## Problem

In the dashboard resource listings (site root and folder views), the row actions menu (`ResourceTableMenu`) only offered **Edit settings** for `Page` rows and **Move to...** for `Page` and `Folder` rows. Rows of type `CollectionPage` or `CollectionLink` showed neither option — the only action available for them was **Delete**, so users could not edit their settings or move them from these listings.

This is inconsistent with the menu shown inside a collection's own view (`CollectionTableMenu`), which already supports both actions for collection items, and with the backend, where the page settings and move endpoints both handle `CollectionPage` and `CollectionLink`.

## Solution

Extend the render conditions in `ResourceTableMenu` to include collection item types:

- **Edit settings** now renders for `CollectionPage` and `CollectionLink` rows (in addition to `Page`), opening the existing `PageSettingsModal`, which already handles both types (e.g. it hides the URL field for collection links).
- **Move to...** now renders for `CollectionPage` and `CollectionLink` rows (in addition to `Page` and `Folder`), opening the existing `MoveResourceModal`, still gated by the `move` permission check.

No backend changes — both modals and their underlying endpoints already support these resource types.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Show the **Edit settings** menu item for collection pages and collection links in the resource table's row actions menu
- Show the **Move to...** menu item for collection pages and collection links in the resource table's row actions menu

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Log in to Studio and navigate to a site listing that contains a collection page or collection link row rendered by the resource table
- [ ] Click the `...` actions menu on a collection page row and verify that **Edit settings** appears; click it and confirm the page settings modal opens with the row's details
- [ ] Verify that **Move to...** appears in the same menu; click it and confirm the move modal opens, and that moving the item to another collection succeeds
- [ ] Repeat the two checks above for a collection link row, and confirm the settings modal does not show a URL field for it
- [ ] Regression: confirm ordinary page rows still show **Edit settings**, **Move to...**, and **Delete**, and folder rows still show **Edit folder settings** and **Move to...**
- [ ] Regression: confirm the default Search page (permalink `/search` at root) still shows all menu items as disabled

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
