### PR TITLE
feat(redirect): auto-create a redirect when a page's permalink changes

### DIFF
--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -251,8 +251,7 @@ const PageSettingsModalContent = ({
               {existingRedirect &&
                 existingRedirect.destinationResourceId !== Number(pageId) && (
                   <Infobox my="0.5rem" variant="warning" size="sm">
-                    This URL already redirects to {existingRedirect.destination}
-                    . Visitors will end up there instead.
+                    {`This URL already redirects to ${existingRedirect.destination}. Visitors will end up there instead.`}
                   </Infobox>
                 )}
               {showRedirectOption && (

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -40,7 +40,6 @@ import {
   MAX_PAGE_URL_LENGTH,
   MAX_TITLE_LENGTH,
 } from "~/schemas/page"
-import { getReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
@@ -131,10 +130,6 @@ const PageSettingsModalContent = ({
   )
 
   const originalPermalink = permalinkTree[permalinkTree.length - 1] ?? ""
-  const selfReference = getReferenceLink({
-    siteId: String(siteId),
-    resourceId: String(pageId),
-  })
   // Offer the redirect only when a Page/CollectionPage URL actually changes.
   const showRedirectOption =
     (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
@@ -254,7 +249,7 @@ const PageSettingsModalContent = ({
               {/* Suppressed when the redirect points back at this page —
                   saving auto-clears it, so it won't actually shadow. */}
               {existingRedirect &&
-                existingRedirect.destination !== selfReference && (
+                existingRedirect.destinationResourceId !== Number(pageId) && (
                   <Infobox my="0.5rem" variant="warning" size="sm">
                     This URL already redirects to {existingRedirect.destination}
                     . Visitors will end up there instead.

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -55,10 +55,11 @@ const PageSettingsModalContent = ({
   onClose,
 }: PageSettingsState & { onClose: () => void }) => {
   const { siteId } = useQueryParse(editSettingsSchema)
-  const [{ title: originalTitle }] = trpc.page.readPage.useSuspenseQuery({
-    pageId: Number(pageId),
-    siteId,
-  })
+  const [{ title: originalTitle, publishedVersionId }] =
+    trpc.page.readPage.useSuspenseQuery({
+      pageId: Number(pageId),
+      siteId,
+    })
   const [permalinkTree] = trpc.page.getPermalinkTree.useSuspenseQuery({
     pageId: Number(pageId),
     siteId,
@@ -130,10 +131,13 @@ const PageSettingsModalContent = ({
   )
 
   const originalPermalink = permalinkTree[permalinkTree.length - 1] ?? ""
-  // Offer the redirect only when a Page/CollectionPage URL actually changes.
+  // Offer the redirect only when a published Page/CollectionPage URL actually
+  // changes — an unpublished page has no live URL to preserve, so the server
+  // skips redirect creation for it anyway.
   const showRedirectOption =
     (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
-    permalink !== originalPermalink
+    permalink !== originalPermalink &&
+    publishedVersionId !== null
   const oldFullPermalink = `${permalinksToRender.parentPermalinks}${originalPermalink}`
 
   const utils = trpc.useUtils()

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -1,5 +1,6 @@
 import type { PageSettingsState } from "~/features/dashboard/atoms"
 import {
+  Box,
   chakra,
   FormControl,
   Input,
@@ -15,6 +16,7 @@ import {
 } from "@chakra-ui/react"
 import {
   Button,
+  Checkbox,
   FormErrorMessage,
   FormHelperText,
   FormLabel,
@@ -38,6 +40,7 @@ import {
   MAX_PAGE_URL_LENGTH,
   MAX_TITLE_LENGTH,
 } from "~/schemas/page"
+import { getReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
@@ -81,6 +84,7 @@ const PageSettingsModalContent = ({
     defaultValues: {
       title: originalTitle,
       permalink: permalinkTree[permalinkTree.length - 1] || "",
+      shouldCreateRedirect: true,
     },
   })
 
@@ -125,6 +129,17 @@ const PageSettingsModalContent = ({
         debouncedPermalink !== "/",
     },
   )
+
+  const originalPermalink = permalinkTree[permalinkTree.length - 1] ?? ""
+  const selfReference = getReferenceLink({
+    siteId: String(siteId),
+    resourceId: String(pageId),
+  })
+  // Offer the redirect only when a Page/CollectionPage URL actually changes.
+  const showRedirectOption =
+    (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
+    permalink !== originalPermalink
+  const oldFullPermalink = `${permalinksToRender.parentPermalinks}${originalPermalink}`
 
   const utils = trpc.useUtils()
   const toast = useToast(BRIEF_TOAST_SETTINGS)
@@ -236,11 +251,48 @@ const PageSettingsModalContent = ({
                 {MAX_PAGE_URL_LENGTH - permalink.length} characters left
               </FormHelperText>
               <FormErrorMessage>{errors.permalink?.message}</FormErrorMessage>
-              {existingRedirect && (
-                <Infobox my="0.5rem" variant="warning" size="sm">
-                  This URL already redirects to {existingRedirect.destination}.
-                  Visitors will end up there instead.
-                </Infobox>
+              {/* Suppressed when the redirect points back at this page —
+                  saving auto-clears it, so it won't actually shadow. */}
+              {existingRedirect &&
+                existingRedirect.destination !== selfReference && (
+                  <Infobox my="0.5rem" variant="warning" size="sm">
+                    This URL already redirects to {existingRedirect.destination}
+                    . Visitors will end up there instead.
+                  </Infobox>
+                )}
+              {showRedirectOption && (
+                <Controller
+                  control={control}
+                  name="shouldCreateRedirect"
+                  render={({ field: { value, onChange, ref, ...field } }) => (
+                    <Box
+                      mt="0.75rem"
+                      w="full"
+                      bg="utility.feedback.info-subtle"
+                      borderRadius="0.5rem"
+                      p="1rem"
+                    >
+                      <Checkbox
+                        alignItems="flex-start"
+                        size="1.25rem"
+                        isChecked={!!value}
+                        onChange={(e) => onChange(e.target.checked)}
+                        ref={ref}
+                        {...field}
+                      >
+                        <VStack align="flex-start" spacing="0.25rem">
+                          <Text textStyle="subhead-2">
+                            Redirect page automatically
+                          </Text>
+                          <Text textStyle="body-2" color="base.content.medium">
+                            Check this box to redirect visitors from{" "}
+                            {oldFullPermalink} to {candidateFullPermalink}.
+                          </Text>
+                        </VStack>
+                      </Checkbox>
+                    </Box>
+                  )}
+                />
               )}
             </FormControl>
           )}

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -52,7 +52,7 @@ const MoveResourceContent = withSuspense(
     >(undefined)
     const { siteId } = useQueryParse(sitePageSchema)
     const setMovedItem = useSetAtom(moveResourceAtom)
-    const [{ title, type, permalink: movedSlug }] =
+    const [{ title, type, permalink: movedSlug, publishedVersionId }] =
       trpc.resource.getMetadataById.useSuspenseQuery({
         siteId: Number(siteId),
         resourceId,
@@ -128,9 +128,11 @@ const MoveResourceContent = withSuspense(
       { enabled: !!curResourceId },
     )
 
-    // Only Page/CollectionPage have a URL worth preserving.
+    // Only published Page/CollectionPage have a live URL worth preserving — the
+    // server skips redirect creation for unpublished pages, so don't offer it.
     const isRedirectableType =
-      type === ResourceType.Page || type === ResourceType.CollectionPage
+      (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
+      publishedVersionId !== null
     const oldFullPermalink = normalizeRedirectPath(movedFullPermalink)
     const newFullPermalink = normalizeRedirectPath(
       `${curResourceId && destination ? destination.fullPermalink : ""}/${movedSlug}`,

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Modal,
   ModalBody,
@@ -8,9 +9,10 @@ import {
   ModalHeader,
   ModalOverlay,
   Skeleton,
+  Text,
   VStack,
 } from "@chakra-ui/react"
-import { Infobox, useToast } from "@opengovsg/design-system-react"
+import { Checkbox, Infobox, useToast } from "@opengovsg/design-system-react"
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { useState } from "react"
 import { ResourceSelector } from "~/components/ResourceSelector/ResourceSelector"
@@ -19,7 +21,10 @@ import { usePermissions } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
+import { normalizeRedirectPath } from "~/schemas/redirect"
+import { getReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import { moveResourceAtom } from "../../atoms"
 
@@ -48,10 +53,11 @@ const MoveResourceContent = withSuspense(
     >(undefined)
     const { siteId } = useQueryParse(sitePageSchema)
     const setMovedItem = useSetAtom(moveResourceAtom)
-    const [{ title }] = trpc.resource.getMetadataById.useSuspenseQuery({
-      siteId: Number(siteId),
-      resourceId,
-    })
+    const [{ title, type, permalink: movedSlug }] =
+      trpc.resource.getMetadataById.useSuspenseQuery({
+        siteId: Number(siteId),
+        resourceId,
+      })
     const ability = usePermissions()
     const utils = trpc.useUtils()
     const toast = useToast({ status: "success" })
@@ -112,6 +118,38 @@ const MoveResourceContent = withSuspense(
 
     const movedItem = useAtomValue(moveResourceAtom)
 
+    const [shouldCreateRedirect, setShouldCreateRedirect] = useState(true)
+    const [{ fullPermalink: movedFullPermalink }] =
+      trpc.resource.getWithFullPermalink.useSuspenseQuery({
+        siteId: Number(siteId),
+        resourceId,
+      })
+    const { data: destination } = trpc.resource.getWithFullPermalink.useQuery(
+      { siteId: Number(siteId), resourceId: curResourceId ?? "" },
+      { enabled: !!curResourceId },
+    )
+
+    // Only Page/CollectionPage have a URL worth preserving; show the option
+    // once a destination is picked.
+    const showRedirectOption =
+      curResourceId !== undefined &&
+      (type === ResourceType.Page || type === ResourceType.CollectionPage)
+    const oldFullPermalink = normalizeRedirectPath(movedFullPermalink)
+    const newFullPermalink = normalizeRedirectPath(
+      `${curResourceId && destination ? destination.fullPermalink : ""}/${movedSlug}`,
+    )
+    const selfReference = getReferenceLink({
+      siteId: String(siteId),
+      resourceId,
+    })
+    const { data: existingRedirect } = trpc.redirect.getBySource.useQuery(
+      { siteId: Number(siteId), source: newFullPermalink },
+      {
+        enabled:
+          showRedirectOption && (curResourceId === null || !!destination),
+      },
+    )
+
     return (
       <ModalContent>
         <ModalHeader mr="3.5rem">Move "{title}" to...</ModalHeader>
@@ -129,6 +167,43 @@ const MoveResourceContent = withSuspense(
               existingResource={movedItem ?? undefined}
               onChange={(resourceId) => setCurResourceId(resourceId)}
             />
+            {showRedirectOption && (
+              <VStack alignItems="flex-start" spacing="0.5rem" w="full">
+                {/* Suppressed when the redirect points back at this page —
+                    the move auto-clears it, so it won't actually shadow. */}
+                {existingRedirect &&
+                  existingRedirect.destination !== selfReference && (
+                    <Infobox variant="warning" size="sm" w="full">
+                      This URL already redirects to{" "}
+                      {existingRedirect.destination}. Visitors will end up there
+                      instead.
+                    </Infobox>
+                  )}
+                <Box
+                  w="full"
+                  bg="utility.feedback.info-subtle"
+                  borderRadius="0.5rem"
+                  p="1rem"
+                >
+                  <Checkbox
+                    alignItems="flex-start"
+                    size="1.25rem"
+                    isChecked={shouldCreateRedirect}
+                    onChange={(e) => setShouldCreateRedirect(e.target.checked)}
+                  >
+                    <VStack align="flex-start" spacing="0.25rem">
+                      <Text textStyle="subhead-2">
+                        Redirect page automatically
+                      </Text>
+                      <Text textStyle="body-2" color="base.content.medium">
+                        Check this box to redirect visitors from{" "}
+                        {oldFullPermalink} to {newFullPermalink}.
+                      </Text>
+                    </VStack>
+                  </Checkbox>
+                </Box>
+              </VStack>
+            )}
           </VStack>
         </ModalBody>
         <ModalFooter>
@@ -157,6 +232,7 @@ const MoveResourceContent = withSuspense(
                 siteId,
                 movedResourceId: movedItem.id,
                 destinationResourceId: curResourceId ?? null,
+                shouldCreateRedirect,
               })
             }
           >

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -22,7 +22,6 @@ import { withSuspense } from "~/hocs/withSuspense"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
 import { normalizeRedirectPath } from "~/schemas/redirect"
-import { getReferenceLink } from "~/utils/link"
 import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
@@ -138,10 +137,6 @@ const MoveResourceContent = withSuspense(
     const newFullPermalink = normalizeRedirectPath(
       `${curResourceId && destination ? destination.fullPermalink : ""}/${movedSlug}`,
     )
-    const selfReference = getReferenceLink({
-      siteId: String(siteId),
-      resourceId,
-    })
     const { data: existingRedirect } = trpc.redirect.getBySource.useQuery(
       { siteId: Number(siteId), source: newFullPermalink },
       {
@@ -172,7 +167,8 @@ const MoveResourceContent = withSuspense(
                 {/* Suppressed when the redirect points back at this page —
                     the move auto-clears it, so it won't actually shadow. */}
                 {existingRedirect &&
-                  existingRedirect.destination !== selfReference && (
+                  existingRedirect.destinationResourceId !==
+                    Number(resourceId) && (
                     <Infobox variant="warning" size="sm" w="full">
                       This URL already redirects to{" "}
                       {existingRedirect.destination}. Visitors will end up there

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -128,21 +128,26 @@ const MoveResourceContent = withSuspense(
       { enabled: !!curResourceId },
     )
 
-    // Only Page/CollectionPage have a URL worth preserving; show the option
-    // once a destination is picked.
-    const showRedirectOption =
-      curResourceId !== undefined &&
-      (type === ResourceType.Page || type === ResourceType.CollectionPage)
+    // Only Page/CollectionPage have a URL worth preserving.
+    const isRedirectableType =
+      type === ResourceType.Page || type === ResourceType.CollectionPage
     const oldFullPermalink = normalizeRedirectPath(movedFullPermalink)
     const newFullPermalink = normalizeRedirectPath(
       `${curResourceId && destination ? destination.fullPermalink : ""}/${movedSlug}`,
     )
+    // The new path is known once a destination is picked (the root needs no
+    // lookup); until then the computed permalink is provisional.
+    const isDestinationResolved =
+      curResourceId === null || (curResourceId !== undefined && !!destination)
+    // Moving a page into its current parent leaves the URL unchanged, so there's
+    // nothing to redirect — only offer the option when the URL actually changes.
+    const showRedirectOption =
+      isRedirectableType &&
+      isDestinationResolved &&
+      oldFullPermalink !== newFullPermalink
     const { data: existingRedirect } = trpc.redirect.getBySource.useQuery(
       { siteId: Number(siteId), source: newFullPermalink },
-      {
-        enabled:
-          showRedirectOption && (curResourceId === null || !!destination),
-      },
+      { enabled: showRedirectOption },
     )
 
     return (

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -124,6 +124,10 @@ export const getRootPageSchema = z.object({
 
 export const basePageSettingsSchema = basePageSchema.extend({
   title: pageTitleSchema,
+  // Create a redirect from the page's old URL when its permalink changes (acted
+  // on only for Page/CollectionPage). On the base so the union destructures
+  // cleanly. Defaults off.
+  shouldCreateRedirect: z.boolean().optional().default(false),
 })
 
 const rootPageSettingsSchema = basePageSettingsSchema.extend({

--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -126,8 +126,8 @@ export const basePageSettingsSchema = basePageSchema.extend({
   title: pageTitleSchema,
   // Create a redirect from the page's old URL when its permalink changes (acted
   // on only for Page/CollectionPage). On the base so the union destructures
-  // cleanly. Defaults off.
-  shouldCreateRedirect: z.boolean().optional().default(false),
+  // cleanly. Defaults on, matching the checkbox's default-checked state.
+  shouldCreateRedirect: z.boolean().optional().default(true),
 })
 
 const rootPageSettingsSchema = basePageSettingsSchema.extend({

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -58,7 +58,7 @@ const REFERENCE_DESTINATION_REGEX = new RegExp(
 // whose host looks like a public domain (has a dot) — this rejects the doubled
 // scheme and bare single-label hosts (localhost, intranet names) that are never
 // valid redirect targets for a published site.
-const isValidExternalDestination = (value: string) => {
+export const isValidExternalDestination = (value: string) => {
   try {
     const url = new URL(value)
     return url.protocol === "https:" && url.hostname.includes(".")
@@ -253,7 +253,7 @@ export type ResolveRedirectReferencesInput = z.infer<
 // not necessarily a clean redirect source, so it is normalised server-side
 // before the lookup.
 export const getRedirectBySourceSchema = z.object({
-  siteId: z.number().min(1),
+  siteId: z.number().min(1, { message: "Site ID is required" }),
   source: z
     .string()
     .min(1, { message: "Source path is required" })
@@ -266,7 +266,7 @@ export type GetRedirectBySourceInput = z.infer<typeof getRedirectBySourceSchema>
 // will remove those redirects. Descendants are resolved server-side from the
 // resource being deleted.
 export const countRedirectsByDestinationSchema = z.object({
-  siteId: z.number().min(1),
+  siteId: z.number().min(1, { message: "Site ID is required" }),
   resourceId: generateBigIntSchema("resource ID"),
 })
 export type CountRedirectsByDestinationInput = z.infer<

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -42,6 +42,8 @@ export const moveSchema = z.object({
   siteId: z.number(),
   movedResourceId: bigIntSchema,
   destinationResourceId: bigIntSchema.nullable(),
+  // Create a redirect from the resource's old URL on move. Defaults off.
+  shouldCreateRedirect: z.boolean().optional().default(false),
 })
 
 export const countResourceSchema = z.object({

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -42,8 +42,9 @@ export const moveSchema = z.object({
   siteId: z.number(),
   movedResourceId: bigIntSchema,
   destinationResourceId: bigIntSchema.nullable(),
-  // Create a redirect from the resource's old URL on move. Defaults off.
-  shouldCreateRedirect: z.boolean().optional().default(false),
+  // Create a redirect from the resource's old URL on move. Defaults on,
+  // matching the checkbox's default-checked state.
+  shouldCreateRedirect: z.boolean().optional().default(true),
 })
 
 export const countResourceSchema = z.object({

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2473,6 +2473,74 @@ describe("page.router", async () => {
 
         expect(await liveRedirects(site.id)).toHaveLength(0)
       })
+
+      it("blocks renaming a published page onto a path a live redirect points elsewhere from", async () => {
+        const { site, page } = await setupPublishedPage("old-page")
+        // A live redirect already occupies the new URL, pointing elsewhere —
+        // renaming the page onto it would shadow the page.
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/new-page",
+            destination: "https://example.gov.sg/elsewhere",
+          })
+          .execute()
+
+        const result = caller.updateSettings({
+          siteId: site.id,
+          pageId: Number(page.id),
+          type: "Page",
+          title: "Contact us",
+          permalink: "new-page",
+          shouldCreateRedirect: false,
+        })
+
+        // Assert — blocked, and the whole edit is rolled back (permalink unchanged).
+        await expect(result).rejects.toMatchObject({ code: "CONFLICT" })
+        const unchanged = await db
+          .selectFrom("Resource")
+          .select("permalink")
+          .where("id", "=", String(page.id))
+          .executeTakeFirstOrThrow()
+        expect(unchanged.permalink).toBe("old-page")
+      })
+
+      it("reclaims a redirect pointing back at the page when the URL is renamed onto it", async () => {
+        const { site, page } = await setupPublishedPage("old-page")
+        // A redirect at the URL the page is about to occupy, pointing back at it
+        // — this is the reclaim case, not a shadow, so the rename is allowed.
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/new-page",
+            destination: `[resource:${site.id}:${page.id}]`,
+          })
+          .execute()
+
+        await caller.updateSettings({
+          siteId: site.id,
+          pageId: Number(page.id),
+          type: "Page",
+          title: "Contact us",
+          permalink: "new-page",
+          shouldCreateRedirect: true,
+        })
+
+        // The self-pointing redirect at /new-page is reclaimed (soft-deleted)...
+        const reclaimed = await db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", site.id)
+          .where("source", "=", "/new-page")
+          .executeTakeFirstOrThrow()
+        expect(reclaimed.deletedAt).not.toBeNull()
+        // ...and the old URL gets its own redirect.
+        const live = await liveRedirects(site.id)
+        expect(live).toHaveLength(1)
+        expect(live[0]!.source).toBe("/old-page")
+      })
     })
 
     it("should throw 401 if not logged in update", async () => {

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2404,6 +2404,77 @@ describe("page.router", async () => {
   })
 
   describe("updateSettings", () => {
+    describe("redirect on settings change", () => {
+      const liveRedirects = (siteId: number) =>
+        db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", siteId)
+          .where("deletedAt", "is", null)
+          .execute()
+
+      const setupPublishedPage = async (permalink: string) => {
+        const { site, page } = await setupPageResource({
+          resourceType: ResourceType.Page,
+          permalink,
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+        await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+        return { site, page }
+      }
+
+      it("creates a redirect from the old URL when the permalink changes", async () => {
+        const { site, page } = await setupPublishedPage("old-page")
+
+        await caller.updateSettings({
+          siteId: site.id,
+          pageId: Number(page.id),
+          type: "Page",
+          title: "Contact us",
+          permalink: "new-page",
+          shouldCreateRedirect: true,
+        })
+
+        const redirects = await liveRedirects(site.id)
+        expect(redirects).toHaveLength(1)
+        expect(redirects[0]!.source).toBe("/old-page")
+        expect(redirects[0]!.destination).toBe(
+          `[resource:${site.id}:${page.id}]`,
+        )
+      })
+
+      it("does not create a redirect for a title-only change", async () => {
+        const { site, page } = await setupPublishedPage("stay")
+
+        await caller.updateSettings({
+          siteId: site.id,
+          pageId: Number(page.id),
+          type: "Page",
+          title: "Renamed title only",
+          permalink: "stay",
+          shouldCreateRedirect: true,
+        })
+
+        expect(await liveRedirects(site.id)).toHaveLength(0)
+      })
+
+      it("does not create a redirect when shouldCreateRedirect is false", async () => {
+        const { site, page } = await setupPublishedPage("old-page")
+
+        await caller.updateSettings({
+          siteId: site.id,
+          pageId: Number(page.id),
+          type: "Page",
+          title: "Contact us",
+          permalink: "new-page",
+          shouldCreateRedirect: false,
+        })
+
+        expect(await liveRedirects(site.id)).toHaveLength(0)
+      })
+    })
+
     it("should throw 401 if not logged in update", async () => {
       // Arrange
       const unauthedSession = applySession()

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2541,6 +2541,44 @@ describe("page.router", async () => {
         expect(live).toHaveLength(1)
         expect(live[0]!.source).toBe("/old-page")
       })
+
+      it("revives a soft-deleted redirect at the old URL instead of duplicating it", async () => {
+        const { site, page } = await setupPublishedPage("old-page")
+        // A previously soft-deleted redirect already occupies the old source
+        // (e.g. it was deleted earlier). The upsert should revive this row, not
+        // insert a second one at the same (siteId, source).
+        const stale = await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/old-page",
+            destination: "https://example.gov.sg/stale",
+            deletedAt: new Date(),
+          })
+          .returningAll()
+          .executeTakeFirstOrThrow()
+
+        await caller.updateSettings({
+          siteId: site.id,
+          pageId: Number(page.id),
+          type: "Page",
+          title: "Contact us",
+          permalink: "new-page",
+          shouldCreateRedirect: true,
+        })
+
+        // Exactly one row at the old source — the stale one, revived in place.
+        const rows = await db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", site.id)
+          .where("source", "=", "/old-page")
+          .execute()
+        expect(rows).toHaveLength(1)
+        expect(rows[0]!.id).toBe(stale.id)
+        expect(rows[0]!.deletedAt).toBeNull()
+        expect(rows[0]!.destination).toBe(`[resource:${site.id}:${page.id}]`)
+      })
     })
 
     it("should throw 401 if not logged in update", async () => {

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -50,11 +50,7 @@ import { alertPublishWhenSingpassDisabled } from "../auth/email/email.service"
 import { db, jsonb, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
-import {
-  assertPermalinkNotShadowed,
-  clearReclaimedRedirect,
-  createRedirectForPermalinkChange,
-} from "../redirect/redirect.service"
+import { applyPermalinkChangeRedirects } from "../redirect/redirect.service"
 import {
   createResourceWithBlob,
   getBlobOfResource,
@@ -895,35 +891,15 @@ export const pageRouter = router({
               const oldFullPermalink = `${parentFullPermalink ?? ""}/${resource.permalink}`
               const newFullPermalink = `${parentFullPermalink ?? ""}/${updatedResource.permalink}`
 
-              // A published page must not land on a path a live redirect already
-              // points elsewhere from — it would be shadowed (mirror of the
-              // publish-block). Block before mutating anything further.
-              if (updatedResource.publishedVersionId !== null) {
-                await assertPermalinkNotShadowed(tx, {
-                  siteId,
-                  newFullPermalink,
-                  resourceId: String(pageId),
-                })
-              }
-              // Drop any redirect that pointed back here (it would self-shadow).
-              await clearReclaimedRedirect(tx, {
+              await applyPermalinkChangeRedirects(tx, {
                 siteId,
+                oldFullPermalink,
                 newFullPermalink,
                 resourceId: String(pageId),
+                isPublished: updatedResource.publishedVersionId !== null,
+                shouldCreateRedirect,
                 byUserId: ctx.user.id,
               })
-              // Preserve the old URL when asked, for a published page.
-              if (
-                shouldCreateRedirect &&
-                updatedResource.publishedVersionId !== null
-              ) {
-                await createRedirectForPermalinkChange(tx, {
-                  siteId,
-                  oldFullPermalink,
-                  resourceId: String(pageId),
-                  byUserId: ctx.user.id,
-                })
-              }
             }
 
             // We do an implicit publish so that we can make the changes to the

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -51,6 +51,10 @@ import { db, jsonb, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import {
+  clearReclaimedRedirect,
+  createRedirectForPermalinkChange,
+} from "../redirect/redirect.service"
+import {
   createResourceWithBlob,
   getBlobOfResource,
   getFooter,
@@ -780,7 +784,14 @@ export const pageRouter = router({
     .mutation(
       async ({
         ctx,
-        input: { pageId, siteId, title, type: _pageType, ...settings },
+        input: {
+          pageId,
+          siteId,
+          title,
+          type,
+          shouldCreateRedirect,
+          ...settings
+        },
       }) => {
         await bulkValidateUserPermissionsForResources({
           siteId,
@@ -866,6 +877,43 @@ export const pageRouter = router({
               delta: { before: resource, after: updatedResource },
               eventType: AuditLogEvent.ResourceUpdate,
             })
+
+            // Keep redirects consistent when a Page/CollectionPage URL changes
+            // (a title-only edit leaves the permalink untouched).
+            if (
+              (type === ResourceType.Page ||
+                type === ResourceType.CollectionPage) &&
+              updatedResource.permalink !== resource.permalink
+            ) {
+              const parentFullPermalink = resource.parentId
+                ? await getResourceFullPermalink(
+                    siteId,
+                    Number(resource.parentId),
+                  )
+                : null
+              const oldFullPermalink = `${parentFullPermalink ?? ""}/${resource.permalink}`
+              const newFullPermalink = `${parentFullPermalink ?? ""}/${updatedResource.permalink}`
+
+              // Drop any redirect that pointed back here (it would self-shadow).
+              await clearReclaimedRedirect(tx, {
+                siteId,
+                newFullPermalink,
+                resourceId: String(pageId),
+                byUserId: ctx.user.id,
+              })
+              // Preserve the old URL when asked, for a published page.
+              if (
+                shouldCreateRedirect &&
+                updatedResource.publishedVersionId !== null
+              ) {
+                await createRedirectForPermalinkChange(tx, {
+                  siteId,
+                  oldFullPermalink,
+                  resourceId: String(pageId),
+                  byUserId: ctx.user.id,
+                })
+              }
+            }
 
             // We do an implicit publish so that we can make the changes to the
             // page settings immediately visible on the end site

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -51,6 +51,7 @@ import { db, jsonb, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import {
+  assertPermalinkNotShadowed,
   clearReclaimedRedirect,
   createRedirectForPermalinkChange,
 } from "../redirect/redirect.service"
@@ -894,6 +895,16 @@ export const pageRouter = router({
               const oldFullPermalink = `${parentFullPermalink ?? ""}/${resource.permalink}`
               const newFullPermalink = `${parentFullPermalink ?? ""}/${updatedResource.permalink}`
 
+              // A published page must not land on a path a live redirect already
+              // points elsewhere from — it would be shadowed (mirror of the
+              // publish-block). Block before mutating anything further.
+              if (updatedResource.publishedVersionId !== null) {
+                await assertPermalinkNotShadowed(tx, {
+                  siteId,
+                  newFullPermalink,
+                  resourceId: String(pageId),
+                })
+              }
               // Drop any redirect that pointed back here (it would self-shadow).
               await clearReclaimedRedirect(tx, {
                 siteId,

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -1686,7 +1686,10 @@ describe("redirect.router", async () => {
       const result = await caller.getBySource({ siteId, source: "/old" })
 
       // Assert
-      expect(result).toEqual({ destination: "https://www.example.gov.sg" })
+      expect(result).toEqual({
+        destination: "https://www.example.gov.sg",
+        destinationResourceId: null,
+      })
     })
 
     it("should resolve a reference destination to the page's current permalink", async () => {
@@ -1710,8 +1713,12 @@ describe("redirect.router", async () => {
       // Act
       const result = await caller.getBySource({ siteId, source: "/old" })
 
-      // Assert
-      expect(result).toEqual({ destination: "/target-page" })
+      // Assert — destinationResourceId lets the caller detect a redirect that
+      // points back at the page being edited
+      expect(result).toEqual({
+        destination: "/target-page",
+        destinationResourceId: Number(page.id),
+      })
     })
 
     it("should match regardless of leading/trailing slashes in the queried path", async () => {
@@ -1729,7 +1736,10 @@ describe("redirect.router", async () => {
       const result = await caller.getBySource({ siteId, source: "old/" })
 
       // Assert
-      expect(result).toEqual({ destination: "https://www.example.gov.sg" })
+      expect(result).toEqual({
+        destination: "https://www.example.gov.sg",
+        destinationResourceId: null,
+      })
     })
 
     it("should not match a soft-deleted redirect", async () => {

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -455,6 +455,125 @@ export const createRedirect = async ({
   return created
 }
 
+// Redirects driven by a permalink change (move / rename). Both run inside the
+// caller's transaction and publish nothing — the caller's publish covers them.
+
+// Creates the "old URL -> this page" redirect when a page's permalink changes.
+// Source/destination are server-derived (the page's own permalink + a reference
+// to itself), so there's no untrusted input: we skip the existing-page, loop
+// and destination guards createRedirect runs for typed-in redirects. They hold
+// by construction — the move vacated the old path, and the (siteId, parentId,
+// permalink) constraint + publish-block keep a page off it. Only (siteId,
+// source) uniqueness is enforced, by the upsert below.
+export const createRedirectForPermalinkChange = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    oldFullPermalink,
+    resourceId,
+    byUserId,
+  }: {
+    siteId: number
+    oldFullPermalink: string
+    resourceId: string
+    byUserId: string
+  },
+) => {
+  const source = normalizeRedirectPath(oldFullPermalink)
+  const destination = getReferenceLink({
+    siteId: String(siteId),
+    resourceId: String(resourceId),
+  })
+  const byUser = await getByUser(byUserId)
+
+  const existing = await tx
+    .selectFrom("Redirect")
+    .selectAll()
+    .where("siteId", "=", siteId)
+    .where("source", "=", source)
+    .executeTakeFirst()
+
+  const created = await tx
+    .insertInto("Redirect")
+    .values({ siteId, source, destination })
+    .onConflict((oc) =>
+      oc
+        .columns(["siteId", "source"])
+        .doUpdateSet({ destination, deletedAt: null, createdAt: new Date() })
+        // Only revive a soft-deleted row; a live one must surface as a conflict.
+        .where("Redirect.deletedAt", "is not", null),
+    )
+    .returningAll()
+    .executeTakeFirstOrThrow(
+      () =>
+        new TRPCError({
+          code: "CONFLICT",
+          message: `A redirect already exists for ${source}`,
+        }),
+    )
+
+  await logRedirectEvent(tx, {
+    siteId,
+    by: byUser,
+    eventType: AuditLogEvent.RedirectCreate,
+    delta: { before: existing ?? null, after: created },
+  })
+
+  return created
+}
+
+// When a permalink change lands a page on a path whose redirect points back at
+// that same page (a self-shadow/loop), soft-delete it — the page reclaims its
+// URL. Scoped to redirects referencing THIS page; one pointing elsewhere is a
+// real conflict left to the user.
+export const clearReclaimedRedirect = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    newFullPermalink,
+    resourceId,
+    byUserId,
+  }: {
+    siteId: number
+    newFullPermalink: string
+    resourceId: string
+    byUserId: string
+  },
+) => {
+  const source = normalizeRedirectPath(newFullPermalink)
+  const reference = getReferenceLink({
+    siteId: String(siteId),
+    resourceId: String(resourceId),
+  })
+
+  const reclaimed = await tx
+    .selectFrom("Redirect")
+    .selectAll()
+    .where("siteId", "=", siteId)
+    .where("source", "=", source)
+    .where("destination", "=", reference)
+    .where("deletedAt", "is", null)
+    .executeTakeFirst()
+  if (!reclaimed) {
+    return null
+  }
+
+  const byUser = await getByUser(byUserId)
+  const after = await tx
+    .updateTable("Redirect")
+    .set({ deletedAt: new Date() })
+    .where("id", "=", reclaimed.id)
+    .returningAll()
+    .executeTakeFirstOrThrow()
+  await logRedirectEvent(tx, {
+    siteId,
+    by: byUser,
+    eventType: AuditLogEvent.RedirectDelete,
+    delta: { before: reclaimed, after },
+  })
+  return after
+}
+
 export const deleteRedirect = async ({
   siteId,
   id,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -20,6 +20,7 @@ import {
 import { TRPCError } from "@trpc/server"
 import { REDIRECT_MESSAGES, RedirectValidationCode } from "~/constants/redirect"
 import {
+  isValidExternalDestination,
   normalizeRedirectPath,
   normalizeRedirectSource,
 } from "~/schemas/redirect"
@@ -173,6 +174,18 @@ const resolveStoredDestination = async (
   }
   const resourceId = getResourceIdFromReferenceLink(storedDestination)
   if (resourceId === "") {
+    // Not an internal path and not a `[resource:...]` reference, so the only
+    // remaining valid shape is an external https URL (the form destinations are
+    // validated into on write). Assert it rather than silently returning the
+    // raw string — if a new destination format is ever added without updating
+    // this resolver, this surfaces the gap loudly instead of leaking an
+    // unresolved value into comparisons and the UI.
+    if (!isValidExternalDestination(storedDestination)) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `Unrecognised redirect destination format: ${storedDestination}`,
+      })
+    }
     return storedDestination
   }
   const permalinks = await getResourceFullPermalinks(siteId, [

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -761,7 +761,7 @@ export const getRedirectBySource = async ({
   // different site's id with a colliding resourceId would suppress it wrongly. The
   // lookup is already siteId-scoped so the ids should match; if they don't, fall
   // back to null (show the warning) rather than trust a cross-site id.
-  const match = REFERENCE_LINK_REGEX.exec(redirect.destination)
+  const match = REFERENCE_DESTINATION_REGEX.exec(redirect.destination)
   const destinationResourceId =
     match && Number(match[1]) === siteId ? Number(match[2]) : null
   return {

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -459,12 +459,13 @@ export const createRedirect = async ({
 // caller's transaction and publish nothing — the caller's publish covers them.
 
 // Creates the "old URL -> this page" redirect when a page's permalink changes.
-// Source/destination are server-derived (the page's own permalink + a reference
-// to itself), so there's no untrusted input: we skip the existing-page, loop
-// and destination guards createRedirect runs for typed-in redirects. They hold
-// by construction — the move vacated the old path, and the (siteId, parentId,
-// permalink) constraint + publish-block keep a page off it. Only (siteId,
-// source) uniqueness is enforced, by the upsert below.
+// Source/destination are server-derived (the page's old permalink + a reference
+// to itself), so we skip the existing-page, loop and format guards createRedirect
+// runs for typed-in input. They hold by construction: the page just vacated the
+// old path, and a published page is never left on a live redirect source (the
+// publish-block plus the move/edit shadow guard), so the old path carries at most
+// a soft-deleted redirect, which the upsert revives. Only (siteId, source)
+// uniqueness is enforced.
 export const createRedirectForPermalinkChange = async (
   tx: Transaction<DB>,
   {
@@ -479,7 +480,7 @@ export const createRedirectForPermalinkChange = async (
     byUserId: string
   },
 ) => {
-  const source = normalizeRedirectPath(oldFullPermalink)
+  const source = normalizeRedirectSource(oldFullPermalink)
   const destination = getReferenceLink({
     siteId: String(siteId),
     resourceId: String(resourceId),
@@ -522,10 +523,43 @@ export const createRedirectForPermalinkChange = async (
   return created
 }
 
+// Blocks a permalink change that would land a PUBLISHED page on a path already
+// served by a live redirect pointing ELSEWHERE — the redirect would shadow the
+// page on the published site (the mirror of the publish-block guard). A redirect
+// pointing back at this page is the reclaim case (cleared separately), not a
+// block, so it is excluded here. Caller gates this on the page being published.
+export const assertPermalinkNotShadowed = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    newFullPermalink,
+    resourceId,
+  }: { siteId: number; newFullPermalink: string; resourceId: string },
+) => {
+  const reference = getReferenceLink({
+    siteId: String(siteId),
+    resourceId: String(resourceId),
+  })
+  const shadowing = await tx
+    .selectFrom("Redirect")
+    .select("Redirect.id")
+    .where("Redirect.siteId", "=", siteId)
+    .where("Redirect.source", "=", normalizeRedirectSource(newFullPermalink))
+    .where("Redirect.destination", "!=", reference)
+    .where("Redirect.deletedAt", "is", null)
+    .executeTakeFirst()
+  if (shadowing) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: `A redirect already exists at ${newFullPermalink}. Remove it on the Redirections page first.`,
+    })
+  }
+}
+
 // When a permalink change lands a page on a path whose redirect points back at
 // that same page (a self-shadow/loop), soft-delete it — the page reclaims its
-// URL. Scoped to redirects referencing THIS page; one pointing elsewhere is a
-// real conflict left to the user.
+// URL. Scoped to redirects referencing THIS page; one pointing elsewhere is
+// blocked by assertPermalinkNotShadowed instead.
 export const clearReclaimedRedirect = async (
   tx: Transaction<DB>,
   {
@@ -540,7 +574,7 @@ export const clearReclaimedRedirect = async (
     byUserId: string
   },
 ) => {
-  const source = normalizeRedirectPath(newFullPermalink)
+  const source = normalizeRedirectSource(newFullPermalink)
   const reference = getReferenceLink({
     siteId: String(siteId),
     resourceId: String(resourceId),
@@ -630,12 +664,18 @@ export const deleteRedirect = async ({
 }
 
 // Powers the page-settings warning: is `source` a live redirect's source, and
-// where does it point? `source` (a candidate page URL) is normalised like
-// stored sources before the lookup; the destination is resolved for display.
+// where does it point? `source` (a candidate page URL) is normalised like stored
+// sources before the lookup. `destination` is the resolved permalink for display;
+// `destinationResourceId` is the referenced resource (null for literal/external
+// destinations) so the caller can tell whether the redirect points back at the
+// page being edited (which would be reclaimed on save, not a real warning).
 export const getRedirectBySource = async ({
   siteId,
   source,
-}: GetRedirectBySourceInput): Promise<{ destination: string } | null> => {
+}: GetRedirectBySourceInput): Promise<{
+  destination: string
+  destinationResourceId: number | null
+} | null> => {
   const redirect = await getLiveRedirectBySource(db, {
     siteId,
     source: normalizeRedirectSource(source),
@@ -643,8 +683,10 @@ export const getRedirectBySource = async ({
   if (!redirect) {
     return null
   }
+  const referencedId = getResourceIdFromReferenceLink(redirect.destination)
   return {
     destination: await resolveStoredDestination(siteId, redirect.destination),
+    destinationResourceId: referencedId === "" ? null : Number(referencedId),
   }
 }
 

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -608,6 +608,65 @@ export const clearReclaimedRedirect = async (
   return after
 }
 
+// Single entry point both permalink-change flows (move and rename) call to keep
+// redirects consistent. Owns the ordering the flows depend on so they can't
+// drift: block a shadowing redirect (published page only) -> clear a redirect
+// the page reclaims -> optionally preserve the old URL. Runs inside the caller's
+// transaction and publishes nothing — the caller's publish covers it. A no-op
+// when the URL is unchanged, so callers may invoke it unconditionally.
+export const applyPermalinkChangeRedirects = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    oldFullPermalink,
+    newFullPermalink,
+    resourceId,
+    isPublished,
+    shouldCreateRedirect,
+    byUserId,
+  }: {
+    siteId: number
+    oldFullPermalink: string
+    newFullPermalink: string
+    resourceId: string
+    isPublished: boolean
+    shouldCreateRedirect: boolean
+    byUserId: string
+  },
+) => {
+  // Nothing to reconcile when the URL did not actually change.
+  if (oldFullPermalink === newFullPermalink) {
+    return
+  }
+
+  // A published page must not land on a path a live redirect already points
+  // elsewhere from — it would be shadowed (mirror of the publish-block). The
+  // throw rolls back the enclosing move/rename.
+  if (isPublished) {
+    await assertPermalinkNotShadowed(tx, {
+      siteId,
+      newFullPermalink,
+      resourceId,
+    })
+  }
+  // Drop any redirect that pointed back here (it would self-shadow).
+  await clearReclaimedRedirect(tx, {
+    siteId,
+    newFullPermalink,
+    resourceId,
+    byUserId,
+  })
+  // Preserve the old URL when asked, for a published page.
+  if (shouldCreateRedirect && isPublished) {
+    await createRedirectForPermalinkChange(tx, {
+      siteId,
+      oldFullPermalink,
+      resourceId,
+      byUserId,
+    })
+  }
+}
+
 export const deleteRedirect = async ({
   siteId,
   id,
@@ -683,10 +742,18 @@ export const getRedirectBySource = async ({
   if (!redirect) {
     return null
   }
-  const referencedId = getResourceIdFromReferenceLink(redirect.destination)
+  // Resolve via the full reference so we can confirm the embedded siteId matches
+  // this site. getResourceIdFromReferenceLink discards the siteId, and the caller
+  // suppresses the shadow warning on a resourceId match — a reference embedding a
+  // different site's id with a colliding resourceId would suppress it wrongly. The
+  // lookup is already siteId-scoped so the ids should match; if they don't, fall
+  // back to null (show the warning) rather than trust a cross-site id.
+  const match = REFERENCE_LINK_REGEX.exec(redirect.destination)
+  const destinationResourceId =
+    match && Number(match[1]) === siteId ? Number(match[2]) : null
   return {
     destination: await resolveStoredDestination(siteId, redirect.destination),
-    destinationResourceId: referencedId === "" ? null : Number(referencedId),
+    destinationResourceId,
   }
 }
 

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -13,6 +13,7 @@ import {
   setupCollection,
   setupCollectionLink,
   setupCollectionMeta,
+  setupCollectionPage,
   setupEditorPermissions,
   setupFolder,
   setupFolderMeta,
@@ -2041,6 +2042,39 @@ describe("resource.router", async () => {
             shouldCreateRedirect: true,
           }),
         ).resolves.toMatchObject({ id: page.id })
+      })
+
+      it("creates a redirect from the old URL for a published CollectionPage", async () => {
+        // Locks in the CollectionPage branch of the redirect orchestration.
+        const { site, collection: srcCollection } = await setupCollection({
+          permalink: "src-collection",
+        })
+        await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+        const { collection: destCollection } = await setupCollection({
+          siteId: site.id,
+          permalink: "dest-collection",
+        })
+        const { page } = await setupCollectionPage({
+          siteId: site.id,
+          parentId: srcCollection.id,
+          permalink: "old-article",
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+
+        await caller.move({
+          siteId: site.id,
+          movedResourceId: page.id,
+          destinationResourceId: destCollection.id,
+          shouldCreateRedirect: true,
+        })
+
+        const redirects = await liveRedirects(site.id)
+        expect(redirects).toHaveLength(1)
+        expect(redirects[0]!.source).toBe("/src-collection/old-article")
+        expect(redirects[0]!.destination).toBe(
+          `[resource:${site.id}:${page.id}]`,
+        )
       })
     })
   })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -25,6 +25,7 @@ import { USER_VIEWABLE_RESOURCE_TYPES } from "~/constants/resources"
 import { MAX_BATCH_RESOURCE_IDS } from "~/schemas/resource"
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"
+import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
 import { db } from "../../database"
 import { resourceRouter } from "../resource.router"
@@ -1848,6 +1849,132 @@ describe("resource.router", async () => {
     it.skip("should throw 403 if user does not have write access to destination resource", async () => {})
 
     it.skip("should throw 403 if user does not have write access to origin resource", async () => {})
+
+    describe("redirect on move", () => {
+      const setup = async () => {
+        const { page: rootPage, site } = await setupPageResource({
+          resourceType: ResourceType.RootPage,
+          parentId: null,
+        })
+        const { folder } = await setupFolder({
+          siteId: site.id,
+          permalink: "dest",
+        })
+        await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+        return { site, rootPage, folder }
+      }
+
+      const liveRedirects = (siteId: number) =>
+        db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", siteId)
+          .where("deletedAt", "is", null)
+          .execute()
+
+      it("creates a redirect from the old URL for a published page", async () => {
+        const { site, rootPage, folder } = await setup()
+        const { page } = await setupPageResource({
+          siteId: site.id,
+          resourceType: ResourceType.Page,
+          parentId: rootPage.id,
+          permalink: "old-page",
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+
+        await caller.move({
+          siteId: site.id,
+          movedResourceId: page.id,
+          destinationResourceId: folder.id,
+          shouldCreateRedirect: true,
+        })
+
+        const redirects = await liveRedirects(site.id)
+        expect(redirects).toHaveLength(1)
+        expect(redirects[0]!.source).toBe("/old-page")
+        expect(redirects[0]!.destination).toBe(
+          `[resource:${site.id}:${page.id}]`,
+        )
+      })
+
+      it("does not create a redirect when shouldCreateRedirect is false", async () => {
+        const { site, rootPage, folder } = await setup()
+        const { page } = await setupPageResource({
+          siteId: site.id,
+          resourceType: ResourceType.Page,
+          parentId: rootPage.id,
+          permalink: "old-page",
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+
+        await caller.move({
+          siteId: site.id,
+          movedResourceId: page.id,
+          destinationResourceId: folder.id,
+          shouldCreateRedirect: false,
+        })
+
+        expect(await liveRedirects(site.id)).toHaveLength(0)
+      })
+
+      it("does not create a redirect for an unpublished page", async () => {
+        const { site, rootPage, folder } = await setup()
+        const { page } = await setupPageResource({
+          siteId: site.id,
+          resourceType: ResourceType.Page,
+          parentId: rootPage.id,
+          permalink: "old-page",
+          state: ResourceState.Draft,
+        })
+
+        await caller.move({
+          siteId: site.id,
+          movedResourceId: page.id,
+          destinationResourceId: folder.id,
+          shouldCreateRedirect: true,
+        })
+
+        expect(await liveRedirects(site.id)).toHaveLength(0)
+      })
+
+      it("soft-deletes a redirect pointing back at the page when it reclaims that URL", async () => {
+        const { site, rootPage, folder } = await setup()
+        const { page } = await setupPageResource({
+          siteId: site.id,
+          resourceType: ResourceType.Page,
+          parentId: rootPage.id,
+          permalink: "old-page",
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+        // A redirect at the path the page is about to occupy, pointing at it.
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/dest/old-page",
+            destination: `[resource:${site.id}:${page.id}]`,
+          })
+          .execute()
+
+        await caller.move({
+          siteId: site.id,
+          movedResourceId: page.id,
+          destinationResourceId: folder.id,
+          shouldCreateRedirect: false,
+        })
+
+        const reclaimed = await db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", site.id)
+          .where("source", "=", "/dest/old-page")
+          .executeTakeFirstOrThrow()
+        expect(reclaimed.deletedAt).not.toBeNull()
+      })
+    })
   })
 
   describe("countWithoutRoot", () => {

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1974,6 +1974,74 @@ describe("resource.router", async () => {
           .executeTakeFirstOrThrow()
         expect(reclaimed.deletedAt).not.toBeNull()
       })
+
+      it("blocks moving a published page onto a path a live redirect points elsewhere from", async () => {
+        const { site, rootPage, folder } = await setup()
+        const { page } = await setupPageResource({
+          siteId: site.id,
+          resourceType: ResourceType.Page,
+          parentId: rootPage.id,
+          permalink: "old-page",
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+        // A live redirect already occupies the destination URL, pointing
+        // elsewhere — moving the page there would shadow it.
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/dest/old-page",
+            destination: "https://example.gov.sg/elsewhere",
+          })
+          .execute()
+
+        const result = caller.move({
+          siteId: site.id,
+          movedResourceId: page.id,
+          destinationResourceId: folder.id,
+          shouldCreateRedirect: false,
+        })
+
+        // Assert — blocked, and the whole move is rolled back (page stays put).
+        await expect(result).rejects.toMatchObject({ code: "CONFLICT" })
+        const stillThere = await db
+          .selectFrom("Resource")
+          .select("parentId")
+          .where("id", "=", page.id)
+          .executeTakeFirstOrThrow()
+        expect(String(stillThere.parentId)).toBe(String(rootPage.id))
+      })
+
+      it("allows moving an unpublished page onto a path with a live redirect", async () => {
+        const { site, rootPage, folder } = await setup()
+        const { page } = await setupPageResource({
+          siteId: site.id,
+          resourceType: ResourceType.Page,
+          parentId: rootPage.id,
+          permalink: "old-page",
+          state: ResourceState.Draft,
+        })
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/dest/old-page",
+            destination: "https://example.gov.sg/elsewhere",
+          })
+          .execute()
+
+        // No live shadow yet (the page isn't published); the eventual publish is
+        // guarded separately, so the move is allowed.
+        await expect(
+          caller.move({
+            siteId: site.id,
+            movedResourceId: page.id,
+            destinationResourceId: folder.id,
+            shouldCreateRedirect: true,
+          }),
+        ).resolves.toMatchObject({ id: page.id })
+      })
     })
   })
 

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -38,11 +38,16 @@ import {
   definePermissionsForResource,
   getResourcePermission,
 } from "../permissions/permissions.service"
-import { softDeleteRedirectsPointingToResource } from "../redirect/redirect.service"
+import {
+  clearReclaimedRedirect,
+  createRedirectForPermalinkChange,
+  softDeleteRedirectsPointingToResource,
+} from "../redirect/redirect.service"
 import { validateUserPermissionsForSite } from "../site/site.service"
 import {
   defaultResourceSelect,
   getBatchAncestryWithSelfQuery,
+  getResourceFullPermalink,
   getSearchRecentlyEdited,
   getSearchResults,
   getSearchWithResourceIds,
@@ -322,7 +327,12 @@ export const resourceRouter = router({
     .mutation(
       async ({
         ctx,
-        input: { siteId, movedResourceId, destinationResourceId },
+        input: {
+          siteId,
+          movedResourceId,
+          destinationResourceId,
+          shouldCreateRedirect,
+        },
       }) => {
         const isValid = await validateUserPermissionsForMove({
           from: movedResourceId,
@@ -481,6 +491,20 @@ export const resourceRouter = router({
               }
             }
 
+            // Old URL = current location (pre-UPDATE); new URL from the
+            // unchanged destination + slug, so neither read is stale.
+            const oldFullPermalink = await getResourceFullPermalink(
+              siteId,
+              Number(movedResourceId),
+            )
+            const destinationFullPermalink = destinationResourceId
+              ? await getResourceFullPermalink(
+                  siteId,
+                  Number(destinationResourceId),
+                )
+              : null
+            const newFullPermalink = `${destinationFullPermalink ?? ""}/${toMove.permalink}`
+
             await tx
               .updateTable("Resource")
               .where("siteId", "=", Number(siteId))
@@ -522,6 +546,35 @@ export const resourceRouter = router({
               delta: { before: toMove, after: moved },
               by: user,
             })
+
+            // Keep redirects consistent with the new URL — Page/CollectionPage
+            // only (folders/collection links have no URL of their own).
+            if (
+              toMove.type === ResourceType.Page ||
+              toMove.type === ResourceType.CollectionPage
+            ) {
+              // Drop any redirect that pointed back here (it would self-shadow).
+              await clearReclaimedRedirect(tx, {
+                siteId,
+                newFullPermalink,
+                resourceId: movedResourceId,
+                byUserId: user.id,
+              })
+              // Preserve the old URL when asked, if published and URL changed.
+              if (
+                shouldCreateRedirect &&
+                toMove.publishedVersionId !== null &&
+                oldFullPermalink !== null &&
+                oldFullPermalink !== newFullPermalink
+              ) {
+                await createRedirectForPermalinkChange(tx, {
+                  siteId,
+                  oldFullPermalink,
+                  resourceId: movedResourceId,
+                  byUserId: user.id,
+                })
+              }
+            }
 
             return moved
           })

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -39,6 +39,7 @@ import {
   getResourcePermission,
 } from "../permissions/permissions.service"
 import {
+  assertPermalinkNotShadowed,
   clearReclaimedRedirect,
   createRedirectForPermalinkChange,
   softDeleteRedirectsPointingToResource,
@@ -553,6 +554,16 @@ export const resourceRouter = router({
               toMove.type === ResourceType.Page ||
               toMove.type === ResourceType.CollectionPage
             ) {
+              // A published page must not land on a path a live redirect already
+              // points elsewhere from — it would be shadowed (mirror of the
+              // publish-block). Block before mutating anything further.
+              if (toMove.publishedVersionId !== null) {
+                await assertPermalinkNotShadowed(tx, {
+                  siteId,
+                  newFullPermalink,
+                  resourceId: movedResourceId,
+                })
+              }
               // Drop any redirect that pointed back here (it would self-shadow).
               await clearReclaimedRedirect(tx, {
                 siteId,

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -39,9 +39,7 @@ import {
   getResourcePermission,
 } from "../permissions/permissions.service"
 import {
-  assertPermalinkNotShadowed,
-  clearReclaimedRedirect,
-  createRedirectForPermalinkChange,
+  applyPermalinkChangeRedirects,
   softDeleteRedirectsPointingToResource,
 } from "../redirect/redirect.service"
 import { validateUserPermissionsForSite } from "../site/site.service"
@@ -551,40 +549,19 @@ export const resourceRouter = router({
             // Keep redirects consistent with the new URL — Page/CollectionPage
             // only (folders/collection links have no URL of their own).
             if (
-              toMove.type === ResourceType.Page ||
-              toMove.type === ResourceType.CollectionPage
+              (toMove.type === ResourceType.Page ||
+                toMove.type === ResourceType.CollectionPage) &&
+              oldFullPermalink !== null
             ) {
-              // A published page must not land on a path a live redirect already
-              // points elsewhere from — it would be shadowed (mirror of the
-              // publish-block). Block before mutating anything further.
-              if (toMove.publishedVersionId !== null) {
-                await assertPermalinkNotShadowed(tx, {
-                  siteId,
-                  newFullPermalink,
-                  resourceId: movedResourceId,
-                })
-              }
-              // Drop any redirect that pointed back here (it would self-shadow).
-              await clearReclaimedRedirect(tx, {
+              await applyPermalinkChangeRedirects(tx, {
                 siteId,
+                oldFullPermalink,
                 newFullPermalink,
                 resourceId: movedResourceId,
+                isPublished: toMove.publishedVersionId !== null,
+                shouldCreateRedirect,
                 byUserId: user.id,
               })
-              // Preserve the old URL when asked, if published and URL changed.
-              if (
-                shouldCreateRedirect &&
-                toMove.publishedVersionId !== null &&
-                oldFullPermalink !== null &&
-                oldFullPermalink !== newFullPermalink
-              ) {
-                await createRedirectForPermalinkChange(tx, {
-                  siteId,
-                  oldFullPermalink,
-                  resourceId: movedResourceId,
-                  byUserId: user.id,
-                })
-              }
             }
 
             return moved

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -124,6 +124,7 @@ export const resourceRouter = router({
           "Resource.permalink",
           "Resource.parentId",
           "Resource.siteId",
+          "Resource.publishedVersionId",
         ])
         .executeTakeFirst()
 

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -687,11 +687,16 @@ const _updateOrderingForResource = (
   }
 }
 
+// Accepts an optional `trx` so callers inside a transaction (e.g. the publish
+// shadow-redirect guard) read the permalink within the same tx, instead of
+// racing a concurrent move that commits between reads. Opens its own
+// transaction only when called standalone.
 export const getResourcePermalinkTree = async (
   siteId: number,
   resourceId: number,
+  trx?: SafeKysely,
 ): Promise<string[]> => {
-  return db.transaction().execute(async (tx) => {
+  const run = async (tx: SafeKysely) => {
     // Guard against invalid resource
     const resource = await getById(tx, {
       siteId,
@@ -727,14 +732,17 @@ export const getResourcePermalinkTree = async (
       .map((r) => r.permalink)
       .reverse()
       .filter((v) => v !== INDEX_PAGE_PERMALINK)
-  })
+  }
+
+  return trx ? run(trx) : db.transaction().execute(run)
 }
 
 export const getResourceFullPermalink = async (
   siteId: number,
   resourceId: number,
+  trx?: SafeKysely,
 ) => {
-  const permalinkTree = await getResourcePermalinkTree(siteId, resourceId)
+  const permalinkTree = await getResourcePermalinkTree(siteId, resourceId, trx)
   if (permalinkTree.length === 0) {
     return null
   }
@@ -1048,6 +1056,7 @@ export const publishPageResource = async ({
       const fullPermalink = await getResourceFullPermalink(
         siteId,
         Number(resourceId),
+        tx,
       )
       if (fullPermalink) {
         const blockingRedirect = await tx

--- a/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
+++ b/apps/studio/src/stories/Page/MoveResourceModal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 import { userEvent, within } from "storybook/test"
 import { pageHandlers } from "tests/msw/handlers/page"
+import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import SitePage from "~/pages/sites/[siteId]"
 
@@ -69,6 +70,7 @@ export const SingleClick: Story = {
       handlers: [
         ...SHARED_HANDLERS,
         resourceHandlers.getBatchAncestryWithSelf.foldersOnly(),
+        redirectHandlers.getBySource.none(),
       ],
     },
   },
@@ -158,5 +160,22 @@ export const SearchNoResults: Story = {
     await SearchTemplate.play?.(context)
 
     await userEvent.keyboard("deiofrehioferhfioehfe")
+  },
+}
+
+// Selecting a destination reveals the redirect option; a redirect already at
+// the new URL surfaces a shadow warning.
+export const RedirectShadowWarning: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...SHARED_HANDLERS,
+        resourceHandlers.getBatchAncestryWithSelf.foldersOnly(),
+        redirectHandlers.getBySource.existing(),
+      ],
+    },
+  },
+  play: async (context) => {
+    await SingleClick.play?.(context)
   },
 }

--- a/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
+++ b/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Box } from "@chakra-ui/react"
 import { useSetAtom } from "jotai"
 import { useEffect } from "react"
+import { userEvent, within } from "storybook/test"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { pageSettingsModalAtom } from "~/features/dashboard/atoms"
@@ -61,5 +62,27 @@ export const UrlIsRedirectSource: Story = {
     msw: {
       handlers: [...BASE_HANDLERS, redirectHandlers.getBySource.existing()],
     },
+  },
+}
+
+// The existing redirect points back at this page, so the warning is suppressed
+// (saving auto-clears it).
+export const UrlRedirectsToThisPage: Story = {
+  parameters: {
+    msw: {
+      handlers: [...BASE_HANDLERS, redirectHandlers.getBySource.toResource()],
+    },
+  },
+}
+
+// Changing the URL reveals the "Redirect page automatically" option.
+export const RedirectOptionShown: Story = {
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body)
+    const urlInput = await body.findByPlaceholderText(
+      "URL will be autopopulated if left untouched",
+    )
+    await userEvent.clear(urlInput)
+    await userEvent.type(urlInput, "renamed-page")
   },
 }

--- a/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
+++ b/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
@@ -24,7 +24,12 @@ const OpenedPageSettingsModal = (): JSX.Element => {
 // at /newsroom/collection-page, which is the path checked against redirects.
 const BASE_HANDLERS = [
   ...ADMIN_HANDLERS,
-  pageHandlers.readPage.homepage({ title: "Contact us" }),
+  // Published page so the "Redirect page automatically" option can appear when
+  // the URL changes (RedirectOptionShown).
+  pageHandlers.readPage.homepage({
+    title: "Contact us",
+    publishedVersionId: "1",
+  }),
   pageHandlers.getPermalinkTree.withParent(),
 ]
 

--- a/apps/studio/tests/msw/handlers/redirect.ts
+++ b/apps/studio/tests/msw/handlers/redirect.ts
@@ -67,6 +67,10 @@ export const redirectHandlers = {
       trpcMsw.redirect.getBySource.query(() => ({
         destination: "/somewhere-else",
       })),
+    // The URL redirects back to this page; the modal suppresses the shadow
+    // warning because saving auto-clears it.
+    toResource: (reference = "[resource:1:1]") =>
+      trpcMsw.redirect.getBySource.query(() => ({ destination: reference })),
   },
   countByDestinationResource: {
     // No redirects point here — no delete-modal warning shown.

--- a/apps/studio/tests/msw/handlers/redirect.ts
+++ b/apps/studio/tests/msw/handlers/redirect.ts
@@ -62,15 +62,20 @@ export const redirectHandlers = {
   getBySource: {
     // The URL is not a redirect source — no settings warning shown.
     none: () => trpcMsw.redirect.getBySource.query(() => null),
-    // The URL is already a redirect source — drives the settings-modal warning.
+    // The URL is already a redirect source pointing elsewhere — drives the
+    // settings-modal warning.
     existing: () =>
       trpcMsw.redirect.getBySource.query(() => ({
         destination: "/somewhere-else",
+        destinationResourceId: null,
       })),
-    // The URL redirects back to this page; the modal suppresses the shadow
-    // warning because saving auto-clears it.
-    toResource: (reference = "[resource:1:1]") =>
-      trpcMsw.redirect.getBySource.query(() => ({ destination: reference })),
+    // The URL redirects back to this page (destinationResourceId === the page
+    // being edited); the modal suppresses the warning since saving auto-clears it.
+    toResource: (resourceId = 1) =>
+      trpcMsw.redirect.getBySource.query(() => ({
+        destination: "/this-page",
+        destinationResourceId: resourceId,
+      })),
   },
   countByDestinationResource: {
     // No redirects point here — no delete-modal warning shown.

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -187,6 +187,7 @@ export const resourceHandlers = {
           permalink: "home",
           parentId: null,
           siteId: 1,
+          publishedVersionId: null,
         }
       }),
     content: () =>
@@ -198,6 +199,7 @@ export const resourceHandlers = {
           permalink: "page-title-here",
           parentId: null,
           siteId: 1,
+          publishedVersionId: "1",
         }
       }),
     article: () =>
@@ -209,6 +211,7 @@ export const resourceHandlers = {
           permalink: "article-layout",
           parentId: null,
           siteId: 1,
+          publishedVersionId: null,
         }
       }),
     index: () =>
@@ -220,6 +223,7 @@ export const resourceHandlers = {
           permalink: "_index",
           parentId: null,
           siteId: 1,
+          publishedVersionId: null,
         }
       }),
     database: () =>
@@ -231,6 +235,7 @@ export const resourceHandlers = {
           permalink: "database-layout",
           parentId: null,
           siteId: 1,
+          publishedVersionId: null,
         }
       }),
   },


### PR DESCRIPTION
## Problem

When a published page's permalink changes — either by moving it to another folder or editing its URL in settings — its old URL stops working. Existing bookmarks, inbound links, and search-engine results that point at the old path break with no way for an editor to preserve them.

Closes ISOM-2265

## Solution

Add an optional **"Redirect page automatically"** option to both permalink-change flows (the Move modal and the Edit-page Settings modal). When it's checked and a published `Page`/`CollectionPage` actually changes URL, the server creates a redirect from the old URL to the page — in the same transaction as the move/rename, with the single existing site publish covering it.

Key technical points:

- **Schema** — a `shouldCreateRedirect` boolean is added to the `move` and `updateSettings` inputs (optional, defaults `false` server-side so no caller mints a redirect implicitly).
- **Server** — a publish-free, in-transaction helper inserts the redirect. The source is the page's own (already-validated) old permalink and the destination is a **page reference** (`[resource:siteId:resourceId]`), so the redirect follows the page on any *future* move. It runs only when `flag ∧ published ∧ permalink-actually-changed`.
- **Auto-clear** — when a permalink change lands a page on a path that already has a redirect pointing back at that same page (e.g. the page is moved back onto its own earlier auto-redirect), that now self-referential redirect is soft-deleted as the page reclaims its URL.
- **Frontend** — the checkbox (default on, shown only when the URL genuinely changes) renders a live "from → to" preview. The Move modal also gains the destination-shadow warning the Settings modal already had; both modals suppress that warning when the existing redirect points back at the page being edited (it gets auto-cleared anyway).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - The new input field is optional and defaults off; existing callers are unaffected.

**Features**:

- "Redirect page automatically" checkbox in the Move modal and the Edit-page Settings modal (`Page`/`CollectionPage` only; default on; shown only when the URL actually changes).
- On move or URL change of a published page, a redirect from the old URL to the page is created automatically, stored as a page reference so it survives future moves.

**Improvements**:

- The Move modal now warns when the chosen destination URL is already a redirect source (parity with the Settings modal).
- Both modals suppress that shadow warning when the existing redirect points back at the page being edited.
- Moving/renaming a page onto a path that redirected to it now clears the redundant redirect instead of leaving a self-shadowing loop.

**Bug Fixes**:

- None.

## Tests

7 tRPC integration tests against a real Postgres (`createCallerFactory`) cover both flows: auto-create on move and on URL edit, the gating (flag off / unpublished / unchanged URL), and the reclaim auto-clear. Storybook stories and MSW handlers cover the checkbox, the destination-shadow warning, and its suppression in both modals.

**Manual Verification Steps**:

- [ ] As a site admin, publish a page (e.g. `/newsroom/contact`). Open its **⋯ → Move to…**, pick a destination folder, leave **Redirect page automatically** checked, and click **Move here**. Confirm a redirect from `/newsroom/contact` to the page now appears on the Redirections page (and resolves on the published site after the build).
- [ ] Open a published page's **Settings**, change the **URL**, confirm the **Redirect page automatically** option appears (checked), and **Publish**. Confirm a redirect from the old URL is created.
- [ ] Repeat a move or URL edit with the checkbox **unchecked** — confirm **no** redirect is created.
- [ ] Move or edit the URL of an **unpublished (draft)** page — confirm the checkbox does **not** appear and no redirect is created.
- [ ] In Settings, change **only the title** (leave the URL untouched) — confirm no redirect is created.
- [ ] Move a page into a folder where a redirect already points back at that page — confirm the redundant redirect is **removed** after the move.
- [ ] Move or edit a page onto a URL that already redirects elsewhere — confirm the amber "This URL already redirects to …" warning is shown.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an optional "Redirect page automatically" checkbox to both the Move modal and the Edit-page Settings modal. When enabled for a published `Page` or `CollectionPage` whose URL genuinely changes, the server creates a redirect from the old permalink to the page (stored as a resource reference) inside the same transaction, covering the implicit publish already present in both flows.

- **Server (`redirect.service.ts`)**: Three new helpers (`createRedirectForPermalinkChange`, `assertPermalinkNotShadowed`, `clearReclaimedRedirect`) are orchestrated by `applyPermalinkChangeRedirects`, which is called from both `page.router.ts` (`updateSettings`) and `resource.router.ts` (`move`). The upsert revives soft-deleted rows and throws `CONFLICT` on a live collision, matching the existing publish-block guard.
- **Schema (`resource.ts`, `page.ts`)**: `shouldCreateRedirect` is added as an optional field; however, both schemas use `.default(true)`, meaning any caller that omits the field will implicitly create redirects—contradicting the PR description's backwards-compatibility claim of "defaults off."
- **Frontend**: Both modals gate the checkbox on `publishedVersionId !== null` and URL actually changing; `getRedirectBySource` now returns `destinationResourceId` so each modal can suppress the shadow warning when the existing redirect already points back at the page being edited.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the redirect creation, shadow-assertion, and reclaim-clear logic are all inside the mutation's existing transaction, so a failure rolls back cleanly; the new checkbox is gated on publication status and URL change on both client and server.

The core orchestration is correct: shadow-assert runs before reclaim-clear, which runs before redirect-create, and the whole sequence is transactional. Thirteen new integration tests against a real Postgres database cover the key scenarios (create, flag-off, unpublished, reclaim, shadow block, upsert revival, CollectionPage). The only notable discrepancy is a documentation-level mismatch: the schema defaults `shouldCreateRedirect` to `true` while the PR description says 'defaults off.' In practice this only matters if a caller built against the previous schema sends a move/settings request without the field — it would unexpectedly create redirects — but the frontend (the only consumer) has been updated to always send the field explicitly.

apps/studio/src/schemas/resource.ts and apps/studio/src/schemas/page.ts — the `shouldCreateRedirect` default of `true` contradicts the PR's backwards-compatibility claim; worth aligning the default with the stated intent.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/redirect/redirect.service.ts | Adds three well-scoped helpers plus the orchestrating `applyPermalinkChangeRedirects`. Ordering is correct (shadow-assert → reclaim-clear → optional create). Upsert logic safely distinguishes live from soft-deleted rows. `getRedirectBySource` now returns `destinationResourceId` with a cross-site siteId guard. |
| apps/studio/src/server/modules/resource/resource.router.ts | Permalink reads for old/destination URLs happen before the UPDATE (pre-move committed state), which is correct. `applyPermalinkChangeRedirects` is gated on Page/CollectionPage with a non-null full permalink. `publishedVersionId` is now returned from `getMetadataById`. |
| apps/studio/src/server/modules/page/page.router.ts | Calls `applyPermalinkChangeRedirects` inside the mutation's transaction before `publishResource`. `isPublished` correctly uses the post-UPDATE `publishedVersionId` (pre-publish), so the shadow-assert is skipped for first-time publications (handled by the existing publish-block guard). |
| apps/studio/src/schemas/resource.ts | Adds `shouldCreateRedirect: z.boolean().optional().default(true)` to `moveSchema`. The server-side default is `true`, inconsistent with the PR description's "defaults off" backwards-compatibility claim. |
| apps/studio/src/schemas/page.ts | Adds `shouldCreateRedirect: z.boolean().optional().default(true)` to `basePageSettingsSchema`. Same default-value concern as `resource.ts`. |
| apps/studio/src/features/dashboard/components/PageSettingsModal.tsx | Correctly gates the checkbox on `publishedVersionId !== null` and URL actually changing. Shadow warning suppressed when `destinationResourceId` matches the current page ID. |
| apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx | Correct publication-status guard using `publishedVersionId` from `getMetadataById`. `isDestinationResolved` properly defers the redirect option until the destination permalink is known. |
| apps/studio/src/server/modules/resource/resource.service.ts | Adds optional `trx` parameter to `getResourcePermalinkTree` and `getResourceFullPermalink`. Correctly passes `tx` in `publishPageResource` for the publish-time shadow guard; move/settings callers use their own connections for pre-UPDATE reads, which is safe and intentional. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant FE as Frontend (Move/Settings modal)
    participant R as Router (move / updateSettings)
    participant S as applyPermalinkChangeRedirects
    participant DB as Database (tx)

    FE->>R: "move/updateSettings { shouldCreateRedirect, ... }"
    R->>DB: UPDATE Resource (parentId / permalink)
    R->>S: "applyPermalinkChangeRedirects(tx, { old, new, isPublished, shouldCreateRedirect })"

    alt URL unchanged
        S-->>R: no-op (early return)
    else URL changed
        alt isPublished
            S->>DB: assertPermalinkNotShadowed(new URL) throws CONFLICT if live redirect elsewhere
        end
        S->>DB: clearReclaimedRedirect(new URL) soft-delete if redirect points back at this page
        alt shouldCreateRedirect AND isPublished
            S->>DB: createRedirectForPermalinkChange upsert (old URL to resource reference)
        end
    end

    R->>DB: publishResource / publishSite
    R-->>FE: updated resource
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant FE as Frontend (Move/Settings modal)
    participant R as Router (move / updateSettings)
    participant S as applyPermalinkChangeRedirects
    participant DB as Database (tx)

    FE->>R: "move/updateSettings { shouldCreateRedirect, ... }"
    R->>DB: UPDATE Resource (parentId / permalink)
    R->>S: "applyPermalinkChangeRedirects(tx, { old, new, isPublished, shouldCreateRedirect })"

    alt URL unchanged
        S-->>R: no-op (early return)
    else URL changed
        alt isPublished
            S->>DB: assertPermalinkNotShadowed(new URL) throws CONFLICT if live redirect elsewhere
        end
        S->>DB: clearReclaimedRedirect(new URL) soft-delete if redirect points back at this page
        alt shouldCreateRedirect AND isPublished
            S->>DB: createRedirectForPermalinkChange upsert (old URL to resource reference)
        end
    end

    R->>DB: publishResource / publishSite
    R-->>FE: updated resource
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(test): include publishedVersionId in..."](https://github.com/opengovsg/isomer/commit/07e2346b19d3352c302cff59a9be6eca01c5c45a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746626)</sub>

<!-- /greptile_comment -->