### PR TITLE
feat(server): add previewLink module with mint procedure

### DIFF
--- a/apps/studio/src/schemas/previewLink.ts
+++ b/apps/studio/src/schemas/previewLink.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const PREVIEW_LINK_EXPIRY_CHOICES = ["24h", "3d", "7d"] as const
+export type PreviewLinkExpiryChoice =
+  (typeof PREVIEW_LINK_EXPIRY_CHOICES)[number]
+
+export const PREVIEW_LINK_LABEL_MAX_LENGTH = 80
+
+export const mintPreviewLinkSchema = z.object({
+  siteId: z.number().int().positive(),
+  resourceId: z.number().int().positive(),
+  expiryChoice: z.enum(PREVIEW_LINK_EXPIRY_CHOICES, {
+    message: "Pick an expiry of 24h, 3d, or 7d.",
+  }),
+  label: z
+    .string()
+    .max(PREVIEW_LINK_LABEL_MAX_LENGTH, {
+      message: `Label must be ${PREVIEW_LINK_LABEL_MAX_LENGTH} characters or fewer.`,
+    })
+    .optional()
+    .nullable(),
+})
+
+export type MintPreviewLinkInput = z.infer<typeof mintPreviewLinkSchema>

--- a/apps/studio/src/server/modules/_app.ts
+++ b/apps/studio/src/server/modules/_app.ts
@@ -10,6 +10,7 @@ import { folderRouter } from "./folder/folder.router"
 import { gazetteRouter } from "./gazette/gazette.router"
 import { meRouter } from "./me/me.router"
 import { pageRouter } from "./page/page.router"
+import { previewLinkRouter } from "./previewLink/previewLink.router"
 import { resourceRouter } from "./resource/resource.router"
 import { siteRouter } from "./site/site.router"
 import { userRouter } from "./user/user.router"
