### PR TITLE
refactor(publishing): migrate types off ~generated to @isomer/db + mapping seam

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1508,12 +1508,18 @@ importers:
       '@isomer/db':
         specifier: workspace:*
         version: link:../../../../packages/db
+      '@opengovsg/isomer-components':
+        specifier: workspace:*
+        version: link:../../../../packages/components
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.3
       '@types/pg':
         specifier: 'catalog:'
         version: 8.20.0
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260608.1
       testcontainers:
         specifier: 'catalog:'
         version: 12.0.1

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -3,10 +3,16 @@ import * as fs from "fs"
 import * as path from "path"
 import { performance } from "perf_hooks"
 import { Client } from "pg"
-import { ResourceType } from "~generated/generatedEnums"
+
+import { ResourceType } from "@isomer/db"
 
 import type { PageResourceType } from "./constants"
-import type { PageOnlySitemapEntry, Resource, SitemapEntry } from "./types"
+import type {
+  PageOnlySitemapEntry,
+  Resource,
+  ResourceRow,
+  SitemapEntry,
+} from "./types"
 import { FOLDER_RESOURCE_TYPES, PAGE_RESOURCE_TYPES } from "./constants"
 import {
   GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
@@ -15,6 +21,7 @@ import {
   GET_NAVBAR,
   GET_REDIRECTS,
 } from "./queries"
+import { toResource } from "./types"
 import {
   getCollectionIndexPageContents,
   getFolderIndexPageContents,
@@ -429,11 +436,18 @@ async function processDanglingDirectories(
       ...collections.map(({ id, title, permalink }) => {
         const meta = resources.find(
           ({ type, parentId }) =>
+            // LATENT BUG, preserved deliberately (plan decision 6): `parentId`
+            // is honestly a string but is compared to `Number(id)`, so this is
+            // always false and CollectionMeta `variant` is never resolved here.
+            // The fix is its own PR with its own test-expectation change; do NOT
+            // coerce `parentId` or change `Number(id)`. The runtime expression
+            // is byte-identical to main; only the type-error is suppressed.
+            // @ts-expect-error string === number comparison is always false (see above)
             parentId === Number(id) && type === "CollectionMeta",
         )
         const content = getCollectionIndexPageContents(
           title,
-          meta?.content.variant,
+          meta?.content?.variant,
         )
         return { title, permalink, content }
       }),
@@ -453,12 +467,13 @@ async function getAllResourcesWithFullPermalinks(
   const values = [SITE_ID]
 
   try {
-    const res = await client.query(
+    const res = await client.query<ResourceRow>(
       GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
       values,
     )
     logDebug("Fetched resources with full permalinks:", res.rows)
-    return res.rows
+    // The seam: adapt honestly-typed raw rows to the script's working shape.
+    return res.rows.map(toResource)
   } catch (err) {
     console.error("Error fetching resources:", err)
     return []
@@ -468,7 +483,10 @@ async function getAllResourcesWithFullPermalinks(
 function writeContentToFile(
   fullPermalink: string | undefined,
   content: any,
-  parentId: number | null,
+  // NOTE: callers pass either a resource's honest string `parentId` or the
+  // numeric DANGLING_DIRECTORY_PAGE_ID sentinel; only the `=== null` branch is
+  // load-bearing, so the value's runtime type is otherwise irrelevant.
+  parentId: string | number | null,
 ) {
   try {
     // NOTE: do a join with ./ here so that

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test-ci:unit": "vitest run",
     "test:watch": "vitest watch",
+    "typecheck": "tsgo --noEmit",
     "upload-redirects": "tsx uploadRedirects.ts"
   },
   "dependencies": {
@@ -20,8 +21,10 @@
   },
   "devDependencies": {
     "@isomer/db": "workspace:*",
+    "@opengovsg/isomer-components": "workspace:*",
     "@types/node": "catalog:",
     "@types/pg": "catalog:",
+    "@typescript/native-preview": "catalog:",
     "testcontainers": "catalog:",
     "vitest": "catalog:vitest"
   }

--- a/tooling/build/scripts/publishing/tsconfig.json
+++ b/tooling/build/scripts/publishing/tsconfig.json
@@ -15,12 +15,25 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
     "paths": {
-      // NOTE: generated Kysely types moved from apps/studio/prisma/generated
-      // to @isomer/db (packages/db/src/generated). This works because we
-      // clone our repo as a whole.
-      "~generated/*": ["../../../../packages/db/src/generated/*"],
-      // Respect the package's default export and use only index
-      "~schema": ["../../../../packages/components/src/index.ts"]
+      // Resolve against the package's built type declarations (turbo's
+      // `typecheck` task `dependsOn: ["^build"]`, so components is built
+      // first). Pointing at `src` would pull the whole components source tree
+      // into this typecheck, which relies on components-internal `~/*` aliases
+      // we don't (and shouldn't) define here.
+      "~schema": ["../../../../packages/components/dist/esm/index.d.ts"]
     }
-  }
+  },
+  "include": [
+    "**/*.ts",
+    // Register @isomer/db's ambient `PrismaJson` global so its generated
+    // Kysely types (consumed via the source `@isomer/db` export) typecheck.
+    "../../../../packages/db/src/prisma-json-types.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    // The e2e suite (#2425) runs under vitest (ESM) and uses `import.meta`,
+    // which conflicts with this package's CommonJS `index.ts` (`__dirname`).
+    // Production source is what this `tsgo` gate guards.
+    "tests"
+  ]
 }

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -1,14 +1,92 @@
-import type { Resource as DbResource } from "~generated/selectableTypes"
+import type {
+  CollectionPagePageProps as SchemaCollectionPagePageProps,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
+
+import type { Resource as DbResource } from "@isomer/db"
 
 import type { PAGE_RESOURCE_TYPES } from "./constants"
 
-// NOTE: this needs the `omit` because the `parentId`
-// we defined in studio
-export interface Resource extends Omit<DbResource, "parentId"> {
-  parentId: number | null
-  content?: any
+// NOTE: The recursive CTE (GET_ALL_RESOURCES_WITH_FULL_PERMALINKS) projects a
+// subset of the Resource columns, joins the published Blob's JSONB `content`,
+// and synthesises `fullPermalink`. We type that raw row honestly here: `id` and
+// `parentId` are strings (Postgres `text`/`uuid`), and `content` is the page's
+// `IsomerSchema` (or NULL for folders / unpublished resources). See plan
+// decision 6 (mapping seam) and decision 7 (content as IsomerSchema).
+export interface ResourceRow extends Pick<
+  DbResource,
+  "id" | "title" | "permalink" | "type" | "publishedVersionId" | "updatedAt"
+> {
+  parentId: string | null
+  content: IsomerSchema | null
   fullPermalink: string
 }
+
+// NOTE: `IsomerSchema["page"]` is a layout-discriminated union and the script
+// reads fields opportunistically across variants (e.g. the summary fallback
+// chain, collection page props, the `order` of a FolderMeta/CollectionMeta).
+// Rather than per-site casts or `any`, we expose a single "page read-model"
+// projection: every field the script reads, as optional. This is the union of
+// the reachable read fields, surfaced through the adapter (decision 7, option
+// 2). Strict per-layout narrowing is deferred to a later PR.
+interface PageReadModel {
+  layout?: string
+  title?: string
+  // FolderMeta / CollectionMeta carry these, not real page schemas
+  order?: string[]
+  variant?: SchemaCollectionPagePageProps["variant"]
+  // The page's content block array. `childrenPagesOrdering` is read off the
+  // `childrenpages` block (generateSitemapTree); `src`/`alt` are read off the
+  // first `image` block (getResourceFirstImage).
+  content?: {
+    type: string
+    childrenPagesOrdering?: string[]
+    src?: string
+    alt?: string
+  }[]
+  page?: {
+    title?: string
+    subtitle?: string
+    description?: string
+    category?: string
+    date?: string
+    ref?: string
+    image?: {
+      src?: string
+      alt?: string
+    }
+    contentPageHeader?: {
+      summary?: string | string[]
+    }
+    articlePageHeader?: {
+      summary?: string
+    }
+    tags?: Tag[]
+    tagged?: Tagged[]
+    tagCategories?: TagCategory[]
+    sortOrder?: string
+    defaultSortBy?: string
+    defaultSortDirection?: string
+    showThumbnail?: boolean
+  }
+  // Read by getResourceFirstImage
+  // (the `content` array entries used to surface the first image component)
+}
+
+// The script's working shape. `content` is the page read-model projection so
+// the union-spanning reads in index.ts type-check without casts.
+export interface Resource extends Omit<ResourceRow, "content"> {
+  content?: PageReadModel
+}
+
+// THE SEAM (plan decision 6): the single, explicit adapter from an honestly
+// typed raw query row to the script's working `Resource`. Runtime behaviour is
+// a pass-through — this only reconciles the boundary type (`IsomerSchema`) with
+// the script's read-model projection.
+export const toResource = (row: ResourceRow): Resource => ({
+  ...row,
+  content: (row.content ?? undefined) as PageReadModel | undefined,
+})
 
 interface Tag {
   selected: string[]
@@ -29,6 +107,8 @@ interface CollectionPagePageProps {
   defaultSortDirection?: string
   sortOrder?: string
   tagCategories?: TagCategory[]
+  showThumbnail?: boolean
+  variant?: string
 }
 
 export type SitemapEntry = Pick<


### PR DESCRIPTION
## Problem

`tooling/build/scripts/publishing` reaches DB types through a `~generated/*` tsconfig alias (a leftover from before the `@isomer/db` extraction) and carries a local `Resource` type that lies about its columns (`parentId: number | null`, `content?: any`). Before migrating its queries onto Kysely, the types should come from `@isomer/db` and reflect reality.

This is the types step (5c) of the publishing migration stack. It stacks on #2426 (`@isomer/db/testing` helper) and is verified against the e2e suite that landed on main in #2425.

Closes N/A (internal refactor)

## Solution

Types only — **runtime behaviour is byte-for-byte identical** (queries still execute via raw `pg.Client`; Kysely execution comes in a later PR).

- Migrated `~generated/*` imports → `@isomer/db` across the publishing package and dropped the `~generated/*` alias from its `tsconfig.json`.
- Introduced an explicit **mapping seam** (`toResource`): honest query-row types at the boundary (`id: string`, `parentId: string | null`, `content: IsomerSchema | null`) adapted to the script's working `Resource`. Removed the `parentId: number | null` lie → honest `string | null`.
- Typed the Blob `content` as `IsomerSchema` (from `@opengovsg/isomer-components`) and reconciled the script's union-spanning page reads via a single "page read-model" projection in the seam — no per-site casts, no `any`.

**Breaking Changes**

- [ ] Yes
- [x] No - backwards compatible (no runtime change)

**Improvements**:

- `@isomer/db` is the single import source for the publishing script's DB types; the `~generated/*` alias is gone.
- Query-result types are honest; the blob content is typed against the real `IsomerSchema`.

**Bug Fixes**:

- None. A pre-existing latent quirk (`parentId === Number(id)` in the dangling-`CollectionMeta` lookup — always false because `parentId` is a string) is **preserved deliberately** with a documented `@ts-expect-error`; #2425's e2e test locks the current output. The fix is tracked separately (plan decision 6).

## Tests

**Manual Verification Steps**:

- [ ] `pnpm --filter publishing typecheck` passes (only one documented line-445 suppression)
- [ ] `pnpm --filter publishing test` — #2425's e2e suite (17 tests) green with **unchanged** expectations (the behaviour-preservation proof)
- [ ] `pnpm --filter isomer-studio test:unit` still 1258 / 41 / 0 (5a sits underneath)
- [ ] `tsx index.ts` still reaches `main()` (fails only at DB connect with prod env unset)

**New dev dependencies**:

- `@opengovsg/isomer-components: workspace:*` — type-only (`IsomerSchema`, `~schema`); declared so turbo builds it before publishing typechecks
