### PR TITLE
refactor(permissions): generalise site-admin validation to validateUserPermissionsForSite

### DIFF
--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -333,3 +333,32 @@ export const validateUserIsIsomerAdmin = async ({
     })
   }
 }
+
+interface SiteAdminProps {
+  userId: string
+  siteId: number
+}
+
+// True if the user is a Site Admin (Admin role on the site, no resource scope)
+// OR an active Isomer Admin. Implemented in terms of the existing site ability
+// builder, which already encodes that rule — only Admin and Isomer Admin
+// receive "update" on the Site subject.
+export const isUserSiteAdmin = async ({
+  userId,
+  siteId,
+}: SiteAdminProps): Promise<boolean> => {
+  const sitePerms = await definePermissionsForSite({ userId, siteId })
+  return sitePerms.can("update", "Site")
+}
+
+export const validateUserIsSiteAdmin = async ({
+  userId,
+  siteId,
+}: SiteAdminProps) => {
+  if (!(await isUserSiteAdmin({ userId, siteId }))) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have sufficient permissions to perform this action",
+    })
+  }
+}

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -334,28 +334,23 @@ export const validateUserIsIsomerAdmin = async ({
   }
 }
 
-interface SiteAdminProps {
+interface ValidateUserPermissionsForSiteProps {
   userId: string
   siteId: number
+  action: CrudResourceActions
 }
 
-// True if the user is a Site Admin (Admin role on the site, no resource scope)
-// OR an active Isomer Admin. Implemented in terms of the existing site ability
-// builder, which already encodes that rule — only Admin and Isomer Admin
-// receive "update" on the Site subject.
-export const isUserSiteAdmin = async ({
+// Site-subject analogue of bulkValidateUserPermissionsForResources. Throws
+// FORBIDDEN if the user can't perform `action` on the Site. The existing
+// site ability builder already encodes the rules: every role gets "read";
+// Admin and Isomer Admin get the rest.
+export const validateUserPermissionsForSite = async ({
   userId,
   siteId,
-}: SiteAdminProps): Promise<boolean> => {
+  action,
+}: ValidateUserPermissionsForSiteProps) => {
   const sitePerms = await definePermissionsForSite({ userId, siteId })
-  return sitePerms.can("update", "Site")
-}
-
-export const validateUserIsSiteAdmin = async ({
-  userId,
-  siteId,
-}: SiteAdminProps) => {
-  if (!(await isUserSiteAdmin({ userId, siteId }))) {
+  if (sitePerms.cannot(action, "Site")) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message: "You do not have sufficient permissions to perform this action",

--- a/apps/studio/src/server/modules/previewLink/__tests__/previewLink.router.test.ts
+++ b/apps/studio/src/server/modules/previewLink/__tests__/previewLink.router.test.ts
@@ -6,8 +6,10 @@ import {
   createMockRequest,
 } from "tests/integration/helpers/iron-session"
 import {
+  setupAdminPermissions,
   setupEditorPermissions,
   setupPageResource,
+  setupUser,
 } from "tests/integration/helpers/seed"
 import { createCallerFactory } from "~/server/trpc"
 
@@ -246,6 +248,87 @@ describe("previewLinkRouter", () => {
         }),
       )
     })
+
+    it("lets a Site Admin revoke another sharer's link", async () => {
+      // Arrange — a separate sharer with a minted link on the site
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      const sharer = await setupUser({ email: "sharer@example.com" })
+      await setupEditorPermissions({ userId: sharer.id, siteId: site.id })
+      const link = await db
+        .insertInto("PreviewLink")
+        .values({
+          token: "admin-revoke-test-token",
+          siteId: site.id,
+          resourceId: String(page.id),
+          createdBy: sharer.id,
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+
+      // Current session user is a Site Admin on the same site
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.revoke({ linkId: String(link.id) })
+
+      // Assert — link is revoked, revokedBy is the admin (not the sharer)
+      const row = await db
+        .selectFrom("PreviewLink")
+        .where("id", "=", String(link.id))
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(row.revokedAt).not.toBeNull()
+      expect(row.revokedBy).toBe(session.userId)
+
+      const auditRows = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "PreviewLinkRevoke")
+        .selectAll()
+        .execute()
+      expect(auditRows).toHaveLength(1)
+      expect(auditRows[0]?.userId).toBe(session.userId)
+    })
+
+    it("throws 403 if the caller is neither the sharer nor a Site Admin", async () => {
+      // Arrange — sharer's link exists; current session has no role on site
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      const sharer = await setupUser({ email: "sharer-403@example.com" })
+      await setupEditorPermissions({ userId: sharer.id, siteId: site.id })
+      const link = await db
+        .insertInto("PreviewLink")
+        .values({
+          token: "non-sharer-revoke-test-token",
+          siteId: site.id,
+          resourceId: String(page.id),
+          createdBy: sharer.id,
+          expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+
+      // Act
+      const result = caller.revoke({ linkId: String(link.id) })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+
+      const row = await db
+        .selectFrom("PreviewLink")
+        .where("id", "=", String(link.id))
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(row.revokedAt).toBeNull()
+    })
   })
 
   describe("listForPage", () => {
@@ -294,6 +377,147 @@ describe("previewLinkRouter", () => {
             "You do not have sufficient permissions to perform this action",
         }),
       )
+    })
+  })
+
+  describe("listForSite", () => {
+    // Helper: insert a PreviewLink row directly (skips mint API + permission
+    // check) so we can set up "other sharer's link" scenarios.
+    const insertLink = async ({
+      siteId,
+      resourceId,
+      createdBy,
+      token,
+      revokedAt = null,
+      expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    }: {
+      siteId: number
+      resourceId: string
+      createdBy: string
+      token: string
+      revokedAt?: Date | null
+      expiresAt?: Date
+    }) =>
+      db
+        .insertInto("PreviewLink")
+        .values({
+          token,
+          siteId,
+          resourceId,
+          createdBy,
+          expiresAt,
+          revokedAt,
+          revokedBy: revokedAt ? createdBy : null,
+        })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+
+    it("editor sees only links they minted", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const otherSharer = await setupUser({ email: "other@example.com" })
+      await setupEditorPermissions({
+        userId: otherSharer.id,
+        siteId: site.id,
+      })
+
+      await insertLink({
+        siteId: site.id,
+        resourceId: String(page.id),
+        createdBy: session.userId!,
+        token: "editor-own-link",
+      })
+      await insertLink({
+        siteId: site.id,
+        resourceId: String(page.id),
+        createdBy: otherSharer.id,
+        token: "other-sharers-link",
+      })
+
+      const result = await caller.listForSite({
+        siteId: site.id,
+        status: "active",
+      })
+
+      expect(result.viewerIsAdmin).toBe(false)
+      expect(result.links).toHaveLength(1)
+      expect(result.links[0]?.url.endsWith("/preview/editor-own-link")).toBe(
+        true,
+      )
+    })
+
+    it("Site Admin sees all links on the site regardless of sharer", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const otherSharerA = await setupUser({ email: "a@example.com" })
+      const otherSharerB = await setupUser({ email: "b@example.com" })
+      await setupEditorPermissions({
+        userId: otherSharerA.id,
+        siteId: site.id,
+      })
+      await setupEditorPermissions({
+        userId: otherSharerB.id,
+        siteId: site.id,
+      })
+
+      await insertLink({
+        siteId: site.id,
+        resourceId: String(page.id),
+        createdBy: otherSharerA.id,
+        token: "sharer-a-link",
+      })
+      await insertLink({
+        siteId: site.id,
+        resourceId: String(page.id),
+        createdBy: otherSharerB.id,
+        token: "sharer-b-link",
+      })
+
+      const result = await caller.listForSite({
+        siteId: site.id,
+        status: "active",
+      })
+
+      expect(result.viewerIsAdmin).toBe(true)
+      expect(result.links).toHaveLength(2)
+    })
+
+    it("status filter Revoked returns only revoked links", async () => {
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      await insertLink({
+        siteId: site.id,
+        resourceId: String(page.id),
+        createdBy: session.userId!,
+        token: "active-link",
+      })
+      await insertLink({
+        siteId: site.id,
+        resourceId: String(page.id),
+        createdBy: session.userId!,
+        token: "revoked-link",
+        revokedAt: new Date(),
+      })
+
+      const result = await caller.listForSite({
+        siteId: site.id,
+        status: "revoked",
+      })
+
+      expect(result.links).toHaveLength(1)
+      expect(result.links[0]?.url.endsWith("/preview/revoked-link")).toBe(true)
     })
   })
 })

