### PR TITLE
feat(redirect): store internal destinations as page references

### DIFF
--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -21,7 +21,7 @@ const FILE_EXPLORER_DEFAULT_HEIGHT_IN_REM = 17.5
 interface ResourceSelectorProps {
   interactionType: "link" | "move"
   siteId: number
-  onChange: (resourceId: string | null) => void
+  onChange: (resourceId: string | null, fullPermalink: string) => void
   selectedResourceId?: string
   existingResource?: ResourceItemContent
   onlyShowFolders?: boolean
@@ -97,8 +97,8 @@ const SuspensableResourceSelector = ({
     existingResource,
     setResourceStack,
     removeFromStack,
-    onChange: (resourceId: string | null) => {
-      onChange(resourceId)
+    onChange: (resourceId: string | null, fullPermalink: string) => {
+      onChange(resourceId, fullPermalink)
       clearSearchValue()
     },
   })

--- a/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
@@ -16,7 +16,9 @@ interface UseResourceSelectorProps {
   existingResource: ResourceItemContent | undefined
   setResourceStack: (resourceStack: ResourceItemContent[]) => void
   removeFromStack: (numberOfResources: number) => ResourceItemContent[]
-  onChange: (resourceId: string | null) => void
+  // fullPermalink is the selected resource's path (no leading slash), built from
+  // the just-updated stack so it never lags a render behind resourceId.
+  onChange: (resourceId: string | null, fullPermalink: string) => void
 }
 
 export const useResourceSelector = ({
@@ -94,7 +96,10 @@ export const useResourceSelector = ({
     }
 
     const lastChild = lastResourceItemInAncestryStack(updatedStack)
-    onChange(lastChild?.id ?? null)
+    onChange(
+      lastChild?.id ?? null,
+      updatedStack.map((resource) => resource.permalink).join("/"),
+    )
   }, [
     isResourceHighlighted,
     onChange,
@@ -125,7 +130,12 @@ export const useResourceSelector = ({
       }
 
       setResourceStack(resourceItemWithAncestryStack)
-      onChange(lastChild.id)
+      onChange(
+        lastChild.id,
+        resourceItemWithAncestryStack
+          .map((resource) => resource.permalink)
+          .join("/"),
+      )
       setIsResourceHighlighted(true)
     },
     [

--- a/apps/studio/src/features/settings/Redirects/__tests__/utils.test.ts
+++ b/apps/studio/src/features/settings/Redirects/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatAddedAt } from "../utils"
+import { formatAddedAt, isReferenceDestination } from "../utils"
 
 describe("formatAddedAt", () => {
   beforeEach(() => {
@@ -57,5 +57,25 @@ describe("formatAddedAt", () => {
 
     // Act / Assert
     expect(formatAddedAt(date)).toBe("8 Jun 2026")
+  })
+})
+
+describe("isReferenceDestination", () => {
+  it("returns true only for a string that is exactly a reference", () => {
+    expect(isReferenceDestination("[resource:1:2]")).toBe(true)
+  })
+
+  it("returns false for literal paths and external URLs", () => {
+    expect(isReferenceDestination("/about-us")).toBe(false)
+    expect(isReferenceDestination("https://example.gov.sg/page")).toBe(false)
+  })
+
+  it("returns false for a value that merely contains the reference substring", () => {
+    // The shared regex is unanchored; isReferenceDestination must not match a
+    // reference embedded in an external URL or a longer string.
+    expect(
+      isReferenceDestination("https://example.gov.sg/[resource:1:2]"),
+    ).toBe(false)
+    expect(isReferenceDestination("[resource:1:2]/extra")).toBe(false)
   })
 })

--- a/apps/studio/src/features/settings/Redirects/__tests__/utils.test.ts
+++ b/apps/studio/src/features/settings/Redirects/__tests__/utils.test.ts
@@ -1,4 +1,8 @@
-import { formatAddedAt, isReferenceDestination } from "../utils"
+import {
+  formatAddedAt,
+  getDestinationDisplay,
+  isReferenceDestination,
+} from "../utils"
 
 describe("formatAddedAt", () => {
   beforeEach(() => {
@@ -77,5 +81,36 @@ describe("isReferenceDestination", () => {
       isReferenceDestination("https://example.gov.sg/[resource:1:2]"),
     ).toBe(false)
     expect(isReferenceDestination("[resource:1:2]/extra")).toBe(false)
+  })
+})
+
+describe("getDestinationDisplay", () => {
+  it("shows a non-reference destination verbatim", () => {
+    expect(getDestinationDisplay("/about-us", new Map())).toEqual({
+      status: "resolved",
+      label: "/about-us",
+    })
+  })
+
+  it("is resolving until the reference lookup lands", () => {
+    expect(getDestinationDisplay("[resource:1:2]", new Map())).toEqual({
+      status: "resolving",
+    })
+  })
+
+  it("resolves a reference to the page's current permalink", () => {
+    const permalinkByReference = new Map([["[resource:1:2]", "/about/contact"]])
+    expect(
+      getDestinationDisplay("[resource:1:2]", permalinkByReference),
+    ).toEqual({ status: "resolved", label: "/about/contact" })
+  })
+
+  it("flags a reference whose page no longer exists as missing", () => {
+    const permalinkByReference = new Map<string, string | null>([
+      ["[resource:1:2]", null],
+    ])
+    expect(
+      getDestinationDisplay("[resource:1:2]", permalinkByReference),
+    ).toEqual({ status: "missing" })
   })
 })

--- a/apps/studio/src/features/settings/Redirects/api.ts
+++ b/apps/studio/src/features/settings/Redirects/api.ts
@@ -25,6 +25,24 @@ export function useCountRedirects(siteId: number) {
   return { data: data ?? 0, isLoading }
 }
 
+// Resolves stored [resource:...] destinations to the page's current permalink
+// for display. Kept separate from the list query so the read path stays plain;
+// the table calls this once with the references on the visible page.
+export function useResolveRedirectReferences(
+  siteId: number,
+  references: string[],
+) {
+  const { data } = trpc.redirect.resolveReferences.useQuery(
+    { siteId, references },
+    {
+      enabled: references.length > 0,
+      // Keep the previous resolutions visible while a new page loads
+      placeholderData: keepPreviousData,
+    },
+  )
+  return { data: data ?? [] }
+}
+
 // Creating a redirect publishes it to the site immediately. Creating a
 // source that already has a live redirect is rejected with CONFLICT.
 export function useCreateRedirect() {

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -8,6 +8,7 @@ import {
   InputGroup,
   InputLeftAddon,
   Text,
+  useDisclosure,
 } from "@chakra-ui/react"
 import {
   Button,
@@ -16,7 +17,6 @@ import {
   Link,
   useToast,
 } from "@opengovsg/design-system-react"
-import { useState } from "react"
 import { BiLinkAlt, BiPlus, BiRightArrowAlt } from "react-icons/bi"
 import {
   BRIEF_TOAST_SETTINGS,
@@ -48,7 +48,11 @@ export const AddRedirectCard = ({
   })
   const toast = useToast(BRIEF_TOAST_SETTINGS)
   const { mutate: createRedirect, isPending } = useCreateRedirect()
-  const [isPageModalOpen, setIsPageModalOpen] = useState(false)
+  const {
+    isOpen: isPageModalOpen,
+    onOpen: onPageModalOpen,
+    onClose: onPageModalClose,
+  } = useDisclosure()
 
   const [source, destination] = watch(["source", "destination"])
   const isAddDisabled = !source?.trim() || !destination?.trim()
@@ -159,7 +163,7 @@ export const AddRedirectCard = ({
             variant="standalone"
             p="0"
             mt="0.25rem"
-            onClick={() => setIsPageModalOpen(true)}
+            onClick={onPageModalOpen}
           >
             <Icon as={BiLinkAlt} mr="0.25rem" />
             Link to a page
@@ -185,7 +189,7 @@ export const AddRedirectCard = ({
       <SelectDestinationPageModal
         isOpen={isPageModalOpen}
         siteId={siteId}
-        onClose={() => setIsPageModalOpen(false)}
+        onClose={onPageModalClose}
         onSelect={(permalink) =>
           setValue("destination", permalink, {
             shouldValidate: true,

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -13,9 +13,11 @@ import {
   Button,
   FormErrorMessage,
   FormLabel,
+  Link,
   useToast,
 } from "@opengovsg/design-system-react"
-import { BiPlus, BiRightArrowAlt } from "react-icons/bi"
+import { useState } from "react"
+import { BiLinkAlt, BiPlus, BiRightArrowAlt } from "react-icons/bi"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
@@ -24,6 +26,7 @@ import { useZodForm } from "~/lib/form"
 
 import { useCreateRedirect } from "../api"
 import { addRedirectSchema, type AddRedirectInput } from "../types"
+import { SelectDestinationPageModal } from "./SelectDestinationPageModal"
 
 interface AddRedirectCardProps {
   siteId: number
@@ -37,6 +40,7 @@ export const AddRedirectCard = ({
     handleSubmit,
     reset,
     watch,
+    setValue,
     formState: { errors },
   } = useZodForm<typeof addRedirectSchema>({
     schema: addRedirectSchema,
@@ -44,13 +48,15 @@ export const AddRedirectCard = ({
   })
   const toast = useToast(BRIEF_TOAST_SETTINGS)
   const { mutate: createRedirect, isPending } = useCreateRedirect()
+  const [isPageModalOpen, setIsPageModalOpen] = useState(false)
 
   const [source, destination] = watch(["source", "destination"])
   const isAddDisabled = !source?.trim() || !destination?.trim()
 
   const onSubmit = ({ source, destination }: AddRedirectInput) => {
     // source arrives normalised (leading slash, no trailing slash) by the
-    // shared schema's transform
+    // shared schema's transform. An internal-path destination is converted to a
+    // page reference server-side, which 404s if the page doesn't exist.
     createRedirect(
       { siteId, source, destination },
       {
@@ -60,23 +66,34 @@ export const AddRedirectCard = ({
         },
         // The inputs are left untouched on error so the user can adjust
         // the source instead of retyping everything
-        onError: (error) =>
-          toast(
-            error.data?.code === "CONFLICT"
-              ? {
-                  title: "A redirect already exists for this path",
-                  description: `Delete the redirect for ${source} first if you want to change where it points to.`,
-                  status: "error",
-                }
-              : {
-                  title: "Failed to add redirect",
-                  // Surface the server's message (e.g. validation rejections).
-                  // Client-side zod validation catches malformed input before
-                  // submit, so what reaches here is a clean TRPCError message.
-                  description: error.message,
-                  status: "error",
-                },
-          ),
+        onError: (error) => {
+          switch (error.data?.code) {
+            case "CONFLICT":
+              toast({
+                title: "A redirect already exists for this path",
+                description: `Delete the redirect for ${source} first if you want to change where it points to.`,
+                status: "error",
+              })
+              break
+            case "NOT_FOUND":
+              toast({
+                title: "That page doesn't exist",
+                description:
+                  "Check the destination, or pick a page with “Link to a page”.",
+                status: "error",
+              })
+              break
+            default:
+              toast({
+                title: "Failed to add redirect",
+                // Surface the server's message (e.g. validation rejections).
+                // Client-side zod validation catches malformed input before
+                // submit, so what reaches here is a clean TRPCError message.
+                description: error.message,
+                status: "error",
+              })
+          }
+        },
       },
     )
   }
@@ -136,6 +153,17 @@ export const AddRedirectCard = ({
             {...register("destination")}
           />
           <FormErrorMessage>{errors.destination?.message}</FormErrorMessage>
+          <Link
+            as="button"
+            type="button"
+            variant="standalone"
+            p="0"
+            mt="0.25rem"
+            onClick={() => setIsPageModalOpen(true)}
+          >
+            <Icon as={BiLinkAlt} mr="0.25rem" />
+            Link to a page
+          </Link>
         </FormControl>
 
         <Box flexShrink={0}>
@@ -153,6 +181,18 @@ export const AddRedirectCard = ({
           </Button>
         </Box>
       </HStack>
+
+      <SelectDestinationPageModal
+        isOpen={isPageModalOpen}
+        siteId={siteId}
+        onClose={() => setIsPageModalOpen(false)}
+        onSelect={(permalink) =>
+          setValue("destination", permalink, {
+            shouldValidate: true,
+            shouldDirty: true,
+          })
+        }
+      />
     </Box>
   )
 }

--- a/apps/studio/src/features/settings/Redirects/components/DeleteRedirectModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/DeleteRedirectModal.tsx
@@ -15,6 +15,9 @@ import type { RedirectRow } from "../types"
 
 interface DeleteRedirectModalProps {
   redirect: RedirectRow | null
+  // Display label for the destination — a reference is resolved to the page's
+  // permalink upstream so the modal never leaks the raw "[resource:...]" string
+  destinationLabel: string
   isPending: boolean
   onClose: () => void
   onDelete: (redirect: RedirectRow) => void
@@ -22,6 +25,7 @@ interface DeleteRedirectModalProps {
 
 export const DeleteRedirectModal = ({
   redirect,
+  destinationLabel,
   isPending,
   onClose,
   onDelete,
@@ -67,7 +71,7 @@ export const DeleteRedirectModal = ({
                   color="base.content.default"
                   wordBreak="break-all"
                 >
-                  {redirect?.destination}
+                  {destinationLabel}
                 </Text>
               </Stack>
             </HStack>

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -4,6 +4,7 @@ import {
   HStack,
   Icon,
   IconButton,
+  Skeleton,
   Stack,
   Text,
   Tooltip,
@@ -37,11 +38,48 @@ import {
   useCountRedirects,
   useDeleteRedirect,
   useListRedirects,
+  useResolveRedirectReferences,
 } from "../api"
-import { formatAddedAt } from "../utils"
+import {
+  formatAddedAt,
+  getDestinationLabel,
+  isReferenceDestination,
+  MISSING_PAGE_LABEL,
+} from "../utils"
 import { DeleteRedirectModal } from "./DeleteRedirectModal"
 
 const columnsHelper = createColumnHelper<RedirectRow>()
+
+// Renders a redirect destination. Reference destinations are shown as the
+// page's current permalink (resolved server-side); while that resolution is in
+// flight we show a skeleton, and a reference whose page no longer exists is
+// flagged rather than leaking the raw "[resource:...]" string.
+function DestinationCell({
+  destination,
+  permalinkByReference,
+}: {
+  destination: string
+  permalinkByReference: Map<string, string | null>
+}): JSX.Element {
+  const label = getDestinationLabel(destination, permalinkByReference)
+  if (label === null) {
+    return <Skeleton height="1.25rem" width="60%" />
+  }
+
+  const isMissing = label === MISSING_PAGE_LABEL
+  return (
+    <Tooltip label={label} openDelay={500} placement="top">
+      <Text
+        textStyle="body-2"
+        color={isMissing ? "utility.feedback.critical" : "base.content.strong"}
+        noOfLines={1}
+        wordBreak="break-all"
+      >
+        {label}
+      </Text>
+    </Tooltip>
+  )
+}
 
 function SortableHeader({
   label,
@@ -81,7 +119,10 @@ function SortableHeader({
   )
 }
 
-const getColumns = (onDeleteClick: (row: RedirectRow) => void) => [
+const getColumns = (
+  onDeleteClick: (row: RedirectRow) => void,
+  permalinkByReference: Map<string, string | null>,
+) => [
   columnsHelper.accessor("source", {
     minSize: 250,
     enableSorting: true,
@@ -148,16 +189,10 @@ const getColumns = (onDeleteClick: (row: RedirectRow) => void) => [
       />
     ),
     cell: ({ getValue }) => (
-      <Tooltip label={getValue()} openDelay={500} placement="top">
-        <Text
-          textStyle="body-2"
-          color="base.content.strong"
-          noOfLines={1}
-          wordBreak="break-all"
-        >
-          {getValue()}
-        </Text>
-      </Tooltip>
+      <DestinationCell
+        destination={getValue()}
+        permalinkByReference={permalinkByReference}
+      />
     ),
   }),
   columnsHelper.accessor("publishedAt", {
@@ -215,8 +250,6 @@ export const RedirectsTable = ({
     null,
   )
 
-  const columns = useMemo(() => getColumns(setRedirectToDelete), [])
-
   const { data: totalRowCount, isLoading: isCountLoading } =
     useCountRedirects(siteId)
 
@@ -235,6 +268,36 @@ export const RedirectsTable = ({
     sortBy: (sorting[0]?.id ?? "publishedAt") as RedirectSortField,
     sortDirection: (sorting[0]?.desc ?? true) ? "desc" : "asc",
   })
+
+  // Resolve the reference destinations on the visible page to permalinks for
+  // display, in one batched request rather than per row
+  const referenceDestinations = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          redirects
+            .map((redirect) => redirect.destination)
+            .filter(isReferenceDestination),
+        ),
+      ),
+    [redirects],
+  )
+  const { data: resolvedReferences } = useResolveRedirectReferences(
+    siteId,
+    referenceDestinations,
+  )
+  const permalinkByReference = useMemo(() => {
+    const map = new Map<string, string | null>()
+    resolvedReferences.forEach(({ reference, permalink }) =>
+      map.set(reference, permalink),
+    )
+    return map
+  }, [resolvedReferences])
+
+  const columns = useMemo(
+    () => getColumns(setRedirectToDelete, permalinkByReference),
+    [permalinkByReference],
+  )
 
   // Changing the sort order reshuffles rows across pages, so jump back to
   // the first page to avoid showing a stale slice
@@ -300,6 +363,14 @@ export const RedirectsTable = ({
       />
       <DeleteRedirectModal
         redirect={redirectToDelete}
+        destinationLabel={
+          redirectToDelete
+            ? (getDestinationLabel(
+                redirectToDelete.destination,
+                permalinkByReference,
+              ) ?? redirectToDelete.destination)
+            : ""
+        }
         isPending={isPending}
         onClose={() => setRedirectToDelete(null)}
         onDelete={handleDelete}

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -365,10 +365,12 @@ export const RedirectsTable = ({
         redirect={redirectToDelete}
         destinationLabel={
           redirectToDelete
-            ? (getDestinationLabel(
+            ? // Fall back to "" (not the raw destination) while a reference is
+              // still resolving, so the modal never shows the "[resource:...]" token.
+              (getDestinationLabel(
                 redirectToDelete.destination,
                 permalinkByReference,
-              ) ?? redirectToDelete.destination)
+              ) ?? "")
             : ""
         }
         isPending={isPending}

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -33,6 +33,7 @@ import {
 import { useTablePagination } from "~/hooks/useTablePagination"
 
 import type { RedirectRow, RedirectSortField } from "../types"
+import type { DestinationDisplay } from "../utils"
 import {
   REDIRECTS_PAGE_SIZE,
   useCountRedirects,
@@ -42,31 +43,32 @@ import {
 } from "../api"
 import {
   formatAddedAt,
-  getDestinationLabel,
+  getDestinationDisplay,
   isReferenceDestination,
-  MISSING_PAGE_LABEL,
 } from "../utils"
 import { DeleteRedirectModal } from "./DeleteRedirectModal"
 
 const columnsHelper = createColumnHelper<RedirectRow>()
 
-// Renders a redirect destination. Reference destinations are shown as the
-// page's current permalink (resolved server-side); while that resolution is in
-// flight we show a skeleton, and a reference whose page no longer exists is
-// flagged rather than leaking the raw "[resource:...]" string.
+// Copy shown when a reference destination's page has since been deleted. Kept
+// here (the render site) so it can change without touching the resolution logic.
+const MISSING_PAGE_LABEL = "Page no longer exists"
+
+// Renders a pre-resolved redirect destination. Reference destinations arrive as
+// the page's current permalink; while that resolution is in flight we show a
+// skeleton, and a reference whose page no longer exists is flagged rather than
+// leaking the raw "[resource:...]" string.
 function DestinationCell({
-  destination,
-  permalinkByReference,
+  display,
 }: {
-  destination: string
-  permalinkByReference: Map<string, string | null>
+  display: DestinationDisplay
 }): JSX.Element {
-  const label = getDestinationLabel(destination, permalinkByReference)
-  if (label === null) {
+  if (display.status === "resolving") {
     return <Skeleton height="1.25rem" width="60%" />
   }
 
-  const isMissing = label === MISSING_PAGE_LABEL
+  const isMissing = display.status === "missing"
+  const label = isMissing ? MISSING_PAGE_LABEL : display.label
   return (
     <Tooltip label={label} openDelay={500} placement="top">
       <Text
@@ -79,6 +81,20 @@ function DestinationCell({
       </Text>
     </Tooltip>
   )
+}
+
+// Plain-text destination label for contexts without a skeleton (e.g. the delete
+// modal): resolved → permalink/path, missing → the missing-page copy, and still
+// resolving → "" so the raw "[resource:...]" token never shows.
+const destinationLabelFor = (display: DestinationDisplay): string => {
+  switch (display.status) {
+    case "resolving":
+      return ""
+    case "missing":
+      return MISSING_PAGE_LABEL
+    case "resolved":
+      return display.label
+  }
 }
 
 function SortableHeader({
@@ -190,8 +206,7 @@ const getColumns = (
     ),
     cell: ({ getValue }) => (
       <DestinationCell
-        destination={getValue()}
-        permalinkByReference={permalinkByReference}
+        display={getDestinationDisplay(getValue(), permalinkByReference)}
       />
     ),
   }),
@@ -365,12 +380,12 @@ export const RedirectsTable = ({
         redirect={redirectToDelete}
         destinationLabel={
           redirectToDelete
-            ? // Fall back to "" (not the raw destination) while a reference is
-              // still resolving, so the modal never shows the "[resource:...]" token.
-              (getDestinationLabel(
-                redirectToDelete.destination,
-                permalinkByReference,
-              ) ?? "")
+            ? destinationLabelFor(
+                getDestinationDisplay(
+                  redirectToDelete.destination,
+                  permalinkByReference,
+                ),
+              )
             : ""
         }
         isPending={isPending}

--- a/apps/studio/src/features/settings/Redirects/components/SelectDestinationPageModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/SelectDestinationPageModal.tsx
@@ -1,0 +1,105 @@
+import {
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react"
+import {
+  Button,
+  ModalCloseButton,
+  useToast,
+} from "@opengovsg/design-system-react"
+import { useState } from "react"
+import { ResourceSelector } from "~/components/ResourceSelector"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
+import { trpc } from "~/utils/trpc"
+
+interface SelectDestinationPageModalProps {
+  isOpen: boolean
+  siteId: number
+  onClose: () => void
+  // Receives the selected page's current full permalink. The redirect stores
+  // this as a reference server-side, so the permalink is only what we show.
+  onSelect: (permalink: string) => void
+}
+
+export const SelectDestinationPageModal = ({
+  isOpen,
+  siteId,
+  onClose,
+  onSelect,
+}: SelectDestinationPageModalProps): JSX.Element => {
+  const toast = useToast(BRIEF_TOAST_SETTINGS)
+  const utils = trpc.useUtils()
+  const [selectedResourceId, setSelectedResourceId] = useState<string | null>(
+    null,
+  )
+  const [isResolving, setIsResolving] = useState(false)
+
+  const handleClose = () => {
+    setSelectedResourceId(null)
+    onClose()
+  }
+
+  const handleConfirm = async () => {
+    if (!selectedResourceId) return
+    setIsResolving(true)
+    try {
+      // Resolve the picked resource to its current permalink so the user sees a
+      // real path in the input; conversion back to a reference happens on save.
+      const permalink = await utils.page.getFullPermalink.fetch({
+        siteId,
+        pageId: Number(selectedResourceId),
+      })
+      onSelect(permalink)
+      handleClose()
+    } catch {
+      toast({
+        title: "Couldn't select this page",
+        description: "Please try again.",
+        status: "error",
+      })
+    } finally {
+      setIsResolving(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} size="xl">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader mr="3.5rem">Link to a page</ModalHeader>
+        <ModalCloseButton size="lg" />
+
+        <ModalBody>
+          <ResourceSelector
+            interactionType="link"
+            siteId={siteId}
+            onChange={setSelectedResourceId}
+            selectedResourceId={selectedResourceId ?? undefined}
+          />
+        </ModalBody>
+
+        <ModalFooter>
+          <Button
+            variant="clear"
+            colorScheme="neutral"
+            onClick={handleClose}
+            mr="1rem"
+          >
+            Cancel
+          </Button>
+          <Button
+            isDisabled={!selectedResourceId}
+            isLoading={isResolving}
+            onClick={() => void handleConfirm()}
+          >
+            Use this page
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/settings/Redirects/components/SelectDestinationPageModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/SelectDestinationPageModal.tsx
@@ -6,15 +6,9 @@ import {
   ModalHeader,
   ModalOverlay,
 } from "@chakra-ui/react"
-import {
-  Button,
-  ModalCloseButton,
-  useToast,
-} from "@opengovsg/design-system-react"
+import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 import { useState } from "react"
 import { ResourceSelector } from "~/components/ResourceSelector"
-import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
-import { trpc } from "~/utils/trpc"
 
 interface SelectDestinationPageModalProps {
   isOpen: boolean
@@ -31,39 +25,25 @@ export const SelectDestinationPageModal = ({
   onClose,
   onSelect,
 }: SelectDestinationPageModalProps): JSX.Element => {
-  const toast = useToast(BRIEF_TOAST_SETTINGS)
-  const utils = trpc.useUtils()
   const [selectedResourceId, setSelectedResourceId] = useState<string | null>(
     null,
   )
-  const [isResolving, setIsResolving] = useState(false)
+  // ResourceSelector already builds the selected resource's full permalink, so
+  // we read it straight off onChange instead of re-fetching it on confirm.
+  const [selectedPermalink, setSelectedPermalink] = useState("")
 
   const handleClose = () => {
     setSelectedResourceId(null)
+    setSelectedPermalink("")
     onClose()
   }
 
-  const handleConfirm = async () => {
+  const handleConfirm = () => {
     if (!selectedResourceId) return
-    setIsResolving(true)
-    try {
-      // Resolve the picked resource to its current permalink so the user sees a
-      // real path in the input; conversion back to a reference happens on save.
-      const permalink = await utils.page.getFullPermalink.fetch({
-        siteId,
-        pageId: Number(selectedResourceId),
-      })
-      onSelect(permalink)
-      handleClose()
-    } catch {
-      toast({
-        title: "Couldn't select this page",
-        description: "Please try again.",
-        status: "error",
-      })
-    } finally {
-      setIsResolving(false)
-    }
+    // ResourceSelector's permalink has no leading slash; destinations are stored
+    // as rooted paths, and conversion to a reference happens on save.
+    onSelect(`/${selectedPermalink}`)
+    handleClose()
   }
 
   return (
@@ -77,7 +57,10 @@ export const SelectDestinationPageModal = ({
           <ResourceSelector
             interactionType="link"
             siteId={siteId}
-            onChange={setSelectedResourceId}
+            onChange={(resourceId, fullPermalink) => {
+              setSelectedResourceId(resourceId)
+              setSelectedPermalink(fullPermalink)
+            }}
             selectedResourceId={selectedResourceId ?? undefined}
           />
         </ModalBody>
@@ -91,11 +74,7 @@ export const SelectDestinationPageModal = ({
           >
             Cancel
           </Button>
-          <Button
-            isDisabled={!selectedResourceId}
-            isLoading={isResolving}
-            onClick={() => void handleConfirm()}
-          >
+          <Button isDisabled={!selectedResourceId} onClick={handleConfirm}>
             Use this page
           </Button>
         </ModalFooter>

--- a/apps/studio/src/features/settings/Redirects/utils.ts
+++ b/apps/studio/src/features/settings/Redirects/utils.ts
@@ -19,10 +19,8 @@ export const isReferenceDestination = (destination: string): boolean =>
   REFERENCE_LINK_REGEX.test(destination)
 
 // Turns a stored destination into a user-facing label: a reference becomes the
-// page's current permalink (resolved server-side), or MISSING_PAGE_LABEL;
-// non-references are shown verbatim. Returns null while a reference is still
-// resolving so the caller can show a loading state instead of the raw
-// "[resource:...]" string.
+// resolved permalink (or MISSING_PAGE_LABEL); non-references show verbatim.
+// Returns null while a reference is still resolving (caller shows a loader).
 export const getDestinationLabel = (
   destination: string,
   permalinkByReference: Map<string, string | null>,

--- a/apps/studio/src/features/settings/Redirects/utils.ts
+++ b/apps/studio/src/features/settings/Redirects/utils.ts
@@ -14,9 +14,14 @@ export const formatAddedAt = (date: Date): string => {
 export const MISSING_PAGE_LABEL = "Page no longer exists"
 
 // Internal-page destinations are stored as "[resource:siteId:resourceId]"
-// references; literal paths and external URLs are not.
+// references; literal paths and external URLs are not. Anchored (the shared
+// REFERENCE_LINK_REGEX is not) so a destination only counts as a reference when
+// it is exactly one — an external URL merely containing the substring doesn't.
+const REFERENCE_DESTINATION_REGEX = new RegExp(
+  `^${REFERENCE_LINK_REGEX.source}$`,
+)
 export const isReferenceDestination = (destination: string): boolean =>
-  REFERENCE_LINK_REGEX.test(destination)
+  REFERENCE_DESTINATION_REGEX.test(destination)
 
 // Turns a stored destination into a user-facing label: a reference becomes the
 // resolved permalink (or MISSING_PAGE_LABEL); non-references show verbatim.

--- a/apps/studio/src/features/settings/Redirects/utils.ts
+++ b/apps/studio/src/features/settings/Redirects/utils.ts
@@ -1,3 +1,4 @@
+import { REFERENCE_LINK_REGEX } from "@opengovsg/isomer-components"
 import { differenceInMinutes, format, isToday, isYesterday } from "date-fns"
 
 // Coarse relative time for the "Added" column, matching the design:
@@ -7,4 +8,30 @@ export const formatAddedAt = (date: Date): string => {
   if (isToday(date)) return "today"
   if (isYesterday(date)) return "yesterday"
   return format(date, "d MMM yyyy")
+}
+
+// Shown in place of a reference destination whose page has since been deleted.
+export const MISSING_PAGE_LABEL = "Page no longer exists"
+
+// Internal-page destinations are stored as "[resource:siteId:resourceId]"
+// references; literal paths and external URLs are not.
+export const isReferenceDestination = (destination: string): boolean =>
+  REFERENCE_LINK_REGEX.test(destination)
+
+// Turns a stored destination into a user-facing label: a reference becomes the
+// page's current permalink (resolved server-side), or MISSING_PAGE_LABEL;
+// non-references are shown verbatim. Returns null while a reference is still
+// resolving so the caller can show a loading state instead of the raw
+// "[resource:...]" string.
+export const getDestinationLabel = (
+  destination: string,
+  permalinkByReference: Map<string, string | null>,
+): string | null => {
+  if (!isReferenceDestination(destination)) {
+    return destination
+  }
+  if (!permalinkByReference.has(destination)) {
+    return null
+  }
+  return permalinkByReference.get(destination) ?? MISSING_PAGE_LABEL
 }

--- a/apps/studio/src/features/settings/Redirects/utils.ts
+++ b/apps/studio/src/features/settings/Redirects/utils.ts
@@ -10,9 +10,6 @@ export const formatAddedAt = (date: Date): string => {
   return format(date, "d MMM yyyy")
 }
 
-// Shown in place of a reference destination whose page has since been deleted.
-export const MISSING_PAGE_LABEL = "Page no longer exists"
-
 // Internal-page destinations are stored as "[resource:siteId:resourceId]"
 // references; literal paths and external URLs are not. Anchored (the shared
 // REFERENCE_LINK_REGEX is not) so a destination only counts as a reference when
@@ -23,18 +20,29 @@ const REFERENCE_DESTINATION_REGEX = new RegExp(
 export const isReferenceDestination = (destination: string): boolean =>
   REFERENCE_DESTINATION_REGEX.test(destination)
 
-// Turns a stored destination into a user-facing label: a reference becomes the
-// resolved permalink (or MISSING_PAGE_LABEL); non-references show verbatim.
-// Returns null while a reference is still resolving (caller shows a loader).
-export const getDestinationLabel = (
+// Resolution state of a stored destination for display. The status is a stable
+// sentinel — user-facing copy for the "missing" case lives at the render site,
+// so the wording can change without touching this logic.
+export type DestinationDisplay =
+  | { status: "resolving" }
+  | { status: "missing" }
+  | { status: "resolved"; label: string }
+
+// Maps a stored destination to its display state: a reference resolves to the
+// page's current permalink (or "missing" once we know the page is gone), and is
+// "resolving" until the lookup lands; non-references show verbatim.
+export const getDestinationDisplay = (
   destination: string,
   permalinkByReference: Map<string, string | null>,
-): string | null => {
+): DestinationDisplay => {
   if (!isReferenceDestination(destination)) {
-    return destination
+    return { status: "resolved", label: destination }
   }
   if (!permalinkByReference.has(destination)) {
-    return null
+    return { status: "resolving" }
   }
-  return permalinkByReference.get(destination) ?? MISSING_PAGE_LABEL
+  const permalink = permalinkByReference.get(destination) ?? null
+  return permalink === null
+    ? { status: "missing" }
+    : { status: "resolved", label: permalink }
 }

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -134,6 +134,19 @@ describe("createRedirectSchema", () => {
       expect(result.success).toBe(true)
     })
 
+    it("should accept an internal page reference as the destination", () => {
+      // Arrange / Act
+      // A destination may already be a [resource:...] reference (the form the
+      // service stores internal paths as)
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: "[resource:1:2]",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
     it("should reject destinations with other prefixes", () => {
       // Arrange
       const invalidDestinations = [

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -188,5 +188,40 @@ describe("createRedirectSchema", () => {
       // Assert
       expect(result.destination).toBe("https://www.example.gov.sg/a//b")
     })
+
+    it("should allow a query string on an internal path", () => {
+      // Arrange / Act: a "?suffix" can't map to one resource, so it stays a
+      // literal path rather than being converted to a reference.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: "/search?q=tax",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject an internal path that links to an on-page anchor", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: "/page#section",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+
+    it("should allow a #fragment on an external https URL", () => {
+      // Arrange / Act: fragments are legitimate on external destinations; only
+      // internal-path anchors are unsupported.
+      const result = createRedirectSchema.safeParse({
+        ...VALID_REDIRECT,
+        destination: "https://www.example.gov.sg/page#section",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
   })
 })

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -5,6 +5,10 @@ import { offsetPaginationSchema } from "./pagination"
 
 export const MAX_REDIRECT_PATH_LENGTH = 2000
 
+// Caps how many references one resolve request can turn back into permalinks.
+// The table sends one page's worth, so this is a generous upper bound.
+export const MAX_REDIRECT_REFERENCES = 100
+
 // Caps the list page size — the shared offset-pagination schema is unbounded,
 // and this input is the trust boundary. The UI requests 25.
 export const MAX_REDIRECT_PAGE_SIZE = 100
@@ -13,6 +17,16 @@ export const MAX_REDIRECT_PAGE_SIZE = 100
 // and "%". Whitelisting keeps anything that could corrupt the published rules
 // (spaces, control chars, "?", "#", "\\", non-ASCII) out up front.
 const SOURCE_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@%/]+$/
+
+// Matches ASCII control characters (0x00-0x1f, 0x7f) and backslashes. These are
+// never valid in a destination and can corrupt the generated redirect rules on
+// the published site. (Source paths use the stricter whitelist above instead.)
+const INVALID_PATH_CHARS_REGEX = /[\x00-\x1f\x7f\\]/
+
+// Anchored form of the [resource:siteId:resourceId] reference. Internal-page
+// destinations are stored in this form (converted from a path on create, see
+// redirect.service) so the redirect follows the page if its permalink changes.
+const REFERENCE_DESTINATION_REGEX = /^\[resource:\d+:\d+\]$/
 
 // Strips slashes from both ends of a path so "/foo/", "foo" and "foo//"
 // all normalise to the same inner segments before validation.
@@ -40,11 +54,20 @@ const destinationSchema = z
   .string()
   .min(1, { message: "Destination is required" })
   .max(MAX_REDIRECT_PATH_LENGTH, { message: "Destination is too long" })
-  // Same-site path ("/...") or external https URL; anything else (http://,
-  // javascript:, ...) is rejected.
-  .refine((value) => value.startsWith("/") || value.startsWith("https://"), {
-    message: "Destination must start with '/' or 'https://'",
+  .refine((value) => !INVALID_PATH_CHARS_REGEX.test(value), {
+    message: "Destination must not contain control characters or backslashes",
   })
+  // Internal path ("/..."), external https URL, or an already-resolved page
+  // reference (internal paths are converted to a reference server-side).
+  .refine(
+    (value) =>
+      value.startsWith("/") ||
+      value.startsWith("https://") ||
+      REFERENCE_DESTINATION_REGEX.test(value),
+    {
+      message: "Destination must start with '/' or 'https://'",
+    },
+  )
   // Collapse a leading run of slashes on an internal path so a protocol-relative
   // "//evil.com" can't pass as an open redirect ("//evil.com" -> "/evil.com").
   .transform((value) =>
@@ -93,3 +116,16 @@ export const countRedirectsSchema = z.object({
   siteId: z.number().min(1),
 })
 export type CountRedirectsInput = z.infer<typeof countRedirectsSchema>
+
+// Resolves stored [resource:...] destinations back to display permalinks. Kept
+// off the list endpoint so the read path stays a plain query; the table calls
+// this once per page to render references as the page's current permalink.
+export const resolveRedirectReferencesSchema = z.object({
+  siteId: z.number().min(1),
+  references: z
+    .array(z.string())
+    .max(MAX_REDIRECT_REFERENCES, { message: "Too many references" }),
+})
+export type ResolveRedirectReferencesInput = z.infer<
+  typeof resolveRedirectReferencesSchema
+>

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -1,3 +1,4 @@
+import { REFERENCE_LINK_REGEX } from "@opengovsg/isomer-components"
 import { z } from "zod"
 
 import { generateBigIntSchema } from "./common"
@@ -23,10 +24,14 @@ const SOURCE_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@%/]+$/
 // the published site. (Source paths use the stricter whitelist above instead.)
 const INVALID_PATH_CHARS_REGEX = /[\x00-\x1f\x7f\\]/
 
-// Anchored form of the [resource:siteId:resourceId] reference. Internal-page
-// destinations are stored in this form (converted from a path on create, see
-// redirect.service) so the redirect follows the page if its permalink changes.
-const REFERENCE_DESTINATION_REGEX = /^\[resource:\d+:\d+\]$/
+// Anchored form of the shared [resource:siteId:resourceId] reference (the shared
+// regex is unanchored, so a value only counts as a reference when it is exactly
+// one). Internal-page destinations are stored in this form (converted from a
+// path on create, see redirect.service) so the redirect follows the page if its
+// permalink changes.
+const REFERENCE_DESTINATION_REGEX = new RegExp(
+  `^${REFERENCE_LINK_REGEX.source}$`,
+)
 
 // Strips slashes from both ends of a path so "/foo/", "foo" and "foo//"
 // all normalise to the same inner segments before validation.
@@ -68,6 +73,12 @@ const destinationSchema = z
       message: "Destination must start with '/' or 'https://'",
     },
   )
+  // An internal path can't redirect to an on-page anchor — the published
+  // redirect emits a Location header, which can't target a fragment. External
+  // https URLs may legitimately carry a #fragment, so this is scoped to paths.
+  .refine((value) => !value.startsWith("/") || !value.includes("#"), {
+    message: "Destination can't link to an anchor on a page",
+  })
   // Collapse a leading run of slashes on an internal path so a protocol-relative
   // "//evil.com" can't pass as an open redirect ("//evil.com" -> "/evil.com").
   .transform((value) =>

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -828,6 +828,26 @@ describe("redirect.router", async () => {
       // Assert
       expect(result).toEqual([{ reference, permalink: null }])
     })
+
+    it("should resolve a reference whose embedded siteId is not this site to null", async () => {
+      // Arrange — the resourceId exists on this site, but the reference claims a
+      // different site, so it must not resolve here.
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "target-page",
+      })
+      const reference = `[resource:${siteId + 1}:${page.id}]`
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([{ reference, permalink: null }])
+    })
   })
 
   describe("delete", () => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -488,7 +488,7 @@ describe("redirect.router", async () => {
       const result = caller.create({
         siteId,
         source: "/old",
-        destination: "/new",
+        destination: "https://example.com/new",
       })
 
       // Assert
@@ -501,7 +501,10 @@ describe("redirect.router", async () => {
         .where("deletedAt", "is", null)
         .execute()
       expect(rows).toHaveLength(1)
-      expect(rows[0]).toMatchObject({ source: "/old", destination: "/new" })
+      expect(rows[0]).toMatchObject({
+        source: "/old",
+        destination: "https://example.com/new",
+      })
     })
 
     it("should log the soft-deleted row as the delta before when reviving", async () => {
@@ -676,6 +679,55 @@ describe("redirect.router", async () => {
         .where("source", "=", "/from")
         .executeTakeFirstOrThrow()
       expect(row.destination).toBe(`[resource:${siteId}:${rootPage.id}]`)
+    })
+
+    it("should store a folder destination as the folder reference, not its index page", async () => {
+      // Arrange — a folder is served by its published IndexPage child, but the
+      // published site keys the URL on the folder's id, so the redirect must
+      // reference the folder itself.
+      const { folder } = await setupFolder({ siteId, permalink: "about" })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        permalink: "_index",
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      await caller.create({ siteId, source: "/from", destination: "/about" })
+
+      // Assert
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe(`[resource:${siteId}:${folder.id}]`)
+    })
+
+    it("should throw 404 for a folder destination whose index page is unpublished", async () => {
+      // Arrange — a folder with no live index page has no live URL behind it
+      const { folder } = await setupFolder({ siteId, permalink: "about" })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        permalink: "_index",
+        parentId: folder.id,
+        state: ResourceState.Draft,
+      })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        source: "/from",
+        destination: "/about",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "NOT_FOUND" })
     })
   })
 

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -8,10 +8,13 @@ import {
 } from "tests/integration/helpers/iron-session"
 import {
   setupAdminPermissions,
+  setupFolder,
+  setupPageResource,
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
 import { createCallerFactory } from "~/server/trpc"
+import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
 import * as codebuildService from "../../aws/codebuild.service"
 import { db } from "../../database"
@@ -356,14 +359,20 @@ describe("redirect.router", async () => {
 
     it("should create a redirect that is immediately live", async () => {
       // Arrange / Act
-      await caller.create({ siteId, source: "/old", destination: "/new" })
+      // An external destination is stored verbatim (only internal paths are
+      // resolved to a page reference)
+      await caller.create({
+        siteId,
+        source: "/old",
+        destination: "https://example.com/new",
+      })
 
       // Assert
       const result = await caller.list({ siteId })
       expect(result).toHaveLength(1)
       expect(result[0]).toMatchObject({
         source: "/old",
-        destination: "/new",
+        destination: "https://example.com/new",
       })
     })
 
@@ -372,7 +381,7 @@ describe("redirect.router", async () => {
       await caller.create({
         siteId,
         source: "old//path/",
-        destination: "/new",
+        destination: "https://example.com/new",
       })
 
       // Assert
@@ -391,7 +400,7 @@ describe("redirect.router", async () => {
       const result = caller.create({
         siteId,
         source: "/page",
-        destination: "/new-dest",
+        destination: "https://example.com/new-dest",
       })
 
       // Assert
@@ -426,7 +435,7 @@ describe("redirect.router", async () => {
       await caller.create({
         siteId,
         source: "/revived",
-        destination: "/new",
+        destination: "https://example.com/new",
       })
 
       // Assert
@@ -434,13 +443,17 @@ describe("redirect.router", async () => {
       expect(result).toHaveLength(1)
       expect(result[0]).toMatchObject({
         source: "/revived",
-        destination: "/new",
+        destination: "https://example.com/new",
       })
     })
 
     it("should write a RedirectCreate audit log entry with the created row", async () => {
       // Arrange / Act
-      await caller.create({ siteId, source: "/hello", destination: "/world" })
+      await caller.create({
+        siteId,
+        source: "/hello",
+        destination: "https://example.com/world",
+      })
 
       // Assert
       const auditEntry = await db
@@ -452,7 +465,7 @@ describe("redirect.router", async () => {
       expect(auditEntry.userId).toBe(session.userId)
       expect(auditEntry.delta).toMatchObject({
         before: null,
-        after: { source: "/hello", destination: "/world" },
+        after: { source: "/hello", destination: "https://example.com/world" },
       })
       // The site publish triggered by the create is audited separately
       const publishEntry = await db
@@ -504,7 +517,11 @@ describe("redirect.router", async () => {
         .execute()
 
       // Act
-      await caller.create({ siteId, source: "/revived", destination: "/new" })
+      await caller.create({
+        siteId,
+        source: "/revived",
+        destination: "https://example.com/new",
+      })
 
       // Assert
       const auditEntry = await db
@@ -515,8 +532,249 @@ describe("redirect.router", async () => {
         .executeTakeFirstOrThrow()
       expect(auditEntry.delta).toMatchObject({
         before: { source: "/revived", destination: "/old" },
-        after: { source: "/revived", destination: "/new" },
+        after: { source: "/revived", destination: "https://example.com/new" },
       })
+    })
+  })
+
+  describe("create — destination resolution", () => {
+    it("should store an internal-path destination as a page reference", async () => {
+      // Arrange
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "target-page",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      await caller.create({
+        siteId,
+        source: "/from",
+        destination: "/target-page",
+      })
+
+      // Assert — the path is resolved to a [resource:...] reference so the
+      // redirect follows the page if its permalink later changes
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe(`[resource:${siteId}:${page.id}]`)
+    })
+
+    it("should resolve a nested internal path to the child page reference", async () => {
+      // Arrange
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "parent-folder",
+      })
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "child-page",
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      await caller.create({
+        siteId,
+        source: "/from",
+        destination: "/parent-folder/child-page",
+      })
+
+      // Assert — the reverse walk matches each segment against its parent
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe(`[resource:${siteId}:${page.id}]`)
+    })
+
+    it("should keep an internal path with a query suffix as a literal path", async () => {
+      // Arrange
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "target-page",
+      })
+
+      // Act — a path with a query string can't map to a single resource
+      await caller.create({
+        siteId,
+        source: "/from",
+        destination: "/target-page?ref=footer",
+      })
+
+      // Assert
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe("/target-page?ref=footer")
+    })
+
+    it("should throw 404 if the internal-path destination does not exist", async () => {
+      // Arrange / Act
+      const result = caller.create({
+        siteId,
+        source: "/from",
+        destination: "/no-such-page",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "NOT_FOUND" })
+    })
+
+    it("should throw 404 if the destination page exists but is unpublished", async () => {
+      // Arrange — a draft page has no live URL, so it isn't a valid target
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "draft-page",
+        state: ResourceState.Draft,
+      })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        source: "/from",
+        destination: "/draft-page",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "NOT_FOUND" })
+    })
+
+    it("should resolve the site root '/' to the RootPage reference", async () => {
+      // Arrange — the published homepage (RootPage has an empty permalink)
+      const { page: rootPage } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        permalink: "",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      await caller.create({ siteId, source: "/from", destination: "/" })
+
+      // Assert
+      const row = await db
+        .selectFrom("Redirect")
+        .select("destination")
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/from")
+        .executeTakeFirstOrThrow()
+      expect(row.destination).toBe(`[resource:${siteId}:${rootPage.id}]`)
+    })
+  })
+
+  describe("resolveReferences", () => {
+    it("should throw 403 if user does not have read access to the site", async () => {
+      // Arrange
+      const { site: otherSite } = await setupSite()
+
+      // Act
+      const result = caller.resolveReferences({
+        siteId: otherSite.id,
+        references: [],
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "FORBIDDEN" })
+    })
+
+    it("should resolve a reference to the page's current permalink", async () => {
+      // Arrange
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "target-page",
+      })
+      const reference = `[resource:${siteId}:${page.id}]`
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([{ reference, permalink: "/target-page" }])
+    })
+
+    it("should resolve a nested reference to its full permalink", async () => {
+      // Arrange
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "parent-folder",
+      })
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "child-page",
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+      const reference = `[resource:${siteId}:${page.id}]`
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference, permalink: "/parent-folder/child-page" },
+      ])
+    })
+
+    it("should resolve an index page reference to its folder's permalink", async () => {
+      // Arrange — an _index page represents its folder, so its segment is
+      // dropped from the resolved permalink
+      const { folder } = await setupFolder({ siteId, permalink: "info" })
+      const { page: indexPage } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        permalink: "_index",
+        parentId: folder.id,
+      })
+      const reference = `[resource:${siteId}:${indexPage.id}]`
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([{ reference, permalink: "/info" }])
+    })
+
+    it("should resolve a deleted page's reference to null", async () => {
+      // Arrange — a reference to a resource that doesn't exist
+      const reference = `[resource:${siteId}:999999]`
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([{ reference, permalink: null }])
     })
   })
 

--- a/apps/studio/src/server/modules/redirect/redirect.router.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.router.ts
@@ -3,6 +3,7 @@ import {
   createRedirectSchema,
   deleteRedirectSchema,
   listRedirectsSchema,
+  resolveRedirectReferencesSchema,
 } from "~/schemas/redirect"
 import { protectedProcedure, router } from "~/server/trpc"
 
@@ -12,6 +13,7 @@ import {
   createRedirect,
   deleteRedirect,
   listRedirects,
+  resolveRedirectReferences,
 } from "./redirect.service"
 
 export const redirectRouter = router({
@@ -37,6 +39,20 @@ export const redirectRouter = router({
       })
 
       return countRedirects(input)
+    }),
+
+  // Resolves stored [resource:...] destinations to display permalinks. A read
+  // is enough — it only surfaces permalinks the caller can already see.
+  resolveReferences: protectedProcedure
+    .input(resolveRedirectReferencesSchema)
+    .query(async ({ ctx, input }) => {
+      await validateUserPermissionsForSite({
+        siteId: input.siteId,
+        userId: ctx.user.id,
+        action: "read",
+      })
+
+      return resolveRedirectReferences(input)
     }),
 
   // create/delete publish immediately (no separate publish step). Site-wide

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -6,6 +6,7 @@ import type {
   RedirectSortField,
   ResolveRedirectReferencesInput,
 } from "~/schemas/redirect"
+import { REFERENCE_LINK_REGEX } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import { getReferenceLink } from "~/utils/link"
 
@@ -30,38 +31,61 @@ const SORT_FIELD_TO_COLUMN = {
   "source" | "destination" | "createdAt"
 >
 
-// Anchored [resource:siteId:resourceId] reference, capturing siteId/resourceId.
-// Such a destination (or an external URL) is stored verbatim; only a bare
-// internal path becomes a reference.
-const REFERENCE_DESTINATION_REGEX = /^\[resource:(\d+):(\d+)\]$/
+// Anchored form of the shared [resource:siteId:resourceId] reference, capturing
+// siteId/resourceId (the shared regex is unanchored). A value only counts as a
+// reference when it is exactly one.
+const REFERENCE_DESTINATION_REGEX = new RegExp(
+  `^${REFERENCE_LINK_REGEX.source}$`,
+)
 
-// Resolves a destination to its stored form. An internal path with no query/hash
-// becomes a [resource:...] reference (so it follows page renames); a path with a
-// query/hash stays literal; references and external URLs are stored verbatim.
+// A destination is exactly one of three shapes. The `type` discriminant keeps
+// the branches in resolveDestinationForStorage explicit instead of a chain of
+// string checks.
+type ParsedDestination =
+  | { type: "reference"; value: string }
+  | { type: "external"; value: string }
+  | { type: "internalPath"; value: string }
+
+const parseDestination = (destination: string): ParsedDestination => {
+  if (REFERENCE_DESTINATION_REGEX.test(destination)) {
+    return { type: "reference", value: destination }
+  }
+  if (destination.startsWith("/")) {
+    return { type: "internalPath", value: destination }
+  }
+  return { type: "external", value: destination }
+}
+
+// Resolves a destination to its stored form. A bare internal path becomes a
+// [resource:...] reference (so it follows page renames); a query-suffixed path
+// stays literal (a query can't map to a single resource); references and
+// external URLs are stored verbatim.
 const resolveDestinationForStorage = async (
   siteId: number,
   destination: string,
 ): Promise<string> => {
-  if (
-    REFERENCE_DESTINATION_REGEX.test(destination) ||
-    !destination.startsWith("/") ||
-    destination.includes("?") ||
-    destination.includes("#")
-  ) {
-    return destination
+  const parsed = parseDestination(destination)
+  switch (parsed.type) {
+    case "reference":
+    case "external":
+      return parsed.value
+    case "internalPath": {
+      if (parsed.value.includes("?")) {
+        return parsed.value
+      }
+      const resourceId = await getResourceIdByPermalink(siteId, parsed.value)
+      if (resourceId === null) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: `The page "${destination}" does not exist`,
+        })
+      }
+      return getReferenceLink({
+        siteId: String(siteId),
+        resourceId: String(resourceId),
+      })
+    }
   }
-
-  const resourceId = await getResourceIdByPermalink(siteId, destination)
-  if (resourceId === null) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: `The page "${destination}" does not exist`,
-    })
-  }
-  return getReferenceLink({
-    siteId: String(siteId),
-    resourceId: String(resourceId),
-  })
 }
 
 // Resolves stored [resource:...] destinations back to current permalinks for

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -31,16 +31,13 @@ const SORT_FIELD_TO_COLUMN = {
   "source" | "destination" | "createdAt"
 >
 
-// Anchored [resource:siteId:resourceId] reference. A destination already in
-// this form (or an external URL) is stored verbatim; only a bare internal path
-// is converted to a reference.
+// Anchored [resource:siteId:resourceId] reference. Such a destination (or an
+// external URL) is stored verbatim; only a bare internal path becomes a reference.
 const REFERENCE_DESTINATION_REGEX = /^\[resource:\d+:\d+\]$/
 
-// Converts a redirect destination into the value stored in the DB. An internal
-// path with no query/hash suffix is resolved to an internal-page reference so
-// the redirect follows the page if its permalink later changes. A path that
-// carries a query/hash suffix can't map to a single resource, so it is kept as
-// a literal path; references and external URLs are stored verbatim.
+// Resolves a destination to its stored form. An internal path with no query/hash
+// becomes a [resource:...] reference (so it follows page renames); a path with a
+// query/hash stays literal; references and external URLs are stored verbatim.
 const resolveDestinationForStorage = async (
   siteId: number,
   destination: string,
@@ -67,10 +64,8 @@ const resolveDestinationForStorage = async (
   })
 }
 
-// Resolves stored [resource:...] destinations back to the page's current
-// permalink for display. Batched into a single query (see
-// getResourceFullPermalinks) so a page of redirects costs one round-trip, not
-// one per row. A reference whose page no longer exists resolves to null.
+// Resolves stored [resource:...] destinations back to current permalinks for
+// display, batched into one query. A reference to a missing page resolves to null.
 export const resolveRedirectReferences = async ({
   siteId,
   references,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -4,14 +4,21 @@ import type {
   DeleteRedirectInput,
   ListRedirectsInput,
   RedirectSortField,
+  ResolveRedirectReferencesInput,
 } from "~/schemas/redirect"
+import { getResourceIdFromReferenceLink } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
+import { getReferenceLink } from "~/utils/link"
 
 import type { Logger } from "@isomer/logging"
 
 import { logPublishEvent, logRedirectEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { AuditLogEvent, db } from "../database"
+import {
+  getResourceFullPermalinks,
+  getResourceIdByPermalink,
+} from "../resource/resource.service"
 
 // Sort field → column. `publishedAt` maps to `createdAt`; `satisfies` keeps the
 // map exhaustive so a new sort field without a column is a compile error.
@@ -23,6 +30,67 @@ const SORT_FIELD_TO_COLUMN = {
   RedirectSortField,
   "source" | "destination" | "createdAt"
 >
+
+// Anchored [resource:siteId:resourceId] reference. A destination already in
+// this form (or an external URL) is stored verbatim; only a bare internal path
+// is converted to a reference.
+const REFERENCE_DESTINATION_REGEX = /^\[resource:\d+:\d+\]$/
+
+// Converts a redirect destination into the value stored in the DB. An internal
+// path with no query/hash suffix is resolved to an internal-page reference so
+// the redirect follows the page if its permalink later changes. A path that
+// carries a query/hash suffix can't map to a single resource, so it is kept as
+// a literal path; references and external URLs are stored verbatim.
+const resolveDestinationForStorage = async (
+  siteId: number,
+  destination: string,
+): Promise<string> => {
+  if (
+    REFERENCE_DESTINATION_REGEX.test(destination) ||
+    !destination.startsWith("/") ||
+    destination.includes("?") ||
+    destination.includes("#")
+  ) {
+    return destination
+  }
+
+  const resourceId = await getResourceIdByPermalink(siteId, destination)
+  if (resourceId === null) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: `The page "${destination}" does not exist`,
+    })
+  }
+  return getReferenceLink({
+    siteId: String(siteId),
+    resourceId: String(resourceId),
+  })
+}
+
+// Resolves stored [resource:...] destinations back to the page's current
+// permalink for display. Batched into a single query (see
+// getResourceFullPermalinks) so a page of redirects costs one round-trip, not
+// one per row. A reference whose page no longer exists resolves to null.
+export const resolveRedirectReferences = async ({
+  siteId,
+  references,
+}: ResolveRedirectReferencesInput): Promise<
+  { reference: string; permalink: string | null }[]
+> => {
+  const parsed = references.map((reference) => ({
+    reference,
+    resourceId: getResourceIdFromReferenceLink(reference),
+  }))
+  const resourceIds = parsed
+    .filter(({ resourceId }) => resourceId !== "")
+    .map(({ resourceId }) => Number(resourceId))
+  const permalinks = await getResourceFullPermalinks(siteId, resourceIds)
+  return parsed.map(({ reference, resourceId }) => ({
+    reference,
+    permalink:
+      resourceId === "" ? null : (permalinks.get(Number(resourceId)) ?? null),
+  }))
+}
 
 const getByUser = async (byUserId: string) =>
   db
@@ -87,6 +155,14 @@ export const createRedirect = async ({
 }) => {
   const byUser = await getByUser(byUserId)
 
+  // Resolve an internal-path destination to a [resource:...] reference (a read,
+  // outside the tx) so the redirect follows the page if its permalink changes.
+  // Throws NOT_FOUND if the path matches no page.
+  const storedDestination = await resolveDestinationForStorage(
+    siteId,
+    destination,
+  )
+
   const created = await db.transaction().execute(async (tx) => {
     // Reject creating over a live redirect. A soft-deleted row for the same
     // source still holds the (siteId, source) unique constraint and is revived
@@ -106,12 +182,12 @@ export const createRedirect = async ({
 
     const created = await tx
       .insertInto("Redirect")
-      .values({ siteId, source, destination })
+      .values({ siteId, source, destination: storedDestination })
       .onConflict((oc) =>
         oc
           .columns(["siteId", "source"])
           .doUpdateSet({
-            destination,
+            destination: storedDestination,
             deletedAt: null,
             // Revived rows republish now, so refresh createdAt (the publish
             // time shown to users).

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -6,7 +6,6 @@ import type {
   RedirectSortField,
   ResolveRedirectReferencesInput,
 } from "~/schemas/redirect"
-import { getResourceIdFromReferenceLink } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import { getReferenceLink } from "~/utils/link"
 
@@ -31,9 +30,10 @@ const SORT_FIELD_TO_COLUMN = {
   "source" | "destination" | "createdAt"
 >
 
-// Anchored [resource:siteId:resourceId] reference. Such a destination (or an
-// external URL) is stored verbatim; only a bare internal path becomes a reference.
-const REFERENCE_DESTINATION_REGEX = /^\[resource:\d+:\d+\]$/
+// Anchored [resource:siteId:resourceId] reference, capturing siteId/resourceId.
+// Such a destination (or an external URL) is stored verbatim; only a bare
+// internal path becomes a reference.
+const REFERENCE_DESTINATION_REGEX = /^\[resource:(\d+):(\d+)\]$/
 
 // Resolves a destination to its stored form. An internal path with no query/hash
 // becomes a [resource:...] reference (so it follows page renames); a path with a
@@ -72,18 +72,24 @@ export const resolveRedirectReferences = async ({
 }: ResolveRedirectReferencesInput): Promise<
   { reference: string; permalink: string | null }[]
 > => {
-  const parsed = references.map((reference) => ({
-    reference,
-    resourceId: getResourceIdFromReferenceLink(reference),
-  }))
+  // Resolve only references that are anchored AND belong to this site — a
+  // reference to another site can't resolve here, so it stays unresolved.
+  const parsed = references.map((reference) => {
+    const match = REFERENCE_DESTINATION_REGEX.exec(reference)
+    return {
+      reference,
+      resourceId:
+        match && Number(match[1]) === siteId ? Number(match[2]) : null,
+    }
+  })
   const resourceIds = parsed
-    .filter(({ resourceId }) => resourceId !== "")
-    .map(({ resourceId }) => Number(resourceId))
+    .map(({ resourceId }) => resourceId)
+    .filter((id): id is number => id !== null)
   const permalinks = await getResourceFullPermalinks(siteId, resourceIds)
   return parsed.map(({ reference, resourceId }) => ({
     reference,
     permalink:
-      resourceId === "" ? null : (permalinks.get(Number(resourceId)) ?? null),
+      resourceId === null ? null : (permalinks.get(resourceId) ?? null),
   }))
 }
 

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -836,9 +836,7 @@ export const getResourceIdByPermalink = async (
   for (const segment of segments) {
     const match = candidates.find(
       (candidate) =>
-        candidate.permalink === segment &&
-        (candidate.parentId === null ? null : String(candidate.parentId)) ===
-          parentId,
+        candidate.permalink === segment && candidate.parentId === parentId,
     )
     if (!match) {
       return null

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -713,9 +713,8 @@ export const getResourceFullPermalink = async (
 // Batched variant of getResourceFullPermalink: resolves many resources' full
 // permalinks in a single recursive query instead of one round-trip per id.
 // Used to render redirect destinations (stored as `[resource:...]` references)
-// without an N+1 over the visible page. Each row carries the `seedId` it
-// descends from so the ancestor chains can be reassembled per resource.
-// Resources missing from the map no longer exist (e.g. the page was deleted).
+// without an N+1 over the visible page. A resourceId absent from the returned
+// map no longer exists (e.g. the page was deleted).
 export const getResourceFullPermalinks = async (
   siteId: number,
   resourceIds: number[],
@@ -724,77 +723,73 @@ export const getResourceFullPermalinks = async (
     return new Map()
   }
 
+  // One recursive walk collects every node on the requested ids' ancestor
+  // chains. A node's permalink and parentId are intrinsic to its id (not to
+  // which chain reached it), so a single id-keyed map lets each requested id
+  // walk from itself up to the root.
   const rows = await db
-    .withRecursive("Ancestors", (eb) =>
+    .withRecursive("PermalinkChain", (eb) =>
       eb
-        // Base case: the resources we want permalinks for, each tagged as its
-        // own ancestry seed
+        // Base case: the resources we want permalinks for
         .selectFrom("Resource")
         .where("Resource.siteId", "=", siteId)
         .where("Resource.id", "in", resourceIds.map(String))
-        .select([
-          "Resource.id as seedId",
-          "Resource.id as id",
-          "Resource.permalink as permalink",
-          "Resource.parentId as parentId",
-        ])
+        .select(["Resource.id", "Resource.permalink", "Resource.parentId"])
         .unionAll((fb) =>
           fb
-            // Recursive case: walk up to each seed's ancestors, carrying the
-            // seedId so chains for different seeds don't intermingle
+            // Recursive case: walk up to each node's parent
             .selectFrom("Resource")
-            .innerJoin("Ancestors", "Ancestors.parentId", "Resource.id")
+            .innerJoin(
+              "PermalinkChain",
+              "PermalinkChain.parentId",
+              "Resource.id",
+            )
             .where("Resource.siteId", "=", siteId)
-            .select([
-              "Ancestors.seedId as seedId",
-              "Resource.id as id",
-              "Resource.permalink as permalink",
-              "Resource.parentId as parentId",
-            ]),
+            .select(["Resource.id", "Resource.permalink", "Resource.parentId"]),
         ),
     )
-    .selectFrom("Ancestors")
-    .select(["Ancestors.seedId", "Ancestors.id", "Ancestors.permalink"])
-    .select("Ancestors.parentId")
+    .selectFrom("PermalinkChain")
+    .select([
+      "PermalinkChain.id",
+      "PermalinkChain.permalink",
+      "PermalinkChain.parentId",
+    ])
     .execute()
 
-  // Index every fetched node by seed so each seed's chain can be walked from
-  // the leaf (the seed itself) up to the root in memory
-  const nodesBySeed = new Map<
+  const nodeById = new Map<
     string,
-    Map<string, { permalink: string; parentId: string | null }>
+    { permalink: string; parentId: string | null }
   >()
   for (const row of rows) {
-    const seedId = String(row.seedId)
-    const nodes =
-      nodesBySeed.get(seedId) ??
-      new Map<string, { permalink: string; parentId: string | null }>()
-    nodes.set(String(row.id), {
+    nodeById.set(String(row.id), {
       permalink: row.permalink,
       parentId: row.parentId === null ? null : String(row.parentId),
     })
-    nodesBySeed.set(seedId, nodes)
   }
 
   const result = new Map<number, string>()
-  for (const [seedId, nodes] of nodesBySeed) {
-    const chain: string[] = []
-    let currentId: string | null = seedId
+  for (const resourceId of resourceIds) {
+    const segments: string[] = []
+    let currentId: string | null = String(resourceId)
     while (currentId !== null) {
-      const node = nodes.get(currentId)
+      const node = nodeById.get(currentId)
       if (node === undefined) {
         break
       }
-      chain.push(node.permalink)
+      segments.push(node.permalink)
       currentId = node.parentId
     }
-    // chain is leaf→root; reverse to root→leaf and drop the `_index` segments
-    // (an index page represents its parent folder, not a path of its own)
-    const permalink = chain
+    // A missing id (deleted resource) yields no segments — omit it.
+    if (segments.length === 0) {
+      continue
+    }
+    // segments are leaf→root; reverse to root→leaf and drop the `_index`
+    // segments (an index page represents its parent folder, not a path).
+    const permalink = segments
       .reverse()
       .filter((segment) => segment !== INDEX_PAGE_PERMALINK)
       .join("/")
-    result.set(Number(seedId), `/${permalink}`)
+    result.set(resourceId, `/${permalink}`)
   }
   return result
 }

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -799,15 +799,11 @@ export const getResourceFullPermalinks = async (
   return result
 }
 
-// Reverse of getResourceFullPermalink: resolves a full permalink path (e.g.
-// "/about/contact") back to the resource it points at, or null if no published
-// resource matches. Used when a redirect destination is entered as a path so it
-// can be stored as a `[resource:...]` reference that follows the page if its
-// permalink later changes. Runs as a single query: it fetches every resource
-// whose permalink matches one of the path segments, then walks the parent chain
-// in memory — the (siteId, parentId, permalink) unique constraint makes each
-// step unambiguous. Only published targets resolve: a draft/unpublished page
-// would otherwise become a redirect to a URL with no live page behind it.
+// Reverse of getResourceFullPermalink: resolves a full permalink path back to
+// the live resource it points at (for storing a redirect destination as a
+// [resource:...] reference), or null if nothing live matches. One query fetches
+// every resource matching a path segment, then walks the parent chain in memory
+// — the (siteId, parentId, permalink) constraint makes each step unambiguous.
 export const getResourceIdByPermalink = async (
   siteId: number,
   fullPermalink: string,
@@ -836,6 +832,7 @@ export const getResourceIdByPermalink = async (
       "Resource.permalink",
       "Resource.parentId",
       "Resource.publishedVersionId",
+      "Resource.type",
     ])
     .execute()
 
@@ -855,9 +852,32 @@ export const getResourceIdByPermalink = async (
     parentId = String(match.id)
   }
 
-  // Only resolve to a published target (the walk above traverses unpublished
-  // folders as path segments, but the destination page itself must be live).
-  if (leaf === null || leaf.publishedVersionId === null) {
+  if (leaf === null) {
+    return null
+  }
+
+  // A Folder/Collection is served by its IndexPage child, and the published
+  // site keys the URL on the container's id (the index page's id never appears
+  // there — the build remaps it to the folder). Resolve to the container,
+  // treating it as live when its index page is published.
+  if (
+    leaf.type === ResourceType.Folder ||
+    leaf.type === ResourceType.Collection
+  ) {
+    const indexPage = await db
+      .selectFrom("Resource")
+      .where("Resource.siteId", "=", siteId)
+      .where("Resource.parentId", "=", String(leaf.id))
+      .where("Resource.type", "=", ResourceType.IndexPage)
+      .where("Resource.publishedVersionId", "is not", null)
+      .select("Resource.id")
+      .executeTakeFirst()
+    return indexPage ? Number(leaf.id) : null
+  }
+
+  // Any other resource type must itself be published — the walk traverses
+  // unpublished folders as path segments, but the target page must be live.
+  if (leaf.publishedVersionId === null) {
     return null
   }
   return Number(leaf.id)

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -710,6 +710,159 @@ export const getResourceFullPermalink = async (
   return `/${permalinkTree.join("/")}`
 }
 
+// Batched variant of getResourceFullPermalink: resolves many resources' full
+// permalinks in a single recursive query instead of one round-trip per id.
+// Used to render redirect destinations (stored as `[resource:...]` references)
+// without an N+1 over the visible page. Each row carries the `seedId` it
+// descends from so the ancestor chains can be reassembled per resource.
+// Resources missing from the map no longer exist (e.g. the page was deleted).
+export const getResourceFullPermalinks = async (
+  siteId: number,
+  resourceIds: number[],
+): Promise<Map<number, string>> => {
+  if (resourceIds.length === 0) {
+    return new Map()
+  }
+
+  const rows = await db
+    .withRecursive("Ancestors", (eb) =>
+      eb
+        // Base case: the resources we want permalinks for, each tagged as its
+        // own ancestry seed
+        .selectFrom("Resource")
+        .where("Resource.siteId", "=", siteId)
+        .where("Resource.id", "in", resourceIds.map(String))
+        .select([
+          "Resource.id as seedId",
+          "Resource.id as id",
+          "Resource.permalink as permalink",
+          "Resource.parentId as parentId",
+        ])
+        .unionAll((fb) =>
+          fb
+            // Recursive case: walk up to each seed's ancestors, carrying the
+            // seedId so chains for different seeds don't intermingle
+            .selectFrom("Resource")
+            .innerJoin("Ancestors", "Ancestors.parentId", "Resource.id")
+            .where("Resource.siteId", "=", siteId)
+            .select([
+              "Ancestors.seedId as seedId",
+              "Resource.id as id",
+              "Resource.permalink as permalink",
+              "Resource.parentId as parentId",
+            ]),
+        ),
+    )
+    .selectFrom("Ancestors")
+    .select(["Ancestors.seedId", "Ancestors.id", "Ancestors.permalink"])
+    .select("Ancestors.parentId")
+    .execute()
+
+  // Index every fetched node by seed so each seed's chain can be walked from
+  // the leaf (the seed itself) up to the root in memory
+  const nodesBySeed = new Map<
+    string,
+    Map<string, { permalink: string; parentId: string | null }>
+  >()
+  for (const row of rows) {
+    const seedId = String(row.seedId)
+    const nodes =
+      nodesBySeed.get(seedId) ??
+      new Map<string, { permalink: string; parentId: string | null }>()
+    nodes.set(String(row.id), {
+      permalink: row.permalink,
+      parentId: row.parentId === null ? null : String(row.parentId),
+    })
+    nodesBySeed.set(seedId, nodes)
+  }
+
+  const result = new Map<number, string>()
+  for (const [seedId, nodes] of nodesBySeed) {
+    const chain: string[] = []
+    let currentId: string | null = seedId
+    while (currentId !== null) {
+      const node = nodes.get(currentId)
+      if (node === undefined) {
+        break
+      }
+      chain.push(node.permalink)
+      currentId = node.parentId
+    }
+    // chain is leaf→root; reverse to root→leaf and drop the `_index` segments
+    // (an index page represents its parent folder, not a path of its own)
+    const permalink = chain
+      .reverse()
+      .filter((segment) => segment !== INDEX_PAGE_PERMALINK)
+      .join("/")
+    result.set(Number(seedId), `/${permalink}`)
+  }
+  return result
+}
+
+// Reverse of getResourceFullPermalink: resolves a full permalink path (e.g.
+// "/about/contact") back to the resource it points at, or null if no published
+// resource matches. Used when a redirect destination is entered as a path so it
+// can be stored as a `[resource:...]` reference that follows the page if its
+// permalink later changes. Runs as a single query: it fetches every resource
+// whose permalink matches one of the path segments, then walks the parent chain
+// in memory — the (siteId, parentId, permalink) unique constraint makes each
+// step unambiguous. Only published targets resolve: a draft/unpublished page
+// would otherwise become a redirect to a URL with no live page behind it.
+export const getResourceIdByPermalink = async (
+  siteId: number,
+  fullPermalink: string,
+): Promise<number | null> => {
+  const segments = fullPermalink.split("/").filter(Boolean)
+
+  // The site root ("/") is the RootPage, whose permalink is empty so it has no
+  // path segments to walk. Resolve it directly (published only, as below).
+  if (segments.length === 0) {
+    const root = await db
+      .selectFrom("Resource")
+      .where("Resource.siteId", "=", siteId)
+      .where("Resource.type", "=", ResourceType.RootPage)
+      .where("Resource.publishedVersionId", "is not", null)
+      .select("Resource.id")
+      .executeTakeFirst()
+    return root ? Number(root.id) : null
+  }
+
+  const candidates = await db
+    .selectFrom("Resource")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.permalink", "in", segments)
+    .select([
+      "Resource.id",
+      "Resource.permalink",
+      "Resource.parentId",
+      "Resource.publishedVersionId",
+    ])
+    .execute()
+
+  let parentId: string | null = null
+  let leaf: (typeof candidates)[number] | null = null
+  for (const segment of segments) {
+    const match = candidates.find(
+      (candidate) =>
+        candidate.permalink === segment &&
+        (candidate.parentId === null ? null : String(candidate.parentId)) ===
+          parentId,
+    )
+    if (!match) {
+      return null
+    }
+    leaf = match
+    parentId = String(match.id)
+  }
+
+  // Only resolve to a published target (the walk above traverses unpublished
+  // folders as path segments, but the destination page itself must be live).
+  if (leaf === null || leaf.publishedVersionId === null) {
+    return null
+  }
+  return Number(leaf.id)
+}
+
 interface PublishPageResourceArgs {
   logger: Logger<string>
   userId: string

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -61,6 +61,49 @@ export const GET_CONFIG = `
 SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
 `
 
+// Internal-page destinations are stored as "[resource:siteId:resourceId]"
+// references so a redirect follows the page when its permalink changes. We
+// resolve each reference to the page's current full permalink at publish time
+// by walking the resource tree (same shape as
+// GET_ALL_RESOURCES_WITH_FULL_PERMALINKS). Non-reference destinations (literal
+// paths and external https URLs) pass through untouched.
+//
+// A reference resolves to NULL — and the redirect is dropped — when its target
+// no longer exists OR is no longer published ("publishedVersionId" IS NULL): a
+// redirect to a deleted or unpublished page is broken, so we don't publish it.
+//
+// The trailing "_index" segment is stripped to match getConvertedPermalink in
+// index.ts (an index page represents its folder, so it has no URL of its own);
+// this keeps the published target identical to what the editor displays.
 export const GET_REDIRECTS = `
-SELECT source, destination FROM public."Redirect" WHERE "siteId" = $1 AND "deletedAt" IS NULL;
+WITH RECURSIVE "resourcePath" (id, "publishedVersionId", "parentId", "fullPermalink") AS (
+    SELECT r.id, r."publishedVersionId", r."parentId", r.permalink AS "fullPermalink"
+    FROM public."Resource" r
+    WHERE r."siteId" = $1 AND r."parentId" IS NULL
+
+    UNION ALL
+
+    SELECT r.id, r."publishedVersionId", r."parentId", CONCAT(path."fullPermalink", '/', r.permalink)
+    FROM public."Resource" r
+    INNER JOIN "resourcePath" path ON r."parentId" = path.id
+    WHERE r."siteId" = $1
+)
+SELECT source, destination FROM (
+    SELECT
+        redirect.source AS source,
+        CASE
+            WHEN redirect.destination ~ '^\\[resource:\\d+:\\d+\\]$'
+            -- "||" (not CONCAT) so an unresolved reference stays NULL and is
+            -- dropped below; CONCAT would coerce NULL to '' and emit "/"
+            THEN '/' || regexp_replace(rp."fullPermalink", '(^|/)_index$', '')
+            ELSE redirect.destination
+        END AS destination
+    FROM public."Redirect" redirect
+    LEFT JOIN "resourcePath" rp
+        ON redirect.destination ~ '^\\[resource:\\d+:\\d+\\]$'
+        AND rp.id = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
+        AND rp."publishedVersionId" IS NOT NULL
+    WHERE redirect."siteId" = $1 AND redirect."deletedAt" IS NULL
+) resolved
+WHERE resolved.destination IS NOT NULL;
 `

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -89,13 +89,17 @@ SELECT source, destination FROM (
         CASE
             WHEN redirect.destination ~ '^\\[resource:\\d+:\\d+\\]$'
             -- "||" (not CONCAT) so an unresolved reference stays NULL and is
-            -- dropped below; CONCAT would coerce NULL to '' and emit "/"
-            THEN '/' || regexp_replace(rp."fullPermalink", '(^|/)_index$', '')
+            -- dropped below; CONCAT would coerce NULL to '' and emit "/".
+            -- Strips a trailing "_index"/"_meta" to match getConvertedPermalink.
+            THEN '/' || regexp_replace(rp."fullPermalink", '(^|/)(_index|_meta)$', '')
             ELSE redirect.destination
         END AS destination
     FROM public."Redirect" redirect
     LEFT JOIN "resourcePath" rp
         ON redirect.destination ~ '^\\[resource:\\d+:\\d+\\]$'
+        -- The reference's siteId must match this site ($1); a mismatched
+        -- reference can't resolve here and is dropped.
+        AND CAST(substring(redirect.destination from '\\[resource:(\\d+):\\d+\\]') AS bigint) = $1
         AND rp."publishedVersionId" IS NOT NULL
         AND (
             -- A page reference resolves to the page itself.

--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -61,29 +61,24 @@ export const GET_CONFIG = `
 SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
 `
 
-// Internal-page destinations are stored as "[resource:siteId:resourceId]"
-// references so a redirect follows the page when its permalink changes. We
-// resolve each reference to the page's current full permalink at publish time
-// by walking the resource tree (same shape as
-// GET_ALL_RESOURCES_WITH_FULL_PERMALINKS). Non-reference destinations (literal
-// paths and external https URLs) pass through untouched.
-//
-// A reference resolves to NULL — and the redirect is dropped — when its target
-// no longer exists OR is no longer published ("publishedVersionId" IS NULL): a
-// redirect to a deleted or unpublished page is broken, so we don't publish it.
-//
-// The trailing "_index" segment is stripped to match getConvertedPermalink in
-// index.ts (an index page represents its folder, so it has no URL of its own);
-// this keeps the published target identical to what the editor displays.
+// Internal destinations are stored as "[resource:siteId:resourceId]" references
+// so a redirect follows the page when its permalink changes. At publish time we
+// resolve each reference to the target's current full permalink by walking the
+// resource tree. A Folder/Collection reference resolves via its published
+// IndexPage child (the container has no version of its own); the trailing
+// "_index" is stripped to match getConvertedPermalink in index.ts. Non-reference
+// destinations (literal paths, external https URLs) pass through untouched. A
+// reference resolves to NULL — and the redirect is dropped — when nothing live
+// matches (deleted/unpublished target), since that redirect would be broken.
 export const GET_REDIRECTS = `
-WITH RECURSIVE "resourcePath" (id, "publishedVersionId", "parentId", "fullPermalink") AS (
-    SELECT r.id, r."publishedVersionId", r."parentId", r.permalink AS "fullPermalink"
+WITH RECURSIVE "resourcePath" (id, "publishedVersionId", "parentId", "fullPermalink", "type") AS (
+    SELECT r.id, r."publishedVersionId", r."parentId", r.permalink AS "fullPermalink", r.type AS "type"
     FROM public."Resource" r
     WHERE r."siteId" = $1 AND r."parentId" IS NULL
 
     UNION ALL
 
-    SELECT r.id, r."publishedVersionId", r."parentId", CONCAT(path."fullPermalink", '/', r.permalink)
+    SELECT r.id, r."publishedVersionId", r."parentId", CONCAT(path."fullPermalink", '/', r.permalink), r.type AS "type"
     FROM public."Resource" r
     INNER JOIN "resourcePath" path ON r."parentId" = path.id
     WHERE r."siteId" = $1
@@ -101,8 +96,17 @@ SELECT source, destination FROM (
     FROM public."Redirect" redirect
     LEFT JOIN "resourcePath" rp
         ON redirect.destination ~ '^\\[resource:\\d+:\\d+\\]$'
-        AND rp.id = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
         AND rp."publishedVersionId" IS NOT NULL
+        AND (
+            -- A page reference resolves to the page itself.
+            rp.id = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
+            -- A Folder/Collection reference resolves via its published IndexPage
+            -- child; "_index" is stripped above to give the container's URL.
+            OR (
+                rp."type" = 'IndexPage'
+                AND rp."parentId" = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
+            )
+        )
     WHERE redirect."siteId" = $1 AND redirect."deletedAt" IS NULL
 ) resolved
 WHERE resolved.destination IS NOT NULL;

--- a/tooling/build/scripts/publishing/tests/publishing.test.ts
+++ b/tooling/build/scripts/publishing/tests/publishing.test.ts
@@ -186,6 +186,10 @@ let siteId: number
 let aboutFolderId: string
 let danglingFolderId: string
 let newsCollectionId: string
+let rootPageId: string
+let aboutIndexPageId: string
+let ourTeamPageId: string
+let draftPageId: string
 
 const readOutput = (...segments: string[]) =>
   JSON.parse(readFileSync(join(outputDir, ...segments), "utf-8"))
@@ -218,7 +222,7 @@ beforeAll(async () => {
     .values({ siteId, content: FOOTER_CONTENT })
     .execute()
 
-  await seedPage({
+  rootPageId = await seedPage({
     siteId,
     type: ResourceType.RootPage,
     title: "Home",
@@ -247,7 +251,7 @@ beforeAll(async () => {
     title: "Who we are",
     permalink: "about",
   })
-  await seedPage({
+  aboutIndexPageId = await seedPage({
     siteId,
     type: ResourceType.IndexPage,
     title: "Who we are",
@@ -260,7 +264,7 @@ beforeAll(async () => {
       content: [],
     },
   })
-  await seedPage({
+  ourTeamPageId = await seedPage({
     siteId,
     type: ResourceType.Page,
     title: "Our team",
@@ -340,7 +344,7 @@ beforeAll(async () => {
   })
 
   // A draft-only page: must NOT be published
-  await seedPage({
+  draftPageId = await seedPage({
     siteId,
     type: ResourceType.Page,
     title: "Secret draft",
@@ -361,6 +365,31 @@ beforeAll(async () => {
     source: "/deleted",
     destination: "/gone",
     deletedAt: new Date(),
+  })
+  // Reference destinations: resolved to the page's current permalink at publish
+  await seedRedirect({
+    siteId,
+    source: "/ref-page",
+    destination: `[resource:${siteId}:${ourTeamPageId}]`,
+  })
+  // A reference to an index page resolves to its folder (the "_index" segment
+  // is stripped, matching what the editor displays)
+  await seedRedirect({
+    siteId,
+    source: "/ref-index",
+    destination: `[resource:${siteId}:${aboutIndexPageId}]`,
+  })
+  // A reference to the root page resolves to "/"
+  await seedRedirect({
+    siteId,
+    source: "/ref-root",
+    destination: `[resource:${siteId}:${rootPageId}]`,
+  })
+  // A reference to an unpublished page is dropped — it has no live URL
+  await seedRedirect({
+    siteId,
+    source: "/ref-draft",
+    destination: `[resource:${siteId}:${draftPageId}]`,
   })
 
   // A second site: nothing from it may leak into the output
@@ -660,15 +689,36 @@ describe("site data files", () => {
 describe("redirects.json", () => {
   it("writes only the live redirects of the site", () => {
     // Arrange / Act
-    const redirects = readOutput("redirects.json")
+    const redirects = readOutput("redirects.json") as {
+      source: string
+      destination: string
+    }[]
 
-    // Assert
-    expect(redirects).toHaveLength(2)
+    // Assert: literal destinations pass through; references resolve to the
+    // target's current permalink; the deleted, unpublished-reference, and
+    // other-site redirects are all excluded
     expect(redirects).toEqual(
       expect.arrayContaining([
         { source: "/old-about", destination: "/about" },
         { source: "/old-news", destination: "/news" },
+        { source: "/ref-page", destination: "/about/our-team" },
+        { source: "/ref-index", destination: "/about" },
+        { source: "/ref-root", destination: "/" },
       ]),
     )
+    expect(redirects).toHaveLength(5)
+  })
+
+  it("drops a redirect whose referenced page is unpublished", () => {
+    // Arrange / Act
+    const redirects = readOutput("redirects.json") as {
+      source: string
+      destination: string
+    }[]
+
+    // Assert
+    expect(
+      redirects.find((redirect) => redirect.source === "/ref-draft"),
+    ).toBeUndefined()
   })
 })

--- a/tooling/build/scripts/publishing/tests/publishing.test.ts
+++ b/tooling/build/scripts/publishing/tests/publishing.test.ts
@@ -379,6 +379,21 @@ beforeAll(async () => {
     source: "/ref-index",
     destination: `[resource:${siteId}:${aboutIndexPageId}]`,
   })
+  // A reference to the folder itself resolves via its published index page to
+  // the folder's URL — this is the form internal folder/collection destinations
+  // are stored as (the build keys the URL on the folder id, not the index page)
+  await seedRedirect({
+    siteId,
+    source: "/ref-folder",
+    destination: `[resource:${siteId}:${aboutFolderId}]`,
+  })
+  // A reference to a folder with no published index page is dropped — there is
+  // no live page behind it
+  await seedRedirect({
+    siteId,
+    source: "/ref-dangling-folder",
+    destination: `[resource:${siteId}:${danglingFolderId}]`,
+  })
   // A reference to the root page resolves to "/"
   await seedRedirect({
     siteId,
@@ -703,10 +718,11 @@ describe("redirects.json", () => {
         { source: "/old-news", destination: "/news" },
         { source: "/ref-page", destination: "/about/our-team" },
         { source: "/ref-index", destination: "/about" },
+        { source: "/ref-folder", destination: "/about" },
         { source: "/ref-root", destination: "/" },
       ]),
     )
-    expect(redirects).toHaveLength(5)
+    expect(redirects).toHaveLength(6)
   })
 
   it("drops a redirect whose referenced page is unpublished", () => {
@@ -719,6 +735,19 @@ describe("redirects.json", () => {
     // Assert
     expect(
       redirects.find((redirect) => redirect.source === "/ref-draft"),
+    ).toBeUndefined()
+  })
+
+  it("drops a folder reference with no published index page", () => {
+    // Arrange / Act
+    const redirects = readOutput("redirects.json") as {
+      source: string
+      destination: string
+    }[]
+
+    // Assert
+    expect(
+      redirects.find((redirect) => redirect.source === "/ref-dangling-folder"),
     ).toBeUndefined()
   })
 })

--- a/tooling/build/scripts/publishing/tests/publishing.test.ts
+++ b/tooling/build/scripts/publishing/tests/publishing.test.ts
@@ -406,6 +406,13 @@ beforeAll(async () => {
     source: "/ref-draft",
     destination: `[resource:${siteId}:${draftPageId}]`,
   })
+  // A reference whose embedded siteId is not this site is dropped, even though
+  // the resourceId exists here — it must not resolve cross-site.
+  await seedRedirect({
+    siteId,
+    source: "/ref-wrong-site",
+    destination: `[resource:${siteId + 999}:${ourTeamPageId}]`,
+  })
 
   // A second site: nothing from it may leak into the output
   const otherSiteId = await seedSite({ name: "Other site" })
@@ -748,6 +755,19 @@ describe("redirects.json", () => {
     // Assert
     expect(
       redirects.find((redirect) => redirect.source === "/ref-dangling-folder"),
+    ).toBeUndefined()
+  })
+
+  it("drops a reference whose embedded siteId is not this site", () => {
+    // Arrange / Act
+    const redirects = readOutput("redirects.json") as {
+      source: string
+      destination: string
+    }[]
+
+    // Assert
+    expect(
+      redirects.find((redirect) => redirect.source === "/ref-wrong-site"),
     ).toBeUndefined()
   })
 })


### PR DESCRIPTION
Addresses the blocking review comment on #2093 (destinations stored as raw strings break when a page's permalink changes): internal-path destinations are now stored as `[resource:siteId:resourceId]` references and resolved to the live permalink at publish time, so a redirect automatically follows the page if its permalink changes.

Fixes ISOM-2270.

## What changed

- **Resolvers** (`resource.service`): batched `getResourceFullPermalinks` (reference → permalink) and `getResourceIdByPermalink` (path → resourceId, reverse segment-walk).
- **Service** (`redirect.service`): on create, an internal path with no query/hash suffix is converted to a reference; external `https://` URLs and query-suffixed paths are stored verbatim; `resolveRedirectReferences` powers display.
- **Router/schema**: `resolveReferences` query; destination accepts the reference form.
- **Publishing**: references resolve to the page's current permalink at build time; the trailing `_index` segment is stripped (matching `getConvertedPermalink`), and an unresolved reference (deleted or unpublished page) drops the redirect rather than emitting `/`.
- **Frontend**: `ResourceSelector` page picker in the add form; references render as the page's current permalink in the table and delete modal.

## Behaviour notes

- Resolution restricts to **published targets only** — a draft/unpublished page has no live URL.
- The site root `/` resolves to the `RootPage`.
- Internal destinations are stored as references, so audit-log entries show the raw `[resource:...]` reference (the stable record of what was configured) rather than a permalink.

## Tests

- Router/schema: reference conversion, nested paths, `_index`, root `/`, query-suffix passthrough, unpublished/non-existent → 404.
- DB-backed publishing tests: reference → permalink, `_index` stripping, root, and dropping references to deleted/unpublished pages.