### PR TITLE
fix: handle footer publish failures

### DIFF
--- a/apps/studio/src/features/settings/FooterEditor/FooterEditor.tsx
+++ b/apps/studio/src/features/settings/FooterEditor/FooterEditor.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from "@opengovsg/design-system-react"
 import { FooterSchema } from "@opengovsg/isomer-components"
 import { isEmpty, isEqual } from "lodash-es"
-import { useCallback, useState } from "react"
+import { useCallback, useMemo } from "react"
 import { BiDirections } from "react-icons/bi"
 import { FORM_BUILDER_PARENT_ID } from "~/features/editing-experience/components/form-builder/constants"
 import {
@@ -24,6 +24,7 @@ import { Can } from "~/features/permissions"
 import { ajv } from "~/utils/ajv"
 
 interface FooterEditorProps {
+  savedFooterState: FooterSchemaType
   previewFooterState?: FooterSchemaType
   setPreviewFooterState: Dispatch<SetStateAction<FooterSchemaType | undefined>>
   onSave: (data?: FooterSchemaType) => void
@@ -31,12 +32,15 @@ interface FooterEditorProps {
 }
 
 export const FooterEditor = ({
+  savedFooterState,
   previewFooterState,
   setPreviewFooterState,
   onSave,
   isSaving,
 }: FooterEditorProps) => {
-  const [isDirty, setIsDirty] = useState(false)
+  const isDirty = useMemo(() => {
+    return !isEqual(previewFooterState, savedFooterState)
+  }, [previewFooterState, savedFooterState])
 
   const validateFn = ajv.compile<FooterSchemaType>(FooterSchema)
 
@@ -44,7 +48,6 @@ export const FooterEditor = ({
     (data: FooterSchemaType) => {
       if (!isEqual(previewFooterState, data)) {
         setPreviewFooterState(data)
-        setIsDirty(true)
       }
     },
     [previewFooterState, setPreviewFooterState],
@@ -52,7 +55,6 @@ export const FooterEditor = ({
 
   const handleSave = () => {
     onSave(previewFooterState)
-    setIsDirty(false)
   }
 
   return (

--- a/apps/studio/src/pages/sites/[siteId]/settings/footer.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/footer.tsx
@@ -8,6 +8,7 @@ import {
   SettingsGrid,
   SettingsPreviewGridItem,
 } from "~/components/Settings"
+import { ISOMER_SUPPORT_EMAIL } from "~/constants/misc"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
@@ -42,6 +43,14 @@ const FooterSettingsPage: NextPageWithLayout = () => {
           ...BRIEF_TOAST_SETTINGS,
         })
       },
+      onError: () => {
+        toast({
+          status: "error",
+          title: "Error saving footer.",
+          description: `If this persists, please report this issue at ${ISOMER_SUPPORT_EMAIL}`,
+          ...BRIEF_TOAST_SETTINGS,
+        })
+      },
     })
 
   const [previewFooterState, setPreviewFooterState] = useState<
@@ -68,6 +77,7 @@ const FooterSettingsPage: NextPageWithLayout = () => {
       <SettingsGrid>
         <SettingsEditorGridItem>
           <FooterEditor
+            savedFooterState={content}
             previewFooterState={previewFooterState}
             setPreviewFooterState={setPreviewFooterState}
             onSave={handleSaveFooter}


### PR DESCRIPTION
## Problem

The footer settings page silently failed when publishing footer changes errored. Users did not see error feedback, and the Publish button became disabled because the editor marked itself clean before the async save completed.

Closes #2390

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Added an error toast for failed footer publish attempts.
- Changed footer dirty-state handling to compare preview footer content against the saved footer content, matching the navbar settings pattern.
- Keeps the Publish button enabled after a failed save so users can retry without making another edit.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<img width="747" height="168" alt="Screenshot 2026-06-23 at 11 06 59 PM" src="https://github.com/user-attachments/assets/234c6cd6-3942-474f-80ce-275ad83558a7" />

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Edit code to force `setFooter` to fail.
- [ ] Update the footer and click Publish.
- [ ] Verify the error toast appears and Publish becomes enabled again.
- [ ] Remove the forced failure and verify footer publishing succeeds.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
