### PR TITLE
Refactor Blockquote to discriminated union with style control

### DIFF
--- a/apps/studio/prisma/scripts/backfill-blockquote-style/README.md
+++ b/apps/studio/prisma/scripts/backfill-blockquote-style/README.md
@@ -1,0 +1,23 @@
+# Backfill blockquote `style`
+
+The Blockquote block gained a `Style` control ("With image" / "Without image"),
+modelled as a discriminated union with a required `style` discriminator. Existing
+blockquotes were stored without `style`, so this script backfills it:
+
+- Blockquotes with an `imageSrc` become `style: "image"`.
+- Blockquotes without an image become `style: "imageless"`, and any dangling
+  `imageSrc`/`imageAlt` (e.g. a leftover placeholder alt text) is stripped.
+
+The script is idempotent and dry-runnable.
+
+## Running
+
+See the parent [`README.md`](../README.md) for the jump-host setup. Then:
+
+```bash
+# Dry run (default) — only logs what would change
+source .env && pnpm exec tsx prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts
+
+# Apply the changes
+source .env && pnpm exec tsx prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts --apply
+```

--- a/apps/studio/prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts
+++ b/apps/studio/prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts
@@ -1,0 +1,57 @@
+import { db } from "~/server/modules/database"
+
+import { backfillBlockquoteStyleInContent } from "./helpers"
+
+// Backfills the `style` discriminator on every blockquote stored in a Blob,
+// so that existing pages stay valid against the new Blockquote schema.
+//
+// This script is idempotent and dry-runnable. By default it only logs what it
+// would change; pass `--apply` to actually write to the database.
+//
+// Usage (see prisma/scripts/README.md for the jump-host setup):
+//   source .env && pnpm exec tsx prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts
+//   source .env && pnpm exec tsx prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts --apply
+
+const DRY_RUN = !process.argv.includes("--apply")
+
+const backfillBlockquoteStyle = async () => {
+  const blobs = await db.selectFrom("Blob").select(["id", "content"]).execute()
+
+  let updatedCount = 0
+
+  for (const blob of blobs) {
+    const { schema, changed } = backfillBlockquoteStyleInContent(blob.content)
+
+    if (!changed) {
+      continue
+    }
+
+    updatedCount++
+
+    if (DRY_RUN) {
+      console.log(`[dry-run] would update Blob ${blob.id}`)
+      continue
+    }
+
+    await db
+      .updateTable("Blob")
+      .set({ content: schema as PrismaJson.BlobJsonContent })
+      .where("id", "=", blob.id)
+      .execute()
+
+    console.log(`Updated Blob ${blob.id}`)
+  }
+
+  console.log(
+    `${DRY_RUN ? "[dry-run] " : ""}${updatedCount}/${blobs.length} blobs ${
+      DRY_RUN ? "would be updated" : "updated"
+    }`,
+  )
+}
+
+void backfillBlockquoteStyle()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/apps/studio/prisma/scripts/backfill-blockquote-style/helpers.test.ts
+++ b/apps/studio/prisma/scripts/backfill-blockquote-style/helpers.test.ts
@@ -1,0 +1,157 @@
+import type {
+  IsomerComponent,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
+import { describe, expect, it } from "vitest"
+
+import {
+  backfillBlockquoteStyle,
+  backfillBlockquoteStyleInContent,
+} from "./helpers"
+
+const makeSchema = (content: IsomerComponent[]): IsomerSchema =>
+  ({
+    version: "0.1.0",
+    layout: "content",
+    page: { title: "Test page" },
+    content,
+  }) as unknown as IsomerSchema
+
+describe("backfillBlockquoteStyle", () => {
+  it("leaves non-blockquote blocks untouched", () => {
+    const component = {
+      type: "prose",
+      content: [],
+    } as unknown as IsomerComponent
+
+    const result = backfillBlockquoteStyle(component)
+
+    expect(result.changed).toBe(false)
+    expect(result.component).toBe(component)
+  })
+
+  it("sets the image style when an image is present", () => {
+    const component = {
+      type: "blockquote",
+      quote: "A quote",
+      source: "A source",
+      imageSrc: "/some-image.png",
+      imageAlt: "A descriptive alt text",
+    } as unknown as IsomerComponent
+
+    const result = backfillBlockquoteStyle(component)
+
+    expect(result.changed).toBe(true)
+    expect(result.component).toEqual({
+      type: "blockquote",
+      style: "image",
+      quote: "A quote",
+      source: "A source",
+      imageSrc: "/some-image.png",
+      imageAlt: "A descriptive alt text",
+    })
+  })
+
+  it("sets the imageless style and strips dangling image fields when there is no image", () => {
+    const component = {
+      type: "blockquote",
+      quote: "A quote",
+      source: "A source",
+      // A placeholder alt text left behind without an actual image.
+      imageAlt: "Enter a descriptive alt text.",
+    } as unknown as IsomerComponent
+
+    const result = backfillBlockquoteStyle(component)
+
+    expect(result.changed).toBe(true)
+    expect(result.component).toEqual({
+      type: "blockquote",
+      style: "imageless",
+      quote: "A quote",
+      source: "A source",
+    })
+  })
+
+  it("treats an empty imageSrc as having no image", () => {
+    const component = {
+      type: "blockquote",
+      quote: "A quote",
+      source: "A source",
+      imageSrc: "   ",
+      imageAlt: "Placeholder",
+    } as unknown as IsomerComponent
+
+    const result = backfillBlockquoteStyle(component)
+
+    expect(result.changed).toBe(true)
+    expect(result.component).toEqual({
+      type: "blockquote",
+      style: "imageless",
+      quote: "A quote",
+      source: "A source",
+    })
+  })
+
+  it("is idempotent for already-migrated blockquotes", () => {
+    const withImage = {
+      type: "blockquote",
+      style: "image",
+      quote: "A quote",
+      source: "A source",
+      imageSrc: "/some-image.png",
+      imageAlt: "A descriptive alt text",
+    } as unknown as IsomerComponent
+    const imageless = {
+      type: "blockquote",
+      style: "imageless",
+      quote: "A quote",
+      source: "A source",
+    } as unknown as IsomerComponent
+
+    expect(backfillBlockquoteStyle(withImage).changed).toBe(false)
+    expect(backfillBlockquoteStyle(imageless).changed).toBe(false)
+  })
+})
+
+describe("backfillBlockquoteStyleInContent", () => {
+  it("returns the same schema reference when nothing changes", () => {
+    const schema = makeSchema([
+      { type: "prose", content: [] } as unknown as IsomerComponent,
+      {
+        type: "blockquote",
+        style: "imageless",
+        quote: "A quote",
+        source: "A source",
+      } as unknown as IsomerComponent,
+    ])
+
+    const result = backfillBlockquoteStyleInContent(schema)
+
+    expect(result.changed).toBe(false)
+    expect(result.schema).toBe(schema)
+  })
+
+  it("migrates every blockquote in the content", () => {
+    const schema = makeSchema([
+      {
+        type: "blockquote",
+        quote: "First",
+        source: "Source",
+        imageSrc: "/image.png",
+        imageAlt: "Alt",
+      } as unknown as IsomerComponent,
+      { type: "prose", content: [] } as unknown as IsomerComponent,
+      {
+        type: "blockquote",
+        quote: "Second",
+        source: "Source",
+      } as unknown as IsomerComponent,
+    ])
+
+    const result = backfillBlockquoteStyleInContent(schema)
+
+    expect(result.changed).toBe(true)
+    expect(result.schema.content[0]).toMatchObject({ style: "image" })
+    expect(result.schema.content[2]).toMatchObject({ style: "imageless" })
+  })
+})

--- a/apps/studio/prisma/scripts/backfill-blockquote-style/helpers.ts
+++ b/apps/studio/prisma/scripts/backfill-blockquote-style/helpers.ts
@@ -1,0 +1,93 @@
+import type {
+  IsomerComponent,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
+import { BLOCKQUOTE_STYLE } from "@opengovsg/isomer-components"
+
+// Legacy blockquotes predate the `style` control. They were stored as a flat
+// object with an optional `imageSrc`/`imageAlt`, e.g.
+//   { type: "blockquote", quote, source, imageSrc?, imageAlt? }
+// This shape lets us read those fields off a blockquote regardless of whether
+// it has already been migrated to the discriminated-union shape.
+interface RawBlockquote {
+  type: "blockquote"
+  quote: string
+  source: string
+  style?: string
+  imageSrc?: string
+  imageAlt?: string
+}
+
+const isValidStyle = (style: string | undefined): boolean =>
+  style === BLOCKQUOTE_STYLE.image || style === BLOCKQUOTE_STYLE.imageless
+
+/**
+ * Backfills the `style` discriminator on a single blockquote.
+ *
+ * - Already-migrated blockquotes (with a valid `style`) are left untouched so
+ *   the script is idempotent.
+ * - Blockquotes with an image become the "image" style.
+ * - Blockquotes without an image become the "imageless" style, and any dangling
+ *   `imageSrc`/`imageAlt` (e.g. a placeholder alt text) is stripped.
+ */
+export const backfillBlockquoteStyle = (
+  component: IsomerComponent,
+): { component: IsomerComponent; changed: boolean } => {
+  if (component.type !== "blockquote") {
+    return { component, changed: false }
+  }
+
+  const blockquote = component as RawBlockquote
+
+  if (isValidStyle(blockquote.style)) {
+    return { component, changed: false }
+  }
+
+  const hasImage =
+    typeof blockquote.imageSrc === "string" && blockquote.imageSrc.trim() !== ""
+
+  if (hasImage) {
+    return {
+      component: {
+        ...blockquote,
+        style: BLOCKQUOTE_STYLE.image,
+      } as IsomerComponent,
+      changed: true,
+    }
+  }
+
+  // Strip the dangling image fields so we don't keep a misleading placeholder
+  // alt text around on a quote that has no image.
+  const { imageSrc: _imageSrc, imageAlt: _imageAlt, ...rest } = blockquote
+  return {
+    component: {
+      ...rest,
+      style: BLOCKQUOTE_STYLE.imageless,
+    } as IsomerComponent,
+    changed: true,
+  }
+}
+
+/**
+ * Applies {@link backfillBlockquoteStyle} to every block in a page's content,
+ * returning the new content and whether anything changed.
+ */
+export const backfillBlockquoteStyleInContent = (
+  schema: IsomerSchema,
+): { schema: IsomerSchema; changed: boolean } => {
+  let changed = false
+
+  const content = schema.content.map((component) => {
+    const result = backfillBlockquoteStyle(component)
+    if (result.changed) {
+      changed = true
+    }
+    return result.component
+  })
+
+  if (!changed) {
+    return { schema, changed: false }
+  }
+
+  return { schema: { ...schema, content }, changed: true }
+}

--- a/apps/studio/src/components/PageEditor/constants.ts
+++ b/apps/studio/src/components/PageEditor/constants.ts
@@ -28,9 +28,9 @@ export const DEFAULT_BLOCKS = {
   },
   blockquote: {
     type: "blockquote",
+    style: "imageless",
     quote: "Enter your quote here.",
     source: "Describe who said the quote.",
-    imageAlt: "Enter a descriptive alt text.",
   },
   callout: {
     type: "callout",

--- a/packages/components/src/interfaces/complex/Blockquote.ts
+++ b/packages/components/src/interfaces/complex/Blockquote.ts
@@ -1,38 +1,88 @@
 import type { Static } from "@sinclair/typebox"
+import type { Simplify } from "type-fest"
 import type { IsomerPageLayoutType, IsomerSiteProps } from "~/types"
 import { Type } from "@sinclair/typebox"
 
+import { ARRAY_RADIO_FORMAT } from "../format"
 import { AltTextSchema, ImageSrcSchema } from "./Image"
 
-export const BlockquoteSchema = Type.Object(
-  {
-    type: Type.Literal("blockquote", { default: "blockquote" }),
-    quote: Type.String({
-      title: "Quote",
-      format: "textarea",
+export const BLOCKQUOTE_STYLE = {
+  imageless: "imageless",
+  image: "image",
+} as const
+
+const BlockquoteBaseSchema = Type.Object({
+  type: Type.Literal("blockquote", { default: "blockquote" }),
+  quote: Type.String({
+    title: "Quote",
+    format: "textarea",
+  }),
+  source: Type.String({
+    title: "Source",
+    description: "Speaker, their designation, or when they said it",
+  }),
+})
+
+const BlockquoteWithoutImageSchema = Type.Composite(
+  [
+    Type.Object({
+      style: Type.Literal(BLOCKQUOTE_STYLE.imageless, {
+        default: BLOCKQUOTE_STYLE.imageless,
+      }),
     }),
-    source: Type.String({
-      title: "Source",
-      description: "Speaker, their designation, or when they said it",
-    }),
-    // NOTE: We are making the image optional but the alt text required as a hack,
-    // because the schema does not support having dependent properties. If no
-    // image is provided, the alt text will be ignored
-    imageSrc: Type.Optional(ImageSrcSchema),
-    // Setting as optional because the image is optional.
-    // If no image is provided and this is required, the schema will throw an error,
-    // making it impossible to create a blockquote without an image on Studio
-    imageAlt: Type.Optional(AltTextSchema),
-  },
+    BlockquoteBaseSchema,
+  ],
   {
-    title: "Blockquote",
-    description:
-      "The Blockquote component is used to display a quote with an image.",
+    title: "Without image",
   },
 )
 
-export type BlockquoteProps = Static<typeof BlockquoteSchema> & {
+const BlockquoteWithImageSchema = Type.Composite(
+  [
+    Type.Object({
+      style: Type.Literal(BLOCKQUOTE_STYLE.image, {
+        default: BLOCKQUOTE_STYLE.image,
+      }),
+      // Both the image and its alt text are required for this style, so that
+      // an image is never published without a descriptive alt text.
+      imageSrc: ImageSrcSchema,
+      imageAlt: AltTextSchema,
+    }),
+    BlockquoteBaseSchema,
+  ],
+  {
+    title: "With image",
+  },
+)
+
+export const BlockquoteSchema = Type.Intersect(
+  [
+    Type.Union([BlockquoteWithoutImageSchema, BlockquoteWithImageSchema], {
+      title: "Style",
+      format: ARRAY_RADIO_FORMAT,
+    }),
+  ],
+  {
+    title: "Blockquote",
+    description:
+      "The Blockquote component is used to display a quote with an optional image.",
+  },
+)
+
+interface BlockquoteCommonProps {
   layout: IsomerPageLayoutType
   shouldLazyLoad?: boolean
   site: IsomerSiteProps
 }
+
+export type BlockquoteWithoutImageProps = Simplify<
+  Static<typeof BlockquoteWithoutImageSchema> & BlockquoteCommonProps
+>
+
+export type BlockquoteWithImageProps = Simplify<
+  Static<typeof BlockquoteWithImageSchema> & BlockquoteCommonProps
+>
+
+export type BlockquoteProps =
+  | BlockquoteWithoutImageProps
+  | BlockquoteWithImageProps

--- a/packages/components/src/interfaces/complex/index.ts
+++ b/packages/components/src/interfaces/complex/index.ts
@@ -1,5 +1,11 @@
 export { AccordionSchema, type AccordionProps } from "./Accordion"
-export { BlockquoteSchema, type BlockquoteProps } from "./Blockquote"
+export {
+  BlockquoteSchema,
+  BLOCKQUOTE_STYLE,
+  type BlockquoteProps,
+  type BlockquoteWithImageProps,
+  type BlockquoteWithoutImageProps,
+} from "./Blockquote"
 export { LogoCloudSchema, type LogoCloudProps } from "./LogoCloud"
 export { CalloutSchema, type CalloutProps } from "./Callout"
 export { type CardsProps } from "./Cards"

--- a/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.stories.tsx
@@ -22,6 +22,7 @@ type Story = StoryObj<typeof Blockquote>
 
 export const WithoutImage: Story = {
   args: {
+    style: "imageless",
     quote:
       "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail.",
     source:
@@ -31,6 +32,7 @@ export const WithoutImage: Story = {
 
 export const WithImage: Story = {
   args: {
+    style: "image",
     quote:
       "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail.",
     source:
@@ -42,6 +44,7 @@ export const WithImage: Story = {
 
 export const ManyWordsWithImage: Story = {
   args: {
+    style: "image",
     quote:
       "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail. When I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew us being there would help spur me to prevail.",
     source:
@@ -53,6 +56,7 @@ export const ManyWordsWithImage: Story = {
 
 export const MinimalWordsWithImage: Story = {
   args: {
+    style: "image",
     quote: "Hi",
     source: "Me",
     imageSrc: "https://placehold.co/600x600",
@@ -62,6 +66,7 @@ export const MinimalWordsWithImage: Story = {
 
 export const HomepageWithoutImage: Story = {
   args: {
+    style: "imageless",
     quote:
       "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail.",
     source:
@@ -72,6 +77,7 @@ export const HomepageWithoutImage: Story = {
 
 export const HomepageWithImage: Story = {
   args: {
+    style: "image",
     quote:
       "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail.",
     source:
@@ -84,6 +90,7 @@ export const HomepageWithImage: Story = {
 
 export const HomepageMinimalWordsWithImage: Story = {
   args: {
+    style: "image",
     quote: "Hi",
     source: "Me",
     imageSrc: "https://placehold.co/600x600",

--- a/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.tsx
+++ b/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.tsx
@@ -1,5 +1,6 @@
 import type { BlockquoteProps } from "~/interfaces"
 import { BiSolidQuoteAltLeft } from "react-icons/bi"
+import { BLOCKQUOTE_STYLE } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
@@ -47,15 +48,17 @@ const createBlockquoteStyles = tv({
   },
 })
 
-export const Blockquote = ({
-  quote,
-  source,
-  imageSrc,
-  imageAlt,
-  layout,
-  shouldLazyLoad,
-  site,
-}: BlockquoteProps) => {
+export const Blockquote = (props: BlockquoteProps) => {
+  const { quote, source, layout, shouldLazyLoad, site } = props
+
+  // The image fields only exist on the "with image" style. Legacy blockquotes
+  // predate the `style` control and may carry an image without a `style`, so we
+  // also fall back to reading the image off the props directly.
+  const imageSrc = "imageSrc" in props ? props.imageSrc : undefined
+  const imageAlt = "imageAlt" in props ? props.imageAlt : undefined
+  const showImage =
+    props.style !== BLOCKQUOTE_STYLE.imageless && !!imageSrc && !!imageAlt
+
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const variants = {
     layout: simplifiedLayout,
@@ -79,7 +82,7 @@ export const Blockquote = ({
           </div>
         </div>
 
-        {imageSrc && imageAlt && (
+        {showImage && imageSrc && imageAlt && (
           <ImageClient
             src={imageSrc}
             alt={imageAlt}

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -339,6 +339,7 @@ export const Default: Story = {
       },
       {
         type: "blockquote",
+        style: "image",
         quote:
           "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail.",
         source:

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -1400,6 +1400,7 @@ export const Default: Story = {
       },
       {
         type: "blockquote",
+        style: "image",
         quote:
           "When I was a rookie, I had trouble overcoming the low rope at first. But when it came to my turn, my buddies knew being there would help spur me to prevail.",
         source:

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.stories.tsx
@@ -451,6 +451,7 @@ const generateArgs = ({
       },
       {
         type: "blockquote",
+        style: "image",
         quote:
           "I managed to experience new things: saw a dead fish in a plastic bag for the first time, which was an eye-opener because I never thought I would actually get to see something like this ever.",
         source: "Hannah Teo, Greenies ambassador",
@@ -527,6 +528,7 @@ const generateArgs = ({
       },
       {
         type: "blockquote",
+        style: "image",
         quote:
           "I managed to experience new things: saw a dead fish in a plastic bag for the first time, which was an eye-opener because I never thought I would actually get to see something like this ever.",
         source: "Hannah Teo, Greenies ambassador",

--- a/packages/components/src/templates/next/render/doesComponentHaveImage.ts
+++ b/packages/components/src/templates/next/render/doesComponentHaveImage.ts
@@ -38,7 +38,7 @@ export const doesComponentHaveImage = ({
     case "collectionblock":
       return component.displayThumbnail
     case "blockquote":
-      return component.imageSrc !== undefined
+      return "imageSrc" in component
     default:
       const _: never = component
       return false


### PR DESCRIPTION
## Problem

The Blockquote component previously stored image-related fields (`imageSrc`, `imageAlt`) as optional properties on a flat object, making it unclear whether an image was intentionally absent or just not provided. This led to potential issues with dangling placeholder alt text and made the schema harder to reason about.

## Solution

Refactored the Blockquote schema into a discriminated union with a required `style` discriminator:
- `style: "imageless"` - blockquote without an image (image fields removed)
- `style: "image"` - blockquote with an image (both `imageSrc` and `imageAlt` required)

**Breaking Changes**

- [x] Yes - this PR contains breaking changes
  - The Blockquote schema now requires a `style` discriminator field
  - Existing blockquotes stored without `style` will be invalid against the new schema
  - A database migration script is provided to backfill `style` on all existing blockquotes

**Features**:

- Added `BLOCKQUOTE_STYLE` constant exporting `{ imageless, image }` discriminator values
- Introduced `BlockquoteWithImageProps` and `BlockquoteWithoutImageProps` types for better type safety
- Created a discriminated union schema using TypeBox `Union` with radio button UI format
- Added comprehensive backfill script (`prisma/scripts/backfill-blockquote-style/`) to migrate existing data:
  - Idempotent and dry-runnable (default behavior is dry-run only)
  - Blockquotes with `imageSrc` become `style: "image"`
  - Blockquotes without an image become `style: "imageless"` and dangling image fields are stripped
  - Already-migrated blockquotes are left untouched

**Improvements**:

- Blockquote component now safely handles both new discriminated union shape and legacy flat shape (for backward compatibility during migration)
- Image rendering logic clarified with explicit `showImage` check
- Schema description updated to reflect optional image support
- Updated all Storybook stories and test fixtures to include the `style` field

**Bug Fixes**:

- Prevents dangling placeholder alt text from being stored on imageless blockquotes
- Ensures image and alt text are always paired (both required for "image" style)

## Tests

**Automated Tests**:

- Added comprehensive unit tests in `helpers.test.ts` covering:
  - Non-blockquote components are left untouched
  - Image style is set when image is present
  - Imageless style is set and dangling fields are stripped when no image
  - Empty/whitespace `imageSrc` is treated as no image
  - Idempotency for already-migrated blockquotes
  - Schema-level migration of all blockquotes in content
  - Reference equality preservation when nothing changes

**Manual Verification Steps**:

- [ ] Run the backfill script in dry-run mode: `source .env && pnpm exec tsx prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts`
- [ ] Verify the script reports the correct number of blobs that would be updated
- [ ] Run with `--apply` flag to apply changes to database
- [ ] Verify existing pages with blockquotes still render correctly in the editor and frontend
- [ ] Create a new blockquote and verify the style control appears with "With image" / "Without image" options
- [ ] Verify blockquotes without images don't show the image section

**New scripts**:

- `prisma/scripts/backfill-blockquote-style/backfillBlockquoteStyle.ts` : Backfills the `style` discriminator on all blockquotes in the database (idempotent, dry-runnable with `--apply` flag)

https://claude.ai/code/session_012XGHfo1N7vKCUrLNn4gcLr