@@ -22,6 +23,7 @@ export const appRouter = router({
   auth: authRouter,
   asset: assetRouter,
   page: pageRouter,
+  previewLink: previewLinkRouter,
   folder: folderRouter,
   collection: collectionRouter,
   gazette: gazetteRouter,

--- a/apps/studio/src/server/modules/previewLink/__tests__/previewLink.router.test.ts
+++ b/apps/studio/src/server/modules/previewLink/__tests__/previewLink.router.test.ts
@@ -1,0 +1,165 @@
+import { TRPCError } from "@trpc/server"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupEditorPermissions,
+  setupPageResource,
+} from "tests/integration/helpers/seed"
+import { createCallerFactory } from "~/server/trpc"
+
+import { db } from "../../database"
+import { previewLinkRouter } from "../previewLink.router"
+
+const createCaller = createCallerFactory(previewLinkRouter)
+
+const TABLES_TO_RESET = [
+  "PreviewLink",
+  "AuditLog",
+  "ResourcePermission",
+  "Resource",
+  "Blob",
+  "Navbar",
+  "Footer",
+  "Site",
+  "VerificationToken",
+  "User",
+] as const
+
+describe("previewLinkRouter", () => {
+  let session: Awaited<ReturnType<typeof applyAuthedSession>>
+  let caller: ReturnType<typeof createCaller>
+
+  beforeEach(async () => {
+    await resetTables(...TABLES_TO_RESET)
+    session = await applyAuthedSession()
+    caller = createCaller(createMockRequest(session))
+  })
+
+  describe("mint", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.mint({
+        siteId: 1,
+        resourceId: 1,
+        expiryChoice: "7d",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if the user lacks edit permission on the site", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+
+      // Act — session.userId has no permission on this site
+      const result = caller.mint({
+        siteId: site.id,
+        resourceId: Number(page.id),
+        expiryChoice: "7d",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+
+      const inserted = await db.selectFrom("PreviewLink").selectAll().execute()
+      expect(inserted).toHaveLength(0)
+    })
+
+    it("should mint a preview link for an authorised editor", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.mint({
+        siteId: site.id,
+        resourceId: Number(page.id),
+        expiryChoice: "7d",
+        label: "For Director Tan",
+      })
+
+      // Assert — response shape
+      expect(result.token).toMatch(/^[A-Za-z0-9_-]{43}$/)
+      expect(result.url.endsWith(`/preview/${result.token}`)).toBe(true)
+      expect(result.label).toBe("For Director Tan")
+      expect(result.expiresAt).toBeInstanceOf(Date)
+
+      // Assert — DB row
+      const row = await db
+        .selectFrom("PreviewLink")
+        .where("token", "=", result.token)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(Number(row.resourceId)).toBe(Number(page.id))
+      expect(row.siteId).toBe(site.id)
+      expect(row.createdBy).toBe(session.userId)
+      expect(row.label).toBe("For Director Tan")
+      expect(row.revokedAt).toBeNull()
+      expect(row.revokedBy).toBeNull()
+    })
+
+    it("should compute expiresAt from the chosen duration", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const before = Date.now()
+      const result = await caller.mint({
+        siteId: site.id,
+        resourceId: Number(page.id),
+        expiryChoice: "24h",
+      })
+      const after = Date.now()
+
+      // Assert — within [before+24h, after+24h]
+      const expectedMin = before + 24 * 60 * 60 * 1000
+      const expectedMax = after + 24 * 60 * 60 * 1000
+      expect(result.expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin)
+      expect(result.expiresAt.getTime()).toBeLessThanOrEqual(expectedMax)
+    })
+
+    it("should reject a label longer than 80 characters", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.mint({
+        siteId: site.id,
+        resourceId: Number(page.id),
+        expiryChoice: "7d",
+        label: "x".repeat(81),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow()
+    })
+  })
+})

--- a/apps/studio/src/server/modules/previewLink/previewLink.router.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.router.ts
@@ -1,0 +1,26 @@
+import { mintPreviewLinkSchema } from "~/schemas/previewLink"
+import { protectedProcedure, router } from "~/server/trpc"
+import { getBaseUrl } from "~/utils/getBaseUrl"
+
+import { mintPreviewLink } from "./previewLink.service"
+
+export const previewLinkRouter = router({
+  mint: protectedProcedure
+    .input(mintPreviewLinkSchema)
+    .mutation(async ({ ctx, input }) => {
+      const link = await mintPreviewLink({
+        userId: ctx.user.id,
+        siteId: input.siteId,
+        resourceId: input.resourceId,
+        expiryChoice: input.expiryChoice,
+        label: input.label,
+      })
+
+      return {
+        token: link.token,
+        url: `${getBaseUrl()}/preview/${link.token}`,
+        expiresAt: link.expiresAt,
+        label: link.label,
+      }
+    }),
+})

--- a/apps/studio/src/server/modules/previewLink/previewLink.service.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.service.ts
@@ -1,0 +1,72 @@
+import type { PreviewLinkExpiryChoice } from "~/schemas/previewLink"
+import { randomBytes } from "node:crypto"
+
+import { db } from "../database"
+import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
+
+const MS_PER_HOUR = 60 * 60 * 1000
+const MS_PER_DAY = 24 * MS_PER_HOUR
+
+const EXPIRY_MS: Record<PreviewLinkExpiryChoice, number> = {
+  "24h": 24 * MS_PER_HOUR,
+  "3d": 3 * MS_PER_DAY,
+  "7d": 7 * MS_PER_DAY,
+}
+
+const TOKEN_BYTES = 32 // 256-bit; base64url-encoded → 43 chars
+
+const generateToken = (): string =>
+  randomBytes(TOKEN_BYTES).toString("base64url")
+
+interface CanSharePreviewProps {
+  userId: string
+  siteId: number
+  resourceId: number
+}
+
+// Single permission gate for minting preview links. Today this is "user can
+// update the resource"; a future site-level toggle (Q6 of the design) flips
+// here without touching call sites.
+export const canSharePreview = async ({
+  userId,
+  siteId,
+}: CanSharePreviewProps) => {
+  await bulkValidateUserPermissionsForResources({
+    action: "update",
+    siteId,
+    userId,
+  })
+}
+
+interface MintPreviewLinkProps {
+  userId: string
+  siteId: number
+  resourceId: number
+  expiryChoice: PreviewLinkExpiryChoice
+  label?: string | null
+}
+
+export const mintPreviewLink = async ({
+  userId,
+  siteId,
+  resourceId,
+  expiryChoice,
+  label,
+}: MintPreviewLinkProps) => {
+  await canSharePreview({ userId, siteId, resourceId })
+
+  const expiresAt = new Date(Date.now() + EXPIRY_MS[expiryChoice])
+
+  return await db
+    .insertInto("PreviewLink")
+    .values({
+      token: generateToken(),
+      siteId,
+      resourceId: String(resourceId),
+      createdBy: userId,
+      label: label ?? null,
+      expiresAt,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}


### PR DESCRIPTION
## Problem

Editors need a way to mint a preview link for a page they can edit. This PR adds the server-side primitive — a tRPC mutation that creates a `PreviewLink` row and returns the full preview URL.

Refs #2482

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add `previewLink` tRPC router with a `mint` procedure.
- Add `canSharePreview(user, resource)` permission gate — today returns true iff the user can edit the resource.
- Input schema (`apps/studio/src/schemas/previewLink.ts`): `resourceId`, expiry choice (`24h` | `3d` | `7d`), optional 80-char `label`. Returns the full preview URL.
- Token generation: 256-bit cryptographically random, base64url-encoded.

## Tests

- Vitest router tests for happy-path mint (authorised), permission-denied (no edit rights), input validation (bad expiry, label > 80 chars).

**Manual Verification Steps**:

- [ ] Call the `previewLink.mint` mutation from the tRPC panel as an admin with the page's `resourceId` and expiry `3d`; confirm a URL of shape `/preview/<token>` is returned.
- [ ] Confirm the corresponding `PreviewLink` row exists in the database with the expected `expiresAt`.
- [ ] Call `mint` as a user without edit rights; confirm 403 / permission error.