### PR TITLE
Add support for rendering Facebook Reels in portrait aspect ratio

### DIFF
--- a/packages/components/src/templates/next/components/complex/Video/Video.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Video/Video.stories.tsx
@@ -53,3 +53,12 @@ export const FacebookVideo: Story = {
     url: "https://www.facebook.com/plugins/video.php?height=314&href=https%3A%2F%2Fwww.facebook.com%2Fworldcitiessummit%2Fvideos%2F696071555825049%2F&show_text=false&width=560&t=0",
   },
 }
+
+// Reels are vertical (9:16) videos and should render in a portrait box that is
+// capped in width, rather than the default 16:9 box (which clips them).
+export const FacebookReel: Story = {
+  args: {
+    title: "Facebook Reel",
+    url: "https://www.facebook.com/plugins/video.php?height=476&href=https%3A%2F%2Fwww.facebook.com%2Freel%2F3028033664054832%2F&show_text=false&width=267&t=0",
+  },
+}

--- a/packages/components/src/templates/next/components/complex/Video/Video.tsx
+++ b/packages/components/src/templates/next/components/complex/Video/Video.tsx
@@ -10,12 +10,13 @@ import {
   getPrivacyEnhancedYouTubeEmbedUrl,
   getVimeoVideoId,
   getYouTubeVideoId,
+  isFacebookReelEmbedUrl,
 } from "./utils"
 
 type ParsedVideo =
   | { type: "youtube"; embedUrl: string; videoId: string }
   | { type: "vimeo"; embedUrl: string; videoId: string }
-  | { type: "facebook"; embedUrl: string }
+  | { type: "facebook"; embedUrl: string; isReel: boolean }
 
 /**
  * Parses a video URL and returns the video type plus the privacy-enhanced embed URL (or videoId for YouTube).
@@ -39,23 +40,31 @@ const parseVideo = (url: string): ParsedVideo | null => {
       videoId: getVimeoVideoId(url) ?? "",
     }
   } else if (VALID_VIDEO_DOMAINS.fbvideo.includes(urlObject.hostname)) {
-    return { type: "facebook", embedUrl: url }
+    return {
+      type: "facebook",
+      embedUrl: url,
+      isReel: isFacebookReelEmbedUrl(url),
+    }
   } else {
     return null
   }
 }
 
 export const Video = ({ title, url, shouldLazyLoad = true }: VideoProps) => {
-  const RenderedVideo = () => {
-    const parsedVideo = parseVideo(url)
-    if (!parsedVideo) return <></>
+  const parsedVideo = parseVideo(url)
+  if (!parsedVideo) return null
 
-    const { type: videoType, embedUrl } = parsedVideo
-    switch (videoType) {
+  // Facebook Reels are vertical (9:16) videos. Rendering them in the default
+  // landscape (16:9) box clips the content, so we use a portrait aspect ratio
+  // and cap the width to keep the embed at a sensible height on wider screens.
+  const isPortrait = parsedVideo.type === "facebook" && parsedVideo.isReel
+
+  const renderVideo = () => {
+    switch (parsedVideo.type) {
       case "youtube":
         return (
           <LiteYouTubeEmbed
-            src={embedUrl}
+            src={parsedVideo.embedUrl}
             videoId={parsedVideo.videoId}
             title={title}
             shouldLazyLoad={shouldLazyLoad}
@@ -64,7 +73,7 @@ export const Video = ({ title, url, shouldLazyLoad = true }: VideoProps) => {
       case "vimeo":
         return (
           <LiteVimeoEmbed
-            src={embedUrl}
+            src={parsedVideo.embedUrl}
             videoId={parsedVideo.videoId}
             title={title}
             shouldLazyLoad={shouldLazyLoad}
@@ -74,7 +83,7 @@ export const Video = ({ title, url, shouldLazyLoad = true }: VideoProps) => {
         // there's no lite facebook embed to copy from
         return (
           <iframe
-            src={embedUrl}
+            src={parsedVideo.embedUrl}
             title={title || "Video player"}
             loading={shouldLazyLoad ? "lazy" : "eager"}
             height="100%"
@@ -86,16 +95,24 @@ export const Video = ({ title, url, shouldLazyLoad = true }: VideoProps) => {
           />
         )
       default:
-        const _exhaustiveCheck: never = videoType
+        const _exhaustiveCheck: never = parsedVideo
         return null
     }
   }
 
   return (
     <section className={`${ComponentContent} mt-7 first:mt-0`}>
-      {/* NOTE: 56.25% is a 16:9 aspect ratio */}
-      <div className="relative w-full overflow-hidden pt-[56.25%]">
-        <RenderedVideo />
+      <div
+        className={isPortrait ? "mx-auto w-full max-w-[20.3125rem]" : "w-full"}
+      >
+        {/* NOTE: 56.25% is a 16:9 (landscape) aspect ratio; 177.78% is a 9:16 (portrait) aspect ratio */}
+        <div
+          className={`relative w-full overflow-hidden ${
+            isPortrait ? "pt-[177.78%]" : "pt-[56.25%]"
+          }`}
+        >
+          {renderVideo()}
+        </div>
       </div>
     </section>
   )

