### PR TITLE
feat(redirect): add create validation, preflight warnings, and loop guard

### DIFF
--- a/apps/studio/src/constants/redirect.ts
+++ b/apps/studio/src/constants/redirect.ts
@@ -1,0 +1,49 @@
+// Shared redirect-validation copy, codes, and the preflight result contract.
+// Kept out of the Zod schema so the same constants back the validate preflight,
+// the create-time guards (redirect.service), and the add-redirect form without
+// the server and client ever drifting.
+
+// Prefixes reserved by the framework that must never be a redirect source —
+// e.g. /_next serves Next.js build assets, so a redirect there would shadow
+// framework internals on the published site.
+export const RESERVED_SOURCE_PREFIXES = ["/_next"] as const
+
+// Codes returned by the redirect.validate preflight so the client can render a
+// specific message (and styling) per issue. Errors block creation; warnings do
+// not, but are surfaced so users can reconsider before the redirect goes live.
+export const RedirectValidationCode = {
+  AlreadyExists: "ALREADY_EXISTS",
+  RedirectLoop: "REDIRECT_LOOP",
+  SourceIsExistingPage: "SOURCE_IS_EXISTING_PAGE",
+  DestinationIsRedirectSource: "DESTINATION_IS_REDIRECT_SOURCE",
+  DestinationNotFound: "DESTINATION_NOT_FOUND",
+  DestinationNotPublished: "DESTINATION_NOT_PUBLISHED",
+} as const
+export type RedirectValidationCode =
+  (typeof RedirectValidationCode)[keyof typeof RedirectValidationCode]
+
+// User-facing copy shared between the validate preflight, the create-time
+// guards, and the add-redirect form, so the server and client can't drift.
+// Messages that interpolate the path (the loop detail and the chain warning)
+// are produced in the service since they aren't reused by the client.
+export const REDIRECT_MESSAGES = {
+  alreadyExists: "This page is already being redirected.",
+  loop: "This will trap visitors in a never-ending loop.",
+  destinationNotLive:
+    "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+  sourceIsExistingPage:
+    "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
+} as const
+
+export interface RedirectValidationIssue {
+  code: RedirectValidationCode
+  message: string
+  // Optional secondary line rendered beneath the main message. The loop error
+  // uses it for its explanatory detail (matching the design's heading + body).
+  description?: string
+}
+
+export interface RedirectValidationResult {
+  errors: RedirectValidationIssue[]
+  warnings: RedirectValidationIssue[]
+}

