### PR TITLE
feat(preview): site-level overview at /sites/[siteId]/preview-links

### DIFF
--- a/apps/studio/src/features/previewLink/components/SitePreviewLinksTable.tsx
+++ b/apps/studio/src/features/previewLink/components/SitePreviewLinksTable.tsx
@@ -1,0 +1,207 @@
+import type { PreviewLinkStatusFilter } from "~/schemas/previewLink"
+import {
+  HStack,
+  Skeleton,
+  Stack,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useClipboard,
+} from "@chakra-ui/react"
+import { Button, useToast } from "@opengovsg/design-system-react"
+import { useState } from "react"
+import { PREVIEW_LINK_STATUS_FILTERS } from "~/schemas/previewLink"
+import { trpc } from "~/utils/trpc"
+
+interface SitePreviewLinksTableProps {
+  siteId: number
+}
+
+const SGT_TIMEZONE = "Asia/Singapore"
+const formatSgt = (value: Date | string | null): string => {
+  if (!value) return "—"
+  const date = typeof value === "string" ? new Date(value) : value
+  return new Intl.DateTimeFormat("en-SG", {
+    timeZone: SGT_TIMEZONE,
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date)
+}
+
+const STATUS_LABEL: Record<PreviewLinkStatusFilter, string> = {
+  active: "Active",
+  expired: "Expired",
+  revoked: "Revoked",
+  all: "All",
+}
+
+const computeStatus = (row: {
+  revokedAt: Date | string | null
+  expiresAt: Date | string
+}): "Active" | "Expired" | "Revoked" => {
+  if (row.revokedAt !== null) return "Revoked"
+  const expiry =
+    typeof row.expiresAt === "string" ? new Date(row.expiresAt) : row.expiresAt
+  if (expiry <= new Date()) return "Expired"
+  return "Active"
+}
+
+export const SitePreviewLinksTable = ({
+  siteId,
+}: SitePreviewLinksTableProps): JSX.Element => {
+  const [status, setStatus] = useState<PreviewLinkStatusFilter>("active")
+  const toast = useToast()
+  const utils = trpc.useUtils()
+
+  const { data, isLoading } = trpc.previewLink.listForSite.useQuery({
+    siteId,
+    status,
+  })
+
+  const revoke = trpc.previewLink.revoke.useMutation({
+    onSuccess: async () => {
+      await utils.previewLink.listForSite.invalidate({ siteId, status })
+    },
+    onError: (err) => {
+      toast({
+        title: "Couldn't revoke",
+        description: err.message,
+        status: "error",
+        isClosable: true,
+      })
+    },
+  })
+
+  return (
+    <Stack spacing="1rem" w="100%">
+      <HStack spacing="0.5rem" wrap="wrap">
+        {PREVIEW_LINK_STATUS_FILTERS.map((option) => (
+          <Button
+            key={option}
+            size="xs"
+            variant={status === option ? "solid" : "clear"}
+            onClick={() => {
+              setStatus(option)
+            }}
+          >
+            {STATUS_LABEL[option]}
+          </Button>
+        ))}
+      </HStack>
+
+      {isLoading ? (
+        <Skeleton h="6rem" />
+      ) : !data || data.links.length === 0 ? (
+        <Text color="base.content.medium" fontSize="sm">
+          No preview links match this filter.
+        </Text>
+      ) : (
+        <Table size="sm" variant="simple">
+          <Thead>
+            <Tr>
+              <Th>Page</Th>
+              <Th>Label</Th>
+              {data.viewerIsAdmin ? <Th>Sharer</Th> : null}
+              <Th>Created</Th>
+              <Th>Expires</Th>
+              <Th>Last viewed</Th>
+              <Th isNumeric>Views</Th>
+              <Th>Status</Th>
+              <Th>Actions</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {data.links.map((row) => {
+              const rowStatus = computeStatus(row)
+              const canRevoke =
+                rowStatus === "Active" && (row.isOwnLink || data.viewerIsAdmin)
+              return (
+                <SitePreviewLinksRow
+                  key={row.id}
+                  row={row}
+                  status={rowStatus}
+                  showSharer={data.viewerIsAdmin}
+                  canRevoke={canRevoke}
+                  onRevoke={() => revoke.mutate({ linkId: row.id })}
+                  isRevoking={
+                    revoke.isPending && revoke.variables?.linkId === row.id
+                  }
+                />
+              )
+            })}
+          </Tbody>
+        </Table>
+      )}
+    </Stack>
+  )
+}
+
+interface SitePreviewLinksRowProps {
+  row: {
+    id: string
+    url: string
+    pageTitle: string | null
+    resourceId: string | null
+    label: string | null
+    sharerName: string | null
+    sharerEmail: string | null
+    createdAt: Date | string
+    expiresAt: Date | string
+    lastViewedAt: Date | string | null
+    viewCount: number
+  }
+  status: "Active" | "Expired" | "Revoked"
+  showSharer: boolean
+  canRevoke: boolean
+  onRevoke: () => void
+  isRevoking: boolean
+}
+
+const SitePreviewLinksRow = ({
+  row,
+  status,
+  showSharer,
+  canRevoke,
+  onRevoke,
+  isRevoking,
+}: SitePreviewLinksRowProps): JSX.Element => {
+  const { onCopy, hasCopied } = useClipboard(row.url)
+  return (
+    <Tr>
+      <Td>{row.pageTitle ?? "—"}</Td>
+      <Td>{row.label ?? "—"}</Td>
+      {showSharer ? <Td>{row.sharerName ?? row.sharerEmail ?? "—"}</Td> : null}
+      <Td>{formatSgt(row.createdAt)}</Td>
+      <Td>{formatSgt(row.expiresAt)}</Td>
+      <Td>{formatSgt(row.lastViewedAt)}</Td>
+      <Td isNumeric>{row.viewCount}</Td>
+      <Td>{status}</Td>
+      <Td>
+        <HStack spacing="0.25rem">
+          <Button size="xs" variant="clear" onClick={onCopy}>
+            {hasCopied ? "Copied" : "Copy"}
+          </Button>
+          {canRevoke ? (
+            <Button
+              size="xs"
+              variant="clear"
+              colorScheme="critical"
+              onClick={onRevoke}
+              isLoading={isRevoking}
+            >
+              Revoke
+            </Button>
+          ) : null}
+        </HStack>
+      </Td>
+    </Tr>
+  )
+}

--- a/apps/studio/src/pages/sites/[siteId]/preview-links.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/preview-links.tsx
@@ -1,0 +1,60 @@
+import type { NextPageWithLayout } from "~/lib/types"
+import { Box, HStack, Text, VStack } from "@chakra-ui/react"
+import { BiShareAlt } from "react-icons/bi"
+import { z } from "zod"
+import { PermissionsBoundary } from "~/components/AuthWrappers"
+import { SitePreviewLinksTable } from "~/features/previewLink/components/SitePreviewLinksTable"
+import { useQueryParse } from "~/hooks/useQueryParse"
+import { SiteBasicLayout } from "~/templates/layouts/SiteBasicLayout"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+const sitePreviewLinksSchema = z.object({
+  siteId: z.coerce.number(),
+})
+
+const SitePreviewLinksPage: NextPageWithLayout = () => {
+  const { siteId } = useQueryParse(sitePreviewLinksSchema)
+
+  return (
+    <VStack
+      w="100%"
+      p="1.75rem"
+      gap="1rem"
+      height="0"
+      overflow="auto"
+      minH="100%"
+      alignItems="start"
+    >
+      <VStack w="100%" align="start" spacing="0.25rem">
+        <HStack mr="1.25rem" gap="0.75rem">
+          <Box
+            aria-hidden
+            bg="brand.secondary.100"
+            p="0.5rem"
+            borderRadius="6px"
+          >
+            <BiShareAlt />
+          </Box>
+          <Text as="h3" textStyle="h3">
+            Preview links
+          </Text>
+        </HStack>
+        <Text color="base.content.medium" fontSize="sm">
+          Short-lived URLs shared for review. Editors see their own; Site Admins
+          see all.
+        </Text>
+      </VStack>
+
+      <SitePreviewLinksTable siteId={siteId} />
+    </VStack>
+  )
+}
+
+SitePreviewLinksPage.getLayout = (page: React.ReactNode) => (
+  <PermissionsBoundary
+    resourceType={ResourceType.RootPage}
+    page={SiteBasicLayout(page)}
+  />
+)
+
+export default SitePreviewLinksPage

--- a/apps/studio/src/schemas/previewLink.ts
+++ b/apps/studio/src/schemas/previewLink.ts
@@ -24,10 +24,26 @@ export const mintPreviewLinkSchema = z.object({
 export type MintPreviewLinkInput = z.infer<typeof mintPreviewLinkSchema>
 
 export const revokePreviewLinkSchema = z.object({
-  linkId: z.string().min(1),
+  linkId: z.string().min(1, {
+    message: "Provide the preview link id to revoke",
+  }),
 })
 
 export const listPagePreviewLinksSchema = z.object({
   siteId: z.number().int().positive(),
   resourceId: z.number().int().positive(),
+})
+
+export const PREVIEW_LINK_STATUS_FILTERS = [
+  "active",
+  "expired",
+  "revoked",
+  "all",
+] as const
+export type PreviewLinkStatusFilter =
+  (typeof PREVIEW_LINK_STATUS_FILTERS)[number]
+
+export const listSitePreviewLinksSchema = z.object({
+  siteId: z.number().int().positive(),
+  status: z.enum(PREVIEW_LINK_STATUS_FILTERS).default("active"),
 })

--- a/apps/studio/src/server/modules/previewLink/previewLink.router.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.router.ts
@@ -1,5 +1,6 @@
 import {
   listPagePreviewLinksSchema,
+  listSitePreviewLinksSchema,
   mintPreviewLinkSchema,
   revokePreviewLinkSchema,
 } from "~/schemas/previewLink"
@@ -9,6 +10,7 @@ import getIP from "~/utils/getClientIp"
 
 import {
   listActivePagePreviewLinks,
+  listSitePreviewLinks,
   mintPreviewLink,
   revokePreviewLink,
 } from "./previewLink.service"
@@ -76,5 +78,34 @@ export const previewLinkRouter = router({
         viewCount,
         lastViewedAt,
       }))
+    }),
+
+  listForSite: protectedProcedure
+    .input(listSitePreviewLinksSchema)
+    .query(async ({ ctx, input }) => {
+      const result = await listSitePreviewLinks({
+        userId: ctx.user.id,
+        siteId: input.siteId,
+        status: input.status,
+      })
+
+      return {
+        viewerIsAdmin: result.viewerIsAdmin,
+        links: result.links.map((row) => ({
+          id: String(row.id),
+          url: `${getBaseUrl()}/preview/${row.token}`,
+          label: row.label,
+          pageTitle: row.pageTitle,
+          resourceId: row.resourceId ? String(row.resourceId) : null,
+          sharerName: row.sharerName,
+          sharerEmail: row.sharerEmail,
+          isOwnLink: row.createdBy === ctx.user.id,
+          createdAt: row.createdAt,
+          expiresAt: row.expiresAt,
+          revokedAt: row.revokedAt,
+          viewCount: row.viewCount,
+          lastViewedAt: row.lastViewedAt,
+        })),
+      }
     }),
 })

