### PR TITLE
fix: show singpass login errors

### DIFF
--- a/apps/studio/src/features/sign-in/components/SingpassLogin/SingpassLoginButton.tsx
+++ b/apps/studio/src/features/sign-in/components/SingpassLogin/SingpassLoginButton.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Text } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { useRouter } from "next/router"
 import { SingpassFullLogo } from "~/components/Svg/SingpassFullLogo"
-import { SIGN_IN } from "~/lib/routes"
+import { SIGN_IN_SINGPASS } from "~/lib/routes"
 import { trpc } from "~/utils/trpc"
 import { getRedirectUrl } from "~/utils/url"
 
@@ -12,8 +12,8 @@ export const SingpassLoginButton = (): JSX.Element | null => {
     onSuccess: async ({ redirectUrl }) => {
       await router.push(redirectUrl)
     },
-    onError: async (error) => {
-      await router.push(`${SIGN_IN}?error=${error.message}`)
+    onError: async () => {
+      await router.push(`${SIGN_IN_SINGPASS}?error=true`)
     },
   })
 


### PR DESCRIPTION
## Problem

Singpass login failures redirected users to `/sign-in?error=...`, but the `/sign-in` page does not read the `error` query param. As a result, the error was silently discarded and users received no feedback.

Closes #2383

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Redirect failed Singpass login attempts to `/sign-in/singpass?error=true`.
- Reuses the existing Singpass error infobox behavior already used by the callback error path.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Edit code to force `auth.singpass.login` to fail.
- [ ] Click the Singpass authentication button.
- [ ] Verify the page redirects to `/sign-in/singpass?error=true`.
- [ ] Verify the Singpass error infobox appears.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where Singpass login failures silently discarded error messages — the `onError` handler redirected to `/sign-in?error=${error.message}`, but the `/sign-in` page never read the `error` query param. The fix redirects to `/sign-in/singpass?error=true` instead, which already has an error infobox wired to `Boolean(router.query.error)`.

- Removes the raw `error.message` from the redirect URL, eliminating a potential info-disclosure path where internal TRPC error messages could appear in browser address bars, server logs, or analytics pipelines.
- Aligns the login-button error path with the existing callback error path in `SingpassCallback.tsx`, which already used `SIGN_IN_SINGPASS?error=true`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge — it narrows a two-line error handler to redirect to the correct page with a fixed opaque flag, removing a raw error-message exposure from URLs.

The diff is minimal: one import swap and two changed lines in an error callback. The redirect target (/sign-in/singpass?error=true) is already used by the SingpassCallback component for the same purpose, and the destination page's isSingpassError = Boolean(router.query.error) guard is already tested by that existing path. Dropping error.message from the URL is a straightforward security improvement with no behavioral regressions.

No files require special attention. The only file changed is SingpassLoginButton.tsx, and the fix aligns it with the already-working callback error path.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/sign-in/components/SingpassLogin/SingpassLoginButton.tsx | Two-line fix: changes onError redirect target from /sign-in (which ignored error param) to /sign-in/singpass?error=true (which already displays the error infobox), and drops the raw error.message from the URL. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant SingpassLoginButton
    participant tRPC as tRPC (auth.singpass.login)
    participant Router

    User->>SingpassLoginButton: clicks "Authenticate with Singpass"
    SingpassLoginButton->>tRPC: "mutate({ landingUrl })"
    alt Success
        tRPC-->>SingpassLoginButton: "{ redirectUrl: authorizationUrl }"
        SingpassLoginButton->>Router: push(redirectUrl)
        Router-->>User: redirect to Singpass authorization page
    else Error (BEFORE fix)
        tRPC-->>SingpassLoginButton: TRPCError
        SingpassLoginButton->>Router: "push("/sign-in?error=error.message")"
        Router-->>User: /sign-in page (error param silently ignored)
    else Error (AFTER fix)
        tRPC-->>SingpassLoginButton: TRPCError
        SingpassLoginButton->>Router: "push("/sign-in/singpass?error=true")"
        Router-->>User: /sign-in/singpass page shows error infobox
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant SingpassLoginButton
    participant tRPC as tRPC (auth.singpass.login)
    participant Router

    User->>SingpassLoginButton: clicks "Authenticate with Singpass"
    SingpassLoginButton->>tRPC: "mutate({ landingUrl })"
    alt Success
        tRPC-->>SingpassLoginButton: "{ redirectUrl: authorizationUrl }"
        SingpassLoginButton->>Router: push(redirectUrl)
        Router-->>User: redirect to Singpass authorization page
    else Error (BEFORE fix)
        tRPC-->>SingpassLoginButton: TRPCError
        SingpassLoginButton->>Router: "push("/sign-in?error=error.message")"
        Router-->>User: /sign-in page (error param silently ignored)
    else Error (AFTER fix)
        tRPC-->>SingpassLoginButton: TRPCError
        SingpassLoginButton->>Router: "push("/sign-in/singpass?error=true")"
        Router-->>User: /sign-in/singpass page shows error infobox
    end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: show singpass login errors"](https://github.com/opengovsg/isomer/commit/cbef3a39d5e36360ed8ea2b3f6d3ded6df85ebe8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39746556)</sub>

<!-- /greptile_comment -->