### PR TITLE
feat(components): add site asset-ref convention helpers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,39 @@
+# Isomer Studio — Context
+
+Studio is the CMS/site-builder where editors manage a site's content tree. This
+glossary fixes the language used when talking about that tree and the operations
+on it.
+
+## Language
+
+**Resource**:
+Any node in a site's content tree — a Page, Folder, Collection, CollectionPage,
+CollectionLink, IndexPage, RootPage, etc. The umbrella entity; everything an
+editor sees in a resource list is a Resource.
+
+**Duplicate**:
+Creating an independent copy of a Resource's current content as a new Draft
+sibling under the same parent. "Independent" means the copy shares no mutable
+state with the original — including its own copies of any embedded assets.
+_Avoid_: Copy, Clone (use these only for the lower-level S3/object sense).
+
+**Duplicable Resource**:
+The subset of Resources that the Duplicate operation accepts: Page,
+CollectionPage, and CollectionLink. (Folders, Collections, and the various
+index/meta resources are out of scope.)
+
+**Current content**:
+The blob a Resource resolves to for editing — its Draft blob if one exists,
+otherwise the blob of its published Version. Duplicate copies the Current
+content, never specifically the published-only state.
+
+**Asset reference**:
+A string inside a blob that points at a site-owned uploaded file (image, PDF,
+etc.) living in the site's asset store. Whether a string is an Asset reference
+is judged from its **value** (the conventional shape of an asset path), not from
+the schema field it sits in — the same `ref`/`link` field can hold an Asset
+reference, an external URL, a page reference, or a mailto, and only the value
+tells them apart. The components package owns this judgement as the single
+source of truth. Only Asset references are deep-copied on Duplicate; everything
+else is shared verbatim.
+_Avoid_: link, src, path (these describe fields, not the asset-vs-not judgement).

--- a/docs/adr/0001-detect-assets-by-value-not-schema-format.md
+++ b/docs/adr/0001-detect-assets-by-value-not-schema-format.md
@@ -1,0 +1,42 @@
+# Detect duplicable assets by value convention, not schema format
+
+When duplicating a Resource we must find which strings in its blob are
+[Asset references](../../CONTEXT.md) (site-owned uploaded files that need a
+deep copy) versus things to share verbatim (external URLs, page references,
+mailto links). We decided to recognize Asset references by the **value's**
+conventional shape — the `{siteId}/{uuid}/{file}` asset-path pattern, owned as a
+single predicate in the components package — rather than by the schema `format`
+annotation of the field the string sits in. Studio does a blind generic walk
+over the whole blob (page + content + meta) and asks the components predicate
+about each string.
+
+## Why not schema/format-driven
+
+It was tempting to drive the decision off the TypeBox `format` the components
+package already declares (`image`, `ref`, `link`). We rejected this because
+format is structurally incapable of deciding here:
+
+- **Polymorphic fields.** A single `format: "ref"` field holds a FileRef (PDF
+  asset → copy) *or* a LinkRef (external URL → share). Every `format: "link"`
+  field (Infopic, Button, InfoCols, Infobar, KeyStatistics, ContactInformation,
+  …) likewise holds a File link, an external URL, or a page ref — chosen per
+  instance. The format is fixed; only the value reveals the kind.
+- **Assets in unformatted fields.** File-links embedded in prose body text live
+  in plain `href` strings with no asset format at all. A format-driven walk
+  would silently fail to copy them.
+- **Freeform subtrees.** A blind value walk handles prose/TipTap (and any future
+  freeform content) for free; a schema-guided walk would need to resolve unions,
+  `$ref`s, and discriminants.
+
+Value detection is therefore both necessary (only it catches polymorphic and
+prose file-links) and sufficient (image/FileRef/prose file-links match the
+convention; URLs/page-refs/mailto do not). The asset-path convention was already
+duplicated in studio's `tryParseSiteAssetFileKey` and the editor's
+`getLinkHrefType`; centralizing it in components makes one source of truth.
+
+## Consequence
+
+A future reader will see a "blind string walk" and may assume the `format`
+annotations should be used instead. They should not: format cannot distinguish a
+copied file from a shared URL in the same field. Keep the convention in one
+place in the components package.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -9,6 +9,9 @@ export {
   REFERENCE_LINK_REGEX,
   NON_EMPTY_STRING_REGEX,
   createChildrenPagesComparator,
+  parseAssetRef,
+  buildNewAssetKey,
+  rewriteAssetRef,
 } from "./utils"
 export * from "./schemas"
 export * from "./types"

