### PR TITLE
fix: aria-hidden for info box icon

### DIFF
--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -107,9 +107,7 @@ const InfoBoxes = ({
               className={compoundStyles.infoBox()}
               isExternal={isExternalLink}
             >
-              {icon && (
-                <InfoBoxIcon icon={icon} hasLink={hasLink} />
-              )}
+              {icon && <InfoBoxIcon icon={icon} hasLink={hasLink} />}
 
               <h3
                 className={compoundStyles.infoBoxTitle({

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -78,6 +78,7 @@ const InfoBoxIcon = ({
 
   return (
     <Icon
+      aria-hidden
       className={compoundStyles.infoBoxIcon({
         hasLink,
       })}
@@ -107,7 +108,7 @@ const InfoBoxes = ({
               isExternal={isExternalLink}
             >
               {icon && (
-                <InfoBoxIcon icon={icon} hasLink={hasLink} aria-hidden="true" />
+                <InfoBoxIcon icon={icon} hasLink={hasLink} />
               )}
 
               <h3


### PR DESCRIPTION
## Problem

Decorative icons in InfoCols were intended to be hidden from screen readers via aria-hidden="true", but the prop was passed to InfoBoxIcon without being forwarded to the underlying <svg>. The attribute was dropped at runtime and caused a TypeScript error.

Closes #2363 

## Solution

Moved aria-hidden onto the <Icon> element inside InfoBoxIcon and removed the invalid prop from the call site. 

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Features**:

NIL

**Improvements**:

NIL

**Bug Fixes**:

- Fix aria-hidden being silently dropped on InfoBoxIcon in InfoCols, restoring intended screen-reader behavior and fixing the TypeScript error.

## Before & After Screenshots

**BEFORE**:

<img width="1174" height="801" alt="Isomer-2" src="https://github.com/user-attachments/assets/683cd566-05b0-4bea-92c9-a4165ceb4d8a" />

**AFTER**:

<img width="1156" height="791" alt="Isomer-1" src="https://github.com/user-attachments/assets/439311ee-d5e8-4cc6-9827-529fa83b357a" />

## Tests

**Manual Verification Steps**:

- [ ] Open Storybook → Next/Components/InfoCols
- [ ] Inspect an info-box icon <svg> in DevTools and confirm aria-hidden="true" is present

**New scripts**:

NIL

**New dependencies**:

NIL

**New dev dependencies**:

NIL
