### PR TITLE
fix: fix default value in JsonFormsIntegerControl

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsIntegerControl.tsx
@@ -74,7 +74,7 @@ function JsonFormsIntegerControl({
         <FormLabel description={description}>{label}</FormLabel>
         <NumberInput
           // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          defaultValue={defaultValue || min}
+          defaultValue={defaultValue ?? min}
           min={min}
           max={max}
           onChange={onChange}

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsIntegerControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsIntegerControl.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { Type } from "@sinclair/typebox"
+
+import { FormBuilder } from "./formBuilder"
+
+const meta: Meta<typeof FormBuilder> = {
+  title: "Pages/Edit Page/components/JsonFormsIntegerControl",
+  component: FormBuilder,
+}
+
+export default meta
+type Story = StoryObj<typeof FormBuilder>
+
+const schema = Type.Object({
+  count: Type.Integer({
+    title: "Count",
+    minimum: -10,
+    maximum: 10,
+    default: 0,
+    description: "The number of items to display",
+  }),
+})
+
+export const Default: Story = {
+  args: {
+    schema,
+    data: {},
+  },
+}


### PR DESCRIPTION
## Problem

Integer fields rendered by JSON Forms incorrectly treated a schema `default` value of `0` as missing.
Because the control used `defaultValue || min`, `0` was considered falsy and replaced with the field
minimum value instead.

Closes #2370

## Solution

Updated `JsonFormsIntegerControl` to use nullish coalescing for the fallback. This preserves valid defaults like 0, while still falling back to min when no default is provided

**Breaking Changes**

- [ ]  Yes - this PR contains breaking changes
    - Details ...
- [x]  No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Added a Storybook example for JsonFormsIntegerControl to make the default integer behavior easier to verify.

**Bug Fixes**:

- Fixed integer fields with default: 0 rendering the minimum value instead of 0.

## Before & After Screenshots

Examples use the following values for the integer field, with default set to 0, hence expected should be 0.

```json
{
  "type": "integer",
  "minimum": -10,
  "maximum": 10,
  "default": 0
}
```

**BEFORE**:

<img width="2982" height="268" alt="image" src="https://github.com/user-attachments/assets/dc17e1ee-96be-44c2-ac8d-2f4a7e8e777d" />

**AFTER**:

<img width="2982" height="232" alt="image" src="https://github.com/user-attachments/assets/81953bed-be7e-41d8-922f-f4e0f0610c44" />

## Tests

**Manual Verification Steps**:

- [ ]  Run pnpm --filter isomer-studio storybook.
- [ ]  Open Pages / Edit Page / components / JsonFormsIntegerControl.
- [ ]  Open the Default story.
- [ ]  Confirm the integer field displays 0, not -10.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None