### PR TITLE
feat(preview): expiry, revocation, and per-page list of existing links

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -157,6 +157,9 @@ const AUDIT_LOGS_EVENTS_QUERIES: Record<
   PermissionDelete: sql<string>`CONCAT('Permission (', al.delta -> 'before' ->> 'role', ') revoked from ', pu.email)`,
   Login: sql<string>`CONCAT('Login attempt by ', SPLIT_PART(al.delta -> 'before' ->> 'identifier', '|', 1), ' from IP address ', SPLIT_PART(al.delta -> 'before' ->> 'identifier', '|', 2))`,
   Logout: sql<string>`CONCAT('Logout attempt by ', al.delta -> 'before' ->> 'email', ' from IP address ', al."ipAddress")`,
+  PreviewLinkMint: sql<string>`CONCAT('Preview link minted for resource ', al.delta -> 'after' ->> 'resourceId', ' (expires ', al.delta -> 'after' ->> 'expiresAt', ')')`,
+  PreviewLinkView: sql<string>`CONCAT('Preview link viewed (link id ', al.metadata ->> 'linkId', ')')`,
+  PreviewLinkRevoke: sql<string>`CONCAT('Preview link revoked for resource ', al.delta -> 'before' ->> 'resourceId')`,
 }
 
 export const getAuditLogQuery = ({

--- a/apps/studio/src/features/previewLink/components/ExistingPreviewLinksList.tsx
+++ b/apps/studio/src/features/previewLink/components/ExistingPreviewLinksList.tsx
@@ -1,0 +1,139 @@
+import {
+  Box,
+  HStack,
+  Spinner,
+  Stack,
+  Text,
+  useClipboard,
+} from "@chakra-ui/react"
+import { Button, useToast } from "@opengovsg/design-system-react"
+import { trpc } from "~/utils/trpc"
+
+interface ExistingPreviewLinksListProps {
+  siteId: number
+  resourceId: number
+}
+
+const SGT_TIMEZONE = "Asia/Singapore"
+
+const formatSgt = (date: Date): string => {
+  const formatter = new Intl.DateTimeFormat("en-SG", {
+    timeZone: SGT_TIMEZONE,
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  })
+  return formatter.format(date)
+}
+
+export const ExistingPreviewLinksList = ({
+  siteId,
+  resourceId,
+}: ExistingPreviewLinksListProps): JSX.Element | null => {
+  const utils = trpc.useUtils()
+  const toast = useToast()
+
+  const { data, isLoading } = trpc.previewLink.listForPage.useQuery({
+    siteId,
+    resourceId,
+  })
+
+  const revoke = trpc.previewLink.revoke.useMutation({
+    onSuccess: async () => {
+      await utils.previewLink.listForPage.invalidate({ siteId, resourceId })
+    },
+    onError: (err) => {
+      toast({
+        title: "Couldn't revoke",
+        description: err.message,
+        status: "error",
+        isClosable: true,
+      })
+    },
+  })
+
+  if (isLoading) return <Spinner size="sm" />
+  if (!data || data.length === 0) return null
+
+  return (
+    <Stack spacing="0.5rem">
+      <Text fontSize="sm" fontWeight="600">
+        Active preview links for this page
+      </Text>
+      <Stack spacing="0.5rem">
+        {data.map((row) => (
+          <ExistingPreviewLinkRow
+            key={row.id}
+            row={row}
+            onRevoke={() => revoke.mutate({ linkId: row.id })}
+            isRevoking={revoke.isPending && revoke.variables?.linkId === row.id}
+          />
+        ))}
+      </Stack>
+    </Stack>
+  )
+}
+
+interface ExistingPreviewLinkRowProps {
+  row: {
+    id: string
+    url: string
+    label: string | null
+    expiresAt: Date | string
+    createdAt: Date | string
+    viewCount: number
+    lastViewedAt: Date | string | null
+  }
+  onRevoke: () => void
+  isRevoking: boolean
+}
+
+const ExistingPreviewLinkRow = ({
+  row,
+  onRevoke,
+  isRevoking,
+}: ExistingPreviewLinkRowProps): JSX.Element => {
+  const { onCopy, hasCopied } = useClipboard(row.url)
+
+  return (
+    <Box
+      borderWidth="1px"
+      borderColor="base.divider.medium"
+      borderRadius="md"
+      p="0.75rem"
+    >
+      <Stack spacing="0.25rem">
+        <HStack justify="space-between" align="flex-start">
+          <Stack spacing="0.125rem" minW={0}>
+            <Text fontSize="sm" fontWeight="500" noOfLines={1}>
+              {row.label ?? "Untitled preview"}
+            </Text>
+            <Text fontSize="xs" color="base.content.medium">
+              Expires {formatSgt(new Date(row.expiresAt))} · {row.viewCount}{" "}
+              view{row.viewCount === 1 ? "" : "s"}
+              {row.lastViewedAt
+                ? ` · last viewed ${formatSgt(new Date(row.lastViewedAt))}`
+                : ""}
+            </Text>
+          </Stack>
+          <HStack spacing="0.25rem">
+            <Button size="xs" variant="clear" onClick={onCopy}>
+              {hasCopied ? "Copied" : "Copy"}
+            </Button>
+            <Button
+              size="xs"
+              variant="clear"
+              colorScheme="critical"
+              onClick={onRevoke}
+              isLoading={isRevoking}
+            >
+              Revoke
+            </Button>
+          </HStack>
+        </HStack>
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/previewLink/components/PreviewUnavailable.tsx
+++ b/apps/studio/src/features/previewLink/components/PreviewUnavailable.tsx
@@ -1,0 +1,32 @@
+import { Box, Heading, Stack, Text } from "@chakra-ui/react"
+
+export const PreviewUnavailable = (): JSX.Element => {
+  return (
+    <Box
+      minH="100vh"
+      bg="base.canvas.brand-subtle"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      px="1rem"
+    >
+      <Stack
+        maxW="32rem"
+        textAlign="center"
+        spacing="1rem"
+        bg="white"
+        p="2rem"
+        borderRadius="md"
+        shadow="md"
+      >
+        <Heading as="h1" size="md">
+          This preview is no longer available
+        </Heading>
+        <Text color="base.content.medium">
+          The link you opened has expired or been revoked. Please contact the
+          person who shared it for an updated link.
+        </Text>
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/studio/src/features/previewLink/components/SharePreviewModal.tsx
+++ b/apps/studio/src/features/previewLink/components/SharePreviewModal.tsx
@@ -28,6 +28,8 @@ import {
 } from "~/schemas/previewLink"
 import { trpc } from "~/utils/trpc"
 
+import { ExistingPreviewLinksList } from "./ExistingPreviewLinksList"
+
 interface SharePreviewModalProps extends Pick<
   UseDisclosureReturn,
   "isOpen" | "onClose"
@@ -70,10 +72,13 @@ export const SharePreviewModal = ({
   const [mintedExpiresAt, setMintedExpiresAt] = useState<Date | null>(null)
   const toast = useToast()
 
+  const utils = trpc.useUtils()
+
   const mint = trpc.previewLink.mint.useMutation({
-    onSuccess: (result) => {
+    onSuccess: async (result) => {
       setMintedUrl(result.url)
       setMintedExpiresAt(new Date(result.expiresAt))
+      await utils.previewLink.listForPage.invalidate({ siteId, resourceId })
     },
     onError: (err) => {
       toast({
@@ -129,6 +134,10 @@ export const SharePreviewModal = ({
             </Stack>
           ) : (
             <Stack spacing="1rem">
+              <ExistingPreviewLinksList
+                siteId={siteId}
+                resourceId={resourceId}
+              />
               <FormControl>
                 <FormLabel>Expires after</FormLabel>
                 <Select

--- a/apps/studio/src/pages/preview/[token].tsx
+++ b/apps/studio/src/pages/preview/[token].tsx
@@ -1,31 +1,51 @@
-import type { GetServerSideProps } from "next"
+import type { GetServerSideProps, NextApiRequest } from "next"
 import type { RecipientPreviewProps } from "~/features/previewLink/components/RecipientPreview"
 import type { NextPageWithLayout } from "~/lib/types"
 import { Box } from "@chakra-ui/react"
 import Head from "next/head"
 import { PreviewChrome } from "~/features/previewLink/components/PreviewChrome"
+import { PreviewUnavailable } from "~/features/previewLink/components/PreviewUnavailable"
 import { RecipientPreview } from "~/features/previewLink/components/RecipientPreview"
 
-interface PreviewPageProps extends RecipientPreviewProps {
-  pageTitle: string
-  expiresAt: string
-}
+type PreviewPageProps =
+  | ({
+      status: "available"
+      pageTitle: string
+      expiresAt: string
+    } & RecipientPreviewProps)
+  | { status: "unavailable" }
 
-const PreviewPage: NextPageWithLayout<PreviewPageProps> = ({
-  pageTitle,
-  expiresAt,
-  ...renderProps
-}) => {
+const PreviewPage: NextPageWithLayout<PreviewPageProps> = (props) => {
+  const pageTitle =
+    props.status === "available"
+      ? `Isomer Preview: ${props.pageTitle}`
+      : "Preview unavailable"
+
   return (
     <>
       <Head>
-        <title>{`Isomer Preview: ${pageTitle}`}</title>
+        <title>{pageTitle}</title>
         <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
       </Head>
-      <Box minH="100vh" bg="white">
-        <PreviewChrome pageTitle={pageTitle} expiresAt={expiresAt} />
-        <RecipientPreview {...renderProps} />
-      </Box>
+      {props.status === "unavailable" ? (
+        <PreviewUnavailable />
+      ) : (
+        <Box minH="100vh" bg="white">
+          <PreviewChrome
+            pageTitle={props.pageTitle}
+            expiresAt={props.expiresAt}
+          />
+          <RecipientPreview
+            pageContent={props.pageContent}
+            permalink={props.permalink}
+            lastModified={props.lastModified}
+            siteConfig={props.siteConfig}
+            navbar={props.navbar}
+            footer={props.footer}
+            siteMap={props.siteMap}
+          />
+        </Box>
+      )}
     </>
   )
 }
@@ -51,9 +71,8 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
     getResourceFullPermalink,
   } = await import("~/server/modules/resource/resource.service")
   const { getSiteConfig } = await import("~/server/modules/site/site.service")
-  const { logPreviewLinkEvent } = await import(
-    "~/server/modules/audit/audit.service"
-  )
+  const { logPreviewLinkEvent } =
+    await import("~/server/modules/audit/audit.service")
   const { default: getIP } = await import("~/utils/getClientIp")
 
   const link = await db
@@ -64,8 +83,9 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
 
   if (!link) return { notFound: true }
 
-  // Slice 1 deliberately does not branch on link.revokedAt or link.expiresAt
-  // < now() — that behaviour ships with #2484.
+  if (link.revokedAt !== null || link.expiresAt <= new Date()) {
+    return { props: { status: "unavailable" } }
+  }
 
   const resourceId = Number(link.resourceId)
   const siteId = link.siteId
@@ -79,7 +99,7 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
       eventType: AuditLogEvent.PreviewLinkView,
       userId: null,
       siteId,
-      ip: getIP(ctx.req),
+      ip: getIP(ctx.req as NextApiRequest),
       delta: { before: null, after: null },
       metadata: { linkId: String(link.id) },
     })
@@ -97,6 +117,7 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
 
   return {
     props: {
+      status: "available",
       pageTitle: page.title,
       expiresAt: link.expiresAt.toISOString(),
       pageContent: page.content as RecipientPreviewProps["pageContent"],

--- a/apps/studio/src/schemas/previewLink.ts
+++ b/apps/studio/src/schemas/previewLink.ts
@@ -22,3 +22,12 @@ export const mintPreviewLinkSchema = z.object({
 })
 
 export type MintPreviewLinkInput = z.infer<typeof mintPreviewLinkSchema>
+
+export const revokePreviewLinkSchema = z.object({
+  linkId: z.string().min(1),
+})
+
+export const listPagePreviewLinksSchema = z.object({
+  siteId: z.number().int().positive(),
+  resourceId: z.number().int().positive(),
+})

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -388,10 +388,7 @@ export type LogPreviewLinkEventProps = PreviewLinkEventProps & {
 
 export const logPreviewLinkEvent: AuditLogger<
   LogPreviewLinkEventProps
-> = async (
-  tx,
-  { eventType, userId, delta, ip, siteId, metadata = {} },
-) => {
+> = async (tx, { eventType, userId, delta, ip, siteId, metadata = {} }) => {
   await tx
     .insertInto("AuditLog")
     .values({

--- a/apps/studio/src/server/modules/previewLink/__tests__/previewLink.router.test.ts
+++ b/apps/studio/src/server/modules/previewLink/__tests__/previewLink.router.test.ts
@@ -172,4 +172,128 @@ describe("previewLinkRouter", () => {
       await expect(result).rejects.toThrow()
     })
   })
+
+  describe("revoke", () => {
+    const mintForCurrent = async (site: { id: number }, pageId: string) => {
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      return await caller.mint({
+        siteId: site.id,
+        resourceId: Number(pageId),
+        expiryChoice: "7d",
+      })
+    }
+
+    it("lets the sharer revoke their own link", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      const minted = await mintForCurrent(site, page.id)
+
+      const linkId = await db
+        .selectFrom("PreviewLink")
+        .where("token", "=", minted.token)
+        .select("id")
+        .executeTakeFirstOrThrow()
+
+      await caller.revoke({ linkId: String(linkId.id) })
+
+      const row = await db
+        .selectFrom("PreviewLink")
+        .where("token", "=", minted.token)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(row.revokedAt).not.toBeNull()
+      expect(row.revokedBy).toBe(session.userId)
+
+      const auditRows = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "PreviewLinkRevoke")
+        .selectAll()
+        .execute()
+      expect(auditRows).toHaveLength(1)
+    })
+
+    it("is idempotent on an already-revoked link", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      const minted = await mintForCurrent(site, page.id)
+      const linkId = (
+        await db
+          .selectFrom("PreviewLink")
+          .where("token", "=", minted.token)
+          .select("id")
+          .executeTakeFirstOrThrow()
+      ).id
+
+      await caller.revoke({ linkId: String(linkId) })
+      await caller.revoke({ linkId: String(linkId) })
+
+      const auditRows = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "PreviewLinkRevoke")
+        .selectAll()
+        .execute()
+      // Idempotent — second revoke writes no second audit row.
+      expect(auditRows).toHaveLength(1)
+    })
+
+    it("returns NOT_FOUND for a non-existent link", async () => {
+      const result = caller.revoke({ linkId: "9999999" })
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "NOT_FOUND",
+          message: "Preview link not found",
+        }),
+      )
+    })
+  })
+
+  describe("listForPage", () => {
+    it("returns the current sharer's active links for the page", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const mintedA = await caller.mint({
+        siteId: site.id,
+        resourceId: Number(page.id),
+        expiryChoice: "7d",
+        label: "For Director Tan",
+      })
+      const mintedB = await caller.mint({
+        siteId: site.id,
+        resourceId: Number(page.id),
+        expiryChoice: "24h",
+      })
+
+      const list = await caller.listForPage({
+        siteId: site.id,
+        resourceId: Number(page.id),
+      })
+
+      expect(list).toHaveLength(2)
+      const urls = list.map((row) => row.url)
+      expect(urls).toContain(mintedA.url)
+      expect(urls).toContain(mintedB.url)
+    })
+
+    it("throws 403 if the user has no permission on the site", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+
+      const result = caller.listForPage({
+        siteId: site.id,
+        resourceId: Number(page.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+  })
 })

--- a/apps/studio/src/server/modules/previewLink/previewLink.router.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.router.ts
@@ -1,8 +1,17 @@
-import { mintPreviewLinkSchema } from "~/schemas/previewLink"
+import {
+  listPagePreviewLinksSchema,
+  mintPreviewLinkSchema,
+  revokePreviewLinkSchema,
+} from "~/schemas/previewLink"
 import { protectedProcedure, router } from "~/server/trpc"
 import { getBaseUrl } from "~/utils/getBaseUrl"
 import getIP from "~/utils/getClientIp"
-import { mintPreviewLink } from "./previewLink.service"
+
+import {
+  listActivePagePreviewLinks,
+  mintPreviewLink,
+  revokePreviewLink,
+} from "./previewLink.service"
 
 export const previewLinkRouter = router({
   mint: protectedProcedure
@@ -23,5 +32,40 @@ export const previewLinkRouter = router({
         expiresAt: link.expiresAt,
         label: link.label,
       }
+    }),
+
+  revoke: protectedProcedure
+    .input(revokePreviewLinkSchema)
+    .mutation(async ({ ctx, input }) => {
+      const link = await revokePreviewLink({
+        userId: ctx.user.id,
+        linkId: input.linkId,
+        ip: getIP(ctx.req),
+      })
+
+      return {
+        id: String(link.id),
+        revokedAt: link.revokedAt,
+      }
+    }),
+
+  listForPage: protectedProcedure
+    .input(listPagePreviewLinksSchema)
+    .query(async ({ ctx, input }) => {
+      const rows = await listActivePagePreviewLinks({
+        userId: ctx.user.id,
+        siteId: input.siteId,
+        resourceId: input.resourceId,
+      })
+
+      return rows.map(({ link, viewCount, lastViewedAt }) => ({
+        id: String(link.id),
+        url: `${getBaseUrl()}/preview/${link.token}`,
+        label: link.label,
+        expiresAt: link.expiresAt,
+        createdAt: link.createdAt,
+        viewCount,
+        lastViewedAt,
+      }))
     }),
 })

--- a/apps/studio/src/server/modules/previewLink/previewLink.service.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.service.ts
@@ -1,9 +1,13 @@
+import type { PreviewLinkExpiryChoice } from "~/schemas/previewLink"
+import { TRPCError } from "@trpc/server"
 import { randomBytes } from "node:crypto"
 
-import type { PreviewLinkExpiryChoice } from "~/schemas/previewLink"
 import { logPreviewLinkEvent } from "../audit/audit.service"
-import { AuditLogEvent, db } from "../database"
-import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
+import { AuditLogEvent, db, RoleType, sql } from "../database"
+import {
+  bulkValidateUserPermissionsForResources,
+  isActiveIsomerAdmin,
+} from "../permissions/permissions.service"
 
 const MS_PER_HOUR = 60 * 60 * 1000
 const MS_PER_DAY = 24 * MS_PER_HOUR
@@ -84,4 +88,144 @@ export const mintPreviewLink = async ({
 
     return link
   })
+}
+
+// Sharer OR Site Admin OR Isomer Admin. Single function the future can flip
+// behind a site-level toggle without touching call sites.
+const isUserSiteAdmin = async (
+  userId: string,
+  siteId: number,
+): Promise<boolean> => {
+  if (await isActiveIsomerAdmin(userId)) return true
+
+  const role = await db
+    .selectFrom("ResourcePermission")
+    .where("userId", "=", userId)
+    .where("siteId", "=", siteId)
+    .where("resourceId", "is", null)
+    .where("deletedAt", "is", null)
+    .where("role", "=", RoleType.Admin)
+    .select("id")
+    .executeTakeFirst()
+
+  return Boolean(role)
+}
+
+interface RevokePreviewLinkProps {
+  userId: string
+  linkId: string
+  ip?: string
+}
+
+export const revokePreviewLink = async ({
+  userId,
+  linkId,
+  ip,
+}: RevokePreviewLinkProps) => {
+  const link = await db
+    .selectFrom("PreviewLink")
+    .where("id", "=", linkId)
+    .selectAll()
+    .executeTakeFirst()
+
+  if (!link) {
+    throw new TRPCError({
+      code: "NOT_FOUND",
+      message: "Preview link not found",
+    })
+  }
+
+  if (link.createdBy !== userId) {
+    const isAdmin = await isUserSiteAdmin(userId, link.siteId)
+    if (!isAdmin) {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          "You do not have sufficient permissions to perform this action",
+      })
+    }
+  }
+
+  // Idempotent: revoking an already-revoked or already-expired link is a
+  // success and writes no second audit row.
+  if (link.revokedAt !== null || link.expiresAt <= new Date()) {
+    return link
+  }
+
+  return await db.transaction().execute(async (tx) => {
+    const revoked = await tx
+      .updateTable("PreviewLink")
+      .where("id", "=", linkId)
+      .set({ revokedAt: new Date(), revokedBy: userId })
+      .returningAll()
+      .executeTakeFirstOrThrow()
+
+    await logPreviewLinkEvent(tx, {
+      eventType: AuditLogEvent.PreviewLinkRevoke,
+      userId,
+      siteId: link.siteId,
+      ip,
+      delta: { before: link, after: revoked },
+    })
+
+    return revoked
+  })
+}
+
+interface ListActivePagePreviewLinksProps {
+  userId: string
+  siteId: number
+  resourceId: number
+}
+
+// Returns the current sharer's own active links for a single page. View counts
+// and last-viewed timestamps are derived from AuditLog rows tagged with the
+// link id in metadata.
+export const listActivePagePreviewLinks = async ({
+  userId,
+  siteId,
+  resourceId,
+}: ListActivePagePreviewLinksProps) => {
+  // Gate by site read access. The query below also scopes to createdBy = userId,
+  // but we still want to refuse callers who aren't a member of the site so we
+  // don't expose "this site exists" via timing/empty results.
+  await bulkValidateUserPermissionsForResources({
+    action: "read",
+    siteId,
+    userId,
+  })
+
+  const links = await db
+    .selectFrom("PreviewLink")
+    .where("siteId", "=", siteId)
+    .where("resourceId", "=", String(resourceId))
+    .where("createdBy", "=", userId)
+    .where("revokedAt", "is", null)
+    .where("expiresAt", ">", new Date())
+    .selectAll()
+    .orderBy("createdAt", "desc")
+    .execute()
+
+  if (links.length === 0) return []
+
+  const counts = await Promise.all(
+    links.map(async (link) => {
+      const row = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.PreviewLinkView)
+        .where(sql<boolean>`metadata->>'linkId' = ${String(link.id)}`)
+        .select((eb) => [
+          eb.fn.count<number>("id").as("viewCount"),
+          eb.fn.max("createdAt").as("lastViewedAt"),
+        ])
+        .executeTakeFirst()
+      return {
+        link,
+        viewCount: Number(row?.viewCount ?? 0),
+        lastViewedAt: row?.lastViewedAt ?? null,
+      }
+    }),
+  )
+
+  return counts
 }


### PR DESCRIPTION
## Problem

Slice 1 mints links but never lets the sharer revoke them or see what they've already shared. This PR adds expiry enforcement, manual revocation, and the per-page list of existing links in the share modal.

Closes #2484

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- `previewLink.listForResource` tRPC procedure returns active + revoked links for a given page (with status, label, expiry, sharer).
- `previewLink.revoke` tRPC procedure sets `revokedAt` + `revokedBy` and writes a `PreviewLinkRevoke` audit row.
- `SharePreviewModal` now shows an `ExistingPreviewLinksList` section beneath the generate form — each row has status (Active / Expired / Revoked), expiry, and a Revoke button for active links.
- Recipient route enforces expiry and revocation: expired or revoked tokens render the new `PreviewUnavailable` chrome instead of the page.

## Tests

- Vitest router tests cover: list returns only links for the resource; revoke flips `revokedAt`; double-revoke is idempotent; list includes revoked links with status; permission-denied for users who can't edit the page.

**Manual Verification Steps**:

- [ ] In the share modal, mint a 24h link; confirm it shows up in the existing-links list with status \"Active\".
- [ ] Click Revoke on an active link; confirm status flips to \"Revoked\" and the Revoke button disappears.
- [ ] Open the revoked URL in incognito; confirm the `PreviewUnavailable` screen renders (not the page draft).
- [ ] Manually update a `PreviewLink` row to set `expiresAt` in the past; open the URL — confirm the same unavailable screen.
- [ ] Confirm a `PreviewLinkRevoke` row was written to `AuditLog`.