--- a/apps/studio/src/server/modules/previewLink/previewLink.service.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.service.ts
@@ -201,6 +201,90 @@ export const checkPreviewViewRateLimit = async (
   }
 }
 
+interface ListSitePreviewLinksProps {
+  userId: string
+  siteId: number
+  status: "active" | "expired" | "revoked" | "all"
+}
+
+// Site-level overview. Editor sees own links; Site Admin or Isomer Admin sees
+// all. The same component renders both — scope is enforced here at the data
+// layer, never in the UI.
+export const listSitePreviewLinks = async ({
+  userId,
+  siteId,
+  status,
+}: ListSitePreviewLinksProps) => {
+  await bulkValidateUserPermissionsForResources({
+    action: "read",
+    siteId,
+    userId,
+  })
+
+  const viewerIsAdmin = await isUserSiteAdmin(userId, siteId)
+
+  let query = db
+    .selectFrom("PreviewLink")
+    .leftJoin("Resource", "Resource.id", "PreviewLink.resourceId")
+    .leftJoin("User", "User.id", "PreviewLink.createdBy")
+    .where("PreviewLink.siteId", "=", siteId)
+    .select([
+      "PreviewLink.id as id",
+      "PreviewLink.token as token",
+      "PreviewLink.label as label",
+      "PreviewLink.expiresAt as expiresAt",
+      "PreviewLink.revokedAt as revokedAt",
+      "PreviewLink.createdAt as createdAt",
+      "PreviewLink.createdBy as createdBy",
+      "PreviewLink.resourceId as resourceId",
+      "Resource.title as pageTitle",
+      "User.name as sharerName",
+      "User.email as sharerEmail",
+    ])
+    .orderBy("PreviewLink.createdAt", "desc")
+
+  if (!viewerIsAdmin) {
+    query = query.where("PreviewLink.createdBy", "=", userId)
+  }
+
+  const now = new Date()
+  if (status === "active") {
+    query = query
+      .where("PreviewLink.revokedAt", "is", null)
+      .where("PreviewLink.expiresAt", ">", now)
+  } else if (status === "expired") {
+    query = query
+      .where("PreviewLink.revokedAt", "is", null)
+      .where("PreviewLink.expiresAt", "<=", now)
+  } else if (status === "revoked") {
+    query = query.where("PreviewLink.revokedAt", "is not", null)
+  }
+
+  const rows = await query.execute()
+
+  const enriched = await Promise.all(
+    rows.map(async (row) => {
+      const viewStats = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.PreviewLinkView)
+        .where(sql<boolean>`metadata->>'linkId' = ${String(row.id)}`)
+        .select((eb) => [
+          eb.fn.count<number>("id").as("viewCount"),
+          eb.fn.max("createdAt").as("lastViewedAt"),
+        ])
+        .executeTakeFirst()
+
+      return {
+        ...row,
+        viewCount: Number(viewStats?.viewCount ?? 0),
+        lastViewedAt: viewStats?.lastViewedAt ?? null,
+      }
+    }),
+  )
+
+  return { viewerIsAdmin, links: enriched }
+}
+
 interface ListActivePagePreviewLinksProps {
   userId: string
   siteId: number


### PR DESCRIPTION
## Problem

Sharers and site admins have no single place to see all preview links across a site — only the per-page modal added in #2484. This PR adds the site-level overview at `/sites/[siteId]/preview-links`.

Closes #2486

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- New page `/sites/[siteId]/preview-links` rendering `SitePreviewLinksTable` — paginated list of all links for the site with: target page, label, status (Active / Expired / Revoked), expiry (SGT), sharer, and Revoke action for active rows.
- `previewLink.listForSite` tRPC procedure with site-admin permission gate, pagination, and status filter.
- Schema additions (`apps/studio/src/schemas/previewLink.ts`) for the new list inputs/outputs.

## Tests

- Vitest router tests cover: list scoped to site; pagination cursor; status filter; site-admin permission required.

**Manual Verification Steps**:

- [ ] As a site admin, navigate to `/sites/<siteId>/preview-links`; confirm the table lists all links for that site.
- [ ] Confirm rows show correct target page, label, status, SGT expiry, and sharer name.
- [ ] Click Revoke on an active row; confirm it flips to Revoked and the corresponding `PreviewLinkRevoke` audit row is written.
- [ ] As a non-admin user on that site, navigate to the same URL; confirm access is denied.
- [ ] Confirm pagination and status filter (Active / Revoked / Expired) work.