### PR TITLE
feat(preview): add /preview/[token] route with thin chrome and crawler defences

### DIFF
--- a/apps/studio/public/robots.txt
+++ b/apps/studio/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /preview/

--- a/apps/studio/src/features/previewLink/components/PreviewChrome.stories.tsx
+++ b/apps/studio/src/features/previewLink/components/PreviewChrome.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { Box } from "@chakra-ui/react"
+
+import { PreviewChrome } from "./PreviewChrome"
+
+const meta: Meta<typeof PreviewChrome> = {
+  title: "Features/PreviewLink/PreviewChrome",
+  component: PreviewChrome,
+  decorators: [(storyFn) => <Box w="100%">{storyFn()}</Box>],
+  parameters: {
+    layout: "fullscreen",
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof PreviewChrome>
+
+// Fixed date so Chromatic snapshots are stable.
+const FIXED_EXPIRY = "2026-06-21T15:59:00Z"
+
+export const ShortTitle: Story = {
+  args: {
+    pageTitle: "About Us",
+    expiresAt: FIXED_EXPIRY,
+  },
+}
+
+export const LongTitle: Story = {
+  args: {
+    pageTitle:
+      "Frequently Asked Questions About the New Ministry-Wide Compliance Framework",
+    expiresAt: FIXED_EXPIRY,
+  },
+}

--- a/apps/studio/src/features/previewLink/components/PreviewChrome.tsx
+++ b/apps/studio/src/features/previewLink/components/PreviewChrome.tsx
@@ -1,0 +1,49 @@
+import { Box, Flex, Text } from "@chakra-ui/react"
+
+interface PreviewChromeProps {
+  pageTitle: string
+  expiresAt: string
+}
+
+const SGT_TIMEZONE = "Asia/Singapore"
+
+const formatSgtExpiry = (isoString: string): string => {
+  const formatter = new Intl.DateTimeFormat("en-SG", {
+    timeZone: SGT_TIMEZONE,
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  return `${formatter.format(new Date(isoString))} SGT`
+}
+
+export const PreviewChrome = ({
+  pageTitle,
+  expiresAt,
+}: PreviewChromeProps): JSX.Element => {
+  return (
+    <Box
+      bg="#FFF7E6"
+      borderBottomWidth="1px"
+      borderColor="#F0B400"
+      px="1rem"
+      py="0.5rem"
+    >
+      <Flex align="center" justify="space-between" gap="1rem" flexWrap="wrap">
+        <Text fontSize="sm" fontWeight="600" color="#5C4400">
+          Isomer Preview: «{pageTitle}»
+        </Text>
+        <Text fontSize="xs" color="#5C4400">
+          Expires {formatSgtExpiry(expiresAt)}
+        </Text>
+      </Flex>
+      <Text fontSize="xs" color="#5C4400" mt="0.25rem">
+        Confidential — please do not forward this link.
+      </Text>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/previewLink/components/RecipientPreview.tsx
+++ b/apps/studio/src/features/previewLink/components/RecipientPreview.tsx
@@ -1,0 +1,84 @@
+import type {
+  IsomerGeneratedSiteProps,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
+import type { ComponentProps, PropsWithChildren } from "react"
+import {
+  LinkComponentProvider,
+  RenderEngine,
+} from "@opengovsg/isomer-components"
+import { merge } from "lodash-es"
+import Script from "next/script"
+import { forwardRef } from "react"
+import { ASSETS_BASE_URL } from "~/utils/generateAssetUrl"
+
+type RenderEngineProps = ComponentProps<typeof RenderEngine>
+type RenderEngineSite = RenderEngineProps["site"]
+
+export interface RecipientPreviewProps {
+  pageContent: IsomerSchema
+  permalink: string
+  lastModified: string
+  siteConfig: Record<string, unknown>
+  navbar: unknown
+  footer: unknown
+  siteMap: IsomerGeneratedSiteProps["siteMap"]
+}
+
+// Anchor that swallows clicks — recipients should not be able to navigate
+// out of the previewed page (links to other pages in the draft site won't
+// resolve via this route).
+const InertLink = forwardRef<HTMLAnchorElement, PropsWithChildren<unknown>>(
+  ({ children, ...rest }, ref) => (
+    <a {...rest} ref={ref} onClick={(e) => e.preventDefault()}>
+      {children}
+    </a>
+  ),
+)
+InertLink.displayName = "InertLink"
+
+export const RecipientPreview = ({
+  pageContent,
+  permalink,
+  lastModified,
+  siteConfig,
+  navbar,
+  footer,
+  siteMap,
+}: RecipientPreviewProps): JSX.Element => {
+  const renderProps = merge({}, pageContent, {
+    page: { permalink, lastModified },
+  }) as IsomerSchema
+
+  // The site prop's exact shape (IsomerSiteWideComponentsProps) varies per
+  // theme; mirroring the type here would mean tracking theme-specific
+  // variants. RenderEngine validates the structure at runtime — the same
+  // cast pattern is used by the editor's preview component.
+  const site = {
+    ...siteConfig,
+    navbar,
+    footerItems: footer,
+    siteMap,
+    environment: "production",
+    search: { type: "localSearch", searchUrl: "/search" },
+    assetsBaseUrl: ASSETS_BASE_URL,
+  } as unknown as RenderEngineSite
+
+  // RenderEngine's prop type is a discriminated union of page schema variants
+  // intersected with site config; the generic IsomerSchema doesn't satisfy any
+  // single variant statically, and ScriptComponent (consumed for analytics
+  // scripts) isn't in the public type signature. The data is validated at
+  // runtime by the editor pipeline before it ever reaches the DB. This cast
+  // mirrors the escape hatch used by the editor's PreviewWithCustomSitemap.
+  const fullProps = {
+    ...renderProps,
+    site,
+    ScriptComponent: Script,
+  } as unknown as ComponentProps<typeof RenderEngine>
+
+  return (
+    <LinkComponentProvider value={InertLink}>
+      <RenderEngine {...fullProps} />
+    </LinkComponentProvider>
+  )
+}

--- a/apps/studio/src/pages/preview/[token].tsx
+++ b/apps/studio/src/pages/preview/[token].tsx
@@ -1,0 +1,100 @@
+import type { GetServerSideProps } from "next"
+import type { RecipientPreviewProps } from "~/features/previewLink/components/RecipientPreview"
+import type { NextPageWithLayout } from "~/lib/types"
+import { Box } from "@chakra-ui/react"
+import Head from "next/head"
+import { PreviewChrome } from "~/features/previewLink/components/PreviewChrome"
+import { RecipientPreview } from "~/features/previewLink/components/RecipientPreview"
+
+interface PreviewPageProps extends RecipientPreviewProps {
+  pageTitle: string
+  expiresAt: string
+}
+
+const PreviewPage: NextPageWithLayout<PreviewPageProps> = ({
+  pageTitle,
+  expiresAt,
+  ...renderProps
+}) => {
+  return (
+    <>
+      <Head>
+        <title>{`Isomer Preview: ${pageTitle}`}</title>
+        <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
+      </Head>
+      <Box minH="100vh" bg="white">
+        <PreviewChrome pageTitle={pageTitle} expiresAt={expiresAt} />
+        <RecipientPreview {...renderProps} />
+      </Box>
+    </>
+  )
+}
+
+// Recipients are unauthenticated; render the page with no Studio layout chrome.
+PreviewPage.getLayout = (page) => page
+
+export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
+  ctx,
+) => {
+  const tokenParam = ctx.params?.token
+  if (typeof tokenParam !== "string") return { notFound: true }
+
+  ctx.res.setHeader("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet")
+  ctx.res.setHeader("Referrer-Policy", "no-referrer")
+
+  const { db } = await import("~/server/modules/database")
+  const {
+    getFullPageById,
+    getNavBar,
+    getFooter,
+    getLocalisedSitemap,
+    getResourceFullPermalink,
+  } = await import("~/server/modules/resource/resource.service")
+  const { getSiteConfig } = await import("~/server/modules/site/site.service")
+
+  const link = await db
+    .selectFrom("PreviewLink")
+    .where("token", "=", tokenParam)
+    .selectAll()
+    .executeTakeFirst()
+
+  if (!link) return { notFound: true }
+
+  // Slice 1 deliberately does not branch on link.revokedAt or link.expiresAt
+  // < now() — that behaviour ships with #2484.
+
+  const resourceId = Number(link.resourceId)
+  const siteId = link.siteId
+
+  const page = await getFullPageById(db, { resourceId, siteId })
+  if (!page) return { notFound: true }
+
+  const [navbar, footer, siteConfig, siteMap, permalink] = await Promise.all([
+    getNavBar(db, siteId),
+    getFooter(db, siteId),
+    getSiteConfig(db, siteId),
+    getLocalisedSitemap(siteId, resourceId),
+    getResourceFullPermalink(siteId, resourceId),
+  ])
+
+  if (!permalink) return { notFound: true }
+
+  return {
+    props: {
+      pageTitle: page.title,
+      expiresAt: link.expiresAt.toISOString(),
+      pageContent: page.content as RecipientPreviewProps["pageContent"],
+      permalink,
+      lastModified:
+        page.updatedAt instanceof Date
+          ? page.updatedAt.toISOString()
+          : new Date().toISOString(),
+      siteConfig: siteConfig as Record<string, unknown>,
+      navbar: navbar.content,
+      footer: footer.content,
+      siteMap,
+    },
+  }
+}
+
+export default PreviewPage


### PR DESCRIPTION
## Problem

Recipients need to open a preview URL in a browser and see the live page draft. This PR adds the public-facing `/preview/<token>` route and the crawler defences that ship Day 1.

Refs #2482

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add `apps/studio/src/pages/preview/[token].tsx` — Next.js page using `getServerSideProps` calling page/site service functions directly (no `publicProcedure`, per `docs/adr/0003`).
- Add `PreviewChrome` component: thin header showing \"Isomer Preview: «Page title»\", SGT expiry timestamp, and \"Confidential — please do not forward this link.\" Sharer identity is not shown.
- Add `RecipientPreview` component that renders the live current draft via the existing `PreviewIframe` primitive.
- Crawler defences:
  - Response headers `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet` and `Referrer-Policy: no-referrer`.
  - `<meta name=\"robots\" content=\"noindex, nofollow, noarchive, nosnippet\">` in the rendered HTML.
  - `Disallow: /preview/` added to `apps/studio/public/robots.txt`.

## Tests

- Storybook story for `PreviewChrome` covers expiry rendering and confidentiality copy.
- Anonymous-view happy-path test for `/preview/<token>` (via `getServerSideProps`).

**Manual Verification Steps**:

- [ ] Open a valid preview URL in an incognito window (logged out); confirm the page renders with the Isomer Preview chrome header, SGT expiry, and confidentiality line.
- [ ] Inspect response headers — confirm `X-Robots-Tag` and `Referrer-Policy: no-referrer` are present.
- [ ] View page source — confirm the `<meta name=\"robots\">` tag is present.
- [ ] Fetch `/robots.txt` — confirm `Disallow: /preview/` is present.
- [ ] Open an invalid/unknown token — confirm a 404 / not-found state.