### PR TITLE
fix: fix default max rows when maxLength is absent

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -58,3 +58,5 @@ export const JSON_FORMS_RANKING = {
 export const PROSE_COMPONENT_NAME = "Text"
 
 export const TEXTAREA_CHARACTERS_PER_ROW = 70
+export const TEXTAREA_DEFAULT_ROWS = 3
+export const TEXTAREA_MAX_ROWS = 5

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
@@ -45,10 +45,9 @@ function JsonFormsTextAreaControl({
   const remainingCharacterCount = maxLength
     ? getRemainingCharacterCount(maxLength, data ? String(data) : undefined)
     : -1
-  const numOfRows = Math.min(
-    5,
-    Math.ceil((maxLength || 0) / TEXTAREA_CHARACTERS_PER_ROW),
-  )
+  const numOfRows = maxLength
+    ? Math.min(5, Math.ceil(maxLength / TEXTAREA_CHARACTERS_PER_ROW))
+    : 3
 
   const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = e.target

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTextAreaControl.tsx
@@ -11,6 +11,8 @@ import {
 import {
   JSON_FORMS_RANKING,
   TEXTAREA_CHARACTERS_PER_ROW,
+  TEXTAREA_DEFAULT_ROWS,
+  TEXTAREA_MAX_ROWS,
 } from "~/constants/formBuilder"
 
 import { getCustomErrorMessage } from "./utils"
@@ -46,8 +48,11 @@ function JsonFormsTextAreaControl({
     ? getRemainingCharacterCount(maxLength, data ? String(data) : undefined)
     : -1
   const numOfRows = maxLength
-    ? Math.min(5, Math.ceil(maxLength / TEXTAREA_CHARACTERS_PER_ROW))
-    : 3
+    ? Math.min(
+        TEXTAREA_MAX_ROWS,
+        Math.ceil(maxLength / TEXTAREA_CHARACTERS_PER_ROW),
+      )
+    : TEXTAREA_DEFAULT_ROWS
 
   const onChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const { value } = e.target

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsTextAreaControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsTextAreaControl.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { Type } from "@sinclair/typebox"
+
+import { FormBuilder } from "./formBuilder"
+
+const meta: Meta<typeof FormBuilder> = {
+  title: "Pages/Edit Page/components/JsonFormsTextAreaControl",
+  component: FormBuilder,
+}
+
+export default meta
+type Story = StoryObj<typeof FormBuilder>
+
+const schema = Type.Object({
+  description: Type.Optional(
+    Type.String({
+      title: "Meta description",
+      description:
+        "This is a description that appears on search engine results.",
+      format: "textarea",
+    }),
+  ),
+})
+
+const maxLengthSchema = Type.Object({
+  quote: Type.String({
+    title: "Quote",
+    maxLength: 280,
+    format: "textarea",
+  }),
+})
+
+export const Default: Story = {
+  args: {
+    schema,
+    data: {},
+  },
+}
+
+export const MaxLength: Story = {
+  args: {
+    schema: maxLengthSchema,
+    data: { quote: "A short quote." },
+  },
+}

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsTextAreaControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsTextAreaControl.stories.tsx
@@ -11,35 +11,31 @@ const meta: Meta<typeof FormBuilder> = {
 export default meta
 type Story = StoryObj<typeof FormBuilder>
 
-const schema = Type.Object({
-  description: Type.Optional(
-    Type.String({
-      title: "Meta description",
-      description:
-        "This is a description that appears on search engine results.",
-      format: "textarea",
-    }),
-  ),
-})
-
-const maxLengthSchema = Type.Object({
-  quote: Type.String({
-    title: "Quote",
-    maxLength: 280,
-    format: "textarea",
-  }),
-})
-
 export const Default: Story = {
   args: {
-    schema,
+    schema: Type.Object({
+      description: Type.Optional(
+        Type.String({
+          title: "Meta description",
+          description:
+            "This is a description that appears on search engine results.",
+          format: "textarea",
+        }),
+      ),
+    }),
     data: {},
   },
 }
 
 export const MaxLength: Story = {
   args: {
-    schema: maxLengthSchema,
+    schema: Type.Object({
+      quote: Type.String({
+        title: "Quote",
+        maxLength: 280,
+        format: "textarea",
+      }),
+    }),
     data: { quote: "A short quote." },
   },
 }


### PR DESCRIPTION
## Problem

Textarea fields in the form builder collapsed to a near-single-line height when the schema had format: "textarea" but no maxLength. The control passed minAutosizeRows={0} and maxAutosizeRows={0}, so `react-textarea-autosize` clamped height to padding and border only (not fully invisible).

Closes #2361 

## Solution

Default numOfRows to 3 when maxLength is absent. When present, keep existing behaviour: Math.min(5, Math.ceil(maxLength / TEXTAREA_CHARACTERS_PER_ROW)).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Features**:

NIL

**Improvements**:

- Add JsonFormsTextAreaControl Storybook stories (Default, MaxLength)

**Bug Fixes**:

- fix textarea when schema has no maxLength

## Before & After Screenshots

Small UI difference, but before is shorter height.

**BEFORE**:

<img width="1177" height="500" alt="image" src="https://github.com/user-attachments/assets/7c1c212f-74dc-48e3-98ce-a903c07e3024" />

**AFTER**:

<img width="1171" height="517" alt="image" src="https://github.com/user-attachments/assets/273d146f-ab84-4240-a080-815713777426" />

## Tests

**Manual Verification Steps**:

- [ ] Run `pnpm --filter isomer-studio storybook` → Pages/Edit Page/components/JsonFormsTextAreaContro
- [ ] Default story: confirm textarea is visible (~3 rows) and editable
- [ ] MaxLength story: confirm textarea is visible, shows character counter, and respects row cap

**New scripts**:

NIL

**New dependencies**:

NIL

**New dev dependencies**:

NIL
