### PR TITLE
fix: prevent template injection in aws_deploy GitHub Action (GTA-109-011)

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -224,10 +224,14 @@ jobs:
 
       # Display Inspector results in the GitHub Actions terminal
       - name: Display CycloneDX SBOM (JSON)
-        run: cat ${{ steps.inspector.outputs.artifact_sbom }}
+        env:
+          ARTIFACT_SBOM: ${{ steps.inspector.outputs.artifact_sbom }}
+        run: cat "$ARTIFACT_SBOM"
 
       - name: Display Inspector vulnerability scan results (JSON)
-        run: cat ${{ steps.inspector.outputs.inspector_scan_results }}
+        env:
+          INSPECTOR_SCAN_RESULTS: ${{ steps.inspector.outputs.inspector_scan_results }}
+        run: cat "$INSPECTOR_SCAN_RESULTS"
 
       # Upload Inspector outputs as a .zip that can be downloaded
       # from the GitHub actions job summary page.
@@ -257,11 +261,12 @@ jobs:
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
           IMAGE_TAG: ${{ github.ref_name }}_${{ github.sha }}
         run: |
-          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          docker push "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
 
       - name: Upload sourcemaps to Datadog
         env:
           DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
+          APP_VERSION: ${{ inputs.app-version }}
         run: |
           if [ -z "$DATADOG_API_KEY" ]; then
             echo "DATADOG_API_KEY not set, skipping sourcemap upload"
@@ -273,9 +278,9 @@ jobs:
           # Upload sourcemaps (extracted earlier from installer stage)
           datadog-ci sourcemaps upload .next-static \
             --service=isomer-next \
-            --release-version=${{ inputs.app-version }} \
+            --release-version="$APP_VERSION" \
             --minified-path-prefix=/_next/static \
-            --repository-url=https://github.com/${{ github.repository }}
+            --repository-url="https://github.com/$GITHUB_REPOSITORY"
 
   deploy:
     name: Deploy image to ECS
@@ -305,22 +310,37 @@ jobs:
 
       - name: Replace variables in task definition file
         id: replace-variables
+        env:
+          AWS_ACCOUNT_ID: ${{ inputs.aws-account-id }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          SHORT_ENV: ${{ inputs.shortEnv }}
+          DD_COMMIT_SHA: ${{ github.sha }}
+          ECS_TASK_ROLE: ${{ inputs.ecs-task-role }}
+          ECS_TASK_EXEC_ROLE: ${{ inputs.ecs-task-exec-role }}
+          ECS_TASK_DEFINITION_PATH: ${{ inputs.ecs-task-definition-path }}
         run: |
-          sed -i 's/<AWS_ACCOUNT_ID>/${{ inputs.aws-account-id }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<ENV>/${{ inputs.environment }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<SHORT_ENV>/${{ inputs.shortEnv }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<CPU>/${{ inputs.environment == 'production' && 1024 || 512 }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<MEMORY>/${{ inputs.environment == 'production' && 2048 || 1024 }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<DD_COMMIT_SHA>/${{ github.sha }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<ECS_TASK_ROLE>/${{ inputs.ecs-task-role }}/g' ${{ inputs.ecs-task-definition-path }}
-          sed -i 's/<ECS_TASK_EXEC_ROLE>/${{ inputs.ecs-task-exec-role }}/g' ${{ inputs.ecs-task-definition-path }}
+          CPU=$([[ "$ENVIRONMENT" == "production" ]] && echo "1024" || echo "512")
+          MEMORY=$([[ "$ENVIRONMENT" == "production" ]] && echo "2048" || echo "1024")
+          sed -i "s/<AWS_ACCOUNT_ID>/$AWS_ACCOUNT_ID/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<ENV>/$ENVIRONMENT/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<SHORT_ENV>/$SHORT_ENV/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<CPU>/$CPU/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<MEMORY>/$MEMORY/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<DD_COMMIT_SHA>/$DD_COMMIT_SHA/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<ECS_TASK_ROLE>/$ECS_TASK_ROLE/g" "$ECS_TASK_DEFINITION_PATH"
+          sed -i "s/<ECS_TASK_EXEC_ROLE>/$ECS_TASK_EXEC_ROLE/g" "$ECS_TASK_DEFINITION_PATH"
 
       - name: Replace variables in appspec
+        env:
+          AWS_ACCOUNT_ID: ${{ inputs.aws-account-id }}
+          ENVIRONMENT: ${{ inputs.environment }}
+          CONTAINER_NAME: ${{ inputs.ecs-container-name }}
+          CONTAINER_PORT: ${{ inputs.ecs-container-port }}
         run: |
-          sed -i 's/<AWS_ACCOUNT_ID>/${{ inputs.aws-account-id }}/g' .aws/deploy/appspec.json
-          sed -i 's/<ENV>/${{ inputs.environment}}/g' .aws/deploy/appspec.json
-          sed -i 's/<CONTAINER_NAME>/${{ inputs.ecs-container-name }}/g' .aws/deploy/appspec.json
-          sed -i 's/<CONTAINER_PORT>/${{ inputs.ecs-container-port }}/g' .aws/deploy/appspec.json
+          sed -i "s/<AWS_ACCOUNT_ID>/$AWS_ACCOUNT_ID/g" .aws/deploy/appspec.json
+          sed -i "s/<ENV>/$ENVIRONMENT/g" .aws/deploy/appspec.json
+          sed -i "s/<CONTAINER_NAME>/$CONTAINER_NAME/g" .aws/deploy/appspec.json
+          sed -i "s/<CONTAINER_PORT>/$CONTAINER_PORT/g" .aws/deploy/appspec.json
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def


### PR DESCRIPTION
## Problem

GitHub Actions security audit (GTA-109-011) identified that `run` blocks in `.github/workflows/aws_deploy.yml` directly interpolated `${{ inputs.* }}` and `${{ github.* }}` expressions into shell commands. This pattern bypasses any escaping and can allow argument or code injection if a workflow caller provides a malicious input value (CWE-1336, CVSS:4.0 2.3).

## Solution

All `${{ inputs.* }}` and `${{ github.* }}` template expressions used inside `run` blocks have been moved into `env` blocks, and the shell commands now reference them as ordinary environment variables (e.g. `$ENV_VAR`). This ensures values are passed to the shell via the process environment rather than being string-interpolated into the command before execution.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Fixed improper template expansion in `aws_deploy.yml`: moved `inputs.aws-account-id`, `inputs.environment`, `inputs.shortEnv`, `inputs.ecs-task-role`, `inputs.ecs-task-exec-role`, `inputs.ecs-task-definition-path`, `inputs.ecs-container-name`, `inputs.ecs-container-port`, `inputs.app-version`, and `github.sha`/`github.repository` out of `run` blocks and into `env` blocks
- Replaced `${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}` in the `docker push` run block with shell variable references
- Replaced `${{ steps.inspector.outputs.* }}` in `cat` run blocks with env-bound shell variables

## Before & After Screenshots

**BEFORE**:

<!-- N/A — CI/CD config change only -->

**AFTER**:

<!-- N/A — CI/CD config change only -->

## Tests

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A