--- a/apps/studio/src/features/settings/Redirects/__tests__/types.test.ts
+++ b/apps/studio/src/features/settings/Redirects/__tests__/types.test.ts
@@ -3,6 +3,17 @@ import { addRedirectSchema } from "../types"
 const VALID = { source: "/old-page" }
 
 describe("addRedirectSchema destination scheme normalisation", () => {
+  it("should prefix https:// to a leading www. host", () => {
+    // Arrange / Act
+    const result = addRedirectSchema.parse({
+      ...VALID,
+      destination: "www.example.gov.sg/page",
+    })
+
+    // Assert
+    expect(result.destination).toBe("https://www.example.gov.sg/page")
+  })
+
   it("should upgrade an http:// destination to https://", () => {
     // Arrange / Act
     const result = addRedirectSchema.parse({
@@ -36,12 +47,12 @@ describe("addRedirectSchema destination scheme normalisation", () => {
     expect(result.destination).toBe("/new-page")
   })
 
-  it("should reject a schemeless host rather than inferring https://", () => {
-    // Arrange / Act — a bare host is ambiguous against an internal path, so it
-    // is not auto-prefixed; it fails validation as an invalid URL instead.
+  it("should reject a schemeless host without a www. prefix", () => {
+    // Arrange / Act — "google.com" is ambiguous against an internal path, so it
+    // is not auto-prefixed (unlike "www."); it fails validation instead.
     const result = addRedirectSchema.safeParse({
       ...VALID,
-      destination: "www.example.gov.sg",
+      destination: "google.com",
     })
 
     // Assert

--- a/apps/studio/src/features/settings/Redirects/__tests__/types.test.ts
+++ b/apps/studio/src/features/settings/Redirects/__tests__/types.test.ts
@@ -1,0 +1,72 @@
+import { addRedirectSchema } from "../types"
+
+const VALID = { source: "/old-page" }
+
+describe("addRedirectSchema destination scheme normalisation", () => {
+  it("should prepend https:// to a bare host", () => {
+    // Arrange / Act
+    const result = addRedirectSchema.parse({
+      ...VALID,
+      destination: "www.example.gov.sg",
+    })
+
+    // Assert
+    expect(result.destination).toBe("https://www.example.gov.sg")
+  })
+
+  it("should upgrade an http:// destination to https://", () => {
+    // Arrange / Act
+    const result = addRedirectSchema.parse({
+      ...VALID,
+      destination: "http://www.example.gov.sg/page",
+    })
+
+    // Assert
+    expect(result.destination).toBe("https://www.example.gov.sg/page")
+  })
+
+  it("should leave an https:// destination untouched", () => {
+    // Arrange / Act
+    const result = addRedirectSchema.parse({
+      ...VALID,
+      destination: "https://www.example.gov.sg/page",
+    })
+
+    // Assert
+    expect(result.destination).toBe("https://www.example.gov.sg/page")
+  })
+
+  it("should leave an internal path untouched (no scheme prepended)", () => {
+    // Arrange / Act
+    const result = addRedirectSchema.parse({
+      ...VALID,
+      destination: "/new-page",
+    })
+
+    // Assert
+    expect(result.destination).toBe("/new-page")
+  })
+
+  it("should trim surrounding whitespace before prepending the scheme", () => {
+    // Arrange / Act
+    const result = addRedirectSchema.parse({
+      ...VALID,
+      destination: "  www.example.gov.sg  ",
+    })
+
+    // Assert
+    expect(result.destination).toBe("https://www.example.gov.sg")
+  })
+
+  it("should still reject a bare single-label host once https:// is prepended", () => {
+    // Arrange / Act — "localhost" has no dot, so the prepended URL isn't a valid
+    // public destination; the scheme fix-up doesn't loosen that check.
+    const result = addRedirectSchema.safeParse({
+      ...VALID,
+      destination: "localhost",
+    })
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/studio/src/features/settings/Redirects/__tests__/types.test.ts
+++ b/apps/studio/src/features/settings/Redirects/__tests__/types.test.ts
@@ -3,17 +3,6 @@ import { addRedirectSchema } from "../types"
 const VALID = { source: "/old-page" }
 
 describe("addRedirectSchema destination scheme normalisation", () => {
-  it("should prepend https:// to a bare host", () => {
-    // Arrange / Act
-    const result = addRedirectSchema.parse({
-      ...VALID,
-      destination: "www.example.gov.sg",
-    })
-
-    // Assert
-    expect(result.destination).toBe("https://www.example.gov.sg")
-  })
-
   it("should upgrade an http:// destination to https://", () => {
     // Arrange / Act
     const result = addRedirectSchema.parse({
@@ -47,23 +36,12 @@ describe("addRedirectSchema destination scheme normalisation", () => {
     expect(result.destination).toBe("/new-page")
   })
 
-  it("should trim surrounding whitespace before prepending the scheme", () => {
-    // Arrange / Act
-    const result = addRedirectSchema.parse({
-      ...VALID,
-      destination: "  www.example.gov.sg  ",
-    })
-
-    // Assert
-    expect(result.destination).toBe("https://www.example.gov.sg")
-  })
-
-  it("should still reject a bare single-label host once https:// is prepended", () => {
-    // Arrange / Act — "localhost" has no dot, so the prepended URL isn't a valid
-    // public destination; the scheme fix-up doesn't loosen that check.
+  it("should reject a schemeless host rather than inferring https://", () => {
+    // Arrange / Act — a bare host is ambiguous against an internal path, so it
+    // is not auto-prefixed; it fails validation as an invalid URL instead.
     const result = addRedirectSchema.safeParse({
       ...VALID,
-      destination: "localhost",
+      destination: "www.example.gov.sg",
     })
 
     // Assert

--- a/apps/studio/src/features/settings/Redirects/api.ts
+++ b/apps/studio/src/features/settings/Redirects/api.ts
@@ -25,6 +25,25 @@ export function useCountRedirects(siteId: number) {
   return { data: data ?? 0, isLoading }
 }
 
+// Preflight a would-be redirect for non-blocking warnings (e.g. the
+// destination doesn't exist or isn't published yet). Only enabled once the
+// caller has a sync-valid source + destination, since validate shares the
+// create input schema and would otherwise reject the half-typed values.
+export function useValidateRedirect(
+  siteId: number,
+  input: { source: string; destination: string } | null,
+) {
+  const { data } = trpc.redirect.validate.useQuery(
+    {
+      siteId,
+      source: input?.source ?? "",
+      destination: input?.destination ?? "",
+    },
+    { enabled: input !== null },
+  )
+  return { warnings: data?.warnings ?? [] }
+}
+
 // Resolves stored [resource:...] destinations to the page's current permalink
 // for display. Kept separate from the list query so the read path stays plain;
 // the table calls this once with the references on the visible page.

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -21,12 +21,12 @@ import {
 } from "@opengovsg/design-system-react"
 import { useState } from "react"
 import { BiLinkAlt, BiPlus, BiRightArrowAlt } from "react-icons/bi"
+import { REDIRECT_MESSAGES } from "~/constants/redirect"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
 } from "~/constants/toast"
 import { useZodForm } from "~/lib/form"
-import { REDIRECT_MESSAGES } from "~/schemas/redirect"
 
 import { useCreateRedirect, useValidateRedirect } from "../api"
 import { addRedirectSchema, type AddRedirectInput } from "../types"

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
+  Stack,
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
@@ -14,17 +15,20 @@ import {
   Button,
   FormErrorMessage,
   FormLabel,
+  Infobox,
   Link,
   useToast,
 } from "@opengovsg/design-system-react"
+import { useState } from "react"
 import { BiLinkAlt, BiPlus, BiRightArrowAlt } from "react-icons/bi"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
 } from "~/constants/toast"
 import { useZodForm } from "~/lib/form"
+import { REDIRECT_MESSAGES } from "~/schemas/redirect"
 
-import { useCreateRedirect } from "../api"
+import { useCreateRedirect, useValidateRedirect } from "../api"
 import { addRedirectSchema, type AddRedirectInput } from "../types"
 import { SelectDestinationPageModal } from "./SelectDestinationPageModal"
 
@@ -39,7 +43,10 @@ export const AddRedirectCard = ({
     register,
     handleSubmit,
     reset,
+    setError,
+    clearErrors,
     watch,
+    getValues,
     setValue,
     formState: { errors },
   } = useZodForm<typeof addRedirectSchema>({
@@ -57,6 +64,30 @@ export const AddRedirectCard = ({
   const [source, destination] = watch(["source", "destination"])
   const isAddDisabled = !source?.trim() || !destination?.trim()
 
+  // Non-blocking warnings (e.g. the destination doesn't exist / isn't
+  // published) are fetched on blur once the inputs are sync-valid.
+  const [validateInput, setValidateInput] = useState<AddRedirectInput | null>(
+    null,
+  )
+  const { warnings } = useValidateRedirect(siteId, validateInput)
+
+  const checkForWarnings = () => {
+    const parsed = addRedirectSchema.safeParse(getValues())
+    setValidateInput(parsed.success ? parsed.data : null)
+  }
+  // Drop any shown warning the moment a field changes, so it never lingers
+  // against edited input. (reset() doesn't fire onChange, so a successful add
+  // clears it explicitly in onSuccess below.)
+  const clearWarnings = () => setValidateInput(null)
+  // On edit, also clear any server-set error on that field — otherwise an
+  // inline "already redirected" / "loop" error (set via setError, which the
+  // onSubmit-mode form doesn't revalidate) would linger over freshly-typed
+  // input.
+  const clearFieldFeedback = (field: keyof AddRedirectInput) => () => {
+    clearWarnings()
+    clearErrors(field)
+  }
+
   const onSubmit = ({ source, destination }: AddRedirectInput) => {
     // source arrives normalised (leading slash, no trailing slash) by the
     // shared schema's transform. An internal-path destination is converted to a
@@ -66,27 +97,33 @@ export const AddRedirectCard = ({
       {
         onSuccess: () => {
           reset()
+          clearWarnings()
           toast({ ...SETTINGS_TOAST_MESSAGES.success, status: "success" })
         },
-        // The inputs are left untouched on error so the user can adjust
-        // the source instead of retyping everything
+        // The inputs are left untouched on error so the user can fix the
+        // offending field. The schema covers the synchronous rules; these are
+        // the DB-level checks the server re-enforces on create — surface them
+        // inline on the relevant field rather than as a toast. redirect.create
+        // only throws these codes; anything else is unexpected.
         onError: (error) => {
           switch (error.data?.code) {
             case "CONFLICT":
-              toast({
-                title: "A redirect already exists for this path",
-                description: `Delete the redirect for ${source} first if you want to change where it points to.`,
-                status: "error",
+              setError("source", { message: REDIRECT_MESSAGES.alreadyExists })
+              break
+            case "PRECONDITION_FAILED":
+              setError("source", {
+                message: REDIRECT_MESSAGES.sourceIsExistingPage,
               })
               break
+            // An internal-path destination is resolved to a page reference on
+            // create, which 404s when no published page lives at that path.
             case "NOT_FOUND":
-              toast({
-                title: "That page doesn't exist",
-                description:
-                  "Check the destination, or pick a page with “Link to a page”.",
-                status: "error",
+              setError("destination", {
+                message: REDIRECT_MESSAGES.destinationNotLive,
               })
               break
+            case "UNPROCESSABLE_CONTENT":
+              setError("destination", { message: REDIRECT_MESSAGES.loop })
             default:
               toast({
                 title: "Failed to add redirect",
@@ -131,7 +168,13 @@ export const AddRedirectCard = ({
             >
               /
             </InputLeftAddon>
-            <Input placeholder="redirect-from" {...register("source")} />
+            <Input
+              placeholder="redirect-from"
+              {...register("source", {
+                onBlur: checkForWarnings,
+                onChange: clearFieldFeedback("source"),
+              })}
+            />
           </InputGroup>
           <FormErrorMessage>{errors.source?.message}</FormErrorMessage>
         </FormControl>
@@ -154,7 +197,10 @@ export const AddRedirectCard = ({
           <Input
             placeholder="/redirect-to"
             size="xs"
-            {...register("destination")}
+            {...register("destination", {
+              onBlur: checkForWarnings,
+              onChange: clearFieldFeedback("destination"),
+            })}
           />
           <FormErrorMessage>{errors.destination?.message}</FormErrorMessage>
           <Link
@@ -168,6 +214,15 @@ export const AddRedirectCard = ({
             <Icon as={BiLinkAlt} mr="0.25rem" />
             Link to a page
           </Link>
+          {warnings.length > 0 && (
+            <Stack spacing="0.5rem" mt="0.5rem">
+              {warnings.map((warning) => (
+                <Infobox key={warning.code} variant="warning" size="sm">
+                  {warning.message}
+                </Infobox>
+              ))}
+            </Stack>
+          )}
         </FormControl>
 
         <Box flexShrink={0}>

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -115,13 +115,6 @@ export const AddRedirectCard = ({
                 message: REDIRECT_MESSAGES.sourceIsExistingPage,
               })
               break
-            // An internal-path destination is resolved to a page reference on
-            // create, which 404s when no published page lives at that path.
-            case "NOT_FOUND":
-              setError("destination", {
-                message: REDIRECT_MESSAGES.destinationNotLive,
-              })
-              break
             case "UNPROCESSABLE_CONTENT":
               setError("destination", { message: REDIRECT_MESSAGES.loop })
               break

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -124,6 +124,7 @@ export const AddRedirectCard = ({
               break
             case "UNPROCESSABLE_CONTENT":
               setError("destination", { message: REDIRECT_MESSAGES.loop })
+              break
             default:
               toast({
                 title: "Failed to add redirect",

--- a/apps/studio/src/features/settings/Redirects/types.ts
+++ b/apps/studio/src/features/settings/Redirects/types.ts
@@ -11,16 +11,24 @@ export type RedirectRow = RouterOutput["redirect"]["list"][number]
 
 export type { RedirectSortField } from "~/schemas/redirect"
 
-// Client-side convenience applied just before validation: upgrade an "http://"
-// destination to "https://", since the published site serves over https. We do
-// NOT infer a scheme for a schemeless host ("google.com") — that's ambiguous
-// against an internal path (e.g. "/test.zip" vs "test.zip"), so it's left to
-// fail validation as an invalid URL. Everything else is passed through
-// untouched. This lives only on the form; the shared server schema is unchanged.
-const normalizeDestinationScheme = (value: string): string =>
-  value.startsWith("http://")
-    ? `https://${value.slice("http://".length)}`
-    : value
+// Client-side convenience applied just before validation, so users don't have
+// to type the scheme the published site serves over:
+//   - an "http://" destination is upgraded to "https://"
+//   - a leading "www." host gets "https://" prefixed
+// A "www." prefix unambiguously signals an external host (an internal path
+// starts with "/"), so it's safe to infer. A schemeless host WITHOUT "www."
+// ("google.com") is left untouched — it's ambiguous against an internal path
+// ("/test.zip" vs "test.zip") — and fails validation as an invalid URL.
+// This lives only on the form; the shared server schema is unchanged.
+const normalizeDestinationScheme = (value: string): string => {
+  if (value.startsWith("http://")) {
+    return `https://${value.slice("http://".length)}`
+  }
+  if (value.startsWith("www.")) {
+    return `https://${value}`
+  }
+  return value
+}
 
 // The add form collects everything except siteId, which comes from the route.
 // Reusing the server schema's field rules keeps client and server validation

--- a/apps/studio/src/features/settings/Redirects/types.ts
+++ b/apps/studio/src/features/settings/Redirects/types.ts
@@ -1,5 +1,5 @@
-import type { z } from "zod"
 import type { RouterOutput } from "~/utils/trpc"
+import { z } from "zod"
 import {
   createRedirectObjectSchema,
   refineSourceDestinationDiffer,
@@ -11,10 +11,40 @@ export type RedirectRow = RouterOutput["redirect"]["list"][number]
 
 export type { RedirectSortField } from "~/schemas/redirect"
 
+// Client-side convenience applied just before validation: turn what a user
+// typed into a destination shape the schema accepts. A bare host ("google.com")
+// gets "https://" prepended and an "http://" URL is upgraded to "https://" —
+// matching how the published site serves links, so users don't have to type the
+// scheme. Internal paths ("/..."), already-https URLs, and "[resource:...]"
+// references are left untouched. This lives only on the form: the shared server
+// schema stays strict, so a direct API caller must still send a full URL.
+const normalizeDestinationScheme = (value: string): string => {
+  const trimmed = value.trim()
+  if (
+    trimmed === "" ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("[") ||
+    trimmed.startsWith("https://")
+  ) {
+    return value
+  }
+  if (trimmed.startsWith("http://")) {
+    return `https://${trimmed.slice("http://".length)}`
+  }
+  return `https://${trimmed}`
+}
+
 // The add form collects everything except siteId, which comes from the route.
-// Reusing the server schema (object + cross-field refinement) keeps client and
-// server validation identical.
-export const addRedirectSchema = createRedirectObjectSchema
-  .omit({ siteId: true })
+// Reusing the server schema's field rules keeps client and server validation
+// identical; the destination first runs through the scheme fix-up (piped into
+// the shared rules so the field's input type stays a plain string for the form).
+export const addRedirectSchema = z
+  .object({
+    source: createRedirectObjectSchema.shape.source,
+    destination: z
+      .string()
+      .transform(normalizeDestinationScheme)
+      .pipe(createRedirectObjectSchema.shape.destination),
+  })
   .superRefine(refineSourceDestinationDiffer)
 export type AddRedirectInput = z.infer<typeof addRedirectSchema>

--- a/apps/studio/src/features/settings/Redirects/types.ts
+++ b/apps/studio/src/features/settings/Redirects/types.ts
@@ -1,6 +1,9 @@
 import type { z } from "zod"
 import type { RouterOutput } from "~/utils/trpc"
-import { createRedirectSchema } from "~/schemas/redirect"
+import {
+  createRedirectObjectSchema,
+  refineSourceDestinationDiffer,
+} from "~/schemas/redirect"
 
 // A live redirect row as returned by the server, so the table type can never
 // drift from what `redirect.list` actually responds with
@@ -9,6 +12,9 @@ export type RedirectRow = RouterOutput["redirect"]["list"][number]
 export type { RedirectSortField } from "~/schemas/redirect"
 
 // The add form collects everything except siteId, which comes from the route.
-// Reusing the server schema keeps client and server validation identical.
-export const addRedirectSchema = createRedirectSchema.omit({ siteId: true })
+// Reusing the server schema (object + cross-field refinement) keeps client and
+// server validation identical.
+export const addRedirectSchema = createRedirectObjectSchema
+  .omit({ siteId: true })
+  .superRefine(refineSourceDestinationDiffer)
 export type AddRedirectInput = z.infer<typeof addRedirectSchema>

--- a/apps/studio/src/features/settings/Redirects/types.ts
+++ b/apps/studio/src/features/settings/Redirects/types.ts
@@ -11,28 +11,16 @@ export type RedirectRow = RouterOutput["redirect"]["list"][number]
 
 export type { RedirectSortField } from "~/schemas/redirect"
 
-// Client-side convenience applied just before validation: turn what a user
-// typed into a destination shape the schema accepts. A bare host ("google.com")
-// gets "https://" prepended and an "http://" URL is upgraded to "https://" —
-// matching how the published site serves links, so users don't have to type the
-// scheme. Internal paths ("/..."), already-https URLs, and "[resource:...]"
-// references are left untouched. This lives only on the form: the shared server
-// schema stays strict, so a direct API caller must still send a full URL.
-const normalizeDestinationScheme = (value: string): string => {
-  const trimmed = value.trim()
-  if (
-    trimmed === "" ||
-    trimmed.startsWith("/") ||
-    trimmed.startsWith("[") ||
-    trimmed.startsWith("https://")
-  ) {
-    return value
-  }
-  if (trimmed.startsWith("http://")) {
-    return `https://${trimmed.slice("http://".length)}`
-  }
-  return `https://${trimmed}`
-}
+// Client-side convenience applied just before validation: upgrade an "http://"
+// destination to "https://", since the published site serves over https. We do
+// NOT infer a scheme for a schemeless host ("google.com") — that's ambiguous
+// against an internal path (e.g. "/test.zip" vs "test.zip"), so it's left to
+// fail validation as an invalid URL. Everything else is passed through
+// untouched. This lives only on the form; the shared server schema is unchanged.
+const normalizeDestinationScheme = (value: string): string =>
+  value.startsWith("http://")
+    ? `https://${value.slice("http://".length)}`
+    : value
 
 // The add form collects everything except siteId, which comes from the route.
 // Reusing the server schema's field rules keeps client and server validation

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -339,20 +339,28 @@ describe("createRedirectSchema", () => {
       }
     })
 
-    it("should reject internal-path destinations with control characters or backslashes", () => {
-      // Arrange
-      const invalidDestinations = ["/bad\tpath", "/bad\\path"]
-
-      invalidDestinations.forEach((destination) => {
-        // Act
-        const result = createRedirectSchema.safeParse({
-          ...VALID_REDIRECT,
-          destination,
-        })
-
-        // Assert
-        expect(result.success).toBe(false)
+    it("should strip control characters from an internal-path destination", () => {
+      // Arrange / Act — a stray control char is silently removed rather than
+      // blocking the user; the stored value is left control-char-free.
+      const result = createRedirectSchema.parse({
+        ...VALID_REDIRECT,
+        destination: "/bad\tpath",
       })
+
+      // Assert
+      expect(result.destination).toBe("/badpath")
+    })
+
+    it("should reject destinations containing backslashes", () => {
+      // Arrange / Act — "\\" is ambiguous and could form an open redirect, so it
+      // is rejected outright rather than stripped.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: "/bad\\path",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
     })
 
     it("should collapse a protocol-relative '//' destination to a single leading slash", () => {
@@ -412,32 +420,32 @@ describe("createRedirectSchema", () => {
       expect(result.success).toBe(true)
     })
 
-    it("should reject https destinations containing control characters (CRLF/NUL)", () => {
-      // Arrange
-      // Control bytes are never valid in a real URL and would otherwise be
-      // stored verbatim and emitted into the published site's redirect rules
-      // (S3 metadata / the CloudFront Location header).
-      const invalidDestinations = [
-        "https://evil.gov.sg/\r\nSet-Cookie: x=1",
-        "https://evil.gov.sg/\npath",
-        "https://evil.gov.sg/\x00",
-        "https://evil.gov.sg/\ttab",
+    it("should strip control characters (CRLF/NUL) from an https destination", () => {
+      // Arrange — control bytes are stripped before storage, so a CR/LF can
+      // never reach the published redirect rules (S3 metadata / the CloudFront
+      // Location header) where it could inject a response header.
+      const cases = [
+        {
+          input: "https://evil.gov.sg/\r\npath",
+          expected: "https://evil.gov.sg/path",
+        },
+        { input: "https://evil.gov.sg/\x00", expected: "https://evil.gov.sg/" },
+        {
+          input: "https://evil.gov.sg/\ttab",
+          expected: "https://evil.gov.sg/tab",
+        },
       ]
 
-      invalidDestinations.forEach((destination) => {
+      cases.forEach(({ input, expected }) => {
         // Act
-        const result = createRedirectSchema.safeParse({
+        const result = createRedirectSchema.parse({
           ...VALID_REDIRECT,
-          destination,
+          destination: input,
         })
 
         // Assert
-        expect(result.success).toBe(false)
-        if (!result.success) {
-          expect(result.error.issues.map((issue) => issue.message)).toContain(
-            "Add a valid URL.",
-          )
-        }
+        expect(result.destination).not.toMatch(/[\x00-\x1f\x7f]/)
+        expect(result.destination).toBe(expected)
       })
     })
 

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -441,15 +441,24 @@ describe("createRedirectSchema", () => {
       })
     })
 
-    it("should reject internal-path destinations with '..' path segments", () => {
-      // Arrange / Act
-      const result = createRedirectSchema.safeParse({
-        ...VALID_REDIRECT,
-        destination: "/foo/../bar",
-      })
+    it("should reject destinations with '..' path segments", () => {
+      // Arrange — "../" traversal is banned outright (internal path and external
+      // https URL alike), since it is never meaningful in a redirect target.
+      const invalidDestinations = [
+        "/foo/../bar",
+        "https://www.example.gov.sg/foo/../bar",
+      ]
 
-      // Assert
-      expect(result.success).toBe(false)
+      invalidDestinations.forEach((destination) => {
+        // Act
+        const result = createRedirectSchema.safeParse({
+          ...VALID_REDIRECT,
+          destination,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+      })
     })
   })
 

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -284,6 +284,12 @@ describe("createRedirectSchema", () => {
         "javascript:alert(1)",
         "example.com/page",
         "link with space",
+        // Doubled scheme parses as a URL with hostname "https" — a prefix check
+        // would let it through, the host-must-have-a-dot rule rejects it.
+        "https://https://www.isomer.gov.sg",
+        // Bare single-label hosts are never valid public redirect targets.
+        "https://localhost",
+        "https://",
       ]
 
       invalidDestinations.forEach((destination) => {

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -25,6 +25,17 @@ describe("createRedirectSchema", () => {
       expect(result.source).toBe("/old/path")
     })
 
+    it("should lowercase the source (page permalinks are lowercase-only)", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.parse({
+        ...VALID_REDIRECT,
+        source: "/Contact-Us",
+      })
+
+      // Assert
+      expect(result.source).toBe("/contact-us")
+    })
+
     it("should keep an already-normalised source unchanged", () => {
       // Arrange / Act
       const result = createRedirectSchema.parse(VALID_REDIRECT)

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -303,7 +303,7 @@ describe("createRedirectSchema", () => {
         expect(result.success).toBe(false)
         if (!result.success) {
           expect(result.error.issues.map((issue) => issue.message)).toContain(
-            "Add a valid URL.",
+            "Enter a valid path (/path-to-page) or URL (starts with www., http://, or https://).",
           )
         }
       })

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { createRedirectSchema } from "../redirect"
+import {
+  createRedirectSchema,
+  MAX_REDIRECT_DESTINATION_LENGTH,
+  MAX_REDIRECT_SOURCE_LENGTH,
+} from "../redirect"
 
 const VALID_REDIRECT = {
   siteId: 1,
@@ -112,9 +116,124 @@ describe("createRedirectSchema", () => {
       // Assert
       expect(result.success).toBe(false)
     })
+
+    it(`should accept a source at the max length of ${MAX_REDIRECT_SOURCE_LENGTH}`, () => {
+      // Arrange / Act
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "a".repeat(MAX_REDIRECT_SOURCE_LENGTH),
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject a source longer than the max length", () => {
+      // Arrange / Act
+      // Sources become part of an S3 object key, so the cap is far tighter than
+      // the destination's — a value under the destination limit is still
+      // rejected here.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "a".repeat(MAX_REDIRECT_SOURCE_LENGTH + 1),
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.map((issue) => issue.message)).toContain(
+          "Source path is too long",
+        )
+      }
+    })
+
+    it("should reject sources under the reserved /_next prefix", () => {
+      // Arrange
+      // The prefix itself and anything nested beneath it is reserved, and the
+      // check is on the normalised value so a missing leading slash is caught
+      // too.
+      const reservedSources = ["/_next", "/_next/static/chunk.js", "_next/data"]
+
+      reservedSources.forEach((source) => {
+        // Act
+        const result = createRedirectSchema.safeParse({
+          ...VALID_REDIRECT,
+          source,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.map((issue) => issue.message)).toContain(
+            "This path is reserved and can't be used as a redirect source",
+          )
+        }
+      })
+    })
+
+    it("should accept a source that merely starts with the reserved prefix as a substring", () => {
+      // Arrange / Act
+      // "/_nextgen" is not under "/_next/", so it must not be blocked.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "/_nextgen",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject a source that is a full URL with the design copy", () => {
+      // Arrange
+      const urlSources = [
+        "https://example.gov.sg/page",
+        "http://example.com",
+        "ftp://example.com/file",
+      ]
+
+      urlSources.forEach((source) => {
+        // Act
+        const result = createRedirectSchema.safeParse({
+          ...VALID_REDIRECT,
+          source,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.map((issue) => issue.message)).toContain(
+            "Enter what comes behind your URL (e.g., /contact-us).",
+          )
+        }
+      })
+    })
   })
 
   describe("destination", () => {
+    it("should normalise an internal destination to a single leading slash with no trailing slash", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.parse({
+        ...VALID_REDIRECT,
+        destination: "/new//path/",
+      })
+
+      // Assert
+      expect(result.destination).toBe("/new/path")
+    })
+
+    it("should leave an external https destination exactly as entered", () => {
+      // Arrange / Act
+      // Trailing slashes / query strings are meaningful off-site, so the
+      // external URL must not be rewritten by the path normaliser.
+      const result = createRedirectSchema.parse({
+        ...VALID_REDIRECT,
+        destination: "https://www.example.gov.sg/path/?ref=1",
+      })
+
+      // Assert
+      expect(result.destination).toBe("https://www.example.gov.sg/path/?ref=1")
+    })
+
     it("should accept destinations starting with '/'", () => {
       // Arrange / Act
       const result = createRedirectSchema.safeParse(VALID_REDIRECT)
@@ -147,13 +266,65 @@ describe("createRedirectSchema", () => {
       expect(result.success).toBe(true)
     })
 
-    it("should reject destinations with other prefixes", () => {
+    it("should reject destinations with other prefixes using the design copy", () => {
       // Arrange
       const invalidDestinations = [
         "http://example.com",
         "javascript:alert(1)",
         "example.com/page",
+        "link with space",
       ]
+
+      invalidDestinations.forEach((destination) => {
+        // Act
+        const result = createRedirectSchema.safeParse({
+          ...VALID_REDIRECT,
+          destination,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.map((issue) => issue.message)).toContain(
+            "Add a valid URL.",
+          )
+        }
+      })
+    })
+
+    it("should accept a destination longer than the source limit", () => {
+      // Arrange / Act
+      // External URLs are legitimately long, so the destination limit is far
+      // more generous than the source's — a value over the source cap but under
+      // the destination cap is accepted.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: `/${"a".repeat(MAX_REDIRECT_SOURCE_LENGTH + 1)}`,
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject a destination longer than the max length", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: `/${"a".repeat(MAX_REDIRECT_DESTINATION_LENGTH)}`,
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.map((issue) => issue.message)).toContain(
+          "Destination is too long",
+        )
+      }
+    })
+
+    it("should reject internal-path destinations with control characters or backslashes", () => {
+      // Arrange
+      const invalidDestinations = ["/bad\tpath", "/bad\\path"]
 
       invalidDestinations.forEach((destination) => {
         // Act
@@ -218,6 +389,105 @@ describe("createRedirectSchema", () => {
       const result = createRedirectSchema.safeParse({
         ...VALID_REDIRECT,
         destination: "https://www.example.gov.sg/page#section",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject https destinations containing control characters (CRLF/NUL)", () => {
+      // Arrange
+      // Control bytes are never valid in a real URL and would otherwise be
+      // stored verbatim and emitted into the published site's redirect rules
+      // (S3 metadata / the CloudFront Location header).
+      const invalidDestinations = [
+        "https://evil.gov.sg/\r\nSet-Cookie: x=1",
+        "https://evil.gov.sg/\npath",
+        "https://evil.gov.sg/\x00",
+        "https://evil.gov.sg/\ttab",
+      ]
+
+      invalidDestinations.forEach((destination) => {
+        // Act
+        const result = createRedirectSchema.safeParse({
+          ...VALID_REDIRECT,
+          destination,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.map((issue) => issue.message)).toContain(
+            "Add a valid URL.",
+          )
+        }
+      })
+    })
+
+    it("should reject internal-path destinations with '..' path segments", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: "/foo/../bar",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe("source and destination", () => {
+    it("should reject a redirect from a source to itself with the design copy", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "/same",
+        destination: "/same",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.issues.map((issue) => issue.message)).toContain(
+          "You can't redirect a URL to itself.",
+        )
+      }
+    })
+
+    it("should reject when source and destination differ only by normalisation", () => {
+      // Arrange / Act
+      // Source normalises to "/same"; the trailing slash on the destination
+      // must not let an identical redirect through.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "same//",
+        destination: "/same/",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+
+    it("should accept a redirect to a different internal path", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "/here",
+        destination: "/there",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should accept an external destination that matches the source path", () => {
+      // Arrange / Act
+      // An external URL can never equal an internal source, so the same-as
+      // check does not apply.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        source: "/same",
+        destination: "https://example.gov.sg/same",
       })
 
       // Assert

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -4,11 +4,19 @@ import { z } from "zod"
 import { generateBigIntSchema } from "./common"
 import { offsetPaginationSchema } from "./pagination"
 
-// The source is persisted as part of an S3 object key, which AWS caps at 1024
-// bytes. Keep the limit well under that so there is headroom for non-latin
-// characters that expand on percent-encoding (a single CJK character can become
-// several bytes / up to ~9 encoded characters).
-export const MAX_REDIRECT_SOURCE_LENGTH = 100
+// A redirect is published as an S3 object whose key is
+// `${siteName}/${buildNumber}/latest/${source}/index.html` (see
+// tooling/build/scripts/publishing/uploadRedirects.ts), and AWS caps an object
+// key at 1024 bytes. Pages publish under the SAME prefix, so a redirect source
+// and a page's full permalink are keyed identically — any path a page can
+// publish at, a redirect can use as its source. The source character whitelist
+// below forbids raw non-latin characters, so a stored source is always ASCII
+// (one byte per char in the key); there is no percent-encoding expansion to
+// budget for. 900 leaves comfortable headroom under 1024 for the site name
+// (realistically <~30), the build number, the `latest/` segment and the
+// `/index.html` suffix, while exceeding the page permalink limit so a moved or
+// renamed page can always auto-create a redirect from its old URL.
+export const MAX_REDIRECT_SOURCE_LENGTH = 900
 
 // Destinations can be a full external https URL — with a query string and
 // fragment those are legitimately long — so they get a far more generous limit

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -4,7 +4,16 @@ import { z } from "zod"
 import { generateBigIntSchema } from "./common"
 import { offsetPaginationSchema } from "./pagination"
 
-export const MAX_REDIRECT_PATH_LENGTH = 2000
+// The source is persisted as part of an S3 object key, which AWS caps at 1024
+// bytes. Keep the limit well under that so there is headroom for non-latin
+// characters that expand on percent-encoding (a single CJK character can become
+// several bytes / up to ~9 encoded characters).
+export const MAX_REDIRECT_SOURCE_LENGTH = 100
+
+// Destinations can be a full external https URL — with a query string and
+// fragment those are legitimately long — so they get a far more generous limit
+// than the source path.
+export const MAX_REDIRECT_DESTINATION_LENGTH = 2000
 
 // Caps how many references one resolve request can turn back into permalinks.
 // The table sends one page's worth, so this is a generous upper bound.
@@ -37,13 +46,45 @@ const REFERENCE_DESTINATION_REGEX = new RegExp(
 // all normalise to the same inner segments before validation.
 const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
 
+// Normalises a path to a single leading slash, no trailing slash, collapsed
+// runs ("/foo/", "foo", "foo//" -> "/foo"). Exported so the server can compare
+// a destination path against stored sources, persisted in this form.
+export const normalizeRedirectPath = (value: string) =>
+  `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`
+
+// Sources are additionally lowercased — page permalinks are lowercase-only, so
+// a source must lowercase to compare against (and not shadow) a real page.
+// Exported so the server's source/loop guards compare in the same form.
+export const normalizeRedirectSource = (value: string) =>
+  normalizeRedirectPath(value).toLowerCase()
+
+// Prefixes reserved by the framework that must never be a redirect source —
+// e.g. /_next serves Next.js build assets, so a redirect there would shadow
+// framework internals on the published site.
+const RESERVED_SOURCE_PREFIXES = ["/_next"] as const
+
+// True when the (normalised) source falls under a reserved prefix — the prefix
+// itself or anything nested beneath it.
+const isReservedSource = (value: string) => {
+  const normalised = normalizeRedirectSource(value)
+  return RESERVED_SOURCE_PREFIXES.some(
+    (prefix) => normalised === prefix || normalised.startsWith(`${prefix}/`),
+  )
+}
+
 const sourceSchema = z
   .string()
   .min(1, { message: "Source path is required" })
-  .max(MAX_REDIRECT_PATH_LENGTH, { message: "Source path is too long" })
+  .max(MAX_REDIRECT_SOURCE_LENGTH, { message: "Source path is too long" })
   .refine((value) => SOURCE_ALLOWED_CHARS_REGEX.test(value), {
     message:
       "Source can only contain letters, numbers, and URL path characters",
+  })
+  // The source is a path on this site, never a full URL — a scheme like
+  // "https://" can never match an incoming request path, so reject it instead
+  // of silently mangling it into a slashed source.
+  .refine((value) => !value.includes("://"), {
+    message: "Enter what comes behind your URL (e.g., /contact-us).",
   })
   .refine((value) => trimSlashes(value).length > 0, {
     message: "Source path cannot consist only of slashes",
@@ -51,27 +92,43 @@ const sourceSchema = z
   .refine((value) => !trimSlashes(value).split("/").includes(".."), {
     message: "Source must not contain '..' path segments",
   })
-  // Normalise to a single leading slash, no trailing slash, collapsed runs, so
-  // equivalent inputs map to one source (keeps the unique constraint meaningful).
-  .transform((value) => `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`)
+  .refine((value) => !isReservedSource(value), {
+    message: "This path is reserved and can't be used as a redirect source",
+  })
+  // Normalise and lowercase so equivalent inputs map to one source. Page
+  // permalinks are lowercase-only, so the source must lowercase to match (and
+  // guard against shadowing) a real page at the same path.
+  .transform(normalizeRedirectSource)
 
 const destinationSchema = z
   .string()
   .min(1, { message: "Destination is required" })
-  .max(MAX_REDIRECT_PATH_LENGTH, { message: "Destination is too long" })
-  .refine((value) => !INVALID_PATH_CHARS_REGEX.test(value), {
-    message: "Destination must not contain control characters or backslashes",
-  })
-  // Internal path ("/..."), external https URL, or an already-resolved page
-  // reference (internal paths are converted to a reference server-side).
+  .max(MAX_REDIRECT_DESTINATION_LENGTH, { message: "Destination is too long" })
+  // Same-site path ("/..."), external https URL, or an already-resolved page
+  // reference ([resource:...]); anything else (http://, javascript:, ...) rejected.
   .refine(
     (value) =>
       value.startsWith("/") ||
       value.startsWith("https://") ||
       REFERENCE_DESTINATION_REGEX.test(value),
-    {
-      message: "Destination must start with '/' or 'https://'",
-    },
+    { message: "Add a valid URL." },
+  )
+  // Control characters (incl. CR/LF/NUL) and backslashes are never valid in a
+  // redirect destination — internal path or external https URL alike. This is
+  // NOT gated on internal paths: a destination is persisted verbatim and later
+  // emitted into the published site's redirect rules (S3 object metadata and
+  // ultimately the CloudFront Location header), so a CR/LF in an https URL
+  // could otherwise reach a live response header.
+  .refine((value) => !INVALID_PATH_CHARS_REGEX.test(value), {
+    message: "Add a valid URL.",
+  })
+  // "../" path traversal only has meaning for an internal path; an external
+  // https URL may legitimately contain ".." in its own path, so scope this one
+  // to internal destinations.
+  .refine(
+    (value) =>
+      !value.startsWith("/") || !trimSlashes(value).split("/").includes(".."),
+    { message: "Add a valid URL." },
   )
   // An internal path can't redirect to an on-page anchor — the published
   // redirect emits a Location header, which can't target a fragment. External
@@ -79,20 +136,85 @@ const destinationSchema = z
   .refine((value) => !value.startsWith("/") || !value.includes("#"), {
     message: "Destination can't link to an anchor on a page",
   })
-  // Collapse a leading run of slashes on an internal path so a protocol-relative
-  // "//evil.com" can't pass as an open redirect ("//evil.com" -> "/evil.com").
+  // Normalise internal-path destinations like sources (this also collapses a
+  // protocol-relative "//evil.com" to "/evil.com", closing an open redirect).
+  // External https URLs and [resource:...] references are left as entered.
   .transform((value) =>
-    value.startsWith("/") ? `/${value.replace(/^\/+/, "")}` : value,
+    value.startsWith("/") ? normalizeRedirectPath(value) : value,
   )
 
-// Shared by the AddRedirectCard form (siteId omitted) and the create endpoint
-// so client and server validate identically.
-export const createRedirectSchema = z.object({
+// Cross-field rule shared by the create schema and the siteId-less form schema:
+// a redirect from a path to itself is a no-op. `source` is already normalised,
+// so the destination is normalised the same way before comparing.
+export const refineSourceDestinationDiffer = (
+  { source, destination }: { source: string; destination: string },
+  ctx: z.RefinementCtx,
+) => {
+  if (
+    destination.startsWith("/") &&
+    normalizeRedirectSource(destination) === source
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["destination"],
+      message: "You can't redirect a URL to itself.",
+    })
+  }
+}
+
+// Refinement-free base so callers can still `.omit()` / `.extend()` it (a
+// refinement turns a ZodObject into a ZodEffects, losing those helpers). The
+// form omits siteId and re-applies the cross-field refinement.
+export const createRedirectObjectSchema = z.object({
   siteId: z.number().min(1),
   source: sourceSchema,
   destination: destinationSchema,
 })
+
+export const createRedirectSchema = createRedirectObjectSchema.superRefine(
+  refineSourceDestinationDiffer,
+)
 export type CreateRedirectInput = z.infer<typeof createRedirectSchema>
+
+// Codes returned by the redirect.validate preflight so the client can render a
+// specific message (and styling) per issue. Errors block creation; warnings do
+// not, but are surfaced so users can reconsider before the redirect goes live.
+export const RedirectValidationCode = {
+  AlreadyExists: "ALREADY_EXISTS",
+  RedirectLoop: "REDIRECT_LOOP",
+  SourceIsExistingPage: "SOURCE_IS_EXISTING_PAGE",
+  DestinationIsRedirectSource: "DESTINATION_IS_REDIRECT_SOURCE",
+  DestinationNotFound: "DESTINATION_NOT_FOUND",
+  DestinationNotPublished: "DESTINATION_NOT_PUBLISHED",
+} as const
+export type RedirectValidationCode =
+  (typeof RedirectValidationCode)[keyof typeof RedirectValidationCode]
+
+// User-facing copy shared between the validate preflight, the create-time
+// guards, and the add-redirect form, so the server and client can't drift.
+// Messages that interpolate the path (the loop detail and the chain warning)
+// are produced in the service since they aren't reused by the client.
+export const REDIRECT_MESSAGES = {
+  alreadyExists: "This page is already being redirected.",
+  loop: "This will trap visitors in a never-ending loop.",
+  destinationNotLive:
+    "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+  sourceIsExistingPage:
+    "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
+} as const
+
+export interface RedirectValidationIssue {
+  code: RedirectValidationCode
+  message: string
+  // Optional secondary line rendered beneath the main message. The loop error
+  // uses it for its explanatory detail (matching the design's heading + body).
+  description?: string
+}
+
+export interface RedirectValidationResult {
+  errors: RedirectValidationIssue[]
+  warnings: RedirectValidationIssue[]
+}
 
 export const deleteRedirectSchema = z.object({
   siteId: z.number().min(1),

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -1,5 +1,6 @@
 import { REFERENCE_LINK_REGEX } from "@opengovsg/isomer-components"
 import { z } from "zod"
+import { RESERVED_SOURCE_PREFIXES } from "~/constants/redirect"
 
 import { generateBigIntSchema } from "./common"
 import { offsetPaginationSchema } from "./pagination"
@@ -80,11 +81,6 @@ export const normalizeRedirectPath = (value: string) =>
 export const normalizeRedirectSource = (value: string) =>
   normalizeRedirectPath(value).toLowerCase()
 
-// Prefixes reserved by the framework that must never be a redirect source —
-// e.g. /_next serves Next.js build assets, so a redirect there would shadow
-// framework internals on the published site.
-const RESERVED_SOURCE_PREFIXES = ["/_next"] as const
-
 // True when the (normalised) source falls under a reserved prefix — the prefix
 // itself or anything nested beneath it.
 const isReservedSource = (value: string) => {
@@ -144,14 +140,13 @@ const destinationSchema = z
   .refine((value) => !INVALID_PATH_CHARS_REGEX.test(value), {
     message: "Add a valid URL.",
   })
-  // "../" path traversal only has meaning for an internal path; an external
-  // https URL may legitimately contain ".." in its own path, so scope this one
-  // to internal destinations.
-  .refine(
-    (value) =>
-      !value.startsWith("/") || !trimSlashes(value).split("/").includes(".."),
-    { message: "Add a valid URL." },
-  )
+  // Reject "../" path traversal in any destination. It is never meaningful here:
+  // an internal path is resolved on our side, and a live site collapses ".." in
+  // an external URL's path anyway — so the user can already express the intended
+  // target directly. Banning it outright keeps the rule simple.
+  .refine((value) => !trimSlashes(value).split("/").includes(".."), {
+    message: "Add a valid URL.",
+  })
   // An internal path can't redirect to an on-page anchor — the published
   // redirect emits a Location header, which can't target a fragment. External
   // https URLs may legitimately carry a #fragment, so this is scoped to paths.
@@ -197,46 +192,6 @@ export const createRedirectSchema = createRedirectObjectSchema.superRefine(
   refineSourceDestinationDiffer,
 )
 export type CreateRedirectInput = z.infer<typeof createRedirectSchema>
-
-// Codes returned by the redirect.validate preflight so the client can render a
-// specific message (and styling) per issue. Errors block creation; warnings do
-// not, but are surfaced so users can reconsider before the redirect goes live.
-export const RedirectValidationCode = {
-  AlreadyExists: "ALREADY_EXISTS",
-  RedirectLoop: "REDIRECT_LOOP",
-  SourceIsExistingPage: "SOURCE_IS_EXISTING_PAGE",
-  DestinationIsRedirectSource: "DESTINATION_IS_REDIRECT_SOURCE",
-  DestinationNotFound: "DESTINATION_NOT_FOUND",
-  DestinationNotPublished: "DESTINATION_NOT_PUBLISHED",
-} as const
-export type RedirectValidationCode =
-  (typeof RedirectValidationCode)[keyof typeof RedirectValidationCode]
-
-// User-facing copy shared between the validate preflight, the create-time
-// guards, and the add-redirect form, so the server and client can't drift.
-// Messages that interpolate the path (the loop detail and the chain warning)
-// are produced in the service since they aren't reused by the client.
-export const REDIRECT_MESSAGES = {
-  alreadyExists: "This page is already being redirected.",
-  loop: "This will trap visitors in a never-ending loop.",
-  destinationNotLive:
-    "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
-  sourceIsExistingPage:
-    "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
-} as const
-
-export interface RedirectValidationIssue {
-  code: RedirectValidationCode
-  message: string
-  // Optional secondary line rendered beneath the main message. The loop error
-  // uses it for its explanatory detail (matching the design's heading + body).
-  description?: string
-}
-
-export interface RedirectValidationResult {
-  errors: RedirectValidationIssue[]
-  warnings: RedirectValidationIssue[]
-}
 
 export const deleteRedirectSchema = z.object({
   siteId: z.number().min(1),

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -120,6 +120,12 @@ const sourceSchema = z
   // guard against shadowing) a real page at the same path.
   .transform(normalizeRedirectSource)
 
+// Shown whenever a destination isn't a shape we accept. Spells out the valid
+// forms (a site path or an external URL) instead of a terse "invalid" so the
+// user knows what to type.
+const INVALID_DESTINATION_MESSAGE =
+  "Enter a valid path (/path-to-page) or URL (starts with www., http://, or https://)."
+
 const destinationSchema = z
   .string()
   .min(1, { message: "Destination is required" })
@@ -135,19 +141,19 @@ const destinationSchema = z
       value.startsWith("/") ||
       isValidExternalDestination(value) ||
       REFERENCE_DESTINATION_REGEX.test(value),
-    { message: "Add a valid URL." },
+    { message: INVALID_DESTINATION_MESSAGE },
   )
   // Backslashes are rejected, not stripped: "\\" is ambiguous in a path/URL and
   // silently removing it could turn "/\\evil.com" into an open redirect.
   .refine((value) => !value.includes("\\"), {
-    message: "Add a valid URL.",
+    message: INVALID_DESTINATION_MESSAGE,
   })
   // Reject "../" path traversal in any destination. It is never meaningful here:
   // an internal path is resolved on our side, and a live site collapses ".." in
   // an external URL's path anyway — so the user can already express the intended
   // target directly. Banning it outright keeps the rule simple.
   .refine((value) => !trimSlashes(value).split("/").includes(".."), {
-    message: "Add a valid URL.",
+    message: INVALID_DESTINATION_MESSAGE,
   })
   // An internal path can't redirect to an on-page anchor — the published
   // redirect emits a Location header, which can't target a fragment. External

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -37,10 +37,12 @@ export const MAX_REDIRECT_PAGE_SIZE = 100
 // (spaces, control chars, "?", "#", "\\", non-ASCII) out up front.
 const SOURCE_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@%/]+$/
 
-// Matches ASCII control characters (0x00-0x1f, 0x7f) and backslashes. These are
-// never valid in a destination and can corrupt the generated redirect rules on
-// the published site. (Source paths use the stricter whitelist above instead.)
-const INVALID_PATH_CHARS_REGEX = /[\x00-\x1f\x7f\\]/
+// ASCII control characters (0x00-0x1f, 0x7f). A destination is persisted verbatim
+// and later emitted into the published site's redirect rules (S3 object metadata
+// and ultimately the CloudFront Location header), so a CR/LF/NUL must never reach
+// it. These are stripped (not rejected) — the global flag strips every match.
+// (Source paths use the stricter whitelist above instead.)
+const CONTROL_CHARS_REGEX = /[\x00-\x1f\x7f]/g
 
 // Anchored form of the shared [resource:siteId:resourceId] reference (the shared
 // regex is unanchored, so a value only counts as a reference when it is exactly
@@ -122,6 +124,10 @@ const destinationSchema = z
   .string()
   .min(1, { message: "Destination is required" })
   .max(MAX_REDIRECT_DESTINATION_LENGTH, { message: "Destination is too long" })
+  // Strip control characters up front (a stray pasted CR/LF/NUL shouldn't block
+  // the user, and must never reach the published redirect rules — see
+  // CONTROL_CHARS_REGEX). The cleaned value flows through the checks below.
+  .transform((value) => value.replace(CONTROL_CHARS_REGEX, ""))
   // Same-site path ("/..."), external https URL, or an already-resolved page
   // reference ([resource:...]); anything else (http://, javascript:, ...) rejected.
   .refine(
@@ -131,13 +137,9 @@ const destinationSchema = z
       REFERENCE_DESTINATION_REGEX.test(value),
     { message: "Add a valid URL." },
   )
-  // Control characters (incl. CR/LF/NUL) and backslashes are never valid in a
-  // redirect destination — internal path or external https URL alike. This is
-  // NOT gated on internal paths: a destination is persisted verbatim and later
-  // emitted into the published site's redirect rules (S3 object metadata and
-  // ultimately the CloudFront Location header), so a CR/LF in an https URL
-  // could otherwise reach a live response header.
-  .refine((value) => !INVALID_PATH_CHARS_REGEX.test(value), {
+  // Backslashes are rejected, not stripped: "\\" is ambiguous in a path/URL and
+  // silently removing it could turn "/\\evil.com" into an open redirect.
+  .refine((value) => !value.includes("\\"), {
     message: "Add a valid URL.",
   })
   // Reject "../" path traversal in any destination. It is never meaningful here:

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -50,6 +50,20 @@ const REFERENCE_DESTINATION_REGEX = new RegExp(
   `^${REFERENCE_LINK_REGEX.source}$`,
 )
 
+// A prefix check ("https://") is too lax: "https://https://www.isomer.gov.sg"
+// passes it, yet parses with hostname "https". Require a parseable https URL
+// whose host looks like a public domain (has a dot) — this rejects the doubled
+// scheme and bare single-label hosts (localhost, intranet names) that are never
+// valid redirect targets for a published site.
+const isValidExternalDestination = (value: string) => {
+  try {
+    const url = new URL(value)
+    return url.protocol === "https:" && url.hostname.includes(".")
+  } catch {
+    return false
+  }
+}
+
 // Strips slashes from both ends of a path so "/foo/", "foo" and "foo//"
 // all normalise to the same inner segments before validation.
 const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
@@ -117,7 +131,7 @@ const destinationSchema = z
   .refine(
     (value) =>
       value.startsWith("/") ||
-      value.startsWith("https://") ||
+      isValidExternalDestination(value) ||
       REFERENCE_DESTINATION_REGEX.test(value),
     { message: "Add a valid URL." },
   )

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -1206,20 +1206,27 @@ describe("redirect.router", async () => {
       expect(row.destination).toBe("/target-page?ref=footer")
     })
 
-    it("should throw 404 if the internal-path destination does not exist", async () => {
-      // Arrange / Act
-      const result = caller.create({
+    it("stores a literal path when the internal destination has no live page", async () => {
+      // Arrange / Act — no page lives at /no-such-page. The preflight warns, but
+      // create keeps the literal path so an admin can pre-create the redirect.
+      await caller.create({
         siteId,
         source: "/from",
         destination: "/no-such-page",
       })
 
       // Assert
-      await expect(result).rejects.toMatchObject({ code: "NOT_FOUND" })
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe("/no-such-page")
     })
 
-    it("should throw 404 if the destination page exists but is unpublished", async () => {
-      // Arrange — a draft page has no live URL, so it isn't a valid target
+    it("stores a literal path when the destination page exists but is unpublished", async () => {
+      // Arrange — a draft page has no live URL yet
       await setupPageResource({
         siteId,
         resourceType: ResourceType.Page,
@@ -1228,14 +1235,20 @@ describe("redirect.router", async () => {
       })
 
       // Act
-      const result = caller.create({
+      await caller.create({
         siteId,
         source: "/from",
         destination: "/draft-page",
       })
 
-      // Assert
-      await expect(result).rejects.toMatchObject({ code: "NOT_FOUND" })
+      // Assert — kept literal (not converted to a reference, not rejected)
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe("/draft-page")
     })
 
     it("should resolve the site root '/' to the RootPage reference", async () => {
@@ -1288,8 +1301,8 @@ describe("redirect.router", async () => {
       expect(row.destination).toBe(`[resource:${siteId}:${folder.id}]`)
     })
 
-    it("should throw 404 for a folder destination whose index page is unpublished", async () => {
-      // Arrange — a folder with no live index page has no live URL behind it
+    it("stores a literal path for a folder destination whose index page is unpublished", async () => {
+      // Arrange — a folder with no live index page has no live URL behind it yet
       const { folder } = await setupFolder({ siteId, permalink: "about" })
       await setupPageResource({
         siteId,
@@ -1300,14 +1313,20 @@ describe("redirect.router", async () => {
       })
 
       // Act
-      const result = caller.create({
+      await caller.create({
         siteId,
         source: "/from",
         destination: "/about",
       })
 
-      // Assert
-      await expect(result).rejects.toMatchObject({ code: "NOT_FOUND" })
+      // Assert — kept literal until the folder is published
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe("/about")
     })
   })
 

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -26,12 +26,16 @@ describe("redirect.router", async () => {
   let caller: ReturnType<typeof createCaller>
   let unauthedCaller: ReturnType<typeof createCaller>
   let siteId: number
+  let userId: string
   const session = await applyAuthedSession()
 
   beforeEach(async () => {
     await resetTables(
       "AuditLog",
       "Redirect",
+      "Blob",
+      "Version",
+      "Resource",
       "ResourcePermission",
       "Whitelist",
       "Site",
@@ -44,6 +48,7 @@ describe("redirect.router", async () => {
     await auth(user)
     const { site } = await setupSite()
     siteId = site.id
+    userId = user.id
     await setupAdminPermissions({ userId: user.id, siteId })
     caller = createCaller(createMockRequest(session))
     unauthedCaller = createCaller(createMockRequest(applySession()))
@@ -52,6 +57,32 @@ describe("redirect.router", async () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
+
+  // Seeds a root page plus a child page at /{permalink} for the given site, so
+  // a destination "/{permalink}" resolves to that page during validation.
+  const seedPageAtRoot = async ({
+    permalink,
+    published,
+  }: {
+    permalink: string
+    published: boolean
+  }) => {
+    const { page: rootPage } = await setupPageResource({
+      siteId,
+      resourceType: ResourceType.RootPage,
+      parentId: null,
+    })
+    const { page } = await setupPageResource({
+      siteId,
+      resourceType: ResourceType.Page,
+      parentId: rootPage.id,
+      permalink,
+      ...(published
+        ? { state: ResourceState.Published, userId }
+        : { state: ResourceState.Draft }),
+    })
+    return page
+  }
 
   describe("list", () => {
     it("should throw 401 if not logged in", async () => {
@@ -321,6 +352,349 @@ describe("redirect.router", async () => {
     })
   })
 
+  describe("validate", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange / Act
+      const result = unauthedCaller.validate({
+        siteId,
+        source: "/old",
+        destination: "/new",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user does not have read access to the site", async () => {
+      // Arrange
+      const { site: otherSite } = await setupSite()
+
+      // Act
+      const result = caller.validate({
+        siteId: otherSite.id,
+        source: "/old",
+        destination: "/new",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should report no issues for a redirect to an external URL", async () => {
+      // Arrange / Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "https://www.example.gov.sg/new",
+      })
+
+      // Assert
+      expect(result).toEqual({ errors: [], warnings: [] })
+    })
+
+    it("should report no issues for a redirect to a published page", async () => {
+      // Arrange
+      await seedPageAtRoot({ permalink: "published-page", published: true })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/published-page",
+      })
+
+      // Assert
+      expect(result).toEqual({ errors: [], warnings: [] })
+    })
+
+    it("should error when a live redirect already exists for the source", async () => {
+      // Arrange
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/old", destination: "/somewhere" })
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "https://www.example.gov.sg",
+      })
+
+      // Assert
+      expect(result.errors).toContainEqual({
+        code: "ALREADY_EXISTS",
+        message: "This page is already being redirected.",
+      })
+    })
+
+    it("should error when the redirect would create a loop", async () => {
+      // Arrange
+      // /b already redirects to /a, so adding /a -> /b bounces straight back
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/a" })
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/a",
+        destination: "/b",
+      })
+
+      // Assert
+      expect(result.errors).toContainEqual({
+        code: "REDIRECT_LOOP",
+        message: "This will trap visitors in a never-ending loop.",
+        description:
+          "/b already redirects to /a. Visitors will get stuck in between pages. Delete existing redirects or direct to a different page.",
+      })
+    })
+
+    it("should detect a loop even when the existing destination has a trailing slash", async () => {
+      // Arrange
+      // Stored "/b -> /a/" must still loop with a new "/a -> /b" once the
+      // stored destination is normalised for comparison.
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/a/" })
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/a",
+        destination: "/b",
+      })
+
+      // Assert
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ code: "REDIRECT_LOOP" }),
+      )
+    })
+
+    it("should not report ALREADY_EXISTS when only a soft-deleted redirect exists for the source", async () => {
+      // Arrange
+      await db
+        .insertInto("Redirect")
+        .values({
+          siteId,
+          source: "/old",
+          destination: "/x",
+          deletedAt: new Date(),
+        })
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "https://www.example.gov.sg",
+      })
+
+      // Assert
+      expect(result.errors).toEqual([])
+    })
+
+    it("should warn when the destination is itself a separate redirect source", async () => {
+      // Arrange
+      // /b redirects to /c, so /a -> /b would chain through /b to /c
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/c" })
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/a",
+        destination: "/b",
+      })
+
+      // Assert
+      expect(result.errors).toEqual([])
+      expect(result.warnings).toContainEqual({
+        code: "DESTINATION_IS_REDIRECT_SOURCE",
+        message:
+          "This page already redirects to /c. Visitors will end up there instead.",
+      })
+    })
+
+    it("should warn when the internal destination does not exist", async () => {
+      // Arrange / Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/missing",
+      })
+
+      // Assert
+      expect(result.warnings).toContainEqual({
+        code: "DESTINATION_NOT_FOUND",
+        message:
+          "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+      })
+    })
+
+    it("should warn when the internal destination exists but is not published", async () => {
+      // Arrange
+      await seedPageAtRoot({ permalink: "draft-page", published: false })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/draft-page",
+      })
+
+      // Assert
+      expect(result.warnings).toContainEqual({
+        code: "DESTINATION_NOT_PUBLISHED",
+        message:
+          "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+      })
+    })
+
+    it("should not warn for a published page nested under a folder", async () => {
+      // Arrange — /folder/leaf, where leaf is a published page under a folder.
+      // This exercises the multi-segment walk past depth 1.
+      const { page: rootPage } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: rootPage.id,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        permalink: "leaf",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/folder/leaf",
+      })
+
+      // Assert
+      expect(result.warnings).toEqual([])
+    })
+
+    it("should not warn for a folder whose index page is published", async () => {
+      // Arrange — "/folder" is served by the folder's published IndexPage, so
+      // it must resolve as published (exercises the folder->IndexPage branch).
+      const { page: rootPage } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: rootPage.id,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/folder",
+      })
+
+      // Assert
+      expect(result.warnings).toEqual([])
+    })
+
+    it("should warn NOT_PUBLISHED for a folder with no index page", async () => {
+      // Arrange — a folder with no IndexPage has no live page at its URL, so
+      // resolution falls back to the (unpublished) container.
+      const { page: rootPage } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: rootPage.id,
+      })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/folder",
+      })
+
+      // Assert
+      expect(result.warnings).toContainEqual({
+        code: "DESTINATION_NOT_PUBLISHED",
+        message:
+          "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+      })
+    })
+
+    it("should error when the source is the URL of a published page", async () => {
+      // Arrange — a live page sits at /live-page; redirecting from there would
+      // shadow it on the published site.
+      await seedPageAtRoot({ permalink: "live-page", published: true })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/live-page",
+        destination: "/somewhere",
+      })
+
+      // Assert
+      expect(result.errors).toContainEqual({
+        code: "SOURCE_IS_EXISTING_PAGE",
+        message:
+          "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
+      })
+    })
+
+    it("should not error when the source matches only an unpublished page", async () => {
+      // Arrange — an unpublished page isn't live, so it can't be shadowed yet
+      // (publishing it later is guarded on the page side).
+      await seedPageAtRoot({ permalink: "draft-page", published: false })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/draft-page",
+        destination: "/somewhere",
+      })
+
+      // Assert
+      expect(result.errors).toEqual([])
+    })
+  })
+
   describe("create", () => {
     it("should throw 401 if not logged in", async () => {
       // Arrange / Act
@@ -389,6 +763,19 @@ describe("redirect.router", async () => {
       expect(result[0]!.source).toBe("/old/path")
     })
 
+    it("should persist an external destination unchanged", async () => {
+      // Arrange / Act
+      await caller.create({
+        siteId,
+        source: "/old",
+        destination: "https://www.example.gov.sg/path/",
+      })
+
+      // Assert
+      const result = await caller.list({ siteId })
+      expect(result[0]!.destination).toBe("https://www.example.gov.sg/path/")
+    })
+
     it("should throw 409 if a live redirect already exists for the source", async () => {
       // Arrange
       await db
@@ -445,6 +832,107 @@ describe("redirect.router", async () => {
         source: "/revived",
         destination: "https://example.com/new",
       })
+    })
+
+    it("should throw 422 and create nothing if the redirect would loop", async () => {
+      // Arrange
+      // /b already redirects to /a, so creating /a -> /b would bounce back
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/a" })
+        .execute()
+
+      // Act
+      const result = caller.create({ siteId, source: "/a", destination: "/b" })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        "This will trap visitors in a never-ending loop.",
+      )
+      const rows = await db
+        .selectFrom("Redirect")
+        .select("source")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/a")
+        .execute()
+      expect(rows).toHaveLength(0)
+    })
+
+    it("should throw 412 and create nothing if the source is a published page's URL", async () => {
+      // Arrange — a live page sits at /live-page
+      await seedPageAtRoot({ permalink: "live-page", published: true })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        source: "/live-page",
+        destination: "/somewhere",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
+        }),
+      )
+      const rows = await db
+        .selectFrom("Redirect")
+        .select("source")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/live-page")
+        .execute()
+      expect(rows).toHaveLength(0)
+    })
+
+    it("should create the redirect when only an unpublished page exists at the source", async () => {
+      // Arrange — an unpublished page at /draft-page isn't live, so it can't be
+      // shadowed; the redirect is allowed (publishing the page later is guarded
+      // on the page side). An external destination keeps the focus on the
+      // source check (an internal destination would need its own live page).
+      await seedPageAtRoot({ permalink: "draft-page", published: false })
+
+      // Act
+      await caller.create({
+        siteId,
+        source: "/draft-page",
+        destination: "https://www.example.gov.sg",
+      })
+
+      // Assert
+      const result = await caller.list({ siteId })
+      expect(result).toContainEqual(
+        expect.objectContaining({
+          source: "/draft-page",
+          destination: "https://www.example.gov.sg",
+        }),
+      )
+    })
+
+    it("should create the redirect when the destination is itself a redirect source", async () => {
+      // Arrange
+      // /b is a live page (so it is a valid destination, resolved to a
+      // reference), but also already redirects to /c. /a -> /b is a chain (a
+      // warning, not a loop), so the create proceeds.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "b",
+        state: ResourceState.Published,
+        userId,
+      })
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/c" })
+        .execute()
+
+      // Act
+      await caller.create({ siteId, source: "/a", destination: "/b" })
+
+      // Assert
+      const result = await caller.list({ siteId })
+      expect(result.map((row) => row.source)).toContain("/a")
     })
 
     it("should write a RedirectCreate audit log entry with the created row", async () => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -482,9 +482,10 @@ describe("redirect.router", async () => {
       )
     })
 
-    it("should detect a multi-hop loop (A -> B -> C -> A)", async () => {
-      // Arrange — /b -> /c and /c -> /a already exist, so adding /a -> /b closes
-      // a three-redirect cycle that a single-hop check would miss.
+    it("should not flag a multi-hop cycle as a loop (only one hop is checked)", async () => {
+      // Arrange — /b -> /c and /c -> /a already exist. Adding /a -> /b closes a
+      // three-redirect cycle, but loop detection only looks one hop deep by
+      // design, so this surfaces as a chain warning rather than a loop error.
       await db
         .insertInto("Redirect")
         .values([
@@ -501,9 +502,14 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result.errors).toContainEqual(
+      expect(result.errors).not.toContainEqual(
         expect.objectContaining({ code: "REDIRECT_LOOP" }),
       )
+      expect(result.warnings).toContainEqual({
+        code: "DESTINATION_IS_REDIRECT_SOURCE",
+        message:
+          "This page already redirects to /c. Visitors will end up there instead.",
+      })
     })
 
     it("should not flag a multi-hop chain that never returns to the source", async () => {
@@ -906,8 +912,10 @@ describe("redirect.router", async () => {
       expect(rows).toHaveLength(0)
     })
 
-    it("should throw 422 and create nothing for a multi-hop loop", async () => {
-      // Arrange — /b -> /c -> /a, so creating /a -> /b closes a 3-redirect cycle
+    it("should create a redirect that only closes a multi-hop cycle (loop check is one hop)", async () => {
+      // Arrange — /b -> /c -> /a. Creating /a -> /b closes a 3-redirect cycle,
+      // but the loop guard only looks one hop deep by design, so the create is
+      // allowed (the preflight surfaces it as a non-blocking chain warning).
       await db
         .insertInto("Redirect")
         .values([
@@ -917,19 +925,17 @@ describe("redirect.router", async () => {
         .execute()
 
       // Act
-      const result = caller.create({ siteId, source: "/a", destination: "/b" })
+      await caller.create({ siteId, source: "/a", destination: "/b" })
 
       // Assert
-      await expect(result).rejects.toThrowError(
-        "This will trap visitors in a never-ending loop.",
-      )
       const rows = await db
         .selectFrom("Redirect")
         .select("source")
         .where("siteId", "=", siteId)
         .where("source", "=", "/a")
+        .where("deletedAt", "is", null)
         .execute()
-      expect(rows).toHaveLength(0)
+      expect(rows).toHaveLength(1)
     })
 
     it("should throw 412 and create nothing if the source is a published page's URL", async () => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -482,6 +482,54 @@ describe("redirect.router", async () => {
       )
     })
 
+    it("should detect a multi-hop loop (A -> B -> C -> A)", async () => {
+      // Arrange — /b -> /c and /c -> /a already exist, so adding /a -> /b closes
+      // a three-redirect cycle that a single-hop check would miss.
+      await db
+        .insertInto("Redirect")
+        .values([
+          { siteId, source: "/b", destination: "/c" },
+          { siteId, source: "/c", destination: "/a" },
+        ])
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/a",
+        destination: "/b",
+      })
+
+      // Assert
+      expect(result.errors).toContainEqual(
+        expect.objectContaining({ code: "REDIRECT_LOOP" }),
+      )
+    })
+
+    it("should not flag a multi-hop chain that never returns to the source", async () => {
+      // Arrange — /b -> /c -> /d terminates at /d, so adding /a -> /b chains but
+      // does not loop; it is a warning, not an error.
+      await db
+        .insertInto("Redirect")
+        .values([
+          { siteId, source: "/b", destination: "/c" },
+          { siteId, source: "/c", destination: "/d" },
+        ])
+        .execute()
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/a",
+        destination: "/b",
+      })
+
+      // Assert
+      expect(result.errors).not.toContainEqual(
+        expect.objectContaining({ code: "REDIRECT_LOOP" }),
+      )
+    })
+
     it("should not report ALREADY_EXISTS when only a soft-deleted redirect exists for the source", async () => {
       // Arrange
       await db
@@ -858,6 +906,32 @@ describe("redirect.router", async () => {
       expect(rows).toHaveLength(0)
     })
 
+    it("should throw 422 and create nothing for a multi-hop loop", async () => {
+      // Arrange — /b -> /c -> /a, so creating /a -> /b closes a 3-redirect cycle
+      await db
+        .insertInto("Redirect")
+        .values([
+          { siteId, source: "/b", destination: "/c" },
+          { siteId, source: "/c", destination: "/a" },
+        ])
+        .execute()
+
+      // Act
+      const result = caller.create({ siteId, source: "/a", destination: "/b" })
+
+      // Assert
+      await expect(result).rejects.toThrowError(
+        "This will trap visitors in a never-ending loop.",
+      )
+      const rows = await db
+        .selectFrom("Redirect")
+        .select("source")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/a")
+        .execute()
+      expect(rows).toHaveLength(0)
+    })
+
     it("should throw 412 and create nothing if the source is a published page's URL", async () => {
       // Arrange — a live page sits at /live-page
       await seedPageAtRoot({ permalink: "live-page", published: true })
@@ -884,6 +958,24 @@ describe("redirect.router", async () => {
         .where("source", "=", "/live-page")
         .execute()
       expect(rows).toHaveLength(0)
+    })
+
+    it("should block an uppercase source that lowercases onto a published page", async () => {
+      // Arrange — the page lives at /live-page; "/Live-Page" lowercases to the
+      // same URL and would shadow it, so it must be blocked too.
+      await seedPageAtRoot({ permalink: "live-page", published: true })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        source: "/Live-Page",
+        destination: "https://example.com/somewhere",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+      })
     })
 
     it("should create the redirect when only an unpublished page exists at the source", async () => {

--- a/apps/studio/src/server/modules/redirect/redirect.router.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.router.ts
@@ -14,6 +14,7 @@ import {
   deleteRedirect,
   listRedirects,
   resolveRedirectReferences,
+  validateRedirect,
 } from "./redirect.service"
 
 export const redirectRouter = router({
@@ -39,6 +40,22 @@ export const redirectRouter = router({
       })
 
       return countRedirects(input)
+    }),
+
+  // Preflight a would-be redirect, returning blocking errors and non-blocking
+  // warnings so the form can surface them before the user commits. Read-only
+  // and gated on "read" like the other queries — it exposes only whether
+  // internal pages/redirects exist, which read access already covers.
+  validate: protectedProcedure
+    .input(createRedirectSchema)
+    .query(async ({ ctx, input }) => {
+      await validateUserPermissionsForSite({
+        siteId: input.siteId,
+        userId: ctx.user.id,
+        action: "read",
+      })
+
+      return validateRedirect(input)
     }),
 
   // Resolves stored [resource:...] destinations to display permalinks. A read

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -72,7 +72,10 @@ const parseDestination = (destination: string): ParsedDestination => {
 // Resolves a destination to its stored form. A bare internal path becomes a
 // [resource:...] reference (so it follows page renames); a query-suffixed path
 // stays literal (a query can't map to a single resource); references and
-// external URLs are stored verbatim.
+// external URLs are stored verbatim. An internal path with no live page yet is
+// also kept literal rather than rejected — the preflight surfaces this as a
+// non-blocking warning, so an admin can pre-create a redirect to a page they're
+// about to publish.
 const resolveDestinationForStorage = async (
   siteId: number,
   destination: string,
@@ -87,11 +90,9 @@ const resolveDestinationForStorage = async (
         return parsed.value
       }
       const resourceId = await getResourceIdByPermalink(siteId, parsed.value)
+      // No live page yet — keep the literal path; the preflight warns about it.
       if (resourceId === null) {
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `The page "${destination}" does not exist`,
-        })
+        return parsed.value
       }
       return getReferenceLink({
         siteId: String(siteId),
@@ -415,8 +416,8 @@ export const createRedirect = async ({
     }
 
     // Resolve an internal-path destination to a [resource:...] reference (so it
-    // follows page renames). After the guards so a bad source / loop surfaces
-    // its own error, not NOT_FOUND. Throws NOT_FOUND if the path has no page.
+    // follows page renames); a path with no live page yet is kept literal (the
+    // preflight already warned). Never blocks the create.
     const storedDestination = await resolveDestinationForStorage(
       siteId,
       destination,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -1,11 +1,13 @@
 import type {
+  RedirectValidationIssue,
+  RedirectValidationResult,
+} from "~/constants/redirect"
+import type {
   CountRedirectsInput,
   CreateRedirectInput,
   DeleteRedirectInput,
   ListRedirectsInput,
   RedirectSortField,
-  RedirectValidationIssue,
-  RedirectValidationResult,
   ResolveRedirectReferencesInput,
 } from "~/schemas/redirect"
 import {
@@ -13,11 +15,10 @@ import {
   REFERENCE_LINK_REGEX,
 } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
+import { REDIRECT_MESSAGES, RedirectValidationCode } from "~/constants/redirect"
 import {
   normalizeRedirectPath,
   normalizeRedirectSource,
-  REDIRECT_MESSAGES,
-  RedirectValidationCode,
 } from "~/schemas/redirect"
 import { getReferenceLink } from "~/utils/link"
 
@@ -176,22 +177,19 @@ const resolveStoredDestination = async (
   return permalinks.get(Number(resourceId)) ?? storedDestination
 }
 
-// Bound on how far the chain is followed when detecting a loop. A new redirect
-// closes a loop if following the existing chain from its destination returns to
-// `source` within this many hops; the visited-set also stops on a pre-existing
-// cycle. Generous — real chains are 1-2 hops.
-const MAX_REDIRECT_CHAIN_HOPS = 10
-
 // Detects whether adding `source -> destination` would chain into, or close a
-// loop with, existing redirects. Follows the chain from the destination (each
-// redirect's resolved target may itself be a redirect source) up to
-// MAX_REDIRECT_CHAIN_HOPS, reporting `isLoop` when it returns to `source`.
-// Returns the immediate next redirect and its `target` so a non-looping chain
-// can still be surfaced as a warning. Stored destinations may be `[resource:...]`
-// references, resolved to the page's current permalink before comparing. Only
-// internal paths chain; an external https destination never matches a source.
-// `source` is assumed already normalised (lowercased), so destinations are
-// normalised the same way before they are looked up as a source.
+// loop with, an existing redirect — looking exactly one hop deep. If the
+// destination is itself the source of a live redirect, that redirect's resolved
+// target is the next hop; the new redirect closes a loop when that target
+// resolves back to `source` (the mirror pair `/a -> /b` while `/b -> /a`).
+// Longer cycles (`/a -> /b -> /c -> /a`) are intentionally not chased — they're
+// rare, and the single-hop check keeps this to one extra read while still
+// surfacing the immediate next hop as a non-looping chain warning. Stored
+// destinations may be `[resource:...]` references, resolved to the page's
+// current permalink before comparing. Only internal paths chain; an external
+// https destination never matches a source. `source` is assumed already
+// normalised (lowercased), so the destination is normalised the same way before
+// it is looked up as a source.
 const getChainedRedirect = async (
   dbInstance: SafeKysely,
   {
@@ -212,36 +210,11 @@ const getChainedRedirect = async (
     return null
   }
 
-  // A hop closes a loop when its resolved (internal) target normalises to
-  // `source`; an external target can never match a source.
-  const closesLoop = (path: string) =>
-    path.startsWith("/") && normalizeRedirectSource(path) === source
-
   const target = await resolveStoredDestination(siteId, redirect.destination)
-  // Walk the chain from the immediate target onward; a loop exists if any hop
-  // resolves back to `source`. `visited` guards against an existing cycle that
-  // doesn't involve `source` (which would otherwise spin until the hop cap).
-  const visited = new Set([normalizedDestination])
-  let current = target
-  let isLoop = closesLoop(current)
-  let hops = 1
-  while (!isLoop && current.startsWith("/") && hops < MAX_REDIRECT_CHAIN_HOPS) {
-    const normalizedCurrent = normalizeRedirectSource(current)
-    if (visited.has(normalizedCurrent)) {
-      break
-    }
-    visited.add(normalizedCurrent)
-    const next = await getLiveRedirectBySource(dbInstance, {
-      siteId,
-      source: normalizedCurrent,
-    })
-    if (!next) {
-      break
-    }
-    current = await resolveStoredDestination(siteId, next.destination)
-    isLoop = closesLoop(current)
-    hops += 1
-  }
+  // The new redirect closes a loop when the existing redirect's (internal)
+  // target normalises back to `source`; an external target can never match.
+  const isLoop =
+    target.startsWith("/") && normalizeRedirectSource(target) === source
 
   return { redirect, normalizedDestination, target, isLoop }
 }

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -15,6 +15,7 @@ import {
 import { TRPCError } from "@trpc/server"
 import {
   normalizeRedirectPath,
+  normalizeRedirectSource,
   REDIRECT_MESSAGES,
   RedirectValidationCode,
 } from "~/schemas/redirect"
@@ -154,11 +155,9 @@ const getLiveRedirectBySource = (
     .where("deletedAt", "is", null)
     .executeTakeFirst()
 
-// Resolves a redirect's stored destination to a comparable / displayable path.
-// Internal destinations are persisted as `[resource:...]` references, so a
-// stored reference is resolved to the page's current permalink; a literal path
-// is normalised; an external https URL (or a reference whose page no longer
-// exists) is returned verbatim.
+// Resolves a stored destination to a comparable/displayable path: a reference
+// to the page's current permalink, a literal path normalised, an external URL
+// (or a reference to a missing page) verbatim.
 const resolveStoredDestination = async (
   siteId: number,
   storedDestination: string,
@@ -176,13 +175,22 @@ const resolveStoredDestination = async (
   return permalinks.get(Number(resourceId)) ?? storedDestination
 }
 
-// Looks up a live redirect whose source equals the given destination path —
-// i.e. the destination is itself a redirect source. Returns the redirect, its
-// resolved `target` (the page it ultimately points at), and whether that target
-// is `source` (a 1-level loop). The stored destination may be a `[resource:...]`
-// reference, so it is resolved to the page's current permalink before comparing
-// or displaying. Only internal paths can chain; an external https destination
-// never matches a stored source. `source` is assumed already normalised.
+// Bound on how far the chain is followed when detecting a loop. A new redirect
+// closes a loop if following the existing chain from its destination returns to
+// `source` within this many hops; the visited-set also stops on a pre-existing
+// cycle. Generous — real chains are 1-2 hops.
+const MAX_REDIRECT_CHAIN_HOPS = 10
+
+// Detects whether adding `source -> destination` would chain into, or close a
+// loop with, existing redirects. Follows the chain from the destination (each
+// redirect's resolved target may itself be a redirect source) up to
+// MAX_REDIRECT_CHAIN_HOPS, reporting `isLoop` when it returns to `source`.
+// Returns the immediate next redirect and its `target` so a non-looping chain
+// can still be surfaced as a warning. Stored destinations may be `[resource:...]`
+// references, resolved to the page's current permalink before comparing. Only
+// internal paths chain; an external https destination never matches a source.
+// `source` is assumed already normalised (lowercased), so destinations are
+// normalised the same way before they are looked up as a source.
 const getChainedRedirect = async (
   dbInstance: SafeKysely,
   {
@@ -194,7 +202,7 @@ const getChainedRedirect = async (
   if (!destination.startsWith("/")) {
     return null
   }
-  const normalizedDestination = normalizeRedirectPath(destination)
+  const normalizedDestination = normalizeRedirectSource(destination)
   const redirect = await getLiveRedirectBySource(dbInstance, {
     siteId,
     source: normalizedDestination,
@@ -202,14 +210,43 @@ const getChainedRedirect = async (
   if (!redirect) {
     return null
   }
+
+  // A hop closes a loop when its resolved (internal) target normalises to
+  // `source`; an external target can never match a source.
+  const closesLoop = (path: string) =>
+    path.startsWith("/") && normalizeRedirectSource(path) === source
+
   const target = await resolveStoredDestination(siteId, redirect.destination)
-  return { redirect, normalizedDestination, target, isLoop: target === source }
+  // Walk the chain from the immediate target onward; a loop exists if any hop
+  // resolves back to `source`. `visited` guards against an existing cycle that
+  // doesn't involve `source` (which would otherwise spin until the hop cap).
+  const visited = new Set([normalizedDestination])
+  let current = target
+  let isLoop = closesLoop(current)
+  let hops = 1
+  while (!isLoop && current.startsWith("/") && hops < MAX_REDIRECT_CHAIN_HOPS) {
+    const normalizedCurrent = normalizeRedirectSource(current)
+    if (visited.has(normalizedCurrent)) {
+      break
+    }
+    visited.add(normalizedCurrent)
+    const next = await getLiveRedirectBySource(dbInstance, {
+      siteId,
+      source: normalizedCurrent,
+    })
+    if (!next) {
+      break
+    }
+    current = await resolveStoredDestination(siteId, next.destination)
+    isLoop = closesLoop(current)
+    hops += 1
+  }
+
+  return { redirect, normalizedDestination, target, isLoop }
 }
 
-// Preflight for redirect.create: returns the blocking errors and non-blocking
-// warnings for a would-be redirect without mutating anything. The create
-// endpoint independently re-enforces every error, so this can never be the
-// only thing standing between an invalid redirect and the database.
+// Preflight for redirect.create: returns blocking errors and non-blocking
+// warnings without mutating. Advisory only — create re-enforces every error.
 export const validateRedirect = async ({
   siteId,
   source,
@@ -228,11 +265,9 @@ export const validateRedirect = async ({
     })
   }
 
-  // A redirect whose source is the live URL of a published page would shadow
-  // that page on the published site (the redirect takes precedence), leaving it
-  // unreachable. Block it. Only PUBLISHED pages block — an unpublished page at
-  // this path isn't live yet, and publishing it later is guarded on the page
-  // side (see ISOM-2266). `source` is already normalised by the schema.
+  // A redirect whose source is a published page's live URL would shadow that
+  // page, so block it. Only published pages block — an unpublished page isn't
+  // live yet, and publishing it later is guarded on the page side.
   const pageAtSource = await getResourceByFullPermalink({
     siteId,
     fullPermalink: source,
@@ -347,41 +382,27 @@ export const createRedirect = async ({
       })
     }
 
-    // Re-enforce the no-loop rule server-side (the client preflights via
-    // redirect.validate, but create must never trust that). A warning-level
-    // chain does not block — only a redirect that points straight back.
-    //
-    // NOTE: unlike the recreate check above (backed by the (siteId, source)
-    // unique constraint), this loop guard is a plain read under READ
-    // COMMITTED. Two admins concurrently creating the mirror pair — /a -> /b
-    // and /b -> /a — can each pass this check before the other commits and
-    // persist a 1-level loop. The window requires two racing admins on the
-    // same site and the impact is a recoverable loop (delete either side), so
-    // we accept it rather than serialize every create with an advisory lock.
-    // Flagged so the asymmetry with the constraint-backed recreate path reads
-    // as intentional, not an oversight.
+    // Re-enforce the no-loop rule server-side; the preflight is advisory. Unlike
+    // the recreate check (constraint-backed), this is a plain read, so two admins
+    // racing the mirror pair (/a->/b and /b->/a) could each pass and persist a
+    // loop — accepted, since the result is recoverable by deleting either side.
     const chained = await getChainedRedirect(tx, {
       siteId,
       source,
       destination,
     })
     if (chained?.isLoop) {
-      // The add-redirect form maps this UNPROCESSABLE_CONTENT code to the loop
-      // message inline on the destination field, so keep this code reserved for
-      // the loop guard — don't reuse it for other create-time failures.
+      // UNPROCESSABLE_CONTENT is reserved for the loop guard — the form maps it
+      // to the loop message on the destination field; don't reuse it elsewhere.
       throw new TRPCError({
         code: "UNPROCESSABLE_CONTENT",
         message: REDIRECT_MESSAGES.loop,
       })
     }
 
-    // Re-enforce the source-vs-published-page guard server-side: a redirect
-    // whose source is a published page's live URL would shadow that page. Like
-    // the loop guard, this is a plain read (not constraint-backed), so a page
-    // published in the same window could still slip through; the impact is a
-    // recoverable shadow (delete the redirect), so we accept it. PRECONDITION_
-    // FAILED keeps this distinct from the CONFLICT used for an already-existing
-    // redirect, so the form can show the right message on the source field.
+    // Re-enforce the source-vs-published-page guard (a published page at this
+    // URL would be shadowed). Also a plain read, so same accepted race as above.
+    // PRECONDITION_FAILED keeps it distinct from the already-exists CONFLICT.
     const pageAtSource = await getResourceByFullPermalink({
       siteId,
       fullPermalink: source,
@@ -393,10 +414,9 @@ export const createRedirect = async ({
       })
     }
 
-    // Resolve an internal-path destination to a [resource:...] reference so the
-    // redirect follows the page if its permalink later changes. Done after the
-    // guards above so a bad source / loop surfaces its own specific error rather
-    // than the destination NOT_FOUND. Throws NOT_FOUND if the path has no page.
+    // Resolve an internal-path destination to a [resource:...] reference (so it
+    // follows page renames). After the guards so a bad source / loop surfaces
+    // its own error, not NOT_FOUND. Throws NOT_FOUND if the path has no page.
     const storedDestination = await resolveDestinationForStorage(
       siteId,
       destination,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -4,18 +4,30 @@ import type {
   DeleteRedirectInput,
   ListRedirectsInput,
   RedirectSortField,
+  RedirectValidationIssue,
+  RedirectValidationResult,
   ResolveRedirectReferencesInput,
 } from "~/schemas/redirect"
-import { REFERENCE_LINK_REGEX } from "@opengovsg/isomer-components"
+import {
+  getResourceIdFromReferenceLink,
+  REFERENCE_LINK_REGEX,
+} from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
+import {
+  normalizeRedirectPath,
+  REDIRECT_MESSAGES,
+  RedirectValidationCode,
+} from "~/schemas/redirect"
 import { getReferenceLink } from "~/utils/link"
 
 import type { Logger } from "@isomer/logging"
 
+import type { SafeKysely } from "../database"
 import { logPublishEvent, logRedirectEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { AuditLogEvent, db } from "../database"
 import {
+  getResourceByFullPermalink,
   getResourceFullPermalinks,
   getResourceIdByPermalink,
 } from "../resource/resource.service"
@@ -130,6 +142,144 @@ const getByUser = async (byUserId: string) =>
         }),
     )
 
+const getLiveRedirectBySource = (
+  dbInstance: SafeKysely,
+  { siteId, source }: { siteId: number; source: string },
+) =>
+  dbInstance
+    .selectFrom("Redirect")
+    .selectAll()
+    .where("siteId", "=", siteId)
+    .where("source", "=", source)
+    .where("deletedAt", "is", null)
+    .executeTakeFirst()
+
+// Resolves a redirect's stored destination to a comparable / displayable path.
+// Internal destinations are persisted as `[resource:...]` references, so a
+// stored reference is resolved to the page's current permalink; a literal path
+// is normalised; an external https URL (or a reference whose page no longer
+// exists) is returned verbatim.
+const resolveStoredDestination = async (
+  siteId: number,
+  storedDestination: string,
+): Promise<string> => {
+  if (storedDestination.startsWith("/")) {
+    return normalizeRedirectPath(storedDestination)
+  }
+  const resourceId = getResourceIdFromReferenceLink(storedDestination)
+  if (resourceId === "") {
+    return storedDestination
+  }
+  const permalinks = await getResourceFullPermalinks(siteId, [
+    Number(resourceId),
+  ])
+  return permalinks.get(Number(resourceId)) ?? storedDestination
+}
+
+// Looks up a live redirect whose source equals the given destination path —
+// i.e. the destination is itself a redirect source. Returns the redirect, its
+// resolved `target` (the page it ultimately points at), and whether that target
+// is `source` (a 1-level loop). The stored destination may be a `[resource:...]`
+// reference, so it is resolved to the page's current permalink before comparing
+// or displaying. Only internal paths can chain; an external https destination
+// never matches a stored source. `source` is assumed already normalised.
+const getChainedRedirect = async (
+  dbInstance: SafeKysely,
+  {
+    siteId,
+    source,
+    destination,
+  }: { siteId: number; source: string; destination: string },
+) => {
+  if (!destination.startsWith("/")) {
+    return null
+  }
+  const normalizedDestination = normalizeRedirectPath(destination)
+  const redirect = await getLiveRedirectBySource(dbInstance, {
+    siteId,
+    source: normalizedDestination,
+  })
+  if (!redirect) {
+    return null
+  }
+  const target = await resolveStoredDestination(siteId, redirect.destination)
+  return { redirect, normalizedDestination, target, isLoop: target === source }
+}
+
+// Preflight for redirect.create: returns the blocking errors and non-blocking
+// warnings for a would-be redirect without mutating anything. The create
+// endpoint independently re-enforces every error, so this can never be the
+// only thing standing between an invalid redirect and the database.
+export const validateRedirect = async ({
+  siteId,
+  source,
+  destination,
+}: CreateRedirectInput): Promise<RedirectValidationResult> => {
+  const errors: RedirectValidationIssue[] = []
+  const warnings: RedirectValidationIssue[] = []
+
+  // Recreating a live redirect for the same source is not allowed — the user
+  // must delete the existing one first.
+  const existing = await getLiveRedirectBySource(db, { siteId, source })
+  if (existing) {
+    errors.push({
+      code: RedirectValidationCode.AlreadyExists,
+      message: REDIRECT_MESSAGES.alreadyExists,
+    })
+  }
+
+  // A redirect whose source is the live URL of a published page would shadow
+  // that page on the published site (the redirect takes precedence), leaving it
+  // unreachable. Block it. Only PUBLISHED pages block — an unpublished page at
+  // this path isn't live yet, and publishing it later is guarded on the page
+  // side (see ISOM-2266). `source` is already normalised by the schema.
+  const pageAtSource = await getResourceByFullPermalink({
+    siteId,
+    fullPermalink: source,
+  })
+  if (pageAtSource && pageAtSource.publishedVersionId !== null) {
+    errors.push({
+      code: RedirectValidationCode.SourceIsExistingPage,
+      message: REDIRECT_MESSAGES.sourceIsExistingPage,
+    })
+  }
+
+  const chained = await getChainedRedirect(db, { siteId, source, destination })
+  if (chained?.isLoop) {
+    errors.push({
+      code: RedirectValidationCode.RedirectLoop,
+      message: REDIRECT_MESSAGES.loop,
+      description: `${chained.normalizedDestination} already redirects to ${source}. Visitors will get stuck in between pages. Delete existing redirects or direct to a different page.`,
+    })
+  } else if (chained) {
+    warnings.push({
+      code: RedirectValidationCode.DestinationIsRedirectSource,
+      message: `This page already redirects to ${chained.target}. Visitors will end up there instead.`,
+    })
+  } else if (destination.startsWith("/")) {
+    // An internal destination with no redirect of its own should point at a
+    // real, published page.
+    const normalizedDestination = normalizeRedirectPath(destination)
+    const resource = await getResourceByFullPermalink({
+      siteId,
+      fullPermalink: normalizedDestination,
+    })
+    if (!resource) {
+      warnings.push({
+        code: RedirectValidationCode.DestinationNotFound,
+        message: REDIRECT_MESSAGES.destinationNotLive,
+      })
+    } else if (resource.publishedVersionId === null) {
+      warnings.push({
+        code: RedirectValidationCode.DestinationNotPublished,
+        message: REDIRECT_MESSAGES.destinationNotLive,
+      })
+    }
+  }
+
+  return { errors, warnings }
+}
+
 export const listRedirects = async ({
   siteId,
   sortBy,
@@ -180,14 +330,6 @@ export const createRedirect = async ({
 }) => {
   const byUser = await getByUser(byUserId)
 
-  // Resolve an internal-path destination to a [resource:...] reference (a read,
-  // outside the tx) so the redirect follows the page if its permalink changes.
-  // Throws NOT_FOUND if the path matches no page.
-  const storedDestination = await resolveDestinationForStorage(
-    siteId,
-    destination,
-  )
-
   const created = await db.transaction().execute(async (tx) => {
     // Reject creating over a live redirect. A soft-deleted row for the same
     // source still holds the (siteId, source) unique constraint and is revived
@@ -204,6 +346,61 @@ export const createRedirect = async ({
         message: `A redirect already exists for ${source}`,
       })
     }
+
+    // Re-enforce the no-loop rule server-side (the client preflights via
+    // redirect.validate, but create must never trust that). A warning-level
+    // chain does not block — only a redirect that points straight back.
+    //
+    // NOTE: unlike the recreate check above (backed by the (siteId, source)
+    // unique constraint), this loop guard is a plain read under READ
+    // COMMITTED. Two admins concurrently creating the mirror pair — /a -> /b
+    // and /b -> /a — can each pass this check before the other commits and
+    // persist a 1-level loop. The window requires two racing admins on the
+    // same site and the impact is a recoverable loop (delete either side), so
+    // we accept it rather than serialize every create with an advisory lock.
+    // Flagged so the asymmetry with the constraint-backed recreate path reads
+    // as intentional, not an oversight.
+    const chained = await getChainedRedirect(tx, {
+      siteId,
+      source,
+      destination,
+    })
+    if (chained?.isLoop) {
+      // The add-redirect form maps this UNPROCESSABLE_CONTENT code to the loop
+      // message inline on the destination field, so keep this code reserved for
+      // the loop guard — don't reuse it for other create-time failures.
+      throw new TRPCError({
+        code: "UNPROCESSABLE_CONTENT",
+        message: REDIRECT_MESSAGES.loop,
+      })
+    }
+
+    // Re-enforce the source-vs-published-page guard server-side: a redirect
+    // whose source is a published page's live URL would shadow that page. Like
+    // the loop guard, this is a plain read (not constraint-backed), so a page
+    // published in the same window could still slip through; the impact is a
+    // recoverable shadow (delete the redirect), so we accept it. PRECONDITION_
+    // FAILED keeps this distinct from the CONFLICT used for an already-existing
+    // redirect, so the form can show the right message on the source field.
+    const pageAtSource = await getResourceByFullPermalink({
+      siteId,
+      fullPermalink: source,
+    })
+    if (pageAtSource && pageAtSource.publishedVersionId !== null) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: REDIRECT_MESSAGES.sourceIsExistingPage,
+      })
+    }
+
+    // Resolve an internal-path destination to a [resource:...] reference so the
+    // redirect follows the page if its permalink later changes. Done after the
+    // guards above so a bad source / loop surfaces its own specific error rather
+    // than the destination NOT_FOUND. Throws NOT_FOUND if the path has no page.
+    const storedDestination = await resolveDestinationForStorage(
+      siteId,
+      destination,
+    )
 
     const created = await tx
       .insertInto("Redirect")

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -710,6 +710,74 @@ export const getResourceFullPermalink = async (
   return `/${permalinkTree.join("/")}`
 }
 
+// Resolves a full permalink path (e.g. "/foo/bar") to the resource that serves
+// it, walking permalink segments from the site's root page. A Folder/Collection
+// is resolved to its IndexPage child, since that is what actually renders at the
+// container's URL (mirroring getFullPageById). Returns undefined when no
+// resource exists at the path. Best-effort: intended for non-blocking
+// validation (e.g. checking a redirect destination), not access control.
+export const getResourceByFullPermalink = async ({
+  siteId,
+  fullPermalink,
+}: {
+  siteId: number
+  fullPermalink: string
+}) => {
+  const segments = fullPermalink.split("/").filter(Boolean)
+
+  const root = await db
+    .selectFrom("Resource")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.type", "=", ResourceType.RootPage)
+    .where("Resource.parentId", "is", null)
+    .select(defaultResourceSelect)
+    .executeTakeFirst()
+  if (!root) {
+    return undefined
+  }
+
+  let current = root
+  for (const segment of segments) {
+    const child = await db
+      .selectFrom("Resource")
+      .where("Resource.siteId", "=", siteId)
+      .where("Resource.parentId", "=", current.id)
+      .where("Resource.permalink", "=", segment)
+      // Meta and index resources are not directly addressable by a path
+      // segment — the index page is reached via its parent container below.
+      .where("Resource.type", "not in", [
+        ResourceType.IndexPage,
+        ResourceType.FolderMeta,
+        ResourceType.CollectionMeta,
+      ])
+      .select(defaultResourceSelect)
+      .executeTakeFirst()
+    if (!child) {
+      return undefined
+    }
+    current = child
+  }
+
+  if (
+    current.type === ResourceType.Folder ||
+    current.type === ResourceType.Collection
+  ) {
+    const indexPage = await db
+      .selectFrom("Resource")
+      .where("Resource.siteId", "=", siteId)
+      .where("Resource.parentId", "=", current.id)
+      .where("Resource.type", "=", ResourceType.IndexPage)
+      .select(defaultResourceSelect)
+      .executeTakeFirst()
+    // A container with no index page has no page rendering at its URL, so fall
+    // back to the container itself — its null publishedVersionId then reads as
+    // "not published", which is the right signal for a destination warning.
+    return indexPage ?? current
+  }
+
+  return current
+}
+
 // Batched variant of getResourceFullPermalink: resolves many resources' full
 // permalinks in a single recursive query instead of one round-trip per id.
 // Used to render redirect destinations (stored as `[resource:...]` references)

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -127,6 +127,9 @@ export const RedirectLoopError: Story = {
         "This will trap visitors in a never-ending loop.",
       ),
     ).toBeVisible()
+    // The loop error is inline only — the generic failure toast must not also
+    // fire (regression guard for the error switch falling through to default).
+    await expect(screen.queryByText("Failed to add redirect")).toBeNull()
   },
 }
 

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { sitesHandlers } from "tests/msw/handlers/sites"
@@ -49,6 +50,7 @@ export const Default: Story = {
       handlers: [
         redirectHandlers.list.default(),
         redirectHandlers.count.default(),
+        redirectHandlers.validate.noIssues(),
         ...COMMON_HANDLERS,
       ],
     },
@@ -62,8 +64,102 @@ export const Empty: Story = {
       handlers: [
         redirectHandlers.list.empty(),
         redirectHandlers.count.empty(),
+        redirectHandlers.validate.noIssues(),
         ...COMMON_HANDLERS,
       ],
     },
+  },
+}
+
+// Fills the add-redirect form with a valid (schema-passing) pair and submits,
+// so the server's response drives the inline error states below.
+const submitNewRedirect = async (canvasElement: HTMLElement) => {
+  const screen = within(canvasElement.ownerDocument.body)
+  const sourceInput = await screen.findByPlaceholderText("redirect-from")
+  await userEvent.type(sourceInput, "old-page")
+  await userEvent.type(screen.getByPlaceholderText("/redirect-to"), "/new-page")
+  const addButton = screen.getByRole("button", { name: "Add" })
+  await waitFor(() => expect(addButton).toBeEnabled())
+  await userEvent.click(addButton, { pointerEventsCheck: 0 })
+  return screen
+}
+
+// Creating over an existing live redirect shows the error inline on the source.
+export const AlreadyExistsError: Story = {
+  parameters: {
+    growthbook: [createRedirectionsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        redirectHandlers.create.alreadyExists(),
+        redirectHandlers.validate.noIssues(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = await submitNewRedirect(canvasElement)
+    await expect(
+      await screen.findByText("This page is already being redirected."),
+    ).toBeVisible()
+  },
+}
+
+// A redirect that loops back shows the error inline on the destination.
+export const RedirectLoopError: Story = {
+  parameters: {
+    growthbook: [createRedirectionsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        redirectHandlers.create.loop(),
+        redirectHandlers.validate.noIssues(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = await submitNewRedirect(canvasElement)
+    await expect(
+      await screen.findByText(
+        "This will trap visitors in a never-ending loop.",
+      ),
+    ).toBeVisible()
+  },
+}
+
+// Typing a destination that doesn't resolve to a page and blurring the field
+// surfaces a (non-blocking) warning beneath the row.
+export const DestinationNotFoundWarning: Story = {
+  parameters: {
+    growthbook: [createRedirectionsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        redirectHandlers.validate.destinationNotFound(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement.ownerDocument.body)
+    await userEvent.type(
+      await screen.findByPlaceholderText("redirect-from"),
+      "old-page",
+    )
+    await userEvent.type(
+      screen.getByPlaceholderText("/redirect-to"),
+      "/no-page",
+    )
+    // Blur the destination to trigger the on-blur validate call.
+    await userEvent.tab()
+    await expect(
+      await screen.findByText(
+        "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+      ),
+    ).toBeVisible()
   },
 }

--- a/apps/studio/tests/msw/handlers/redirect.ts
+++ b/apps/studio/tests/msw/handlers/redirect.ts
@@ -1,3 +1,5 @@
+import { TRPCError } from "@trpc/server"
+
 import { MOCK_STORY_DATE } from "../constants"
 import { trpcMsw } from "../mockTrpc"
 
@@ -28,5 +30,33 @@ export const redirectHandlers = {
     default: () =>
       trpcMsw.redirect.count.query(() => DEFAULT_REDIRECT_ITEMS.length),
     empty: () => trpcMsw.redirect.count.query(() => 0),
+  },
+  create: {
+    // The source already has a live redirect — surfaced inline on the source.
+    alreadyExists: () =>
+      trpcMsw.redirect.create.mutation(() => {
+        throw new TRPCError({ code: "CONFLICT" })
+      }),
+    // The redirect would point straight back — surfaced inline on the
+    // destination. redirect.create throws UNPROCESSABLE_CONTENT for a loop.
+    loop: () =>
+      trpcMsw.redirect.create.mutation(() => {
+        throw new TRPCError({ code: "UNPROCESSABLE_CONTENT" })
+      }),
+  },
+  validate: {
+    noIssues: () =>
+      trpcMsw.redirect.validate.query(() => ({ errors: [], warnings: [] })),
+    destinationNotFound: () =>
+      trpcMsw.redirect.validate.query(() => ({
+        errors: [],
+        warnings: [
+          {
+            code: "DESTINATION_NOT_FOUND",
+            message:
+              "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
+          },
+        ],
+      })),
   },
 }


### PR DESCRIPTION
## Problem

Studio users can create individual redirects, but until now nothing stopped them from creating redirects that are broken on arrival: a redirect pointing a path to itself, a pair of redirects that trap visitors in a loop, a destination that is a full external-looking URL stuffed into the source field, or a destination pointing at a page that doesn't exist (or isn't published) yet. There was also no feedback loop warning users about destinations that themselves redirect elsewhere.

Closes [ISOM-2263](https://linear.app/ogp/issue/ISOM-2263) — Add validation to prevent a redirect source from being created when a page exists, and vice versa.
Closes [ISOM-2264](https://linear.app/ogp/issue/ISOM-2264) — Add validation logic for creating redirects.

## Solution

Adds a validation layer for creating redirects, shared between the client form and the server so the two can never drift, plus a non-blocking preflight that surfaces "this might not do what you expect" warnings before the user commits.

**Blocking errors** (reject creation):
- Invalid source/destination paths — control characters, backslashes, `..` traversal segments, and a source that is a full URL (contains `://`).
- Recreating a redirect that already exists for the same (normalised) source.
- A redirect whose source and destination are the same path.
- A redirect loop up to 1 level deep (e.g. `/a → /b` while `/b → /a` already exists).

**Non-blocking warnings** (surfaced inline, don't block):
- The destination is itself the source of another redirect, so visitors end up somewhere else.
- The destination is an internal path that doesn't exist, or exists but isn't published yet.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Adds a new read-only `redirect.validate` query and tightens `redirect.create`. Existing redirects are unaffected.

**Features**:

- New `redirect.validate` tRPC query: a read-only preflight (gated on `read`) that returns blocking `errors` and non-blocking `warnings` for a would-be redirect without mutating anything.
- `getResourceByFullPermalink` in the resource service: resolves a full permalink (e.g. `/foo/bar`) to the resource that serves it, walking permalink segments from the site root and resolving Folder/Collection containers to their IndexPage child. Used to check whether a redirect destination is a real, published page.
- The Add Redirect form now fetches warnings on blur once inputs are sync-valid and renders them as inline warning infoboxes under the destination field.

**Improvements**:

- Path normalisation (`normalizeRedirectPath`) is now exported and reused for both sources and internal destinations, so equivalent inputs (`/foo`, `foo/`, `/foo//`) canonicalise identically — keeping the `(siteId, source)` unique constraint meaningful and making same-source/destination comparison reliable. External `https://` destinations are left verbatim (trailing slash, query, fragment are meaningful off-site).
- The create schema is split into a refinement-free `createRedirectObjectSchema` (so callers can still `.omit()` / `.extend()`) plus a `superRefine`d `createRedirectSchema`. The form reuses the object schema and re-applies the same cross-field refinement, so client and server validate identically.
- Redirect validation copy is centralised in `REDIRECT_MESSAGES` / `RedirectValidationCode`, shared by the preflight, the create-time guards, and the form, so server and client messages can't drift.
- Create-time errors (`CONFLICT` for already-exists, `UNPROCESSABLE_CONTENT` for loop) are now surfaced inline on the relevant field instead of as a generic toast.

**Bug Fixes**:

- Destination validation now rejects control characters (incl. CR/LF/NUL) and backslashes for both internal paths and external `https://` URLs. A destination is persisted verbatim and later emitted into the published site's redirect rules (S3 object metadata → CloudFront `Location` header), so a CR/LF could otherwise reach a live response header.

## Tests

`pnpm test:unit` (from `apps/studio`) covers the new schema rules and service logic:
- `src/schemas/__tests__/redirect.test.ts` — source/destination validation, normalisation, and the source-equals-destination cross-field refinement.
- `src/server/modules/redirect/__tests__/redirect.router.test.ts` — `validate` preflight (errors + warnings) and the create-time loop re-enforcement.

The `Redirects.stories.tsx` Storybook stories exercise the inline error and warning states in the Add Redirect form.

**Manual Verification Steps**:

- [ ] Go to a site's **Settings → Redirects** page.
- [ ] In **Add redirect**, enter a source and a destination set to the same path (e.g. source `/contact`, destination `/contact`) and confirm the form blocks with "You can't redirect a URL to itself."
- [ ] Enter a full URL in the source field (e.g. `https://example.com/foo`) and confirm it is rejected with a message to enter the path only.
- [ ] Create a redirect `/a → /b`, then attempt `/b → /a` and confirm it is blocked with the redirect-loop message.
- [ ] Attempt to recreate a redirect for a source that already has a live redirect and confirm it is blocked with "This page is already being redirected."
- [ ] Enter a destination pointing to an internal path that does not exist (or exists but is unpublished), blur the field, and confirm a non-blocking warning infobox appears under the destination — and that creation is still allowed.
- [ ] Enter a destination that is itself the source of another redirect, blur, and confirm the "this page already redirects to …" warning appears.
- [ ] Confirm a valid, real, published internal destination (and a valid `https://` external destination) shows no warnings and creates successfully, publishing immediately.
