### PR TITLE
fix: pass pull-request-number to auto-approve for issue_comment trigger

### DIFF
--- a/.github/workflows/isobot-pr-review.yml
+++ b/.github/workflows/isobot-pr-review.yml
@@ -175,3 +175,5 @@ jobs:
             - 🔒 Security: no blockers
 
             Still needs a human to merge — this just clears the approvals gate.
+
+            <sub>Posted by [🤖 IsoBot: PR Review](https://github.com/opengovsg/isomer/blob/main/.github/workflows/isobot-pr-review.yml)</sub>

--- a/.github/workflows/isobot-pr-review.yml
+++ b/.github/workflows/isobot-pr-review.yml
@@ -167,6 +167,7 @@ jobs:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          pull-request-number: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
           review-message: |
             🤖 All clear!
             - 🟢 Risk: low


### PR DESCRIPTION
## Problem

When IsoBot is triggered via `/isobot-review` comment (the `issue_comment` event), the `auto-approve` job was failing with:

> Error: This action must be run using a `pull_request` event or have an explicit `pull-request-number` provided

`hmarr/auto-approve-action` cannot infer the PR number from an `issue_comment` event — it only works automatically for `pull_request` events.

Additionally, the auto-approve review comment was missing the IsoBot attribution footer present on all other IsoBot review comments.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Pass `pull-request-number` explicitly to `hmarr/auto-approve-action`, using the same conditional expression already used in the three review jobs above it: `github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number`. This resolves the action for both `pull_request` and `issue_comment` triggers.
- Add `<sub>Posted by [🤖 IsoBot: PR Review](...)</sub>` attribution footer to the auto-approve review message, consistent with the other three IsoBot review comments.

## Before & After Screenshots

N/A — CI workflow fix.

## Tests

No production code changes — CI/CD config only. Manual verification steps not applicable.

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none