### PR TITLE
feat(studio): duplicate CollectionPage and CollectionLink

### DIFF
--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -22,7 +22,7 @@ import { COLLECTION_TABLE_SORT_OPTIONS } from "./constants"
 
 const columnsHelper = createColumnHelper<CollectionTableData>()
 
-const getColumns = ({ siteId }: CollectionTableProps) => [
+const getColumns = ({ siteId, resourceId }: CollectionTableProps) => [
   columnsHelper.accessor("title", {
     minSize: 300,
     header: () => <TableHeader>Title</TableHeader>,
@@ -46,6 +46,8 @@ const getColumns = ({ siteId }: CollectionTableProps) => [
     header: () => <TableHeader>Actions</TableHeader>,
     cell: ({ row }) => (
       <CollectionTableMenu
+        siteId={siteId}
+        tableScopeResourceId={resourceId}
         permalink={row.original.permalink}
         parentId={row.original.parentId}
         resourceType={row.original.type}

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -3,18 +3,26 @@ import { IconButton, Menu } from "@opengovsg/design-system-react"
 import { useSetAtom } from "jotai"
 import {
   BiCog,
+  BiCopy,
   BiDotsHorizontalRounded,
   BiFolderOpen,
   BiTrash,
 } from "react-icons/bi"
 import { MenuItem } from "~/components/Menu"
 import { moveResourceAtom } from "~/features/editing-experience/atoms"
+import { Can } from "~/features/permissions"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { CollectionTableData } from "./types"
-import { deleteResourceModalAtom, pageSettingsModalAtom } from "../../atoms"
+import {
+  deleteResourceModalAtom,
+  duplicateResourceModalAtom,
+  pageSettingsModalAtom,
+} from "../../atoms"
 
 interface CollectionTableMenuProps {
+  siteId: number
+  tableScopeResourceId: number
   title: CollectionTableData["title"]
   parentId: CollectionTableData["parentId"]
   permalink: CollectionTableData["permalink"]
@@ -23,6 +31,8 @@ interface CollectionTableMenuProps {
 }
 
 export const CollectionTableMenu = ({
+  siteId,
+  tableScopeResourceId,
   title,
   resourceId,
   resourceType,
@@ -31,6 +41,7 @@ export const CollectionTableMenu = ({
 }: CollectionTableMenuProps) => {
   const setValue = useSetAtom(deleteResourceModalAtom)
   const setPageSettingsModalState = useSetAtom(pageSettingsModalAtom)
+  const setDuplicateResourceModal = useSetAtom(duplicateResourceModalAtom)
   const setMoveResource = useSetAtom(moveResourceAtom)
   const handleMoveResourceClick = () => {
     setMoveResource({
@@ -67,6 +78,28 @@ export const CollectionTableMenu = ({
             >
               Edit settings
             </MenuItem>
+          )}
+          {(resourceType === ResourceType.CollectionPage ||
+            resourceType === ResourceType.CollectionLink) && (
+            <Can do="create" on={{ parentId }}>
+              <MenuItem
+                as="button"
+                onClick={() =>
+                  setDuplicateResourceModal({
+                    siteId,
+                    pageId: resourceId,
+                    sourceTitle: title,
+                    sourcePermalink: permalink,
+                    parentId,
+                    tableScopeResourceId,
+                  })
+                }
+                icon={<BiCopy fontSize="1rem" />}
+                aria-label={`Duplicate ${title}`}
+              >
+                Duplicate
+              </MenuItem>
+            </Can>
           )}
           {isSearchPage ? (
             <MenuItem

--- a/apps/studio/src/features/dashboard/components/DuplicateResourceModal/DuplicateResourceModal.tsx
+++ b/apps/studio/src/features/dashboard/components/DuplicateResourceModal/DuplicateResourceModal.tsx
@@ -166,6 +166,10 @@ export const DuplicateResourceModal = ({
                 siteId,
                 resourceId: tableScopeResourceId,
               }),
+              utils.collection.list.invalidate({
+                siteId,
+                resourceId: tableScopeResourceId,
+              }),
             ])
             toast({
               status: "success",

--- a/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
@@ -13,6 +13,7 @@ import {
   getBreadcrumbsFromRoot,
 } from "~/features/dashboard/components/DashboardLayout"
 import { DeleteResourceModal } from "~/features/dashboard/components/DeleteResourceModal"
+import { DuplicateResourceModal } from "~/features/dashboard/components/DuplicateResourceModal"
 import { FolderSettingsModal } from "~/features/dashboard/components/FolderSettingsModal"
 import { IndexpageRow } from "~/features/dashboard/components/IndexpageRow/IndexpageRow"
 import { PageSettingsModal } from "~/features/dashboard/components/PageSettingsModal"
@@ -96,6 +97,7 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
         collectionId={collectionId}
       />
       <DeleteResourceModal siteId={siteId} />
+      <DuplicateResourceModal siteId={siteId} />
       <FolderSettingsModal />
       <PageSettingsModal />
       <MoveResourceModal />

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   setupAdminPermissions,
   setupCollection,
+  setupCollectionLink,
   setupEditorPermissions,
   setupFolder,
   setupPageResource,
@@ -1941,14 +1942,9 @@ describe("page.router", async () => {
       )
     })
 
-    it("should return 404 for non-Page resources", async () => {
+    it("should return 404 for non-duplicatable resources (e.g. Folder)", async () => {
       // Arrange
-      const { collection, site } = await setupCollection()
-      const { page } = await setupPageResource({
-        siteId: site.id,
-        parentId: collection.id,
-        resourceType: ResourceType.CollectionPage,
-      })
+      const { folder, site } = await setupFolder()
       await setupAdminPermissions({
         userId: session.userId ?? undefined,
         siteId: site.id,
@@ -1957,7 +1953,7 @@ describe("page.router", async () => {
       // Act
       const result = caller.duplicate({
         siteId: site.id,
-        pageId: Number(page.id),
+        pageId: Number(folder.id),
         title: "Copy",
         permalink: "copy",
       })
@@ -1966,6 +1962,85 @@ describe("page.router", async () => {
       await expect(result).rejects.toThrowError(
         new TRPCError({ code: "NOT_FOUND", message: "Page not found" }),
       )
+    })
+
+    it("should duplicate a CollectionPage as a CollectionPage draft under the same parent", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+      const { page } = await setupPageResource({
+        siteId: site.id,
+        parentId: collection.id,
+        resourceType: ResourceType.CollectionPage,
+        permalink: "news-item",
+        title: "News item",
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.duplicate({
+        siteId: site.id,
+        pageId: Number(page.id),
+        title: "Copy of News item",
+        permalink: "news-item-copy",
+      })
+
+      // Assert
+      const duplicate = await db
+        .selectFrom("Resource")
+        .where("id", "=", result.pageId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+
+      expect(duplicate).toMatchObject({
+        title: "Copy of News item",
+        permalink: "news-item-copy",
+        type: ResourceType.CollectionPage,
+        state: ResourceState.Draft,
+        publishedVersionId: null,
+        parentId: collection.id,
+      })
+    })
+
+    it("should duplicate a CollectionLink as a CollectionLink draft under the same parent", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection()
+      const { collectionLink } = await setupCollectionLink({
+        siteId: site.id,
+        collectionId: collection.id,
+        permalink: "external-link",
+        title: "External link",
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.duplicate({
+        siteId: site.id,
+        pageId: Number(collectionLink.id),
+        title: "Copy of External link",
+        permalink: "external-link-copy",
+      })
+
+      // Assert
+      const duplicate = await db
+        .selectFrom("Resource")
+        .where("id", "=", result.pageId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+
+      expect(duplicate).toMatchObject({
+        title: "Copy of External link",
+        permalink: "external-link-copy",
+        type: ResourceType.CollectionLink,
+        state: ResourceState.Draft,
+        publishedVersionId: null,
+        parentId: collection.id,
+      })
     })
 
     it("should duplicate a page as draft with a new permalink", async () => {

--- a/apps/studio/src/server/modules/page/helpers/duplicateResourcePreconditions.ts
+++ b/apps/studio/src/server/modules/page/helpers/duplicateResourcePreconditions.ts
@@ -15,13 +15,24 @@ export const assertDuplicateResourcePreconditions = async ({
   pageId: number
   permalink: string
   userId: string
-}): Promise<{ parentKey: string | null }> => {
+}): Promise<{
+  parentKey: string | null
+  type:
+    | typeof ResourceType.Page
+    | typeof ResourceType.CollectionPage
+    | typeof ResourceType.CollectionLink
+}> => {
   const source = await getPageById(db, {
     resourceId: pageId,
     siteId,
   })
 
-  if (!source || source.type !== ResourceType.Page) {
+  if (
+    !source ||
+    (source.type !== ResourceType.Page &&
+      source.type !== ResourceType.CollectionPage &&
+      source.type !== ResourceType.CollectionLink)
+  ) {
     throw new TRPCError({
       code: "NOT_FOUND",
       message: "Page not found",
@@ -66,5 +77,5 @@ export const assertDuplicateResourcePreconditions = async ({
     })
   }
 
-  return { parentKey }
+  return { parentKey, type: source.type }
 }

--- a/apps/studio/src/server/modules/page/helpers/insertPageWithBlob.ts
+++ b/apps/studio/src/server/modules/page/helpers/insertPageWithBlob.ts
@@ -1,10 +1,10 @@
-import type {
-  ResourceState,
-  ResourceType,
-} from "~prisma/generated/generatedEnums"
+import type { ResourceState } from "~prisma/generated/generatedEnums"
 import { TRPCError } from "@trpc/server"
 import { get } from "lodash-es"
-import { AuditLogEvent } from "~prisma/generated/generatedEnums"
+import {
+  AuditLogEvent,
+  ResourceType,
+} from "~prisma/generated/generatedEnums"
 
 import type { DB, SafeKysely, Transaction, User } from "../../database"
 import { logResourceEvent } from "../../audit/audit.service"
@@ -39,7 +39,10 @@ interface NewPageResourceFields {
   permalink: string
   siteId: number
   parentId?: string
-  type: typeof ResourceType.Page
+  type:
+    | typeof ResourceType.Page
+    | typeof ResourceType.CollectionPage
+    | typeof ResourceType.CollectionLink
   state?: ResourceState
   publishedVersionId?: string | null
   scheduledAt?: Date | null

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -627,12 +627,13 @@ export const pageRouter = router({
   duplicate: protectedProcedure
     .input(duplicateResourceSchema)
     .mutation(async ({ ctx, input: { siteId, pageId, title, permalink } }) => {
-      const { parentKey } = await assertDuplicateResourcePreconditions({
-        siteId,
-        pageId,
-        permalink,
-        userId: ctx.user.id,
-      })
+      const { parentKey, type: sourceType } =
+        await assertDuplicateResourcePreconditions({
+          siteId,
+          pageId,
+          permalink,
+          userId: ctx.user.id,
+        })
 
       const fullPage = await getFullPageById(db, {
         resourceId: pageId,
@@ -691,7 +692,7 @@ export const pageRouter = router({
             permalink,
             siteId,
             parentId: parentKey ?? undefined,
-            type: ResourceType.Page,
+            type: sourceType,
             state: ResourceState.Draft,
             publishedVersionId: null,
             scheduledAt: null,


### PR DESCRIPTION
## Problem

Duplicate only works for `Page` resources. The "Duplicate" action is absent for `CollectionPage` and `CollectionLink`, even though they are page-like content that editors reasonably want to copy (e.g. an article in a collection, or a link/file entry).

Part of the duplicate-resource refactor stacked on #2529. Depends on #2531 (generic asset traversal) and #2533 (rename).

## Solution

Extend duplication to `CollectionPage` and `CollectionLink`, preserving the source resource's type and landing the copy as a new Draft sibling under the same parent. The asset-copy logic is already generic, so a CollectionLink's uploaded file (`ref`) and card image are deep-copied while its external URL is shared verbatim.

- Relax `assertDuplicateResourcePreconditions` to accept `Page` / `CollectionPage` / `CollectionLink` (other types still 404), and return the source type.
- Use the source type on insert instead of a hardcoded `Page` (widen `insertPageBlobResourceAndAudit`'s accepted type).
- Add a "Duplicate" action to the collection table row menu (`CollectionTableMenu`), gated by create permission on the parent collection.
- Mount `DuplicateResourceModal` on the collection page and invalidate `collection.list` (alongside the existing resource list/count) on success.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Page duplication behaviour is unchanged; this only adds two new source types.

**Features**:

- Duplicate a `CollectionPage` or `CollectionLink` from the collection view; the copy keeps the same type and lands as a Draft in the same collection.

## Before & After Screenshots

Collection row menu gains a **"Duplicate"** item for CollectionPage/CollectionLink rows (mirrors the folder view).

## Tests

- `page.router.test.ts` — adds cases asserting a CollectionPage duplicates as a CollectionPage Draft and a CollectionLink as a CollectionLink Draft, each under the same parent; the existing negative case now asserts a Folder is rejected. **These run in CI** (Postgres testcontainer / Docker required; they cannot run in the local worktree).
- `pnpm --filter isomer-studio typecheck` — clean.
