### PR TITLE
Preserve input on card variant change

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCombinatorControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCombinatorControl.tsx
@@ -81,14 +81,17 @@ function JsonFormsCombinatorControl({
       handleChange(path, {})
     } else {
       // oxlint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const newData = createDefaultValue(newSchema, rootSchema)
+      const newData = createDefaultValue(newSchema, rootSchema) as Record<
+        string,
+        unknown
+      >
 
       if (newSchema.type === "string") {
         handleChange(path, newSchema.const || "")
       } else {
         handleChange(path, {
           ...newData,
-          ...data,
+          ...(data ?? {}),
           variant: newData.variant,
         })
       }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCombinatorControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCombinatorControl.tsx
@@ -87,8 +87,9 @@ function JsonFormsCombinatorControl({
         handleChange(path, newSchema.const || "")
       } else {
         handleChange(path, {
-          ...data,
           ...newData,
+          ...data,
+          variant: newData.variant,
         })
       }
     }


### PR DESCRIPTION
Trying to use Claude to fix small bugs 👀 

## Problem

When you toggle between Infocards with image and no image, the inputs get flushed. This is annoying when agencies are trying to see what the other variant looks like. 

## Solution

Preserve inputs on variation change.