--- a/packages/components/src/utils/__tests__/assetRef.test.ts
+++ b/packages/components/src/utils/__tests__/assetRef.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest"
+
+import { buildNewAssetKey, parseAssetRef, rewriteAssetRef } from "../assetRef"
+
+const SITE_ID = 1
+const VALID_UUID = "dc2b609a-355e-406c-af6c-003683731e7e"
+const VALID_KEY = `${SITE_ID}/${VALID_UUID}/report.pdf`
+
+describe("parseAssetRef", () => {
+  it("should parse a valid reference with a leading slash", () => {
+    expect(parseAssetRef(`/${VALID_KEY}`, SITE_ID)).toBe(VALID_KEY)
+  })
+
+  it("should parse a valid reference without a leading slash", () => {
+    expect(parseAssetRef(VALID_KEY, SITE_ID)).toBe(VALID_KEY)
+  })
+
+  it("should parse a valid reference with a nested filename path", () => {
+    const nestedKey = `${SITE_ID}/${VALID_UUID}/subdir/file.docx`
+    expect(parseAssetRef(`/${nestedKey}`, SITE_ID)).toBe(nestedKey)
+    expect(parseAssetRef(nestedKey, SITE_ID)).toBe(nestedKey)
+  })
+
+  it("should return null for a different siteId", () => {
+    expect(parseAssetRef(`/${VALID_KEY}`, 2)).toBeNull()
+    expect(parseAssetRef(VALID_KEY, 2)).toBeNull()
+  })
+
+  it("should return null for an external https URL", () => {
+    expect(parseAssetRef("https://example.com/file.pdf", SITE_ID)).toBeNull()
+  })
+
+  it("should return null for a mailto: link", () => {
+    expect(parseAssetRef("mailto:a@b.com", SITE_ID)).toBeNull()
+  })
+
+  it("should return null for a page reference", () => {
+    expect(parseAssetRef("[resource:1:2]", SITE_ID)).toBeNull()
+  })
+
+  it("should return null for plain text", () => {
+    expect(parseAssetRef("just plain text", SITE_ID)).toBeNull()
+  })
+
+  it("should return null when the filename segment is missing", () => {
+    // Only siteId/uuid — no trailing filename
+    expect(parseAssetRef(`${SITE_ID}/${VALID_UUID}`, SITE_ID)).toBeNull()
+    expect(parseAssetRef(`/${SITE_ID}/${VALID_UUID}/`, SITE_ID)).toBeNull()
+  })
+
+  it("should return null for a bad uuid", () => {
+    expect(
+      parseAssetRef(`${SITE_ID}/not-a-valid-uuid/report.pdf`, SITE_ID),
+    ).toBeNull()
+    expect(
+      parseAssetRef(
+        `${SITE_ID}/dc2b609a-355e-406c-af6c/report.pdf`,
+        SITE_ID,
+      ),
+    ).toBeNull()
+  })
+
+  it("should handle trimming of surrounding whitespace", () => {
+    expect(parseAssetRef(`  /${VALID_KEY}  `, SITE_ID)).toBe(VALID_KEY)
+  })
+})
+
+describe("buildNewAssetKey", () => {
+  it("should return a key with the same siteId and filename but a different uuid", () => {
+    const newKey = buildNewAssetKey(SITE_ID, VALID_KEY)
+
+    // Same siteId prefix
+    expect(newKey.startsWith(`${SITE_ID}/`)).toBe(true)
+
+    // Same filename suffix
+    expect(newKey.endsWith("/report.pdf")).toBe(true)
+
+    // Different uuid
+    const oldUuid = VALID_KEY.split("/")[1]
+    const newUuid = newKey.split("/")[1]
+    expect(newUuid).not.toBe(oldUuid)
+  })
+
+  it("should produce a key that round-trips through parseAssetRef", () => {
+    const newKey = buildNewAssetKey(SITE_ID, VALID_KEY)
+    expect(parseAssetRef(newKey, SITE_ID)).toBe(newKey)
+  })
+
+  it("should throw when the key belongs to a different siteId", () => {
+    expect(() => buildNewAssetKey(2, VALID_KEY)).toThrow()
+  })
+
+  it("should preserve nested filename paths", () => {
+    const nestedKey = `${SITE_ID}/${VALID_UUID}/subdir/document.pdf`
+    const newKey = buildNewAssetKey(SITE_ID, nestedKey)
+    expect(newKey.endsWith("/subdir/document.pdf")).toBe(true)
+  })
+})
+
+describe("rewriteAssetRef", () => {
+  const NEW_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+  const NEW_KEY = `${SITE_ID}/${NEW_UUID}/report.pdf`
+
+  it("should return the new key WITH a leading slash when the original had one", () => {
+    const map = new Map([[VALID_KEY, NEW_KEY]])
+    expect(rewriteAssetRef(`/${VALID_KEY}`, map, SITE_ID)).toBe(`/${NEW_KEY}`)
+  })
+
+  it("should return the new key WITHOUT a leading slash when the original had none", () => {
+    const map = new Map([[VALID_KEY, NEW_KEY]])
+    expect(rewriteAssetRef(VALID_KEY, map, SITE_ID)).toBe(NEW_KEY)
+  })
+
+  it("should return the value unchanged when the key is not in the map", () => {
+    const map = new Map<string, string>()
+    expect(rewriteAssetRef(`/${VALID_KEY}`, map, SITE_ID)).toBe(`/${VALID_KEY}`)
+  })
+
+  it("should return a non-asset value unchanged", () => {
+    const map = new Map([[VALID_KEY, NEW_KEY]])
+    expect(rewriteAssetRef("https://example.com", map, SITE_ID)).toBe(
+      "https://example.com",
+    )
+  })
+
+  it("should return a page reference unchanged", () => {
+    const map = new Map([[VALID_KEY, NEW_KEY]])
+    expect(rewriteAssetRef("[resource:1:2]", map, SITE_ID)).toBe(
+      "[resource:1:2]",
+    )
+  })
+})

