### PR TITLE
fix: trigger isobot review when PR is opened directly as ready

### DIFF
--- a/.github/workflows/isobot-pr-review.yml
+++ b/.github/workflows/isobot-pr-review.yml
@@ -1,11 +1,11 @@
 name: "🤖 IsoBot: PR Review"
 
-# Runs when the author explicitly signals the PR is ready, or comments /isobot-review
-# after pushing fixes. Does NOT run on every synchronize — engineers should keep
-# the PR in draft while iterating to avoid burning review cycles on WIP commits.
+# Runs when a non-draft PR is opened or converted from draft to ready, or when a
+# member comments /isobot-review after pushing fixes. Does NOT run on every
+# synchronize — keep the PR in draft while iterating to avoid burning review cycles.
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [ready_for_review, opened]
   issue_comment:
     types: [created]
 
@@ -14,12 +14,14 @@ jobs:
   # Downstream jobs use `needs: gate` so this condition is defined exactly once.
   gate:
     # Only run this job if the event matches one of these authorized triggers:
-    # 1. The event is a 'pull_request' and the PR author is an OWNER or MEMBER.
+    # 1. The event is a 'pull_request', the PR is not a draft, and the author is an OWNER or MEMBER.
+    #    Covers both 'opened' (PR created ready) and 'ready_for_review' (draft converted to ready).
     # 2. The event is a 'issue_comment', the comment is on a PR,
     #    the comment starts with '/isobot-review', and the comment author is an OWNER or MEMBER.
     if: |
       (
         github.event_name == 'pull_request' &&
+        !github.event.pull_request.draft &&
         contains(fromJSON('["OWNER", "MEMBER"]'), github.event.pull_request.author_association)
       ) ||
       (


### PR DESCRIPTION
## Problem

The IsoBot PR review workflow (`isobot-pr-review.yml`) was silently skipped whenever a PR was opened directly in ready state. The workflow only subscribed to the `ready_for_review` event, which GitHub fires exclusively when a **draft** PR is converted to ready — not when a PR is created ready from the start.

Closes #

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Added `opened` to the `pull_request` trigger event types so the workflow fires for PRs created directly as ready, in addition to draft → ready conversions.
- Added a `!github.event.pull_request.draft` guard to the `gate` job condition to prevent the workflow from running on PRs opened as drafts (which would now also match the `opened` event type).
- Updated comments in the workflow file to accurately describe both trigger paths.

## Before & After Screenshots

N/A — CI/CD config change only.

## Tests

No Manual Verification Steps required — this is a CI/CD configuration change with no production code changes.

**New scripts**:

N/A

**New dependencies**:

N/A

**New dev dependencies**:

N/A