### PR TITLE
fix: show correct category and tags in collection link preview

### DIFF
--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -38,6 +38,11 @@ export const EditCollectionLinkPreview = ({
     siteId,
   })
 
+  const [{ categoryOptions }] = trpc.page.getCategoryOptions.useSuspenseQuery({
+    pageId: linkId,
+    siteId,
+  })
+
   const parentPermalink = useMemo(
     () => permalink.split("/").slice(0, -1).join("/"),
     [permalink],
@@ -64,7 +69,7 @@ export const EditCollectionLinkPreview = ({
             layout: "collection",
             title: parentTitle,
             summary: "",
-            collectionPagePageProps: { tagCategories },
+            collectionPagePageProps: { tagCategories, categoryOptions },
             children: [
               {
                 id: "9999999",
@@ -79,14 +84,22 @@ export const EditCollectionLinkPreview = ({
           },
         ],
       }) satisfies IsomerSitemap,
-    [parentPermalink, parentTitle, tagCategories, link, permalink, title],
+    [
+      parentPermalink,
+      parentTitle,
+      tagCategories,
+      categoryOptions,
+      link,
+      permalink,
+      title,
+    ],
   )
 
   return (
     <ViewportContainer siteId={siteId}>
       <PreviewWithCustomSitemap
         content={[]}
-        page={{ title: parentTitle }}
+        page={{ title: parentTitle, tagCategories, categoryOptions }}
         layout={"collection"}
         siteId={siteId}
         siteMap={siteMap}


### PR DESCRIPTION
## Problem

The collection link preview (`EditLinkPreview`) was rendering items with:
1. **Wrong category label** — always fell back to the legacy `category` string instead of deriving the label from `categoryId` + `categoryOptions`
2. **No tag pills** — `tagged` UUIDs were never resolved to tag labels because `tagCategories` wasn't passed to the layout
3. **Wrong filters** — filter options were empty because `tagCategories` and `categoryOptions` weren't present

All three stem from `PreviewWithCustomSitemap` being called with `page={{ title: parentTitle }}`. The `CollectionLayout` reads `tagCategories` and `categoryOptions` from `page` to process items and build filters, but neither field was present.

## Fix

- Fetches `categoryOptions` via `trpc.page.getCategoryOptions` (using the link's ID, same pattern as the existing `getCollectionTags` call)
- Passes both `tagCategories` and `categoryOptions` in the `page` prop so `CollectionLayout` can:
  - Map `categoryId` → display label
  - Convert `tagged` UUID arrays → tag objects
  - Build correct filter options

The `sitemap.ts` type change (`categoryOptions` in `collectionPagePageProps`) is already covered by the parent branch — no new type changes needed here.

## Not covered by existing branches

Verified that neither `fix/required-tag-ux` nor `feat/categoryid-published-site-rendering` touches `EditLinkPreview.tsx`.

## Test plan

- [ ] Open a collection link with `categoryId` set — preview shows the correct category label (not "Others" or the raw string)
- [ ] Open a collection link with `tagged` values — preview shows tag pills
- [ ] Filter dropdown in the collection preview shows correct category options and tag categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)