--- a/packages/components/src/utils/assetRef.ts
+++ b/packages/components/src/utils/assetRef.ts
@@ -1,0 +1,107 @@
+// Matches a canonical v4-style UUID folder: 8-4-4-4-12 hex chars, case-insensitive
+const UUID_FOLDER_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * Parses a stored asset reference and returns the normalized S3 key (no leading
+ * slash) if the value is a valid reference for the given siteId.
+ *
+ * Accepted forms: `{siteId}/{uuid}/{filename}` or `/{siteId}/{uuid}/{filename}`
+ *
+ * Returns null for any other string (external URLs, mailto:, page references,
+ * wrong siteId, malformed UUIDs, missing filename, etc.).
+ */
+export const parseAssetRef = (
+  value: string,
+  siteId: number,
+): string | null => {
+  const trimmed = value.trim()
+
+  // Strip a single optional leading "/"
+  const stripped = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed
+
+  const prefix = `${siteId}/`
+  if (!stripped.startsWith(prefix)) {
+    return null
+  }
+
+  const rest = stripped.slice(prefix.length)
+  const slashIndex = rest.indexOf("/")
+  if (slashIndex === -1) {
+    return null
+  }
+
+  const uuid = rest.slice(0, slashIndex)
+  const filePart = rest.slice(slashIndex + 1)
+
+  if (!UUID_FOLDER_RE.test(uuid) || filePart.length === 0) {
+    return null
+  }
+
+  return `${siteId}/${uuid}/${filePart}`
+}
+
+/**
+ * Given a normalized S3 key (no leading slash) as returned by parseAssetRef,
+ * returns a new key for the same site and filename but with a fresh UUID folder.
+ *
+ * Throws if the key does not belong to the given siteId or has no filename
+ * segment after the uuid.
+ */
+export const buildNewAssetKey = (
+  siteId: number,
+  sourceKey: string,
+): string => {
+  const prefix = `${siteId}/`
+  if (!sourceKey.startsWith(prefix)) {
+    throw new Error(
+      `buildNewAssetKey: sourceKey "${sourceKey}" does not belong to siteId ${siteId}`,
+    )
+  }
+
+  const rest = sourceKey.slice(prefix.length)
+  const slashIndex = rest.indexOf("/")
+  if (slashIndex === -1) {
+    throw new Error(
+      `buildNewAssetKey: sourceKey "${sourceKey}" is missing a filename segment after the uuid`,
+    )
+  }
+
+  const filePart = rest.slice(slashIndex + 1)
+  if (filePart.length === 0) {
+    throw new Error(
+      `buildNewAssetKey: sourceKey "${sourceKey}" has an empty filename segment`,
+    )
+  }
+
+  const newUuid = globalThis.crypto.randomUUID()
+  return `${siteId}/${newUuid}/${filePart}`
+}
+
+/**
+ * Rewrites a stored asset reference value using the provided oldToNew key map.
+ *
+ * This is a whole-string operation: if the parsed S3 key is present in oldToNew,
+ * the value is rebuilt with the new key, preserving whether the original had a
+ * leading slash. Otherwise the value is returned unchanged.
+ */
+export const rewriteAssetRef = (
+  value: string,
+  oldToNew: ReadonlyMap<string, string>,
+  siteId: number,
+): string => {
+  const trimmed = value.trim()
+  const hasLeadingSlash = trimmed.startsWith("/")
+
+  const oldKey = parseAssetRef(trimmed, siteId)
+  if (oldKey === null) {
+    return value
+  }
+
+  const newKey = oldToNew.get(oldKey)
+  if (newKey === undefined) {
+    return value
+  }
+
+  return hasLeadingSlash ? `/${newKey}` : newKey
+}

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -36,3 +36,8 @@ export {
 } from "./validation"
 
 export { createChildrenPagesComparator } from "./createChildrenPagesComparator"
