### PR TITLE
fix: redirects styling, validation, and reference handling

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -12,6 +12,7 @@ const __dirname = dirname(__filename)
 // Sites requiring audit logs
 const SITES_WITH_AUDIT_LOGS = [
   1, // stb.gov.sg
+  41, // ssg.gov.sg
   46, // sportsingapore.gov.sg
   48, // muis.gov.sg
   50, // knowledgehub.clc.gov.sg

--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -12,7 +12,6 @@ const __dirname = dirname(__filename)
 // Sites requiring audit logs
 const SITES_WITH_AUDIT_LOGS = [
   1, // stb.gov.sg
-  41, // ssg.gov.sg
   46, // sportsingapore.gov.sg
   48, // muis.gov.sg
   50, // knowledgehub.clc.gov.sg

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -26,6 +26,9 @@ interface ResourceSelectorProps {
   existingResource?: ResourceItemContent
   onlyShowFolders?: boolean
   fileExplorerHeight?: number
+  // Whether to render the "You selected ..." preview box below the tree.
+  // Defaults to true; the move modal hides it in favour of its own notice.
+  showSelectedResourcePreview?: boolean
 }
 
 const SuspensableResourceSelector = ({
@@ -36,6 +39,7 @@ const SuspensableResourceSelector = ({
   existingResource,
   onlyShowFolders = false,
   fileExplorerHeight = FILE_EXPLORER_DEFAULT_HEIGHT_IN_REM,
+  showSelectedResourcePreview = true,
   searchQuery,
   isLoading,
   matchedResources,
@@ -183,17 +187,19 @@ const SuspensableResourceSelector = ({
           </Button>
         )}
       </Box>
-      <Box bg="utility.feedback.info-subtle" p="0.75rem" w="full">
-        <Flex flexDirection="column" gap="0.25rem">
-          <Text textStyle="caption-1">You selected /{fullPermalink}</Text>
-          {existingResource && (
-            <Text textStyle="caption-2">
-              The URL for "{existingResource.title}" will change to /
-              {moveDestPermalink}
-            </Text>
-          )}
-        </Flex>
-      </Box>
+      {showSelectedResourcePreview && (
+        <Box bg="utility.feedback.info-subtle" p="0.75rem" w="full">
+          <Flex flexDirection="column" gap="0.25rem">
+            <Text textStyle="caption-1">You selected /{fullPermalink}</Text>
+            {existingResource && (
+              <Text textStyle="caption-2">
+                The URL for "{existingResource.title}" will change to /
+                {moveDestPermalink}
+              </Text>
+            )}
+          </Flex>
+        </Box>
+      )}
     </>
   )
 }

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -121,6 +121,10 @@ const SuspendableModalContent = ({
     onSettled: onClose,
     onSuccess: async () => {
       await utils.resource.listWithoutRoot.invalidate()
+      // Renaming a folder changes its title/permalink, so the cached resource
+      // search results are now stale — invalidate them too (the page-settings
+      // path already does a broad invalidate; this keeps folder rename in sync).
+      await utils.resource.search.invalidate()
       await utils.resource.getChildrenOf.invalidate({
         resourceId: parentId ? String(parentId) : null,
       })

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -272,7 +272,7 @@ const PageSettingsModalContent = ({
                     >
                       <Checkbox
                         alignItems="flex-start"
-                        size="1.25rem"
+                        size="lg"
                         isChecked={!!value}
                         onChange={(e) => onChange(e.target.checked)}
                         ref={ref}

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -295,7 +295,7 @@ const PageSettingsModalContent = ({
             </FormControl>
           )}
 
-          <Infobox variant="warning">
+          <Infobox variant="warning" size="sm">
             {`Changes to your title${type === ResourceType.CollectionLink ? "" : " and URL"} will get published immediately. If you
             don't want to publish ${type === ResourceType.CollectionLink ? "it" : "them"}, make this change later.`}
           </Infobox>

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -190,7 +190,7 @@ const MoveResourceContent = withSuspense(
                 >
                   <Checkbox
                     alignItems="flex-start"
-                    size="1.25rem"
+                    size="lg"
                     isChecked={shouldCreateRedirect}
                     onChange={(e) => setShouldCreateRedirect(e.target.checked)}
                   >

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -166,6 +166,7 @@ const MoveResourceContent = withSuspense(
               interactionType="move"
               siteId={siteId}
               onlyShowFolders
+              showSelectedResourcePreview={false}
               existingResource={movedItem ?? undefined}
               onChange={(resourceId) => setCurResourceId(resourceId)}
             />

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -147,6 +147,10 @@ const MoveResourceContent = withSuspense(
       isRedirectableType &&
       isDestinationResolved &&
       oldFullPermalink !== newFullPermalink
+    // The URL-change notice shows for any resource once a picked destination
+    // actually changes its URL; the redirect checkbox is the published subset.
+    const showUrlChangeNotice =
+      isDestinationResolved && oldFullPermalink !== newFullPermalink
     const { data: existingRedirect } = trpc.redirect.getBySource.useQuery(
       { siteId: Number(siteId), source: newFullPermalink },
       { enabled: showRedirectOption },
@@ -158,10 +162,6 @@ const MoveResourceContent = withSuspense(
         <ModalCloseButton size="lg" />
         <ModalBody>
           <VStack alignItems="flex-start" spacing="1.25rem">
-            <Infobox size="sm" w="full">
-              Moving a page, folder, or collection changes its URL, effective
-              immediately
-            </Infobox>
             <ResourceSelector
               interactionType="move"
               siteId={siteId}
@@ -169,42 +169,47 @@ const MoveResourceContent = withSuspense(
               existingResource={movedItem ?? undefined}
               onChange={(resourceId) => setCurResourceId(resourceId)}
             />
-            {showRedirectOption && (
-              <VStack alignItems="flex-start" spacing="0.5rem" w="full">
-                {/* Suppressed when the redirect points back at this page —
-                    the move auto-clears it, so it won't actually shadow. */}
-                {existingRedirect &&
-                  existingRedirect.destinationResourceId !==
-                    Number(resourceId) && (
-                    <Infobox variant="warning" size="sm" w="full">
-                      This URL already redirects to{" "}
-                      {existingRedirect.destination}. Visitors will end up there
-                      instead.
-                    </Infobox>
-                  )}
+            {showUrlChangeNotice && (
+              <VStack alignItems="flex-start" spacing="0.75rem" w="full">
                 <Box
                   w="full"
                   bg="utility.feedback.info-subtle"
                   borderRadius="0.5rem"
                   p="1rem"
                 >
-                  <Checkbox
-                    alignItems="flex-start"
-                    size="lg"
-                    isChecked={shouldCreateRedirect}
-                    onChange={(e) => setShouldCreateRedirect(e.target.checked)}
-                  >
-                    <VStack align="flex-start" spacing="0.25rem">
-                      <Text textStyle="subhead-2">
-                        Redirect page automatically
-                      </Text>
-                      <Text textStyle="body-2" color="base.content.medium">
-                        Check this box to redirect visitors from{" "}
-                        {oldFullPermalink} to {newFullPermalink}.
-                      </Text>
-                    </VStack>
-                  </Checkbox>
+                  <Text textStyle="body-2" color="base.content.strong">
+                    The page URL will change to {newFullPermalink}.
+                  </Text>
                 </Box>
+                {showRedirectOption && (
+                  <>
+                    {/* Suppressed when the redirect points back at this page —
+                        the move auto-clears it, so it won't actually shadow. */}
+                    {existingRedirect &&
+                      existingRedirect.destinationResourceId !==
+                        Number(resourceId) && (
+                        <Infobox variant="warning" size="sm" w="full">
+                          This URL already redirects to{" "}
+                          {existingRedirect.destination}. Visitors will end up
+                          there instead.
+                        </Infobox>
+                      )}
+                    <Checkbox
+                      alignItems="flex-start"
+                      size="sm"
+                      px="0.25rem"
+                      isChecked={shouldCreateRedirect}
+                      onChange={(e) =>
+                        setShouldCreateRedirect(e.target.checked)
+                      }
+                    >
+                      <Text textStyle="body-2" color="base.content.strong">
+                        Check this box to automatically redirect visitors from{" "}
+                        {oldFullPermalink} to this new URL.
+                      </Text>
+                    </Checkbox>
+                  </>
+                )}
               </VStack>
             )}
           </VStack>

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -141,6 +141,7 @@ export const AddRedirectCard = ({
       borderWidth="1px"
       borderRadius="0.5rem"
       p="1.25rem"
+      pb="1.5rem"
       bgColor="base.canvas.default"
     >
       <Text textStyle="h6" mb="0.25rem">

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -144,7 +144,7 @@ export const AddRedirectCard = ({
       pb="1.5rem"
       bgColor="base.canvas.default"
     >
-      <Text textStyle="h6" mb="0.25rem">
+      <Text textStyle="h6" mb="0.25rem" color="base.content.strong">
         Add new redirects
       </Text>
       <Text textStyle="body-2" color="base.content.medium" mb="1.25rem">

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -197,27 +197,32 @@ export const AddRedirectCard = ({
           isRequired
         >
           <FormLabel size="sm">Redirect them to</FormLabel>
-          <Input
-            placeholder="/path-to-page or https://www.google.com"
-            size="sm"
-            onFocus={() => setIsDestinationFocused(true)}
-            {...register("destination", {
-              onBlur: () => {
-                setIsDestinationFocused(false)
-                checkForWarnings()
-              },
-              onChange: clearFieldFeedback("destination"),
-            })}
-          />
-          <FormErrorMessage>{errors.destination?.message}</FormErrorMessage>
+          <Box position="relative">
+            <Input
+              placeholder="/path-to-page or https://www.google.com"
+              size="sm"
+              onFocus={() => setIsDestinationFocused(true)}
+              {...register("destination", {
+                onBlur: () => {
+                  setIsDestinationFocused(false)
+                  checkForWarnings()
+                },
+                onChange: clearFieldFeedback("destination"),
+              })}
+            />
 
-          {/* Dropdown opens the page picker. Preventing the default mousedown
-              keeps the input focused so the click lands before blur removes
-              this element. */}
-          {isDestinationFocused && !errors.destination && (
-            <>
+            {/* Dropdown opens the page picker. Preventing the default mousedown
+                keeps the input focused so the click lands before blur removes
+                this element. It's absolutely positioned below the input so
+                showing it doesn't shift the surrounding layout. */}
+            {isDestinationFocused && !errors.destination && (
               <Box
-                mt={0}
+                position="absolute"
+                top="100%"
+                left={0}
+                right={0}
+                zIndex="dropdown"
+                mt="0.25rem"
                 py="0.5rem"
                 bgColor="white"
                 borderRadius="0.25rem"
@@ -245,8 +250,9 @@ export const AddRedirectCard = ({
                   </Text>
                 </HStack>
               </Box>
-            </>
-          )}
+            )}
+          </Box>
+          <FormErrorMessage>{errors.destination?.message}</FormErrorMessage>
 
           {warnings.length > 0 && (
             <Stack spacing="0.5rem" mt="0.5rem">

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -7,8 +7,10 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
+  ListItem,
   Stack,
   Text,
+  UnorderedList,
   useDisclosure,
 } from "@chakra-ui/react"
 import {
@@ -16,11 +18,10 @@ import {
   FormErrorMessage,
   FormLabel,
   Infobox,
-  Link,
   useToast,
 } from "@opengovsg/design-system-react"
 import { useState } from "react"
-import { BiLinkAlt, BiPlus, BiRightArrowAlt } from "react-icons/bi"
+import { BiPlus, BiRightArrowAlt, BiSearch } from "react-icons/bi"
 import { REDIRECT_MESSAGES } from "~/constants/redirect"
 import {
   BRIEF_TOAST_SETTINGS,
@@ -63,6 +64,10 @@ export const AddRedirectCard = ({
 
   const [source, destination] = watch(["source", "destination"])
   const isAddDisabled = !source?.trim() || !destination?.trim()
+
+  // The "Redirect to a page on your site..." dropdown only surfaces while the
+  // destination field is focused (per the design).
+  const [isDestinationFocused, setIsDestinationFocused] = useState(false)
 
   // Non-blocking warnings (e.g. the destination doesn't exist / isn't
   // published) are fetched on blur once the inputs are sync-valid.
@@ -191,23 +196,70 @@ export const AddRedirectCard = ({
           <Input
             placeholder="/redirect-to"
             size="xs"
+            onFocus={() => setIsDestinationFocused(true)}
             {...register("destination", {
-              onBlur: checkForWarnings,
+              onBlur: () => {
+                setIsDestinationFocused(false)
+                checkForWarnings()
+              },
               onChange: clearFieldFeedback("destination"),
             })}
           />
           <FormErrorMessage>{errors.destination?.message}</FormErrorMessage>
-          <Link
-            as="button"
-            type="button"
-            variant="standalone"
-            p="0"
-            mt="0.25rem"
-            onClick={onPageModalOpen}
-          >
-            <Icon as={BiLinkAlt} mr="0.25rem" />
-            Link to a page
-          </Link>
+
+          {/* Dropdown opens the page picker. Preventing the default mousedown
+              keeps the input focused so the click lands before blur removes
+              this element. */}
+          {isDestinationFocused && !errors.destination && (
+            <>
+              <Box
+                mt={0}
+                py="0.5rem"
+                bgColor="white"
+                borderRadius="0.25rem"
+                boxShadow="0px 0px 10px 0px rgba(191, 191, 191, 0.5)"
+                overflow="hidden"
+              >
+                <HStack
+                  as="button"
+                  type="button"
+                  w="full"
+                  spacing="0.5rem"
+                  px="0.75rem"
+                  py="0.5rem"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={onPageModalOpen}
+                  _hover={{ bgColor: "interaction.muted.main.hover" }}
+                >
+                  <Icon
+                    as={BiSearch}
+                    boxSize="1rem"
+                    color="interaction.main.default"
+                  />
+                  <Text textStyle="body-2" color="interaction.main.default">
+                    Redirect to a page on your site...
+                  </Text>
+                </HStack>
+              </Box>
+              <Infobox variant="info" size="sm" mt="1.25rem">
+                <Box>
+                  <Text textStyle="subhead-2" color="base.content.strong">
+                    Where can I redirect visitors to?
+                  </Text>
+                  <UnorderedList
+                    textStyle="body-2"
+                    color="base.content.default"
+                  >
+                    <ListItem>A page on your new site</ListItem>
+                    <ListItem>
+                      An external URL (e.g., https://www.gov.sg)
+                    </ListItem>
+                  </UnorderedList>
+                </Box>
+              </Infobox>
+            </>
+          )}
+
           {warnings.length > 0 && (
             <Stack spacing="0.5rem" mt="0.5rem">
               {warnings.map((warning) => (

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -246,22 +246,6 @@ export const AddRedirectCard = ({
                   </Text>
                 </HStack>
               </Box>
-              <Infobox variant="info" size="sm" mt="1.25rem">
-                <Box>
-                  <Text textStyle="subhead-2" color="base.content.strong">
-                    Where can I redirect visitors to?
-                  </Text>
-                  <UnorderedList
-                    textStyle="body-2"
-                    color="base.content.default"
-                  >
-                    <ListItem>A page on your new site</ListItem>
-                    <ListItem>
-                      An external URL (e.g., https://www.gov.sg)
-                    </ListItem>
-                  </UnorderedList>
-                </Box>
-              </Infobox>
             </>
           )}
 

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -148,7 +148,8 @@ export const AddRedirectCard = ({
         Add new redirects
       </Text>
       <Text textStyle="body-2" color="base.content.medium" mb="1.25rem">
-        Redirects go live as soon as you add them.
+        New redirects publish right away, but can take a few minutes to take
+        effect on your live site.
       </Text>
 
       <HStack as="form" align="flex-start" onSubmit={handleSubmit(onSubmit)}>

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -7,10 +7,8 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
-  ListItem,
   Stack,
   Text,
-  UnorderedList,
   useDisclosure,
 } from "@chakra-ui/react"
 import {

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -145,22 +145,22 @@ export const AddRedirectCard = ({
       p="1.25rem"
       bgColor="base.canvas.default"
     >
-      <Text textStyle="subhead-1" mb="0.25rem">
+      <Text textStyle="h6" mb="0.25rem">
         Add new redirects
       </Text>
       <Text textStyle="body-2" color="base.content.medium" mb="1.25rem">
         Redirects go live as soon as you add them.
       </Text>
 
-      <HStack
-        as="form"
-        spacing="0.75rem"
-        align="flex-start"
-        onSubmit={handleSubmit(onSubmit)}
-      >
-        <FormControl flex={1} isInvalid={!!errors.source} isRequired>
-          <FormLabel>When someone visits</FormLabel>
-          <InputGroup size="xs">
+      <HStack as="form" align="flex-start" onSubmit={handleSubmit(onSubmit)}>
+        <FormControl
+          flex={1}
+          maxW="24rem"
+          isInvalid={!!errors.source}
+          isRequired
+        >
+          <FormLabel size="sm">When someone visits</FormLabel>
+          <InputGroup size="sm">
             <InputLeftAddon
               borderColor="base.divider.strong"
               bgColor="interaction.support.disabled"
@@ -179,23 +179,28 @@ export const AddRedirectCard = ({
         </FormControl>
 
         <Box flexShrink={0}>
-          <FormLabel aria-hidden visibility="hidden">
+          <FormLabel size="sm" aria-hidden visibility="hidden">
             &nbsp;
           </FormLabel>
           <Center h="2.5rem">
             <Icon
               as={BiRightArrowAlt}
               boxSize="1.5rem"
-              color="standard.black"
+              color="base.content.medium"
             />
           </Center>
         </Box>
 
-        <FormControl flex={1} isInvalid={!!errors.destination} isRequired>
-          <FormLabel>Redirect them to</FormLabel>
+        <FormControl
+          flex={1}
+          maxW="22rem"
+          isInvalid={!!errors.destination}
+          isRequired
+        >
+          <FormLabel size="sm">Redirect them to</FormLabel>
           <Input
-            placeholder="/redirect-to"
-            size="xs"
+            placeholder="/path-to-page or https://www.google.com"
+            size="sm"
             onFocus={() => setIsDestinationFocused(true)}
             {...register("destination", {
               onBlur: () => {
@@ -237,7 +242,7 @@ export const AddRedirectCard = ({
                     color="interaction.main.default"
                   />
                   <Text textStyle="body-2" color="interaction.main.default">
-                    Redirect to a page on your site...
+                    Redirect to a page on your site
                   </Text>
                 </HStack>
               </Box>
@@ -271,8 +276,8 @@ export const AddRedirectCard = ({
           )}
         </FormControl>
 
-        <Box flexShrink={0}>
-          <FormLabel aria-hidden visibility="hidden">
+        <Box flexShrink={0} ml="0.5rem">
+          <FormLabel size="sm" aria-hidden visibility="hidden">
             &nbsp;
           </FormLabel>
           <Button
@@ -280,7 +285,7 @@ export const AddRedirectCard = ({
             isDisabled={isAddDisabled}
             isLoading={isPending}
             leftIcon={<Icon as={BiPlus} />}
-            size="xs"
+            size="sm"
           >
             Add
           </Button>

--- a/apps/studio/src/features/settings/Redirects/components/DeleteRedirectModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/DeleteRedirectModal.tsx
@@ -41,7 +41,7 @@ export const DeleteRedirectModal = ({
         <ModalBody>
           <Stack spacing="1.5rem">
             <Text textStyle="body-1">
-              Are you sure you want to delete this redirect?
+              This will permanently delete the redirect.
             </Text>
             <HStack
               spacing="1.5rem"

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
@@ -14,7 +14,11 @@ export const RedirectsEmptyPlaceholder = (): JSX.Element => {
             </Text>
             <Text textStyle="body-2" color="base.content.default">
               Unsure how to use redirects?{" "}
-              <Link variant="inline" href="https://support.isomer.gov.sg">
+              <Link
+                variant="inline"
+                isExternal
+                href="https://support.isomer.gov.sg"
+              >
                 Read our guide
               </Link>
               .

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
@@ -5,7 +5,7 @@ import { Link } from "@opengovsg/design-system-react"
 // generic EmptyTablePlaceholder, this points users to the redirects guide.
 export const RedirectsEmptyPlaceholder = (): JSX.Element => {
   return (
-    <Tr aria-hidden>
+    <Tr>
       <Td colSpan={4} border="none">
         <Flex align="center" justify="center" py="8.5rem">
           <Stack align="center" spacing="0.5rem" textAlign="center">

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
@@ -1,0 +1,27 @@
+import { Flex, Stack, Td, Text, Tr } from "@chakra-ui/react"
+import { Link } from "@opengovsg/design-system-react"
+
+// Shown in place of table rows when a site has no redirects yet. Unlike the
+// generic EmptyTablePlaceholder, this points users to the redirects guide.
+export const RedirectsEmptyPlaceholder = (): JSX.Element => {
+  return (
+    <Tr aria-hidden>
+      <Td colSpan={4} border="none">
+        <Flex align="center" justify="center" py="8.5rem">
+          <Stack align="center" spacing="0.5rem" textAlign="center">
+            <Text textStyle="subhead-1" color="base.content.default">
+              No redirects yet
+            </Text>
+            <Text textStyle="body-2" color="base.content.default">
+              Unsure how to use redirects?{" "}
+              <Link variant="inline" href="https://support.isomer.gov.sg">
+                Read our guide
+              </Link>
+              .
+            </Text>
+          </Stack>
+        </Flex>
+      </Td>
+    </Tr>
+  )
+}

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
@@ -20,8 +20,8 @@ export const RedirectsHeader = (): JSX.Element => {
           </Text>
         </Flex>
         <Text textStyle="body-2" color="base.content.medium">
-          When someone visits a link that is no longer in use, redirects send
-          them elsewhere so they don&apos;t get lost. Learn{" "}
+          Keep old links working. Redirects send anyone who visits an outdated
+          URL to the right place instead. Learn{" "}
           <Link variant="inline" href="https://support.isomer.gov.sg">
             how to use redirects
           </Link>

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -231,9 +231,10 @@ const getColumns = (
     size: 80,
     enableSorting: false,
     header: () => (
-      <TableHeader textStyle="subhead-2" color="base.content.medium">
-        Delete
-      </TableHeader>
+      <TableHeader
+        textStyle="subhead-2"
+        color="base.content.medium"
+      ></TableHeader>
     ),
     cell: ({ row }) => (
       <IconButton

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -29,6 +29,7 @@ import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
 } from "~/constants/toast"
+import { useIsTruncated } from "~/hooks/useIsTruncated"
 import { useTablePagination } from "~/hooks/useTablePagination"
 
 import type { RedirectRow, RedirectSortField } from "../types"
@@ -63,6 +64,8 @@ function DestinationCell({
 }: {
   display: DestinationDisplay
 }): JSX.Element {
+  const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>()
+
   if (display.status === "resolving") {
     return <Skeleton height="1.25rem" width="60%" />
   }
@@ -70,8 +73,14 @@ function DestinationCell({
   const isMissing = display.status === "missing"
   const label = isMissing ? MISSING_PAGE_LABEL : display.label
   return (
-    <Tooltip label={label} openDelay={500} placement="top">
+    <Tooltip
+      label={label}
+      openDelay={500}
+      placement="top"
+      isDisabled={!isTruncated}
+    >
       <Text
+        ref={ref}
         textStyle="body-2"
         color={isMissing ? "utility.feedback.critical" : "base.content.strong"}
         noOfLines={1}
@@ -135,6 +144,60 @@ function SortableHeader({
   )
 }
 
+// Renders a redirect source. A trailing "*" wildcard is shown as a badge rather
+// than literal text. The tooltip surfaces the full source only when the visible
+// text is clipped by the cell width.
+function SourceCell({ source }: { source: string }): JSX.Element {
+  const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>()
+  const isWildcard = source.endsWith("*")
+  const base = isWildcard ? source.slice(0, -1) : source
+  return (
+    <Tooltip
+      label={source}
+      openDelay={500}
+      placement="top"
+      isDisabled={!isTruncated}
+    >
+      <HStack spacing="0" align="baseline" overflow="hidden">
+        <Text
+          ref={ref}
+          textStyle="body-2"
+          color="base.content.strong"
+          noOfLines={1}
+          wordBreak="break-all"
+        >
+          {base}
+        </Text>
+        {isWildcard && (
+          <Box
+            as="span"
+            display="inline-flex"
+            alignItems="center"
+            justifyContent="center"
+            borderWidth="1px"
+            borderColor="base.divider.medium"
+            bg="utility.feedback.critical-subtle"
+            borderRadius="2px"
+            px="0.2rem"
+            ml="0.125rem"
+            flexShrink={0}
+            lineHeight="1"
+          >
+            <Text
+              as="span"
+              fontFamily="mono"
+              textStyle="subhead-2"
+              color="utility.feedback.critical"
+            >
+              *
+            </Text>
+          </Box>
+        )}
+      </HStack>
+    </Tooltip>
+  )
+}
+
 const getColumns = (
   onDeleteClick: (row: RedirectRow) => void,
   permalinkByReference: Map<string, string | null>,
@@ -149,50 +212,7 @@ const getColumns = (
         onClick={column.getToggleSortingHandler()}
       />
     ),
-    cell: ({ getValue }) => {
-      const source = getValue()
-      const isWildcard = source.endsWith("*")
-      const base = isWildcard ? source.slice(0, -1) : source
-      return (
-        <Tooltip label={source} openDelay={500} placement="top">
-          <HStack spacing="0" align="baseline" overflow="hidden">
-            <Text
-              textStyle="body-2"
-              color="base.content.strong"
-              noOfLines={1}
-              wordBreak="break-all"
-            >
-              {base}
-            </Text>
-            {isWildcard && (
-              <Box
-                as="span"
-                display="inline-flex"
-                alignItems="center"
-                justifyContent="center"
-                borderWidth="1px"
-                borderColor="base.divider.medium"
-                bg="utility.feedback.critical-subtle"
-                borderRadius="2px"
-                px="0.2rem"
-                ml="0.125rem"
-                flexShrink={0}
-                lineHeight="1"
-              >
-                <Text
-                  as="span"
-                  fontFamily="mono"
-                  textStyle="subhead-2"
-                  color="utility.feedback.critical"
-                >
-                  *
-                </Text>
-              </Box>
-            )}
-          </HStack>
-        </Tooltip>
-      )
-    },
+    cell: ({ getValue }) => <SourceCell source={getValue()} />,
   }),
   columnsHelper.accessor("destination", {
     minSize: 250,

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -56,6 +56,17 @@ const columnsHelper = createColumnHelper<RedirectRow>()
 // here (the render site) so it can change without touching the resolution logic.
 const MISSING_PAGE_LABEL = "Page no longer exists"
 
+// Middle truncation: the head CSS-truncates with an ellipsis while the last
+// TRUNCATION_TAIL_LENGTH characters stay pinned, so a long path keeps its most
+// specific segment visible ("/promo/really-long…/end.html") instead of losing
+// the tail to a plain end-ellipsis.
+const TRUNCATION_TAIL_LENGTH = 10
+
+const splitForMiddleTruncation = (value: string) => {
+  const splitAt = Math.max(0, value.length - TRUNCATION_TAIL_LENGTH)
+  return { head: value.slice(0, splitAt), tail: value.slice(splitAt) }
+}
+
 // Renders a pre-resolved redirect destination. Reference destinations arrive as
 // the page's current permalink; while that resolution is in flight we show a
 // skeleton, and a reference whose page no longer exists is flagged rather than
@@ -73,6 +84,8 @@ function DestinationCell({
 
   const isMissing = display.status === "missing"
   const label = isMissing ? MISSING_PAGE_LABEL : display.label
+  const color = isMissing ? "utility.feedback.critical" : "base.content.strong"
+  const { head, tail } = splitForMiddleTruncation(label)
   return (
     <Tooltip
       label={label}
@@ -80,15 +93,27 @@ function DestinationCell({
       placement="top"
       isDisabled={!isTruncated}
     >
-      <Text
-        ref={ref}
-        textStyle="body-2"
-        color={isMissing ? "utility.feedback.critical" : "base.content.strong"}
-        noOfLines={1}
-        wordBreak="break-all"
-      >
-        {label}
-      </Text>
+      <HStack spacing="0" align="center" overflow="hidden">
+        <Text
+          ref={ref}
+          textStyle="body-2"
+          color={color}
+          minW={0}
+          overflow="hidden"
+          whiteSpace="nowrap"
+          textOverflow="ellipsis"
+        >
+          {head}
+        </Text>
+        <Text
+          textStyle="body-2"
+          color={color}
+          flexShrink={0}
+          whiteSpace="nowrap"
+        >
+          {tail}
+        </Text>
+      </HStack>
     </Tooltip>
   )
 }
@@ -158,6 +183,7 @@ function SourceCell({ source }: { source: string }): JSX.Element {
     useIsTruncated<HTMLDivElement>()
   const isWildcard = source.endsWith("*")
   const base = isWildcard ? source.slice(0, -1) : source
+  const { head, tail } = splitForMiddleTruncation(base)
   return (
     <Tooltip
       label={source}
@@ -165,15 +191,25 @@ function SourceCell({ source }: { source: string }): JSX.Element {
       placement="top"
       isDisabled={!isTextTruncated && !isRowTruncated}
     >
-      <HStack ref={rowRef} spacing="0" align="baseline" overflow="hidden">
+      <HStack ref={rowRef} spacing="0" align="center" overflow="hidden">
         <Text
           ref={textRef}
           textStyle="body-2"
           color="base.content.strong"
-          noOfLines={1}
-          wordBreak="break-all"
+          minW={0}
+          overflow="hidden"
+          whiteSpace="nowrap"
+          textOverflow="ellipsis"
         >
-          {base}
+          {head}
+        </Text>
+        <Text
+          textStyle="body-2"
+          color="base.content.strong"
+          flexShrink={0}
+          whiteSpace="nowrap"
+        >
+          {tail}
         </Text>
         {isWildcard && (
           <Box

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   Text,
   Tooltip,
+  VisuallyHidden,
 } from "@chakra-ui/react"
 import { useToast } from "@opengovsg/design-system-react"
 import {
@@ -148,7 +149,13 @@ function SortableHeader({
 // than literal text. The tooltip surfaces the full source only when the visible
 // text is clipped by the cell width.
 function SourceCell({ source }: { source: string }): JSX.Element {
-  const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>()
+  // Measure both the text and the row: the text catches its own clamp, while the
+  // row catches the case where the wildcard badge is clipped even though the
+  // text is not.
+  const { ref: textRef, isTruncated: isTextTruncated } =
+    useIsTruncated<HTMLParagraphElement>()
+  const { ref: rowRef, isTruncated: isRowTruncated } =
+    useIsTruncated<HTMLDivElement>()
   const isWildcard = source.endsWith("*")
   const base = isWildcard ? source.slice(0, -1) : source
   return (
@@ -156,11 +163,11 @@ function SourceCell({ source }: { source: string }): JSX.Element {
       label={source}
       openDelay={500}
       placement="top"
-      isDisabled={!isTruncated}
+      isDisabled={!isTextTruncated && !isRowTruncated}
     >
-      <HStack spacing="0" align="baseline" overflow="hidden">
+      <HStack ref={rowRef} spacing="0" align="baseline" overflow="hidden">
         <Text
-          ref={ref}
+          ref={textRef}
           textStyle="body-2"
           color="base.content.strong"
           noOfLines={1}
@@ -251,10 +258,9 @@ const getColumns = (
     size: 80,
     enableSorting: false,
     header: () => (
-      <TableHeader
-        textStyle="subhead-2"
-        color="base.content.medium"
-      ></TableHeader>
+      <TableHeader textStyle="subhead-2" color="base.content.medium">
+        <VisuallyHidden>Actions</VisuallyHidden>
+      </TableHeader>
     ),
     cell: ({ row }) => (
       <IconButton

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -25,7 +25,6 @@ import {
 } from "react-icons/bi"
 import { TableHeader } from "~/components/Datatable"
 import { Datatable } from "~/components/Datatable/Datatable"
-import { EmptyTablePlaceholder } from "~/components/Datatable/EmptyTablePlaceholder"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
@@ -47,6 +46,7 @@ import {
   isReferenceDestination,
 } from "../utils"
 import { DeleteRedirectModal } from "./DeleteRedirectModal"
+import { RedirectsEmptyPlaceholder } from "./RedirectsEmptyPlaceholder"
 
 const columnsHelper = createColumnHelper<RedirectRow>()
 
@@ -211,7 +211,7 @@ const getColumns = (
     ),
   }),
   columnsHelper.accessor("publishedAt", {
-    size: 160,
+    size: 80,
     enableSorting: true,
     header: ({ column }) => (
       <SortableHeader
@@ -367,13 +367,7 @@ export const RedirectsTable = ({
         pagination
         totalRowCount={totalRowCount}
         isFetching={isLoading || isCountLoading}
-        emptyPlaceholder={
-          <EmptyTablePlaceholder
-            groupLabel="redirects"
-            entityName="redirect"
-            hasSearchTerm={false}
-          />
-        }
+        emptyPlaceholder={<RedirectsEmptyPlaceholder />}
         instance={tableInstance}
         sx={{ tableLayout: "fixed" }}
       />

--- a/apps/studio/src/features/settings/Redirects/components/SelectDestinationPageModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/SelectDestinationPageModal.tsx
@@ -5,6 +5,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Text,
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 import { useState } from "react"
@@ -47,13 +48,17 @@ export const SelectDestinationPageModal = ({
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={handleClose} size="xl">
+    <Modal isOpen={isOpen} onClose={handleClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader mr="3.5rem">Link to a page</ModalHeader>
+        <ModalHeader mr="3.5rem">Redirect to a page on your site</ModalHeader>
         <ModalCloseButton size="lg" />
 
         <ModalBody>
+          <Text textStyle="subhead-1" mb="0.75rem">
+            Redirect to...
+          </Text>
+
           <ResourceSelector
             interactionType="link"
             siteId={siteId}
@@ -66,16 +71,8 @@ export const SelectDestinationPageModal = ({
         </ModalBody>
 
         <ModalFooter>
-          <Button
-            variant="clear"
-            colorScheme="neutral"
-            onClick={handleClose}
-            mr="1rem"
-          >
-            Cancel
-          </Button>
           <Button isDisabled={!selectedResourceId} onClick={handleConfirm}>
-            Use this page
+            Redirect here
           </Button>
         </ModalFooter>
       </ModalContent>

--- a/apps/studio/src/features/settings/Redirects/types.ts
+++ b/apps/studio/src/features/settings/Redirects/types.ts
@@ -39,6 +39,7 @@ export const addRedirectSchema = z
     source: createRedirectObjectSchema.shape.source,
     destination: z
       .string()
+      .trim()
       .transform(normalizeDestinationScheme)
       .pipe(createRedirectObjectSchema.shape.destination),
   })

--- a/apps/studio/src/hooks/useIsTruncated.ts
+++ b/apps/studio/src/hooks/useIsTruncated.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from "react"
+
+// Tracks whether an element's text is being clipped by CSS (e.g. noOfLines /
+// ellipsis). A ResizeObserver keeps the value in sync as the cell resizes, so a
+// tooltip can stay disabled until the content actually overflows.
+export const useIsTruncated = <T extends HTMLElement>() => {
+  const ref = useRef<T>(null)
+  const [isTruncated, setIsTruncated] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const measure = () => {
+      setIsTruncated(
+        element.scrollWidth > element.clientWidth ||
+          element.scrollHeight > element.clientHeight,
+      )
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return { ref, isTruncated }
+}

--- a/apps/studio/src/hooks/useIsTruncated.ts
+++ b/apps/studio/src/hooks/useIsTruncated.ts
@@ -1,14 +1,19 @@
-import { useEffect, useRef, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 // Tracks whether an element's text is being clipped by CSS (e.g. noOfLines /
 // ellipsis). A ResizeObserver keeps the value in sync as the cell resizes, so a
-// tooltip can stay disabled until the content actually overflows.
+// tooltip can stay disabled until the content actually overflows. Uses a
+// callback ref so measurement (re)attaches whenever the node mounts — e.g. after
+// a cell swaps a Skeleton for its real content — and no-ops where ResizeObserver
+// is unavailable (jsdom/older browsers).
 export const useIsTruncated = <T extends HTMLElement>() => {
-  const ref = useRef<T>(null)
   const [isTruncated, setIsTruncated] = useState(false)
+  const observerRef = useRef<ResizeObserver | null>(null)
 
-  useEffect(() => {
-    const element = ref.current
+  const ref = useCallback((element: T | null) => {
+    observerRef.current?.disconnect()
+    observerRef.current = null
+
     if (!element) return
 
     const measure = () => {
@@ -19,10 +24,13 @@ export const useIsTruncated = <T extends HTMLElement>() => {
     }
 
     measure()
+    if (typeof ResizeObserver === "undefined") return
     const observer = new ResizeObserver(measure)
     observer.observe(element)
-    return () => observer.disconnect()
+    observerRef.current = observer
   }, [])
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
 
   return { ref, isTruncated }
 }

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -397,20 +397,20 @@ describe("createRedirectSchema", () => {
       expect(result.success).toBe(true)
     })
 
-    it("should reject an internal path that links to an on-page anchor", () => {
-      // Arrange / Act
+    it("should allow an internal path that links to an on-page anchor", () => {
+      // Arrange / Act: anchors are permitted on internal paths too — the
+      // published redirect's Location header can carry the fragment.
       const result = createRedirectSchema.safeParse({
         ...VALID_REDIRECT,
         destination: "/page#section",
       })
 
       // Assert
-      expect(result.success).toBe(false)
+      expect(result.success).toBe(true)
     })
 
     it("should allow a #fragment on an external https URL", () => {
-      // Arrange / Act: fragments are legitimate on external destinations; only
-      // internal-path anchors are unsupported.
+      // Arrange / Act: fragments are legitimate on external destinations too.
       const result = createRedirectSchema.safeParse({
         ...VALID_REDIRECT,
         destination: "https://www.example.gov.sg/page#section",

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -218,6 +218,38 @@ describe("createRedirectSchema", () => {
         }
       })
     })
+
+    it("should trim surrounding whitespace from the source", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.parse({
+        ...VALID_REDIRECT,
+        source: "  /old-page  ",
+      })
+
+      // Assert
+      expect(result.source).toBe("/old-page")
+    })
+
+    it("should reject sources containing a wildcard with the unsupported-wildcard message", () => {
+      // Arrange
+      const wildcardSources = ["/promo/*", "/promo/**", "/pro*mo"]
+
+      wildcardSources.forEach((source) => {
+        // Act
+        const result = createRedirectSchema.safeParse({
+          ...VALID_REDIRECT,
+          source,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+        if (!result.success) {
+          expect(result.error.issues.map((issue) => issue.message)).toContain(
+            "Wildcards aren't supported yet — enter the full path",
+          )
+        }
+      })
+    })
   })
 
   describe("destination", () => {
@@ -251,6 +283,17 @@ describe("createRedirectSchema", () => {
 
       // Assert
       expect(result.success).toBe(true)
+    })
+
+    it("should trim surrounding whitespace from an internal destination", () => {
+      // Arrange / Act
+      const result = createRedirectSchema.parse({
+        ...VALID_REDIRECT,
+        destination: "  /new-page  ",
+      })
+
+      // Assert
+      expect(result.destination).toBe("/new-page")
     })
 
     it("should accept destinations starting with 'https://'", () => {

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -94,11 +94,18 @@ const isReservedSource = (value: string) => {
 
 const sourceSchema = z
   .string()
+  .trim()
   .min(1, { message: "Source path is required" })
   .max(MAX_REDIRECT_SOURCE_LENGTH, { message: "Source path is too long" })
   .refine((value) => SOURCE_ALLOWED_CHARS_REGEX.test(value), {
     message:
       "Source can only contain letters, numbers, and URL path characters",
+  })
+  // Wildcard redirects aren't supported yet. A "*" would be stored as a literal
+  // path character that can never match an incoming request, so reject it with a
+  // clear message instead of silently creating a dead redirect.
+  .refine((value) => !value.includes("*"), {
+    message: "Wildcards aren't supported yet — enter the full path",
   })
   // The source is a path on this site, never a full URL — a scheme like
   // "https://" can never match an incoming request path, so reject it instead
@@ -128,6 +135,7 @@ const INVALID_DESTINATION_MESSAGE =
 
 const destinationSchema = z
   .string()
+  .trim()
   .min(1, { message: "Destination is required" })
   .max(MAX_REDIRECT_DESTINATION_LENGTH, { message: "Destination is too long" })
   // Strip control characters up front (a stray pasted CR/LF/NUL shouldn't block

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -155,12 +155,6 @@ const destinationSchema = z
   .refine((value) => !trimSlashes(value).split("/").includes(".."), {
     message: INVALID_DESTINATION_MESSAGE,
   })
-  // An internal path can't redirect to an on-page anchor — the published
-  // redirect emits a Location header, which can't target a fragment. External
-  // https URLs may legitimately carry a #fragment, so this is scoped to paths.
-  .refine((value) => !value.startsWith("/") || !value.includes("#"), {
-    message: "Destination can't link to an anchor on a page",
-  })
   // Normalise internal-path destinations like sources (this also collapses a
   // protocol-relative "//evil.com" to "/evil.com", closing an open redirect).
   // External https URLs and [resource:...] references are left as entered.

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2332,6 +2332,76 @@ describe("page.router", async () => {
         caller.publishPage({ siteId: site.id, pageId: Number(page.id) }),
       ).resolves.toBeUndefined()
     })
+
+    it("should back-fill a literal redirect destination into a reference on first publish", async () => {
+      // Arrange — a draft page, plus a redirect whose destination is the page's
+      // literal path (created before the page was live). Publishing the page
+      // should rewrite that literal into a [resource:...] reference so the
+      // redirect follows the page's future moves.
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+      const fullPermalink = await getResourceFullPermalink(
+        site.id,
+        Number(page.id),
+      )
+      await db
+        .insertInto("Redirect")
+        .values({
+          siteId: site.id,
+          source: "/old-url",
+          destination: normalizeRedirectPath(fullPermalink!),
+        })
+        .execute()
+
+      // Act
+      await caller.publishPage({ siteId: site.id, pageId: Number(page.id) })
+
+      // Assert — the literal destination is now a reference to the page
+      const redirect = await db
+        .selectFrom("Redirect")
+        .selectAll()
+        .where("siteId", "=", site.id)
+        .where("source", "=", "/old-url")
+        .executeTakeFirstOrThrow()
+      expect(redirect.destination).toEqual(`[resource:${site.id}:${page.id}]`)
+    })
+
+    it("should leave a literal redirect to a different path untouched on publish", async () => {
+      // Arrange — a redirect pointing at some other path must not be rewritten
+      // when an unrelated page is published.
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+      await db
+        .insertInto("Redirect")
+        .values({
+          siteId: site.id,
+          source: "/old-url",
+          destination: "/some-other-page",
+        })
+        .execute()
+
+      // Act
+      await caller.publishPage({ siteId: site.id, pageId: Number(page.id) })
+
+      // Assert — destination is unchanged
+      const redirect = await db
+        .selectFrom("Redirect")
+        .selectAll()
+        .where("siteId", "=", site.id)
+        .where("source", "=", "/old-url")
+        .executeTakeFirstOrThrow()
+      expect(redirect.destination).toEqual("/some-other-page")
+    })
   })
 
   describe("updateMeta", () => {

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2402,6 +2402,51 @@ describe("page.router", async () => {
         .executeTakeFirstOrThrow()
       expect(redirect.destination).toEqual("/some-other-page")
     })
+
+    it("should back-fill a literal redirect to a folder URL into a container reference when the folder's index page is first published", async () => {
+      // Arrange — a folder served by its (draft) IndexPage, plus a redirect
+      // whose destination is the folder's literal path. The IndexPage renders at
+      // the folder's URL, so publishing it should rewrite the literal into a
+      // reference to the CONTAINER (folder), not the index page itself.
+      const { site, folder } = await setupFolder({ permalink: "guides" })
+      const { page: indexPage } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+      const fullPermalink = await getResourceFullPermalink(
+        site.id,
+        Number(folder.id),
+      )
+      await db
+        .insertInto("Redirect")
+        .values({
+          siteId: site.id,
+          source: "/old-url",
+          destination: normalizeRedirectPath(fullPermalink!),
+        })
+        .execute()
+
+      // Act — publish the folder's index page (first publish)
+      await caller.publishPage({
+        siteId: site.id,
+        pageId: Number(indexPage.id),
+      })
+
+      // Assert — the literal destination now references the folder, so it will
+      // follow the folder's future renames
+      const redirect = await db
+        .selectFrom("Redirect")
+        .selectAll()
+        .where("siteId", "=", site.id)
+        .where("source", "=", "/old-url")
+        .executeTakeFirstOrThrow()
+      expect(redirect.destination).toEqual(`[resource:${site.id}:${folder.id}]`)
+    })
   })
 
   describe("updateMeta", () => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -1231,9 +1231,10 @@ describe("redirect.router", async () => {
       expect(row.destination).toBe("/no-such-page")
     })
 
-    it("stores a literal path when the destination page exists but is unpublished", async () => {
-      // Arrange — a draft page has no live URL yet
-      await setupPageResource({
+    it("stores a reference when the destination page exists but is unpublished", async () => {
+      // Arrange — a draft page exists at /draft-page; it has no live URL yet, but
+      // the redirect references it so it starts working once the page publishes
+      const { page } = await setupPageResource({
         siteId,
         resourceType: ResourceType.Page,
         permalink: "draft-page",
@@ -1247,14 +1248,14 @@ describe("redirect.router", async () => {
         destination: "/draft-page",
       })
 
-      // Assert — kept literal (not converted to a reference, not rejected)
+      // Assert — resolved to a [resource:...] reference, not kept literal
       const row = await db
         .selectFrom("Redirect")
         .select("destination")
         .where("siteId", "=", siteId)
         .where("source", "=", "/from")
         .executeTakeFirstOrThrow()
-      expect(row.destination).toBe("/draft-page")
+      expect(row.destination).toBe(`[resource:${siteId}:${page.id}]`)
     })
 
     it("should resolve the site root '/' to the RootPage reference", async () => {
@@ -1307,8 +1308,9 @@ describe("redirect.router", async () => {
       expect(row.destination).toBe(`[resource:${siteId}:${folder.id}]`)
     })
 
-    it("stores a literal path for a folder destination whose index page is unpublished", async () => {
-      // Arrange — a folder with no live index page has no live URL behind it yet
+    it("stores the folder reference for a folder destination whose index page is unpublished", async () => {
+      // Arrange — a folder whose index page is still a draft has no live URL yet,
+      // but the redirect references the folder so it works once it's published
       const { folder } = await setupFolder({ siteId, permalink: "about" })
       await setupPageResource({
         siteId,
@@ -1325,14 +1327,14 @@ describe("redirect.router", async () => {
         destination: "/about",
       })
 
-      // Assert — kept literal until the folder is published
+      // Assert — resolved to the folder reference, not kept literal
       const row = await db
         .selectFrom("Redirect")
         .select("destination")
         .where("siteId", "=", siteId)
         .where("source", "=", "/from")
         .executeTakeFirstOrThrow()
-      expect(row.destination).toBe("/about")
+      expect(row.destination).toBe(`[resource:${siteId}:${folder.id}]`)
     })
   })
 

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -686,6 +686,34 @@ describe("redirect.router", async () => {
       expect(result.warnings).toEqual([])
     })
 
+    it("should not warn for a published destination that carries a #fragment", async () => {
+      // Arrange — an internal destination may keep a literal "#fragment"; it must
+      // still resolve to the underlying published page rather than 404-ing.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: null,
+        permalink: "leaf",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/old",
+        destination: "/leaf#section",
+      })
+
+      // Assert
+      expect(result.warnings).toEqual([])
+    })
+
     it("should warn NOT_PUBLISHED for a folder with no index page", async () => {
       // Arrange — a folder with no IndexPage has no live page at its URL, so
       // resolution falls back to the (unpublished) container.

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -67,7 +67,10 @@ describe("redirect.router", async () => {
     permalink: string
     published: boolean
   }) => {
-    const { page: rootPage } = await setupPageResource({
+    // Top-level resources are stored with parentId = null in production (they
+    // are NOT children of the RootPage's id), so seed them that way — otherwise
+    // getResourceByFullPermalink can't resolve them.
+    await setupPageResource({
       siteId,
       resourceType: ResourceType.RootPage,
       parentId: null,
@@ -75,7 +78,7 @@ describe("redirect.router", async () => {
     const { page } = await setupPageResource({
       siteId,
       resourceType: ResourceType.Page,
-      parentId: rootPage.id,
+      parentId: null,
       permalink,
       ...(published
         ? { state: ResourceState.Published, userId }
@@ -621,7 +624,7 @@ describe("redirect.router", async () => {
     it("should not warn for a published page nested under a folder", async () => {
       // Arrange — /folder/leaf, where leaf is a published page under a folder.
       // This exercises the multi-segment walk past depth 1.
-      const { page: rootPage } = await setupPageResource({
+      await setupPageResource({
         siteId,
         resourceType: ResourceType.RootPage,
         parentId: null,
@@ -629,7 +632,7 @@ describe("redirect.router", async () => {
       const { folder } = await setupFolder({
         siteId,
         permalink: "folder",
-        parentId: rootPage.id,
+        parentId: null,
       })
       await setupPageResource({
         siteId,
@@ -654,7 +657,7 @@ describe("redirect.router", async () => {
     it("should not warn for a folder whose index page is published", async () => {
       // Arrange — "/folder" is served by the folder's published IndexPage, so
       // it must resolve as published (exercises the folder->IndexPage branch).
-      const { page: rootPage } = await setupPageResource({
+      await setupPageResource({
         siteId,
         resourceType: ResourceType.RootPage,
         parentId: null,
@@ -662,7 +665,7 @@ describe("redirect.router", async () => {
       const { folder } = await setupFolder({
         siteId,
         permalink: "folder",
-        parentId: rootPage.id,
+        parentId: null,
       })
       await setupPageResource({
         siteId,
@@ -686,7 +689,7 @@ describe("redirect.router", async () => {
     it("should warn NOT_PUBLISHED for a folder with no index page", async () => {
       // Arrange — a folder with no IndexPage has no live page at its URL, so
       // resolution falls back to the (unpublished) container.
-      const { page: rootPage } = await setupPageResource({
+      await setupPageResource({
         siteId,
         resourceType: ResourceType.RootPage,
         parentId: null,
@@ -694,7 +697,7 @@ describe("redirect.router", async () => {
       await setupFolder({
         siteId,
         permalink: "folder",
-        parentId: rootPage.id,
+        parentId: null,
       })
 
       // Act
@@ -746,6 +749,43 @@ describe("redirect.router", async () => {
 
       // Assert
       expect(result.errors).toEqual([])
+    })
+
+    it("should error when the source is the URL of a live folder (published index)", async () => {
+      // Arrange — a folder whose index page is published is live at "/folder",
+      // so a redirect there would shadow it. Regression test: the source guard
+      // must resolve top-level containers (parentId = null), not only pages.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.validate({
+        siteId,
+        source: "/folder",
+        destination: "/somewhere",
+      })
+
+      // Assert
+      expect(result.errors).toContainEqual({
+        code: "SOURCE_IS_EXISTING_PAGE",
+        message:
+          "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
+      })
     })
   })
 

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -266,8 +266,10 @@ export const validateRedirect = async ({
   }
 
   // A redirect whose source is a published page's live URL would shadow that
-  // page, so block it. Only published pages block — an unpublished page isn't
-  // live yet, and publishing it later is guarded on the page side.
+  // page, so block it. Resolves a folder/collection to its index page, so a
+  // live container is caught too. Only published resources block — an
+  // unpublished page isn't live yet, and publishing it later is guarded on the
+  // page side.
   const pageAtSource = await getResourceByFullPermalink({
     siteId,
     fullPermalink: source,
@@ -400,9 +402,10 @@ export const createRedirect = async ({
       })
     }
 
-    // Re-enforce the source-vs-published-page guard (a published page at this
-    // URL would be shadowed). Also a plain read, so same accepted race as above.
-    // PRECONDITION_FAILED keeps it distinct from the already-exists CONFLICT.
+    // Re-enforce the source-vs-published-page guard (a published page or live
+    // folder/collection at this URL would be shadowed). Also a plain read, so
+    // same accepted race as above. PRECONDITION_FAILED keeps it distinct from
+    // the already-exists CONFLICT.
     const pageAtSource = await getResourceByFullPermalink({
       siteId,
       fullPermalink: source,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -18,6 +18,7 @@ import {
   REFERENCE_LINK_REGEX,
 } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
+import { sql } from "kysely"
 import { REDIRECT_MESSAGES, RedirectValidationCode } from "~/constants/redirect"
 import {
   isValidExternalDestination,
@@ -57,6 +58,14 @@ const REFERENCE_DESTINATION_REGEX = new RegExp(
   `^${REFERENCE_LINK_REGEX.source}$`,
 )
 
+// Write timestamps with the database clock, matching the columns' @default(now()).
+// A JS `new Date()` is serialized by the pg driver in the Node process's local
+// timezone; because these are `timestamp without time zone` columns, Postgres
+// stores that local wall-clock verbatim — so a value written as new Date() lands
+// hours off from the UTC that the now() default writes on a fresh insert. Using
+// now() server-side keeps every createdAt/deletedAt consistent and in UTC.
+const dbNow = sql<Date>`now()`
+
 // A destination is exactly one of three shapes. The `type` discriminant keeps
 // the branches in resolveDestinationForStorage explicit instead of a chain of
 // string checks.
@@ -76,12 +85,12 @@ const parseDestination = (destination: string): ParsedDestination => {
 }
 
 // Resolves a destination to its stored form. A bare internal path becomes a
-// [resource:...] reference (so it follows page renames); a query-suffixed path
-// stays literal (a query can't map to a single resource); references and
-// external URLs are stored verbatim. An internal path with no live page yet is
-// also kept literal rather than rejected — the preflight surfaces this as a
-// non-blocking warning, so an admin can pre-create a redirect to a page they're
-// about to publish.
+// [resource:...] reference (so it follows page renames, and starts working once
+// the page is published); references and external URLs are stored verbatim. A
+// path that can't map to a single resource — a query- or fragment-suffixed path,
+// or one with no matching resource at all — stays literal. A resource that
+// exists but is unpublished still resolves to a reference: the preflight warns
+// it isn't live yet, and the published redirect rules only include it once it is.
 const resolveDestinationForStorage = async (
   siteId: number,
   destination: string,
@@ -92,11 +101,11 @@ const resolveDestinationForStorage = async (
     case "external":
       return parsed.value
     case "internalPath": {
-      if (parsed.value.includes("?")) {
+      if (parsed.value.includes("?") || parsed.value.includes("#")) {
         return parsed.value
       }
       const resourceId = await getResourceIdByPermalink(siteId, parsed.value)
-      // No live page yet — keep the literal path; the preflight warns about it.
+      // No resource at this path — keep the literal path; the preflight warns.
       if (resourceId === null) {
         return parsed.value
       }
@@ -424,7 +433,7 @@ export const createRedirect = async ({
             deletedAt: null,
             // Revived rows republish now, so refresh createdAt (the publish
             // time shown to users).
-            createdAt: new Date(),
+            createdAt: dbNow,
           })
           // Only soft-deleted rows may be revived; a concurrent live create
           // must surface as a conflict, not silently overwrite.
@@ -513,7 +522,7 @@ export const createRedirectForPermalinkChange = async (
     .onConflict((oc) =>
       oc
         .columns(["siteId", "source"])
-        .doUpdateSet({ destination, deletedAt: null, createdAt: new Date() })
+        .doUpdateSet({ destination, deletedAt: null, createdAt: dbNow })
         // Only revive a soft-deleted row; a live one must surface as a conflict.
         .where("Redirect.deletedAt", "is not", null),
     )
@@ -608,7 +617,7 @@ export const clearReclaimedRedirect = async (
   const byUser = await getByUser(byUserId)
   const after = await tx
     .updateTable("Redirect")
-    .set({ deletedAt: new Date() })
+    .set({ deletedAt: dbNow })
     .where("id", "=", reclaimed.id)
     .returningAll()
     .executeTakeFirstOrThrow()
@@ -708,7 +717,7 @@ export const deleteRedirect = async ({
 
     const deleted = await tx
       .updateTable("Redirect")
-      .set({ deletedAt: new Date() })
+      .set({ deletedAt: dbNow })
       .where("id", "=", before.id)
       .returningAll()
       .executeTakeFirstOrThrow()
@@ -843,7 +852,7 @@ export const softDeleteRedirectsPointingToResource = async (
   // committed after-row.
   const deleted = await tx
     .updateTable("Redirect")
-    .set({ deletedAt: new Date() })
+    .set({ deletedAt: dbNow })
     .where(
       "id",
       "in",

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -932,10 +932,14 @@ export const getResourceFullPermalinks = async (
 }
 
 // Reverse of getResourceFullPermalink: resolves a full permalink path back to
-// the live resource it points at (for storing a redirect destination as a
-// [resource:...] reference), or null if nothing live matches. One query fetches
-// every resource matching a path segment, then walks the parent chain in memory
-// — the (siteId, parentId, permalink) constraint makes each step unambiguous.
+// the resource it points at (for storing a redirect destination as a
+// [resource:...] reference), or null if no resource matches. Resolves
+// regardless of publish state — a reference to a not-yet-published page is
+// valid, and the published redirect rules only include it once it goes live, so
+// the redirect can be pre-created and starts working on publish. One query
+// fetches every resource matching a path segment, then walks the parent chain in
+// memory — the (siteId, parentId, permalink) constraint makes each step
+// unambiguous.
 export const getResourceIdByPermalink = async (
   siteId: number,
   fullPermalink: string,
@@ -943,13 +947,12 @@ export const getResourceIdByPermalink = async (
   const segments = fullPermalink.split("/").filter(Boolean)
 
   // The site root ("/") is the RootPage, whose permalink is empty so it has no
-  // path segments to walk. Resolve it directly (published only, as below).
+  // path segments to walk. Resolve it directly.
   if (segments.length === 0) {
     const root = await db
       .selectFrom("Resource")
       .where("Resource.siteId", "=", siteId)
       .where("Resource.type", "=", ResourceType.RootPage)
-      .where("Resource.publishedVersionId", "is not", null)
       .select("Resource.id")
       .executeTakeFirst()
     return root ? Number(root.id) : null
@@ -988,8 +991,9 @@ export const getResourceIdByPermalink = async (
 
   // A Folder/Collection is served by its IndexPage child, and the published
   // site keys the URL on the container's id (the index page's id never appears
-  // there — the build remaps it to the folder). Resolve to the container,
-  // treating it as live when its index page is published.
+  // there — the build remaps it to the folder). Resolve to the container when it
+  // has an index page; publish state doesn't matter here (the build emits the
+  // redirect only once that index page is published).
   if (
     leaf.type === ResourceType.Folder ||
     leaf.type === ResourceType.Collection
@@ -999,17 +1003,11 @@ export const getResourceIdByPermalink = async (
       .where("Resource.siteId", "=", siteId)
       .where("Resource.parentId", "=", String(leaf.id))
       .where("Resource.type", "=", ResourceType.IndexPage)
-      .where("Resource.publishedVersionId", "is not", null)
       .select("Resource.id")
       .executeTakeFirst()
     return indexPage ? Number(leaf.id) : null
   }
 
-  // Any other resource type must itself be published — the walk traverses
-  // unpublished folders as path segments, but the target page must be live.
-  if (leaf.publishedVersionId === null) {
-    return null
-  }
   return Number(leaf.id)
 }
 

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -8,7 +8,10 @@ import {
 import { TRPCError } from "@trpc/server"
 import get from "lodash-es/get"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
-import { normalizeRedirectSource } from "~/schemas/redirect"
+import {
+  normalizeRedirectPath,
+  normalizeRedirectSource,
+} from "~/schemas/redirect"
 import {
   getSitemapTree,
   injectTagMappings,
@@ -794,37 +797,51 @@ export const getResourceByFullPermalink = async ({
 }) => {
   const segments = fullPermalink.split("/").filter(Boolean)
 
-  const root = await db
-    .selectFrom("Resource")
-    .where("Resource.siteId", "=", siteId)
-    .where("Resource.type", "=", ResourceType.RootPage)
-    .where("Resource.parentId", "is", null)
-    .select(defaultResourceSelect)
-    .executeTakeFirst()
-  if (!root) {
-    return undefined
-  }
-
-  let current = root
-  for (const segment of segments) {
-    const child = await db
+  // The site root ("/") is the RootPage, whose permalink is empty so it has no
+  // path segments to walk. Resolve it directly.
+  if (segments.length === 0) {
+    return db
       .selectFrom("Resource")
       .where("Resource.siteId", "=", siteId)
-      .where("Resource.parentId", "=", current.id)
-      .where("Resource.permalink", "=", segment)
-      // Meta and index resources are not directly addressable by a path
-      // segment — the index page is reached via its parent container below.
-      .where("Resource.type", "not in", [
-        ResourceType.IndexPage,
-        ResourceType.FolderMeta,
-        ResourceType.CollectionMeta,
-      ])
+      .where("Resource.type", "=", ResourceType.RootPage)
+      .where("Resource.parentId", "is", null)
       .select(defaultResourceSelect)
       .executeTakeFirst()
-    if (!child) {
+  }
+
+  // Fetch every resource whose permalink matches a segment, then walk the
+  // (parentId, permalink) chain in memory. Top-level resources have
+  // parentId = null (they are NOT stored as children of the RootPage's id), so
+  // the walk starts from null — matching getResourceIdByPermalink. Walking from
+  // the root page's id instead silently misses every top-level resource. Meta
+  // and index resources are never addressable by a path segment; the index page
+  // is reached via its parent container below.
+  const candidates = await db
+    .selectFrom("Resource")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.permalink", "in", segments)
+    .where("Resource.type", "not in", [
+      ResourceType.IndexPage,
+      ResourceType.FolderMeta,
+      ResourceType.CollectionMeta,
+    ])
+    .select(defaultResourceSelect)
+    .execute()
+
+  let parentId: string | null = null
+  let current: (typeof candidates)[number] | undefined
+  for (const segment of segments) {
+    current = candidates.find(
+      (candidate) =>
+        candidate.permalink === segment && candidate.parentId === parentId,
+    )
+    if (!current) {
       return undefined
     }
-    current = child
+    parentId = String(current.id)
+  }
+  if (!current) {
+    return undefined
   }
 
   if (
@@ -1045,31 +1062,32 @@ export const publishPageResource = async ({
       })
     }
 
+    // Only the first publish needs the redirect handling below: the shadow
+    // guard (re-publishing an already-live page is fine) and the reference
+    // back-fill (a page that has published before was already back-filled). The
+    // full permalink drives both, so compute it once here.
+    const isFirstPublish = fullResource.publishedVersionId === null
+    const fullPermalink = isFirstPublish
+      ? await getResourceFullPermalink(siteId, Number(resourceId), tx)
+      : null
+
     // First-publish guard: taking a page live at a URL a live redirect occupies
-    // would let the redirect shadow it. Only the first publish is gated
-    // (re-publishing an already-live page is fine). Mirror of the redirect-create
+    // would let the redirect shadow it. Mirror of the redirect-create
     // SOURCE_IS_EXISTING_PAGE guard. The Redirect table is queried directly to
     // avoid a circular import (redirect.service already depends on this module).
-    if (fullResource.publishedVersionId === null) {
-      const fullPermalink = await getResourceFullPermalink(
-        siteId,
-        Number(resourceId),
-        tx,
-      )
-      if (fullPermalink) {
-        const blockingRedirect = await tx
-          .selectFrom("Redirect")
-          .select("Redirect.id")
-          .where("Redirect.siteId", "=", siteId)
-          .where("Redirect.source", "=", normalizeRedirectSource(fullPermalink))
-          .where("Redirect.deletedAt", "is", null)
-          .executeTakeFirst()
-        if (blockingRedirect) {
-          throw new TRPCError({
-            code: "CONFLICT",
-            message: `Can't publish — a redirect already exists at ${fullPermalink}. Remove it on the Redirections page first.`,
-          })
-        }
+    if (isFirstPublish && fullPermalink) {
+      const blockingRedirect = await tx
+        .selectFrom("Redirect")
+        .select("Redirect.id")
+        .where("Redirect.siteId", "=", siteId)
+        .where("Redirect.source", "=", normalizeRedirectSource(fullPermalink))
+        .where("Redirect.deletedAt", "is", null)
+        .executeTakeFirst()
+      if (blockingRedirect) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Can't publish — a redirect already exists at ${fullPermalink}. Remove it on the Redirections page first.`,
+        })
       }
     }
 
@@ -1080,6 +1098,27 @@ export const publishPageResource = async ({
         `No draft found for resource ${resourceId} in site ${siteId}. Publish aborted.`,
       )
       return
+    }
+
+    // Reference back-fill: a redirect created to this page before it existed (or
+    // was published) is stored as a literal path — so it works once the page is
+    // live but does NOT follow the page's future moves. Now that the page is
+    // live at its URL, rewrite those literal destinations into a
+    // [resource:...] reference so they track the page from here on. Scoped to
+    // the first publish and to regular pages (an IndexPage's URL belongs to its
+    // container, whose reference is the container id — handled separately).
+    if (
+      isFirstPublish &&
+      fullPermalink &&
+      fullResource.type !== ResourceType.IndexPage
+    ) {
+      await tx
+        .updateTable("Redirect")
+        .set({ destination: `[resource:${siteId}:${resourceId}]` })
+        .where("siteId", "=", siteId)
+        .where("destination", "=", normalizeRedirectPath(fullPermalink))
+        .where("deletedAt", "is", null)
+        .execute()
     }
 
     const { previousVersion, newVersion } = version

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -33,7 +33,7 @@ import type {
   User,
 } from "../database"
 import type { SearchResultResource } from "./resource.types"
-import { logPublishEvent } from "../audit/audit.service"
+import { logPublishEvent, logRedirectEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceState, ResourceType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
@@ -1118,13 +1118,37 @@ export const publishPageResource = async ({
           ? fullResource.parentId
           : resourceId
       if (referenceId) {
-        await tx
+        const literalDestination = normalizeRedirectPath(fullPermalink)
+        const backfilled = await tx
           .updateTable("Redirect")
           .set({ destination: `[resource:${siteId}:${referenceId}]` })
           .where("siteId", "=", siteId)
-          .where("destination", "=", normalizeRedirectPath(fullPermalink))
+          .where("destination", "=", literalDestination)
           .where("deletedAt", "is", null)
+          .returningAll()
           .execute()
+
+        // Audit the rewrite as a delete of the literal redirect followed by a
+        // create of the reference one — the destination change isn't otherwise
+        // captured, and there's no dedicated RedirectUpdate event.
+        if (backfilled.length > 0) {
+          const byUser = await getUserById(userId)
+          for (const rewritten of backfilled) {
+            const literal = { ...rewritten, destination: literalDestination }
+            await logRedirectEvent(tx, {
+              siteId,
+              by: byUser,
+              eventType: AuditLogEvent.RedirectDelete,
+              delta: { before: literal, after: literal },
+            })
+            await logRedirectEvent(tx, {
+              siteId,
+              by: byUser,
+              eventType: AuditLogEvent.RedirectCreate,
+              delta: { before: null, after: rewritten },
+            })
+          }
+        }
       }
     }
 

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -795,7 +795,12 @@ export const getResourceByFullPermalink = async ({
   siteId: number
   fullPermalink: string
 }) => {
-  const segments = fullPermalink.split("/").filter(Boolean)
+  // A redirect destination may keep a literal "?query"/"#fragment" suffix, which
+  // isn't part of the resource path — strip it before walking segments so
+  // "/page#section" still resolves to the "/page" resource.
+  const segments = (fullPermalink.split(/[?#]/)[0] ?? "")
+    .split("/")
+    .filter(Boolean)
 
   // The site root ("/") is the RootPage, whose permalink is empty so it has no
   // path segments to walk. Resolve it directly.
@@ -1100,25 +1105,27 @@ export const publishPageResource = async ({
       return
     }
 
-    // Reference back-fill: a redirect created to this page before it existed (or
-    // was published) is stored as a literal path — so it works once the page is
-    // live but does NOT follow the page's future moves. Now that the page is
-    // live at its URL, rewrite those literal destinations into a
-    // [resource:...] reference so they track the page from here on. Scoped to
-    // the first publish and to regular pages (an IndexPage's URL belongs to its
-    // container, whose reference is the container id — handled separately).
-    if (
-      isFirstPublish &&
-      fullPermalink &&
-      fullResource.type !== ResourceType.IndexPage
-    ) {
-      await tx
-        .updateTable("Redirect")
-        .set({ destination: `[resource:${siteId}:${resourceId}]` })
-        .where("siteId", "=", siteId)
-        .where("destination", "=", normalizeRedirectPath(fullPermalink))
-        .where("deletedAt", "is", null)
-        .execute()
+    // Reference back-fill: a redirect created to this resource's URL before it
+    // existed (or was published) is stored as a literal path — so it works once
+    // the URL is live but does NOT follow future moves. Now that the URL is
+    // live, rewrite those literal destinations into a [resource:...] reference
+    // so they track the resource from here on. An IndexPage renders at its
+    // container's URL, and creation stores the container id for that path, so
+    // reference the container (parent) id rather than the index page's own id.
+    if (isFirstPublish && fullPermalink) {
+      const referenceId =
+        fullResource.type === ResourceType.IndexPage
+          ? fullResource.parentId
+          : resourceId
+      if (referenceId) {
+        await tx
+          .updateTable("Redirect")
+          .set({ destination: `[resource:${siteId}:${referenceId}]` })
+          .where("siteId", "=", siteId)
+          .where("destination", "=", normalizeRedirectPath(fullPermalink))
+          .where("deletedAt", "is", null)
+          .execute()
+      }
     }
 
     const { previousVersion, newVersion } = version

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -77,7 +77,10 @@ const submitNewRedirect = async (canvasElement: HTMLElement) => {
   const screen = within(canvasElement.ownerDocument.body)
   const sourceInput = await screen.findByPlaceholderText("redirect-from")
   await userEvent.type(sourceInput, "old-page")
-  await userEvent.type(screen.getByPlaceholderText("/redirect-to"), "/new-page")
+  await userEvent.type(
+    screen.getByPlaceholderText("/path-to-page or https://www.google.com"),
+    "/new-page",
+  )
   const addButton = screen.getByRole("button", { name: "Add" })
   await waitFor(() => expect(addButton).toBeEnabled())
   await userEvent.click(addButton, { pointerEventsCheck: 0 })
@@ -154,7 +157,7 @@ export const DestinationNotFoundWarning: Story = {
       "old-page",
     )
     await userEvent.type(
-      screen.getByPlaceholderText("/redirect-to"),
+      screen.getByPlaceholderText("/path-to-page or https://www.google.com"),
       "/no-page",
     )
     // Blur the destination to trigger the on-blur validate call.

--- a/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
+++ b/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Box } from "@chakra-ui/react"
 import { useSetAtom } from "jotai"
 import { useEffect } from "react"
-import { userEvent, within } from "storybook/test"
+import { expect, userEvent, within } from "storybook/test"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { pageSettingsModalAtom } from "~/features/dashboard/atoms"
@@ -20,8 +20,9 @@ const OpenedPageSettingsModal = (): JSX.Element => {
   return <PageSettingsModal />
 }
 
-// readPage supplies the title; getPermalinkTree.withParent makes the page live
-// at /newsroom/collection-page, which is the path checked against redirects.
+// readPage supplies the title and (here) a published page, so the redirect
+// option can surface; getPermalinkTree.withParent makes the page live at
+// /newsroom/collection-page, which is the path checked against redirects.
 const BASE_HANDLERS = [
   ...ADMIN_HANDLERS,
   // Published page so the "Redirect page automatically" option can appear when
@@ -29,6 +30,7 @@ const BASE_HANDLERS = [
   pageHandlers.readPage.homepage({
     title: "Contact us",
     publishedVersionId: "1",
+    state: "Published",
   }),
   pageHandlers.getPermalinkTree.withParent(),
 ]
@@ -89,5 +91,34 @@ export const RedirectOptionShown: Story = {
     )
     await userEvent.clear(urlInput)
     await userEvent.type(urlInput, "renamed-page")
+  },
+}
+
+// An unpublished page has no live URL to preserve, so changing its URL must NOT
+// offer the redirect option even though the URL changed.
+export const UnpublishedPageHidesRedirectOption: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...ADMIN_HANDLERS,
+        pageHandlers.readPage.homepage({
+          title: "Contact us",
+          publishedVersionId: null,
+          state: "Draft",
+        }),
+        pageHandlers.getPermalinkTree.withParent(),
+        redirectHandlers.getBySource.none(),
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body)
+    const urlInput = await body.findByPlaceholderText(
+      "URL will be autopopulated if left untouched",
+    )
+    await userEvent.clear(urlInput)
+    await userEvent.type(urlInput, "renamed-page")
+    // The "Redirect page automatically" option must not appear.
+    await expect(body.queryByText("Redirect page automatically")).toBeNull()
   },
 }


### PR DESCRIPTION
## Problem

This branch bundles two threads of work on the redirects feature:

1. **Design & copy** — the destination page selector didn't match the intended design.
2. **Validation & reference handling** — a set of correctness issues surfaced during dogfooding (source-shadow guard missing top-level/container URLs, literal destinations that never became references, unsupported wildcards, untrimmed whitespace, and a stale search cache after folder renames).

## Solution

### Design & copy (destination selector)

- The destination field now shows a **"Redirect to a page on your site"** dropdown option while focused, replacing the always-visible "Link to a page" standalone button. A placeholder (`/path-to-page or https://www.google.com`) clarifies the accepted input.
- The `SelectDestinationPageModal` header is updated to **"Redirect to a page on your site"** with a "Redirect to…" subheading, the confirm button reads **"Redirect here"** (was "Use this page"), and the Cancel button is removed.
- A `mousedown` on the dropdown button is prevented so the input keeps focus and the click registers before blur hides the dropdown.
- Empty-state placeholder, table column sizing, tooltip-only-on-truncation, infobox sizing/colour, and checkbox sizing adjustments.

### Validation & reference handling

- **Source-shadow guard** now resolves **top-level** and **container (folder/collection)** URLs correctly. The full-permalink resolver walks from `parentId = null` (matching the storage resolver) instead of the root page's id, so a redirect whose source is a live top-level page — or a live folder/collection index — is correctly blocked from shadowing it.
- **Reference back-fill on first publish**: a redirect created to a path before the page exists is stored as a literal path (so it works immediately) and is rewritten to a `[resource:…]` reference when that page is first published, so it tracks the page's future moves.
- **Wildcard sources rejected** with a clear message instead of silently creating a dead redirect.
- **Source and destination are trimmed** of surrounding whitespace before validation.
- **Resource search cache invalidated on folder rename**, so renamed folders appear in search immediately.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

## Before & After Screenshots

**AFTER** (focused destination field with the redesigned dropdown):

<!-- attach scratchpad/redirects-after-styling.png -->
<img width="1999" height="1066" alt="image" src="https://github.com/user-attachments/assets/cc60f1a2-599b-443b-ac2c-16e0513e3df7" />


## Tests

Unit + integration coverage added/updated (all green):

- Redirect schema — wildcard rejection and source/destination trim.
- Redirect router — source guard errors for a live folder (published index) and top-level page.
- Page router — reference back-fill on first publish, and leaving unrelated literal destinations untouched.

**Manual Verification Steps**:

- [ ] Focus the destination field and confirm the "Redirect to a page on your site" dropdown appears; select a page and confirm the field is populated.
- [ ] Confirm the modal title reads "Redirect to a page on your site" and the confirm button reads "Redirect here".
- [ ] Add a redirect whose source is a live top-level page's URL and confirm it's blocked.
- [ ] Enter a wildcard (`/promo/*`) source and confirm it's rejected.
- [ ] Create a redirect to a not-yet-existing path, then create + publish a page there, and confirm the stored destination becomes a `[resource:…]` reference.
- [ ] Rename a folder and confirm it appears under its new name in search without a reload.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related threads on the redirects feature: UI/UX design improvements to the destination selector (focused dropdown, updated modal copy, middle-truncation for long paths), and several server-side correctness fixes (source-shadow guard now resolves top-level/container URLs, literal destinations are back-filled to `[resource:…]` references on first publish, wildcards are rejected, whitespace is trimmed, and the resource search cache is invalidated on folder rename).

- **`getResourceByFullPermalink` refactor** — the old implementation walked from `RootPage.id` instead of `parentId = null`, silently missing every top-level resource; the new in-memory walk with a single bulk candidate query matches how resources are actually stored, and now strips `?`/`#` suffixes before path resolution.
- **Reference back-fill on first publish** — `publishPageResource` now rewrites all literal-path redirect destinations that match the newly-live page's permalink into `[resource:…]` references, including IndexPage publishes (which back-fill to the container's id); an audit log pair (delete + create) is written for each rewritten row.
- **Schema fixes** — `.trim()` added to both `sourceSchema` and `destinationSchema`, wildcard rejection via `.refine`, and the internal-path `#fragment` restriction removed (fragment-suffixed destinations now resolve to the underlying page resource).
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The core logic changes are correct and well-tested; the source-shadow guard and reference back-fill both execute atomically within the publish transaction.

The three main server-side fixes — getResourceByFullPermalink walking from parentId=null, back-filling literal destinations to references on first publish, and resolving unpublished resources to references immediately — are all correct and backed by targeted integration tests. The UI changes are straightforward styling and copy updates. The one anomaly (audit log after: literal on the back-fill delete event) is a record-keeping inconsistency that does not affect redirect correctness or the publish flow.

apps/studio/src/server/modules/resource/resource.service.ts — the back-fill audit delete event records the before-state in both before and after, inconsistent with how other delete events capture the post-state.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/resource/resource.service.ts | Core fix: getResourceByFullPermalink now starts the walk from parentId=null and uses a single bulk query; publishPageResource gains first-publish reference back-fill with audit logging. The delete-event audit log entry emits after: literal (the before-state) rather than the expected post-state, making that audit record semantically inconsistent with the existing soft-delete convention. |
| apps/studio/src/server/modules/redirect/redirect.service.ts | resolveDestinationForStorage now resolves unpublished resources to references; # check added to the literal-path pass-through; dbNow replaces new Date() for consistent DB-side timestamps. Logic is clean and aligns with updated tests. |
| apps/studio/src/schemas/redirect.ts | Adds .trim() to both sourceSchema and destinationSchema, wildcard rejection with a clear message, and removes the internal-path #fragment restriction. Changes are correct and well-tested. |
| apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx | Destination field redesigned: focus-triggered dropdown replaces standalone Link to a page button. mousedown preventDefault correctly keeps input focus so the click lands before blur hides the dropdown. Clean implementation. |
| apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx | Extracts SourceCell with tooltip-only-on-truncation and middle-truncation rendering; reduces publishedAt column width; replaces generic EmptyTablePlaceholder with a redirects-specific one. Well-structured refactor. |
| apps/studio/src/hooks/useIsTruncated.ts | New hook: ResizeObserver-based truncation tracker using a callback ref. Correctly handles node remounts (Skeleton to real content), StrictMode double-invocation, and environments without ResizeObserver. |
| apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx | Adds utils.resource.search.invalidate() on successful folder rename, keeping the resource search cache in sync. Small, correct change. |
| apps/studio/src/server/modules/page/__tests__/page.router.test.ts | Adds three new back-fill tests: literal-to-reference for a regular page, unchanged redirect for an unrelated page, and container reference for an IndexPage publish. Tests are well-structured and cover the key paths. |
| apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts | Fixes test setup: top-level resources now seeded with parentId=null (matching production); adds source-guard test for live folder (published index); updates create tests to expect references for unpublished destinations. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant Router as page.router
    participant Service as resource.service
    participant DB

    User->>Router: publishPage(siteId, pageId)
    Router->>Service: publishPageResource(...)
    Service->>DB: "SELECT fullResource WHERE id=pageId"
    Service-->>Service: "isFirstPublish = (publishedVersionId === null)"
    
    alt isFirstPublish
        Service->>Service: getResourceFullPermalink(siteId, pageId, tx)
        Note over Service: Walk from parentId=null (not from RootPage.id)
        
        Service->>DB: "SELECT Redirect WHERE source = normalizedPermalink"
        alt blocking redirect exists
            Service-->>Router: throw CONFLICT
        end
        
        Service->>DB: incrementVersion(...)
        
        Note over Service: Reference back-fill
        alt "fullResource.type === IndexPage"
            Service-->>Service: "referenceId = fullResource.parentId (container)"
        else
            Service-->>Service: "referenceId = resourceId"
        end
        
        Service->>DB: "UPDATE Redirect SET destination=[resource:siteId:referenceId] WHERE destination = literalPath"
        DB-->>Service: backfilled rows
        
        alt "backfilled.length > 0"
            Service->>DB: logRedirectEvent(DELETE literal)
            Service->>DB: logRedirectEvent(CREATE reference)
        end
    end
    
    Service->>DB: logPublishEvent(...)
    Service->>DB: publishSite(...)
    Service-->>Router: success
    Router-->>User: undefined
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant Router as page.router
    participant Service as resource.service
    participant DB

    User->>Router: publishPage(siteId, pageId)
    Router->>Service: publishPageResource(...)
    Service->>DB: "SELECT fullResource WHERE id=pageId"
    Service-->>Service: "isFirstPublish = (publishedVersionId === null)"
    
    alt isFirstPublish
        Service->>Service: getResourceFullPermalink(siteId, pageId, tx)
        Note over Service: Walk from parentId=null (not from RootPage.id)
        
        Service->>DB: "SELECT Redirect WHERE source = normalizedPermalink"
        alt blocking redirect exists
            Service-->>Router: throw CONFLICT
        end
        
        Service->>DB: incrementVersion(...)
        
        Note over Service: Reference back-fill
        alt "fullResource.type === IndexPage"
            Service-->>Service: "referenceId = fullResource.parentId (container)"
        else
            Service-->>Service: "referenceId = resourceId"
        end
        
        Service->>DB: "UPDATE Redirect SET destination=[resource:siteId:referenceId] WHERE destination = literalPath"
        DB-->>Service: backfilled rows
        
        alt "backfilled.length > 0"
            Service->>DB: logRedirectEvent(DELETE literal)
            Service->>DB: logRedirectEvent(CREATE reference)
        end
    end
    
    Service->>DB: logPublishEvent(...)
    Service->>DB: publishSite(...)
    Service-->>Router: success
    Router-->>User: undefined
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Claimed trim and wildcard behavior is unchanged from base**

   - **Bug**
     - The validation objective says redirect creation/validation now trims surrounding whitespace and now rejects wildcard source paths such as `/promo/*`. Running the same schema scenarios on base and head produced identical results: base already trims the padded source/destination and already rejects `/promo/*` with the claimed clear message. This contradicts the change contract that these behaviors are newly introduced at head.
   - **Cause**
     - The claimed behavior is already present in the base revision in `apps/studio/src/schemas/redirect.ts`: the source and destination schemas trim strings before validation/storage, and the source schema rejects `*` with `Wildcards aren't supported yet — enter the full path`.
   - **Fix**
     - Update the PR/validation contract to remove these already-existing behaviors from the claimed delta, or adjust the patch if a different new behavior was intended. Re-run router-level validation for source-shadow behavior in an environment with a working container runtime.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (5): Last reviewed commit: ["feat(studio): middle-truncate redirect s..."](https://github.com/opengovsg/isomer/commit/279ff5fa00f2488c458ef8349a846871e642c657) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746559)</sub>

<!-- /greptile_comment -->