### PR TITLE
feat(preview-link): add CONTEXT glossary, ADRs, and PreviewLink schema

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,31 @@
+# CONTEXT
+
+This file is the canonical glossary for the Isomer Next codebase. It is **policy-free** — it defines what concepts *are*, not how they are configured. Specific numbers, thresholds, and policies live in `docs/adr/` instead.
+
+When you encounter a term in conversation or code that disagrees with this glossary, treat the glossary as the source of truth and either correct the term or update this file.
+
+## Terms
+
+### Preview link
+
+A revocable, **short-lived** URL (hours to days, never weeks or longer) minted by an editor that grants a non-logged-in person read-only access to the live current draft of a single page.
+
+The short lifetime is part of the definition, not a config knob: a long-lived equivalent would be a different concept (an account, an API key) — not a preview link. Concrete lifetime bounds are a policy decision recorded separately in an ADR; this term only commits to "short" at the order of magnitude of days.
+
+A preview link is the *access grant*. The rendered page itself is the *preview*. The URL is the *token-bearing form* of the grant.
+
+### Preview
+
+The rendered draft of a page as seen by a non-editor (typically via a preview link). Always reflects the latest saved draft at view time — no separate stored representation, no snapshot. Visually identical to the public-site render of the page, wrapped in a thin Studio chrome that identifies it as a preview.
+
+### Sharer
+
+The Studio user (editor or admin) who minted a preview link. The link is attributed to them in audit logs and shown in their personal "Manage preview links" list. A sharer can revoke their own links; a Site Admin can revoke any link on their site.
+
+### Recipient
+
+Any person who opens a preview link. Has no Studio identity — preview links intentionally do not require account creation or login. Recorded only as `(IP, user-agent, country)` in audit-log view rows, never as a named user.
+
+### Mint (verb)
+
+The act of creating a new preview link. "Minting" is preferred over "creating" or "generating" because each link is a single-use token grant attributable to a specific sharer at a specific time — minting carries the connotation of issuing a credential, which is what's happening. Used consistently in code (`mintPreviewLink`), event names (`PreviewLinkMint`), and UI copy where the action verb appears.

--- a/docs/adr/0001-preview-links-are-url-only.md
+++ b/docs/adr/0001-preview-links-are-url-only.md
@@ -1,0 +1,13 @@
+# Preview links are URL-only, no per-recipient gate
+
+Preview links grant read-only access to a draft page via a long random token in the URL alone — no OTP, no email-binding, no password. We picked this over an OTP-style gate (the obvious "gov-safe" choice) because the feature exists to reduce friction for non-Studio reviewers (a director signing off on a draft), and any auth step undermines that goal; the threat model is casual forwarding rather than determined attackers, and is mitigated by short lifetimes, revocation, audit logging, and a 256-bit token.
+
+## Considered Options
+
+- **URL-only (chosen).** One click for the recipient. Bounded risk from forwarding via short lifetime + audit.
+- **URL + email OTP.** Higher security; binds access to a named recipient. Rejected because OTP UX (check email, copy code, paste) is exactly the friction the feature exists to remove, and gov inbox delivery is often slow or quarantined.
+- **URL + shared password.** Sharer mints link + passphrase, shares via separate channels. Rejected as v1 — extra coordination burden on the sharer for a threat we don't have.
+
+## Consequences
+
+If a soft-gate is ever added (sharer-provided password or matching recipient email, checked at view time without OTP infra), it ships as an additive migration adding nullable columns to `PreviewLink` at that time — the v1 schema does **not** reserve placeholder columns upfront. Switching the *default* posture from URL-only to gated would be a one-way break for already-minted tokens, so any future change should be an additive per-link opt-in, not a global flip.

--- a/docs/adr/0002-preview-link-lifetime-bounds.md
+++ b/docs/adr/0002-preview-link-lifetime-bounds.md
@@ -1,0 +1,14 @@
+# Preview link lifetime is capped at 7 days
+
+Preview links expire after a sharer-chosen duration of `24h`, `3d`, or `7d` (default `3d`). The cap is 7 days, not 30 or longer. Anyone asking for a longer-lived preview link is asking for a different feature (an account, an API key) — not a longer preview link.
+
+## Why these numbers
+
+- **24h** covers same-day sign-off.
+- **3d** covers a normal review cycle (share Friday, reviewed by Monday).
+- **7d** covers "review while I'm overseas" extended cases.
+- Anything beyond a week stops being a "preview" and starts being persistent unauthenticated access to gov draft content — which has a different threat model and should be a separate feature with a different name and design.
+
+## Consequences
+
+Editors who need to keep a page reviewable for longer than 7 days must re-mint a link. This is intentional friction — it forces a fresh access decision rather than letting a one-time grant drift into a long-term credential. If a sharer asks "why can't I just make it 30 days?" the answer is to revisit this ADR, not to bump the cap.

