### PR TITLE
isError can never be true because fetchDgsMetadata swallows all errors

### DIFF
--- a/packages/components/src/hooks/useDgsMetadata.ts
+++ b/packages/components/src/hooks/useDgsMetadata.ts
@@ -15,9 +15,7 @@ export const useDgsMetadata = ({
 }: UseDgsMetadataProps) => {
   const [isLoading, setIsLoading] = useState(enabled)
   const [isError, setIsError] = useState(false)
-  const [metadata, setMetadata] = useState<FetchDgsMetadataOutput | undefined>(
-    undefined,
-  )
+  const [metadata, setMetadata] = useState<FetchDgsMetadataOutput | undefined>()
 
   useEffect(() => {
     if (!enabled) {

--- a/packages/components/src/utils/dgs/fetchDgsMetadata.ts
+++ b/packages/components/src/utils/dgs/fetchDgsMetadata.ts
@@ -37,28 +37,23 @@ export type FetchDgsMetadataOutput = Pick<
 
 export const fetchDgsMetadata = async ({
   resourceId,
-}: FetchDgsMetadataProps): Promise<FetchDgsMetadataOutput | undefined> => {
-  try {
-    // For simplicity sake, we will always use data.gov.sg production API
-    const response = await fetch(
-      `https://api-production.data.gov.sg/v2/public/api/datasets/${resourceId}/metadata`,
-    )
+}: FetchDgsMetadataProps): Promise<FetchDgsMetadataOutput> => {
+  // For simplicity sake, we will always use data.gov.sg production API
+  const response = await fetch(
+    `https://api-production.data.gov.sg/v2/public/api/datasets/${resourceId}/metadata`,
+  )
 
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`)
+  }
 
-    const data = (await response.json()) as FetchDgsMetadataResponse
+  const data = (await response.json()) as FetchDgsMetadataResponse
 
-    return {
-      name: data.data.name,
-      format: data.data.format,
-      size: data.data.datasetSize,
-      columnMetadata: extractColumnMetadata(data),
-    }
-  } catch (error) {
-    console.error("Error fetching DGS metadata:", error)
-    return undefined
+  return {
+    name: data.data.name,
+    format: data.data.format,
+    size: data.data.datasetSize,
+    columnMetadata: extractColumnMetadata(data),
   }
 }
 


### PR DESCRIPTION
## Problem

fetchDgsMetadata silently swallowed all errors by returning undefined from its catch block, making setIsError(true) in useDgsMetadata unreachable dead code. Network failures and non-OK HTTP responses produced an empty table with no error state shown to the user.

Closes #2376

## Solution

**Breaking Changes**

- [ ]  Yes - this PR contains breaking changes
    - Details ...
- [x]  No - this PR is backwards compatible

**Features**:

- NIL

**Improvements**:

- NIL

**Bug Fixes**:

- fetchDgsMetadata now re-throws on network errors and non-OK HTTP responses, allowing useDgsMetadata to set isError: true and surface error UI in StaticDGSSearchableTable and DynamicDGSSearchableTable

## Before & After Screenshots

**BEFORE**: NIL

**AFTER**: NIL

## Tests

**Manual Verification Steps**:

- [ ]  Open a page with a DGS table component and set the resourceId to an invalid ID (e.g. invalid-id-xyz). Confirm the component renders an error state rather than a blank/empty table.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None