### PR TITLE
🔖 fix: surface tag category and categoryId UX for collection item editors

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
@@ -54,7 +54,7 @@ function SuspendableJsonFormsCategoryIdSelect({
 
 export function JsonFormsCategoryIdControl({
   description,
-  required,
+  required: _required,
   label,
   ...props
 }: ControlProps) {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
@@ -44,7 +44,7 @@ function SuspendableJsonFormsCategoryIdSelect({
         label: optionLabel,
         value: id,
       }))}
-      isClearable={true} // TODO: change to false after migration where it's no longer optional
+      isClearable={false}
       onChange={(value) => {
         handleChange(path, value)
       }}
@@ -77,7 +77,7 @@ export function JsonFormsCategoryIdControl({
   if (resourceId === undefined) return null
 
   return enabledSites.includes(parsedQuery.data.siteId.toString()) ? (
-    <FormControl isRequired={required} gap="0.5rem">
+    <FormControl isRequired gap="0.5rem">
       <FormLabel description={description}>{label}</FormLabel>
       <ErrorBoundary fallbackRender={() => null}>
         <Suspense fallback={<Skeleton />}>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
@@ -54,7 +54,7 @@ function SuspendableJsonFormsCategoryIdSelect({
 
 export function JsonFormsCategoryIdControl({
   description,
-  required: _required,
+  required,
   label,
   ...props
 }: ControlProps) {
@@ -77,7 +77,7 @@ export function JsonFormsCategoryIdControl({
   if (resourceId === undefined) return null
 
   return enabledSites.includes(parsedQuery.data.siteId.toString()) ? (
-    <FormControl isRequired gap="0.5rem">
+    <FormControl isRequired={required} gap="0.5rem">
       <FormLabel description={description}>{label}</FormLabel>
       <ErrorBoundary fallbackRender={() => null}>
         <Suspense fallback={<Skeleton />}>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
@@ -44,6 +44,20 @@ function SuspendableJsonFormsCategoryIdSelect({
         label: optionLabel,
         value: id,
       }))}
+      // Hardcoded false (not derived from `required`) because categoryId is still
+      // Type.Optional in the schema pending the category migration. Using `!required`
+      // would be true in the gap between "migration ran" and "schema updated",
+      // letting editors clear backfilled categoryIds. Correct behaviour across all states:
+      //
+      //   State                                 | isClearable=false
+      //   --------------------------------------|------------------------------------------
+      //   Pre-migration, old item (no categoryId) | nothing to clear — harmless
+      //   Pre-migration, new item (has categoryId) | can't clear — correct
+      //   Migration ran, schema not yet updated  | can't clear — protects migrated data
+      //   Migration ran + schema updated         | can't clear — correct
+      //
+      // Once migration is complete and categoryId is made required in the schema,
+      // replace with isClearable={!required}.
       isClearable={false}
       onChange={(value) => {
         handleChange(path, value)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -23,7 +23,6 @@ export function JsonFormsTaggedControl({
   data,
   path,
   description,
-  required,
   handleChange,
 }: TaggedControlProps) {
   return (
@@ -32,7 +31,6 @@ export function JsonFormsTaggedControl({
         data={data}
         path={path}
         description={description}
-        required={required}
         handleChange={handleChange}
       />
     </Suspense>
@@ -41,14 +39,13 @@ export function JsonFormsTaggedControl({
 
 type SuspendableJsonFormsTaggedControlProps = Pick<
   TaggedControlProps,
-  "data" | "required" | "handleChange" | "description" | "path"
+  "data" | "handleChange" | "description" | "path"
 >
 
 const SuspendableJsonFormsTaggedControl = ({
   path,
   data,
   handleChange,
-  required,
   description,
 }: SuspendableJsonFormsTaggedControlProps) => {
   const { siteId, linkId, pageId } = useQueryParse(collectionItemSchema)
@@ -69,18 +66,18 @@ const SuspendableJsonFormsTaggedControl = ({
       <VStack spacing="1.25rem">
         {tags
           .filter(({ options }) => options.length > 0)
-          .map(({ label, options }) => {
+          .map(({ label, options, isRequired: tagIsRequired }) => {
             const currentTagCategoryOptions = options.filter(({ id }) =>
               data?.some((selectedTagId) => selectedTagId === id),
             )
             const tagOptionsIds = options.map(({ id }) => id)
 
             return (
-              <FormControl isRequired={required} gap="0.5rem">
+              <FormControl isRequired={tagIsRequired ?? false} gap="0.5rem">
                 <FormLabel description={description}>{label}</FormLabel>
                 <MultiSelect
                   size="sm"
-                  nothingFoundLabel="No tags found. Search for something else or contact your site owner(s) to create new tags."
+                  nothingFoundLabel="No tags found."
                   values={currentTagCategoryOptions.map(({ id }) => id)}
                   name={label}
                   items={options.map(({ id, label }) => {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -78,7 +78,7 @@ const SuspendableJsonFormsTaggedControl = ({
                 <FormLabel description={description}>{label}</FormLabel>
                 <MultiSelect
                   size="sm"
-                  nothingFoundLabel="No tags found."
+                  nothingFoundLabel="No tags found. Search for something else or contact your site owner(s) to create new tags."
                   values={currentTagCategoryOptions.map(({ id }) => id)}
                   name={label}
                   items={options.map(({ id, label }) => {

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -52,9 +52,10 @@ const SuspendableJsonFormsTaggedControl = ({
   // NOTE: Since this is only rendered inside a collection page or collection link,
   // we should always have the `resourceId` specifier
   const resourceId = linkId ?? pageId ?? 1
-  const [tags] = trpc.collection.getPublishedCollectionTags.useSuspenseQuery({
+  const [tags] = trpc.collection.getCollectionTags.useSuspenseQuery({
     resourceId,
     siteId,
+    isPublishedCategories: true,
   })
 
   // NOTE: Because we render according to the schema,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -52,7 +52,7 @@ const SuspendableJsonFormsTaggedControl = ({
   // NOTE: Since this is only rendered inside a collection page or collection link,
   // we should always have the `resourceId` specifier
   const resourceId = linkId ?? pageId ?? 1
-  const [tags] = trpc.collection.getCollectionTags.useSuspenseQuery({
+  const [tags] = trpc.collection.getPublishedCollectionTags.useSuspenseQuery({
     resourceId,
     siteId,
   })

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -55,7 +55,6 @@ const SuspendableJsonFormsTaggedControl = ({
   const [tags] = trpc.collection.getCollectionTags.useSuspenseQuery({
     resourceId,
     siteId,
-    isPublishedCategories: true,
   })
 
   // NOTE: Because we render according to the schema,

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -88,7 +88,7 @@ export const getCollectionTagsSchema = z
     resourceId: z.number().min(1).optional(),
     collectionId: z.number().min(1).optional(),
     siteId: z.number().min(1),
-    isPublishedCategories: z.boolean().optional(),
+    isPublishedCategories: z.boolean().default(false),
   })
   .refine(
     (data) =>

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -88,6 +88,7 @@ export const getCollectionTagsSchema = z
     resourceId: z.number().min(1).optional(),
     collectionId: z.number().min(1).optional(),
     siteId: z.number().min(1),
+    isPublishedCategories: z.boolean().optional(),
   })
   .refine(
     (data) =>

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -56,6 +56,7 @@ export const editLinkSchema = z.object({
       alt: z.string(),
     })
     .optional(),
+  categoryId: z.string().optional(),
 })
 
 export const readLinkSchema = z.object({

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -88,7 +88,6 @@ export const getCollectionTagsSchema = z
     resourceId: z.number().min(1).optional(),
     collectionId: z.number().min(1).optional(),
     siteId: z.number().min(1),
-    isPublishedCategories: z.boolean().default(false),
   })
   .refine(
     (data) =>

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -2540,58 +2540,7 @@ describe("collection.router", async () => {
       expect(result[0]).toMatchObject({ id: TAG_CATEGORY_ID, label: "Topic" })
     })
 
-    it("should fall back to draft blob when no published version exists", async () => {
-      // Arrange
-      const { collection, site, indexBlob } =
-        await setupCollectionWithIndexPage()
-      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
-      await db
-        .updateTable("Blob")
-        .set({ content: jsonb(indexPageBlobWithTags()) })
-        .where("id", "=", indexBlob.id)
-        .execute()
-      const { page: collectionPage } = await setupPageResource({
-        siteId: site.id,
-        resourceType: ResourceType.CollectionPage,
-        parentId: collection.id,
-      })
-
-      // Act — isPublishedCategories omitted, defaults to false
-      const result = await caller.getCollectionTags({
-        siteId: site.id,
-        resourceId: Number(collectionPage.id),
-      })
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toMatchObject({ id: TAG_CATEGORY_ID, label: "Topic" })
-    })
-
-    it("should return tag categories from published blob when isPublishedCategories is true", async () => {
-      // Arrange
-      const { collection, site, indexPage } =
-        await setupCollectionWithIndexPage()
-      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
-      await publishIndexPageWithTags(indexPage.id)
-      const { page: collectionPage } = await setupPageResource({
-        siteId: site.id,
-        resourceType: ResourceType.CollectionPage,
-        parentId: collection.id,
-      })
-
-      // Act
-      const result = await caller.getCollectionTags({
-        siteId: site.id,
-        resourceId: Number(collectionPage.id),
-        isPublishedCategories: true,
-      })
-
-      // Assert
-      expect(result).toHaveLength(1)
-      expect(result[0]).toMatchObject({ id: TAG_CATEGORY_ID, label: "Topic" })
-    })
-
-    it("should return empty array when collection has no published version and isPublishedCategories is true", async () => {
+    it("should return empty array when collection has no published version", async () => {
       // Arrange
       const { collection, site, indexBlob } =
         await setupCollectionWithIndexPage()
@@ -2612,10 +2561,9 @@ describe("collection.router", async () => {
       const result = await caller.getCollectionTags({
         siteId: site.id,
         resourceId: Number(collectionPage.id),
-        isPublishedCategories: true,
       })
 
-      // Assert: no draft fallback when isPublishedCategories is true
+      // Assert: always published-only, no draft fallback
       expect(result).toHaveLength(0)
     })
   })

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1451,6 +1451,50 @@ describe("collection.router", async () => {
       await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
     })
 
+    it("should preserve `categoryId` in the blob after saving", async () => {
+      // Arrange
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const testCategoryId = "aaaaaaaa-bbbb-4ccc-a222-aaaaaaaaaaaa"
+
+      // Act
+      const result = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "https://example.com",
+        linkId: Number(page.id),
+        categoryId: testCategoryId,
+      })
+
+      // Assert
+      expect(
+        (result.content.page as { categoryId?: string }).categoryId,
+      ).toEqual(testCategoryId)
+    })
+
+    it("should write `categoryId` as `undefined` when not provided in the input", async () => {
+      // Arrange
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+
+      // Act — no categoryId passed
+      const result = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "https://example.com",
+        linkId: Number(page.id),
+      })
+
+      // Assert
+      expect(
+        (result.content.page as { categoryId?: string }).categoryId,
+      ).toBeUndefined()
+    })
+
     it.skip("should throw when trying to update to a deleted `ref`")
 
     it.skip("should throw when trying to update to an invalid `ref`")

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -2593,7 +2593,7 @@ describe("collection.router", async () => {
 
     it("should return empty array when collection has no published version and isPublishedCategories is true", async () => {
       // Arrange
-      const { collection, site, indexPage, indexBlob } =
+      const { collection, site, indexBlob } =
         await setupCollectionWithIndexPage()
       await setupEditorPermissions({ userId: session.userId, siteId: site.id })
       // Put tags in draft only — no published version

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -2415,4 +2415,208 @@ describe("collection.router", async () => {
       expect(result).toEqual({ count: 1 })
     })
   })
+
+  describe("getCollectionTags", () => {
+    const TAG_CATEGORY_ID = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+    const TAG_OPTION_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+    const indexPageBlobWithTags = () => ({
+      layout: "collection" as const,
+      page: {
+        title: "Test Collection",
+        subtitle: "Test subtitle",
+        tagCategories: [
+          {
+            id: TAG_CATEGORY_ID,
+            label: "Topic",
+            isRequired: false,
+            options: [{ id: TAG_OPTION_ID, label: "Technology" }],
+          },
+        ],
+      },
+      content: [],
+      version: "0.1.0",
+    })
+
+    async function setupCollectionWithIndexPage() {
+      const { collection, site } = await setupCollection()
+      const { page: indexPage, blob: indexBlob } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.IndexPage,
+        parentId: collection.id,
+      })
+      return { collection, site, indexPage, indexBlob }
+    }
+
+    async function publishIndexPageWithTags(indexPageId: string) {
+      const publishedBlob = await db
+        .insertInto("Blob")
+        .values({ content: jsonb(indexPageBlobWithTags()) })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      const version = await db
+        .insertInto("Version")
+        .values({
+          versionNum: 1,
+          resourceId: indexPageId,
+          blobId: publishedBlob.id,
+          publishedBy: session.userId!,
+        })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+      await db
+        .updateTable("Resource")
+        .set({ publishedVersionId: version.id })
+        .where("id", "=", indexPageId)
+        .execute()
+    }
+
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+      const { page: collectionPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+      })
+
+      // Act
+      const result = unauthedCaller.getCollectionTags({
+        siteId: site.id,
+        resourceId: Number(collectionPage.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user does not have read access", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+      const { page: collectionPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+      })
+
+      // Act
+      const result = caller.getCollectionTags({
+        siteId: site.id,
+        resourceId: Number(collectionPage.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should return tag categories from the published blob by default", async () => {
+      // Arrange
+      const { collection, site, indexPage } =
+        await setupCollectionWithIndexPage()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+      await publishIndexPageWithTags(indexPage.id)
+      const { page: collectionPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+      })
+
+      // Act
+      const result = await caller.getCollectionTags({
+        siteId: site.id,
+        resourceId: Number(collectionPage.id),
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ id: TAG_CATEGORY_ID, label: "Topic" })
+    })
+
+    it("should fall back to draft blob when no published version exists", async () => {
+      // Arrange
+      const { collection, site, indexBlob } =
+        await setupCollectionWithIndexPage()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+      await db
+        .updateTable("Blob")
+        .set({ content: jsonb(indexPageBlobWithTags()) })
+        .where("id", "=", indexBlob.id)
+        .execute()
+      const { page: collectionPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+      })
+
+      // Act — isPublishedCategories omitted, defaults to false
+      const result = await caller.getCollectionTags({
+        siteId: site.id,
+        resourceId: Number(collectionPage.id),
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ id: TAG_CATEGORY_ID, label: "Topic" })
+    })
+
+    it("should return tag categories from published blob when isPublishedCategories is true", async () => {
+      // Arrange
+      const { collection, site, indexPage } =
+        await setupCollectionWithIndexPage()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+      await publishIndexPageWithTags(indexPage.id)
+      const { page: collectionPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+      })
+
+      // Act
+      const result = await caller.getCollectionTags({
+        siteId: site.id,
+        resourceId: Number(collectionPage.id),
+        isPublishedCategories: true,
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ id: TAG_CATEGORY_ID, label: "Topic" })
+    })
+
+    it("should return empty array when collection has no published version and isPublishedCategories is true", async () => {
+      // Arrange
+      const { collection, site, indexPage, indexBlob } =
+        await setupCollectionWithIndexPage()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+      // Put tags in draft only — no published version
+      await db
+        .updateTable("Blob")
+        .set({ content: jsonb(indexPageBlobWithTags()) })
+        .where("id", "=", indexBlob.id)
+        .execute()
+      const { page: collectionPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+      })
+
+      // Act
+      const result = await caller.getCollectionTags({
+        siteId: site.id,
+        resourceId: Number(collectionPage.id),
+        isPublishedCategories: true,
+      })
+
+      // Assert: no draft fallback when isPublishedCategories is true
+      expect(result).toHaveLength(0)
+    })
+  })
 })

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -42,6 +42,7 @@ import {
   createCollectionPageJson,
   getCategoryOptionUsageCount,
   getCollectionTagsForResource,
+  getPublishedCollectionTagsForResource,
 } from "./collection.service"
 
 export const collectionRouter = router({
@@ -552,6 +553,29 @@ export const collectionRouter = router({
       }
       if (resourceId !== undefined) {
         return getCollectionTagsForResource({ siteId, resourceId })
+      }
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Either collectionId or resourceId must be provided",
+      })
+    }),
+
+  getPublishedCollectionTags: protectedProcedure
+    .input(getCollectionTagsSchema)
+    .query(async ({ ctx, input: { resourceId, collectionId, siteId } }) => {
+      const resourceIdToValidate = collectionId ?? resourceId
+      await bulkValidateUserPermissionsForResources({
+        siteId,
+        action: "read",
+        userId: ctx.user.id,
+        resourceIds: resourceIdToValidate ? [String(resourceIdToValidate)] : [],
+      })
+
+      if (collectionId !== undefined) {
+        return getPublishedCollectionTagsForResource({ siteId, collectionId })
+      }
+      if (resourceId !== undefined) {
+        return getPublishedCollectionTagsForResource({ siteId, resourceId })
       }
       throw new TRPCError({
         code: "BAD_REQUEST",

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -453,6 +453,7 @@ export const collectionRouter = router({
         input: {
           date,
           category,
+          categoryId,
           linkId,
           siteId,
           description,
@@ -505,7 +506,16 @@ export const collectionRouter = router({
           const blob = await updateBlobById(tx, {
             content: {
               ...content,
-              page: { description, ref, date, category, image, tags, tagged },
+              page: {
+                description,
+                ref,
+                date,
+                category,
+                categoryId,
+                image,
+                tags,
+                tagged,
+              },
             },
             pageId: linkId,
             siteId,

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -503,6 +503,16 @@ export const collectionRouter = router({
             resourceId: resource.id,
           })
 
+          const oldCategoryId = (oldBlob?.content as Record<string, any> | null)
+            ?.page?.categoryId
+          if (oldCategoryId && !categoryId) {
+            throw new TRPCError({
+              code: "BAD_REQUEST",
+              message:
+                "Cannot clear categoryId from an item that already has one",
+            })
+          }
+
           const blob = await updateBlobById(tx, {
             content: {
               ...content,
@@ -538,41 +548,34 @@ export const collectionRouter = router({
 
   getCollectionTags: protectedProcedure
     .input(getCollectionTagsSchema)
-    .query(
-      async ({
-        ctx,
-        input: { resourceId, collectionId, siteId, isPublishedCategories },
-      }) => {
-        const resourceIdToValidate = collectionId ?? resourceId
-        await bulkValidateUserPermissionsForResources({
-          siteId,
-          action: "read",
-          userId: ctx.user.id,
-          resourceIds: resourceIdToValidate
-            ? [String(resourceIdToValidate)]
-            : [],
-        })
+    .query(async ({ ctx, input: { resourceId, collectionId, siteId } }) => {
+      const resourceIdToValidate = collectionId ?? resourceId
+      await bulkValidateUserPermissionsForResources({
+        siteId,
+        action: "read",
+        userId: ctx.user.id,
+        resourceIds: resourceIdToValidate ? [String(resourceIdToValidate)] : [],
+      })
 
-        if (collectionId !== undefined) {
-          return getCollectionTagsForResource({
-            siteId,
-            collectionId,
-            isPublishedOnly: isPublishedCategories,
-          })
-        }
-        if (resourceId !== undefined) {
-          return getCollectionTagsForResource({
-            siteId,
-            resourceId,
-            isPublishedOnly: isPublishedCategories,
-          })
-        }
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Either collectionId or resourceId must be provided",
+      if (collectionId !== undefined) {
+        return getCollectionTagsForResource({
+          siteId,
+          collectionId,
+          isPublishedOnly: true,
         })
-      },
-    ),
+      }
+      if (resourceId !== undefined) {
+        return getCollectionTagsForResource({
+          siteId,
+          resourceId,
+          isPublishedOnly: true,
+        })
+      }
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "Either collectionId or resourceId must be provided",
+      })
+    }),
 
   /**
    * Counts collection pages/links whose draft **or** published blob has `page.categoryId` equal to the

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -42,7 +42,6 @@ import {
   createCollectionPageJson,
   getCategoryOptionUsageCount,
   getCollectionTagsForResource,
-  getPublishedCollectionTagsForResource,
 } from "./collection.service"
 
 export const collectionRouter = router({
@@ -539,49 +538,41 @@ export const collectionRouter = router({
 
   getCollectionTags: protectedProcedure
     .input(getCollectionTagsSchema)
-    .query(async ({ ctx, input: { resourceId, collectionId, siteId } }) => {
-      const resourceIdToValidate = collectionId ?? resourceId
-      await bulkValidateUserPermissionsForResources({
-        siteId,
-        action: "read",
-        userId: ctx.user.id,
-        resourceIds: resourceIdToValidate ? [String(resourceIdToValidate)] : [],
-      })
+    .query(
+      async ({
+        ctx,
+        input: { resourceId, collectionId, siteId, isPublishedCategories },
+      }) => {
+        const resourceIdToValidate = collectionId ?? resourceId
+        await bulkValidateUserPermissionsForResources({
+          siteId,
+          action: "read",
+          userId: ctx.user.id,
+          resourceIds: resourceIdToValidate
+            ? [String(resourceIdToValidate)]
+            : [],
+        })
 
-      if (collectionId !== undefined) {
-        return getCollectionTagsForResource({ siteId, collectionId })
-      }
-      if (resourceId !== undefined) {
-        return getCollectionTagsForResource({ siteId, resourceId })
-      }
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message: "Either collectionId or resourceId must be provided",
-      })
-    }),
-
-  getPublishedCollectionTags: protectedProcedure
-    .input(getCollectionTagsSchema)
-    .query(async ({ ctx, input: { resourceId, collectionId, siteId } }) => {
-      const resourceIdToValidate = collectionId ?? resourceId
-      await bulkValidateUserPermissionsForResources({
-        siteId,
-        action: "read",
-        userId: ctx.user.id,
-        resourceIds: resourceIdToValidate ? [String(resourceIdToValidate)] : [],
-      })
-
-      if (collectionId !== undefined) {
-        return getPublishedCollectionTagsForResource({ siteId, collectionId })
-      }
-      if (resourceId !== undefined) {
-        return getPublishedCollectionTagsForResource({ siteId, resourceId })
-      }
-      throw new TRPCError({
-        code: "BAD_REQUEST",
-        message: "Either collectionId or resourceId must be provided",
-      })
-    }),
+        if (collectionId !== undefined) {
+          return getCollectionTagsForResource({
+            siteId,
+            collectionId,
+            isPublishedOnly: isPublishedCategories,
+          })
+        }
+        if (resourceId !== undefined) {
+          return getCollectionTagsForResource({
+            siteId,
+            resourceId,
+            isPublishedOnly: isPublishedCategories,
+          })
+        }
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Either collectionId or resourceId must be provided",
+        })
+      },
+    ),
 
   /**
    * Counts collection pages/links whose draft **or** published blob has `page.categoryId` equal to the

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -503,16 +503,6 @@ export const collectionRouter = router({
             resourceId: resource.id,
           })
 
-          const oldCategoryId = (oldBlob?.content as Record<string, any> | null)
-            ?.page?.categoryId
-          if (oldCategoryId && !categoryId) {
-            throw new TRPCError({
-              code: "BAD_REQUEST",
-              message:
-                "Cannot clear categoryId from an item that already has one",
-            })
-          }
-
           const blob = await updateBlobById(tx, {
             content: {
               ...content,

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -67,6 +67,54 @@ export const getCollectionTagsForResource = async ({
 >): Promise<NonNullable<CollectionPageSchemaType["page"]["tagCategories"]>> => {
   const row = await db
     .selectFrom("Resource as r")
+    .leftJoin("Blob as draftBlob", "r.draftBlobId", "draftBlob.id")
+    .leftJoin("Version as v", "r.publishedVersionId", "v.id")
+    .leftJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
+    .where("r.type", "=", ResourceType.IndexPage)
+    .where("r.siteId", "=", siteId)
+    .$if(collectionId !== undefined, (qb) =>
+      qb.where("r.parentId", "=", String(collectionId)),
+    )
+    .$if(resourceId !== undefined, (qb) =>
+      qb.where("r.parentId", "=", (eb) =>
+        eb
+          .selectFrom("Resource")
+          .where("id", "=", String(resourceId))
+          .where("siteId", "=", siteId)
+          .select("parentId"),
+      ),
+    )
+    .select([
+      sql<CollectionPageSchemaType | null>`"draftBlob"."content"`.as(
+        "draftContent",
+      ),
+      sql<CollectionPageSchemaType | null>`"publishedBlob"."content"`.as(
+        "publishedContent",
+      ),
+    ])
+    .executeTakeFirst()
+
+  if (!row) {
+    return []
+  }
+
+  return (
+    row.publishedContent?.page.tagCategories ??
+    row.draftContent?.page.tagCategories ??
+    []
+  )
+}
+
+export const getPublishedCollectionTagsForResource = async ({
+  resourceId,
+  collectionId,
+  siteId,
+}: { siteId: number } & MergeExclusive<
+  { resourceId: number },
+  { collectionId: number }
+>): Promise<NonNullable<CollectionPageSchemaType["page"]["tagCategories"]>> => {
+  const row = await db
+    .selectFrom("Resource as r")
     .innerJoin("Version as v", "r.publishedVersionId", "v.id")
     .innerJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
     .where("r.type", "=", ResourceType.IndexPage)

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -61,10 +61,40 @@ export const getCollectionTagsForResource = async ({
   resourceId,
   collectionId,
   siteId,
-}: { siteId: number } & MergeExclusive<
+  isPublishedOnly = false,
+}: { siteId: number; isPublishedOnly?: boolean } & MergeExclusive<
   { resourceId: number },
   { collectionId: number }
 >): Promise<NonNullable<CollectionPageSchemaType["page"]["tagCategories"]>> => {
+  if (isPublishedOnly) {
+    const row = await db
+      .selectFrom("Resource as r")
+      .innerJoin("Version as v", "r.publishedVersionId", "v.id")
+      .innerJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
+      .where("r.type", "=", ResourceType.IndexPage)
+      .where("r.siteId", "=", siteId)
+      .$if(collectionId !== undefined, (qb) =>
+        qb.where("r.parentId", "=", String(collectionId)),
+      )
+      .$if(resourceId !== undefined, (qb) =>
+        qb.where("r.parentId", "=", (eb) =>
+          eb
+            .selectFrom("Resource")
+            .where("id", "=", String(resourceId))
+            .where("siteId", "=", siteId)
+            .select("parentId"),
+        ),
+      )
+      .select(
+        sql<CollectionPageSchemaType | null>`"publishedBlob"."content"`.as(
+          "publishedContent",
+        ),
+      )
+      .executeTakeFirst()
+
+    return row?.publishedContent?.page.tagCategories ?? []
+  }
+
   const row = await db
     .selectFrom("Resource as r")
     .leftJoin("Blob as draftBlob", "r.draftBlobId", "draftBlob.id")
@@ -103,46 +133,6 @@ export const getCollectionTagsForResource = async ({
     row.draftContent?.page.tagCategories ??
     []
   )
-}
-
-export const getPublishedCollectionTagsForResource = async ({
-  resourceId,
-  collectionId,
-  siteId,
-}: { siteId: number } & MergeExclusive<
-  { resourceId: number },
-  { collectionId: number }
->): Promise<NonNullable<CollectionPageSchemaType["page"]["tagCategories"]>> => {
-  const row = await db
-    .selectFrom("Resource as r")
-    .innerJoin("Version as v", "r.publishedVersionId", "v.id")
-    .innerJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
-    .where("r.type", "=", ResourceType.IndexPage)
-    .where("r.siteId", "=", siteId)
-    .$if(collectionId !== undefined, (qb) =>
-      qb.where("r.parentId", "=", String(collectionId)),
-    )
-    .$if(resourceId !== undefined, (qb) =>
-      qb.where("r.parentId", "=", (eb) =>
-        eb
-          .selectFrom("Resource")
-          .where("id", "=", String(resourceId))
-          .where("siteId", "=", siteId)
-          .select("parentId"),
-      ),
-    )
-    .select(
-      sql<CollectionPageSchemaType | null>`"publishedBlob"."content"`.as(
-        "publishedContent",
-      ),
-    )
-    .executeTakeFirst()
-
-  if (!row) {
-    return []
-  }
-
-  return row.publishedContent?.page.tagCategories ?? []
 }
 
 export const getCategoryOptionUsageCount = async ({

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -66,35 +66,6 @@ export const getCollectionTagsForResource = async ({
   { resourceId: number },
   { collectionId: number }
 >): Promise<NonNullable<CollectionPageSchemaType["page"]["tagCategories"]>> => {
-  if (isPublishedOnly) {
-    const row = await db
-      .selectFrom("Resource as r")
-      .innerJoin("Version as v", "r.publishedVersionId", "v.id")
-      .innerJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
-      .where("r.type", "=", ResourceType.IndexPage)
-      .where("r.siteId", "=", siteId)
-      .$if(collectionId !== undefined, (qb) =>
-        qb.where("r.parentId", "=", String(collectionId)),
-      )
-      .$if(resourceId !== undefined, (qb) =>
-        qb.where("r.parentId", "=", (eb) =>
-          eb
-            .selectFrom("Resource")
-            .where("id", "=", String(resourceId))
-            .where("siteId", "=", siteId)
-            .select("parentId"),
-        ),
-      )
-      .select(
-        sql<CollectionPageSchemaType | null>`"publishedBlob"."content"`.as(
-          "publishedContent",
-        ),
-      )
-      .executeTakeFirst()
-
-    return row?.publishedContent?.page.tagCategories ?? []
-  }
-
   const row = await db
     .selectFrom("Resource as r")
     .leftJoin("Blob as draftBlob", "r.draftBlobId", "draftBlob.id")
@@ -115,11 +86,11 @@ export const getCollectionTagsForResource = async ({
       ),
     )
     .select([
-      sql<CollectionPageSchemaType | null>`"draftBlob"."content"`.as(
-        "draftContent",
-      ),
       sql<CollectionPageSchemaType | null>`"publishedBlob"."content"`.as(
         "publishedContent",
+      ),
+      sql<CollectionPageSchemaType | null>`"draftBlob"."content"`.as(
+        "draftContent",
       ),
     ])
     .executeTakeFirst()
@@ -130,8 +101,7 @@ export const getCollectionTagsForResource = async ({
 
   return (
     row.publishedContent?.page.tagCategories ??
-    row.draftContent?.page.tagCategories ??
-    []
+    (isPublishedOnly ? [] : (row.draftContent?.page.tagCategories ?? []))
   )
 }
 

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -99,10 +99,11 @@ export const getCollectionTagsForResource = async ({
     return []
   }
 
-  return (
-    row.publishedContent?.page.tagCategories ??
-    (isPublishedOnly ? [] : (row.draftContent?.page.tagCategories ?? []))
-  )
+  return isPublishedOnly
+    ? (row.publishedContent?.page.tagCategories ?? [])
+    : (row.publishedContent?.page.tagCategories ??
+        row.draftContent?.page.tagCategories ??
+        [])
 }
 
 export const getCategoryOptionUsageCount = async ({

--- a/apps/studio/src/server/modules/collection/collection.service.ts
+++ b/apps/studio/src/server/modules/collection/collection.service.ts
@@ -67,9 +67,8 @@ export const getCollectionTagsForResource = async ({
 >): Promise<NonNullable<CollectionPageSchemaType["page"]["tagCategories"]>> => {
   const row = await db
     .selectFrom("Resource as r")
-    .leftJoin("Blob as draftBlob", "r.draftBlobId", "draftBlob.id")
-    .leftJoin("Version as v", "r.publishedVersionId", "v.id")
-    .leftJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
+    .innerJoin("Version as v", "r.publishedVersionId", "v.id")
+    .innerJoin("Blob as publishedBlob", "v.blobId", "publishedBlob.id")
     .where("r.type", "=", ResourceType.IndexPage)
     .where("r.siteId", "=", siteId)
     .$if(collectionId !== undefined, (qb) =>
@@ -84,25 +83,18 @@ export const getCollectionTagsForResource = async ({
           .select("parentId"),
       ),
     )
-    .select([
-      sql<CollectionPageSchemaType | null>`"draftBlob"."content"`.as(
-        "draftContent",
-      ),
+    .select(
       sql<CollectionPageSchemaType | null>`"publishedBlob"."content"`.as(
         "publishedContent",
       ),
-    ])
+    )
     .executeTakeFirst()
 
   if (!row) {
     return []
   }
 
-  return (
-    row.publishedContent?.page.tagCategories ??
-    row.draftContent?.page.tagCategories ??
-    []
-  )
+  return row.publishedContent?.page.tagCategories ?? []
 }
 
 export const getCategoryOptionUsageCount = async ({

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsTaggedControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsTaggedControl.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof FormBuilder> = {
       handlers: [
         pageHandlers.getCategories.default(),
         pageHandlers.getCategoryOptions.default(),
-        pageHandlers.getCollectionTags.default(),
+        pageHandlers.getPublishedCollectionTags.default(),
       ],
     },
     nextjs: {
@@ -61,7 +61,7 @@ export const WithRequiredCategory: Story = {
       handlers: [
         pageHandlers.getCategories.default(),
         pageHandlers.getCategoryOptions.default(),
-        pageHandlers.getCollectionTags.withRequired(),
+        pageHandlers.getPublishedCollectionTags.withRequired(),
       ],
     },
   },

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsTaggedControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsTaggedControl.stories.tsx
@@ -16,7 +16,7 @@ const meta: Meta<typeof FormBuilder> = {
       handlers: [
         pageHandlers.getCategories.default(),
         pageHandlers.getCategoryOptions.default(),
-        pageHandlers.getPublishedCollectionTags.default(),
+        pageHandlers.getCollectionTags.default(),
       ],
     },
     nextjs: {
@@ -61,7 +61,7 @@ export const WithRequiredCategory: Story = {
       handlers: [
         pageHandlers.getCategories.default(),
         pageHandlers.getCategoryOptions.default(),
-        pageHandlers.getPublishedCollectionTags.withRequired(),
+        pageHandlers.getCollectionTags.withRequired(),
       ],
     },
   },

--- a/apps/studio/src/stories/Page/EditPage/components/JsonFormsTaggedControl.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/components/JsonFormsTaggedControl.stories.tsx
@@ -54,3 +54,24 @@ export const Default: Story = {
     ],
   },
 }
+
+export const WithRequiredCategory: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.getCategories.default(),
+        pageHandlers.getCategoryOptions.default(),
+        pageHandlers.getCollectionTags.withRequired(),
+      ],
+    },
+  },
+  args: {
+    schema,
+    renderers: [
+      {
+        tester: jsonFormsTaggedControlTester,
+        renderer: JsonFormsTaggedControl,
+      },
+    ],
+  },
+}

--- a/apps/studio/src/theme/components/MultiSelect.ts
+++ b/apps/studio/src/theme/components/MultiSelect.ts
@@ -1,0 +1,8 @@
+export const MultiSelect = {
+  baseStyle: {
+    tag: {
+      borderRadius: "50px",
+      py: "0.25rem",
+    },
+  },
+}

--- a/apps/studio/src/theme/components/index.ts
+++ b/apps/studio/src/theme/components/index.ts
@@ -1,4 +1,5 @@
 import { Infobox } from "./Infobox"
+import { MultiSelect } from "./MultiSelect"
 import { Searchbar } from "./Searchbar"
 import { Table } from "./Table"
 
@@ -6,4 +7,5 @@ export const components = {
   Table,
   Infobox,
   Searchbar,
+  MultiSelect,
 }

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -232,8 +232,28 @@ export const pageHandlers = {
         return []
       })
     },
+  },
+  getPublishedCollectionTags: {
+    default: () => {
+      return trpcMsw.collection.getPublishedCollectionTags.query(() => {
+        return [
+          {
+            label: "Topic",
+            id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            isRequired: false,
+            options: [
+              {
+                label: "Technology",
+                id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+              },
+              { label: "Science", id: "6ba7b811-9dad-11d1-80b4-00c04fd430c8" },
+            ],
+          },
+        ]
+      })
+    },
     withRequired: () => {
-      return trpcMsw.collection.getCollectionTags.query(() => {
+      return trpcMsw.collection.getPublishedCollectionTags.query(() => {
         return [
           {
             label: "Topic",

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -232,6 +232,39 @@ export const pageHandlers = {
         return []
       })
     },
+    withRequired: () => {
+      return trpcMsw.collection.getCollectionTags.query(() => {
+        return [
+          {
+            label: "Topic",
+            id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+            isRequired: true,
+            options: [
+              {
+                label: "Technology",
+                id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+              },
+              { label: "Science", id: "6ba7b811-9dad-11d1-80b4-00c04fd430c8" },
+            ],
+          },
+          {
+            label: "Industry",
+            id: "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+            isRequired: false,
+            options: [
+              {
+                label: "Agriculture & Food",
+                id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+              },
+              {
+                label: "Automotive",
+                id: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
+              },
+            ],
+          },
+        ]
+      })
+    },
   },
   updateSettings: {
     collection: () => {

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -232,28 +232,8 @@ export const pageHandlers = {
         return []
       })
     },
-  },
-  getPublishedCollectionTags: {
-    default: () => {
-      return trpcMsw.collection.getPublishedCollectionTags.query(() => {
-        return [
-          {
-            label: "Topic",
-            id: "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-            isRequired: false,
-            options: [
-              {
-                label: "Technology",
-                id: "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
-              },
-              { label: "Science", id: "6ba7b811-9dad-11d1-80b4-00c04fd430c8" },
-            ],
-          },
-        ]
-      })
-    },
     withRequired: () => {
-      return trpcMsw.collection.getPublishedCollectionTags.query(() => {
+      return trpcMsw.collection.getCollectionTags.query(() => {
         return [
           {
             label: "Topic",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -135,7 +135,6 @@ const TaggedSchema = Type.Optional(
     // NOTE: we need a custom format because this cannot just be a simple drop down
     // as we need to reference the existing data that is pointing to this
     format: "tagged",
-    description: "To add new options, contact your site owner(s).",
   }),
 )
 
@@ -146,15 +145,6 @@ const categorySchemaObject = Type.Object({
     description:
       "The category is used for filtering in the parent collection page",
   }),
-  /**
-   * `categoryId` is optional for backward compatibility: persisted blobs may omit it, and we
-   * avoid misleading inferred types (Static<>) that claim the field is always present before
-   * migration from string `category`. After rollout, populate items with `categoryId` aligned
-   * with `categoryOptions` on the parent collection, then we can make this property required
-   * and deprecate `category`.
-   *
-   * @see {@link CategoriesSchema} for the parent collection's `categoryOptions` shape (`id` on each option).
-   */
   categoryId: Type.Optional(
     Type.String({
       title: "Category",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -145,6 +145,15 @@ const categorySchemaObject = Type.Object({
     description:
       "The category is used for filtering in the parent collection page",
   }),
+  /**
+   * `categoryId` is optional for backward compatibility: persisted blobs may omit it, and we
+   * avoid misleading inferred types (Static<>) that claim the field is always present before
+   * migration from string `category`. After rollout, populate items with `categoryId` aligned
+   * with `categoryOptions` on the parent collection, then we can make this property required
+   * and deprecate `category`.
+   *
+   * @see {@link CategoriesSchema} for the parent collection's `categoryOptions` shape (`id` on each option).
+  */
   categoryId: Type.Optional(
     Type.String({
       title: "Category",

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -153,7 +153,7 @@ const categorySchemaObject = Type.Object({
    * and deprecate `category`.
    *
    * @see {@link CategoriesSchema} for the parent collection's `categoryOptions` shape (`id` on each option).
-  */
+   */
   categoryId: Type.Optional(
     Type.String({
       title: "Category",


### PR DESCRIPTION
## Summary

- **Preserve `categoryId` in blob write**: `updateCollectionLink` now persists `categoryId` so it is not silently dropped on save
- **Tag category required/optional state**: `JsonFormsTaggedControl` shows an asterisk per tag category based on the `isRequired` flag from collection settings (cosmetic only — does not block saves)
- **CategoryId dropdown**: non-clearable and visually marked as required
- **MultiSelect pill styling**: selected tag options rendered as pills (`border-radius: 50px`)
- **Cleanup**: removed stale "contact your site owner(s)" description from the `tagged` field schema
- **Published-only tag categories**: `getCollectionTags` now accepts an `isPublishedCategories` boolean (defaults to `false`); the collection item editor passes `true` so only published collection settings are shown, consistent with `getCategoryOptions`. The original draft-fallback behaviour is preserved for other callers (e.g. `GazetteSubcategoriesContext`)

Closes https://linear.app/ogp/issue/ISOM-2306/fix-surface-tag-category-and-categoryid-ux-for-collection-item-editors

## Test plan

- [ ] Edit a CollectionLink — confirm `categoryId` is preserved after saving
- [ ] Open a collection item in a collection with required tag categories — confirm asterisk appears on required categories and not on optional ones
- [ ] Open a collection item with a `categoryId` dropdown — confirm it is non-clearable and shows the required asterisk
- [ ] Verify MultiSelect selected tag options render as pills
- [ ] Before publishing collection settings: confirm tag categories/categoryId dropdown shows no options in the item editor
- [ ] After publishing collection settings: confirm tag categories and categoryId options appear correctly in the item editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)