### PR TITLE
fix: update resource service tests to use getFooter instead of getNavBar

### DIFF
--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -17,6 +17,7 @@ import type { Resource } from "../../database"
 import { db, ResourceState } from "../../database"
 import {
   getBatchAncestryWithSelfQuery,
+  getFooter,
   getFullPageById,
   getLocalisedSitemap,
   getNavBar,
@@ -764,7 +765,7 @@ describe("resource.service", () => {
       // Arrange
       const { site } = await setupSite()
       // Act
-      const result = await getNavBar(db, site.id)
+      const result = await getFooter(db, site.id)
       // Assert
       expect(result).toBeDefined()
       expect(result.siteId).toBe(site.id)
@@ -772,7 +773,7 @@ describe("resource.service", () => {
 
     it("should throw an error if the `siteId` is not found", async () => {
       // Act
-      const result = getNavBar(db, 99999)
+      const result = getFooter(db, 99999)
       // Assert
       await expect(result).rejects.toThrow()
     })


### PR DESCRIPTION
## Problem

The `getFooter` test block in `resource.service.test.ts` was incorrectly calling `getNavBar` instead of
`getFooter`. This meant the tests could pass even if `getFooter` was broken, removed, or no longer
queried the `Footer` table.

Closes #2371

## Solution

Updated the `getFooter` tests to import and call `getFooter` directly.

**Breaking Changes**

- [ ]  Yes - this PR contains breaking changes
    - Details ...
- [x]  No - this PR is backwards compatible

**Features**:

- NIL

**Improvements**:

- NIL

**Bug Fixes**:

- Fixed `getFooter` tests so they no longer call `getNavBar`.

## Before & After Screenshots

**BEFORE**:

NIL

**AFTER**:

NIL

## Tests

**Manual Verification Steps**:

- [ ]  `pnpm --filter isomer-studio test:unit -- resource.service.test.ts -t "getFooter|getNavBar"`

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None