### PR TITLE
🔖 feat: render categoryId correctly on published collection pages

### DIFF
--- a/apps/studio/src/utils/sitemap.ts
+++ b/apps/studio/src/utils/sitemap.ts
@@ -270,6 +270,14 @@ export const injectTagMappings = async (
     resourceId: resource.parentId,
   })
 
+  const childPageProps = draftBlobOfResource.content.page as
+    | ArticlePagePageProps
+    | FileRefPageProps
+    | LinkRefPageProps
+
+  const collectionPageProps = publishedIndexBlob.content
+    .page as unknown as CollectionPagePageProps
+
   return _injectTagMappings(
     sitemapTree,
     // NOTE: This cast is abit overkill,
@@ -278,14 +286,10 @@ export const injectTagMappings = async (
     // not the exact type so for safety,
     // we cast to all the possible `page` props
     // of a collection item
-    (
-      draftBlobOfResource.content.page as
-        | ArticlePagePageProps
-        | FileRefPageProps
-        | LinkRefPageProps
-    ).tagged,
-    (publishedIndexBlob.content.page as unknown as CollectionPagePageProps)
-      .tagCategories,
+    childPageProps.tagged,
+    collectionPageProps.tagCategories,
+    childPageProps.categoryId,
+    collectionPageProps.categoryOptions,
     resource.id,
     resource.parentId,
   )
@@ -296,17 +300,19 @@ const _injectTagMappings = (
   sitemap: IsomerSitemap,
   tagged: ArticlePagePageProps["tagged"],
   tagCategories: CollectionPagePageProps["tagCategories"],
+  categoryId: ArticlePagePageProps["categoryId"],
+  categoryOptions: CollectionPagePageProps["categoryOptions"],
   childId: CollectionItemResourceDto["id"],
   collectionId: CollectionItemResourceDto["parentId"],
 ): IsomerSitemap => {
   // NOTE: If the child id matches,
-  // just inject the tags
+  // inject the tags and categoryId
   if (sitemap.id === childId) {
-    return { ...sitemap, tagged }
+    return { ...sitemap, tagged, categoryId }
   }
 
   // NOTE: If the collection id matches,
-  // inject tag categories and process the children
+  // inject tag categories, categoryOptions and process the children
   if (
     sitemap.layout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
     sitemap.id === collectionId
@@ -316,9 +322,18 @@ const _injectTagMappings = (
       collectionPagePageProps: {
         ...sitemap.collectionPagePageProps,
         tagCategories,
+        categoryOptions,
       },
       children: sitemap.children?.map((child) =>
-        _injectTagMappings(child, tagged, tagCategories, childId, collectionId),
+        _injectTagMappings(
+          child,
+          tagged,
+          tagCategories,
+          categoryId,
+          categoryOptions,
+          childId,
+          collectionId,
+        ),
       ),
     }
   }
@@ -328,7 +343,15 @@ const _injectTagMappings = (
   return {
     ...sitemap,
     children: sitemap.children?.map((child) =>
-      _injectTagMappings(child, tagged, tagCategories, childId, collectionId),
+      _injectTagMappings(
+        child,
+        tagged,
+        tagCategories,
+        categoryId,
+        categoryOptions,
+        childId,
+        collectionId,
+      ),
     ),
   }
 }

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -347,7 +347,8 @@ const CATEGORY_ID_ITEMS: IsomerSitemap[] = [
     permalink: "/publications/policy-article",
     lastModified: "",
     layout: "article",
-    summary: "This article uses a categoryId UUID instead of a category string.",
+    summary:
+      "This article uses a categoryId UUID instead of a category string.",
     date: "2024-03-01",
     categoryId: "cat-uuid-policy",
   },

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -333,3 +333,63 @@ export const Blog: Story = {
     variant: "blog",
   }),
 }
