### PR TITLE
Chore: uat feedback for eGazette

### DIFF
--- a/apps/studio/src/features/gazettes/components/GazetteTable/CategoryCell.tsx
+++ b/apps/studio/src/features/gazettes/components/GazetteTable/CategoryCell.tsx
@@ -18,7 +18,7 @@ export const CategoryCell = ({
       <Text textStyle="subhead-2" color="base.content.strong">
         {category}
       </Text>
-      <Text textStyle="caption-2" color="base.content.medium">
+      <Text textStyle="caption-2" color="base.content.medium" fontSize="sm">
         {subcategoryMap[subcategory] ?? subcategory}
       </Text>
     </VStack>

--- a/apps/studio/src/features/gazettes/constants.ts
+++ b/apps/studio/src/features/gazettes/constants.ts
@@ -1,14 +1,18 @@
-export const GAZETTE_CATEGORIES: { label: string; value: string }[] = [
-  { label: "Government Gazette", value: "Government Gazette" },
-  { label: "Legislative Supplements", value: "Legislative Supplements" },
-  { label: "Other Supplements", value: "Other Supplements" },
-]
-
+// Single source of truth for gazette category values. The SingleSelect items
+// (`GAZETTE_CATEGORIES`) and the `GazettesCategory` union (see ./types) are both
+// derived from this, so a category only ever needs to be declared once here.
 export const GazetteCategories = {
   GovernmentGazettes: "Government Gazette",
   LegislativeSupplements: "Legislative Supplements",
   OtherSupplements: "Other Supplements",
-}
+} as const
+
+// SingleSelect items — label and value are identical for gazette categories.
+export const GAZETTE_CATEGORIES: { label: string; value: string }[] =
+  Object.values(GazetteCategories).map((category) => ({
+    label: category,
+    value: category,
+  }))
 
 export const GAZETTE_SUBCATEGORY_LABEL = "Sub-category"
 

--- a/apps/studio/src/features/gazettes/constants.ts
+++ b/apps/studio/src/features/gazettes/constants.ts
@@ -1,12 +1,12 @@
 export const GAZETTE_CATEGORIES: { label: string; value: string }[] = [
   { label: "Government Gazette", value: "Government Gazette" },
-  { label: "Legislation Supplements", value: "Legislation Supplements" },
+  { label: "Legislative Supplements", value: "Legislative Supplements" },
   { label: "Other Supplements", value: "Other Supplements" },
 ]
 
 export const GazetteCategories = {
   GovernmentGazettes: "Government Gazette",
-  LegislationSupplements: "Legislation Supplements",
+  LegislativeSupplements: "Legislative Supplements",
   OtherSupplements: "Other Supplements",
 }
 

--- a/apps/studio/src/features/gazettes/constants.ts
+++ b/apps/studio/src/features/gazettes/constants.ts
@@ -4,6 +4,12 @@ export const GAZETTE_CATEGORIES: { label: string; value: string }[] = [
   { label: "Other Supplements", value: "Other Supplements" },
 ]
 
+export const GazetteCategories = {
+  GovernmentGazettes: "Government Gazette",
+  LegislationSupplements: "Legislation Supplements",
+  OtherSupplements: "Other Supplements",
+}
+
 export const GAZETTE_SUBCATEGORY_LABEL = "Sub-category"
 
 export const governmentGazetteSubcategories = {

--- a/apps/studio/src/features/gazettes/contexts/GazetteSubcategoriesContext.tsx
+++ b/apps/studio/src/features/gazettes/contexts/GazetteSubcategoriesContext.tsx
@@ -70,7 +70,7 @@ export const GazetteSubcategoriesProvider = ({
           })
         }
 
-        case "Legislation Supplements": {
+        case "Legislative Supplements": {
           return filter(subcategories, ({ label }) => {
             return legislativeSupplementsSubcategoriesKeys.some(
               (key) => key === label,

--- a/apps/studio/src/features/gazettes/types.ts
+++ b/apps/studio/src/features/gazettes/types.ts
@@ -1,4 +1,4 @@
 export type GazettesCategory =
   | "Government Gazette"
-  | "Legislation Supplements"
+  | "Legislative Supplements"
   | "Other Supplements"

--- a/apps/studio/src/features/gazettes/types.ts
+++ b/apps/studio/src/features/gazettes/types.ts
@@ -1,4 +1,4 @@
+import type { GazetteCategories } from "./constants"
+
 export type GazettesCategory =
-  | "Government Gazette"
-  | "Legislative Supplements"
-  | "Other Supplements"
+  (typeof GazetteCategories)[keyof typeof GazetteCategories]

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -345,6 +345,87 @@ describe("gazette.router", async () => {
         }),
       )
     })
+
+    it("rejects creation for a non-Government Gazette category when notification number, year and subcategory all match", async () => {
+      // Arrange
+      const { site, collection } = await seedToppanWithCollection()
+
+      await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "First Supplement",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/first-file.pdf",
+        category: "Legislative Supplements",
+        date: "30/04/2026",
+        description: "N-2026-001",
+        tagged: ["Acts Supplement"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Act & Assert: same notification number + same year + same subcategory is a duplicate
+      await expect(
+        caller.create({
+          siteId: site.id,
+          collectionId: Number(collection.id),
+          title: "Second Supplement",
+          permalink: crypto.randomUUID(),
+          ref: "/sites/1/gazettes/uuid2/second-file.pdf", // Different filename
+          category: "Legislative Supplements",
+          date: "30/04/2026",
+          description: "N-2026-001", // Same notification number
+          tagged: ["Acts Supplement"], // Same subcategory
+          scheduledAt: PAST_DATE,
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A gazette with the same notification number already exists",
+        }),
+      )
+    })
+
+    it("allows creation for a non-Government Gazette category when the subcategory differs, even with the same notification number and year", async () => {
+      // Arrange
+      const { site, collection } = await seedToppanWithCollection()
+
+      await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "First Supplement",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/first-file.pdf",
+        category: "Legislative Supplements",
+        date: "30/04/2026",
+        description: "N-2026-001",
+        tagged: ["Acts Supplement"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Act: same notification number + same year but a different subcategory.
+      // For non-Government Gazette categories the subcategory disambiguates, so
+      // this is not a duplicate and must be allowed.
+      const { gazetteId } = await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "Second Supplement",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid2/second-file.pdf",
+        category: "Legislative Supplements",
+        date: "30/04/2026",
+        description: "N-2026-001", // Same notification number
+        tagged: ["Bills Supplement"], // Different subcategory
+        scheduledAt: PAST_DATE,
+      })
+
+      // Assert: the second gazette was created
+      const resource = await db
+        .selectFrom("Resource")
+        .where("id", "=", String(gazetteId))
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(resource.title).toBe("Second Supplement")
+    })
   })
 
   describe("update", () => {

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -305,6 +305,46 @@ describe("gazette.router", async () => {
         }),
       )
     })
