### PR TITLE
feat: make IsoBot risk computation reflect actual reversibility

### DIFF
--- a/.claude/skills/compute-risk-tier/SKILL.md
+++ b/.claude/skills/compute-risk-tier/SKILL.md
@@ -33,11 +33,11 @@ Compute the risk tier for a pull request.
 
 4. **Determine the tier.**
    a. Apply file-glob matching top-down — highest tier across all changed files wins.
-   b. Apply reversibility modifiers — bump one level if the diff:
-      - Sends external side-effects (email, Slack notification, outbound webhook call)
-      - Mutates existing rows outside of a database migration (backfill script, ad-hoc update)
-      - Changes a pgboss job handler function signature or job payload type
-   c. Note (but do not change the tier) if all new behaviour is gated behind a GrowthBook feature flag — record this in the reason.
+   b. Apply reversibility modifiers — bump one level if the diff matches any signal in the taxonomy's reversibility table. Detection hints: email/Slack/webhook calls, backfill scripts, pgboss handler removal/rename/payload change, `deleteObject`/`s3.delete`/CDN purge calls.
+   c. If the glob tier is MEDIUM, check content signals (see taxonomy) — these can lower MEDIUM → LOW, never HIGH:
+      - **Feature-flag gated**: All changed behaviour is wrapped in `useGrowthbookFlags`, `gb.isOn`, or `gb.getFeatureValue`. If yes, downgrade to LOW.
+      - **Purely additive**: No `-` hunks in MEDIUM-path files (excluding `---` diff metadata). If yes, downgrade to LOW.
+      If either applies, set tier to LOW and record which signal triggered it. See "What is NOT a reversibility risk" in the taxonomy for examples of changes that look risky but aren't.
 
 5. **Post a comment** on the PR explaining the decision:
    ```
@@ -67,8 +67,8 @@ Compute the risk tier for a pull request.
 ## Hard rules
 
 - **Read the taxonomy at run time.** Never rely on remembered glob patterns — the team updates the file frequently.
-- **Never downgrade a tier because the diff looks small.** Tier is determined by what is touched, not by how much is changed.
-- **Reversibility modifiers can only raise the tier, never lower it.** The feature-flag note is informational only.
+- **Never downgrade a HIGH-tier PR.** HIGH is determined by what is touched (auth, migrations, infra), not by how much is changed or whether it looks safe.
+- **Reversibility modifiers can only raise the tier, never lower it.**
 - **If `docs/risk-taxonomy.md` is missing**, abort and print an error — do not guess.
 
 ## Failure modes

--- a/docs/risk-taxonomy.md
+++ b/docs/risk-taxonomy.md
@@ -1,20 +1,20 @@
 # PR risk taxonomy
 
-This doc maps file-glob heuristics → risk tier. It is the source of truth for the `/compute-risk-tier`, `/pr-review`, and `/security-review` skills, the auto-approve gate, and any future code-review automation.
+This doc maps file-glob heuristics and content signals → risk tier. It is the source of truth for the `/compute-risk-tier`, `/pr-review`, and `/security-review` skills, the auto-approve gate, and any future code-review automation.
 
-Tiers are conservative on purpose: if multiple globs match a single PR, the **highest** tier wins.
+Tiers reflect actual reversibility and blast radius: if multiple globs match a single PR, the **highest** tier wins, but content-based signals (additive-only, feature-flag gating) can lower MEDIUM → LOW.
 
 ## Tiers
 
 | Tier         | Meaning                                                                                       | Auto-approve? |
 | ------------ | --------------------------------------------------------------------------------------------- | ------------- |
-| `risk:low`   | Cosmetic, docs, deps, copy. Cannot break runtime behaviour or change data.                    | Yes, with caveats below. |
-| `risk:medium`| Adds or changes app behaviour but in a contained area. Requires human approve.                | No.           |
-| `risk:high`  | Touches security, auth, billing, migrations, infra, or cross-cutting code. Requires human approve + a tagged reviewer. | No.           |
+| `risk:low`   | Cosmetic, docs, deps, copy, pure UI, utilities. Cannot break runtime behaviour or change data. | Yes, with caveats below. |
+| `risk:medium`| Changes server-side behaviour, data contracts, or shared library code. Requires human approve. | No.           |
+| `risk:high`  | Touches security, auth, migrations, infra, or cross-cutting code. Requires human approve + a tagged reviewer. | No.           |
 
 ## File-glob → tier
 
-Match top-down — the first matching glob wins for that file. The PR's tier is the max across its files.
+Match top-down — the first matching glob wins for that file. The PR's tier is the max across its files, then content signals are applied.
 
 ### `risk:high`
 
@@ -36,36 +36,45 @@ Match top-down — the first matching glob wins for that file. The PR's tier is 
 
 **Reversibility modifiers — any file, any tier:**
 
-The following signals bump a PR's tier by one level regardless of which globs matched:
+These signals bump a PR's tier by one level. The test: *can a user's data be lost or corrupted in a way that survives rolling back the PR?*
 
 | Signal | Why |
 | ------ | ---- |
 | Sends external side-effects (email, Slack notification, outbound webhook) | Cannot be unsent after deploy |
 | Mutates existing rows outside of a migration (backfill script, ad-hoc update) | Cannot be un-mutated without another migration |
-| Modifies a pgboss job handler signature or payload type | Jobs already in the queue at deploy time are processed by the new handler — silent data corruption risk |
+| Removes or renames a pgboss job handler, or changes its payload type | Jobs already in the queue are processed by the new handler or fail silently — no code rollback can fix in-flight jobs |
+| Deletes objects from S3 or CDN storage (look for `deleteObject`, `s3.delete`, CDN purge calls) | Deleted objects do not come back on code rollback; published pages referencing them stay broken until manually re-published |
 
-The following signals _lower_ a PR's effective tier for human review routing (not for the glob tier label):
+**What is NOT a reversibility risk:**
+
+Any change that leaves no externally-persisted state after a rollback. Rolling back a PR reverts all code atomically — so schema changes (Zod/Prisma), tRPC procedure changes, and Redis/cache structure changes are all safe when every caller is updated in the same PR. TypeScript catches mismatches at compile time; CI validates the rest.
+
+**Content signals — lower MEDIUM → LOW (never lower HIGH):**
 
 | Signal | Why |
 | ------ | ---- |
-| All changed behaviour is gated behind a GrowthBook feature flag | Can be disabled without a redeploy |
+| All changed behaviour is gated behind a GrowthBook feature flag | Can be disabled without a redeploy; safe to treat as low blast radius |
+| PR is purely additive in MEDIUM-path files — no `-` hunks (excluding `---` diff metadata) | No existing behaviour changed; full rollback with no data consequences |
+
+If either applies to a MEDIUM PR, output `risk:low` and state which signal triggered it.
 
 ### `risk:medium`
 
-- `apps/studio/src/server/modules/**` (all other modules)
+Server-side logic, data contracts, and shared libraries — things where a bug can corrupt data or break published sites.
+
+- `apps/studio/src/server/modules/**` (all modules except auth/permissions/audit/rate-limit which are high)
 - `apps/studio/src/pages/api/**`
 - `apps/studio/src/features/**`
 - `apps/studio/src/schemas/**`
-- `apps/studio/src/hooks/**`
 - `apps/studio/src/lib/**`
-- `apps/studio/src/utils/**`
-- `apps/studio/src/components/**`
 - `packages/components/src/templates/**`
 - `packages/components/src/schemas/**`
 - `packages/components/src/engine/**`
-- `packages/pgboss/**`, `packages/redis/**`, `packages/logging/**`, `packages/validators/**` — exception: changes to pgboss job handler signatures or payload types are bumped to risk:high via the reversibility modifier above
+- `packages/pgboss/**`, `packages/redis/**`, `packages/logging/**`, `packages/validators/**` — exception: removing/renaming a pgboss job handler or changing its payload type triggers the reversibility modifier and bumps to risk:high
 
 ### `risk:low`
+
+Client-side UI code, utilities, docs, and tests — reversible, contained blast radius, no direct data integrity implications.
 
 - `**/*.md`, `**/*.mdx`
 - `docs/**`
@@ -76,6 +85,9 @@ The following signals _lower_ a PR's effective tier for human review routing (no
 - `pnpm-lock.yaml` paired with a dep-only `package.json` change
 - `apps/studio/src/constants/**` for copy / strings only (no logic)
 - `**/i18n/**`, `**/locales/**`
+- `apps/studio/src/components/**`
+- `apps/studio/src/hooks/**`
+- `apps/studio/src/utils/**`
 
 ## Auto-approve caveats
 
@@ -86,7 +98,7 @@ The following signals _lower_ a PR's effective tier for human review routing (no
 3. The code review agent finds no Must Fix or Should Fix findings (after any dismissals).
 4. The security review agent finds no blocking findings.
 5. The PR does not change `package.json` scripts, `engines`, `pnpm.overrides`, or workspace dependencies.
-6. No reversibility modifier (external side-effects, row mutations, pgboss payload changes) applies.
+6. No reversibility modifier applies (external side-effects, row mutations, pgboss handler removal/rename/payload change, S3 object deletions).
 
 If any condition fails, the PR is downgraded to "human review required" and the agent leaves an annotation explaining why. A human still clicks merge — the bot approval satisfies the required-approvals gate but does not auto-merge.
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The IsoBot PR risk computation was too conservative: everything outside explicit HIGH globs (auth, migrations, infra) and LOW globs (docs, tests) defaulted to MEDIUM. This made the tier label too coarse to be useful — ~80% of PRs landed at MEDIUM regardless of actual risk.

## Solution

Reworked `docs/risk-taxonomy.md` and the `compute-risk-tier` skill to base tiers on actual reversibility and blast radius rather than file-path pessimism.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- Moved `src/components/**`, `src/hooks/**`, and `src/utils/**` from MEDIUM → LOW. These are client-side paths with no direct data integrity implications; bugs are cosmetic and immediately reverted by rolling back the PR.
- Added two content signals that can lower a MEDIUM PR to LOW: (1) all changed behaviour is gated behind a GrowthBook feature flag, and (2) the diff is purely additive in MEDIUM-path files (no `-` hunks). Both signals mean the change leaves no persistent state that survives a rollback.
- Added "What is NOT a reversibility risk" clarification: schema changes (Zod/Prisma), tRPC procedure changes, and Redis/cache changes are safe when all callers are updated in the same PR — TypeScript and CI catch mismatches; rollback is atomic.
- Added S3/CDN object deletion as a new reversibility modifier (deleted objects don't come back on code rollback; published pages stay broken).
- Expanded the pgboss reversibility modifier to cover handler removal and rename, not just payload type changes.
- Updated the skill's hard rules: HIGH never downgrades regardless of diff size, but MEDIUM can legitimately become LOW via content signals.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

No production code changes — this PR only modifies AI skill instructions and the risk taxonomy documentation used by IsoBot.