--- a/docs/adr/0003-preview-route-bypasses-trpc.md
+++ b/docs/adr/0003-preview-route-bypasses-trpc.md
@@ -1,0 +1,16 @@
+# Preview route bypasses tRPC — token validation via `getServerSideProps`
+
+The `/preview/<token>` route validates its token and fetches page data inside Next.js `getServerSideProps`, calling service functions in `server/modules/*` directly rather than going through a tRPC procedure. This is a deliberate deviation from the codebase's default pattern (every other client-facing endpoint goes through tRPC).
+
+## Why
+
+A tRPC procedure for the preview route would need to be a `publicProcedure` (anonymous caller) that takes the token as its only auth input. That works, but it splits the trust boundary across two layers: the page route renders something, and the tRPC call validates the token. Token validation, audit-row write, rate-limit check, and the decision to render-vs-show-revoked-page all need to happen *together* and *exactly once per page load*. Putting them in `getServerSideProps` makes that atomicity obvious and lets the route own the entire flow.
+
+## Considered Options
+
+- **New `publicProcedure` endpoints (rejected).** Reuses the tRPC pipeline. Rejected because preview is the only surface in Studio with anonymous read access; introducing a `publicProcedure` family for one feature creates an auth-shape that future engineers may accidentally reach for in contexts where it doesn't belong.
+- **`getServerSideProps` + direct service calls (chosen).** Token check and audit write co-located with the route that depends on them. The "preview is different" boundary is enforced at one file.
+
+## Consequences
+
+A future engineer reading the codebase will see "every endpoint goes through tRPC except `/preview/<token>`" and may want to "fix" it for consistency. This ADR exists to stop that — the divergence is intentional. If a second anonymous-access feature appears later, revisit this decision rather than copy the pattern blindly.