+
+    it("rejects creation when a gazette with the same notification number already exists", async () => {
+      // Arrange
+      const { site, collection } = await seedToppanWithCollection()
+
+      // Create first gazette with a specific notification number
+      await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "First Notice",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/first-file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        description: "N-2026-001",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Act & Assert: creating a second gazette with the same notification number is rejected
+      await expect(
+        caller.create({
+          siteId: site.id,
+          collectionId: Number(collection.id),
+          title: "Second Notice",
+          permalink: crypto.randomUUID(),
+          ref: "/sites/1/gazettes/uuid2/second-file.pdf", // Different filename
+          category: "Government Gazette",
+          date: "30/04/2026",
+          description: "N-2026-001", // Same notification number
+          tagged: ["sub-1"],
+          scheduledAt: PAST_DATE,
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A gazette with the same notification number already exists",
+        }),
+      )
+    })
   })
 
   describe("update", () => {
@@ -453,6 +493,96 @@ describe("gazette.router", async () => {
           message: "A gazette with the same file ID already exists",
         }),
       )
+    })
+
+    it("rejects update when changing to a notification number that already exists", async () => {
+      // Arrange
+      const { site, collection } = await seedToppanWithCollection()
+
+      // Create first gazette with a notification number
+      await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "First Notice",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/first-file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        description: "N-2026-001",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Create second gazette with a different notification number
+      const { gazetteId } = await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "Second Notice",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid2/second-file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        description: "N-2026-002",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Act & Assert: updating to a notification number used by another gazette is rejected
+      await expect(
+        caller.update({
+          siteId: site.id,
+          gazetteId: Number(gazetteId),
+          title: "Second Notice",
+          category: "Government Gazette",
+          date: "30/04/2026",
+          description: "N-2026-001", // Same notification number as first
+          tagged: ["sub-1"],
+          scheduledAt: PAST_DATE,
+        }),
+      ).rejects.toThrowError(
+        new TRPCError({
+          code: "CONFLICT",
+          message: "A gazette with the same notification number already exists",
+        }),
+      )
+    })
+
+    it("allows update that keeps the gazette's own notification number", async () => {
+      // Arrange
+      const { site, collection } = await seedToppanWithCollection()
+      const { gazetteId } = await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "Original",
+        permalink: crypto.randomUUID(),
+        ref: "/sites/1/gazettes/uuid1/file.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        description: "N-2026-001",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Act: editing other fields while retaining the same notification number
+      // must not trip the duplicate check against the gazette's own record.
+      await caller.update({
+        siteId: site.id,
+        gazetteId: Number(gazetteId),
+        title: "Renamed",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        description: "N-2026-001", // Unchanged
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Assert
+      const resource = await db
+        .selectFrom("Resource")
+        .where("id", "=", String(gazetteId))
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(resource.title).toBe("Renamed")
     })
   })
 

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -125,7 +125,7 @@ export const gazetteRouter = router({
             .case()
             .when(categoryExpr, "=", "Government Gazette")
             .then(1)
-            .when(categoryExpr, "=", "Legislation Supplements")
+            .when(categoryExpr, "=", "Legislative Supplements")
             .then(2)
             .when(categoryExpr, "=", "Other Supplements")
             .then(3)

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -34,6 +34,7 @@ import {
 } from "../resource/resource.service"
 import {
   findCollectionLinkWithFilename,
+  hasDuplicateNotificationNumber,
   assertGazetteAccess,
   copyFileWithNewName,
   deleteGazetteAsset,
@@ -248,6 +249,28 @@ export const gazetteRouter = router({
               })
             }
           }
+
+          // Reject a duplicate notification number within the same category and
+          // publish year (and subcategory, for non-Government Gazette categories).
+          if (
+            description &&
+            (await hasDuplicateNotificationNumber({
+              trx: tx,
+              siteId,
+              parentId: String(collectionId),
+              notificationNumber: description,
+              publishDate: date,
+              category,
+              subCategory: tagged[0] ?? "",
+            }))
+          ) {
+            throw new TRPCError({
+              code: "CONFLICT",
+              message:
+                "A gazette with the same notification number already exists",
+            })
+          }
+
           const parentCollection = await tx
             .selectFrom("Resource")
             .where("Resource.id", "=", String(collectionId))
@@ -473,6 +496,29 @@ export const gazetteRouter = router({
                   message: "A gazette with the same file ID already exists",
                 })
               }