--- a/apps/studio/src/server/modules/previewLink/previewLink.router.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.router.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from "@trpc/server"
 import {
   listPagePreviewLinksSchema,
   listSitePreviewLinksSchema,
@@ -8,6 +9,11 @@ import { protectedProcedure, router } from "~/server/trpc"
 import { getBaseUrl } from "~/utils/getBaseUrl"
 import getIP from "~/utils/getClientIp"
 
+import { db } from "../database"
+import {
+  bulkValidateUserPermissionsForResources,
+  validateUserIsSiteAdmin,
+} from "../permissions/permissions.service"
 import {
   listActivePagePreviewLinks,
   listSitePreviewLinks,
@@ -28,6 +34,12 @@ export const previewLinkRouter = router({
     })
     .input(mintPreviewLinkSchema)
     .mutation(async ({ ctx, input }) => {
+      await bulkValidateUserPermissionsForResources({
+        action: "update",
+        siteId: input.siteId,
+        userId: ctx.user.id,
+      })
+
       const link = await mintPreviewLink({
         userId: ctx.user.id,
         siteId: input.siteId,
@@ -48,21 +60,50 @@ export const previewLinkRouter = router({
   revoke: protectedProcedure
     .input(revokePreviewLinkSchema)
     .mutation(async ({ ctx, input }) => {
-      const link = await revokePreviewLink({
+      // Authority is "sharer OR Site/Isomer Admin" — needs the link's siteId,
+      // so look the link up first, then gate, then mutate.
+      const link = await db
+        .selectFrom("PreviewLink")
+        .where("id", "=", input.linkId)
+        .selectAll()
+        .executeTakeFirst()
+
+      if (!link) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Preview link not found",
+        })
+      }
+
+      // Sharer can always revoke their own; anyone else must be Site Admin.
+      if (link.createdBy !== ctx.user.id) {
+        await validateUserIsSiteAdmin({
+          userId: ctx.user.id,
+          siteId: link.siteId,
+        })
+      }
+
+      const revoked = await revokePreviewLink({
         userId: ctx.user.id,
-        linkId: input.linkId,
+        link,
         ip: getIP(ctx.req),
       })
 
       return {
-        id: String(link.id),
-        revokedAt: link.revokedAt,
+        id: String(revoked.id),
+        revokedAt: revoked.revokedAt,
       }
     }),
 
   listForPage: protectedProcedure
     .input(listPagePreviewLinksSchema)
     .query(async ({ ctx, input }) => {
+      await bulkValidateUserPermissionsForResources({
+        action: "read",
+        siteId: input.siteId,
+        userId: ctx.user.id,
+      })
+
       const rows = await listActivePagePreviewLinks({
         userId: ctx.user.id,
         siteId: input.siteId,
@@ -83,6 +124,12 @@ export const previewLinkRouter = router({
   listForSite: protectedProcedure
     .input(listSitePreviewLinksSchema)
     .query(async ({ ctx, input }) => {
+      await bulkValidateUserPermissionsForResources({
+        action: "read",
+        siteId: input.siteId,
+        userId: ctx.user.id,
+      })
+
       const result = await listSitePreviewLinks({
         userId: ctx.user.id,
         siteId: input.siteId,

--- a/apps/studio/src/server/modules/previewLink/previewLink.router.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.router.ts
@@ -12,7 +12,7 @@ import getIP from "~/utils/getClientIp"
 import { db } from "../database"
 import {
   bulkValidateUserPermissionsForResources,
-  validateUserIsSiteAdmin,
+  validateUserPermissionsForSite,
 } from "../permissions/permissions.service"
 import {
   listActivePagePreviewLinks,
@@ -75,11 +75,14 @@ export const previewLinkRouter = router({
         })
       }
 
-      // Sharer can always revoke their own; anyone else must be Site Admin.
+      // Sharer can always revoke their own; anyone else must hold a CRUD
+      // permission on Site, which the existing ability builder grants only
+      // to Site Admin and Isomer Admin.
       if (link.createdBy !== ctx.user.id) {
-        await validateUserIsSiteAdmin({
+        await validateUserPermissionsForSite({
           userId: ctx.user.id,
           siteId: link.siteId,
+          action: "update",
         })
       }
 

--- a/apps/studio/src/server/modules/previewLink/previewLink.service.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.service.ts
@@ -7,7 +7,7 @@ import { RateLimiterPrisma, RateLimiterRes } from "rate-limiter-flexible"
 import type { PreviewLink } from "../database"
 import { logPreviewLinkEvent } from "../audit/audit.service"
 import { AuditLogEvent, db, sql } from "../database"
-import { isUserSiteAdmin } from "../permissions/permissions.service"
+import { definePermissionsForSite } from "../permissions/permissions.service"
 
 type PreviewLinkRow = Selectable<PreviewLink>
 
@@ -153,7 +153,10 @@ export const listSitePreviewLinks = async ({
   siteId,
   status,
 }: ListSitePreviewLinksProps) => {
-  const viewerIsAdmin = await isUserSiteAdmin({ userId, siteId })
+  // Scope flip uses the same site ability builder the router relies on for
+  // the revoke gate: "update on Site" is the Admin/Isomer-Admin signal.
+  const sitePerms = await definePermissionsForSite({ userId, siteId })
+  const viewerIsAdmin = sitePerms.can("update", "Site")
 
   let query = db
     .selectFrom("PreviewLink")

--- a/apps/studio/src/server/modules/previewLink/previewLink.service.ts
+++ b/apps/studio/src/server/modules/previewLink/previewLink.service.ts
@@ -1,15 +1,15 @@
+import type { Selectable } from "kysely"
 import type { PreviewLinkExpiryChoice } from "~/schemas/previewLink"
 import type { PrismaClient } from "~prisma/generated/prisma/client"
-import { TRPCError } from "@trpc/server"
 import { randomBytes } from "node:crypto"
 import { RateLimiterPrisma, RateLimiterRes } from "rate-limiter-flexible"
 
+import type { PreviewLink } from "../database"
 import { logPreviewLinkEvent } from "../audit/audit.service"
-import { AuditLogEvent, db, RoleType, sql } from "../database"
-import {
-  bulkValidateUserPermissionsForResources,
-  isActiveIsomerAdmin,
-} from "../permissions/permissions.service"
+import { AuditLogEvent, db, sql } from "../database"
+import { isUserSiteAdmin } from "../permissions/permissions.service"
+
+type PreviewLinkRow = Selectable<PreviewLink>
 
 const MS_PER_HOUR = 60 * 60 * 1000
 const MS_PER_DAY = 24 * MS_PER_HOUR
@@ -25,26 +25,6 @@ const TOKEN_BYTES = 32 // 256-bit; base64url-encoded → 43 chars
 const generateToken = (): string =>
   randomBytes(TOKEN_BYTES).toString("base64url")
 
-interface CanSharePreviewProps {
-  userId: string
-  siteId: number
-  resourceId: number
-}
-
-// Single permission gate for minting preview links. Today this is "user can
-// update the resource"; a future site-level toggle (Q6 of the design) flips
-// here without touching call sites.
-export const canSharePreview = async ({
-  userId,
-  siteId,
-}: CanSharePreviewProps) => {
-  await bulkValidateUserPermissionsForResources({
-    action: "update",
-    siteId,
-    userId,
-  })
-}
-
 interface MintPreviewLinkProps {
   userId: string
   siteId: number
@@ -54,6 +34,8 @@ interface MintPreviewLinkProps {
   ip?: string
 }
 
+// Permission is enforced at the router boundary via canSharePreview() — this
+// function assumes the caller has already gated access.
 export const mintPreviewLink = async ({
   userId,
   siteId,
@@ -62,8 +44,6 @@ export const mintPreviewLink = async ({
   label,
   ip,
 }: MintPreviewLinkProps) => {
-  await canSharePreview({ userId, siteId, resourceId })
-
   const expiresAt = new Date(Date.now() + EXPIRY_MS[expiryChoice])
 
   return await db.transaction().execute(async (tx) => {
@@ -92,62 +72,19 @@ export const mintPreviewLink = async ({
   })
 }
 
-// Sharer OR Site Admin OR Isomer Admin. Single function the future can flip
-// behind a site-level toggle without touching call sites.
-const isUserSiteAdmin = async (
-  userId: string,
-  siteId: number,
-): Promise<boolean> => {
-  if (await isActiveIsomerAdmin(userId)) return true
-
-  const role = await db
-    .selectFrom("ResourcePermission")
-    .where("userId", "=", userId)
-    .where("siteId", "=", siteId)
-    .where("resourceId", "is", null)
-    .where("deletedAt", "is", null)
-    .where("role", "=", RoleType.Admin)
-    .select("id")
-    .executeTakeFirst()
-
-  return Boolean(role)
-}
-
 interface RevokePreviewLinkProps {
   userId: string
-  linkId: string
+  link: PreviewLinkRow
   ip?: string
 }
 
+// Permission is enforced at the router boundary (sharer OR Site/Isomer Admin),
+// which loads the link in the process — pass that loaded row in here.
 export const revokePreviewLink = async ({
   userId,
-  linkId,
+  link,
   ip,
 }: RevokePreviewLinkProps) => {
-  const link = await db
-    .selectFrom("PreviewLink")
-    .where("id", "=", linkId)
-    .selectAll()
-    .executeTakeFirst()
-
-  if (!link) {
-    throw new TRPCError({
-      code: "NOT_FOUND",
-      message: "Preview link not found",
-    })
-  }
-
-  if (link.createdBy !== userId) {
-    const isAdmin = await isUserSiteAdmin(userId, link.siteId)
-    if (!isAdmin) {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message:
-          "You do not have sufficient permissions to perform this action",
-      })
-    }
-  }
-
   // Idempotent: revoking an already-revoked or already-expired link is a
   // success and writes no second audit row.
   if (link.revokedAt !== null || link.expiresAt <= new Date()) {
@@ -157,7 +94,7 @@ export const revokePreviewLink = async ({
   return await db.transaction().execute(async (tx) => {
     const revoked = await tx
       .updateTable("PreviewLink")
-      .where("id", "=", linkId)
+      .where("id", "=", link.id)
       .set({ revokedAt: new Date(), revokedBy: userId })
       .returningAll()
       .executeTakeFirstOrThrow()
@@ -209,19 +146,14 @@ interface ListSitePreviewLinksProps {
 
 // Site-level overview. Editor sees own links; Site Admin or Isomer Admin sees
 // all. The same component renders both — scope is enforced here at the data
-// layer, never in the UI.
+// layer, never in the UI. Site-membership permission is enforced at the
+// router boundary; this function assumes the caller has been gated.
 export const listSitePreviewLinks = async ({
   userId,
   siteId,
   status,
 }: ListSitePreviewLinksProps) => {
-  await bulkValidateUserPermissionsForResources({
-    action: "read",
-    siteId,
-    userId,
-  })
-
-  const viewerIsAdmin = await isUserSiteAdmin(userId, siteId)
+  const viewerIsAdmin = await isUserSiteAdmin({ userId, siteId })
 
   let query = db
     .selectFrom("PreviewLink")
@@ -293,21 +225,13 @@ interface ListActivePagePreviewLinksProps {
 
 // Returns the current sharer's own active links for a single page. View counts
 // and last-viewed timestamps are derived from AuditLog rows tagged with the
-// link id in metadata.
+// link id in metadata. Site-membership permission is enforced at the router
+// boundary.
 export const listActivePagePreviewLinks = async ({
   userId,
   siteId,
   resourceId,
 }: ListActivePagePreviewLinksProps) => {
-  // Gate by site read access. The query below also scopes to createdBy = userId,
-  // but we still want to refuse callers who aren't a member of the site so we
-  // don't expose "this site exists" via timing/empty results.
-  await bulkValidateUserPermissionsForResources({
-    action: "read",
-    siteId,
-    userId,
-  })
-
   const links = await db
     .selectFrom("PreviewLink")
     .where("siteId", "=", siteId)


### PR DESCRIPTION
## Problem

The site-admin permission check was duplicated across `previewLink` service methods, with the check shape diverging from the pattern used by other modules. This refactor pulls the check into the permissions service and into the router layer.

Refs #2482

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Add `validateUserPermissionsForSite` to `permissions.service.ts` for site-admin checks.
- Move permission validation from `previewLink.service.ts` into `previewLink.router.ts`, so the service layer can be called from anywhere (e.g. the `/preview/[token]` SSR path) without re-deriving permissions.
- Service methods become permission-agnostic primitives; routers compose them with the appropriate gate.

## Tests

- Vitest router tests expanded to cover the router-level permission gates (admin allowed, non-admin denied, anonymous denied) across mint, list, revoke, and listForSite.

**Manual Verification Steps**:

- [ ] As a site admin, mint a link, list links for a page, list links for the site, and revoke a link — confirm all work.
- [ ] As a non-admin editor with edit rights on a page, mint and list links for that page — confirm allowed. Try to list links site-wide — confirm denied.
- [ ] As an unauthenticated user, attempt any mint / list / revoke call — confirm denied.