### PR TITLE
feat(preview): add share-preview button and modal to the page editor

### DIFF
--- a/apps/studio/src/features/editing-experience/components/PageEditNavbar.tsx
+++ b/apps/studio/src/features/editing-experience/components/PageEditNavbar.tsx
@@ -10,6 +10,7 @@ import Link from "next/link"
 import { useRouter } from "next/router"
 import { TabLink } from "~/components/TabLink"
 import { ADMIN_NAVBAR_HEIGHT } from "~/constants/layouts"
+import { SharePreviewButton } from "~/features/previewLink"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { getResourceSubpath } from "~/utils/resource"
 import { trpc } from "~/utils/trpc"
@@ -131,7 +132,13 @@ export const PageEditNavbar = (): JSX.Element => {
         </TabLink>
       </Flex>
       {pageId && siteId && (
-        <Flex justifyContent={"end"} alignItems={"center"} flex={1}>
+        <Flex
+          justifyContent={"end"}
+          alignItems={"center"}
+          flex={1}
+          gap="0.5rem"
+        >
+          <SharePreviewButton siteId={siteId} resourceId={pageId} />
           <PublishButton pageId={pageId} siteId={siteId} />
         </Flex>
       )}

--- a/apps/studio/src/features/previewLink/components/SharePreviewButton.tsx
+++ b/apps/studio/src/features/previewLink/components/SharePreviewButton.tsx
@@ -1,0 +1,37 @@
+import { IconButton, useDisclosure } from "@chakra-ui/react"
+import { TouchableTooltip } from "@opengovsg/design-system-react"
+import { BiShareAlt } from "react-icons/bi"
+
+import { SharePreviewModal } from "./SharePreviewModal"
+
+interface SharePreviewButtonProps {
+  siteId: number
+  resourceId: number
+}
+
+export const SharePreviewButton = ({
+  siteId,
+  resourceId,
+}: SharePreviewButtonProps): JSX.Element => {
+  const disclosure = useDisclosure()
+
+  return (
+    <>
+      <TouchableTooltip label="Share preview" placement="bottom">
+        <IconButton
+          aria-label="Share preview"
+          icon={<BiShareAlt />}
+          variant="ghost"
+          size="sm"
+          onClick={disclosure.onOpen}
+        />
+      </TouchableTooltip>
+      <SharePreviewModal
+        isOpen={disclosure.isOpen}
+        onClose={disclosure.onClose}
+        siteId={siteId}
+        resourceId={resourceId}
+      />
+    </>
+  )
+}

--- a/apps/studio/src/features/previewLink/components/SharePreviewModal.stories.tsx
+++ b/apps/studio/src/features/previewLink/components/SharePreviewModal.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { Box } from "@chakra-ui/react"
+
+import { SharePreviewModal } from "./SharePreviewModal"
+
+const meta: Meta<typeof SharePreviewModal> = {
+  title: "Features/PreviewLink/SharePreviewModal",
+  component: SharePreviewModal,
+  decorators: [
+    (storyFn) => (
+      <Box w="100%" h="100vh">
+        {storyFn()}
+      </Box>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    isOpen: true,
+    onClose: () => {
+      // no-op for the story
+    },
+    siteId: 1,
+    resourceId: 1,
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof SharePreviewModal>
+
+export const InitialForm: Story = {}
+
+export const Closed: Story = {
+  args: {
+    isOpen: false,
+  },
+}

--- a/apps/studio/src/features/previewLink/components/SharePreviewModal.tsx
+++ b/apps/studio/src/features/previewLink/components/SharePreviewModal.tsx
@@ -1,0 +1,190 @@
+import type { UseDisclosureReturn } from "@chakra-ui/react"
+import type { PreviewLinkExpiryChoice } from "~/schemas/previewLink"
+import {
+  FormControl,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Select,
+  Stack,
+  Text,
+  useClipboard,
+} from "@chakra-ui/react"
+import {
+  Button,
+  FormLabel,
+  Input,
+  useToast,
+} from "@opengovsg/design-system-react"
+import { useState } from "react"
+import {
+  PREVIEW_LINK_EXPIRY_CHOICES,
+  PREVIEW_LINK_LABEL_MAX_LENGTH,
+} from "~/schemas/previewLink"
+import { trpc } from "~/utils/trpc"
+
+interface SharePreviewModalProps extends Pick<
+  UseDisclosureReturn,
+  "isOpen" | "onClose"
+> {
+  siteId: number
+  resourceId: number
+}
+
+const EXPIRY_LABELS: Record<PreviewLinkExpiryChoice, string> = {
+  "24h": "24 hours",
+  "3d": "3 days",
+  "7d": "7 days",
+}
+
+const SGT_TIMEZONE = "Asia/Singapore"
+
+const formatSgtExpiry = (date: Date): string => {
+  const formatter = new Intl.DateTimeFormat("en-SG", {
+    timeZone: SGT_TIMEZONE,
+    weekday: "short",
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  return `${formatter.format(date)} SGT`
+}
+
+export const SharePreviewModal = ({
+  isOpen,
+  onClose,
+  siteId,
+  resourceId,
+}: SharePreviewModalProps): JSX.Element => {
+  const [expiry, setExpiry] = useState<PreviewLinkExpiryChoice>("3d")
+  const [label, setLabel] = useState("")
+  const [mintedUrl, setMintedUrl] = useState<string | null>(null)
+  const [mintedExpiresAt, setMintedExpiresAt] = useState<Date | null>(null)
+  const toast = useToast()
+
+  const mint = trpc.previewLink.mint.useMutation({
+    onSuccess: (result) => {
+      setMintedUrl(result.url)
+      setMintedExpiresAt(new Date(result.expiresAt))
+    },
+    onError: (err) => {
+      toast({
+        title: "Couldn't create preview link",
+        description: err.message,
+        status: "error",
+        isClosable: true,
+      })
+    },
+  })
+
+  const { onCopy, hasCopied } = useClipboard(mintedUrl ?? "")
+
+  const resetAndClose = (): void => {
+    setExpiry("3d")
+    setLabel("")
+    setMintedUrl(null)
+    setMintedExpiresAt(null)
+    onClose()
+  }
+
+  const handleGenerate = (): void => {
+    const trimmedLabel = label.trim()
+    mint.mutate({
+      siteId,
+      resourceId,
+      expiryChoice: expiry,
+      label: trimmedLabel.length > 0 ? trimmedLabel : undefined,
+    })
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={resetAndClose} size="lg">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Share preview</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          {mintedUrl && mintedExpiresAt ? (
+            <Stack spacing="1rem">
+              <Text>
+                Anyone with this link can view a read-only preview of this page
+                until it expires.
+              </Text>
+              <Input value={mintedUrl} isReadOnly aria-label="Preview link" />
+              <Text fontSize="sm" color="base.content.medium">
+                Expires {formatSgtExpiry(mintedExpiresAt)}
+              </Text>
+              <Text fontSize="xs" color="base.content.medium">
+                Confidential — please ask the recipient not to forward this
+                link.
+              </Text>
+            </Stack>
+          ) : (
+            <Stack spacing="1rem">
+              <FormControl>
+                <FormLabel>Expires after</FormLabel>
+                <Select
+                  value={expiry}
+                  onChange={(e) => {
+                    setExpiry(e.target.value as PreviewLinkExpiryChoice)
+                  }}
+                >
+                  {PREVIEW_LINK_EXPIRY_CHOICES.map((choice) => (
+                    <option key={choice} value={choice}>
+                      {EXPIRY_LABELS[choice]}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl>
+                <FormLabel>
+                  Label{" "}
+                  <Text as="span" color="base.content.medium" fontWeight={400}>
+                    (optional)
+                  </Text>
+                </FormLabel>
+                <Input
+                  value={label}
+                  onChange={(e) => {
+                    setLabel(e.target.value)
+                  }}
+                  maxLength={PREVIEW_LINK_LABEL_MAX_LENGTH}
+                  placeholder="e.g. For Director Tan"
+                />
+              </FormControl>
+            </Stack>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          {mintedUrl ? (
+            <HStack>
+              <Button variant="clear" onClick={resetAndClose}>
+                Close
+              </Button>
+              <Button onClick={onCopy}>
+                {hasCopied ? "Copied" : "Copy link"}
+              </Button>
+            </HStack>
+          ) : (
+            <HStack>
+              <Button variant="clear" onClick={resetAndClose}>
+                Cancel
+              </Button>
+              <Button onClick={handleGenerate} isLoading={mint.isPending}>
+                Generate link
+              </Button>
+            </HStack>
+          )}
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/previewLink/index.ts
+++ b/apps/studio/src/features/previewLink/index.ts
@@ -1,0 +1,1 @@
+export { SharePreviewButton } from "./components/SharePreviewButton"


### PR DESCRIPTION
## Problem

Editors need a UI to mint and copy a preview URL from within the page editor. This PR adds the share button and modal, completing the slice-1 tracer-bullet user journey.

Closes #2482

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- `SharePreviewButton`: share icon (no text, tooltip \"Share preview\") added to the page-editor top toolbar (`PageEditNavbar`), adjacent to the Publish button.
- `SharePreviewModal`: expiry dropdown defaulting to `3d` (options: `24h`, `3d`, `7d`), optional 80-char label field, and a `Generate` button. On mint, the modal switches to a result view showing the URL with a copy-to-clipboard button and the formatted expiry in Singapore time.
- The modal does NOT yet list existing links for the page — that lands in #2484.

## Before & After Screenshots

**BEFORE**: no share-preview affordance in the page editor.

**AFTER**: share icon in the toolbar opens the mint modal; clicking Generate produces a copyable preview URL.

## Tests

- Storybook stories for `SharePreviewModal` cover: initial form state, generating state, and success state with URL + expiry.

**Manual Verification Steps**:

- [ ] Open the page editor for any page; confirm the share icon appears next to Publish with a \"Share preview\" tooltip.
- [ ] Click the icon — confirm the modal opens with expiry defaulting to 3d.
- [ ] Click Generate — confirm a preview URL and SGT expiry display, with a working copy button.
- [ ] Open the generated URL in an incognito window — confirm the page renders correctly.
- [ ] Confirm the share icon is hidden / disabled for users without edit rights on the page.