### PR TITLE
fix: use ISOBOT_GITHUB_TOKEN for auto-approve to satisfy CODEOWNERS

### DIFF
--- a/.github/workflows/isobot-pr-review.yml
+++ b/.github/workflows/isobot-pr-review.yml
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ISOBOT_GITHUB_TOKEN }}
           pull-request-number: ${{ github.event_name == 'issue_comment' && github.event.issue.number || github.event.pull_request.number }}
           review-message: |
             🤖 All clear!


### PR DESCRIPTION
## Problem

The IsoBot auto-approve step was using the default `GITHUB_TOKEN` (the GitHub Actions bot identity) to submit PR approvals. The Actions bot is not a member of `@opengovsg/isomer-engineers`, so its approval did not satisfy the CODEOWNERS requirement — PRs were left showing "Waiting on code owner review from opengovsg/isomer-engineers" even after IsoBot approved them.

Closes [insert issue #]

## Solution

Switch the `hmarr/auto-approve-action` step to use `ISOBOT_GITHUB_TOKEN` — a fine-grained PAT from a dedicated bot account that is a member of `opengovsg/isomer-engineers`. Since the approval is now submitted under a team member identity, it counts toward the CODEOWNERS requirement.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Auto-approve now satisfies the CODEOWNERS gate — approvals from `ISOBOT_GITHUB_TOKEN` (a team member) count toward required reviews, so low-risk PRs no longer remain stuck waiting for a human code owner review after IsoBot approves.

## Before & After Screenshots

N/A — CI/CD config change only.

## Tests

This is a CI/CD config change with no production code changes. No manual verification steps are required.

**New dependencies**:

- None

**New dev dependencies**:

- None