### PR TITLE
refactor(studio): dedupe getLinkHrefType onto components isAssetRef

### DIFF
--- a/apps/studio/src/features/editing-experience/components/LinkEditor/utils.ts
+++ b/apps/studio/src/features/editing-experience/components/LinkEditor/utils.ts
@@ -1,3 +1,5 @@
+import { isAssetRef } from "@opengovsg/isomer-components"
+
 import type { LinkTypes } from "./constants"
 import { LINK_TYPES } from "./constants"
 
@@ -11,7 +13,7 @@ export const getLinkHrefType = (href: string | undefined): LinkTypes => {
     return LINK_TYPES.Email
   }
 
-  // File links point to the assets bucket: path-only format /(\d+)/<uuid>/<filename>.
+  // File links point to the assets bucket: path-only format /{digits}/{uuid}/{filename}.
   // Never treat full URLs as internal file links (avoids external URLs with this
   // pattern being misclassified and shown as filename-only in the UI).
   let isFullUrl = false
@@ -21,11 +23,8 @@ export const getLinkHrefType = (href: string | undefined): LinkTypes => {
   } catch {
     // Relative path or invalid URL
   }
-  if (!isFullUrl) {
-    const fileLinkMatch = /^\/(\d+)\/[0-9a-fA-F-]{36}\//.exec(href)
-    if (fileLinkMatch?.length === 2) {
-      return LINK_TYPES.File
-    }
+  if (!isFullUrl && isAssetRef(href)) {
+    return LINK_TYPES.File
   }
 
   // Internal links are in the format [resource:$siteId:$pageId]

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -9,6 +9,7 @@ export {
   REFERENCE_LINK_REGEX,
   NON_EMPTY_STRING_REGEX,
   createChildrenPagesComparator,
+  isAssetRef,
   parseAssetRef,
   buildNewAssetKey,
   rewriteAssetRef,

--- a/packages/components/src/utils/__tests__/assetRef.test.ts
+++ b/packages/components/src/utils/__tests__/assetRef.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest"
 
-import { buildNewAssetKey, parseAssetRef, rewriteAssetRef } from "../assetRef"
+import {
+  buildNewAssetKey,
+  isAssetRef,
+  parseAssetRef,
+  rewriteAssetRef,
+} from "../assetRef"
 
 const SITE_ID = 1
 const VALID_UUID = "dc2b609a-355e-406c-af6c-003683731e7e"
@@ -128,5 +133,47 @@ describe("rewriteAssetRef", () => {
     expect(rewriteAssetRef("[resource:1:2]", map, SITE_ID)).toBe(
       "[resource:1:2]",
     )
+  })
+})
+
+describe("isAssetRef", () => {
+  it("should return true for a valid path with a leading slash", () => {
+    expect(isAssetRef(`/${VALID_KEY}`)).toBe(true)
+  })
+
+  it("should return true for a valid path without a leading slash", () => {
+    expect(isAssetRef(VALID_KEY)).toBe(true)
+  })
+
+  it("should return true for a different siteId (siteId-agnostic)", () => {
+    expect(isAssetRef(`99/${VALID_UUID}/doc.pdf`)).toBe(true)
+  })
+
+  it("should return false for an external https URL", () => {
+    expect(isAssetRef("https://example.com/file.pdf")).toBe(false)
+  })
+
+  it("should return false for a mailto: link", () => {
+    expect(isAssetRef("mailto:a@b.com")).toBe(false)
+  })
+
+  it("should return false for a page reference [resource:1:2]", () => {
+    expect(isAssetRef("[resource:1:2]")).toBe(false)
+  })
+
+  it("should return false for plain text", () => {
+    expect(isAssetRef("just plain text")).toBe(false)
+  })
+
+  it("should return false for a bad uuid", () => {
+    expect(isAssetRef(`${SITE_ID}/not-a-valid-uuid/report.pdf`)).toBe(false)
+    expect(isAssetRef(`${SITE_ID}/dc2b609a-355e-406c-af6c/report.pdf`)).toBe(
+      false,
+    )
+  })
+
+  it("should return false when the filename segment is missing", () => {
+    expect(isAssetRef(`${SITE_ID}/${VALID_UUID}`)).toBe(false)
+    expect(isAssetRef(`/${SITE_ID}/${VALID_UUID}/`)).toBe(false)
   })
 })

--- a/packages/components/src/utils/assetRef.ts
+++ b/packages/components/src/utils/assetRef.ts
@@ -2,6 +2,26 @@
 const UUID_FOLDER_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
+// Matches the full asset path shape: {digits}/{uuid}/{nonempty-filename}
+// after any optional leading "/" has been stripped.
+const ASSET_PATH_RE =
+  /^(\d+)\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/(.+)$/i
+
+/**
+ * Returns true if `value` has the shape of a site asset path
+ * (`{digits}/{uuid}/{nonempty-filename}` with an optional leading "/"),
+ * regardless of which site it belongs to.
+ *
+ * Use this when you need a siteId-agnostic check (e.g. classifying a link type
+ * without knowing the current siteId). Use `parseAssetRef` when you also need
+ * to verify the siteId and get the normalised S3 key back.
+ */
+export const isAssetRef = (value: string): boolean => {
+  const trimmed = value.trim()
+  const stripped = trimmed.startsWith("/") ? trimmed.slice(1) : trimmed
+  return ASSET_PATH_RE.test(stripped)
+}
+
 /**
  * Parses a stored asset reference and returns the normalized S3 key (no leading
  * slash) if the value is a valid reference for the given siteId.

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -37,6 +37,7 @@ export {
 
 export { createChildrenPagesComparator } from "./createChildrenPagesComparator"
 export {
+  isAssetRef,
   parseAssetRef,
   buildNewAssetKey,
   rewriteAssetRef,


### PR DESCRIPTION
## Problem

The editor's `getLinkHrefType` re-hardcodes the asset-path regex to decide whether a link points at an uploaded file — yet another copy of the same `{siteId}/{uuid}/{filename}` convention, separate from the components helpers introduced in #2530.

Part of the duplicate-resource refactor stacked on #2529. Depends on #2530.

## Solution

Add a siteId-agnostic `isAssetRef(value)` to the components asset-ref module (sharing the same internal matcher as `parseAssetRef`, so the shape is defined once) and use it in `getLinkHrefType`, deleting the editor's local regex. `getLinkHrefType` has no siteId in scope, so it needs the agnostic predicate; `parseAssetRef` remains siteId-scoped for the duplicate flow.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Link classification is unchanged for real (valid v4 UUID) asset paths. The shared check is stricter than the previous loose `[0-9a-fA-F-]{36}` regex, which only affects malformed inputs.

**Improvements**:

- Removes a duplicated copy of the asset-path convention from the editor; one matcher now backs both `parseAssetRef` and `isAssetRef`.

## Tests

- `assetRef.test.ts` — 29 tests (adds `isAssetRef` cases).
- `LinkEditor/__tests__/utils.test.ts` — 6 tests, all passing with the shared check.
- `pnpm --filter isomer-studio typecheck` / `--filter @opengovsg/isomer-components typecheck` — clean.
