### PR TITLE
refactor(publishing): convert simple queries to Kysely builder (CTE stays sql)

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -13,13 +13,7 @@ import type {
   SitemapEntry,
 } from "./types"
 import { FOLDER_RESOURCE_TYPES, PAGE_RESOURCE_TYPES } from "./constants"
-import {
-  GET_ALL_RESOURCES_WITH_FULL_PERMALINKS,
-  GET_CONFIG,
-  GET_FOOTER,
-  GET_NAVBAR,
-  GET_REDIRECTS,
-} from "./queries"
+import { GET_ALL_RESOURCES_WITH_FULL_PERMALINKS } from "./queries"
 import { toResource } from "./types"
 import {
   getCollectionIndexPageContents,
@@ -464,13 +458,14 @@ async function processDanglingDirectories(
   )
 }
 
-// Execute a byte-identical SQL string from `queries.ts` through Kysely's `sql`
-// tag, binding `SITE_ID` to the query's `$1` placeholder(s) as a real bound
+// Execute the recursive-CTE SQL string from `queries.ts` through Kysely's `sql`
+// tag, binding `SITE_ID` to the query's `$1` placeholders as a real bound
 // parameter (never string-concatenated). The SQL text in `queries.ts` still
 // contains `$1`; we split on it and interleave the bound `SITE_ID` value so the
-// compiled query carries it as a parameter. Queries that reference `$1` more
-// than once (the recursive CTE) bind `SITE_ID` once per occurrence, which is
-// equivalent for these read-only lookups.
+// compiled query carries it as a parameter. The CTE references `$1` more than
+// once and binds `SITE_ID` once per occurrence, which is equivalent for this
+// read-only lookup. The four simple queries are now Kysely builder constructs
+// (decision 9); only the CTE remains a typed `sql` template.
 const runQuery = <Row>(db: Db, query: string) => {
   const fragments = query.split("$1")
   return sql<Row>`${sql.join(
@@ -545,44 +540,40 @@ function writeContentToFile(
   }
 }
 
-interface NavbarRow {
-  content: unknown
-}
-interface FooterRow {
-  content: unknown
-}
-interface ConfigRow {
-  name: string
-  config: Record<string, unknown>
-  theme: Record<string, unknown>
-}
-interface RedirectRow {
-  source: string
-  destination: string
-}
-
 async function fetchAndWriteSiteData(db: Db) {
   try {
     // Fetch navbar.json
-    const navbarResult = await runQuery<NavbarRow>(db, GET_NAVBAR)
-    if (navbarResult.rows.length > 0) {
-      writeJsonToFile(navbarResult.rows[0].content, "navbar.json")
+    const navbarRows = await db
+      .selectFrom("Navbar")
+      .select("content")
+      .where("siteId", "=", SITE_ID)
+      .execute()
+    if (navbarRows.length > 0) {
+      writeJsonToFile(navbarRows[0].content, "navbar.json")
     }
 
     // Fetch footer.json
-    const footerResult = await runQuery<FooterRow>(db, GET_FOOTER)
-    if (footerResult.rows.length > 0) {
-      writeJsonToFile(footerResult.rows[0].content, "footer.json")
+    const footerRows = await db
+      .selectFrom("Footer")
+      .select("content")
+      .where("siteId", "=", SITE_ID)
+      .execute()
+    if (footerRows.length > 0) {
+      writeJsonToFile(footerRows[0].content, "footer.json")
     }
 
     // Fetch config.json
-    const configResult = await runQuery<ConfigRow>(db, GET_CONFIG)
-    if (configResult.rows.length > 0) {
+    const configRows = await db
+      .selectFrom("Site")
+      .select(["name", "config", "theme"])
+      .where("id", "=", SITE_ID)
+      .execute()
+    if (configRows.length > 0) {
       const config = {
         site: {
-          ...configResult.rows[0].config,
+          ...configRows[0].config,
         },
-        ...configResult.rows[0].theme,
+        ...configRows[0].theme,
       }
 
       writeJsonToFile(config, "config.json")
@@ -594,8 +585,12 @@ async function fetchAndWriteSiteData(db: Db) {
 
 async function fetchAndWriteRedirects(db: Db) {
   try {
-    const result = await runQuery<RedirectRow>(db, GET_REDIRECTS)
-    const redirects = result.rows
+    const redirects = await db
+      .selectFrom("Redirect")
+      .select(["source", "destination"])
+      .where("siteId", "=", SITE_ID)
+      .where("deletedAt", "is", null)
+      .execute()
     const filePath = path.join(OUTPUT_DIR, "redirects.json")
     fs.writeFileSync(filePath, JSON.stringify(redirects), "utf-8")
     logDebug(`Successfully wrote redirects: ${filePath}`)

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -48,19 +48,3 @@ WITH RECURSIVE "resourcePath" (id, title, permalink, parentId, type, content, "f
 )
 SELECT * FROM "resourcePath";
 `
-
-export const GET_NAVBAR = `
-SELECT content FROM public."Navbar" WHERE "siteId" = $1;
-`
-
-export const GET_FOOTER = `
-SELECT content FROM public."Footer" WHERE "siteId" = $1;
-`
-
-export const GET_CONFIG = `
-SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
-`
-
-export const GET_REDIRECTS = `
-SELECT source, destination FROM public."Redirect" WHERE "siteId" = $1 AND "deletedAt" IS NULL;
-`


### PR DESCRIPTION
## Problem

After #2470 the publishing queries run through Kysely's `sql` tag but are still hand-written SQL strings. The simple single-table lookups can be expressed with the Kysely query builder for type-safety and readability.

Step 3 (final) of the publishing migration; stacks on #2470, verified against #2425's e2e suite.

Closes N/A (internal refactor)

## Solution

Converted the four simple queries to Kysely builder constructs; **behaviour identical**:

- `GET_NAVBAR` / `GET_FOOTER` → `db.selectFrom("Navbar"|"Footer").select("content").where("siteId", "=", SITE_ID)`
- `GET_CONFIG` → `db.selectFrom("Site").select(["name", "config", "theme"]).where("id", "=", SITE_ID)`
- `GET_REDIRECTS` → `db.selectFrom("Redirect").select(["source", "destination"]).where("siteId", "=", SITE_ID).where("deletedAt", "is", null)`

The four raw constants are removed from `queries.ts`. `.execute()` returns rows directly, so the call sites (navbar/footer write, the `{ site: {...config}, ...theme }` config merge, the redirects mapping + empty-array error fallback) were updated accordingly, behaviour-identical.

**The recursive CTE (`GET_ALL_RESOURCES_WITH_FULL_PERMALINKS`) is deliberately left as a typed `sql` template** (plan decision 9): it is load-bearing and historically fragile, and converting it to `withRecursive` buys little while risking semantic drift. It stays byte-identical, executed via the `sql` tag.

Because the rewritten queries' SQL text legitimately changes, equivalence is proven by #2425's e2e suite (rows-in → output-files), not by SQL snapshots — exactly the reason that suite is the gate for this step.

**Breaking Changes**

- [ ] Yes
- [x] No - backwards compatible (no runtime change)

**Improvements**:

- The four simple queries are now type-safe Kysely builder calls checked against the `@isomer/db` schema; only the recursive CTE remains as raw SQL.

## Tests

**Manual Verification Steps**:

- [ ] `pnpm --filter publishing typecheck` passes
- [ ] `pnpm --filter publishing test` — #2425's e2e suite (17 tests) green with **unchanged** expectations (the equivalence proof for the rewritten queries)
- [ ] `pnpm --filter isomer-studio test:unit` still 1258 / 41 / 0

**New dependencies**: none