+            }
+
+            // Reject a duplicate notification number within the same category
+            // and publish year (and subcategory, for non-Government Gazette
+            // categories), excluding the gazette being edited.
+            if (
+              description &&
+              (await hasDuplicateNotificationNumber({
+                trx: tx,
+                siteId,
+                parentId: existingResource.parentId,
+                notificationNumber: description,
+                publishDate: date,
+                category,
+                subCategory: tagged[0] ?? "",
+                excludeId: String(gazetteId),
+              }))
+            ) {
+              throw new TRPCError({
+                code: "CONFLICT",
+                message:
+                  "A gazette with the same notification number already exists",
+              })
             }
 
             const updatedBlob = await updateBlobById(tx, {

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -116,9 +116,7 @@ export const gazetteRouter = router({
             END`,
           "asc",
         )
-        // 2. Publish date descending
-        .orderBy("Version.publishedAt", (ob) => ob.desc())
-        // 3. Category priority from blob content
+        // 2. Category priority from blob content
         .orderBy((eb) => {
           const categoryExpr = sql<string>`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'category'`
           return eb
@@ -132,16 +130,21 @@ export const gazetteRouter = router({
             .else(4)
             .end()
         }, "asc")
-        // 4. Notification number descending (stored in page.description)
+        // 3. Notification number descending (stored in page.description)
         .orderBy(
           sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'description'`,
           (ob) => ob.desc(),
         )
-        // 5. File ID descending (extract filename from page.ref)
+        // 4. Toppan file ID descending — the last path segment of page.ref.
+        //    e.g. "/2026/Government Gazette/Advertisements/26adv6175b.pdf"
+        //    -> "26adv6175b.pdf". Strip everything up to the final slash so we
+        //    sort on the file ID, not the full path.
         .orderBy(
-          sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref'`,
+          sql`regexp_replace(COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref', '.*/', '')`,
           (ob) => ob.desc(),
         )
+        // 5. Publish date descending
+        .orderBy("Version.publishedAt", (ob) => ob.desc())
         // 6. Updated at descending (tie-breaker)
         .orderBy("Resource.updatedAt", "desc")
         .orderBy("Resource.id", "asc")

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -117,7 +117,7 @@ export const gazetteRouter = router({
           "asc",
         )
         // 2. Publish date descending
-        .orderBy("Version.publishedAt", (ob) => ob.desc().nullsLast())
+        .orderBy("Version.publishedAt", (ob) => ob.desc())
         // 3. Category priority from blob content
         .orderBy((eb) => {
           const categoryExpr = sql<string>`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'category'`
@@ -135,12 +135,12 @@ export const gazetteRouter = router({
         // 4. Notification number descending (stored in page.description)
         .orderBy(
           sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'description'`,
-          (ob) => ob.desc().nullsLast(),
+          (ob) => ob.desc(),
         )
         // 5. File ID descending (extract filename from page.ref)
         .orderBy(
           sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref'`,
-          (ob) => ob.desc().nullsLast(),
+          (ob) => ob.desc(),
         )
         // 6. Updated at descending (tie-breaker)
         .orderBy("Resource.updatedAt", "desc")

--- a/apps/studio/src/server/modules/gazette/gazette.service.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.service.ts
@@ -4,6 +4,7 @@ import filenamify from "filenamify"
 import { PdfReader } from "pdfreader"
 import { TOPPAN_EMAIL_DOMAIN } from "~/constants/toppan"
 import { env } from "~/env.mjs"
+import { GazetteCategories } from "~/features/gazettes/constants"
 import { deleteObjectsFromSearchIndexByFilter } from "~/lib/algolia"
 import { createBaseLogger } from "~/lib/logger"
 import {
@@ -490,4 +491,73 @@ export const pushDocumentsForIngestion = async (documents: PushDocument[]) => {
     { count: documents.length },
     "Successfully pushed documents for ingestion",
   )
+}
+
+/**
+ * Detects whether another gazette in the same collection already uses the
+ * given notification number. A gazette is a duplicate when it shares the
+ * same notification number, category and publish year. For non-Government
+ * Gazette categories the subcategory must match too — Government Gazette
+ * numbers are unique within the category, not the subcategory.
+ *
+ * Gazette metadata lives in the resource's draft (or published) blob:
+ * `content.page.{description,category,date,tagged}`. `date` is stored as a
+ * "dd/MM/yyyy" string, so the year is its third "/"-delimited segment.
+ * Deleted gazettes are hard-deleted, so no soft-delete filter is needed.
+ */
+export const hasDuplicateNotificationNumber = async ({
+  trx = db,
+  siteId,
+  parentId,
+  notificationNumber,
+  publishDate,
+  category,
+  subCategory,
+  excludeId,
+}: {
+  trx?: Kysely<DB> | Transaction<DB>
+  siteId: number
+  parentId: string | null
+  notificationNumber: string
+  publishDate: string
+  category: string
+  subCategory: string
+  excludeId?: string
+}): Promise<boolean> => {
+  const isGovernmentGazette = category === GazetteCategories.GovernmentGazettes
+  // publishDate is a "dd/MM/yyyy" string — the year is the last segment.
+  const publishYear = publishDate.split("/").at(-1)
+
+  const content = sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")`
+
+  let query = trx
+    .selectFrom("Resource")
+    .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
+    .leftJoin("Version", "Resource.publishedVersionId", "Version.id")
+    .leftJoin("Blob as PublishedBlob", "Version.blobId", "PublishedBlob.id")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.parentId", "=", parentId)
+    .where("Resource.type", "=", ResourceType.CollectionLink)
+    .where(
+      sql<boolean>`${content}->'page'->>'description' = ${notificationNumber}`,
+    )
+    .where(sql<boolean>`${content}->'page'->>'category' = ${category}`)
+    .where(
+      sql<boolean>`split_part(${content}->'page'->>'date', '/', 3) = ${publishYear}`,
+    )
+    .select("Resource.id")
+
+  // Government gazettes are unique within category, not subcategory.
+  if (!isGovernmentGazette) {
+    query = query.where(
+      sql<boolean>`${content}->'page'->'tagged'->>0 = ${subCategory}`,
+    )
+  }
+
+  if (excludeId) {
+    query = query.where("Resource.id", "!=", excludeId)
+  }
+
+  const duplicate = await query.executeTakeFirst()
+  return duplicate !== undefined
 }

--- a/apps/studio/src/stories/Page/CreateGazetteModal.stories.tsx
+++ b/apps/studio/src/stories/Page/CreateGazetteModal.stories.tsx
@@ -1,20 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Box } from "@chakra-ui/react"
+import { Suspense } from "react"
+import { gazetteHandlers } from "tests/msw/handlers/gazette"
 import { CreateGazetteModal } from "~/features/gazettes"
+import { GazetteSubcategoriesProvider } from "~/features/gazettes/contexts/GazetteSubcategoriesContext"
 
 const meta: Meta<typeof CreateGazetteModal> = {
   title: "Pages/eGazette/Create Gazette Modal",
   component: CreateGazetteModal,
   decorators: [
-    (storyFn) => (
+    (storyFn, { args }) => (
       <Box w="100%" h="100vh">
-        {storyFn()}
+        <Suspense fallback={null}>
+          <GazetteSubcategoriesProvider
+            siteId={args.siteId}
+            gazettesCollectionId={args.collectionId}
+          >
+            {storyFn()}
+          </GazetteSubcategoriesProvider>
+        </Suspense>
       </Box>
     ),
   ],
   parameters: {
     layout: "fullscreen",
     chromatic: { delay: 200 },
+    msw: {
+      handlers: [gazetteHandlers.collectionTags.default()],
+    },
   },
   args: {
     isOpen: true,

--- a/apps/studio/src/stories/Page/GazettesPage.stories.tsx
+++ b/apps/studio/src/stories/Page/GazettesPage.stories.tsx
@@ -122,7 +122,7 @@ export const InlineExternalLinkIcon: Story = {
             title: "Bills Supplement - Companies (Amendment) Bill 2024",
             content: createGazetteContent({
               ref: "/gazettes/26gg-bills-supplement-companies-amendment.pdf",
-              category: "Legislation Supplements",
+              category: "Legislative Supplements",
               description: "2199",
               tagged: ["Bills Supplement"],
             }),

--- a/apps/studio/src/stories/Page/GazettesPage.stories.tsx
+++ b/apps/studio/src/stories/Page/GazettesPage.stories.tsx
@@ -1,4 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
+import { delay, http, HttpResponse } from "msw"
+import { expect, userEvent, within } from "storybook/test"
 import {
   createGazetteContent,
   createGazetteItem,
@@ -11,6 +13,12 @@ import GazettesPage from "~/pages/sites/[siteId]/gazettes"
 
 import { ADMIN_HANDLERS } from "../handlers"
 import { createEgazetteInfoGbParameters } from "../utils/growthbook"
+
+// Stands in for the S3 PUT during the create flow's file upload step.
+const uploadHandler = http.put("/storybook/upload", async () => {
+  await delay()
+  return HttpResponse.json()
+})
 
 // Must precede ADMIN_HANDLERS' isIsomerAdmin.default() (returns false), since
 // MSW resolves to the first matching handler. The page redirects away unless
@@ -130,5 +138,84 @@ export const InlineExternalLinkIcon: Story = {
         ]),
       ],
     },
+  },
+}
+
+// The collection already contains a Government Gazette with notification number
+// "2145" (visible in the table). Submitting the create form with that same
+// number surfaces the backend's CONFLICT error as an error toast, rather than
+// silently creating a duplicate.
+const DUPLICATE_NOTIFICATION_NUMBER = "2145"
+
+export const DuplicateNotificationNumber: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...baseHandlers,
+        // The existing gazette the new one would duplicate — its notification
+        // number shows in the table as the visual context for this scenario.
+        gazetteHandlers.list.default(),
+        gazetteHandlers.getPresignedPutUrl.default(),
+        gazetteHandlers.create.duplicateNotificationNumber(),
+        uploadHandler,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    // The modal renders in a portal, so query the whole document body.
+    const screen = within(canvasElement.ownerDocument.body)
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Add a new Gazette/i }),
+    )
+
+    await userEvent.type(
+      await screen.findByPlaceholderText("Enter a title"),
+      "Duplicate notice",
+    )
+
+    // Category defaults to "Government Gazette"; the form renders the Category
+    // and Subcategory SingleSelects in that order, so the second combobox is
+    // the subcategory. Pick "Tenders" — a label that doesn't appear in the
+    // seeded table row, so matching the option by its visible text stays
+    // unambiguous. Government Gazette duplicates are detected by category and
+    // year regardless of subcategory, so this is still a duplicate.
+    const subcategoryCombobox = (await screen.findAllByRole("combobox"))[1]
+    if (!subcategoryCombobox) {
+      throw new Error("Expected a subcategory combobox to be rendered")
+    }
+    await userEvent.click(subcategoryCombobox)
+    const virtuoso = await screen.findByTestId("virtuoso-item-list")
+    await userEvent.click(
+      await within(virtuoso).findByText(
+        governmentGazetteSubcategories.NOTICES_UNDER_OTHER_ACTS,
+      ),
+    )
+
+    await userEvent.type(
+      await screen.findByPlaceholderText("Enter Notification Number"),
+      DUPLICATE_NOTIFICATION_NUMBER,
+    )
+
+    // Uploading the PDF auto-fills the File ID and enables the submit button.
+    await userEvent.upload(
+      await screen.findByTestId("file-upload"),
+      new File(["dummy"], "26gg9999.pdf", { type: "application/pdf" }),
+    )
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: /Add Gazette/i }),
+    )
+
+    // The CONFLICT message is surfaced in the error toast's description.
+    // Submit awaits the upload + create round-trips before the toast renders,
+    // so allow more than the default 1s for the message to appear.
+    await expect(
+      await screen.findByText(
+        "A gazette with the same notification number already exists",
+        undefined,
+        { timeout: 5000 },
+      ),
+    ).toBeInTheDocument()
   },
 }