--- a/packages/components/src/templates/next/components/complex/Video/__tests__/utils.test.ts
+++ b/packages/components/src/templates/next/components/complex/Video/__tests__/utils.test.ts
@@ -248,6 +248,18 @@ describe("utils", () => {
       })
     })
 
+    it("should return false for non-embed Facebook URLs even when the href points to a reel", () => {
+      const testCases = [
+        "https://www.facebook.com/?href=https%3A%2F%2Fwww.facebook.com%2Freel%2F123",
+        "https://www.facebook.com/reel/123",
+        "https://www.facebook.com/plugins/post.php?href=https%3A%2F%2Fwww.facebook.com%2Freel%2F123",
+      ]
+
+      testCases.forEach((testCase) => {
+        expect(isFacebookReelEmbedUrl(testCase)).toBe(false)
+      })
+    })
+
     it("should return false when the href param is missing", () => {
       expect(
         isFacebookReelEmbedUrl(

--- a/packages/components/src/templates/next/components/complex/Video/__tests__/utils.test.ts
+++ b/packages/components/src/templates/next/components/complex/Video/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getPrivacyEnhancedYouTubeEmbedUrl,
   getVimeoVideoId,
   getYouTubeVideoId,
+  isFacebookReelEmbedUrl,
 } from "../utils"
 
 describe("utils", () => {
@@ -220,6 +221,57 @@ describe("utils", () => {
 
       testCases.forEach((testCase) => {
         expect(getVimeoVideoId(testCase)).toBeNull()
+      })
+    })
+  })
+
+  describe("isFacebookReelEmbedUrl", () => {
+    it("should return true for Facebook Reel embed URLs", () => {
+      const testCases = [
+        "https://www.facebook.com/plugins/video.php?height=476&href=https%3A%2F%2Fwww.facebook.com%2Freel%2F3028033664054832%2F&show_text=false&width=267&t=0",
+        "https://www.facebook.com/plugins/video.php?href=https%3A%2F%2Fwww.facebook.com%2Freel%2F123",
+      ]
+
+      testCases.forEach((testCase) => {
+        expect(isFacebookReelEmbedUrl(testCase)).toBe(true)
+      })
+    })
+
+    it("should return false for regular Facebook video embed URLs", () => {
+      const testCases = [
+        "https://www.facebook.com/plugins/video.php?height=314&href=https%3A%2F%2Fwww.facebook.com%2Fworldcitiessummit%2Fvideos%2F696071555825049%2F&show_text=false&width=560&t=0",
+        "https://www.facebook.com/plugins/video.php?href=https%3A%2F%2Fwww.facebook.com%2Fwatch%2F%3Fv%3D123",
+      ]
+
+      testCases.forEach((testCase) => {
+        expect(isFacebookReelEmbedUrl(testCase)).toBe(false)
+      })
+    })
+
+    it("should return false when the href param is missing", () => {
+      expect(
+        isFacebookReelEmbedUrl(
+          "https://www.facebook.com/plugins/video.php?show_text=false",
+        ),
+      ).toBe(false)
+    })
+
+    it("should return false for non-Facebook URLs", () => {
+      const testCases = [
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://player.vimeo.com/video/984159615",
+      ]
+
+      testCases.forEach((testCase) => {
+        expect(isFacebookReelEmbedUrl(testCase)).toBe(false)
+      })
+    })
+
+    it("should return false for invalid URLs", () => {
+      const testCases = ["", "not-a-url"]
+
+      testCases.forEach((testCase) => {
+        expect(isFacebookReelEmbedUrl(testCase)).toBe(false)
       })
     })
   })

--- a/packages/components/src/templates/next/components/complex/Video/utils.ts
+++ b/packages/components/src/templates/next/components/complex/Video/utils.ts
@@ -60,6 +60,32 @@ export const getYouTubeVideoId = (url: string): string | null => {
   }
 }
 
+/**
+ * Detects whether a Facebook video embed URL points to a Reel.
+ *
+ * Reels are embedded through the same plugins/video.php endpoint as regular
+ * Facebook videos, with the reel's URL passed in the `href` query param, e.g.
+ * https://www.facebook.com/plugins/video.php?href=https%3A%2F%2Fwww.facebook.com%2Freel%2F123
+ *
+ * Reels are vertical (9:16) videos, so we need to detect them to render them
+ * in a portrait aspect ratio instead of the default 16:9 box (which clips them).
+ */
+export const isFacebookReelEmbedUrl = (url: string): boolean => {
+  try {
+    const urlObject = new URL(url)
+    if (!VALID_VIDEO_DOMAINS.fbvideo.includes(urlObject.hostname)) {
+      return false
+    }
+    const href = urlObject.searchParams.get("href")
+    if (!href) {
+      return false
+    }
+    return new URL(href).pathname.startsWith("/reel/")
+  } catch {
+    return false
+  }
+}
+
 // NOTE: We are setting a do-not-track attribute on Vimeo embeds
 // Ref: https://developer.vimeo.com/api/oembed/videos
 export const getPrivacyEnhancedVimeoEmbedUrl = (url: string): string => {

--- a/packages/components/src/templates/next/components/complex/Video/utils.ts
+++ b/packages/components/src/templates/next/components/complex/Video/utils.ts
@@ -73,7 +73,10 @@ export const getYouTubeVideoId = (url: string): string | null => {
 export const isFacebookReelEmbedUrl = (url: string): boolean => {
   try {
     const urlObject = new URL(url)
-    if (!VALID_VIDEO_DOMAINS.fbvideo.includes(urlObject.hostname)) {
+    if (
+      !VALID_VIDEO_DOMAINS.fbvideo.includes(urlObject.hostname) ||
+      urlObject.pathname !== "/plugins/video.php"
+    ) {
       return false
     }
     const href = urlObject.searchParams.get("href")

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -672,7 +672,7 @@ export const VideoEmbed: Story = {
   name: "VideoEmbed",
   parameters: {
     // Delay the Chromatic snapshot so iframes have time to load and don’t appear as white blocks.
-    chromatic: { delay: 5000 },
+    chromatic: { delay: 10000 },
   },
   args: {
     ...generateArgs({
@@ -680,25 +680,6 @@ export const VideoEmbed: Story = {
         "Showing how video embeds render within an article page layout, including a vertical Facebook Reel.",
     }),
     content: [
-      {
-        type: "prose",
-        content: [
-          {
-            type: "paragraph",
-            content: [
-              {
-                type: "text",
-                text: "A regular 16:9 landscape video renders full width within the article content column.",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: "video",
-        title: "Rick Astley - Never Gonna Give You Up",
-        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-      },
       {
         type: "prose",
         content: [

--- a/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.stories.tsx
@@ -667,3 +667,57 @@ export const OrderedList100Items: Story = {
     ],
   },
 }
+
+export const VideoEmbed: Story = {
+  name: "VideoEmbed",
+  parameters: {
+    // Delay the Chromatic snapshot so iframes have time to load and don’t appear as white blocks.
+    chromatic: { delay: 5000 },
+  },
+  args: {
+    ...generateArgs({
+      summary:
+        "Showing how video embeds render within an article page layout, including a vertical Facebook Reel.",
+    }),
+    content: [
+      {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "A regular 16:9 landscape video renders full width within the article content column.",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "video",
+        title: "Rick Astley - Never Gonna Give You Up",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Facebook Reels are vertical (9:16) videos. They render in a width-capped portrait box, centred within the article content column, so they are not clipped.",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "video",
+        title: "Facebook Reel",
+        url: "https://www.facebook.com/plugins/video.php?height=476&href=https%3A%2F%2Fwww.facebook.com%2Freel%2F3028033664054832%2F&show_text=false&width=267&t=0",
+      },
+    ],
+  },
+}

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -4839,3 +4839,79 @@ export const AudioEmbedStory: Story = {
     ],
   },
 }
+
+export const VideoEmbedStory: Story = {
+  parameters: {
+    // Delay the Chromatic snapshot so iframes have time to load and don’t appear as white blocks.
+    chromatic: {
+      ...withChromaticModes(["mobile", "tablet", "desktop"]),
+      delay: 5000,
+    },
+  },
+  args: {
+    layout: "content",
+    site: generateSiteConfig({}),
+    page: {
+      permalink: "/content",
+      title: "Content page",
+      lastModified: "2024-05-02T14:12:57.160Z",
+      contentPageHeader: {
+        showThumbnail: false,
+        summary:
+          "Showing how different video embeds render within a content page layout, including a vertical Facebook Reel.",
+        buttonLabel: "Submit a proposal",
+        buttonUrl: "/submit-proposal",
+      },
+    },
+    content: [
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: { id: "youtube-video", level: 2 },
+            content: [{ type: "text", text: "Landscape video (YouTube)" }],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "A regular 16:9 landscape video renders full width within the content column.",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "video",
+        title: "Rick Astley - Never Gonna Give You Up",
+        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      },
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: { id: "facebook-reel", level: 2 },
+            content: [{ type: "text", text: "Vertical video (Facebook Reel)" }],
+          },
+          {
+            type: "paragraph",
+            content: [
+              {
+                type: "text",
+                text: "Facebook Reels are vertical (9:16) videos. They render in a width-capped portrait box, centred within the content column, so they are not clipped or blown up to full-page height.",
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "video",
+        title: "Facebook Reel",
+        url: "https://www.facebook.com/plugins/video.php?height=476&href=https%3A%2F%2Fwww.facebook.com%2Freel%2F3028033664054832%2F&show_text=false&width=267&t=0",
+      },
+    ],
+  },
+}

--- a/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.stories.tsx
@@ -4845,7 +4845,7 @@ export const VideoEmbedStory: Story = {
     // Delay the Chromatic snapshot so iframes have time to load and don’t appear as white blocks.
     chromatic: {
       ...withChromaticModes(["mobile", "tablet", "desktop"]),
-      delay: 5000,
+      delay: 10000,
     },
   },
   args: {
@@ -4864,30 +4864,6 @@ export const VideoEmbedStory: Story = {
       },
     },
     content: [
-      {
-        type: "prose",
-        content: [
-          {
-            type: "heading",
-            attrs: { id: "youtube-video", level: 2 },
-            content: [{ type: "text", text: "Landscape video (YouTube)" }],
-          },
-          {
-            type: "paragraph",
-            content: [
-              {
-                type: "text",
-                text: "A regular 16:9 landscape video renders full width within the content column.",
-              },
-            ],
-          },
-        ],
-      },
-      {
-        type: "video",
-        title: "Rick Astley - Never Gonna Give You Up",
-        url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
-      },
       {
         type: "prose",
         content: [


### PR DESCRIPTION
## Problem

Facebook Reels are vertical (9:16) videos, but the Video component was rendering them in the default landscape (16:9) aspect ratio box, which clips the content and makes them unusable.

## Solution

Added detection for Facebook Reel embed URLs and conditional rendering logic to display them in a portrait aspect ratio instead of landscape.

**Features**:

- Added `isFacebookReelEmbedUrl()` utility function that detects whether a Facebook video embed URL points to a Reel by checking if the `href` query parameter contains a `/reel/` path
- Updated `ParsedVideo` type to include an `isReel` boolean flag for Facebook videos
- Modified the Video component to:
  - Detect portrait-oriented videos (Facebook Reels)
  - Apply a 9:16 aspect ratio (177.78% padding) for Reels instead of the default 16:9 (56.25%)
  - Cap the width of portrait videos to 20.3125rem to maintain sensible dimensions on wider screens
- Refactored Video component to move `parseVideo()` call outside the `RenderedVideo` function for cleaner logic flow

**Improvements**:

- Added comprehensive test coverage for `isFacebookReelEmbedUrl()` including valid Reels, regular Facebook videos, missing href params, non-Facebook URLs, and invalid inputs
- Added Storybook story for Facebook Reel to demonstrate the portrait rendering

**Breaking Changes**:

- [ ] No - this PR is backwards compatible

The `ParsedVideo` type change is internal to the component and does not affect the public API.

## Tests

Added comprehensive unit tests in `__tests__/utils.test.ts`:
- Tests for valid Facebook Reel embed URLs (returns true)
- Tests for regular Facebook video URLs (returns false)
- Tests for missing href parameter (returns false)
- Tests for non-Facebook URLs (returns false)
- Tests for invalid URLs (returns false)

All existing tests continue to pass. The new Storybook story (`FacebookReel`) provides visual verification of the portrait aspect ratio rendering.

**Manual Verification Steps**:

- [ ] View the FacebookReel story in Storybook and verify it renders in portrait orientation with appropriate width constraints
- [ ] Verify regular Facebook videos still render in landscape (16:9) aspect ratio
- [ ] Verify YouTube and Vimeo videos are unaffected

https://claude.ai/code/session_01GTTv9LANYopBgYjjkXaLGW