### PR TITLE
test(publishing): add full template build end-to-end test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,11 @@ jobs:
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
           # Set timezone to Singapore to ensure that the tests are run in the correct timezone
           TZ: Asia/Singapore
+      - name: Test full template build from publishing script output
+        run: pnpm exec turbo test-ci:build --filter=publishing --env-mode=loose
+        env:
+          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+          TZ: Asia/Singapore
 
   end-to-end-tests:
     name: End-to-end tests

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "start": "tsx index.ts ",
     "test": "vitest run",
+    "test-ci:build": "vitest run --config vitest.build.config.ts",
     "test-ci:unit": "vitest run",
+    "test:full-build": "vitest run --config vitest.build.config.ts",
     "test:watch": "vitest watch",
     "upload-redirects": "tsx uploadRedirects.ts"
   },

--- a/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
+++ b/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
@@ -66,10 +66,15 @@ beforeAll(async () => {
   try {
     // Act: replay publisher.sh's pre-build steps, then build the template
     backupDir = mkdtempSync(join(tmpdir(), "template-fixtures-"))
+    // Phase 1: back up everything before touching the template so restoreTemplate
+    // always has a complete backupDir even if a later copy fails.
     for (const swappedPath of SWAPPED_PATHS) {
       cpSync(join(TEMPLATE_DIR, swappedPath), join(backupDir, swappedPath), {
         recursive: true,
       })
+    }
+    // Phase 2: replace template fixtures with publishing script output
+    for (const swappedPath of SWAPPED_PATHS) {
       rmSync(join(TEMPLATE_DIR, swappedPath), { recursive: true, force: true })
       cpSync(join(outputDir, swappedPath), join(TEMPLATE_DIR, swappedPath), {
         recursive: true,
@@ -79,10 +84,13 @@ beforeAll(async () => {
       join(TEMPLATE_DIR, "sitemap.json"),
       join(TEMPLATE_DIR, "public", "sitemap.json"),
     )
-    cpSync(
-      join(TEMPLATE_DIR, "schema", "_index.json"),
-      join(TEMPLATE_DIR, "schema", "not-found.json"),
-    )
+    const indexJsonPath = join(TEMPLATE_DIR, "schema", "_index.json")
+    if (!existsSync(indexJsonPath)) {
+      throw new Error(
+        "Publishing script did not produce schema/_index.json; check the root page seed",
+      )
+    }
+    cpSync(indexJsonPath, join(TEMPLATE_DIR, "schema", "not-found.json"))
     rmSync(OUT_DIR, { recursive: true, force: true })
 
     const buildResult = spawnSync(NEXT_BIN, ["build", "--webpack"], {
@@ -111,6 +119,9 @@ afterAll(async () => {
   if (outputDir) {
     rmSync(outputDir, { recursive: true, force: true })
   }
+  if (backupDir) {
+    rmSync(backupDir, { recursive: true, force: true })
+  }
 })
 
 describe("full template build", () => {
@@ -137,7 +148,7 @@ describe("full template build", () => {
     expect(existsSync(join(OUT_DIR, "draft-page"))).toBe(false)
   })
 
-  it("renders the seeded site name and page title into the homepage", () => {
+  it("renders the seeded site name into the homepage", () => {
     // Arrange / Act
     const homepage = readFileSync(join(OUT_DIR, "index.html"), "utf-8")
 

--- a/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
+++ b/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
@@ -1,0 +1,154 @@
+import { spawnSync } from "node:child_process"
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+import { seedPublishingSite, TEST_DB_ENV, db } from "../seed"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const PACKAGE_DIR = join(__dirname, "..", "..")
+const TSX_BIN = join(PACKAGE_DIR, "node_modules", ".bin", "tsx")
+
+// publisher.sh moves the script output into the template before building, so
+// the template's committed placeholder fixtures are swapped for the real
+// output here and restored afterwards
+const TEMPLATE_DIR = join(PACKAGE_DIR, "..", "..", "..", "template")
+const NEXT_BIN = join(TEMPLATE_DIR, "node_modules", ".bin", "next")
+const OUT_DIR = join(TEMPLATE_DIR, "out")
+const SWAPPED_PATHS = ["schema", "data", "sitemap.json"]
+
+let outputDir: string
+let backupDir: string | undefined
+let restored = false
+
+// Idempotent so it can run both on beforeAll failure and in afterAll.
+// If the process is killed mid-build, `git checkout tooling/template` restores
+// the fixtures manually.
+const restoreTemplate = () => {
+  if (restored || !backupDir) return
+  for (const swappedPath of SWAPPED_PATHS) {
+    rmSync(join(TEMPLATE_DIR, swappedPath), { recursive: true, force: true })
+    cpSync(join(backupDir, swappedPath), join(TEMPLATE_DIR, swappedPath), {
+      recursive: true,
+    })
+  }
+  rmSync(join(TEMPLATE_DIR, "public", "sitemap.json"), { force: true })
+  rmSync(OUT_DIR, { recursive: true, force: true })
+  restored = true
+}
+
+beforeAll(async () => {
+  // Arrange: the same rich site the publishing suite asserts on
+  const { siteId } = await seedPublishingSite()
+
+  outputDir = mkdtempSync(join(tmpdir(), "publishing-full-build-"))
+  const publishResult = spawnSync(TSX_BIN, ["index.ts"], {
+    cwd: PACKAGE_DIR,
+    encoding: "utf-8",
+    timeout: 120_000,
+    env: {
+      ...process.env,
+      // dd-trace (loaded via NODE_OPTIONS in CI) breaks spawned subprocesses
+      NODE_OPTIONS: "",
+      SITE_ID: String(siteId),
+      ...TEST_DB_ENV,
+      OUTPUT_DIR: outputDir,
+    },
+  })
+  if (publishResult.error || publishResult.status !== 0) {
+    throw new Error(
+      `publishing script exited with ${publishResult.status} (${publishResult.error}):\n${publishResult.stdout}\n${publishResult.stderr}`,
+    )
+  }
+
+  try {
+    // Act: replay publisher.sh's pre-build steps, then build the template
+    backupDir = mkdtempSync(join(tmpdir(), "template-fixtures-"))
+    for (const swappedPath of SWAPPED_PATHS) {
+      cpSync(join(TEMPLATE_DIR, swappedPath), join(backupDir, swappedPath), {
+        recursive: true,
+      })
+      rmSync(join(TEMPLATE_DIR, swappedPath), { recursive: true, force: true })
+      cpSync(join(outputDir, swappedPath), join(TEMPLATE_DIR, swappedPath), {
+        recursive: true,
+      })
+    }
+    cpSync(
+      join(TEMPLATE_DIR, "sitemap.json"),
+      join(TEMPLATE_DIR, "public", "sitemap.json"),
+    )
+    cpSync(
+      join(TEMPLATE_DIR, "schema", "_index.json"),
+      join(TEMPLATE_DIR, "schema", "not-found.json"),
+    )
+    rmSync(OUT_DIR, { recursive: true, force: true })
+
+    const buildResult = spawnSync(NEXT_BIN, ["build", "--webpack"], {
+      cwd: TEMPLATE_DIR,
+      encoding: "utf-8",
+      timeout: 600_000,
+      env: {
+        ...process.env,
+        NODE_OPTIONS: "",
+      },
+    })
+    if (buildResult.error || buildResult.status !== 0) {
+      throw new Error(
+        `template build exited with ${buildResult.status} (${buildResult.error}):\n${buildResult.stdout}\n${buildResult.stderr}`,
+      )
+    }
+  } catch (error) {
+    restoreTemplate()
+    throw error
+  }
+})
+
+afterAll(async () => {
+  restoreTemplate()
+  await db.destroy()
+  if (outputDir) {
+    rmSync(outputDir, { recursive: true, force: true })
+  }
+})
+
+describe("full template build", () => {
+  it("renders every published page to static HTML", () => {
+    // Arrange / Act / Assert
+    const expectedPages = [
+      "index.html",
+      join("about", "index.html"),
+      join("about", "our-team", "index.html"),
+      join("dangling", "index.html"),
+      join("dangling", "lonely-page", "index.html"),
+      join("news", "index.html"),
+      join("news", "zebra-article", "index.html"),
+    ]
+    for (const page of expectedPages) {
+      expect(existsSync(join(OUT_DIR, page)), page).toBe(true)
+    }
+  })
+
+  it("does not render pages for collection links or drafts", () => {
+    // Arrange / Act / Assert
+    expect(existsSync(join(OUT_DIR, "news", "alpha-link"))).toBe(false)
+    expect(existsSync(join(OUT_DIR, "news", "alpha-link.html"))).toBe(false)
+    expect(existsSync(join(OUT_DIR, "draft-page"))).toBe(false)
+  })
+
+  it("renders the seeded site name and page title into the homepage", () => {
+    // Arrange / Act
+    const homepage = readFileSync(join(OUT_DIR, "index.html"), "utf-8")
+
+    // Assert
+    expect(homepage).toContain("E2E Test Site")
+  })
+
+  it("emits the 404 page and crawler files", () => {
+    // Arrange / Act / Assert
+    expect(existsSync(join(OUT_DIR, "404.html"))).toBe(true)
+    expect(existsSync(join(OUT_DIR, "sitemap.xml"))).toBe(true)
+    expect(existsSync(join(OUT_DIR, "robots.txt"))).toBe(true)
+  })
+})

--- a/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
+++ b/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
@@ -65,14 +65,17 @@ beforeAll(async () => {
 
   try {
     // Act: replay publisher.sh's pre-build steps, then build the template
-    backupDir = mkdtempSync(join(tmpdir(), "template-fixtures-"))
-    // Phase 1: back up everything before touching the template so restoreTemplate
-    // always has a complete backupDir even if a later copy fails.
+    //
+    // Phase 1: complete all backups before touching the template. backupDir is
+    // only assigned once all copies succeed so restoreTemplate is never called
+    // with a partial backup (which would crash on a missing path).
+    const tmpBackupDir = mkdtempSync(join(tmpdir(), "template-fixtures-"))
     for (const swappedPath of SWAPPED_PATHS) {
-      cpSync(join(TEMPLATE_DIR, swappedPath), join(backupDir, swappedPath), {
+      cpSync(join(TEMPLATE_DIR, swappedPath), join(tmpBackupDir, swappedPath), {
         recursive: true,
       })
     }
+    backupDir = tmpBackupDir
     // Phase 2: replace template fixtures with publishing script output
     for (const swappedPath of SWAPPED_PATHS) {
       rmSync(join(TEMPLATE_DIR, swappedPath), { recursive: true, force: true })
@@ -81,7 +84,7 @@ beforeAll(async () => {
       })
     }
     cpSync(
-      join(TEMPLATE_DIR, "sitemap.json"),
+      join(outputDir, "sitemap.json"),
       join(TEMPLATE_DIR, "public", "sitemap.json"),
     )
     const indexJsonPath = join(TEMPLATE_DIR, "schema", "_index.json")

--- a/tooling/build/scripts/publishing/tests/publishing.test.ts
+++ b/tooling/build/scripts/publishing/tests/publishing.test.ts
@@ -5,160 +5,21 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 
-import { createDb, ResourceState, ResourceType } from "@isomer/db"
+import { ResourceType } from "@isomer/db"
+
+import {
+  db,
+  FOOTER_CONTENT,
+  NAVBAR_CONTENT,
+  seedPublishingSite,
+  SITE_CONFIG,
+  SITE_THEME,
+  TEST_DB_ENV,
+} from "./seed"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const PACKAGE_DIR = join(__dirname, "..")
 const TSX_BIN = join(PACKAGE_DIR, "node_modules", ".bin", "tsx")
-
-const DB_HOST = process.env.TEST_DB_HOST ?? ""
-const DB_PORT = process.env.TEST_DB_PORT ?? ""
-const DB_USERNAME = process.env.TEST_DB_USERNAME ?? ""
-const DB_PASSWORD = process.env.TEST_DB_PASSWORD ?? ""
-const DB_NAME = process.env.TEST_DB_NAME ?? ""
-
-const db = createDb({
-  connectionString: `postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`,
-})
-
-const USER_ID = "publishing-e2e-user"
-
-const NAVBAR_CONTENT = {
-  items: [{ name: "Who we are", url: "/about" }],
-}
-const FOOTER_CONTENT = {
-  siteNavItems: [{ title: "Who we are", url: "/about" }],
-  contactUsLink: "/contact",
-}
-const SITE_CONFIG = {
-  siteName: "E2E Test Site",
-  url: "https://e2e.example.com",
-  isGovernment: true,
-}
-const SITE_THEME = {
-  colors: { brand: "#4d2dc4" },
-}
-
-const seedSite = async ({
-  name,
-  config = {},
-  theme = null,
-}: {
-  name: string
-  config?: object
-  theme?: object | null
-}) => {
-  const site = await db
-    .insertInto("Site")
-    .values({ name, config, theme })
-    .returning("id")
-    .executeTakeFirstOrThrow()
-  return site.id
-}
-
-const seedFolder = async ({
-  siteId,
-  type,
-  title,
-  permalink,
-  parentId = null,
-}: {
-  siteId: number
-  type: typeof ResourceType.Folder | typeof ResourceType.Collection
-  title: string
-  permalink: string
-  parentId?: string | null
-}) => {
-  const folder = await db
-    .insertInto("Resource")
-    .values({
-      siteId,
-      type,
-      title,
-      permalink,
-      parentId,
-      state: ResourceState.Published,
-    })
-    .returning("id")
-    .executeTakeFirstOrThrow()
-  return folder.id
-}
-
-const seedPage = async ({
-  siteId,
-  type,
-  title,
-  permalink,
-  parentId = null,
-  content,
-  publish = true,
-}: {
-  siteId: number
-  type: ResourceType
-  title: string
-  permalink: string
-  parentId?: string | null
-  content: object
-  publish?: boolean
-}) => {
-  const blob = await db
-    .insertInto("Blob")
-    .values({ content })
-    .returning("id")
-    .executeTakeFirstOrThrow()
-
-  const page = await db
-    .insertInto("Resource")
-    .values({
-      siteId,
-      type,
-      title,
-      permalink,
-      parentId,
-      ...(publish
-        ? { state: ResourceState.Published }
-        : { state: ResourceState.Draft, draftBlobId: blob.id }),
-    })
-    .returning("id")
-    .executeTakeFirstOrThrow()
-
-  if (publish) {
-    const version = await db
-      .insertInto("Version")
-      .values({
-        versionNum: 1,
-        resourceId: page.id,
-        blobId: blob.id,
-        publishedBy: USER_ID,
-      })
-      .returning("id")
-      .executeTakeFirstOrThrow()
-    await db
-      .updateTable("Resource")
-      .set({ publishedVersionId: version.id })
-      .where("id", "=", page.id)
-      .execute()
-  }
-
-  return page.id
-}
-
-const seedRedirect = async ({
-  siteId,
-  source,
-  destination,
-  deletedAt = null,
-}: {
-  siteId: number
-  source: string
-  destination: string
-  deletedAt?: Date | null
-}) => {
-  await db
-    .insertInto("Redirect")
-    .values({ siteId, source, destination, deletedAt })
-    .execute()
-}
 
 interface SitemapEntry {
   id: string
@@ -186,10 +47,6 @@ let siteId: number
 let aboutFolderId: string
 let danglingFolderId: string
 let newsCollectionId: string
-let rootPageId: string
-let aboutIndexPageId: string
-let ourTeamPageId: string
-let draftPageId: string
 
 const readOutput = (...segments: string[]) =>
   JSON.parse(readFileSync(join(outputDir, ...segments), "utf-8"))
@@ -198,253 +55,8 @@ const readSitemap = () => readOutput("sitemap.json") as SitemapEntry
 
 beforeAll(async () => {
   // Arrange: one rich site covering every code path the script handles
-  await db
-    .insertInto("User")
-    .values({
-      id: USER_ID,
-      name: "Publishing E2E",
-      email: "publishing-e2e@example.com",
-      phone: "",
-    })
-    .execute()
-
-  siteId = await seedSite({
-    name: "E2E Test Site",
-    config: SITE_CONFIG,
-    theme: SITE_THEME,
-  })
-  await db
-    .insertInto("Navbar")
-    .values({ siteId, content: NAVBAR_CONTENT })
-    .execute()
-  await db
-    .insertInto("Footer")
-    .values({ siteId, content: FOOTER_CONTENT })
-    .execute()
-
-  rootPageId = await seedPage({
-    siteId,
-    type: ResourceType.RootPage,
-    title: "Home",
-    permalink: "",
-    content: {
-      version: "0.1.0",
-      layout: "homepage",
-      page: { description: "The official E2E test site" },
-      content: [],
-    },
-  })
-
-  // Orders the root-level children; "_meta" must also be stripped from permalinks
-  await seedPage({
-    siteId,
-    type: ResourceType.FolderMeta,
-    title: "Root meta",
-    permalink: "_meta",
-    content: { order: ["news", "about", "dangling"] },
-  })
-
-  // A folder with its own index page and a child page
-  aboutFolderId = await seedFolder({
-    siteId,
-    type: ResourceType.Folder,
-    title: "Who we are",
-    permalink: "about",
-  })
-  aboutIndexPageId = await seedPage({
-    siteId,
-    type: ResourceType.IndexPage,
-    title: "Who we are",
-    permalink: "_index",
-    parentId: aboutFolderId,
-    content: {
-      version: "0.1.0",
-      layout: "index",
-      page: { contentPageHeader: { summary: "All about us" } },
-      content: [],
-    },
-  })
-  ourTeamPageId = await seedPage({
-    siteId,
-    type: ResourceType.Page,
-    title: "Our team",
-    permalink: "our-team",
-    parentId: aboutFolderId,
-    content: {
-      version: "0.1.0",
-      layout: "content",
-      page: { contentPageHeader: { summary: ["Meet", "the team"] } },
-      content: [{ type: "image", src: "/images/team.png", alt: "The team" }],
-    },
-  })
-
-  // A folder WITHOUT an index page: the script must auto-generate one
-  danglingFolderId = await seedFolder({
-    siteId,
-    type: ResourceType.Folder,
-    title: "All the danglers",
-    permalink: "dangling",
-  })
-  await seedPage({
-    siteId,
-    type: ResourceType.Page,
-    title: "Lonely page",
-    permalink: "lonely-page",
-    parentId: danglingFolderId,
-    content: {
-      version: "0.1.0",
-      layout: "content",
-      page: { contentPageHeader: { summary: "A lonely page" } },
-      content: [],
-    },
-  })
-
-  // A collection (also without an index page) with a page and a link
-  newsCollectionId = await seedFolder({
-    siteId,
-    type: ResourceType.Collection,
-    title: "News",
-    permalink: "news",
-  })
-  await seedPage({
-    siteId,
-    type: ResourceType.CollectionPage,
-    title: "Zebra article",
-    permalink: "zebra-article",
-    parentId: newsCollectionId,
-    content: {
-      version: "0.1.0",
-      layout: "article",
-      page: {
-        date: "15/01/2026",
-        category: "Press releases",
-        articlePageHeader: { summary: "Zebra article summary" },
-        image: { src: "/images/zebra.png", alt: "A zebra" },
-      },
-      content: [],
-    },
-  })
-  await seedPage({
-    siteId,
-    type: ResourceType.CollectionLink,
-    title: "Alpha link",
-    permalink: "alpha-link",
-    parentId: newsCollectionId,
-    content: {
-      version: "0.1.0",
-      layout: "link",
-      page: {
-        ref: "https://example.com",
-        date: "01/01/2026",
-        category: "Press releases",
-        description: "An external link",
-      },
-      content: [],
-    },
-  })
-
-  // A draft-only page: must NOT be published
-  draftPageId = await seedPage({
-    siteId,
-    type: ResourceType.Page,
-    title: "Secret draft",
-    permalink: "draft-page",
-    content: {
-      version: "0.1.0",
-      layout: "content",
-      page: { contentPageHeader: { summary: "Not ready yet" } },
-      content: [],
-    },
-    publish: false,
-  })
-
-  await seedRedirect({ siteId, source: "/old-about", destination: "/about" })
-  await seedRedirect({ siteId, source: "/old-news", destination: "/news" })
-  await seedRedirect({
-    siteId,
-    source: "/deleted",
-    destination: "/gone",
-    deletedAt: new Date(),
-  })
-  // Reference destinations: resolved to the page's current permalink at publish
-  await seedRedirect({
-    siteId,
-    source: "/ref-page",
-    destination: `[resource:${siteId}:${ourTeamPageId}]`,
-  })
-  // A reference to an index page resolves to its folder (the "_index" segment
-  // is stripped, matching what the editor displays)
-  await seedRedirect({
-    siteId,
-    source: "/ref-index",
-    destination: `[resource:${siteId}:${aboutIndexPageId}]`,
-  })
-  // A reference to the folder itself resolves via its published index page to
-  // the folder's URL — this is the form internal folder/collection destinations
-  // are stored as (the build keys the URL on the folder id, not the index page)
-  await seedRedirect({
-    siteId,
-    source: "/ref-folder",
-    destination: `[resource:${siteId}:${aboutFolderId}]`,
-  })
-  // A reference to a folder with no published index page is dropped — there is
-  // no live page behind it
-  await seedRedirect({
-    siteId,
-    source: "/ref-dangling-folder",
-    destination: `[resource:${siteId}:${danglingFolderId}]`,
-  })
-  // A reference to the root page resolves to "/"
-  await seedRedirect({
-    siteId,
-    source: "/ref-root",
-    destination: `[resource:${siteId}:${rootPageId}]`,
-  })
-  // A reference to an unpublished page is dropped — it has no live URL
-  await seedRedirect({
-    siteId,
-    source: "/ref-draft",
-    destination: `[resource:${siteId}:${draftPageId}]`,
-  })
-  // A reference whose embedded siteId is not this site is dropped, even though
-  // the resourceId exists here — it must not resolve cross-site.
-  await seedRedirect({
-    siteId,
-    source: "/ref-wrong-site",
-    destination: `[resource:${siteId + 999}:${ourTeamPageId}]`,
-  })
-
-  // A second site: nothing from it may leak into the output
-  const otherSiteId = await seedSite({ name: "Other site" })
-  await seedPage({
-    siteId: otherSiteId,
-    type: ResourceType.RootPage,
-    title: "Other home",
-    permalink: "",
-    content: {
-      version: "0.1.0",
-      layout: "homepage",
-      page: { description: "Other site" },
-      content: [],
-    },
-  })
-  await seedPage({
-    siteId: otherSiteId,
-    type: ResourceType.Page,
-    title: "Other page",
-    permalink: "other-page",
-    content: {
-      version: "0.1.0",
-      layout: "content",
-      page: { contentPageHeader: { summary: "Other site page" } },
-      content: [],
-    },
-  })
-  await seedRedirect({
-    siteId: otherSiteId,
-    source: "/other-old",
-    destination: "/other-new",
-  })
+  ;({ siteId, aboutFolderId, danglingFolderId, newsCollectionId } =
+    await seedPublishingSite())
 
   // Act: run the script exactly as CodeBuild does, via the tsx entrypoint
   outputDir = mkdtempSync(join(tmpdir(), "publishing-e2e-"))
@@ -456,11 +68,7 @@ beforeAll(async () => {
       // dd-trace (loaded via NODE_OPTIONS in CI) breaks spawned subprocesses
       NODE_OPTIONS: "",
       SITE_ID: String(siteId),
-      DB_HOST,
-      DB_PORT,
-      DB_USERNAME,
-      DB_PASSWORD,
-      DB_NAME,
+      ...TEST_DB_ENV,
       OUTPUT_DIR: outputDir,
     },
   })

--- a/tooling/build/scripts/publishing/tests/seed.ts
+++ b/tooling/build/scripts/publishing/tests/seed.ts
@@ -1,0 +1,437 @@
+import { createDb, ResourceState, ResourceType } from "@isomer/db"
+
+const DB_HOST = process.env.TEST_DB_HOST ?? ""
+const DB_PORT = process.env.TEST_DB_PORT ?? ""
+const DB_USERNAME = process.env.TEST_DB_USERNAME ?? ""
+const DB_PASSWORD = process.env.TEST_DB_PASSWORD ?? ""
+const DB_NAME = process.env.TEST_DB_NAME ?? ""
+
+export const db = createDb({
+  connectionString: `postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`,
+})
+
+// Connection env vars for spawning the publishing script as a subprocess
+export const TEST_DB_ENV = {
+  DB_HOST,
+  DB_PORT,
+  DB_USERNAME,
+  DB_PASSWORD,
+  DB_NAME,
+}
+
+const USER_ID = "publishing-e2e-user"
+
+export const NAVBAR_CONTENT = {
+  items: [{ name: "Who we are", url: "/about" }],
+}
+export const FOOTER_CONTENT = {
+  siteNavItems: [{ title: "Who we are", url: "/about" }],
+  contactUsLink: "/contact",
+}
+export const SITE_CONFIG = {
+  siteName: "E2E Test Site",
+  url: "https://e2e.example.com",
+  isGovernment: true,
+}
+// The site-theme Tailwind preset reads colors.brand.{canvas,interaction} at
+// template build time, so the seeded theme must be structurally valid
+export const SITE_THEME = {
+  colors: {
+    brand: {
+      canvas: {
+        default: "#e6ecef",
+        alt: "#bfcfd7",
+        backdrop: "#80a0af",
+        inverse: "#00405f",
+      },
+      interaction: {
+        default: "#00405f",
+        hover: "#002e44",
+        pressed: "#00283b",
+      },
+    },
+  },
+}
+
+const seedSite = async ({
+  name,
+  config = {},
+  theme = null,
+}: {
+  name: string
+  config?: object
+  theme?: object | null
+}) => {
+  const site = await db
+    .insertInto("Site")
+    .values({ name, config, theme })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+  return site.id
+}
+
+const seedFolder = async ({
+  siteId,
+  type,
+  title,
+  permalink,
+  parentId = null,
+}: {
+  siteId: number
+  type: typeof ResourceType.Folder | typeof ResourceType.Collection
+  title: string
+  permalink: string
+  parentId?: string | null
+}) => {
+  const folder = await db
+    .insertInto("Resource")
+    .values({
+      siteId,
+      type,
+      title,
+      permalink,
+      parentId,
+      state: ResourceState.Published,
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+  return folder.id
+}
+
+const seedPage = async ({
+  siteId,
+  type,
+  title,
+  permalink,
+  parentId = null,
+  content,
+  publish = true,
+}: {
+  siteId: number
+  type: ResourceType
+  title: string
+  permalink: string
+  parentId?: string | null
+  content: object
+  publish?: boolean
+}) => {
+  const blob = await db
+    .insertInto("Blob")
+    .values({ content })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+
+  const page = await db
+    .insertInto("Resource")
+    .values({
+      siteId,
+      type,
+      title,
+      permalink,
+      parentId,
+      ...(publish
+        ? { state: ResourceState.Published }
+        : { state: ResourceState.Draft, draftBlobId: blob.id }),
+    })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+
+  if (publish) {
+    const version = await db
+      .insertInto("Version")
+      .values({
+        versionNum: 1,
+        resourceId: page.id,
+        blobId: blob.id,
+        publishedBy: USER_ID,
+      })
+      .returning("id")
+      .executeTakeFirstOrThrow()
+    await db
+      .updateTable("Resource")
+      .set({ publishedVersionId: version.id })
+      .where("id", "=", page.id)
+      .execute()
+  }
+
+  return page.id
+}
+
+const seedRedirect = async ({
+  siteId,
+  source,
+  destination,
+  deletedAt = null,
+}: {
+  siteId: number
+  source: string
+  destination: string
+  deletedAt?: Date | null
+}) => {
+  await db
+    .insertInto("Redirect")
+    .values({ siteId, source, destination, deletedAt })
+    .execute()
+}
+
+// One rich site covering every code path the publishing script handles:
+// homepage, FolderMeta ordering, folder with its own index page, dangling
+// folder and collection (auto-generated index pages), drafts, redirects,
+// and a second site to verify site scoping
+export const seedPublishingSite = async () => {
+  await db
+    .insertInto("User")
+    .values({
+      id: USER_ID,
+      name: "Publishing E2E",
+      email: "publishing-e2e@example.com",
+      phone: "",
+    })
+    .execute()
+
+  const siteId = await seedSite({
+    name: "E2E Test Site",
+    config: SITE_CONFIG,
+    theme: SITE_THEME,
+  })
+  await db
+    .insertInto("Navbar")
+    .values({ siteId, content: NAVBAR_CONTENT })
+    .execute()
+  await db
+    .insertInto("Footer")
+    .values({ siteId, content: FOOTER_CONTENT })
+    .execute()
+
+  const rootPageId = await seedPage({
+    siteId,
+    type: ResourceType.RootPage,
+    title: "Home",
+    permalink: "",
+    content: {
+      version: "0.1.0",
+      layout: "homepage",
+      page: { description: "The official E2E test site" },
+      content: [],
+    },
+  })
+
+  // Orders the root-level children; "_meta" must also be stripped from permalinks
+  await seedPage({
+    siteId,
+    type: ResourceType.FolderMeta,
+    title: "Root meta",
+    permalink: "_meta",
+    content: { order: ["news", "about", "dangling"] },
+  })
+
+  // A folder with its own index page and a child page
+  const aboutFolderId = await seedFolder({
+    siteId,
+    type: ResourceType.Folder,
+    title: "Who we are",
+    permalink: "about",
+  })
+  const aboutIndexPageId = await seedPage({
+    siteId,
+    type: ResourceType.IndexPage,
+    title: "Who we are",
+    permalink: "_index",
+    parentId: aboutFolderId,
+    content: {
+      version: "0.1.0",
+      layout: "index",
+      page: { contentPageHeader: { summary: "All about us" } },
+      content: [],
+    },
+  })
+  const ourTeamPageId = await seedPage({
+    siteId,
+    type: ResourceType.Page,
+    title: "Our team",
+    permalink: "our-team",
+    parentId: aboutFolderId,
+    content: {
+      version: "0.1.0",
+      layout: "content",
+      page: { contentPageHeader: { summary: ["Meet", "the team"] } },
+      content: [{ type: "image", src: "/images/team.png", alt: "The team" }],
+    },
+  })
+
+  // A folder WITHOUT an index page: the script must auto-generate one
+  const danglingFolderId = await seedFolder({
+    siteId,
+    type: ResourceType.Folder,
+    title: "All the danglers",
+    permalink: "dangling",
+  })
+  await seedPage({
+    siteId,
+    type: ResourceType.Page,
+    title: "Lonely page",
+    permalink: "lonely-page",
+    parentId: danglingFolderId,
+    content: {
+      version: "0.1.0",
+      layout: "content",
+      page: { contentPageHeader: { summary: "A lonely page" } },
+      content: [],
+    },
+  })
+
+  // A collection (also without an index page) with a page and a link
+  const newsCollectionId = await seedFolder({
+    siteId,
+    type: ResourceType.Collection,
+    title: "News",
+    permalink: "news",
+  })
+  await seedPage({
+    siteId,
+    type: ResourceType.CollectionPage,
+    title: "Zebra article",
+    permalink: "zebra-article",
+    parentId: newsCollectionId,
+    content: {
+      version: "0.1.0",
+      layout: "article",
+      page: {
+        date: "15/01/2026",
+        category: "Press releases",
+        articlePageHeader: { summary: "Zebra article summary" },
+        image: { src: "/images/zebra.png", alt: "A zebra" },
+      },
+      content: [],
+    },
+  })
+  await seedPage({
+    siteId,
+    type: ResourceType.CollectionLink,
+    title: "Alpha link",
+    permalink: "alpha-link",
+    parentId: newsCollectionId,
+    content: {
+      version: "0.1.0",
+      layout: "link",
+      page: {
+        ref: "https://example.com",
+        date: "01/01/2026",
+        category: "Press releases",
+        description: "An external link",
+      },
+      content: [],
+    },
+  })
+
+  // A draft-only page: must NOT be published
+  const draftPageId = await seedPage({
+    siteId,
+    type: ResourceType.Page,
+    title: "Secret draft",
+    permalink: "draft-page",
+    content: {
+      version: "0.1.0",
+      layout: "content",
+      page: { contentPageHeader: { summary: "Not ready yet" } },
+      content: [],
+    },
+    publish: false,
+  })
+
+  await seedRedirect({ siteId, source: "/old-about", destination: "/about" })
+  await seedRedirect({ siteId, source: "/old-news", destination: "/news" })
+  await seedRedirect({
+    siteId,
+    source: "/deleted",
+    destination: "/gone",
+    deletedAt: new Date(),
+  })
+  // Reference destinations: resolved to the page's current permalink at publish
+  await seedRedirect({
+    siteId,
+    source: "/ref-page",
+    destination: `[resource:${siteId}:${ourTeamPageId}]`,
+  })
+  // A reference to an index page resolves to its folder (the "_index" segment
+  // is stripped, matching what the editor displays)
+  await seedRedirect({
+    siteId,
+    source: "/ref-index",
+    destination: `[resource:${siteId}:${aboutIndexPageId}]`,
+  })
+  // A reference to the folder itself resolves via its published index page to
+  // the folder's URL
+  await seedRedirect({
+    siteId,
+    source: "/ref-folder",
+    destination: `[resource:${siteId}:${aboutFolderId}]`,
+  })
+  // A reference to a folder with no published index page is dropped
+  await seedRedirect({
+    siteId,
+    source: "/ref-dangling-folder",
+    destination: `[resource:${siteId}:${danglingFolderId}]`,
+  })
+  // A reference to the root page resolves to "/"
+  await seedRedirect({
+    siteId,
+    source: "/ref-root",
+    destination: `[resource:${siteId}:${rootPageId}]`,
+  })
+  // A reference to an unpublished page is dropped
+  await seedRedirect({
+    siteId,
+    source: "/ref-draft",
+    destination: `[resource:${siteId}:${draftPageId}]`,
+  })
+  // A reference whose embedded siteId is not this site is dropped
+  await seedRedirect({
+    siteId,
+    source: "/ref-wrong-site",
+    destination: `[resource:${siteId + 999}:${ourTeamPageId}]`,
+  })
+
+  // A second site: nothing from it may leak into the output
+  const otherSiteId = await seedSite({ name: "Other site" })
+  await seedPage({
+    siteId: otherSiteId,
+    type: ResourceType.RootPage,
+    title: "Other home",
+    permalink: "",
+    content: {
+      version: "0.1.0",
+      layout: "homepage",
+      page: { description: "Other site" },
+      content: [],
+    },
+  })
+  await seedPage({
+    siteId: otherSiteId,
+    type: ResourceType.Page,
+    title: "Other page",
+    permalink: "other-page",
+    content: {
+      version: "0.1.0",
+      layout: "content",
+      page: { contentPageHeader: { summary: "Other site page" } },
+      content: [],
+    },
+  })
+  await seedRedirect({
+    siteId: otherSiteId,
+    source: "/other-old",
+    destination: "/other-new",
+  })
+
+  return {
+    siteId,
+    aboutFolderId,
+    danglingFolderId,
+    newsCollectionId,
+    rootPageId,
+    aboutIndexPageId,
+    ourTeamPageId,
+    draftPageId,
+  }
+}

--- a/tooling/build/scripts/publishing/turbo.json
+++ b/tooling/build/scripts/publishing/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "test-ci:unit": {}
+    "test-ci:unit": {},
+    "test-ci:build": {
+      "dependsOn": ["@opengovsg/isomer-components#build"]
+    }
   }
 }

--- a/tooling/build/scripts/publishing/vitest.build.config.ts
+++ b/tooling/build/scripts/publishing/vitest.build.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["tests/full-build/**/*.test.ts"],
+    globalSetup: ["tests/global-setup.ts"],
+    // The suite starts a Postgres container, replays all migrations, runs the
+    // publishing script and then a full Next.js static export of the template
+    testTimeout: 60_000,
+    hookTimeout: 900_000,
+  },
+})

--- a/tooling/build/scripts/publishing/vitest.config.ts
+++ b/tooling/build/scripts/publishing/vitest.config.ts
@@ -2,7 +2,8 @@ import { defineConfig } from "vitest/config"
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
+    // Top-level tests only; tests/full-build/** runs via vitest.build.config.ts
+    include: ["tests/*.test.ts"],
     globalSetup: ["tests/global-setup.ts"],
     // The suite starts a Postgres container, replays all migrations and spawns
     // the publishing script as a subprocess, so hooks need generous timeouts


### PR DESCRIPTION
> [!NOTE]
> Stacked on #2425 (publishing script E2E test) via Graphite.

## Problem

#2425 proves the publishing script emits the right JSON, but nothing proves the **template can actually build a static site from that JSON**. The script's output and the template/components are an unchecked contract: the template statically imports `data/config.json` and `sitemap.json` and dynamically imports `schema/**`, and the `isomerSiteTheme` Tailwind preset consumes `colors.brand.{canvas,interaction}` from the site theme *at build time*. A drift on either side (script output shape, component schema, theme structure) only surfaces today when a real CodeBuild publish fails.

Proof this gap is real: the seeded theme in #2425 (`colors: { brand: "#4d2dc4" }`) passes every JSON-level assertion but **fails the template build** — the Tailwind preset crashes reading `colors.canvas.default`.

## Solution

Add a second E2E suite that picks up where #2425 stops: seed the same fixture site, run the publishing script, then replay `publisher.sh`'s pre-build steps against the real `tooling/template` (swap in `schema/`, `data/`, `sitemap.json`, copy `sitemap.json` to `public/`, create `schema/not-found.json` from `_index.json`), run `next build --webpack`, and assert on the emitted HTML in `out/`. The template's committed placeholder fixtures are backed up and restored afterwards (idempotent, runs even when setup fails; a hard kill mid-build is recoverable with `git checkout tooling/template`).

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Features**:

- `tests/build/full-build.test.ts`: full-build E2E suite (4 tests) — every published page renders to static HTML (including the auto-generated folder/collection index pages), collection links and drafts get no page, seeded site name appears in the homepage HTML, and `404.html`/`sitemap.xml`/`robots.txt` are emitted
- Separate `vitest.build.config.ts` so the fast unit job is untouched; the unit config now only globs `tests/*.test.ts`
- New turbo task `test-ci:build` with `dependsOn: @opengovsg/isomer-components#build` (the template build needs the components dist), wired as a second step into the existing `publishing-script-tests` CI job

**Improvements**:

- The rich-site seed moves wholesale from `publishing.test.ts` to `tests/seed.ts`, so both suites exercise the *identical* fixture: DB rows → JSON (unit suite) → static HTML (this suite) is one continuous contract chain
- Both script spawns in the new suite carry explicit `timeout`s and check `result.error`, so a hung subprocess fails in minutes instead of blocking CI

**Bug Fixes**:

- `SITE_THEME` in the seed now uses the structured `colors.brand.{canvas,interaction}` shape the `isomerSiteTheme` preset requires — the previous flat string theme builds broken CSS in any real publish and crashes this suite's build step

## Before & After Screenshots

**BEFORE**:

N/A — test/CI-only change

**AFTER**:

N/A — test/CI-only change

## Tests

- From `tooling/build/scripts/publishing`: `pnpm test` (17/17 passing — unchanged assertions against the refactored seed) and `pnpm test:full-build` (4/4 passing, ~27s locally with warm caches; requires Docker and a built components package)
- Or as CI runs them: `pnpm exec turbo test-ci:unit --filter=publishing --env-mode=loose` and `pnpm exec turbo test-ci:build --filter=publishing --env-mode=loose`
- Verified the restore path: `git status` is clean after both passing and failing runs

**New scripts**:

- `test:full-build` / `test-ci:build` in the publishing package: run the full-build suite via `vitest.build.config.ts`

**New dependencies**:

- None

**New dev dependencies**:

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a full-template-build E2E test suite that closes the gap between the publishing script's JSON output and the actual `tooling/template` Next.js static export. The rich fixture site is extracted into a shared `tests/seed.ts` so both the unit suite and the new build suite exercise the identical DB → JSON → HTML contract chain, with a corrected `SITE_THEME` structure that was silently breaking the Tailwind preset in any real publish.

- **New `tests/full-build/full-build.test.ts`**: seeds the DB, spawns the publishing script, replays `publisher.sh`'s pre-build file-swap steps against the real `tooling/template`, runs `next build --webpack`, and asserts 4 properties on the `out/` directory (pages rendered, drafts/links excluded, site name in HTML, 404/crawler files).
- **Backup/restore lifecycle**: uses a two-phase approach — all template paths are copied to a temp dir before any template file is touched, so `restoreTemplate` always has a complete backup even if a mid-swap error is thrown; the `restored` flag makes it idempotent across the `catch` path and `afterAll`.
- **Infra wiring**: separate `vitest.build.config.ts` keeps the fast unit job untouched; a new `test-ci:build` turbo task with `dependsOn: @opengovsg/isomer-components#build` is added as a second step in the existing `publishing-script-tests` CI job.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change with no production code touched; template mutations are fully reversed by a carefully guarded restore path verified to leave git status clean.

Every changed file is test infrastructure. The backup/restore lifecycle is correctly sequenced — the two-phase design ensures restoreTemplate always has a complete backup, the restored flag prevents double-restoration, and spawnSync calls carry explicit timeouts and error checks. The SITE_THEME fix resolves a real build-time crash. No production paths are affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publishing/tests/full-build/full-build.test.ts | New E2E suite that seeds DB, runs publishing script, swaps template fixtures with two-phase backup/restore, builds the template, and asserts on HTML output. Lifecycle handling is correct: backupDir is only assigned after all copies succeed, the restored flag prevents double-restoration, and both spawnSync calls carry explicit timeouts and error checks. |
| tooling/build/scripts/publishing/tests/seed.ts | Extracts the rich fixture site into a shared seedPublishingSite() that both test suites consume. SITE_THEME is corrected from a flat string to the structured colors.brand.{canvas,interaction} object the isomerSiteTheme Tailwind preset requires at build time. |
| tooling/build/scripts/publishing/vitest.build.config.ts | New vitest config scoped to tests/full-build/**. hookTimeout of 900s (15 min) gives adequate headroom around the 600s build spawnSync timeout plus DB/script setup overhead. |
| tooling/build/scripts/publishing/vitest.config.ts | Include glob narrowed from tests/**/*.test.ts to tests/*.test.ts so the slow full-build suite is never pulled into the fast unit run. |
| tooling/build/scripts/publishing/turbo.json | Adds test-ci:build task with dependsOn: @opengovsg/isomer-components#build, ensuring the components dist is available before the template build runs. |
| tooling/build/scripts/publishing/tests/publishing.test.ts | Refactored to consume the shared seed — 140+ lines of duplicated setup removed, replaced with a single seedPublishingSite() call. No assertion logic changed. |
| .github/workflows/ci.yml | Appends the build test step sequentially after the unit test step in the publishing-script-tests job, reusing the same NODE_OPTIONS and TZ env vars. |
| tooling/build/scripts/publishing/package.json | Adds test:full-build (local convenience) and test-ci:build (CI entry point) scripts both pointing at vitest.build.config.ts. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant V as Vitest (full-build)
    participant DB as Postgres (global-setup)
    participant PS as publishing script (tsx)
    participant FS as Filesystem
    participant NB as next build

    V->>DB: seedPublishingSite() — seed site, pages, redirects
    V->>PS: "spawnSync(tsx index.ts, timeout=120s)"
    PS-->>V: "outputDir/{schema/,data/,sitemap.json}"

    note over V,FS: Phase 1 — full backup before any template mutation
    V->>FS: "cpSync template/{schema,data,sitemap.json} → tmpBackupDir"
    V->>FS: "backupDir = tmpBackupDir (only after all copies succeed)"

    note over V,FS: Phase 2 — swap template fixtures
    V->>FS: "rm+cp outputDir/{schema,data,sitemap.json} → template"
    V->>FS: cp sitemap.json → template/public/sitemap.json
    V->>FS: cp schema/_index.json → schema/not-found.json
    V->>FS: rm template/out

    V->>NB: "spawnSync(next build --webpack, timeout=600s)"
    NB-->>V: "template/out/{index.html,about/*,news/*,...}"

    note over V,FS: afterAll — restore template
    V->>FS: restoreTemplate(): rm+cpSync backupDir → template
    V->>FS: rm tmpBackupDir, rm outputDir
    V->>DB: db.destroy()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant V as Vitest (full-build)
    participant DB as Postgres (global-setup)
    participant PS as publishing script (tsx)
    participant FS as Filesystem
    participant NB as next build

    V->>DB: seedPublishingSite() — seed site, pages, redirects
    V->>PS: "spawnSync(tsx index.ts, timeout=120s)"
    PS-->>V: "outputDir/{schema/,data/,sitemap.json}"

    note over V,FS: Phase 1 — full backup before any template mutation
    V->>FS: "cpSync template/{schema,data,sitemap.json} → tmpBackupDir"
    V->>FS: "backupDir = tmpBackupDir (only after all copies succeed)"

    note over V,FS: Phase 2 — swap template fixtures
    V->>FS: "rm+cp outputDir/{schema,data,sitemap.json} → template"
    V->>FS: cp sitemap.json → template/public/sitemap.json
    V->>FS: cp schema/_index.json → schema/not-found.json
    V->>FS: rm template/out

    V->>NB: "spawnSync(next build --webpack, timeout=600s)"
    NB-->>V: "template/out/{index.html,about/*,news/*,...}"

    note over V,FS: afterAll — restore template
    V->>FS: restoreTemplate(): rm+cpSync backupDir → template
    V->>FS: rm tmpBackupDir, rm outputDir
    V->>DB: db.destroy()
```

</a>
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(publishing): harden full-build test ..."](https://github.com/opengovsg/isomer/commit/143c3ef56cff07e1851dbe3ef5d2bd65ee3b3874) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746708)</sub>

<!-- /greptile_comment -->