### PR TITLE
test(publishing): add DB test net before Kysely migration

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1499,9 +1499,15 @@ importers:
 
   tooling/build/scripts/publishing:
     dependencies:
+      '@isomer/db':
+        specifier: workspace:*
+        version: link:../../../../packages/db
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
+      kysely:
+        specifier: 'catalog:'
+        version: 0.29.2
       pg:
         specifier: 'catalog:'
         version: 8.21.0
@@ -1509,9 +1515,30 @@ importers:
         specifier: 'catalog:'
         version: 4.22.3
     devDependencies:
+      '@opengovsg/isomer-components':
+        specifier: workspace:*
+        version: link:../../../../packages/components
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.0
       '@types/pg':
         specifier: 'catalog:'
         version: 8.20.0
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260513.1
+      dotenv-cli:
+        specifier: 'catalog:'
+        version: 11.0.0
+      npm-run-all2:
+        specifier: 'catalog:'
+        version: 9.0.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: catalog:vitest
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.0)(@vitest/coverage-istanbul@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3))(vite@8.0.16(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.99.0)(terser@5.46.1)(tsx@4.22.3)(yaml@2.8.3))
 
   tooling/export-import:
     dependencies:

--- a/tooling/build/scripts/publishing/.env.test
+++ b/tooling/build/scripts/publishing/.env.test
@@ -1,0 +1,13 @@
+# Test database for the publishing script's characterization + integration tests.
+# Points at the docker-compose Postgres service (see docker-compose.yml), which
+# is booted on a fresh host port (5430) so it never collides with studio or
+# pgboss (5431). The schema is applied via `@isomer/db/testing`'s applyMigrations.
+DATABASE_URL=postgres://root:root@localhost:5430/test
+
+# Discrete vars mirroring the production CodeBuild contract, kept in sync with
+# DATABASE_URL above for any consumer that reads them individually.
+DB_USERNAME=root
+DB_PASSWORD=root
+DB_HOST=localhost
+DB_PORT=5430
+DB_NAME=test

