### PR TITLE
refactor(db): extract applyMigrations to @isomer/db/testing

### DIFF
--- a/apps/studio/tests/mocks/db.ts
+++ b/apps/studio/tests/mocks/db.ts
@@ -2,26 +2,13 @@ import type { DB } from "~/server/modules/database"
 import { PrismaPg } from "@prisma/adapter-pg"
 import { Kysely, PostgresDialect } from "kysely"
 import { randomUUID } from "node:crypto"
-import { readdirSync, readFileSync, statSync } from "node:fs"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
 import { Client, Pool } from "pg"
 import { parse } from "superjson"
 import { PrismaClient } from "~prisma/generated/prisma/client"
 
-import { CONTAINER_INFORMATION_SCHEMA } from "../common"
+import { applyMigrations } from "@isomer/db/testing"
 
-const prismaMigrationDir = join(
-  fileURLToPath(dirname(import.meta.url)),
-  "..",
-  "..",
-  "..",
-  "..",
-  "packages",
-  "db",
-  "prisma",
-  "migrations",
-)
+import { CONTAINER_INFORMATION_SCHEMA } from "../common"
 
 const parsed = CONTAINER_INFORMATION_SCHEMA.parse(
   parse(process.env.testcontainers ?? ""),
@@ -57,23 +44,6 @@ const setupPgClient = async () => {
   await _pgClient.connect()
   await _pgClient.query(`CREATE DATABASE "${testSpecificDb}";`)
   await _pgClient.end()
-
-  const client = new Client({
-    connectionString,
-  })
-  return client
-}
-
-// Running migrations manually; dd-trace intercepts `exec` usage and prevents runs
-const applyMigrations = async (client: Client) => {
-  const directory = readdirSync(prismaMigrationDir).sort()
-  for (const file of directory) {
-    const name = `${prismaMigrationDir}/${file}`
-    if (statSync(name).isDirectory()) {
-      const migration = readFileSync(`${name}/migration.sql`, "utf8")
-      await client.query(migration)
-    }
-  }
 }
 
 const db = new Kysely<DB>({
@@ -96,7 +66,5 @@ vi.mock("../../src/server/prisma", () => ({
   prisma,
 }))
 
-const pgClient = await setupPgClient()
-await pgClient.connect()
-await applyMigrations(pgClient)
-await pgClient.end()
+await setupPgClient()
+await applyMigrations(connectionString)

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing.ts"
   },
   "scripts": {
     "clean": "git clean -xdf .cache .turbo node_modules",

--- a/packages/db/src/testing.ts
+++ b/packages/db/src/testing.ts
@@ -1,0 +1,42 @@
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import pg from "pg"
+
+// Resolve our own migrations directory relative to this file so consumers never
+// hard-code a path to `@isomer/db`'s migrations. `src/testing.ts` sits one level
+// below the package root, and migrations live at `prisma/migrations`.
+const migrationsDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "prisma",
+  "migrations",
+)
+
+/**
+ * Applies all `@isomer/db` migrations to a fresh test database.
+ *
+ * Reads each migration's `migration.sql` in lexicographic order and executes it
+ * over a short-lived `pg` client. This deliberately does NOT shell out to
+ * `prisma migrate deploy`: dd-trace is loaded in the test process and intercepts
+ * child-process `exec`/`spawn`, which prevents the Prisma CLI from launching.
+ * See `docs/adr/0001-isomer-db-testing-applies-migrations-via-sql.md`.
+ */
+export const applyMigrations = async (
+  connectionString: string,
+): Promise<void> => {
+  const client = new pg.Client({ connectionString })
+  await client.connect()
+  try {
+    const entries = readdirSync(migrationsDir).sort()
+    for (const entry of entries) {
+      const path = join(migrationsDir, entry)
+      if (statSync(path).isDirectory()) {
+        const migration = readFileSync(join(path, "migration.sql"), "utf8")
+        await client.query(migration)
+      }
+    }
+  } finally {
+    await client.end()
+  }
+}

--- a/tooling/build/scripts/publishing/tests/global-setup.ts
+++ b/tooling/build/scripts/publishing/tests/global-setup.ts
@@ -1,39 +1,10 @@
-import { readdirSync, readFileSync, statSync } from "node:fs"
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
-import { Client } from "pg"
 import { GenericContainer, Wait } from "testcontainers"
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-
-const prismaMigrationDir = join(
-  __dirname,
-  "..",
-  "..",
-  "..",
-  "..",
-  "..",
-  "packages",
-  "db",
-  "prisma",
-  "migrations",
-)
+import { applyMigrations } from "@isomer/db/testing"
 
 const DB_USERNAME = "root"
 const DB_PASSWORD = "root"
 const DB_NAME = "test"
-
-// Running migrations manually; dd-trace intercepts `exec` usage and prevents runs
-const applyMigrations = async (client: Client) => {
-  const directory = readdirSync(prismaMigrationDir).sort()
-  for (const file of directory) {
-    const name = `${prismaMigrationDir}/${file}`
-    if (statSync(name).isDirectory()) {
-      const migration = readFileSync(`${name}/migration.sql`, "utf8")
-      await client.query(migration)
-    }
-  }
-}
 
 export default async () => {
   const container = await new GenericContainer("postgres:15-alpine")
@@ -47,21 +18,19 @@ export default async () => {
     .withWaitStrategy(Wait.forListeningPorts())
     .start()
 
-  const client = new Client({
-    host: container.getHost(),
-    port: container.getMappedPort(5432),
-    user: DB_USERNAME,
-    password: DB_PASSWORD,
-    database: DB_NAME,
-  })
-  await client.connect()
-  await applyMigrations(client)
-  await client.end()
+  const host = container.getHost()
+  const port = container.getMappedPort(5432)
+
+  // Apply @isomer/db's migrations via the shared helper, which owns the
+  // migrations path + the read-`.sql` (dd-trace-safe) apply loop.
+  await applyMigrations(
+    `postgres://${DB_USERNAME}:${DB_PASSWORD}@${host}:${port}/${DB_NAME}`,
+  )
 
   // Test workers fork off this process after global setup, so plain env
   // assignments are visible to the test files
-  process.env.TEST_DB_HOST = container.getHost()
-  process.env.TEST_DB_PORT = String(container.getMappedPort(5432))
+  process.env.TEST_DB_HOST = host
+  process.env.TEST_DB_PORT = String(port)
   process.env.TEST_DB_USERNAME = DB_USERNAME
   process.env.TEST_DB_PASSWORD = DB_PASSWORD
   process.env.TEST_DB_NAME = DB_NAME


### PR DESCRIPTION
## Problem

Integration tests that need the Isomer schema must apply `@isomer/db`'s migrations to a fresh database before seeding. Two places did this with the same fragile inline copy — a relative path reaching several levels up into `packages/db/prisma/migrations` plus a read-and-execute loop:

- `apps/studio/tests/mocks/db.ts`
- `tooling/build/scripts/publishing/tests/global-setup.ts` (added by #2425, which independently reinvented the identical loop **and** the same "dd-trace blocks exec" workaround)

The migrations are owned by `@isomer/db`, so where they live and how they are applied belongs in that package — not hard-coded in each consumer.

First PR (5a) of the publishing → `@isomer/db` + Kysely migration stack.

Closes N/A (internal refactor)

## Solution

- Added `applyMigrations(connectionString)` to a new `@isomer/db/testing` subpath export (`packages/db/src/testing.ts`). It resolves its **own** migrations directory via `import.meta.url`, then reads each `migration.sql` in lexicographic order and executes it over a short-lived `pg` client.
- It deliberately reads `.sql` rather than shelling out to `prisma migrate deploy`: dd-trace (loaded in the test process) intercepts child-process `exec`/`spawn` and blocks the Prisma CLI. See `docs/adr/0001-isomer-db-testing-applies-migrations-via-sql.md`.
- Flipped **both** inline copies to the shared helper, deleting two `../../../..` paths and two read-loops:
  - `apps/studio/tests/mocks/db.ts`
  - `tooling/build/scripts/publishing/tests/global-setup.ts`

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- New `@isomer/db/testing` export: a shared, path-safe way to schema a test database from the package that owns the migrations.
- Removes two duplicated, fragile inline migration loops; centralises the "read `.sql`, don't `exec` Prisma" constraint in one documented place (the ADR).

## Tests

**Manual Verification Steps**:

- [ ] `pnpm --filter @isomer/db typecheck` / `lint` pass
- [ ] `pnpm --filter isomer-studio test:unit` — full studio integration suite green (baseline 1258 passed / 41 skipped / 0 failed); key regression gate, the harness change sits under every studio integration test
- [ ] `pnpm --filter publishing test` — #2425's e2e suite (17 tests) green via the refactored `global-setup`

**New dependencies**: N/A (helper uses `pg` + `node:*`, already present)
