### PR TITLE
fix: transform dgs field numeric values

### DIFF
--- a/packages/components/src/hooks/useDgsData/transformDgsField.ts
+++ b/packages/components/src/hooks/useDgsData/transformDgsField.ts
@@ -27,6 +27,9 @@ export const transformDgsField = <T extends string | undefined | null>(
   if (typeof value === "object") {
     return JSON.stringify(value) as T
   }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value) as T
+  }
 
-  return String(value) as T
+  return field
 }

--- a/packages/components/src/hooks/useDgsData/transformDgsField.ts
+++ b/packages/components/src/hooks/useDgsData/transformDgsField.ts
@@ -16,12 +16,17 @@ export const transformDgsField = <T extends string | undefined | null>(
   field: T,
   record: Record<string, unknown>,
 ): T => {
-  try {
-    if (!field || !isStringDgs(field)) {
-      return field
-    }
-    return record[extractDgsFieldKey(field)] as T
-  } catch {
+  if (!field || !isStringDgs(field)) {
     return field
   }
+
+  const value = record[extractDgsFieldKey(field)]
+  if (value === undefined || value === null || typeof value === "string") {
+    return value as T
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value) as T
+  }
+
+  return String(value) as T
 }

--- a/packages/components/src/templates/next/components/complex/ContactInformation/DgsContactInformation/DgsContactInformation.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/DgsContactInformation/DgsContactInformation.stories.tsx
@@ -168,6 +168,37 @@ const EmptyFieldsParameters = {
   },
 }
 