+
+const CATEGORY_OPTIONS = [
+  { id: "cat-uuid-policy", label: "Policy" },
+  { id: "cat-uuid-research", label: "Research" },
+  { id: "cat-uuid-news", label: "News" },
+]
+
+const CATEGORY_ID_ITEMS: IsomerSitemap[] = [
+  {
+    id: "ci-1",
+    title: "A Policy article",
+    permalink: "/publications/policy-article",
+    lastModified: "",
+    layout: "article",
+    summary: "This article uses a categoryId UUID instead of a category string.",
+    date: "2024-03-01",
+    categoryId: "cat-uuid-policy",
+  },
+  {
+    id: "ci-2",
+    title: "A Research article",
+    permalink: "/publications/research-article",
+    lastModified: "",
+    layout: "article",
+    summary: "This article is tagged with the Research category via UUID.",
+    date: "2024-06-15",
+    categoryId: "cat-uuid-research",
+  },
+  {
+    id: "ci-3",
+    title: "A News article",
+    permalink: "/publications/news-article",
+    lastModified: "",
+    layout: "article",
+    summary: "This article is tagged with the News category via UUID.",
+    date: "2024-09-20",
+    categoryId: "cat-uuid-news",
+  },
+  {
+    id: "ci-4",
+    title: "Another Policy article",
+    permalink: "/publications/policy-article-2",
+    lastModified: "",
+    layout: "article",
+    summary: "A second Policy article to show the count in the filter.",
+    date: "2024-11-01",
+    categoryId: "cat-uuid-policy",
+  },
+]
+
+export const WithCategoryIdItems: Story = {
+  name: "With categoryId items (resolved labels in filter)",
+  args: {
+    ...generateArgs({ collectionItems: CATEGORY_ID_ITEMS }),
+    page: {
+      ...generateArgs({ collectionItems: CATEGORY_ID_ITEMS }).page,
+      categoryOptions: CATEGORY_OPTIONS,
+    },
+  },
+}

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -21,6 +21,7 @@ export const CollectionLayout = ({
     defaultSortBy,
     defaultSortDirection,
     tagCategories,
+    categoryOptions,
     showDate,
     showThumbnail,
   } = page
@@ -32,6 +33,7 @@ export const CollectionLayout = ({
     sortBy: defaultSortBy,
     sortDirection: defaultSortDirection,
     tagCategories,
+    categoryOptions,
     showDate,
     showThumbnail,
   })
@@ -47,7 +49,11 @@ export const CollectionLayout = ({
         page={page}
         breadcrumb={breadcrumb}
         items={processedItems}
-        filters={getAvailableFilters(processedItems, tagCategories)}
+        filters={getAvailableFilters(
+          processedItems,
+          tagCategories,
+          categoryOptions,
+        )}
         shouldShowDate={shouldShowDate(processedItems)}
         siteAssetsBaseUrl={site.assetsBaseUrl}
       />

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
@@ -128,6 +128,31 @@ describe("getCategoryFilter", () => {
     )
   })
 
+  it("orders correctly when categoryOptions labels are lowercase", () => {
+    // Arrange — admin saved labels in lowercase; schema only enforces non-empty, not case
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "news" } as ProcessedCollectionCardProps,
+      { category: "policy" } as ProcessedCollectionCardProps,
+      { category: "research" } as ProcessedCollectionCardProps,
+    ]
+
+    const categoryOptions: CollectionPageCategoryOption[] = [
+      { id: "cat-uuid-1", label: "research" },
+      { id: "cat-uuid-2", label: "policy" },
+      { id: "cat-uuid-3", label: "news" },
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, categoryOptions)
+
+    // Assert — order must follow categoryOptions, not fall back to alphabetical
+    expect(result.items.map((i) => i.id)).toEqual([
+      "research",
+      "policy",
+      "news",
+    ])
+  })
+
   it("places categories not listed in categoryOptions at the end", () => {
     // Arrange
     const items: ProcessedCollectionCardProps[] = [
@@ -150,6 +175,33 @@ describe("getCategoryFilter", () => {
       "Policy",
       "News",
       "Others",
+    ])
+  })
+
+  it("sorts multiple unknown categories alphabetically when appended after known categories", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "Zebra" } as ProcessedCollectionCardProps, // unknown
+      { category: "News" } as ProcessedCollectionCardProps, // known
+      { category: "Apple" } as ProcessedCollectionCardProps, // unknown
+      { category: "Policy" } as ProcessedCollectionCardProps, // known
+    ]
+
+    const categoryOptions: CollectionPageCategoryOption[] = [
+      { id: "cat-uuid-1", label: "Policy" },
+      { id: "cat-uuid-2", label: "News" },
+      // "Zebra" and "Apple" are intentionally absent
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, categoryOptions)
+
+    // Assert — known items first in editor order, unknown items alphabetically after
+    expect(result.items.map((i) => i.label)).toEqual([
+      "Policy",
+      "News",
+      "Apple",
+      "Zebra",
     ])
   })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
@@ -1,4 +1,5 @@
 import type { ProcessedCollectionCardProps } from "~/interfaces"