--- a/apps/studio/src/stories/Page/ModifyGazetteModal.stories.tsx
+++ b/apps/studio/src/stories/Page/ModifyGazetteModal.stories.tsx
@@ -1,20 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
 import { Box } from "@chakra-ui/react"
+import { Suspense } from "react"
+import { gazetteHandlers } from "tests/msw/handlers/gazette"
 import { ModifyGazetteModal } from "~/features/gazettes"
+import { GazetteSubcategoriesProvider } from "~/features/gazettes/contexts/GazetteSubcategoriesContext"
 
 const meta: Meta<typeof ModifyGazetteModal> = {
   title: "Pages/eGazette/Modify Gazette Modal",
   component: ModifyGazetteModal,
   decorators: [
-    (storyFn) => (
+    (storyFn, { args }) => (
       <Box w="100%" h="100vh">
-        {storyFn()}
+        <Suspense fallback={null}>
+          <GazetteSubcategoriesProvider
+            siteId={args.siteId}
+            gazettesCollectionId={args.collectionId}
+          >
+            {storyFn()}
+          </GazetteSubcategoriesProvider>
+        </Suspense>
       </Box>
     ),
   ],
   parameters: {
     layout: "fullscreen",
     chromatic: { delay: 200 },
+    msw: {
+      handlers: [gazetteHandlers.collectionTags.default()],
+    },
   },
   args: {
     isOpen: true,

--- a/apps/studio/tests/msw/handlers/gazette.ts
+++ b/apps/studio/tests/msw/handlers/gazette.ts
@@ -1,4 +1,5 @@
 import type { RouterOutput } from "~/utils/trpc"
+import { TRPCError } from "@trpc/server"
 import {
   GAZETTE_SUBCATEGORY_LABEL,
   governmentGazetteSubcategories,
@@ -135,5 +136,26 @@ export const gazetteHandlers = {
   collectionTags: {
     default: () =>
       trpcMsw.collection.getCollectionTags.query(() => GAZETTE_TAG_CATEGORIES),
+  },
+  getPresignedPutUrl: {
+    // Points the upload at the in-memory "/storybook/upload" PUT handler so the
+    // create flow can reach the gazette.create mutation without hitting S3.
+    default: () =>
+      trpcMsw.gazette.getPresignedPutUrl.mutation(() => ({
+        fileKey: "MOCK_STORYBOOK_GAZETTE.pdf",
+        presignedPutUrl: "/storybook/upload",
+        contentType: "application/pdf",
+        contentDisposition:
+          "inline; filename*=UTF-8''MOCK_STORYBOOK_GAZETTE.pdf",
+      })),
+  },
+  create: {
+    duplicateNotificationNumber: () =>
+      trpcMsw.gazette.create.mutation(() => {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "A gazette with the same notification number already exists",
+        })
+      }),
   },
 }


### PR DESCRIPTION
## Problem
UAT surfaced several issues with the eGazette feature:

1. **Duplicate notification numbers could be created.** Nothing stopped a user from creating (or editing) two gazettes that shared the same notification number within the same category and publish year, producing ambiguous records.
2. **Incorrect category label.** The category was mislabelled "Legislation Supplements" instead of the correct "Legislative Supplements".
3. **Gazette list ordering was wrong.** Gazettes were sorted by the full `page.ref` path rather than the Toppan file ID, and publish date was prioritised ahead of category, producing an order that did not match expectations. `nullsLast()` was also applied inconsistently.
4. **Subcategory text was too small** to read comfortably in the gazette table.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Reject duplicate notification numbers on gazette create and update. A new `hasDuplicateNotificationNumber` service helper checks for an existing gazette in the same collection with the same notification number, category, and publish year. For non–Government Gazette categories the subcategory must also match (Government Gazette numbers are unique within the category, not the subcategory). Both `create` and `update` throw a `CONFLICT` `TRPCError` ("A gazette with the same notification number already exists") when a clash is found; `update` excludes the gazette being edited so re-saving its own number is allowed.

**Improvements**:

- Corrected the category label from "Legislation Supplements" to "Legislative Supplements" across constants, types, the subcategory context, and stories. Added a `GazetteCategories` constant for the canonical category values.
- Reworked the gazette list ordering: category priority now sorts before publish date; the file-ID sort extracts the final path segment of `page.ref` (the Toppan file ID) via `regexp_replace` instead of comparing the full path; publish date moves to a lower-priority tie-breaker; and the inconsistent `nullsLast()` modifiers were removed.
- Increased the subcategory caption font size in the gazette table for readability.
- Wrapped the Create/Modify Gazette Modal stories in `GazetteSubcategoriesProvider` with MSW handlers so the subcategory dropdown renders in Storybook.

**Bug Fixes**:

- See Features and Improvements above (duplicate rejection, label correction, ordering fix).

## Tests

Run the gazette router unit tests:

```bash
cd apps/studio && pnpm test:unit -- src/server/modules/gazette/__tests__/gazette.router.test.ts
```

New test coverage added:

- Rejects creation when a gazette with the same notification number already exists.
- Rejects update when changing to a notification number used by another gazette.
- Allows update that keeps the gazette's own notification number.

**Manual Verification Steps**:

- [ ] Create a gazette, then attempt to create another with the same notification number, category, and publish year — confirm it is rejected with a conflict error.
- [ ] Edit an existing gazette without changing its notification number — confirm the save succeeds.
- [ ] Confirm the category label reads "Legislative Supplements" throughout the UI.
- [ ] Confirm the gazette list is ordered by category, then notification number, then Toppan file ID.
- [ ] Confirm the subcategory text in the gazette table is legible.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
