### PR TITLE
docs(conventions): add useDisclosure modal convention

### DIFF
--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -47,6 +47,7 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 
 - [Prefer a new component over overloading props](conventions/react-new-component-over-prop-overload.md) — smell: flag soup / single-caller props bending one component into two jobs
 - [Build forms with useZodForm, not per-field useState](conventions/react-forms-usezodform-over-usestate.md) — best practice: forms use the zod-wired useForm wrapper, schema reused from ~/schemas
+- [Drive modals with useDisclosure, renamed on destructure](conventions/react-modal-usedisclosure-renamed.md) — best practice: modals use Chakra's useDisclosure (not custom useState), aliased to names like isDeleteModalOpen
 
 ### Audit logging
 - [Audit deltas must log real DB rows, not hand-built objects](conventions/audit-log-real-db-rows.md) — best practice: log before/after as rows re-read from the DB inside the same tx, so deltas are accurate

--- a/.claude/skills/isomer-conventions/conventions/react-modal-usedisclosure-renamed.md
+++ b/.claude/skills/isomer-conventions/conventions/react-modal-usedisclosure-renamed.md
@@ -1,0 +1,54 @@
+---
+title: Drive modals with useDisclosure, renamed on destructure
+category: React
+type: best-practice
+---
+
+## Pattern
+
+Manage modal/dialog open state with Chakra's `useDisclosure` hook, not a
+hand-rolled `useState` boolean. Destructure it immediately and alias the
+generic `isOpen` / `onOpen` / `onClose` to names that say which modal they
+drive (e.g. `isDeleteModalOpen`, `onDeleteModalOpen`, `onDeleteModalClose`).
+
+## Why
+
+`useDisclosure` already gives you the exact open/close API Chakra modals
+expect, so re-implementing it with `useState` is redundant and easy to get
+subtly wrong. When a component owns more than one modal, the bare `isOpen` /
+`onOpen` names collide — aliasing on destructure keeps each disclosure
+unambiguous at every call site.
+
+## Bad
+
+```tsx
+const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+// ...
+<Button onClick={() => setIsDeleteModalOpen(true)}>Delete</Button>
+<DeleteModal
+  isOpen={isDeleteModalOpen}
+  onClose={() => setIsDeleteModalOpen(false)}
+/>
+```
+
+## Good
+
+```tsx
+const {
+  isOpen: isDeleteModalOpen,
+  onOpen: onDeleteModalOpen,
+  onClose: onDeleteModalClose,
+} = useDisclosure()
+// ...
+<Button onClick={onDeleteModalOpen}>Delete</Button>
+<DeleteModal isOpen={isDeleteModalOpen} onClose={onDeleteModalClose} />
+```
+
+## How to detect
+
+Look for `useState(false)` paired with a `setX(true)` / `setX(false)` that
+only toggles a modal/dialog — that should be `useDisclosure`. Also flag
+`useDisclosure()` destructured to the bare `isOpen` / `onOpen` / `onClose`
+when the component renders a modal (especially with more than one), since the
+names should be aliased. Good reference:
+`apps/studio/src/pages/sites/[siteId]/index.tsx:79`.


### PR DESCRIPTION
## Problem

The `isomer-conventions` skill catalog had no recorded guidance on how modal/dialog open state should be managed in this repo. Without it, new code (and AI-assisted code) tends to reach for a hand-rolled `useState` boolean, and even when `useDisclosure` is used, the bare `isOpen` / `onOpen` / `onClose` names collide when a component owns more than one modal.

## Solution

Add a new best-practice convention entry documenting the blessed pattern: drive modals with Chakra's `useDisclosure`, destructured immediately with `isOpen` / `onOpen` / `onClose` aliased to modal-specific names (e.g. `isDeleteModalOpen`). The entry is grounded in a real example at `apps/studio/src/pages/sites/[siteId]/index.tsx:79`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- New convention entry `conventions/react-modal-usedisclosure-renamed.md` covering the `useDisclosure` modal pattern (pattern, rationale, Bad/Good pair, and how to detect violations).
- Indexed the entry under the **React** category in `SKILL.md` so reviewers loading the catalog pick it up.

**Bug Fixes**:

- N/A

## Tests

This is a documentation-only change to the `isomer-conventions` skill — no production code is affected, so there is nothing to run beyond confirming the catalog link resolves to the new entry.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01649DQD535ngjULA6RRgXH2)_