### PR TITLE
fix: agencyName silently dropped on every save

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/settings/agency.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/agency.tsx
@@ -71,6 +71,7 @@ const AgencySettingsPage: NextPageWithLayout = () => {
   const onSubmit = () =>
     updateSiteConfigMutation.mutate({
       siteName: state.siteName,
+      agencyName: state.agencyName,
       siteId,
       ...rest,
     })

--- a/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
@@ -109,6 +109,7 @@ const IntegrationsSettingsPage: NextPageWithLayout = () => {
         ...complexIntegrationSettings,
         siteName,
         url: url || `https://sample.isomer.gov.sg`,
+        ...(agencyName !== undefined && { agencyName }),
       },
     })
 


### PR DESCRIPTION
## Problem

agencyName was being silently dropped from the site config on every save in two separate flows:

1. Agency settings page (/settings/agency): agencyName was never included in the updateSiteConfigMutation payload, so saving any agency setting would overwrite the stored config without agencyName, effectively deleting it.
2. Integrations settings page (/settings/integrations): the mutation payload was assembled by spreading only siteName and url, so agencyName was silently omitted every time integration settings were saved.

Closes #2357 and #2358 

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [X] No - this PR is backwards compatible

**Features**:

- NIL

**Improvements**:

- NIL

**Bug Fixes**:

- agencyName was permanently deleted from site config on every agency settings save
- agencyName was silently dropped from site config on every integrations settings save

## Before & After Screenshots

**BEFORE**: NIL

**AFTER**: NIL

## Tests

**Manual Verification Steps**:

- [ ]  Set an agencyName for a site (via agency settings page) and confirm it is saved
- [ ]  Navigate to the integrations settings page and save without changes — confirm agencyName is still present in the site config afterwards
- [ ]  Navigate back to the agency settings page and save — confirm agencyName is still present afterwards

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
