### PR TITLE
fix: prevent login response user enumeration

### DIFF
--- a/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
+++ b/apps/studio/src/server/modules/auth/email/__tests__/email.router.test.ts
@@ -5,7 +5,7 @@ import {
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
 import { setupUser, setUpWhitelist } from "tests/integration/helpers/seed"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { env } from "~/env.mjs"
 import * as mailService from "~/features/mail/service"
 import * as growthbookLib from "~/lib/growthbook"
@@ -34,6 +34,10 @@ describe("auth.email", () => {
   })
 
   describe("login", () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
     it("should throw 400 if email is not provided", async () => {
       // Act
       const result = caller.login({ email: "" })
@@ -74,8 +78,26 @@ describe("auth.email", () => {
       expect(result).toEqual(expectedReturn)
     })
 
-    it("should throw 401 if user is deleted", async () => {
+    it("should return email and a prefix without sending an OTP if email is not whitelisted", async () => {
       // Arrange
+      const spy = vi.spyOn(mailLib, "sendMail")
+      const email = "not-whitelisted@open.gov.sg"
+
+      // Act
+      const result = await caller.login({ email })
+
+      // Assert
+      expect(result).toEqual({
+        email,
+        otpPrefix: expect.any(String),
+      })
+      expect(spy).not.toHaveBeenCalled()
+      await expect(prisma.verificationToken.count()).resolves.toBe(0)
+    })
+
+    it("should return email and a prefix without sending an OTP if user is deleted", async () => {
+      // Arrange
+      const spy = vi.spyOn(mailLib, "sendMail")
       await setupUser({
         name: "Deleted",
         userId: "deleted123",
@@ -85,15 +107,15 @@ describe("auth.email", () => {
       })
 
       // Act
-      const result = caller.login({ email: TEST_VALID_EMAIL })
+      const result = await caller.login({ email: TEST_VALID_EMAIL })
 
       // Assert
-      await expect(result).rejects.toThrow(
-        new TRPCError({
-          code: "UNAUTHORIZED",
-          message: "Email address is not whitelisted",
-        }),
-      )
+      expect(result).toEqual({
+        email: TEST_VALID_EMAIL,
+        otpPrefix: expect.any(String),
+      })
+      expect(spy).not.toHaveBeenCalled()
+      await expect(prisma.verificationToken.count()).resolves.toBe(0)
     })
   })
 

--- a/apps/studio/src/server/modules/auth/email/email.router.ts
+++ b/apps/studio/src/server/modules/auth/email/email.router.ts
@@ -32,17 +32,13 @@ export const emailSessionRouter = router({
       const isWhitelisted = await isEmailWhitelisted(email)
       const isDeleted = await isUserDeleted(email)
 
-      // Assert that the user is both whitelisted and not deleted
       if (!isWhitelisted || isDeleted) {
         ctx.logger.warn(
           { email, isDeleted, isWhitelisted },
           "User is not whitelisted or deleted",
         )
 
-        throw new TRPCError({
-          code: "UNAUTHORIZED",
-          message: "Email address is not whitelisted",
-        })
+        return { email, otpPrefix: createVfnPrefix() }
       }
 
       // TODO: instead of storing expires, store issuedAt to calculate when the next otp can be re-issued


### PR DESCRIPTION
## Problem

The email login endpoint returned a differentiated response for valid emails depending on whether the user was whitelisted or deleted. Whitelisted active users received the OTP flow response, while non-whitelisted or deleted users received an `UNAUTHORIZED` error with a whitelist-specific message.

This allowed user enumeration through the login response.

Closes #2353

## Solution

The email login endpoint now returns the same outward success response shape for all syntactically valid emails. For non-whitelisted or deleted users, the server still logs the denied attempt, but it does not send an OTP email and does not create a verification token.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Prevent user enumeration by removing the differentiated `UNAUTHORIZED` login response for non-whitelisted or deleted users.

## Before & After Screenshots

**BEFORE**:

N/A - backend auth response change.

**AFTER**:

N/A - backend auth response change.

## Tests

**Manual Verification Steps**:

- [ ] Navigate to `/sign-in` and submit a whitelisted active email. Verify that the OTP screen is shown and an OTP email is sent.
- [ ] Submit a non-whitelisted valid email. Verify that the OTP screen is shown and no OTP email is sent.
- [ ] Submit a deleted user's valid email. Verify that the OTP screen is shown and no OTP email is sent.
- [ ] Confirm in server logs that both denied attempts log `User is not whitelisted or deleted`.

**Automated tests run**:

- `pnpm test:unit -- src/server/modules/auth/email/__tests__/email.router.test.ts`

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
