### PR TITLE
fix: allow Write tool in IsoBot CI so auto-approve gate can fire

### DIFF
--- a/.github/workflows/isobot-pr-review.yml
+++ b/.github/workflows/isobot-pr-review.yml
@@ -71,6 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--allowedTools Write"
           prompt: /compute-risk-tier ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Read risk tier result
@@ -103,6 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--allowedTools Write"
           prompt: /code-review ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Read code review result
@@ -136,6 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: "--allowedTools Write"
           prompt: /security-review ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
 
       - name: Read security review result


### PR DESCRIPTION
## Problem

The \`auto-approve\` job in the IsoBot PR review pipeline was always skipped, even for low-risk PRs with no code or security blockers.

Root cause: \`claude-code-action\` runs Claude non-interactively (\`-p\` flag), so any tool not pre-approved in \`.claude/settings.json\` is silently **blocked**. The project's \`settings.json\` only pre-approves specific \`gh pr *\` Bash commands — it does not allow the \`Write\` tool. When each review skill tried to write its result JSON to \`/tmp/\` (e.g. \`/tmp/risk-result.json\`), that call was denied. The fallback path then wrote \`tier=high\` / \`blocking=true\`, making the auto-approve condition permanently false. Confirmed via \`permission_denials_count: 2–3\` in every run's SDK result message.

Closes #

## Solution

Add \`claude_args: "--allowedTools Write"\` to each of the three \`claude-code-action\` steps.

**Why just \`Write\`, and not \`Read\` or \`Bash\`:**
- \`Read\` is allowed by default (non-destructive, no confirmation required in Claude Code's permission model).
- The specific \`gh pr *\` Bash commands the skills need are already pre-approved in \`.claude/settings.json\`; those permissions are additive with \`--allowedTools\` — confirmed from the Claude binary: CLI tools go into a \`cliArg\` bucket inside \`alwaysAllowRules\`, settings.json rules go into their own buckets, and all buckets are unioned at permission-check time.
- Adding \`Write\` lets Claude write the result JSONs on the first attempt instead of falling back to a blocked Bash write, dropping the denial count to zero.

**Why \`claude_args\` instead of modifying \`settings.json\`:**
- CI-scoped — only applies to these three action steps; local dev sessions are unaffected.
- Avoids triggering the \`PostToolUse\` \`pnpm format:fix\` hook on every \`Write\` in CI (where packages aren't installed).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- IsoBot \`auto-approve\` job now correctly fires for \`risk:low\` PRs with no Must Fix or security findings.

## Before & After Screenshots

N/A — CI behaviour change only.

## Tests

No production code changes — CI/CD config only.

Manual verification: open a low-risk PR (single additive change, no auth/migration/infra files touched) and confirm that after IsoBot runs, the \`auto-approve\` job moves from \`skipped\` to \`success\` and a formal GitHub approval is posted.