### PR TITLE
fix(components): filter CKAN internal columns from DGS searchable table

### DIFF
--- a/packages/components/src/templates/next/components/internal/SearchableTable/DGS/DynamicDGSSearchableTable.tsx
+++ b/packages/components/src/templates/next/components/internal/SearchableTable/DGS/DynamicDGSSearchableTable.tsx
@@ -8,6 +8,7 @@ import type {
 import { useMemo, useState } from "react"
 import { useDebounce } from "~/hooks/useDebounce"
 import { useDgsData } from "~/hooks/useDgsData"
+import { isCkanInternalColumn } from "~/utils/dgs"
 
 import { PAGINATION_MAX_ITEMS } from "../shared/constants"
 import { SearchableTableClientUI } from "../shared/SearchableTableClientUI"
@@ -63,7 +64,12 @@ export const DynamicDGSSearchableTable = ({
     fetchAll: false,
   })
 
-  const items = records?.map((record) => Object.values(record)) ?? []
+  const items =
+    records?.map((record) =>
+      Object.entries(record)
+        .filter(([key]) => !isCkanInternalColumn(key))
+        .map(([, value]) => value),
+    ) ?? []
 
   const isInitiallyEmpty =
     typeof total === "number" && (total === 0 || maxNoOfColumns === 0)

--- a/packages/components/src/utils/dgs/__tests__/isCkanInternalColumn.test.ts
+++ b/packages/components/src/utils/dgs/__tests__/isCkanInternalColumn.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { isCkanInternalColumn } from "../isCkanInternalColumn"
+
+describe("isCkanInternalColumn", () => {
+  it("should return true for _id", () => {
+    expect(isCkanInternalColumn("_id")).toBe(true)
+  })
+
+  it("should return true for _full_text", () => {
+    expect(isCkanInternalColumn("_full_text")).toBe(true)
+  })
+
+  it("should return false for regular column names", () => {
+    expect(isCkanInternalColumn("employment_rate")).toBe(false)
+    expect(isCkanInternalColumn("year")).toBe(false)
+    expect(isCkanInternalColumn("value")).toBe(false)
+  })
+
+  it("should return false for partial matches", () => {
+    expect(isCkanInternalColumn("_id_extra")).toBe(false)
+    expect(isCkanInternalColumn("my_id")).toBe(false)
+    expect(isCkanInternalColumn("full_text")).toBe(false)
+  })
+
+  it("should be case-sensitive", () => {
+    expect(isCkanInternalColumn("_ID")).toBe(false)
+    expect(isCkanInternalColumn("_Full_Text")).toBe(false)
+  })
+})

--- a/packages/components/src/utils/dgs/fetchDgsMetadata.ts
+++ b/packages/components/src/utils/dgs/fetchDgsMetadata.ts
@@ -64,15 +64,23 @@ const extractColumnMetadata = (
   data: FetchDgsMetadataResponse,
 ): FetchDgsMetadataOutput["columnMetadata"] => {
   try {
-    return Object.values(data.data.columnMetadata.metaMapping)
-      .sort((a, b) => Number(a.index) - Number(b.index))
-      .reduce<NonNullable<FetchDgsMetadataOutput["columnMetadata"]>>(
-        (acc, mapping) => {
-          acc.push([mapping.name, mapping.columnTitle])
-          return acc
-        },
-        [],
-      )
+    return (
+      Object.values(data.data.columnMetadata.metaMapping)
+        // CKAN datastore auto-generates _id (row counter) and _full_text
+        // (PostgreSQL tsvector for full-text search) on every dataset — they are
+        // never part of the source data and should not be shown as columns.
+        .filter(
+          (mapping) => mapping.name !== "_id" && mapping.name !== "_full_text",
+        )
+        .sort((a, b) => Number(a.index) - Number(b.index))
+        .reduce<NonNullable<FetchDgsMetadataOutput["columnMetadata"]>>(
+          (acc, mapping) => {
+            acc.push([mapping.name, mapping.columnTitle])
+            return acc
+          },
+          [],
+        )
+    )
   } catch {
     return undefined
   }

--- a/packages/components/src/utils/dgs/fetchDgsMetadata.ts
+++ b/packages/components/src/utils/dgs/fetchDgsMetadata.ts
@@ -1,3 +1,5 @@
+import { isCkanInternalColumn } from "./isCkanInternalColumn"
+
 interface FetchDgsMetadataProps {
   resourceId: string
 }
@@ -64,23 +66,16 @@ const extractColumnMetadata = (
   data: FetchDgsMetadataResponse,
 ): FetchDgsMetadataOutput["columnMetadata"] => {
   try {
-    return (
-      Object.values(data.data.columnMetadata.metaMapping)
-        // CKAN datastore auto-generates _id (row counter) and _full_text
-        // (PostgreSQL tsvector for full-text search) on every dataset — they are
-        // never part of the source data and should not be shown as columns.
-        .filter(
-          (mapping) => mapping.name !== "_id" && mapping.name !== "_full_text",
-        )
-        .sort((a, b) => Number(a.index) - Number(b.index))
-        .reduce<NonNullable<FetchDgsMetadataOutput["columnMetadata"]>>(
-          (acc, mapping) => {
-            acc.push([mapping.name, mapping.columnTitle])
-            return acc
-          },
-          [],
-        )
-    )
+    return Object.values(data.data.columnMetadata.metaMapping)
+      .filter((mapping) => !isCkanInternalColumn(mapping.name))
+      .sort((a, b) => Number(a.index) - Number(b.index))
+      .reduce<NonNullable<FetchDgsMetadataOutput["columnMetadata"]>>(
+        (acc, mapping) => {
+          acc.push([mapping.name, mapping.columnTitle])
+          return acc
+        },
+        [],
+      )
   } catch {
     return undefined
   }

--- a/packages/components/src/utils/dgs/index.ts
+++ b/packages/components/src/utils/dgs/index.ts
@@ -1,4 +1,5 @@
 export { getDgsIdFromDgsLink } from "./getDgsIdFromDgsLink"
 export { fetchDgsMetadata } from "./fetchDgsMetadata"
 export { fetchDgsFileDownloadUrl } from "./fetchDgsFileDownloadUrl"
+export { isCkanInternalColumn } from "./isCkanInternalColumn"
 export { DGS_REQUEST_MAX_BYTES } from "./constants"

--- a/packages/components/src/utils/dgs/isCkanInternalColumn.ts
+++ b/packages/components/src/utils/dgs/isCkanInternalColumn.ts
@@ -1,0 +1,6 @@
+// CKAN datastore auto-generates these columns on every dataset:
+// - _id: integer row counter added by CKAN, not part of the source data
+// - _full_text: PostgreSQL tsvector used for full-text search, not part of the source data
+// Neither should be shown to users.
+export const isCkanInternalColumn = (columnName: string): boolean =>
+  columnName === "_id" || columnName === "_full_text"


### PR DESCRIPTION
## Summary

- CKAN datastore auto-generates `_id` (row counter) and `_full_text` (PostgreSQL tsvector) on every dataset ingested into data.gov.sg
- These were being included in `extractColumnMetadata`, causing `_id` to appear as the first column header (it always has `index: "0"`)
- This also shifted user columns out of their expected positions when `MAX_NUMBER_OF_COLUMNS` trimming was in play

## Test plan

- [ ] Verify a DGS searchable table using dataset `d_21359ecc93954aea7b8c0d48157b11d9` — first column should now show `Course_Id` instead of `_id`
- [ ] Check that column count matches the number of user-defined columns in the source dataset (no phantom `_id` column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)