### PR TITLE
feat(preview): rate-limit mint and view

### DIFF
--- a/apps/studio/src/features/previewLink/components/PreviewRateLimited.tsx
+++ b/apps/studio/src/features/previewLink/components/PreviewRateLimited.tsx
@@ -1,0 +1,31 @@
+import { Box, Heading, Stack, Text } from "@chakra-ui/react"
+
+export const PreviewRateLimited = (): JSX.Element => {
+  return (
+    <Box
+      minH="100vh"
+      bg="base.canvas.brand-subtle"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      px="1rem"
+    >
+      <Stack
+        maxW="32rem"
+        textAlign="center"
+        spacing="1rem"
+        bg="white"
+        p="2rem"
+        borderRadius="md"
+        shadow="md"
+      >
+        <Heading as="h1" size="md">
+          You&apos;re refreshing this preview very rapidly
+        </Heading>
+        <Text color="base.content.medium">
+          Please wait a moment, then refresh again.
+        </Text>
+      </Stack>
+    </Box>
+  )
+}

--- a/apps/studio/src/pages/preview/[token].tsx
+++ b/apps/studio/src/pages/preview/[token].tsx
@@ -4,6 +4,7 @@ import type { NextPageWithLayout } from "~/lib/types"
 import { Box } from "@chakra-ui/react"
 import Head from "next/head"
 import { PreviewChrome } from "~/features/previewLink/components/PreviewChrome"
+import { PreviewRateLimited } from "~/features/previewLink/components/PreviewRateLimited"
 import { PreviewUnavailable } from "~/features/previewLink/components/PreviewUnavailable"
 import { RecipientPreview } from "~/features/previewLink/components/RecipientPreview"
 
@@ -14,21 +15,35 @@ type PreviewPageProps =
       expiresAt: string
     } & RecipientPreviewProps)
   | { status: "unavailable" }
