### PR TITLE
refactor(publishing): execute queries via @isomer/db createDb + sql tag

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1495,28 +1495,22 @@ importers:
 
   tooling/build/scripts/publishing:
     dependencies:
+      '@isomer/db':
+        specifier: workspace:*
+        version: link:../../../../packages/db
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
-      pg:
-        specifier: 'catalog:'
-        version: 8.21.0
       tsx:
         specifier: 'catalog:'
         version: 4.22.3
     devDependencies:
-      '@isomer/db':
-        specifier: workspace:*
-        version: link:../../../../packages/db
       '@opengovsg/isomer-components':
         specifier: workspace:*
         version: link:../../../../packages/components
       '@types/node':
         specifier: 'catalog:'
         version: 25.9.3
-      '@types/pg':
-        specifier: 'catalog:'
-        version: 8.20.0
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260608.1

--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -2,9 +2,8 @@ import * as dotenv from "dotenv"
 import * as fs from "fs"
 import * as path from "path"
 import { performance } from "perf_hooks"
-import { Client } from "pg"
 
-import { ResourceType } from "@isomer/db"
+import { createDb, ResourceType, sql } from "@isomer/db"
 
 import type { PageResourceType } from "./constants"
 import type {
@@ -29,6 +28,11 @@ import {
 import { getResourceFirstImage } from "./utils/getResourceFirstImage"
 
 dotenv.config()
+
+// The Kysely instance produced by `@isomer/db`'s `createDb`. Each query is
+// executed through it via the `sql` tag (SQL text is byte-identical to the
+// previous raw-`pg` path; see queries.ts).
+type Db = ReturnType<typeof createDb>
 
 // Env vars
 const DB_USERNAME = process.env.DB_USERNAME
@@ -74,27 +78,25 @@ function logDebug(message: string, ...optionalParams: any[]) {
 }
 
 async function main() {
-  const client = new Client({
-    user: DB_USERNAME,
-    host: DB_HOST,
-    database: DB_NAME,
-    password: decodeURIComponent(DB_PASSWORD ?? ""),
-    port: Number(DB_PORT),
+  // Connection string assembled from the existing discrete env vars (decision
+  // 8). The password is intentionally NOT `decodeURIComponent`-ed: the env
+  // value is already percent-encoded, which is exactly what a URL userinfo
+  // segment wants, and pg's URL parser decodes it.
+  const db = createDb({
+    connectionString: `postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`,
   })
 
   const start = performance.now() // Start profiling
 
   try {
-    await client.connect()
-
     // Fetch and write navbar, footer, and config JSONs
-    await fetchAndWriteSiteData(client)
+    await fetchAndWriteSiteData(db)
 
     // Fetch and write redirects
-    await fetchAndWriteRedirects(client)
+    await fetchAndWriteRedirects(db)
 
     // Fetch all resources and their full permalinks
-    const resources = await getAllResourcesWithFullPermalinks(client)
+    const resources = await getAllResourcesWithFullPermalinks(db)
 
     // Construct an array of sitemap entries
     const sitemapEntries: PageOnlySitemapEntry[] = []
@@ -211,7 +213,8 @@ async function main() {
       console.error(`Error writing sitemap to file:`, error)
     }
   } finally {
-    await client.end()
+    // One-shot script: drain the Kysely pool so the process exits.
+    await db.destroy()
     const end = performance.now() // End profiling
     console.log(`Program completed in ${(end - start) / 1000} seconds`)
   }
@@ -461,19 +464,30 @@ async function processDanglingDirectories(
   )
 }
 
-async function getAllResourcesWithFullPermalinks(
-  client: Client,
-): Promise<Resource[]> {
-  const values = [SITE_ID]
+// Execute a byte-identical SQL string from `queries.ts` through Kysely's `sql`
+// tag, binding `SITE_ID` to the query's `$1` placeholder(s) as a real bound
+// parameter (never string-concatenated). The SQL text in `queries.ts` still
+// contains `$1`; we split on it and interleave the bound `SITE_ID` value so the
+// compiled query carries it as a parameter. Queries that reference `$1` more
+// than once (the recursive CTE) bind `SITE_ID` once per occurrence, which is
+// equivalent for these read-only lookups.
+const runQuery = <Row>(db: Db, query: string) => {
+  const fragments = query.split("$1")
+  return sql<Row>`${sql.join(
+    fragments.map((fragment) => sql.raw(fragment)),
+    sql`${SITE_ID}`,
+  )}`.execute(db)
+}
 
+async function getAllResourcesWithFullPermalinks(db: Db): Promise<Resource[]> {
   try {
-    const res = await client.query<ResourceRow>(
+    const { rows } = await runQuery<ResourceRow>(
+      db,
       GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
-      values,
     )
-    logDebug("Fetched resources with full permalinks:", res.rows)
+    logDebug("Fetched resources with full permalinks:", rows)
     // The seam: adapt honestly-typed raw rows to the script's working shape.
-    return res.rows.map(toResource)
+    return rows.map(toResource)
   } catch (err) {
     console.error("Error fetching resources:", err)
     return []
@@ -531,22 +545,38 @@ function writeContentToFile(
   }
 }
 
-async function fetchAndWriteSiteData(client: Client) {
+interface NavbarRow {
+  content: unknown
+}
+interface FooterRow {
+  content: unknown
+}
+interface ConfigRow {
+  name: string
+  config: Record<string, unknown>
+  theme: Record<string, unknown>
+}
+interface RedirectRow {
+  source: string
+  destination: string
+}
+
+async function fetchAndWriteSiteData(db: Db) {
   try {
     // Fetch navbar.json
-    const navbarResult = await client.query(GET_NAVBAR, [SITE_ID])
+    const navbarResult = await runQuery<NavbarRow>(db, GET_NAVBAR)
     if (navbarResult.rows.length > 0) {
       writeJsonToFile(navbarResult.rows[0].content, "navbar.json")
     }
 
     // Fetch footer.json
-    const footerResult = await client.query(GET_FOOTER, [SITE_ID])
+    const footerResult = await runQuery<FooterRow>(db, GET_FOOTER)
     if (footerResult.rows.length > 0) {
       writeJsonToFile(footerResult.rows[0].content, "footer.json")
     }
 
     // Fetch config.json
-    const configResult = await client.query(GET_CONFIG, [SITE_ID])
+    const configResult = await runQuery<ConfigRow>(db, GET_CONFIG)
     if (configResult.rows.length > 0) {
       const config = {
         site: {
@@ -562,10 +592,10 @@ async function fetchAndWriteSiteData(client: Client) {
   }
 }
 
-async function fetchAndWriteRedirects(client: Client) {
+async function fetchAndWriteRedirects(db: Db) {
   try {
-    const result = await client.query(GET_REDIRECTS, [SITE_ID])
-    const redirects = result.rows as { source: string; destination: string }[]
+    const result = await runQuery<RedirectRow>(db, GET_REDIRECTS)
+    const redirects = result.rows
     const filePath = path.join(OUTPUT_DIR, "redirects.json")
     fs.writeFileSync(filePath, JSON.stringify(redirects), "utf-8")
     logDebug(`Successfully wrote redirects: ${filePath}`)

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -15,15 +15,13 @@
     "upload-redirects": "tsx uploadRedirects.ts"
   },
   "dependencies": {
+    "@isomer/db": "workspace:*",
     "dotenv": "catalog:",
-    "pg": "catalog:",
     "tsx": "catalog:"
   },
   "devDependencies": {
-    "@isomer/db": "workspace:*",
     "@opengovsg/isomer-components": "workspace:*",
     "@types/node": "catalog:",
-    "@types/pg": "catalog:",
     "@typescript/native-preview": "catalog:",
     "testcontainers": "catalog:",
     "vitest": "catalog:vitest"


### PR DESCRIPTION
## Problem

The publishing script connects with a raw `pg.Client` and runs hand-written SQL via `client.query(...)`. Now that the types come from `@isomer/db` (#2467), the *execution* should go through the package's Kysely instance too — without yet changing any SQL.

Step 2 of the publishing migration; stacks on #2467 and is verified against #2425's e2e suite.

Closes N/A (internal refactor)

## Solution

Mechanism swap only — **SQL text is byte-for-byte unchanged; behaviour identical.**

- Replaced the `new pg.Client({...})` construction with `createDb({ connectionString })` from `@isomer/db`. The connection string is assembled from the existing discrete env vars (`postgres://${DB_USERNAME}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`) — the deploy/env contract is unchanged.
- Removed the manual `decodeURIComponent(DB_PASSWORD)`: the env value is already percent-encoded, which is what a URL userinfo segment expects, so pg's URL parser decodes it.
- Every `client.query(SQL, [SITE_ID])` now runs through Kysely's `sql` tag against the `createDb` instance, with `SITE_ID` preserved as a **bound parameter** (not string-concatenated). The five SQL strings in `queries.ts` are untouched.
- One-shot teardown: `await db.destroy()` in `finally` (was `client.end()`), so the Kysely pool drains and the process exits.

**Breaking Changes**

- [ ] Yes
- [x] No - backwards compatible (no runtime change)

**Improvements**:

- Publishing now executes through `@isomer/db`'s Kysely instance; the direct `pg`/`@types/pg` dependency is dropped (`@isomer/db` moves to a runtime dependency).

## Tests

**Manual Verification Steps**:

- [ ] `pnpm --filter publishing typecheck` passes
- [ ] `pnpm --filter publishing test` — #2425's e2e suite (17 tests) green with **unchanged** expectations (behaviour-preservation proof)
- [ ] `git diff` shows `queries.ts` SQL unchanged
- [ ] `pnpm --filter isomer-studio test:unit` still 1258 / 41 / 0

**New dependencies**:

- `@isomer/db` moved devDependency → dependency (runtime `createDb` import); `sql` is re-exported by `@isomer/db`, so no direct `kysely` dep.
- Dropped: `pg`, `@types/pg`.