+import type { CollectionPageCategoryOption } from "~/types/page"
 import { describe, expect, it } from "vitest"
 
 import { getCategoryFilter } from "../getCategoryFilter"
@@ -52,5 +53,99 @@ describe("getCategoryFilter", () => {
         { id: "tutorials", label: "Tutorials", count: 2 },
       ],
     })
+  })
+
+  it("sorts alphabetically when categoryOptions is not provided", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "Zebra" } as ProcessedCollectionCardProps,
+      { category: "Apple" } as ProcessedCollectionCardProps,
+      { category: "Mango" } as ProcessedCollectionCardProps,
+      { category: "Apple" } as ProcessedCollectionCardProps,
+    ]
+
+    // Act
+    const result = getCategoryFilter(items)
+
+    // Assert
+    expect(result.items.map((i) => i.label)).toEqual(["Apple", "Mango", "Zebra"])
+  })
+
+  it("orders filter items according to categoryOptions order, not alphabetically", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "News" } as ProcessedCollectionCardProps,
+      { category: "Policy" } as ProcessedCollectionCardProps,
+      { category: "Research" } as ProcessedCollectionCardProps,
+      { category: "News" } as ProcessedCollectionCardProps,
+    ]
+
+    const categoryOptions: CollectionPageCategoryOption[] = [
+      { id: "cat-uuid-1", label: "Research" },
+      { id: "cat-uuid-2", label: "Policy" },
+      { id: "cat-uuid-3", label: "News" },
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, categoryOptions)
+
+    // Assert
+    expect(result).toEqual({
+      id: "category",
+      label: "Category",
+      items: [
+        { id: "research", label: "Research", count: 1 },
+        { id: "policy", label: "Policy", count: 1 },
+        { id: "news", label: "News", count: 2 },
+      ],
+    })
+  })
+
+  it("excludes categoryOptions entries that have no matching items", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "News" } as ProcessedCollectionCardProps,
+      { category: "Policy" } as ProcessedCollectionCardProps,
+    ]
+
+    const categoryOptions: CollectionPageCategoryOption[] = [
+      { id: "cat-uuid-1", label: "Research" }, // No items with this category
+      { id: "cat-uuid-2", label: "Policy" },
+      { id: "cat-uuid-3", label: "News" },
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, categoryOptions)
+
+    // Assert
+    expect(result.items.map((i) => i.label)).toEqual(["Policy", "News"])
+    expect(result.items).not.toContainEqual(
+      expect.objectContaining({ label: "Research" }),
+    )
+  })
+
+  it("places categories not listed in categoryOptions at the end", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "Others" } as ProcessedCollectionCardProps, // Not in categoryOptions
+      { category: "News" } as ProcessedCollectionCardProps,
+      { category: "Policy" } as ProcessedCollectionCardProps,
+    ]
+
+    const categoryOptions: CollectionPageCategoryOption[] = [
+      { id: "cat-uuid-2", label: "Policy" },
+      { id: "cat-uuid-3", label: "News" },
+      // "Others" is intentionally absent
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, categoryOptions)
+
+    // Assert
+    expect(result.items.map((i) => i.label)).toEqual([
+      "Policy",
+      "News",
+      "Others",
+    ])
   })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