+export {
+  parseAssetRef,
+  buildNewAssetKey,
+  rewriteAssetRef,
+} from "./assetRef"


### PR DESCRIPTION
## Problem

The convention that identifies a "site asset" inside a page blob — the path shape `{siteId}/{uuid}/{filename}` — is hand-rolled in several places (the duplicate-page feature's `tryParseSiteAssetFileKey`, the editor's `getLinkHrefType`, `validation.ts`, `convertAssetLinks`). There is no single owner of "is this string a site-owned asset, and what is its key?". This makes the duplicate-page feature (which must deep-copy assets) harder to reason about and keeps the rule duplicated.

This is the first PR in a stack that moves that judgement into the components package, then has Studio consume it.

Part of the duplicate-resource refactor stacked on #2529. No tracking issue.

## Solution

Introduce the canonical asset-reference convention as pure helpers in `@opengovsg/isomer-components`, exported from the package root. Nothing consumes them yet — this PR is purely additive and safe to revert on its own.

- `parseAssetRef(value, siteId)` → the normalized S3 key (no leading slash) if `value` is a site asset reference for `siteId`, else `null`. siteId-scoped; external URLs, `[resource:…]` page refs and `mailto:` return `null`.
- `buildNewAssetKey(siteId, sourceKey)` → a new key with the same site + filename but a fresh UUID folder (for copies).
- `rewriteAssetRef(value, oldToNew, siteId)` → whole-string rewrite: if `value` parses to a key in the map, returns it rebuilt with the new key (preserving any leading slash), else returns `value` unchanged.

Also documents the decision:
- `CONTEXT.md` — glossary for Resource / Duplicate / Asset reference.
- `docs/adr/0001-detect-assets-by-value-not-schema-format.md` — records *why* assets are detected by value convention rather than the schema `format` annotation (polymorphic `ref`/`link`/`href` fields and prose file-links mean value is the only complete signal).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Purely additive new exports; no existing code paths changed.

**Features**:

- New `parseAssetRef`, `buildNewAssetKey`, `rewriteAssetRef` helpers in `@opengovsg/isomer-components`.

**Improvements**:

- Establishes a single source of truth for the asset-path convention, documented in `CONTEXT.md` and ADR-0001.

## Tests

- `pnpm --filter @opengovsg/isomer-components test:unit src/utils/__tests__/assetRef.test.ts` — 20 unit tests covering recognition (with/without leading slash, wrong siteId, non-asset strings, page-refs, mailto, bad uuid), key generation, and whole-string rewrite.
