### PR TITLE
fix: reset OTP resend timer on email login

### DIFF
--- a/apps/studio/src/features/sign-in/components/EmailLogin/EmailLoginForm.tsx
+++ b/apps/studio/src/features/sign-in/components/EmailLogin/EmailLoginForm.tsx
@@ -7,12 +7,14 @@ import { useSignInContext } from "../SignInContext"
 import { EmailInput } from "./EmailInput"
 
 export const EmailLoginForm = () => {
-  const { setVfnStepData, proceedToVerification } = useSignInContext()
+  const { setVfnStepData, proceedToVerification, resetTimer } =
+    useSignInContext()
   const gb = useGrowthBook()
 
   const handleOnSuccessEmail = useCallback(
     ({ email, otpPrefix }: VfnStepData) => {
       setVfnStepData({ email, otpPrefix })
+      resetTimer()
 
       const newAttributes: Partial<GrowthbookAttributes> = {
         email,
@@ -21,7 +23,7 @@ export const EmailLoginForm = () => {
       void gb.updateAttributes(newAttributes)
       proceedToVerification()
     },
-    [gb, proceedToVerification, setVfnStepData],
+    [gb, proceedToVerification, resetTimer, setVfnStepData],
   )
 
   return <EmailInput onSuccess={handleOnSuccessEmail} />


### PR DESCRIPTION
## Problem

The email OTP resend cooldown was not reset when a user clicked “Use a different email” and requested a fresh OTP.

Closes #2394

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Reset the resend timer after a successful email OTP request before proceeding to the verification step.

## Before & After Screenshots

**BEFORE**:

N/A

**AFTER**:

N/A

## Tests

**Manual Verification Steps**:

- [ ] Open `http://localhost:3000/sign-in`
- [ ] Submit a valid whitelisted email, e.g. `editor@open.gov.sg`
- [ ] Verify the OTP screen shows `Resend OTP in 60s`
- [ ] Wait until the resend timer reaches `0` and the resend button becomes enabled
- [ ] Click `Use a different email`
- [ ] Submit the email again
- [ ] Verify the OTP screen shows `Resend OTP in 60s` instead of an immediately enabled `Resend OTP` button

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
