### PR TITLE
refactor(studio): generic blob asset traversal via components convention

### DIFF
--- a/apps/studio/src/server/modules/page/__tests__/duplicatePageContent.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/duplicatePageContent.test.ts
@@ -1,76 +1,12 @@
 import { describe, expect, it } from "vitest"
 
 import {
-  buildNewAssetFileKeyForSite,
-  collectUniqueAssetFileKeys,
-  rewriteAssetFileKeysInValue,
-  tryParseSiteAssetFileKey,
+  collectAssetKeys,
+  rewriteAssetKeys,
 } from "../helpers/duplicatePageContent"
 
 describe("duplicatePageContent", () => {
-  describe("tryParseSiteAssetFileKey", () => {
-    it("parses leading-slash path", () => {
-      // Arrange
-      const path = "/25/550e8400-e29b-41d4-a716-446655440000/photo.png"
-      const siteId = 25
-
-      // Act
-      const parsed = tryParseSiteAssetFileKey(path, siteId)
-
-      // Assert
-      expect(parsed).toBe("25/550e8400-e29b-41d4-a716-446655440000/photo.png")
-    })
-
-    it("parses path without leading slash", () => {
-      // Arrange
-      const path = "25/550e8400-e29b-41d4-a716-446655440000/photo.png"
-      const siteId = 25
-
-      // Act
-      const parsed = tryParseSiteAssetFileKey(path, siteId)
-
-      // Assert
-      expect(parsed).toBe("25/550e8400-e29b-41d4-a716-446655440000/photo.png")
-    })
-
-    it("returns null for wrong site", () => {
-      // Arrange
-      const path = "/99/550e8400-e29b-41d4-a716-446655440000/photo.png"
-      const siteId = 25
-
-      // Act
-      const parsed = tryParseSiteAssetFileKey(path, siteId)
-
-      // Assert
-      expect(parsed).toBeNull()
-    })
-
-    it("returns null for external URL", () => {
-      // Arrange
-      const path = "https://x.com/a.png"
-      const siteId = 25
-
-      // Act
-      const parsed = tryParseSiteAssetFileKey(path, siteId)
-
-      // Assert
-      expect(parsed).toBeNull()
-    })
-
-    it("returns null for placeholder", () => {
-      // Arrange
-      const path = "/placeholder_no_image.png"
-      const siteId = 25
-
-      // Act
-      const parsed = tryParseSiteAssetFileKey(path, siteId)
-
-      // Assert
-      expect(parsed).toBeNull()
-    })
-  })
-
-  describe("collectUniqueAssetFileKeys", () => {
+  describe("collectAssetKeys", () => {
     it("dedupes nested occurrences", () => {
       // Arrange
       const siteId = 3
@@ -84,15 +20,15 @@ describe("duplicatePageContent", () => {
       }
 
       // Act
-      const keys = collectUniqueAssetFileKeys(content, siteId)
+      const keys = collectAssetKeys(content, siteId)
 
       // Assert
       expect(keys).toEqual([key])
     })
   })
 
-  describe("rewriteAssetFileKeysInValue", () => {
-    it("rewrites whole strings and embedded substrings", () => {
+  describe("rewriteAssetKeys", () => {
+    it("rewrites whole-string asset references and leaves others untouched", () => {
       // Arrange
       const siteId = 3
       const oldKey = `${siteId}/550e8400-e29b-41d4-a716-446655440000/doc.pdf`
@@ -100,37 +36,19 @@ describe("duplicatePageContent", () => {
       const map = new Map([[oldKey, newKey]])
       const content = {
         a: `/${oldKey}`,
-        b: `<img src="/${oldKey}" />`,
+        b: oldKey,
         c: "leave-me",
       }
 
       // Act
-      rewriteAssetFileKeysInValue(content, siteId, map)
+      rewriteAssetKeys(content, siteId, map)
 
       // Assert
       expect(content).toEqual({
         a: `/${newKey}`,
-        b: `<img src="/${newKey}" />`,
+        b: newKey,
         c: "leave-me",
       })
-    })
-  })
-
-  describe("buildNewAssetFileKeyForSite", () => {
-    it("builds a new key with fresh uuid folder", () => {
-      // Arrange
-      const siteId = 25
-      const oldKey = "25/550e8400-e29b-41d4-a716-446655440000/report.pdf"
-
-      // Act
-      const result = buildNewAssetFileKeyForSite(siteId, oldKey)
-
-      // Assert
-      const match = result.match(
-        /^25\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/report\.pdf$/i,
-      )
-      expect(match).not.toBeNull()
-      expect(match![1]).not.toBe("550e8400-e29b-41d4-a716-446655440000")
     })
   })
 })

--- a/apps/studio/src/server/modules/page/helpers/duplicatePageContent.ts
+++ b/apps/studio/src/server/modules/page/helpers/duplicatePageContent.ts
@@ -1,68 +1,14 @@
-import { randomUUID } from "crypto"
-
-// Canonical v4 UUID string shape (same 8-4-4-4-12 hex pattern as crypto.randomUUID()).
-const UUID_FOLDER_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
-
-/** New S3 key for a copied asset: same site and filename, new UUID folder. */
-export const buildNewAssetFileKeyForSite = (
-  siteId: number,
-  oldFileKey: string,
-): string => {
-  const prefix = `${siteId}/`
-  if (!oldFileKey.startsWith(prefix)) {
-    throw new Error("Expected asset key to start with siteId")
-  }
-  const rest = oldFileKey.slice(prefix.length)
-  const firstSlash = rest.indexOf("/")
-  if (firstSlash === -1) {
-    throw new Error("Expected asset key to contain uuid and filename")
-  }
-  const filePart = rest.slice(firstSlash + 1)
-  if (!filePart) {
-    throw new Error("Expected asset filename segment")
-  }
-  return `${siteId}/${randomUUID()}/${filePart}`
-}
+import { parseAssetRef, rewriteAssetRef } from "@opengovsg/isomer-components"
 
 /**
- * If `value` is a Studio asset path for this site, returns the S3 object key
- * (`{siteId}/{uuid}/{file...}`) without a leading slash. Otherwise null.
+ * Recursively walks the whole blob (objects, arrays, strings) and returns the
+ * deduped list of normalized asset keys for this site.
  */
-export const tryParseSiteAssetFileKey = (
-  value: string,
-  siteId: number,
-): string | null => {
-  const trimmed = value.trim()
-  let path = trimmed
-  if (path.startsWith("/")) {
-    path = path.slice(1)
-  }
-  const sitePrefix = `${siteId}/`
-  if (!path.startsWith(sitePrefix)) {
-    return null
-  }
-  const rest = path.slice(sitePrefix.length)
-  const firstSlash = rest.indexOf("/")
-  if (firstSlash === -1) {
-    return null
-  }
-  const uuidPart = rest.slice(0, firstSlash)
-  const filePart = rest.slice(firstSlash + 1)
-  if (!filePart || !UUID_FOLDER_RE.test(uuidPart)) {
-    return null
-  }
-  return `${sitePrefix}${uuidPart}/${filePart}`
-}
-
-export const collectUniqueAssetFileKeys = (
-  value: unknown,
-  siteId: number,
-): string[] => {
+export const collectAssetKeys = (value: unknown, siteId: number): string[] => {
   const keys = new Set<string>()
   const visit = (v: unknown) => {
     if (typeof v === "string") {
-      const key = tryParseSiteAssetFileKey(v, siteId)
+      const key = parseAssetRef(v, siteId)
       if (key) {
         keys.add(key)
       }
@@ -82,43 +28,22 @@ export const collectUniqueAssetFileKeys = (
   return [...keys]
 }
 
-const sortMappingsLongestOldKeyFirst = (
-  map: ReadonlyMap<string, string>,
-): [string, string][] =>
-  [...map.entries()].sort((a, b) => b[0].length - a[0].length)
-
 /**
- * Rewrites asset paths in arbitrary JSON (page blob). Mutates `value` in place.
+ * Recursively walks the whole blob and rewrites each string via the asset key
+ * map. Whole-string only. Mutates `value` in place.
  */
-export const rewriteAssetFileKeysInValue = (
+export const rewriteAssetKeys = (
   value: unknown,
   siteId: number,
-  oldToNewFileKey: ReadonlyMap<string, string>,
+  oldToNew: ReadonlyMap<string, string>,
 ): void => {
-  if (oldToNewFileKey.size === 0) {
+  if (oldToNew.size === 0) {
     return
-  }
-  const ordered = sortMappingsLongestOldKeyFirst(oldToNewFileKey)
-
-  const rewriteString = (s: string): string => {
-    const fullKey = tryParseSiteAssetFileKey(s, siteId)
-    if (fullKey) {
-      const newKey = oldToNewFileKey.get(fullKey)
-      if (newKey) {
-        const t = s.trim()
-        return t.startsWith("/") ? `/${newKey}` : newKey
-      }
-    }
-    let out = s
-    for (const [oldKey, newKey] of ordered) {
-      out = out.replaceAll(`/${oldKey}`, `/${newKey}`)
-    }
-    return out
   }
 
   const visit = (v: unknown): unknown => {
     if (typeof v === "string") {
-      return rewriteString(v)
+      return rewriteAssetRef(v, oldToNew, siteId)
     }
     if (Array.isArray(v)) {
       for (let i = 0; i < v.length; i++) {

--- a/apps/studio/src/server/modules/page/helpers/insertPageWithBlob.ts
+++ b/apps/studio/src/server/modules/page/helpers/insertPageWithBlob.ts
@@ -3,7 +3,7 @@ import type {
   ResourceType,
 } from "~prisma/generated/generatedEnums"
 import { TRPCError } from "@trpc/server"
-import { get } from "lodash"
+import { get } from "lodash-es"
 import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 
 import type { DB, SafeKysely, Transaction, User } from "../../database"

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -3,6 +3,7 @@ import type {
   IsomerSchema,
 } from "@opengovsg/isomer-components"
 import {
+  buildNewAssetKey,
   COLLECTION_VARIANT_OPTIONS,
   getLayoutMetadataSchema,
   ISOMER_USABLE_PAGE_LAYOUTS,
@@ -68,9 +69,8 @@ import {
 } from "../resource/resource.service"
 import { getSiteConfig } from "../site/site.service"
 import {
-  buildNewAssetFileKeyForSite,
-  collectUniqueAssetFileKeys,
-  rewriteAssetFileKeysInValue,
+  collectAssetKeys,
+  rewriteAssetKeys,
 } from "./helpers/duplicatePageContent"
 import { assertDuplicatePagePreconditions } from "./helpers/duplicatePagePreconditions"
 import {
@@ -648,10 +648,10 @@ export const pageRouter = router({
       }
 
       const newContent = cloneDeep(fullPage.content) as IsomerSchema
-      const assetKeys = collectUniqueAssetFileKeys(newContent, siteId)
+      const assetKeys = collectAssetKeys(newContent, siteId)
       const oldToNew = new Map<string, string>()
       const copyTasks = assetKeys.map((oldKey) => {
-        const newKey = buildNewAssetFileKeyForSite(siteId, oldKey)
+        const newKey = buildNewAssetKey(siteId, oldKey)
         oldToNew.set(oldKey, newKey)
         return copyObjectInBucket({
           Bucket: env.NEXT_PUBLIC_S3_ASSETS_BUCKET_NAME,
@@ -668,7 +668,7 @@ export const pageRouter = router({
       })
       await Promise.all(copyTasks)
 
-      rewriteAssetFileKeysInValue(newContent, siteId, oldToNew)
+      rewriteAssetKeys(newContent, siteId, oldToNew)
 
       if (!schemaValidator(newContent)) {
         throw new TRPCError({


### PR DESCRIPTION
## Problem

The duplicate feature carried its own copy of the asset-path convention (`tryParseSiteAssetFileKey`, `buildNewAssetFileKeyForSite`) and a bespoke blob walk whose rewrite step had a substring `replaceAll` fallback for asset paths embedded inside larger strings. With the convention now owned by the components package (#2530), Studio should consume it and keep only a generic traversal. The substring fallback also handles a shape that no field actually stores (no blob field holds embedded/HTML asset paths) and risks rewriting incidental text that merely mentions a path.

Part of the duplicate-resource refactor stacked on #2529. Depends on #2530.

## Solution

Replace the studio-local asset helpers with the components convention. Studio keeps a generic recursive walk over the whole blob and delegates per-string recognition and rewrite to `parseAssetRef` / `buildNewAssetKey` / `rewriteAssetRef`. The dead substring-rewrite path is removed (whole-string only). Behaviour for duplicating a page is unchanged.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Internal refactor; the duplicate flow is behaviour-preserving.

**Improvements**:

- Single source of truth for the asset convention (studio no longer re-implements it).
- Generic whole-blob traversal; net ~157 fewer lines.
- Removes the substring-rewrite fallback that could corrupt incidental text and matched no real data shape.

**Bug Fixes**:

- Corrects a pre-existing `lodash` → `lodash-es` import in `insertPageWithBlob.ts` that failed `tsc` (`lodash` is not a dependency).

## Tests

- `duplicateResourceContent.test.ts` (pure-unit) — 2 tests covering generic collect (dedupe across nested structures) and whole-string rewrite.
- `pnpm --filter isomer-studio typecheck` — clean.
- `page.router.test.ts` (duplicate integration) is exercised in CI — it requires a Postgres testcontainer (Docker) and cannot run locally in this worktree.