@@ -68,7 +68,11 @@ describe("getCategoryFilter", () => {
     const result = getCategoryFilter(items)
 
     // Assert
-    expect(result.items.map((i) => i.label)).toEqual(["Apple", "Mango", "Zebra"])
+    expect(result.items.map((i) => i.label)).toEqual([
+      "Apple",
+      "Mango",
+      "Zebra",
+    ])
   })
 
   it("orders filter items according to categoryOptions order, not alphabetically", () => {

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts
@@ -1,4 +1,5 @@
 import type { IsomerSitemap } from "~/types"
+import type { CollectionPageCategoryOption } from "~/types/page"
 import { describe, expect, it } from "vitest"
 import { generateSiteConfig } from "~/stories/helpers/generateSiteConfig"
 
@@ -322,6 +323,146 @@ describe("getCollectionItems", () => {
       expect(result[1]!.isContainNeeded).toBe(false)
       expect(result[2]!.image).toEqual(SITE_LOGO_FALLBACK)
       expect(result[2]!.isContainNeeded).toBe(true)
+    })
+  })
+
+  describe("categoryId resolution", () => {
+    const CATEGORY_OPTIONS: CollectionPageCategoryOption[] = [
+      { id: "cat-uuid-1", label: "Policy" },
+      { id: "cat-uuid-2", label: "Research" },
+      { id: "cat-uuid-3", label: "News" },
+    ]
+
+    it("should resolve categoryId to the matching label from categoryOptions", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({ categoryId: "cat-uuid-2", category: "legacy" }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        categoryOptions: CATEGORY_OPTIONS,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Research")
+    })
+
+    it("should fall back to legacy category string when no categoryId is present", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({ category: "Legacy Category" }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        categoryOptions: CATEGORY_OPTIONS,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Legacy Category")
+    })
+
+    it("should fall back to 'Others' when item has neither categoryId nor category", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({ categoryId: undefined, category: undefined }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        categoryOptions: CATEGORY_OPTIONS,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Others")
+    })
+
+    it("should fall back to category string when categoryId does not match any option", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({
+          categoryId: "unknown-uuid",
+          category: "Legacy Fallback",
+        }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        categoryOptions: CATEGORY_OPTIONS,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Legacy Fallback")
+    })
+
+    it("should fall back to 'Others' when categoryId does not match any option and category is also absent", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({
+          categoryId: "unknown-uuid",
+          category: undefined,
+        }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        categoryOptions: CATEGORY_OPTIONS,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Others")
+    })
+
+    it("should use legacy category string when no categoryOptions are passed", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({ categoryId: "cat-uuid-1", category: "Legacy" }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        // categoryOptions intentionally omitted
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Legacy")
+    })
+
+    it("should fall back to 'Others' when no categoryOptions and no category string", () => {
+      // Arrange
+      const site = createSiteWithChildren([
+        createArticleChild({ category: undefined }),
+      ])
+
+      // Act
+      const result = getCollectionItems({
+        site,
+        permalink: "/collection",
+        // categoryOptions intentionally omitted
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]!.category).toBe("Others")
     })
   })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts
@@ -1,5 +1,6 @@
 import type { ProcessedCollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
+import type { CollectionPageCategoryOption } from "~/types/page"
 
 import type { Filter } from "../../../types/Filter"
 import { getCategoryFilter } from "./getCategoryFilter"
@@ -9,11 +10,12 @@ import { getYearFilter } from "./getYearFilter"
 export const getAvailableFilters = (
   items: ProcessedCollectionCardProps[],
   tagCategories?: CollectionPageSchemaType["page"]["tagCategories"],
+  categoryOptions?: CollectionPageCategoryOption[],
 ): Filter[] => {
   // TODO: Allow user to pass in order of filters to be shown
   return [
     ...getTagFilters(items, tagCategories),
-    getCategoryFilter(items),
+    getCategoryFilter(items, categoryOptions),
     getYearFilter(items),
   ].filter((filter) => filter.items.length >= 1)
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -35,11 +35,11 @@ export const getCategoryFilter = (
       label.toLowerCase(),
     )
 
-    const known = categoryFilterItems.filter(
-      (item) => categoryOptionLabels.indexOf(item.id) !== -1,
+    const known = categoryFilterItems.filter((item) =>
+      categoryOptionLabels.includes(item.id),
     )
     const unknown = categoryFilterItems.filter(
-      (item) => categoryOptionLabels.indexOf(item.id) === -1,
+      (item) => !categoryOptionLabels.includes(item.id),
     )
 
     known.sort(

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -1,10 +1,12 @@
 import type { ProcessedCollectionCardProps } from "~/interfaces"
 import type { Filter } from "~/templates/next/types/Filter"
+import type { CollectionPageCategoryOption } from "~/types/page"
 
 import { FILTER_ID_CATEGORY } from "./constants"
 
 export const getCategoryFilter = (
   items: ProcessedCollectionCardProps[],
+  categoryOptions?: CollectionPageCategoryOption[],
 ): Filter => {
   const categories: Record<string, number> = {}
 
@@ -16,15 +18,31 @@ export const getCategoryFilter = (
     }
   })
 
-  const categoryFilterItems = Object.entries(categories)
-    .map(([label, count]) => ({
+  const categoryFilterItems = Object.entries(categories).map(
+    ([label, count]) => ({
       id: label.toLowerCase(),
       label: label.charAt(0).toUpperCase() + label.slice(1),
       count,
-    }))
-    .sort((a, b) =>
+    }),
+  )
+
+  if (categoryOptions && categoryOptions.length > 0) {
+    const categoryOptionLabels = categoryOptions.map(({ label }) => label)
+    categoryFilterItems.sort((a, b) => {
+      const indexA = categoryOptionLabels.indexOf(a.label)
+      const indexB = categoryOptionLabels.indexOf(b.label)
+
+      if (indexA === -1 && indexB === -1) return 0
+      if (indexA === -1) return 1
+      if (indexB === -1) return -1
+
+      return indexA - indexB
+    })
+  } else {
+    categoryFilterItems.sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { numeric: true }),
     )
+  }
 
   return {
     id: FILTER_ID_CATEGORY,

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -27,23 +27,39 @@ export const getCategoryFilter = (
   )
 
   if (categoryOptions && categoryOptions.length > 0) {
-    // Sort by the editor-defined order in categoryOptions; unknown categories fall to the end
-    const categoryOptionLabels = categoryOptions.map(({ label }) => label)
-    categoryFilterItems.sort((a, b) => {
-      const indexA = categoryOptionLabels.indexOf(a.label)
-      const indexB = categoryOptionLabels.indexOf(b.label)
+    // Split into two groups: items whose id matches a categoryOption (known) and those that don't
+    // (unknown). Known items are ordered by the editor-defined categoryOptions order; unknown items
+    // are appended alphabetically. Matching is done on the lowercased id (= lowercased label) so
+    // it is case-insensitive and stable even if the display label is later re-cased.
+    const categoryOptionLabels = categoryOptions.map(({ label }) =>
+      label.toLowerCase(),
+    )
 
-      if (indexA === -1 && indexB === -1) return 0 // both unknown, preserve order
-      if (indexA === -1) return 1 // a unknown, push after b
-      if (indexB === -1) return -1 // b unknown, push after a
+    const known = categoryFilterItems.filter(
+      (item) => categoryOptionLabels.indexOf(item.id) !== -1,
+    )
+    const unknown = categoryFilterItems.filter(
+      (item) => categoryOptionLabels.indexOf(item.id) === -1,
+    )
 
-      return indexA - indexB
-    })
-  } else {
-    categoryFilterItems.sort((a, b) =>
+    known.sort(
+      (a, b) =>
+        categoryOptionLabels.indexOf(a.id) - categoryOptionLabels.indexOf(b.id),
+    )
+    unknown.sort((a, b) =>
       a.label.localeCompare(b.label, undefined, { numeric: true }),
     )
+
+    return {
+      id: FILTER_ID_CATEGORY,
+      label: "Category",
+      items: [...known, ...unknown],
+    }
   }
+
+  categoryFilterItems.sort((a, b) =>
+    a.label.localeCompare(b.label, undefined, { numeric: true }),
+  )
 
   return {
     id: FILTER_ID_CATEGORY,

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -27,14 +27,15 @@ export const getCategoryFilter = (
   )
 
   if (categoryOptions && categoryOptions.length > 0) {
+    // Sort by the editor-defined order in categoryOptions; unknown categories fall to the end
     const categoryOptionLabels = categoryOptions.map(({ label }) => label)
     categoryFilterItems.sort((a, b) => {
       const indexA = categoryOptionLabels.indexOf(a.label)
       const indexB = categoryOptionLabels.indexOf(b.label)
 
-      if (indexA === -1 && indexB === -1) return 0
-      if (indexA === -1) return 1
-      if (indexB === -1) return -1
+      if (indexA === -1 && indexB === -1) return 0 // both unknown, preserve order
+      if (indexA === -1) return 1 // a unknown, push after b
+      if (indexB === -1) return -1 // b unknown, push after a
 
       return indexA - indexB
     })

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCollectionItems.ts
@@ -1,6 +1,9 @@
 import type { AllCardProps } from "~/interfaces"
 import type { IsomerSitemap, IsomerSiteProps } from "~/types"
-import type { CollectionPagePageProps } from "~/types/page"
+import type {
+  CollectionPageCategoryOption,
+  CollectionPagePageProps,
+} from "~/types/page"
 import { getParsedDate } from "~/utils/getParsedDate"
 import { getSitemapAsArray } from "~/utils/getSitemapAsArray"
 
@@ -70,6 +73,7 @@ export type GetCollectionItemsProps = Pick<
   permalink: string
   sortBy?: CollectionPagePageProps["defaultSortBy"]
   sortDirection?: CollectionPagePageProps["defaultSortDirection"]
+  categoryOptions?: CollectionPageCategoryOption[]
 }
 
 export const getCollectionItems = ({
@@ -81,6 +85,7 @@ export const getCollectionItems = ({
   showDate,
   showThumbnail,
   tagCategories,
+  categoryOptions,
 }: GetCollectionItemsProps): AllCardProps[] => {
   let currSitemap: IsomerSitemap = site.siteMap
   const permalinkParts = permalink.split("/")
@@ -128,7 +133,12 @@ export const getCollectionItems = ({
       id: item.permalink,
       date,
       lastModified: item.lastModified,
-      category: item.category || CATEGORY_OTHERS,
+      category:
+        item.categoryId && categoryOptions
+          ? (categoryOptions.find((opt) => opt.id === item.categoryId)?.label ??
+            item.category ??
+            CATEGORY_OTHERS)
+          : (item.category ?? CATEGORY_OTHERS),
       title: item.title,
       description: item.summary,
       image,

--- a/packages/components/src/types/sitemap.ts
+++ b/packages/components/src/types/sitemap.ts
@@ -1,6 +1,9 @@
 import type { CollectionCardProps } from "~/interfaces"
 import type { FileCardProps } from "~/interfaces/internal/CollectionCard"
-import type { CollectionPagePageProps } from "~/types"
+import type {
+  CollectionPageCategoryOption,
+  CollectionPagePageProps,
+} from "~/types"
 
 import type { IsomerPageLayoutType } from "./schema"
 
@@ -11,6 +14,7 @@ interface IsomerBaseSitemap {
   lastModified: string
   permalink: string
   category?: string
+  categoryId?: string
   // TODO: we should aim to separate BaseSiteMap into different types
   // so that the properties that are exclusive to, for example, `CollectionCard`
   // will only be available there
@@ -31,6 +35,7 @@ export interface IsomerCollectionPageSitemap extends IsomerBaseSitemap {
   // TODO: Reconsider how this is done as currently every item in the sitemap has the same props
   collectionPagePageProps?: {
     tagCategories?: CollectionPagePageProps["tagCategories"]
+    categoryOptions?: CollectionPageCategoryOption[]
     sortOrder?: CollectionPagePageProps["sortOrder"]
     defaultSortBy?: CollectionPagePageProps["defaultSortBy"]
     defaultSortDirection?: CollectionPagePageProps["defaultSortDirection"]


### PR DESCRIPTION
> [!NOTE]
> this works for both pre/post migration of category 

## Summary

- **Bug**: Published collection pages were not rendering categories for items that used the new UUID-based `categoryId` field introduced in the category management backend. Items defaulted to \"Others\" because the rendering pipeline only read the legacy `category` string field.
- **Fix**: Threads `categoryId` (on child sitemap nodes) and `categoryOptions` (on the collection sitemap node) through `injectTagMappings` → `IsomerBaseSitemap` / `IsomerCollectionPageSitemap`, mirroring the existing `tagged`/`tagCategories` pattern.
- **UUID → label resolution**: `getCollectionItems` now looks up `categoryId` against `categoryOptions` and resolves it to the human-readable label, falling back to the legacy `category` string, then to `\"Others\"`.
- **Admin-defined ordering**: `getCategoryFilter` respects the order of `categoryOptions` when building the filter sidebar, rather than always sorting alphabetically. Categories not present in `categoryOptions` are appended at the end.
- **Storybook**: Added a `WithCategoryIdItems` story to `Collection.stories.tsx` so the resolved-label flow is visible in isolation.
- **Unit tests**: New test cases in `getCollectionItems.test.ts` and `getCategoryFilter.test.ts` cover UUID resolution, legacy fallback, unknown-UUID fallback, and ordering logic.

Closes https://linear.app/ogp/issue/ISOM-2302/feat-render-categoryid-correctly-on-published-collection-pages

## Test plan

- [ ] Run unit tests: `pnpm test:unit -- src/templates/next/layouts/Collection/utils/__tests__/getCollectionItems.test.ts` and `getCategoryFilter.test.ts` — all new cases pass
- [ ] Open Storybook (`pnpm storybook`) and view the **Collection → With categoryId items** story — filter sidebar shows \"Policy\", \"Research\", \"News\" with correct counts
- [ ] On a local environment, create a collection page with items assigned to categories via the category management UI, then visit the published page and confirm the category filter sidebar shows the correct labels in the admin-defined order
- [ ] Confirm that existing collection pages with the legacy `category` string field still render correctly (no regression)
- [ ] Confirm that items with neither `categoryId` nor `category` still fall back to \"Others\"