--- a/tooling/build/scripts/publishing/__tests__/fixtures/buildFixtureSite.ts
+++ b/tooling/build/scripts/publishing/__tests__/fixtures/buildFixtureSite.ts
@@ -1,0 +1,367 @@
+import type { createDb } from "@isomer/db"
+import { ResourceState, ResourceType } from "@isomer/db"
+
+import { jsonb } from "../helpers/jsonb"
+import {
+  articlePage,
+  contentPage,
+  contentPageWithImage,
+  indexPage,
+} from "./page-content"
+
+type Db = ReturnType<typeof createDb>
+
+const MOCK_DATE = new Date("2026-01-01T00:00:00.000Z")
+
+const setupUser = async (db: Db) =>
+  db
+    .insertInto("User")
+    .values({
+      id: "fixture-user",
+      name: "Fixture Publisher",
+      email: "publisher@fixture.test",
+      phone: "",
+    })
+    .onConflict((oc) => oc.column("id").doNothing())
+    .returningAll()
+    .executeTakeFirstOrThrow()
+
+interface SetupSiteResult {
+  siteId: number
+}
+
+const setupSite = async (
+  db: Db,
+  siteId: number,
+  name: string,
+): Promise<SetupSiteResult> => {
+  await db
+    .insertInto("Site")
+    .values({
+      // @ts-expect-error id is GeneratedAlways but we override it for fixtures
+      id: siteId,
+      name,
+      config: jsonb({
+        theme: "isomer-next",
+        logoUrl: "",
+        siteName: name,
+        isGovernment: true,
+        url: "https://fixture.test",
+      }),
+      theme: jsonb({ colors: { brand: { canvas: { default: "#ffffff" } } } }),
+      codeBuildId: null,
+    })
+    .execute()
+
+  await db
+    .insertInto("Navbar")
+    .values({
+      siteId,
+      content: jsonb({
+        items: [{ url: "/parent-folder", name: "Parent Folder" }],
+      }),
+    })
+    .execute()
+
+  await db
+    .insertInto("Footer")
+    .values({
+      siteId,
+      content: jsonb({
+        siteNavItems: [{ url: "/parent-folder", title: "Parent Folder" }],
+        contactUsLink: "/contact-us",
+      }),
+    })
+    .execute()
+
+  return { siteId }
+}
+
+// Insert a Blob + a Version, returning the version id so the resource can be
+// marked published (publishedVersionId). Mirrors how studio publishes a page.
+const publishBlob = async (
+  db: Db,
+  resourceId: string,
+  content: object,
+): Promise<string> => {
+  const blob = await db
+    .insertInto("Blob")
+    .values({ content: jsonb(content) })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+
+  const version = await db
+    .insertInto("Version")
+    .values({
+      versionNum: 1,
+      resourceId,
+      blobId: blob.id,
+      publishedBy: "fixture-user",
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+
+  await db
+    .updateTable("Resource")
+    .where("id", "=", resourceId)
+    .set({ publishedVersionId: version.id })
+    .execute()
+
+  return version.id
+}
+
+interface InsertResourceArgs {
+  siteId: number
+  type: ResourceType
+  title: string
+  permalink: string
+  parentId?: string | null
+  state?: ResourceState
+}
+
+const insertResource = async (
+  db: Db,
+  {
+    siteId,
+    type,
+    title,
+    permalink,
+    parentId = null,
+    state,
+  }: InsertResourceArgs,
+): Promise<string> => {
+  const row = await db
+    .insertInto("Resource")
+    .values({
+      siteId,
+      type,
+      title,
+      permalink,
+      parentId,
+      state: state ?? null,
+      publishedVersionId: null,
+      draftBlobId: null,
+      createdAt: MOCK_DATE,
+      updatedAt: MOCK_DATE,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+  return row.id
+}
+
+export interface FixtureSite {
+  siteId: number
+  ids: Record<string, string>
+}
+
+/**
+ * Builds the rich main fixture site (plan decision 10). The tree exercises:
+ * - a multi-level resource tree (root → folder → nested page) for recursive
+ *   permalink building;
+ * - a published page (Version→Blob content) vs a Folder (null content) vs an
+ *   UNPUBLISHED resource (publishedVersionId null → null content);
+ * - a dangling directory (a Folder with a child page but no IndexPage);
+ * - an IndexPage with `childrenPagesOrdering`;
+ * - a Collection + CollectionMeta + CollectionPages;
+ * - a FolderMeta (deprecated ordering);
+ * - Site/Navbar/Footer rows, and Redirect rows incl. one soft-deleted.
+ */
+export const buildFixtureSite = async (
+  db: Db,
+  siteId = 1,
+): Promise<FixtureSite> => {
+  await setupUser(db)
+  await setupSite(db, siteId, "Fixture Ministry")
+
+  const ids: Record<string, string> = {}
+
+  // Root page (published, has content)
+  ids.rootPage = await insertResource(db, {
+    siteId,
+    type: ResourceType.RootPage,
+    title: "Home",
+    permalink: "",
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.rootPage, contentPage("Welcome to the home page"))
+
+  // Top-level folder "parent-folder"
+  ids.parentFolder = await insertResource(db, {
+    siteId,
+    type: ResourceType.Folder,
+    title: "Parent Folder",
+    permalink: "parent-folder",
+  })
+
+  // Two published pages under parent-folder (b-page sorts before a-page
+  // alphabetically by title; ordering overrides this via the IndexPage).
+  ids.aboutPage = await insertResource(db, {
+    siteId,
+    type: ResourceType.Page,
+    title: "About Page",
+    permalink: "about",
+    parentId: ids.parentFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(
+    db,
+    ids.aboutPage,
+    contentPageWithImage("About us summary", "/img/about.png"),
+  )
+
+  ids.contactPage = await insertResource(db, {
+    siteId,
+    type: ResourceType.Page,
+    title: "Contact Page",
+    permalink: "contact",
+    parentId: ids.parentFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.contactPage, contentPage("Contact us summary"))
+
+  // IndexPage for parent-folder, ordering contact BEFORE about (reverse of
+  // alphabetical) to prove the ordering is respected. childrenPagesOrdering
+  // references child resource ids.
+  ids.parentIndex = await insertResource(db, {
+    siteId,
+    type: ResourceType.IndexPage,
+    title: "Parent Folder",
+    permalink: "_index",
+    parentId: ids.parentFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(
+    db,
+    ids.parentIndex,
+    indexPage([ids.contactPage, ids.aboutPage]),
+  )
+
+  // Dangling directory: a Folder with a child page but NO IndexPage.
+  ids.danglingFolder = await insertResource(db, {
+    siteId,
+    type: ResourceType.Folder,
+    title: "Dangling Folder",
+    permalink: "dangling-folder",
+    parentId: ids.parentFolder,
+  })
+  ids.danglingChild = await insertResource(db, {
+    siteId,
+    type: ResourceType.Page,
+    title: "Buried Page",
+    permalink: "buried",
+    parentId: ids.danglingFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.danglingChild, contentPage("Buried page summary"))
+
+  // A second top-level folder using the deprecated FolderMeta ordering.
+  ids.metaFolder = await insertResource(db, {
+    siteId,
+    type: ResourceType.Folder,
+    title: "Meta Folder",
+    permalink: "meta-folder",
+  })
+  ids.metaAlpha = await insertResource(db, {
+    siteId,
+    type: ResourceType.Page,
+    title: "Alpha",
+    permalink: "alpha",
+    parentId: ids.metaFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.metaAlpha, contentPage("Alpha summary"))
+  ids.metaBeta = await insertResource(db, {
+    siteId,
+    type: ResourceType.Page,
+    title: "Beta",
+    permalink: "beta",
+    parentId: ids.metaFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.metaBeta, contentPage("Beta summary"))
+  // FolderMeta orders beta before alpha (reverse alphabetical).
+  ids.folderMeta = await insertResource(db, {
+    siteId,
+    type: ResourceType.FolderMeta,
+    title: "Meta Folder Meta",
+    permalink: "_meta",
+    parentId: ids.metaFolder,
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.folderMeta, { order: ["beta", "alpha"] })
+
+  // Collection + CollectionMeta + CollectionPages
+  ids.collection = await insertResource(db, {
+    siteId,
+    type: ResourceType.Collection,
+    title: "News",
+    permalink: "news",
+  })
+  ids.collectionMeta = await insertResource(db, {
+    siteId,
+    type: ResourceType.CollectionMeta,
+    title: "News Meta",
+    permalink: "_meta",
+    parentId: ids.collection,
+    state: ResourceState.Published,
+  })
+  await publishBlob(db, ids.collectionMeta, { variant: "collection" })
+  ids.articleOne = await insertResource(db, {
+    siteId,
+    type: ResourceType.CollectionPage,
+    title: "Article One",
+    permalink: "article-one",
+    parentId: ids.collection,
+    state: ResourceState.Published,
+  })
+  await publishBlob(
+    db,
+    ids.articleOne,
+    articlePage("First article", "Feature Articles"),
+  )
+  ids.articleTwo = await insertResource(db, {
+    siteId,
+    type: ResourceType.CollectionPage,
+    title: "Article Two",
+    permalink: "article-two",
+    parentId: ids.collection,
+    state: ResourceState.Published,
+  })
+  await publishBlob(
+    db,
+    ids.articleTwo,
+    articlePage("Second article", "Feature Articles"),
+  )
+
+  // An UNPUBLISHED top-level page: publishedVersionId stays null, so the
+  // content CASE in the recursive query yields null content for it.
+  ids.unpublishedPage = await insertResource(db, {
+    siteId,
+    type: ResourceType.Page,
+    title: "Draft Page",
+    permalink: "draft-page",
+    state: ResourceState.Draft,
+  })
+
+  // Redirects: one live, one soft-deleted (deletedAt set).
+  await db
+    .insertInto("Redirect")
+    .values({
+      siteId,
+      source: "/old-home",
+      destination: "/",
+      deletedAt: null,
+    })
+    .execute()
+  await db
+    .insertInto("Redirect")
+    .values({
+      siteId,
+      source: "/deleted-redirect",
+      destination: "/gone",
+      deletedAt: MOCK_DATE,
+    })
+    .execute()
+
+  return { siteId, ids }
+}

--- a/tooling/build/scripts/publishing/__tests__/fixtures/page-content.ts
+++ b/tooling/build/scripts/publishing/__tests__/fixtures/page-content.ts
@@ -1,0 +1,73 @@
+// Minimal-but-valid Isomer page schemas used as `Blob.content` in fixtures.
+// `Blob.content` is `IsomerSchema` (a layout-discriminated union), so fixture
+// content must be a real, minimally-valid page schema rather than arbitrary
+// JSON — this validates real-shaped content end-to-end (plan decisions 7 & 10).
+
+const ISOMER_SCHEMA_VERSION = "0.1.0"
+
+export const contentPage = (summary: string) => ({
+  version: ISOMER_SCHEMA_VERSION,
+  layout: "content",
+  page: {
+    contentPageHeader: { summary },
+  },
+  content: [
+    {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: summary }],
+        },
+      ],
+    },
+  ],
+})
+
+// A content page whose first block is an image, to exercise getResourceFirstImage.
+export const contentPageWithImage = (summary: string, src: string) => ({
+  version: ISOMER_SCHEMA_VERSION,
+  layout: "content",
+  page: {
+    contentPageHeader: { summary },
+  },
+  content: [
+    { type: "image", src, alt: "fixture image" },
+    {
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: summary }],
+        },
+      ],
+    },
+  ],
+})
+
+export const articlePage = (summary: string, category: string) => ({
+  version: ISOMER_SCHEMA_VERSION,
+  layout: "article",
+  page: {
+    date: "01/01/2026",
+    category,
+    articlePageHeader: { summary },
+  },
+  content: [],
+})
+
+// An index page carrying an explicit `childrenpages` ordering block. The
+// ordering is filled in by the fixture builder once child resource ids exist.
+export const indexPage = (childrenPagesOrdering: string[]) => ({
+  version: ISOMER_SCHEMA_VERSION,
+  layout: "index",
+  page: {
+    contentPageHeader: { summary: "Index" },
+  },
+  content: [
+    {
+      type: "childrenpages",
+      childrenPagesOrdering,
+    },
+  ],
+})

--- a/tooling/build/scripts/publishing/__tests__/helpers/db.ts
+++ b/tooling/build/scripts/publishing/__tests__/helpers/db.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from "node:crypto"
+import pg from "pg"
+
+import { createDb } from "@isomer/db"
+import { applyMigrations } from "@isomer/db/testing"
+
+// The docker-compose Postgres service (see docker-compose.yml) exposes a
+// `postgres://root:root@localhost:5430/test` admin connection. Each test file
+// creates its own throwaway database on that service so files do not interfere
+// with one another, then applies the `@isomer/db` schema via the shared
+// `applyMigrations` helper (PR 5a) — never `prisma migrate deploy` (see
+// docs/adr/0001-isomer-db-testing-applies-migrations-via-sql.md).
+const ADMIN_CONNECTION_STRING =
+  process.env.DATABASE_URL ?? "postgres://root:root@localhost:5430/test"
+
+const buildConnectionString = (dbName: string): string => {
+  const url = new URL(ADMIN_CONNECTION_STRING)
+  url.pathname = `/${dbName}`
+  return url.toString()
+}
+
+export interface TestDb {
+  /** Connection string pointing at the freshly-created, migrated database. */
+  connectionString: string
+  /** Kysely instance for building fixtures via `@isomer/db`. */
+  db: ReturnType<typeof createDb>
+  /** Drops the database and tears down the Kysely pool. */
+  destroy: () => Promise<void>
+}
+
+/**
+ * Creates a fresh database on the docker-compose service, applies the
+ * `@isomer/db` schema to it, and returns a Kysely instance + teardown.
+ */
+export const setupTestDb = async (): Promise<TestDb> => {
+  const dbName = `publishing_test_${randomUUID().replace(/-/g, "")}`
+
+  const admin = new pg.Client({ connectionString: ADMIN_CONNECTION_STRING })
+  await admin.connect()
+  try {
+    await admin.query(`CREATE DATABASE "${dbName}"`)
+  } finally {
+    await admin.end()
+  }
+
+  const connectionString = buildConnectionString(dbName)
+  await applyMigrations(connectionString)
+
+  const db = createDb({ connectionString })
+
+  const destroy = async () => {
+    await db.destroy()
+    const cleanup = new pg.Client({
+      connectionString: ADMIN_CONNECTION_STRING,
+    })
+    await cleanup.connect()
+    try {
+      await cleanup.query(
+        `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+        [dbName],
+      )
+      await cleanup.query(`DROP DATABASE IF EXISTS "${dbName}"`)
+    } finally {
+      await cleanup.end()
+    }
+  }
+
+  return { connectionString, db, destroy }
+}

--- a/tooling/build/scripts/publishing/__tests__/helpers/jsonb.ts
+++ b/tooling/build/scripts/publishing/__tests__/helpers/jsonb.ts
@@ -1,0 +1,9 @@
+import type { RawBuilder } from "kysely"
+
+import { sql } from "@isomer/db"
+
+// Mirror of studio's `jsonb` helper
+// (apps/studio/src/server/modules/database/utils.ts): wraps a plain JS value as
+// a JSONB literal so it can be inserted into JSONB columns via Kysely.
+export const jsonb = <T>(value: T): RawBuilder<T> =>
+  sql`CAST(${JSON.stringify(value)} AS JSONB)`

--- a/tooling/build/scripts/publishing/__tests__/queries.integration.test.ts
+++ b/tooling/build/scripts/publishing/__tests__/queries.integration.test.ts
@@ -1,0 +1,228 @@
+import pg from "pg"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+import { sql } from "@isomer/db"
+
+import {
+  GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+  GET_CONFIG,
+  GET_FOOTER,
+  GET_NAVBAR,
+  GET_REDIRECTS,
+} from "../queries"
+import { buildFixtureSite } from "./fixtures/buildFixtureSite"
+import { setupTestDb, type TestDb } from "./helpers/db"
+
+// These tests run the FIVE production queries through a raw `pg` client, exactly
+// as the publishing script does today (PR 5b is still the raw-`pg` era — no
+// Kysely execution of the queries-under-test). The fixture *builder* uses Kysely
+// via `@isomer/db`, but the queries below are executed verbatim against `pg`.
+const SITE_ID = 1
+
+// Shape of a row returned by GET_ALL_RESOURCES_WITH_FULL_PERMALINKS. Raw `pg`
+// returns untyped rows, so we describe just the fields these tests assert on.
+interface ResourceRow {
+  id: string
+  type: string
+  title: string
+  fullPermalink: string
+  parentId: string | null
+  publishedVersionId: string | null
+  content: unknown
+}
+
+describe("publishing queries (raw pg, against fixture site)", () => {
+  let testDb: TestDb
+  let client: pg.Client
+
+  beforeAll(async () => {
+    testDb = await setupTestDb()
+    await buildFixtureSite(testDb.db, SITE_ID)
+    // The script connects via raw pg; mirror that here.
+    client = new pg.Client({ connectionString: testDb.connectionString })
+    await client.connect()
+  })
+
+  afterAll(async () => {
+    await client.end()
+    await testDb.destroy()
+  })
+
+  describe("GET_ALL_RESOURCES_WITH_FULL_PERMALINKS", () => {
+    it("returns every resource for the site with a recursively-built fullPermalink", async () => {
+      const { rows } = await client.query(
+        GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+        [SITE_ID],
+      )
+
+      const byPermalink = new Map<string, ResourceRow>(
+        (rows as ResourceRow[]).map((r) => [r.fullPermalink, r]),
+      )
+
+      // Multi-level tree: root → parent-folder → nested page, with recursive
+      // permalink concatenation.
+      expect(byPermalink.has("")).toBe(true) // root page (empty permalink)
+      expect(byPermalink.has("parent-folder")).toBe(true)
+      expect(byPermalink.has("parent-folder/about")).toBe(true)
+      expect(byPermalink.has("parent-folder/contact")).toBe(true)
+      expect(byPermalink.has("parent-folder/_index")).toBe(true)
+      expect(byPermalink.has("parent-folder/dangling-folder")).toBe(true)
+      expect(byPermalink.has("parent-folder/dangling-folder/buried")).toBe(true)
+      expect(byPermalink.has("news/article-one")).toBe(true)
+      expect(byPermalink.has("news/_meta")).toBe(true)
+    })
+
+    it("populates content for published pages, null for folders and unpublished resources", async () => {
+      const { rows } = await client.query(
+        GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+        [SITE_ID],
+      )
+      const byPermalink = new Map<string, ResourceRow>(
+        (rows as ResourceRow[]).map((r) => [r.fullPermalink, r]),
+      )
+
+      // Published Page → Blob content present
+      const about = byPermalink.get("parent-folder/about")
+      expect(about?.content).not.toBeNull()
+      expect(about?.content).toMatchObject({ layout: "content" })
+
+      // Folder → content NULL (folder type not in the content CASE list)
+      const folder = byPermalink.get("parent-folder")
+      expect(folder?.content).toBeNull()
+
+      // Unpublished Page → publishedVersionId null → Blob join yields NULL content
+      const draft = byPermalink.get("draft-page")
+      expect(draft?.publishedVersionId).toBeNull()
+      expect(draft?.content).toBeNull()
+    })
+
+    it("only returns resources for the requested site", async () => {
+      // A non-existent site returns no rows.
+      const { rows: none } = await client.query(
+        GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+        [999],
+      )
+      expect(none).toHaveLength(0)
+    })
+  })
+
+  describe("GET_NAVBAR", () => {
+    it("returns the navbar content for the site", async () => {
+      const { rows } = await client.query(GET_NAVBAR, [SITE_ID])
+      expect(rows).toHaveLength(1)
+      expect(rows[0].content).toMatchObject({
+        items: [{ url: "/parent-folder", name: "Parent Folder" }],
+      })
+    })
+  })
+
+  describe("GET_FOOTER", () => {
+    it("returns the footer content for the site", async () => {
+      const { rows } = await client.query(GET_FOOTER, [SITE_ID])
+      expect(rows).toHaveLength(1)
+      expect(rows[0].content).toMatchObject({ contactUsLink: "/contact-us" })
+    })
+  })
+
+  describe("GET_CONFIG", () => {
+    it("returns name, config, and theme for the site", async () => {
+      const { rows } = await client.query(GET_CONFIG, [SITE_ID])
+      expect(rows).toHaveLength(1)
+      expect(rows[0].name).toBe("Fixture Ministry")
+      expect(rows[0].config).toMatchObject({ theme: "isomer-next" })
+      expect(rows[0].theme).not.toBeNull()
+    })
+  })
+
+  describe("GET_REDIRECTS", () => {
+    it("returns only non-soft-deleted redirects (deletedAt IS NULL)", async () => {
+      const { rows } = await client.query(GET_REDIRECTS, [SITE_ID])
+      expect(rows).toEqual([{ source: "/old-home", destination: "/" }])
+    })
+  })
+})
+
+describe("edge fixtures", () => {
+  it("GET_ALL... returns an empty array for an empty site", async () => {
+    const testDb = await setupTestDb()
+    try {
+      // Empty site: a Site row with no resources.
+      await testDb.db
+        .insertInto("Site")
+        .values({
+          // @ts-expect-error id is GeneratedAlways but we override it for fixtures
+          id: 2,
+          name: "Empty Site",
+          config: testDbConfig(),
+          theme: null,
+          codeBuildId: null,
+        })
+        .execute()
+
+      const client = new pg.Client({
+        connectionString: testDb.connectionString,
+      })
+      await client.connect()
+      try {
+        const { rows } = await client.query(
+          GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
+          [2],
+        )
+        expect(rows).toHaveLength(0)
+      } finally {
+        await client.end()
+      }
+    } finally {
+      await testDb.destroy()
+    }
+  })
+
+  it("GET_REDIRECTS returns empty when the only redirect is soft-deleted", async () => {
+    const testDb = await setupTestDb()
+    try {
+      await testDb.db
+        .insertInto("Site")
+        .values({
+          // @ts-expect-error id is GeneratedAlways but we override it for fixtures
+          id: 3,
+          name: "Redirect Edge Site",
+          config: testDbConfig(),
+          theme: null,
+          codeBuildId: null,
+        })
+        .execute()
+      await testDb.db
+        .insertInto("Redirect")
+        .values({
+          siteId: 3,
+          source: "/only-deleted",
+          destination: "/gone",
+          deletedAt: new Date("2026-01-01T00:00:00.000Z"),
+        })
+        .execute()
+
+      const client = new pg.Client({
+        connectionString: testDb.connectionString,
+      })
+      await client.connect()
+      try {
+        const { rows } = await client.query(GET_REDIRECTS, [3])
+        expect(rows).toHaveLength(0)
+      } finally {
+        await client.end()
+      }
+    } finally {
+      await testDb.destroy()
+    }
+  })
+})
+
+// Local minimal config JSONB literal for the edge fixtures.
+const testDbConfig = () =>
+  sql`CAST(${JSON.stringify({
+    theme: "isomer-next",
+    logoUrl: "",
+    siteName: "Edge",
+    isGovernment: true,
+    url: "",
+  })} AS JSONB)`

--- a/tooling/build/scripts/publishing/__tests__/sitemap.test.ts
+++ b/tooling/build/scripts/publishing/__tests__/sitemap.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from "vitest"
+
+import type { PageOnlySitemapEntry, Resource, SitemapEntry } from "../types"
+import {
+  buildPageSitemapEntry,
+  DANGLING_DIRECTORY_PAGE_ID,
+  generateSitemapTree,
+  getConvertedPermalink,
+  getDanglingDirectoryIndexPages,
+  getFoldersAndCollections,
+} from "../sitemap"
+
+// Minimal Resource factory. The pure functions only read a handful of fields,
+// so we cast through `unknown` to keep fixtures terse while preserving the
+// runtime shape the code actually touches.
+const resource = (r: Partial<Resource>): Resource =>
+  ({
+    id: "r",
+    title: "Resource",
+    permalink: "",
+    type: "Page",
+    parentId: null,
+    fullPermalink: "",
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    ...r,
+  }) as unknown as Resource
+
+const pageEntry = (e: Partial<PageOnlySitemapEntry>): PageOnlySitemapEntry =>
+  ({
+    id: "p",
+    title: "Page",
+    type: "Page",
+    permalink: "/page",
+    lastModified: "2026-01-01T00:00:00.000Z",
+    layout: "content",
+    summary: "",
+    ...e,
+  }) as PageOnlySitemapEntry
+
+describe("getConvertedPermalink", () => {
+  it("strips a trailing _index segment", () => {
+    expect(getConvertedPermalink("parent-folder/_index")).toBe("parent-folder")
+  })
+
+  it("strips a trailing _meta segment", () => {
+    expect(getConvertedPermalink("parent-folder/_meta")).toBe("parent-folder")
+  })
+
+  it("strips the resulting trailing slash after removing _index", () => {
+    // "_index" alone -> "" after slice, no trailing slash; a bare root index
+    // collapses to empty string.
+    expect(getConvertedPermalink("_index")).toBe("")
+  })
+
+  it("leaves a normal permalink untouched", () => {
+    expect(getConvertedPermalink("parent-folder/about")).toBe(
+      "parent-folder/about",
+    )
+  })
+
+  it("matches _index as a suffix anywhere (current endsWith behavior)", () => {
+    // Documents the current quirk: any permalink *ending* in the literal
+    // "_index" is trimmed, even mid-segment text like "foo_index".
+    expect(getConvertedPermalink("foo_index")).toBe("foo")
+  })
+})
+
+describe("buildPageSitemapEntry", () => {
+  const base = resource({
+    id: "page-1",
+    title: "About Page",
+    type: "Page",
+    fullPermalink: "parent-folder/about",
+    content: {
+      layout: "content",
+      page: { contentPageHeader: { summary: "About summary" } },
+    },
+  })
+
+  it("projects a page resource into a sitemap entry with a leading slash", () => {
+    const entry = buildPageSitemapEntry([base], base)
+    expect(entry).toMatchObject({
+      id: "page-1",
+      type: "Page",
+      title: "About Page",
+      permalink: "/parent-folder/about",
+      layout: "content",
+      summary: "About summary",
+    })
+  })
+
+  it("joins an array summary with spaces (contentPageHeader.summary array)", () => {
+    const arrayed = resource({
+      ...base,
+      content: {
+        layout: "content",
+        page: { contentPageHeader: { summary: ["a", "b", "c"] } },
+      },
+    })
+    expect(buildPageSitemapEntry([arrayed], arrayed).summary).toBe("a b c")
+  })
+
+  it("falls back through the summary chain (article -> subtitle -> description)", () => {
+    const articled = resource({
+      ...base,
+      content: {
+        layout: "article",
+        page: { articlePageHeader: { summary: "article summary" } },
+      },
+    })
+    expect(buildPageSitemapEntry([articled], articled).summary).toBe(
+      "article summary",
+    )
+  })
+
+  it("remaps an _index page id to the matching folder's id", () => {
+    const folder = resource({
+      id: "folder-1",
+      type: "Folder",
+      fullPermalink: "parent-folder",
+    })
+    const indexPage = resource({
+      id: "index-1",
+      type: "IndexPage",
+      fullPermalink: "parent-folder/_index",
+      content: { layout: "index", page: {} },
+    })
+    const entry = buildPageSitemapEntry([folder, indexPage], indexPage)
+    expect(entry.id).toBe("folder-1")
+    expect(entry.permalink).toBe("/parent-folder")
+  })
+
+  it("does NOT remap a RootPage id even when it ends with _index logic", () => {
+    const root = resource({
+      id: "root-1",
+      type: "RootPage",
+      fullPermalink: "",
+      content: { layout: "homepage", page: {} },
+    })
+    expect(buildPageSitemapEntry([root], root).id).toBe("root-1")
+  })
+
+  it("extracts the first image block via getResourceFirstImage", () => {
+    const withImage = resource({
+      ...base,
+      content: {
+        layout: "content",
+        page: { contentPageHeader: { summary: "s" } },
+        content: [{ type: "image", src: "/x.png", alt: "x" }],
+      },
+    })
+    expect(buildPageSitemapEntry([withImage], withImage).firstImage).toEqual({
+      src: "/x.png",
+      alt: "x",
+    })
+  })
+})
+
+describe("generateSitemapTree", () => {
+  it("returns undefined for a leaf with no descendant entries", () => {
+    const entries = [pageEntry({ permalink: "/about" })]
+    expect(generateSitemapTree([], entries, "/about")).toBeUndefined()
+  })
+
+  it("builds immediate children of the root", () => {
+    const entries = [
+      pageEntry({ id: "a", title: "Alpha", permalink: "/alpha" }),
+      pageEntry({ id: "b", title: "Beta", permalink: "/beta" }),
+    ]
+    const tree = generateSitemapTree([], entries, "/")
+    expect(tree?.map((c) => c.permalink)).toEqual(["/alpha", "/beta"])
+  })
+
+  it("sorts children alphabetically (numeric-aware) by title when no ordering", () => {
+    const entries = [
+      pageEntry({ id: "10", title: "Item 10", permalink: "/item-10" }),
+      pageEntry({ id: "2", title: "Item 2", permalink: "/item-2" }),
+    ]
+    const tree = generateSitemapTree([], entries, "/")
+    // numeric: true means "Item 2" sorts before "Item 10"
+    expect(tree?.map((c) => c.permalink)).toEqual(["/item-2", "/item-10"])
+  })
+
+  it("respects childrenPagesOrdering from an IndexPage resource", () => {
+    const entries = [
+      pageEntry({ id: "about", title: "About", permalink: "/f/about" }),
+      pageEntry({ id: "contact", title: "Contact", permalink: "/f/contact" }),
+    ]
+    const resources = [
+      resource({
+        type: "IndexPage",
+        fullPermalink: "f/_index",
+        content: {
+          content: [
+            {
+              type: "childrenpages",
+              // contact ordered before about (reverse of alphabetical)
+              childrenPagesOrdering: ["contact", "about"],
+            },
+          ],
+        },
+      }),
+    ]
+    const tree = generateSitemapTree(resources, entries, "/f")
+    expect(tree?.map((c) => c.permalink)).toEqual(["/f/contact", "/f/about"])
+  })
+
+  it("falls back to deprecated FolderMeta order when no IndexPage ordering", () => {
+    const entries = [
+      pageEntry({ id: "alpha", title: "Alpha", permalink: "/f/alpha" }),
+      pageEntry({ id: "beta", title: "Beta", permalink: "/f/beta" }),
+    ]
+    const resources = [
+      resource({
+        type: "FolderMeta",
+        fullPermalink: "f/_meta",
+        content: { order: ["beta", "alpha"] },
+      }),
+    ]
+    const tree = generateSitemapTree(resources, entries, "/f")
+    expect(tree?.map((c) => c.permalink)).toEqual(["/f/beta", "/f/alpha"])
+  })
+
+  it("synthesises a dangling-directory entry for a folder with children but no own page", () => {
+    // There is an entry under /f/sub/ but none exactly at /f/sub, so /f/sub is
+    // dangling. The matching Folder resource supplies its title + id.
+    const entries = [pageEntry({ id: "deep", permalink: "/f/sub/deep" })]
+    const resources = [
+      resource({
+        id: "sub-folder",
+        type: "Folder",
+        title: "Sub Folder",
+        fullPermalink: "f/sub",
+      }),
+    ]
+    const tree = generateSitemapTree(resources, entries, "/f")
+    expect(tree).toHaveLength(1)
+    expect(tree?.[0]).toMatchObject({
+      id: "sub-folder",
+      title: "Sub Folder",
+      permalink: "/f/sub",
+      layout: "index",
+      type: "Folder",
+    })
+    // and it recurses into the dangling directory's children
+    expect(tree?.[0]?.children?.[0]?.permalink).toBe("/f/sub/deep")
+  })
+
+  it("uses a generated title + sentinel id when no folder resource matches", () => {
+    const entries = [pageEntry({ id: "deep", permalink: "/f/my-sub/deep" })]
+    const tree = generateSitemapTree([], entries, "/f")
+    expect(tree?.[0]).toMatchObject({
+      id: DANGLING_DIRECTORY_PAGE_ID,
+      title: "My sub",
+      type: "Folder",
+    })
+  })
+
+  it("labels a dangling Collection directory with collection layout", () => {
+    const entries = [pageEntry({ id: "art", permalink: "/news/art" })]
+    const resources = [
+      resource({
+        id: "news",
+        type: "Collection",
+        title: "News",
+        fullPermalink: "news",
+      }),
+    ]
+    const tree = generateSitemapTree(resources, entries, "/")
+    expect(tree?.[0]).toMatchObject({
+      id: "news",
+      layout: "collection",
+      type: "Collection",
+    })
+  })
+})
+
+describe("getFoldersAndCollections", () => {
+  it("returns folder + collection children recursively, by resource type", () => {
+    const resources = [
+      resource({ id: "folder", type: "Folder" }),
+      resource({ id: "coll", type: "Collection" }),
+      resource({ id: "page", type: "Page" }),
+    ]
+    const tree: SitemapEntry = {
+      id: "root",
+      title: "Home",
+      permalink: "/",
+      type: "RootPage",
+      lastModified: "",
+      layout: "homepage",
+      summary: "",
+      children: [
+        { ...pageEntry({ id: "folder", permalink: "/folder" }), children: [] },
+        { ...pageEntry({ id: "coll", permalink: "/coll" }), children: [] },
+        { ...pageEntry({ id: "page", permalink: "/page" }), children: [] },
+      ],
+    }
+    const result = getFoldersAndCollections(resources, tree)
+    expect(result.map((r) => r.id).sort()).toEqual(["coll", "folder"])
+  })
+})
+
+describe("getDanglingDirectoryIndexPages", () => {
+  const folderContents = (title: string) => ({ kind: "folder", title })
+  const collectionContents = (title: string, variant?: unknown) => ({
+    kind: "collection",
+    title,
+    variant,
+  })
+
+  it("emits a folder index page (with /_index suffix) for each dangling folder", () => {
+    const resources = [resource({ id: "folder", type: "Folder" })]
+    const tree: SitemapEntry = {
+      id: "root",
+      title: "Home",
+      permalink: "/",
+      type: "RootPage",
+      lastModified: "",
+      layout: "homepage",
+      summary: "",
+      children: [
+        {
+          ...pageEntry({ id: "folder", title: "Folder", permalink: "/folder" }),
+          // A dangling-directory entry carries the folder's resource type;
+          // getDanglingDirectoryIndexPages filters on the sitemap entry type.
+          type: "Folder" as PageOnlySitemapEntry["type"],
+          children: [],
+        },
+      ],
+    }
+    const pages = getDanglingDirectoryIndexPages(
+      resources,
+      tree,
+      folderContents,
+      collectionContents,
+    )
+    expect(pages).toEqual([
+      {
+        permalink: "/folder/_index",
+        content: { kind: "folder", title: "Folder" },
+      },
+    ])
+  })
+
+  it("looks up CollectionMeta variant via the current parentId === Number(id) quirk", () => {
+    // Resource ids are strings; `Number(id)` is NaN for a non-numeric id, so the
+    // CollectionMeta lookup never matches and variant stays undefined. This
+    // locks in the known latent bug (plan decision 6) — do NOT 'fix' it here.
+    const resources = [
+      resource({ id: "coll", type: "Collection" }),
+      resource({
+        id: "meta",
+        type: "CollectionMeta",
+        parentId: "coll" as unknown as number,
+        content: { variant: "fullpage" },
+      }),
+    ]
+    const tree: SitemapEntry = {
+      id: "root",
+      title: "Home",
+      permalink: "/",
+      type: "RootPage",
+      lastModified: "",
+      layout: "homepage",
+      summary: "",
+      children: [
+        {
+          ...pageEntry({ id: "coll", title: "News", permalink: "/news" }),
+          type: "Collection" as PageOnlySitemapEntry["type"],
+          children: [],
+        },
+      ],
+    }
+    const pages = getDanglingDirectoryIndexPages(
+      resources,
+      tree,
+      folderContents,
+      collectionContents,
+    )
+    expect(pages).toEqual([
+      {
+        permalink: "/news/_index",
+        content: { kind: "collection", title: "News", variant: undefined },
+      },
+    ])
+  })
+
+  it("returns nothing for a leaf with no children", () => {
+    const leaf: SitemapEntry = {
+      id: "leaf",
+      title: "Leaf",
+      permalink: "/leaf",
+      type: "Page",
+      lastModified: "",
+      layout: "content",
+      summary: "",
+    }
+    expect(
+      getDanglingDirectoryIndexPages(
+        [],
+        leaf,
+        folderContents,
+        collectionContents,
+      ),
+    ).toEqual([])
+  })
+})

--- a/tooling/build/scripts/publishing/docker-compose.yml
+++ b/tooling/build/scripts/publishing/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  postgres:
+    image: postgres:15.10
+    ports:
+      - 5430:5432
+    environment:
+      - POSTGRES_DB=test
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=root
+    volumes:
+      - postgres-volume:/var/lib/postgresql-publishing-test/data
+
+volumes:
+  postgres-volume:

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -5,9 +5,8 @@ import { performance } from "perf_hooks"
 import { Client } from "pg"
 import { ResourceType } from "~generated/generatedEnums"
 
-import type { PageResourceType } from "./constants"
 import type { PageOnlySitemapEntry, Resource, SitemapEntry } from "./types"
-import { FOLDER_RESOURCE_TYPES, PAGE_RESOURCE_TYPES } from "./constants"
+import { PAGE_RESOURCE_TYPES } from "./constants"
 import {
   GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
   GET_CONFIG,
@@ -16,10 +15,17 @@ import {
   GET_REDIRECTS,
 } from "./queries"
 import {
+  buildPageSitemapEntry,
+  DANGLING_DIRECTORY_PAGE_ID,
+  generateSitemapTree,
+  getDanglingDirectoryIndexPages,
+  INDEX_PAGE_PERMALINK,
+  logDebug,
+} from "./sitemap"
+import {
   getCollectionIndexPageContents,
   getFolderIndexPageContents,
 } from "./utils/getIndexPageContent"
-import { getResourceFirstImage } from "./utils/getResourceFirstImage"
 
 dotenv.config()
 
@@ -30,39 +36,6 @@ const DB_HOST = process.env.DB_HOST
 const DB_PORT = process.env.DB_PORT
 const DB_NAME = process.env.DB_NAME
 const SITE_ID = Number(process.env.SITE_ID)
-
-// Unique identifier for pages of dangling directories
-// Guaranteed to not be present in the database because we start from 1
-const DANGLING_DIRECTORY_PAGE_ID = "-1"
-const INDEX_PAGE_PERMALINK = "_index"
-const META_PERMALINK = "_meta"
-
-const getConvertedPermalink = (fullPermalink: string) => {
-  // NOTE: If the full permalink ends with `_index`,
-  // we should remove it because this function
-  // is called for generation of the permalink in the sitemap
-  // and reflects what the users see.
-  // Note that we can do an `endsWith` because
-  // we prohibit users from using `_` as a character
-  const fullPermalinkWithoutIndex = fullPermalink.endsWith(INDEX_PAGE_PERMALINK)
-    ? fullPermalink.slice(0, -INDEX_PAGE_PERMALINK.length)
-    : fullPermalink.endsWith(META_PERMALINK)
-      ? fullPermalink.slice(0, -META_PERMALINK.length)
-      : fullPermalink
-
-  if (fullPermalinkWithoutIndex.endsWith("/")) {
-    return fullPermalinkWithoutIndex.slice(0, -1)
-  }
-
-  return fullPermalinkWithoutIndex
-}
-
-// Wrapper function for debug logging
-function logDebug(message: string, ...optionalParams: any[]) {
-  if (process.env.DEBUG === "true") {
-    console.log(message, ...optionalParams)
-  }
-}
 
 async function main() {
   const client = new Client({
@@ -113,49 +86,7 @@ async function main() {
           resource.parentId,
         )
 
-        // NOTE: We remap the ID for _index pages to be the ID of the folder,
-        // as both will have the same permalink and the folder is recognized as
-        // the parent of all the children resources
-        const idOfFolder = resources.find(
-          (item) =>
-            resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
-            resource.type !== "RootPage" &&
-            item.fullPermalink ===
-              getConvertedPermalink(resource.fullPermalink),
-        )?.id
-
-        const sitemapEntry: PageOnlySitemapEntry = {
-          id: idOfFolder ?? resource.id,
-          type: resource.type as PageResourceType,
-          title: resource.title,
-          permalink: `/${getConvertedPermalink(resource.fullPermalink)}`,
-          lastModified: resource.updatedAt.toISOString(),
-          layout: resource.content.layout || "content",
-          summary:
-            (Array.isArray(resource.content.page.contentPageHeader?.summary)
-              ? resource.content.page.contentPageHeader.summary.join(" ")
-              : resource.content.page.contentPageHeader?.summary) ||
-            resource.content.page.articlePageHeader?.summary ||
-            resource.content.page.subtitle ||
-            resource.content.page.description ||
-            "",
-          category: resource.content.page.category,
-          tags: resource.content.page.tags,
-          tagged: resource.content.page.tagged,
-          date: resource.content.page.date,
-          image: resource.content.page.image,
-          firstImage: getResourceFirstImage(resource),
-          ref: resource.content.page.ref, // For file and link layouts
-          collectionPagePageProps: {
-            tagCategories: resource.content.page?.tagCategories,
-            sortOrder: resource.content.page?.sortOrder,
-            defaultSortBy: resource.content.page?.defaultSortBy,
-            defaultSortDirection: resource.content.page?.defaultSortDirection,
-            showThumbnail: resource.content.page?.showThumbnail,
-          },
-        }
-
-        sitemapEntries.push(sitemapEntry)
+        sitemapEntries.push(buildPageSitemapEntry(resources, resource))
       } else {
         logDebug(
           `Skipping resource with id ${resource.id} as it is not a Page or has no content.`,
@@ -208,236 +139,23 @@ async function main() {
   }
 }
 
-function generateSitemapTree(
-  resources: Resource[],
-  sitemapEntries: PageOnlySitemapEntry[],
-  pathPrefix: string,
-): SitemapEntry[] | undefined {
-  const pathPrefixWithoutLeadingSlash = pathPrefix.slice(1)
-
-  const entriesWithPathPrefix = sitemapEntries.filter(
-    (entry) =>
-      entry.permalink.startsWith(
-        `${pathPrefix.length === 1 ? "" : pathPrefix}/`,
-      ) && entry.permalink !== "/",
-  )
-
-  // Base case: No entries with the path prefix - this is a leaf node
-  if (entriesWithPathPrefix.length === 0) {
-    return undefined
-  }
-
-  // NOTE: Get the immediate children of the current path
-  const childrenPaths = Array.from(
-    new Set(
-      entriesWithPathPrefix.map(
-        (entry) =>
-          entry.permalink
-            .slice(
-              // NOTE: This is either one or two based on whether it is the root.
-              // This is because at this point, the path prefix would either be
-              // `/`if root, or `/a/b/` if not root.
-              // Hence, we have to remove the whole prefix based on whether it has
-              // just a single `/`(the single `/` is both leading and trailing) or both leading and trailing `/`
-              pathPrefixWithoutLeadingSlash.length +
-                (pathPrefix.length === 1 ? 1 : 2),
-            )
-            .split("/")[0],
-      ),
-    ),
-  )
-
-  // Identify children paths that might be dangling directories
-  const danglingDirectories: SitemapEntry[] = childrenPaths
-    .filter(
-      (childPath) =>
-        sitemapEntries.some((entry) =>
-          entry.permalink.startsWith(
-            `${pathPrefix.length === 1 ? "" : pathPrefix}/${childPath}/`,
-          ),
-        ) &&
-        !sitemapEntries.some(
-          (entry) =>
-            entry.permalink ===
-            `${pathPrefix.length === 1 ? "" : pathPrefix}/${childPath}`,
-        ),
-    )
-    .map((danglingDirectory) => {
-      const pageName = danglingDirectory.replace(/-/g, " ")
-      const generatedTitle =
-        pageName.charAt(0).toUpperCase() + pageName.slice(1)
-
-      const folder = resources.find(
-        (resource) =>
-          getConvertedPermalink(resource.fullPermalink) ===
-            (pathPrefixWithoutLeadingSlash.length === 0
-              ? danglingDirectory
-              : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`) &&
-          FOLDER_RESOURCE_TYPES.find((t) => t === resource.type),
-      )
-      const title = folder?.title ?? generatedTitle
-
-      logDebug(
-        `Creating index page for dangling directory: ${danglingDirectory}`,
-      )
-      logDebug(
-        "Checking using permalink:",
-        pathPrefixWithoutLeadingSlash.length === 0
-          ? danglingDirectory
-          : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`,
-      )
-
-      return {
-        id: folder?.id ?? DANGLING_DIRECTORY_PAGE_ID,
-        title,
-        permalink: `${pathPrefix.length === 1 ? "" : pathPrefix}/${danglingDirectory}`,
-        lastModified: new Date().toISOString(),
-        layout: folder?.type === "Collection" ? "collection" : "index",
-        summary: `Pages in ${title}`,
-        type: folder?.type ?? ResourceType.Folder,
-      }
-    })
-
-  const existingChildren = entriesWithPathPrefix.filter(
-    (entry) =>
-      entry.permalink
-        .slice(
-          pathPrefixWithoutLeadingSlash.length +
-            (pathPrefix.length === 1 ? 1 : 2),
-        )
-        .split("/").length === 1,
-  )
-  const children = [...existingChildren, ...danglingDirectories]
-
-  // Get the page sorting order from the FolderMeta resource
-  // TODO: delete this once `FolderMeta` is removed
-  /** @deprecated use `pageOrderFromIndex` instead; we should remove this once `FolderMeta` is removed from db */
-  const pageOrderFromMeta = resources.find(
-    (resource) =>
-      resource.type === "FolderMeta" &&
-      resource.fullPermalink ===
-        (pathPrefixWithoutLeadingSlash.length === 0
-          ? META_PERMALINK
-          : `${pathPrefixWithoutLeadingSlash}/${META_PERMALINK}`),
-  )?.content?.order
-
-  const pageOrderFromIndex = resources
-    .find(
-      (resource) =>
-        resource.type === "IndexPage" &&
-        resource.fullPermalink ===
-          (pathPrefixWithoutLeadingSlash.length === 0
-            ? INDEX_PAGE_PERMALINK
-            : `${pathPrefixWithoutLeadingSlash}/${INDEX_PAGE_PERMALINK}`),
-    )
-    ?.content?.content?.find(
-      ({ type }: { type: string }) => type === "childrenpages",
-    )
-    ?.childrenPagesOrdering?.map((id: string) => {
-      const child = children.find(({ id: childId }) => {
-        return id === childId
-      })
-
-      return child?.permalink.split("/").pop()
-    })
-    .filter((permalink: string | undefined) => !!permalink)
-
-  const pageOrder = pageOrderFromIndex ?? pageOrderFromMeta
-
-  children.sort((a, b) => {
-    const aPermalink = a.permalink.split("/").pop()
-    const bPermalink = b.permalink.split("/").pop()
-
-    if (
-      pageOrder === undefined ||
-      pageOrder.indexOf(aPermalink) === pageOrder.indexOf(bPermalink)
-    ) {
-      return a.title.localeCompare(b.title, undefined, { numeric: true })
-    }
-
-    if (pageOrder.indexOf(aPermalink) === -1) {
-      return 1
-    }
-
-    if (pageOrder.indexOf(bPermalink) === -1) {
-      return -1
-    }
-
-    return pageOrder.indexOf(aPermalink) - pageOrder.indexOf(bPermalink)
-  })
-
-  return children.map((child) => ({
-    ...child,
-    children: generateSitemapTree(resources, sitemapEntries, child.permalink),
-  }))
-}
-
-function getFoldersAndCollections(
-  resources: Resource[],
-  sitemapEntry: SitemapEntry,
-): SitemapEntry[] {
-  // Base case: No children - this is a leaf node
-  if (!sitemapEntry.children) {
-    return []
-  }
-
-  // Get all immediate children that are folders
-  const folders = sitemapEntry.children.filter((child) =>
-    resources.some(
-      (resource) =>
-        resource.id === child.id &&
-        FOLDER_RESOURCE_TYPES.find((t) => t === resource.type),
-    ),
-  )
-
-  // Recurse on all children
-  return [
-    ...folders,
-    ...sitemapEntry.children.flatMap((child) =>
-      getFoldersAndCollections(resources, child),
-    ),
-  ]
-}
-
 // Create the index page for all dangling directories
 async function processDanglingDirectories(
   resources: Resource[],
   sitemapEntry: SitemapEntry,
 ) {
-  // Base case: No children - this is a leaf node
-  if (!sitemapEntry.children) {
-    return
-  }
-
-  const directories = getFoldersAndCollections(resources, sitemapEntry)
-  const folders = directories.filter(
-    (siteMapEntry) => siteMapEntry.type === ResourceType.Folder,
-  )
-  const collections = directories.filter(
-    (siteMapEntry) => siteMapEntry.type === ResourceType.Collection,
+  const indexPages = getDanglingDirectoryIndexPages(
+    resources,
+    sitemapEntry,
+    getFolderIndexPageContents,
+    getCollectionIndexPageContents,
   )
 
   // Create index page for all immediate children that are dangling directories
   await Promise.all(
-    [
-      ...folders.map(({ title, permalink }) => {
-        const content = getFolderIndexPageContents(title)
-        return { title, permalink, content }
-      }),
-      ...collections.map(({ id, title, permalink }) => {
-        const meta = resources.find(
-          ({ type, parentId }) =>
-            parentId === Number(id) && type === "CollectionMeta",
-        )
-        const content = getCollectionIndexPageContents(
-          title,
-          meta?.content.variant,
-        )
-        return { title, permalink, content }
-      }),
-    ].map((child) => {
+    indexPages.map((child) => {
       return writeContentToFile(
-        `${child.permalink}/${INDEX_PAGE_PERMALINK}`,
+        child.permalink,
         child.content,
         Number(DANGLING_DIRECTORY_PAGE_ID),
       )

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -7,16 +7,31 @@
   "author": "",
   "main": "index.ts",
   "scripts": {
+    "db:sleep": "sleep 3",
+    "services:setup": "docker compose -f \"docker-compose.yml\" up -d --wait",
+    "setup:test": "run-s --print-label services:setup db:sleep",
     "start": "tsx index.ts ",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "run-s test:*",
+    "test:unit": "dotenv -e .env.test pnpm exec vitest run",
+    "test:watch": "dotenv -e .env.test pnpm exec vitest watch",
+    "typecheck": "tsgo --noEmit",
     "upload-redirects": "tsx uploadRedirects.ts"
   },
   "dependencies": {
+    "@isomer/db": "workspace:*",
     "dotenv": "catalog:",
+    "kysely": "catalog:",
     "pg": "catalog:",
     "tsx": "catalog:"
   },
   "devDependencies": {
-    "@types/pg": "catalog:"
+    "@opengovsg/isomer-components": "workspace:*",
+    "@types/node": "catalog:",
+    "@types/pg": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "dotenv-cli": "catalog:",
+    "npm-run-all2": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:vitest"
   }
 }

--- a/tooling/build/scripts/publishing/prisma-json-types.d.ts
+++ b/tooling/build/scripts/publishing/prisma-json-types.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Loose ambient declaration of the `PrismaJson` global namespace.
+ *
+ * The publishing tsconfig resolves `~generated/*` to `@isomer/db`'s generated
+ * Kysely types (see tsconfig `paths`). Those generated types reference
+ * `PrismaJson.X` JSON-column shapes whose precise declaration lives in
+ * `apps/studio/prisma/types.ts` — which is outside this package's tsconfig
+ * include glob. This stub mirrors `packages/db/src/prisma-json-types.d.ts` so
+ * the generated types typecheck here without pulling in studio-flavoured shape
+ * dependencies. It is typecheck-only; runtime resolution is unaffected.
+ */
+
+/* oxlint-disable @typescript-eslint/no-namespace, @typescript-eslint/no-empty-object-type */
+declare global {
+  namespace PrismaJson {
+    interface SiteJsonConfig {}
+    interface SiteThemeJson {}
+    interface BlobJsonContent {}
+    interface NavbarJsonContent {}
+    interface FooterJsonContent {}
+    interface AuditLogDeltaJsonContent {}
+  }
+}
+
+export {}

--- a/tooling/build/scripts/publishing/sitemap.ts
+++ b/tooling/build/scripts/publishing/sitemap.ts
@@ -1,0 +1,326 @@
+import { ResourceType } from "~generated/generatedEnums"
+
+import type { PageResourceType } from "./constants"
+import type { PageOnlySitemapEntry, Resource, SitemapEntry } from "./types"
+import { FOLDER_RESOURCE_TYPES } from "./constants"
+import { getResourceFirstImage } from "./utils/getResourceFirstImage"
+
+// Unique identifier for pages of dangling directories
+// Guaranteed to not be present in the database because we start from 1
+export const DANGLING_DIRECTORY_PAGE_ID = "-1"
+export const INDEX_PAGE_PERMALINK = "_index"
+export const META_PERMALINK = "_meta"
+
+// Wrapper function for debug logging
+export function logDebug(message: string, ...optionalParams: any[]) {
+  if (process.env.DEBUG === "true") {
+    console.log(message, ...optionalParams)
+  }
+}
+
+export const getConvertedPermalink = (fullPermalink: string) => {
+  // NOTE: If the full permalink ends with `_index`,
+  // we should remove it because this function
+  // is called for generation of the permalink in the sitemap
+  // and reflects what the users see.
+  // Note that we can do an `endsWith` because
+  // we prohibit users from using `_` as a character
+  const fullPermalinkWithoutIndex = fullPermalink.endsWith(INDEX_PAGE_PERMALINK)
+    ? fullPermalink.slice(0, -INDEX_PAGE_PERMALINK.length)
+    : fullPermalink.endsWith(META_PERMALINK)
+      ? fullPermalink.slice(0, -META_PERMALINK.length)
+      : fullPermalink
+
+  if (fullPermalinkWithoutIndex.endsWith("/")) {
+    return fullPermalinkWithoutIndex.slice(0, -1)
+  }
+
+  return fullPermalinkWithoutIndex
+}
+
+// Build a single page-only sitemap entry from a resource. The caller has
+// already established that the resource is a page with content. This is the
+// pure projection of a resource row into a sitemap entry — file I/O and the
+// `resource.content.page.title` mutation remain in the entry point.
+export const buildPageSitemapEntry = (
+  resources: Resource[],
+  resource: Resource,
+): PageOnlySitemapEntry => {
+  // NOTE: We remap the ID for _index pages to be the ID of the folder,
+  // as both will have the same permalink and the folder is recognized as
+  // the parent of all the children resources
+  const idOfFolder = resources.find(
+    (item) =>
+      resource.fullPermalink.endsWith(INDEX_PAGE_PERMALINK) &&
+      resource.type !== "RootPage" &&
+      item.fullPermalink === getConvertedPermalink(resource.fullPermalink),
+  )?.id
+
+  return {
+    id: idOfFolder ?? resource.id,
+    type: resource.type as PageResourceType,
+    title: resource.title,
+    permalink: `/${getConvertedPermalink(resource.fullPermalink)}`,
+    lastModified: resource.updatedAt.toISOString(),
+    layout: resource.content.layout || "content",
+    summary:
+      (Array.isArray(resource.content.page.contentPageHeader?.summary)
+        ? resource.content.page.contentPageHeader.summary.join(" ")
+        : resource.content.page.contentPageHeader?.summary) ||
+      resource.content.page.articlePageHeader?.summary ||
+      resource.content.page.subtitle ||
+      resource.content.page.description ||
+      "",
+    category: resource.content.page.category,
+    tags: resource.content.page.tags,
+    tagged: resource.content.page.tagged,
+    date: resource.content.page.date,
+    image: resource.content.page.image,
+    firstImage: getResourceFirstImage(resource),
+    ref: resource.content.page.ref, // For file and link layouts
+    collectionPagePageProps: {
+      tagCategories: resource.content.page?.tagCategories,
+      sortOrder: resource.content.page?.sortOrder,
+      defaultSortBy: resource.content.page?.defaultSortBy,
+      defaultSortDirection: resource.content.page?.defaultSortDirection,
+      showThumbnail: resource.content.page?.showThumbnail,
+    },
+  }
+}
+
+export function generateSitemapTree(
+  resources: Resource[],
+  sitemapEntries: PageOnlySitemapEntry[],
+  pathPrefix: string,
+): SitemapEntry[] | undefined {
+  const pathPrefixWithoutLeadingSlash = pathPrefix.slice(1)
+
+  const entriesWithPathPrefix = sitemapEntries.filter(
+    (entry) =>
+      entry.permalink.startsWith(
+        `${pathPrefix.length === 1 ? "" : pathPrefix}/`,
+      ) && entry.permalink !== "/",
+  )
+
+  // Base case: No entries with the path prefix - this is a leaf node
+  if (entriesWithPathPrefix.length === 0) {
+    return undefined
+  }
+
+  // NOTE: Get the immediate children of the current path
+  const childrenPaths = Array.from(
+    new Set(
+      entriesWithPathPrefix.map(
+        (entry) =>
+          entry.permalink
+            .slice(
+              // NOTE: This is either one or two based on whether it is the root.
+              // This is because at this point, the path prefix would either be
+              // `/`if root, or `/a/b/` if not root.
+              // Hence, we have to remove the whole prefix based on whether it has
+              // just a single `/`(the single `/` is both leading and trailing) or both leading and trailing `/`
+              pathPrefixWithoutLeadingSlash.length +
+                (pathPrefix.length === 1 ? 1 : 2),
+            )
+            .split("/")[0],
+      ),
+    ),
+  )
+
+  // Identify children paths that might be dangling directories
+  const danglingDirectories: SitemapEntry[] = childrenPaths
+    .filter(
+      (childPath) =>
+        sitemapEntries.some((entry) =>
+          entry.permalink.startsWith(
+            `${pathPrefix.length === 1 ? "" : pathPrefix}/${childPath}/`,
+          ),
+        ) &&
+        !sitemapEntries.some(
+          (entry) =>
+            entry.permalink ===
+            `${pathPrefix.length === 1 ? "" : pathPrefix}/${childPath}`,
+        ),
+    )
+    .map((danglingDirectory) => {
+      const pageName = danglingDirectory.replace(/-/g, " ")
+      const generatedTitle =
+        pageName.charAt(0).toUpperCase() + pageName.slice(1)
+
+      const folder = resources.find(
+        (resource) =>
+          getConvertedPermalink(resource.fullPermalink) ===
+            (pathPrefixWithoutLeadingSlash.length === 0
+              ? danglingDirectory
+              : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`) &&
+          FOLDER_RESOURCE_TYPES.find((t) => t === resource.type),
+      )
+      const title = folder?.title ?? generatedTitle
+
+      logDebug(
+        `Creating index page for dangling directory: ${danglingDirectory}`,
+      )
+      logDebug(
+        "Checking using permalink:",
+        pathPrefixWithoutLeadingSlash.length === 0
+          ? danglingDirectory
+          : `${pathPrefixWithoutLeadingSlash}/${danglingDirectory}`,
+      )
+
+      return {
+        id: folder?.id ?? DANGLING_DIRECTORY_PAGE_ID,
+        title,
+        permalink: `${pathPrefix.length === 1 ? "" : pathPrefix}/${danglingDirectory}`,
+        lastModified: new Date().toISOString(),
+        layout: folder?.type === "Collection" ? "collection" : "index",
+        summary: `Pages in ${title}`,
+        type: folder?.type ?? ResourceType.Folder,
+      }
+    })
+
+  const existingChildren = entriesWithPathPrefix.filter(
+    (entry) =>
+      entry.permalink
+        .slice(
+          pathPrefixWithoutLeadingSlash.length +
+            (pathPrefix.length === 1 ? 1 : 2),
+        )
+        .split("/").length === 1,
+  )
+  const children = [...existingChildren, ...danglingDirectories]
+
+  // Get the page sorting order from the FolderMeta resource
+  // TODO: delete this once `FolderMeta` is removed
+  /** @deprecated use `pageOrderFromIndex` instead; we should remove this once `FolderMeta` is removed from db */
+  const pageOrderFromMeta = resources.find(
+    (resource) =>
+      resource.type === "FolderMeta" &&
+      resource.fullPermalink ===
+        (pathPrefixWithoutLeadingSlash.length === 0
+          ? META_PERMALINK
+          : `${pathPrefixWithoutLeadingSlash}/${META_PERMALINK}`),
+  )?.content?.order
+
+  const pageOrderFromIndex = resources
+    .find(
+      (resource) =>
+        resource.type === "IndexPage" &&
+        resource.fullPermalink ===
+          (pathPrefixWithoutLeadingSlash.length === 0
+            ? INDEX_PAGE_PERMALINK
+            : `${pathPrefixWithoutLeadingSlash}/${INDEX_PAGE_PERMALINK}`),
+    )
+    ?.content?.content?.find(
+      ({ type }: { type: string }) => type === "childrenpages",
+    )
+    ?.childrenPagesOrdering?.map((id: string) => {
+      const child = children.find(({ id: childId }) => {
+        return id === childId
+      })
+
+      return child?.permalink.split("/").pop()
+    })
+    .filter((permalink: string | undefined) => !!permalink)
+
+  const pageOrder = pageOrderFromIndex ?? pageOrderFromMeta
+
+  children.sort((a, b) => {
+    const aPermalink = a.permalink.split("/").pop()
+    const bPermalink = b.permalink.split("/").pop()
+
+    if (
+      pageOrder === undefined ||
+      pageOrder.indexOf(aPermalink) === pageOrder.indexOf(bPermalink)
+    ) {
+      return a.title.localeCompare(b.title, undefined, { numeric: true })
+    }
+
+    if (pageOrder.indexOf(aPermalink) === -1) {
+      return 1
+    }
+
+    if (pageOrder.indexOf(bPermalink) === -1) {
+      return -1
+    }
+
+    return pageOrder.indexOf(aPermalink) - pageOrder.indexOf(bPermalink)
+  })
+
+  return children.map((child) => ({
+    ...child,
+    children: generateSitemapTree(resources, sitemapEntries, child.permalink),
+  }))
+}
+
+export function getFoldersAndCollections(
+  resources: Resource[],
+  sitemapEntry: SitemapEntry,
+): SitemapEntry[] {
+  // Base case: No children - this is a leaf node
+  if (!sitemapEntry.children) {
+    return []
+  }
+
+  // Get all immediate children that are folders
+  const folders = sitemapEntry.children.filter((child) =>
+    resources.some(
+      (resource) =>
+        resource.id === child.id &&
+        FOLDER_RESOURCE_TYPES.find((t) => t === resource.type),
+    ),
+  )
+
+  // Recurse on all children
+  return [
+    ...folders,
+    ...sitemapEntry.children.flatMap((child) =>
+      getFoldersAndCollections(resources, child),
+    ),
+  ]
+}
+
+// Pure decision for `processDanglingDirectories`: given the sitemap tree,
+// compute the list of dangling-directory index pages that need to be written
+// (permalink + content), without performing any file I/O. The caller writes
+// each returned entry to disk. The line-430 `CollectionMeta` lookup quirk
+// (`parentId === Number(id)`) is preserved verbatim — see plan decision 6.
+export const getDanglingDirectoryIndexPages = (
+  resources: Resource[],
+  sitemapEntry: SitemapEntry,
+  getFolderIndexPageContents: (title: string) => unknown,
+  getCollectionIndexPageContents: (title: string, variant?: any) => unknown,
+): { permalink: string; content: unknown }[] => {
+  // Base case: No children - this is a leaf node
+  if (!sitemapEntry.children) {
+    return []
+  }
+
+  const directories = getFoldersAndCollections(resources, sitemapEntry)
+  const folders = directories.filter(
+    (siteMapEntry) => siteMapEntry.type === ResourceType.Folder,
+  )
+  const collections = directories.filter(
+    (siteMapEntry) => siteMapEntry.type === ResourceType.Collection,
+  )
+
+  return [
+    ...folders.map(({ title, permalink }) => {
+      const content = getFolderIndexPageContents(title)
+      return { title, permalink, content }
+    }),
+    ...collections.map(({ id, title, permalink }) => {
+      const meta = resources.find(
+        ({ type, parentId }) =>
+          parentId === Number(id) && type === "CollectionMeta",
+      )
+      const content = getCollectionIndexPageContents(
+        title,
+        meta?.content.variant,
+      )
+      return { title, permalink, content }
+    }),
+  ].map((child) => ({
+    permalink: `${child.permalink}/${INDEX_PAGE_PERMALINK}`,
+    content: child.content,
+  }))
+}

--- a/tooling/build/scripts/publishing/tsconfig.json
+++ b/tooling/build/scripts/publishing/tsconfig.json
@@ -3,9 +3,19 @@
     /* Visit https://aka.ms/tsconfig to read more about this file */
 
     /* Language and Environment */
-    "target": "es2016" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "lib": ["es2022"],
+    /* Modules
+     * NOTE: this is typecheck-only config. The script is executed via
+     * `tsx index.ts` (CodeBuild + the `start` script), and tsx transpiles each
+     * file with esbuild's own module detection, so it does not consult `module`
+     * here. ESNext + Bundler resolution is required to typecheck the ESM-only
+     * test harness (which uses `import.meta.url`) and the `@isomer/db` package. */
+    "module": "esnext" /* Specify what module code is generated. */,
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node", "vitest/globals"],
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
 
     /* Type Checking */
@@ -19,8 +29,13 @@
       // to @isomer/db (packages/db/src/generated). This works because we
       // clone our repo as a whole.
       "~generated/*": ["../../../../packages/db/src/generated/*"],
-      // Respect the package's default export and use only index
-      "~schema": ["../../../../packages/components/src/index.ts"]
+      // Resolve `~schema` to the components package's BUILT declaration file
+      // rather than its TS source. The script's only `~schema` reference is a
+      // type-only import (erased at runtime by tsx/esbuild), so this is purely
+      // a typecheck concern: pointing at the published `.d.ts` lets `tsgo`
+      // resolve the type under `skipLibCheck` without descending into (and
+      // type-erroring on) the JSX-bearing components source tree.
+      "~schema": ["../../../../packages/components/dist/esm/index.d.ts"]
     }
   }
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -29,6 +29,10 @@ interface CollectionPagePageProps {
   defaultSortDirection?: string
   sortOrder?: string
   tagCategories?: TagCategory[]
+  // `showThumbnail` is read opportunistically from page content and written
+  // into the sitemap entry by buildPageSitemapEntry; declared here so the
+  // (previously untypechecked) projection in sitemap.ts typechecks.
+  showThumbnail?: boolean
 }
 
 export type SitemapEntry = Pick<

--- a/tooling/build/scripts/publishing/vitest.config.ts
+++ b/tooling/build/scripts/publishing/vitest.config.ts
@@ -1,0 +1,27 @@
+import { fileURLToPath } from "node:url"
+import { configDefaults, defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Mirror the tsconfig `paths`. `~generated/*` resolves to @isomer/db's
+      // generated Kysely types/enums (used by the script + extracted sitemap
+      // module). `~schema` is type-only at runtime, so it never needs to load,
+      // but we map it for completeness.
+      "~generated": fileURLToPath(
+        new URL("../../../../packages/db/src/generated", import.meta.url),
+      ),
+    },
+  },
+  test: {
+    globals: true,
+    exclude: [...configDefaults.exclude],
+    // Integration tests share a single docker-compose Postgres service and each
+    // create their own database, so run files serially to avoid cross-test
+    // interference on that one container.
+    fileParallelism: false,
+    // Schema application + container round-trips are slower than the default.
+    hookTimeout: 60_000,
+    testTimeout: 60_000,
+  },
+})


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

`tooling/build/scripts/publishing` is a production code path (it generates each site's sitemap, page JSONs, navbar/footer/config, and redirects during a publish) with **zero automated tests** — its `package.json` had `"test": "echo no test specified && exit 1"`. The next PRs migrate its raw `pg` + hand-written SQL onto `@isomer/db` + Kysely, including rewriting a load-bearing recursive CTE. Doing that safely requires a behaviour-locking test net **first**.

This is PR 5b of the publishing migration stack (depends on 5a, #2426).

Closes N/A (internal refactor / test hardening)

## Solution

<!-- How did you solve the problem? -->

Establishes the safety net against the **current raw-`pg` code** — no runtime behaviour change.

- **Test infrastructure** (following the `@isomer/pgboss` precedent): own `docker-compose.yml` (Postgres 15 on port 5430), `.env.test`, `vitest.config.ts`, vitest dep, and `services:setup`/`db:sleep`/`setup:test`/`test`/`typecheck` scripts. The test DB schema is applied via `@isomer/db/testing`'s `applyMigrations` (from 5a) — not a hand-rolled reader.
- **Testability refactor (behaviour-preserving):** extracted the pure sitemap/permalink logic (`generateSitemapTree`, `getConvertedPermalink`, `getFoldersAndCollections`, the page-ordering sort, and the pure decision part of dangling-directory handling) out of `index.ts` into a new sibling module `sitemap.ts`. `index.ts`'s `main().catch(...)` auto-run is untouched, so the `tsx index.ts` CodeBuild entry point still runs identically. This avoids guarding `main()` (which risks silently breaking the entry point).
- **Fixture:** one rich "fixture site" built via Kysely inserts using `@isomer/db`, plus tiny edge fixtures. It exercises recursive permalink building, the content `CASE` (published page → Blob content, folder → null, unpublished → null), a dangling directory, an `IndexPage` with `childrenPagesOrdering`, a `Collection` + `CollectionMeta` + `CollectionPage`s, a `FolderMeta`, and a soft-deleted redirect. Blob content is minimal valid `IsomerSchema`.
- **Tests:** 23 DB-free characterization tests over the extracted pure logic + 9 integration tests running the five current raw queries against the seeded fixture (asserting rows-in → rows-out). The queries under test still run via raw `pg` exactly as production does today.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A (test + harness only)

**Improvements**:

- Publishing now has a real test suite (32 tests) and CI-runnable test infrastructure where it previously had none.
- Pure sitemap logic is isolated in `sitemap.ts`, independently testable.

**Bug Fixes**:

- None. A pre-existing latent quirk (a `CollectionMeta` lookup that never matches) is intentionally **captured, not fixed**, by a characterization test, so the later migration can be proven behaviour-preserving. The fix is tracked separately.

## Before & After Screenshots

**BEFORE**:

<!-- No UI change. -->

**AFTER**:

<!-- No UI change. -->

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

- [ ] `pnpm --filter publishing typecheck` passes
- [ ] `pnpm --filter publishing setup:test && pnpm --filter publishing test` → 32 passed (23 unit + 9 integration); tear down with `docker compose down -v`
- [ ] `pnpm --filter isomer-studio test:unit` still 1235 / 41 / 0 (5a sits underneath)
- [ ] `tsx index.ts` (entry point) still reaches `main()` — fails only on DB connect with prod env unset, not on import/parse

**New scripts** (in `tooling/build/scripts/publishing`):

- `services:setup` : `docker compose up -d --wait` for the test Postgres
- `db:sleep` : brief wait for readiness
- `setup:test` : `run-s services:setup db:sleep`
- `test` / `test:unit` : run vitest
- `typecheck` : type-check the package

**New dependencies**:

- `@isomer/db: workspace:*` — fixture builder + `@isomer/db/testing`
- `kysely: catalog:` — building the fixture

**New dev dependencies**:

- `vitest: catalog:vitest`
- `@opengovsg/isomer-components: workspace:*` — type-only (`~schema`); declared so turbo builds it before publishing typechecks
