### PR TITLE
chore: add Claude Code LSP plugin config

### DIFF
--- a/.claude/plugin.json
+++ b/.claude/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "isomer-lsp-config",
+  "lspServers": {
+    "typescript": {
+      "command": "typescript-language-server",
+      "args": ["--stdio"],
+      "extensionToLanguage": {
+        ".ts": "typescript",
+        ".tsx": "typescriptreact",
+        ".js": "javascript",
+        ".jsx": "javascriptreact",
+        ".mjs": "javascript",
+        ".cjs": "javascript"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Claude Code working in this repo had no language-server backing, so it relied on text search and heuristics for TypeScript/JavaScript navigation. This makes go-to-definition, type-aware lookups, and accurate symbol resolution unavailable to the agent when assisting in this monorepo.

Closes [insert issue #]

## Solution

Adds a Claude Code plugin manifest at `.claude/plugin.json` that registers a `typescript-language-server` (stdio) LSP server for the repo. The manifest maps the relevant file extensions to their language IDs so the server is engaged across all TS/JS source in the monorepo:

- `.ts` → `typescript`
- `.tsx` → `typescriptreact`
- `.js`, `.mjs`, `.cjs` → `javascript`
- `.jsx` → `javascriptreact`

This is tooling/configuration only — it does not touch application code, build, or runtime behaviour.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Registers a TypeScript LSP server for Claude Code via `.claude/plugin.json`, enabling type-aware code navigation across the monorepo's TS/JS files.

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- N/A - configuration-only change -->

**AFTER**:

<!-- N/A - configuration-only change -->

## Tests

No automated tests apply — this is a Claude Code tooling configuration file. To confirm functionality, open the repo in Claude Code and verify the TypeScript language server starts and powers symbol navigation (e.g. go-to-definition) on `.ts`/`.tsx` files.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