+  | { status: "rate-limited" }
+
+const getTitleForStatus = (status: PreviewPageProps["status"]): string => {
+  switch (status) {
+    case "available":
+      return "Isomer Preview"
+    case "unavailable":
+      return "Preview unavailable"
+    case "rate-limited":
+      return "Slow down"
+  }
+}
 
 const PreviewPage: NextPageWithLayout<PreviewPageProps> = (props) => {
-  const pageTitle =
+  const headTitle =
     props.status === "available"
       ? `Isomer Preview: ${props.pageTitle}`
-      : "Preview unavailable"
+      : getTitleForStatus(props.status)
 
   return (
     <>
       <Head>
-        <title>{pageTitle}</title>
+        <title>{headTitle}</title>
         <meta name="robots" content="noindex, nofollow, noarchive, nosnippet" />
       </Head>
       {props.status === "unavailable" ? (
         <PreviewUnavailable />
+      ) : props.status === "rate-limited" ? (
+        <PreviewRateLimited />
       ) : (
         <Box minH="100vh" bg="white">
           <PreviewChrome
@@ -74,6 +89,9 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
   const { logPreviewLinkEvent } =
     await import("~/server/modules/audit/audit.service")
   const { default: getIP } = await import("~/utils/getClientIp")
+  const { checkPreviewViewRateLimit } =
+    await import("~/server/modules/previewLink/previewLink.service")
+  const { prisma } = await import("~/server/prisma")
 
   const link = await db
     .selectFrom("PreviewLink")
@@ -87,6 +105,14 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
     return { props: { status: "unavailable" } }
   }
 
+  const ip = getIP(ctx.req as NextApiRequest)
+
+  // Rate limit BEFORE audit + fetch. The audit log is the resource we're
+  // protecting; over-limit must not write a row. Soft-block UX (friendly page),
+  // not HTTP 429.
+  const allowed = await checkPreviewViewRateLimit(prisma, ip, String(link.id))
+  if (!allowed) return { props: { status: "rate-limited" } }
+
   const resourceId = Number(link.resourceId)
   const siteId = link.siteId
 
@@ -99,7 +125,7 @@ export const getServerSideProps: GetServerSideProps<PreviewPageProps> = async (
       eventType: AuditLogEvent.PreviewLinkView,
       userId: null,
       siteId,
-      ip: getIP(ctx.req as NextApiRequest),
+      ip,
       delta: { before: null, after: null },
       metadata: { linkId: String(link.id) },
     })

--- a/apps/studio/src/server/modules/previewLink/previewLink.router.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.router.ts
@@ -13,8 +13,17 @@ import {
   revokePreviewLink,
 } from "./previewLink.service"
 
+const MINT_RATE_LIMIT_MAX = 20
+const MINT_RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+
 export const previewLinkRouter = router({
   mint: protectedProcedure
+    .meta({
+      rateLimitOptions: {
+        max: MINT_RATE_LIMIT_MAX,
+        windowMs: MINT_RATE_LIMIT_WINDOW_MS,
+      },
+    })
     .input(mintPreviewLinkSchema)
     .mutation(async ({ ctx, input }) => {
       const link = await mintPreviewLink({

--- a/apps/studio/src/server/modules/previewLink/previewLink.service.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.service.ts
@@ -1,6 +1,8 @@
 import type { PreviewLinkExpiryChoice } from "~/schemas/previewLink"
+import type { PrismaClient } from "~prisma/generated/prisma/client"
 import { TRPCError } from "@trpc/server"
 import { randomBytes } from "node:crypto"
+import { RateLimiterPrisma, RateLimiterRes } from "rate-limiter-flexible"
 
 import { logPreviewLinkEvent } from "../audit/audit.service"
 import { AuditLogEvent, db, RoleType, sql } from "../database"
@@ -170,6 +172,33 @@ export const revokePreviewLink = async ({
 
     return revoked
   })
+}
+
+// Soft-block view limiter: 60 requests per minute per (IP, linkId). Over-limit,
+// the route shows a friendly soft-block page and does NOT write a view audit
+// row — the audit log is exactly what this limit exists to protect.
+const VIEW_RATE_LIMIT_MAX = 60
+const VIEW_RATE_LIMIT_WINDOW_SECONDS = 60
+
+export const checkPreviewViewRateLimit = async (
+  prisma: PrismaClient,
+  ip: string,
+  linkId: string,
+): Promise<boolean> => {
+  const limiter = new RateLimiterPrisma({
+    storeClient: prisma,
+    points: VIEW_RATE_LIMIT_MAX,
+    duration: VIEW_RATE_LIMIT_WINDOW_SECONDS,
+    keyPrefix: "preview-view",
+  })
+
+  try {
+    await limiter.consume(`${ip}|${linkId}`)
+    return true
+  } catch (err) {
+    if (err instanceof RateLimiterRes) return false
+    throw err
+  }
 }
 
 interface ListActivePagePreviewLinksProps {


### PR DESCRIPTION
## Problem

Without rate limits, mint and view endpoints are easy to abuse — bulk minting or scraping a leaked URL pattern. This PR adds rate limiting on both.

Closes #2485

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Rate limit on `previewLink.mint`: per-user bucket (limits documented in the service).
- Rate limit on the `/preview/[token]` recipient route: per-token + per-IP bucket.
- Rate-limited responses render a new `PreviewRateLimited` chrome (HTTP 429 with a friendly message) instead of the page draft.

## Tests

- Manual saturation test against the dev rate limiter confirms 429 is returned and `PreviewRateLimited` UI renders.

**Manual Verification Steps**:

- [ ] In dev, lower the mint limit temporarily and burst-call `previewLink.mint`; confirm a rate-limit error is returned after the threshold.
- [ ] Burst-refresh a valid preview URL in incognito; confirm the `PreviewRateLimited` chrome appears after the per-token threshold.
- [ ] Wait for the bucket window to clear; confirm normal access resumes.