--- a/packages/db/prisma/migrations/20260616175853_add_preview_link_table/migration.sql
+++ b/packages/db/prisma/migrations/20260616175853_add_preview_link_table/migration.sql
@@ -1,0 +1,40 @@
+-- CreateTable
+CREATE TABLE "PreviewLink" (
+    "id" BIGSERIAL NOT NULL,
+    "token" TEXT NOT NULL,
+    "siteId" INTEGER NOT NULL,
+    "resourceId" BIGINT NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "label" TEXT,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "revokedAt" TIMESTAMP(3),
+    "revokedBy" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PreviewLink_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PreviewLink_token_key" ON "PreviewLink"("token");
+
+-- CreateIndex
+CREATE INDEX "PreviewLink_siteId_idx" ON "PreviewLink"("siteId");
+
+-- CreateIndex
+CREATE INDEX "PreviewLink_resourceId_idx" ON "PreviewLink"("resourceId");
+
+-- CreateIndex
+CREATE INDEX "PreviewLink_createdBy_idx" ON "PreviewLink"("createdBy");
+
+-- AddForeignKey
+ALTER TABLE "PreviewLink" ADD CONSTRAINT "PreviewLink_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreviewLink" ADD CONSTRAINT "PreviewLink_resourceId_fkey" FOREIGN KEY ("resourceId") REFERENCES "Resource"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreviewLink" ADD CONSTRAINT "PreviewLink_createdBy_fkey" FOREIGN KEY ("createdBy") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PreviewLink" ADD CONSTRAINT "PreviewLink_revokedBy_fkey" FOREIGN KEY ("revokedBy") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -80,6 +80,7 @@ model Resource {
   ResourcePermission ResourcePermission[]
   CodeBuildJobs      CodeBuildJobs[]
   pushDocumentJobs   PushDocumentJob[]
+  PreviewLink        PreviewLink[]
 
   // This unique index is subsequently replaced with a custom index that
   // treats nulls as not distinct.
@@ -135,13 +136,15 @@ model User {
   deletedAt   DateTime?
   lastLoginAt DateTime?
 
-  ResourcePermission ResourcePermission[]
-  IsomerAdmin        IsomerAdmin[]
-  versions           Version[]
-  AuditLog           AuditLog[]
-  CodeBuildJobs      CodeBuildJobs[]
-  ScheduledResources Resource[]
-  pushDocumentJobs   PushDocumentJob[]
+  ResourcePermission   ResourcePermission[]
+  IsomerAdmin          IsomerAdmin[]
+  versions             Version[]
+  AuditLog             AuditLog[]
+  CodeBuildJobs        CodeBuildJobs[]
+  ScheduledResources   Resource[]
+  pushDocumentJobs     PushDocumentJob[]
+  PreviewLinksCreated  PreviewLink[]        @relation("PreviewLinkCreator")
+  PreviewLinksRevoked  PreviewLink[]        @relation("PreviewLinkRevoker")
 
   // This unique index is subsequently replaced with a custom index that
   // treats nulls as not distinct.
@@ -174,6 +177,7 @@ model Site {
   AuditLog           AuditLog[]
   CodeBuildJobs      CodeBuildJobs[]
   Redirect           Redirect[]
+  PreviewLink        PreviewLink[]
 }
 
 model Redirect {
@@ -363,4 +367,33 @@ model PushDocumentJob {
 
   @@index([scheduledAt])
   @@index([resourceId])
+}
+
+model PreviewLink {
+  id    BigInt @id @default(autoincrement())
+  token String @unique
+
+  siteId Int
+  site   Site @relation(fields: [siteId], references: [id])
+
+  resourceId BigInt
+  resource   Resource @relation(fields: [resourceId], references: [id])
+
+  createdBy String
+  creator   User   @relation("PreviewLinkCreator", fields: [createdBy], references: [id])
+
+  label String?
+
+  expiresAt DateTime
+
+  revokedAt DateTime?
+  revokedBy String?
+  revoker   User?     @relation("PreviewLinkRevoker", fields: [revokedBy], references: [id])
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @default(now()) @updatedAt
+
+  @@index([siteId])
+  @@index([resourceId])
+  @@index([createdBy])
 }

--- a/packages/db/src/generated/generatedTypes.ts
+++ b/packages/db/src/generated/generatedTypes.ts
@@ -83,6 +83,19 @@ export interface Navbar {
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }
+export interface PreviewLink {
+  id: GeneratedAlways<string>
+  token: string
+  siteId: number
+  resourceId: string
+  createdBy: string
+  label: string | null
+  expiresAt: Timestamp
+  revokedAt: Timestamp | null
+  revokedBy: string | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
+}
 export interface PushDocumentJob {
   id: GeneratedAlways<string>
   resourceId: string
@@ -187,6 +200,7 @@ export interface DB {
   Footer: Footer
   IsomerAdmin: IsomerAdmin
   Navbar: Navbar
+  PreviewLink: PreviewLink
   PushDocumentJob: PushDocumentJob
   RateLimiterFlexible: RateLimiterFlexible
   Redirect: Redirect

--- a/packages/db/src/generated/selectableTypes.ts
+++ b/packages/db/src/generated/selectableTypes.ts
@@ -8,6 +8,7 @@ export type CodeBuildJobs = Selectable<T.CodeBuildJobs>
 export type Footer = Selectable<T.Footer>
 export type IsomerAdmin = Selectable<T.IsomerAdmin>
 export type Navbar = Selectable<T.Navbar>
+export type PreviewLink = Selectable<T.PreviewLink>
 export type PushDocumentJob = Selectable<T.PushDocumentJob>
 export type RateLimiterFlexible = Selectable<T.RateLimiterFlexible>
 export type Redirect = Selectable<T.Redirect>


### PR DESCRIPTION
## Problem

Foundational groundwork for the preview-link feature: shared vocabulary, locked architectural decisions, and the database schema that all subsequent slices build on.

Refs #2482

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add `Preview link`, `Preview`, `Sharer`, `Recipient`, `Mint` glossary entries to `CONTEXT.md`.
- Add `docs/adr/0001-preview-links-are-url-only.md` (no auth, single-URL share model).
- Add `docs/adr/0002-preview-link-lifetime-bounds.md` (24h / 3d / 7d expiry choices).
- Add `docs/adr/0003-preview-route-bypasses-trpc.md` (recipient route uses `getServerSideProps` + direct service calls).
- Add `PreviewLink` Prisma model with: opaque 256-bit token (base64url), `siteId`, `resourceId` (scalar FK — one page per link), `createdBy`, nullable `label` (80 chars), `expiresAt`, nullable `revokedAt` + `revokedBy`, timestamps.

`revokedAt`/`revokedBy` are intentionally introduced now even though slice 1 never populates them — slice 3 (expiry/revocation) will.

## Tests

Schema-only change — verified by Prisma migration applying cleanly and generated types compiling.