### PR TITLE
🔖 fix: suppress legacy category free-text field when categoryId flag is on

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -8,7 +8,10 @@ import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { collectionItemSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { CATEGORY_DROPDOWN_FEATURE_KEY } from "~/lib/growthbook"
+import {
+  CATEGORY_DROPDOWN_FEATURE_KEY,
+  CATEGORY_ID_DROPDOWN_FEATURE_KEY,
+} from "~/lib/growthbook"
 import { trpc } from "~/utils/trpc"
 
 import { JsonFormsTextControl } from "./JsonFormsTextControl"
@@ -64,6 +67,11 @@ export function JsonFormsCategoryControl({
     CATEGORY_DROPDOWN_FEATURE_KEY,
     { enabledSites: [] },
   )
+  const { enabledSites: categoryIdEnabledSites } = useFeatureValue<{
+    enabledSites: string[]
+  }>(CATEGORY_ID_DROPDOWN_FEATURE_KEY, { enabledSites: [] })
+
+  if (categoryIdEnabledSites.includes(siteId.toString())) return null
 
   const isDropdownEnabled = enabledSites.includes(siteId.toString())
   return isDropdownEnabled ? (

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsCategoryControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsCategoryControl.stories.tsx
@@ -5,7 +5,10 @@ import {
   JsonFormsCategoryControl,
   jsonFormsCategoryControlTester,
 } from "~/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl"
-import { createDropdownGbParameters } from "~/stories/utils/growthbook"
+import {
+  createCategoryIdDropdownGbParameters,
+  createDropdownGbParameters,
+} from "~/stories/utils/growthbook"
 
 import { FormBuilder } from "./formBuilder"
 
@@ -43,7 +46,24 @@ const schema = Type.Object({
   }),
 })
 
-export const Default: Story = {
+/** CATEGORY_ID_DROPDOWN_FEATURE_KEY flag is off for this site — legacy free-text field is visible. */
+export const FlagOff: Story = {
+  args: {
+    schema,
+    renderers: [
+      {
+        tester: jsonFormsCategoryControlTester,
+        renderer: JsonFormsCategoryControl,
+      },
+    ],
+  },
+}
+
+/** CATEGORY_ID_DROPDOWN_FEATURE_KEY flag is on for this site — component renders nothing. */
+export const FlagOn: Story = {
+  parameters: {
+    growthbook: [createCategoryIdDropdownGbParameters("1")],
+  },
   args: {
     schema,
     renderers: [

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -3,6 +3,7 @@ import { GrowthBook } from "@growthbook/growthbook"
 import {
   BANNER_FEATURE_KEY,
   CATEGORY_DROPDOWN_FEATURE_KEY,
+  CATEGORY_ID_DROPDOWN_FEATURE_KEY,
   EGAZETTE_INFO_FEATURE_KEY,
   IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
   IS_REDIRECTIONS_ENABLED_FEATURE_KEY,
@@ -34,6 +35,10 @@ export const createBannerGbParameters = ({
 
 export const createDropdownGbParameters = (siteId: string) => {
   return [CATEGORY_DROPDOWN_FEATURE_KEY, { enabledSites: [siteId] }]
+}
+
+export const createCategoryIdDropdownGbParameters = (siteId: string) => {
+  return [CATEGORY_ID_DROPDOWN_FEATURE_KEY, { enabledSites: [siteId] }]
 }
 
 export const createSingpassEnabledGbParameters = (isEnabled: boolean) => {


### PR DESCRIPTION
> [!NOTE]
> Both feature flags will be gone once the feature goes live 

## Summary

- When `CATEGORY_ID_DROPDOWN_FEATURE_KEY` is enabled for a site, `JsonFormsCategoryControl` (the legacy free-text category field) now returns `null`, so editors only see the new `categoryId` dropdown — not both fields simultaneously.
- The legacy `category` value stored in the blob is preserved unchanged; the component simply hides itself rather than clearing any data.
- Adds a `createCategoryIdDropdownGbParameters` helper to `stories/utils/growthbook.ts` to keep Storybook GrowthBook setup consistent with existing helpers.
- Adds `FlagOff` and `FlagOn` Storybook stories for `JsonFormsCategoryControl` to document and visually verify both states.

Closes https://linear.app/ogp/issue/ISOM-2304/feat-suppress-legacy-category-free-text-field-when-categoryid-flag-is

## Test plan

- [ ] With `CATEGORY_ID_DROPDOWN_FEATURE_KEY` **disabled** for the site: the legacy free-text category field renders as expected (no regression).
- [ ] With `CATEGORY_ID_DROPDOWN_FEATURE_KEY` **enabled** for the site: the legacy free-text category field is hidden; only the `categoryId` dropdown is visible.
- [ ] Existing `category` value in the blob is not cleared when the flag is turned on — data is preserved.
- [ ] Storybook: `FlagOff` story shows the legacy free-text field; `FlagOn` story renders nothing (empty canvas).