### PR TITLE
🔖 fix: updateCollectionLink silently drops categoryId on every save

### DIFF
--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -56,6 +56,7 @@ export const editLinkSchema = z.object({
       alt: z.string(),
     })
     .optional(),
+  categoryId: z.string().optional(),
 })
 
 export const readLinkSchema = z.object({

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1469,9 +1469,9 @@ describe("collection.router", async () => {
       })
 
       // Assert
-      expect((result.content.page as { categoryId?: string }).categoryId).toEqual(
-        testCategoryId,
-      )
+      expect(
+        (result.content.page as { categoryId?: string }).categoryId,
+      ).toEqual(testCategoryId)
     })
 
     it("should write `categoryId` as `undefined` when not provided in the input", async () => {

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -1451,6 +1451,50 @@ describe("collection.router", async () => {
       await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
     })
 
+    it("should preserve `categoryId` in the blob after saving", async () => {
+      // Arrange
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+      const testCategoryId = "aaaaaaaa-bbbb-4ccc-a222-aaaaaaaaaaaa"
+
+      // Act
+      const result = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "https://example.com",
+        linkId: Number(page.id),
+        categoryId: testCategoryId,
+      })
+
+      // Assert
+      expect((result.content.page as { categoryId?: string }).categoryId).toEqual(
+        testCategoryId,
+      )
+    })
+
+    it("should write `categoryId` as `undefined` when not provided in the input", async () => {
+      // Arrange
+      const { page, site } = await setupPageResource({
+        resourceType: "CollectionLink",
+      })
+      await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+
+      // Act — no categoryId passed
+      const result = await caller.updateCollectionLink({
+        siteId: site.id,
+        category: "category",
+        ref: "https://example.com",
+        linkId: Number(page.id),
+      })
+
+      // Assert
+      expect(
+        (result.content.page as { categoryId?: string }).categoryId,
+      ).toBeUndefined()
+    })
+
     it.skip("should throw when trying to update to a deleted `ref`")
 
     it.skip("should throw when trying to update to an invalid `ref`")

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -453,6 +453,7 @@ export const collectionRouter = router({
         input: {
           date,
           category,
+          categoryId,
           linkId,
           siteId,
           description,
@@ -505,7 +506,16 @@ export const collectionRouter = router({
           const blob = await updateBlobById(tx, {
             content: {
               ...content,
-              page: { description, ref, date, category, image, tags, tagged },
+              page: {
+                description,
+                ref,
+                date,
+                category,
+                categoryId,
+                image,
+                tags,
+                tagged,
+              },
             },
             pageId: linkId,
             siteId,


### PR DESCRIPTION
## Summary

- `updateCollectionLink` was silently dropping `categoryId` from the blob on every save because the field was never included in `editLinkSchema` and was not destructured into the blob write.
- Fixed by adding `categoryId: z.string().optional()` to `editLinkSchema` in `apps/studio/src/schemas/collection.ts` and including `categoryId` in the blob write inside `collection.router.ts`.
- Adds 2 integration tests: one verifying that a provided `categoryId` is preserved in the blob after saving, and one verifying that omitting `categoryId` results in `undefined` (no phantom value written).

Closes https://linear.app/ogp/issue/ISOM-2301/fix-updatecollectionlink-silently-drops-categoryid-on-every-save

## Test plan

- [ ] Run `pnpm test:unit -- src/server/modules/collection/__tests__/collection.router.test.ts` in `apps/studio` — all tests pass, including the 2 new `categoryId` integration tests.
- [ ] Manually edit a collection link on a site that uses `categoryId` — verify the `categoryId` field is retained in the blob after saving and is not lost on subsequent edits.
- [ ] Manually edit a collection link without a `categoryId` — verify no phantom `categoryId` value is introduced.