+const NumericColumnValuesParameters = {
+  msw: {
+    handlers: [
+      http.get(DgsUrl, () =>
+        HttpResponse.json({
+          success: true,
+          result: {
+            records: [
+              {
+                entity_name: 2023,
+                description: 45678,
+                methods: JSON.stringify([
+                  {
+                    method: "telephone",
+                    label: "Telephone",
+                    values: ["+65-63798000 (MFA)"],
+                  },
+                ]),
+                other_information: JSON.stringify({
+                  label: "Other Information",
+                  value: "Contact us for more details.",
+                }),
+              },
+            ],
+          },
+        }),
+      ),
+    ],
+  },
+}
+
 export const Default: Story = {
   parameters: DgsParameters,
   args: {
@@ -203,6 +234,27 @@ export const DefaultEmptyFields: Story = {
       ],
     },
     title: "[dgs:entity_name]", // to show that they can have different value from DGS
+    description: "[dgs:description]",
+    methods: "[dgs:methods]",
+    otherInformation: "[dgs:other_information]",
+  },
+}
+
+export const NumericColumnValues: Story = {
+  name: "Default (Numeric Field)",
+  parameters: NumericColumnValuesParameters,
+  args: {
+    dataSource: {
+      type: "dgs",
+      resourceId: "PLACEHOLDER_RESOURCE_ID",
+      filters: [
+        {
+          fieldKey: "testFieldKey",
+          fieldValue: "testFieldValue",
+        },
+      ],
+    },
+    title: "[dgs:entity_name]",
     description: "[dgs:description]",
     methods: "[dgs:methods]",
     otherInformation: "[dgs:other_information]",


### PR DESCRIPTION
## Problem

DGS columns can return numeric values (e.g. entity_name: 2023), but transformDgsField passed them through as numbers. Components expecting strings failed to render correctly. safeJsonParse also accepted JSON primitives, which could surface invalid parsed values.

Closes #1954 

## Solution

Coerce numeric/boolean DGS values to strings in transformDgsField. Restrict safeJsonParse to objects and arrays only.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Features**:

NIL

**Improvements**:

- Add NumericColumnValues Storybook story for DgsContactInformation

**Bug Fixes**:

- Coerce DGS numeric/boolean column values to strings in transformDgsField
- Reject JSON primitives in safeJsonParse (only objects/arrays)

## Before & After Screenshots

**BEFORE**:

NIL

**AFTER**:

NIL

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

- [ ] Storybook → Next/Components/ContactInformation/DGS → NumericColumnValues — title/description render correctly
- [ ] `pnpm --filter @opengovsg/isomer-components test` — transformDgsField and safeJsonParse tests pass

**New scripts**:

NIL

**New dependencies**:

NIL

**New dev dependencies**:

NIL

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `transformDgsField` to coerce numeric and boolean DGS column values to strings and adds a Storybook story exercising that path. The core logic change is correct for direct string fields (`title`, `description`), but the stated companion fix to restrict `safeJsonParse` to objects and arrays was not included.

- `transformDgsField.ts`: removes the outer try/catch and adds explicit type-dispatch branches (string passthrough, object → `JSON.stringify`, number/boolean → `String()`).
- `DgsContactInformation.stories.tsx`: adds a `NumericColumnValues` story backed by an MSW handler that returns raw numeric column values.
- `safeJsonParse.ts` is unchanged; a numeric DGS value routed through `methods` or `otherInformation` is now coerced to a string by `transformDgsField`, parsed back to a number by `JSON.parse` inside `safeJsonParse`, and passed as a non-array to `ContactInformationUI` — a regression from the previous graceful `[]` fallback.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The coercion fix is correct for title/description fields, but the companion safeJsonParse guard was not applied, leaving a regression path for fields that flow through safeJsonParse.

The transformDgsField changes are safe for title and description, which are used directly as strings. However, the same coercion applied to methods or otherInformation converts a raw number to a numeric JSON string, which safeJsonParse then parses back to a number. Previously the number input was swallowed safely and returned undefined (falling back to []); now it leaks through as a non-array, which would cause ContactInformationUI to crash when iterating methods. The safeJsonParse restriction described in the PR was not committed.

packages/components/src/hooks/useDgsData/transformDgsField.ts and packages/components/src/utils/safeJsonParse.ts (unchanged but needs the primitive-rejection guard)
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/components/src/hooks/useDgsData/transformDgsField.ts | Adds type-based coercion for DGS record values (number/boolean → string, object → JSON.stringify); removes the outer try/catch; the new branches work correctly for the happy path but introduce a regression when numeric values reach safeJsonParse |
| packages/components/src/templates/next/components/complex/ContactInformation/DgsContactInformation/DgsContactInformation.stories.tsx | Adds a NumericColumnValues Storybook story with a mock handler returning numeric DGS column values; straightforward story addition, no issues |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DGS API Record\n(record[key])"] --> B{typeof value}
    B -->|undefined / null| C["return value as T\n(undefined/null)"]
    B -->|string| D["return value as T\n(string passthrough)"]
    B -->|object| E["return JSON.stringify(value)\n(object to string)"]
    B -->|number / boolean| F["return String(value)\n(coerce to string)"]
    B -->|other| G["return field\n(original DGS template)"]
    D --> H{Field used for}
    E --> H
    F --> H
    H -->|title / description| I["Rendered directly as string"]
    H -->|methods / otherInformation| J["safeJsonParse(stringValue)"]
    J -->|JSON object/array string| K["Parsed object/array to component"]
    J -->|numeric string e.g. 2023| L["JSON.parse returns number"]
    L --> M["methods ?? [] evaluates to 2023 - crash"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["DGS API Record\n(record[key])"] --> B{typeof value}
    B -->|undefined / null| C["return value as T\n(undefined/null)"]
    B -->|string| D["return value as T\n(string passthrough)"]
    B -->|object| E["return JSON.stringify(value)\n(object to string)"]
    B -->|number / boolean| F["return String(value)\n(coerce to string)"]
    B -->|other| G["return field\n(original DGS template)"]
    D --> H{Field used for}
    E --> H
    F --> H
    H -->|title / description| I["Rendered directly as string"]
    H -->|methods / otherInformation| J["safeJsonParse(stringValue)"]
    J -->|JSON object/array string| K["Parsed object/array to component"]
    J -->|numeric string e.g. 2023| L["JSON.parse returns number"]
    L --> M["methods ?? [] evaluates to 2023 - crash"]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/components/src/hooks/useDgsData/transformDgsField.ts`, line 1-35 ([link](https://github.com/opengovsg/isomer/blob/7502e5c75a94f8f99bbf937ee96d2b71bf1a29a9/packages/components/src/hooks/useDgsData/transformDgsField.ts#L1-L35)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No unit tests for `transformDgsField`**

   The CLAUDE.md for `packages/components` states unit tests are expected for utilities. `transformDgsField` now has four distinct value-type branches (string, undefined/null, object, number/boolean) plus a final fallback, but there is no `__tests__/transformDgsField.test.ts`. A few targeted tests covering each branch (including the edge case where `value` is missing from the record) would help prevent future regressions without relying solely on Storybook smoke-testing.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["chore: fix lint issue"](https://github.com/opengovsg/isomer/commit/7502e5c75a94f8f99bbf937ee96d2b71bf1a29a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746690)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->