### PR TITLE
Suppress success emails for Toppan users on publish

### DIFF
--- a/apps/studio/src/server/modules/webhook/__test__/webhook.router.test.ts
+++ b/apps/studio/src/server/modules/webhook/__test__/webhook.router.test.ts
@@ -17,6 +17,7 @@ import {
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
+import { TOPPAN_EMAIL_DOMAIN } from "~/constants/toppan"
 import {
   sendFailedPublishEmail,
   sendSuccessfulPublishEmail,
@@ -125,6 +126,41 @@ describe("webhook.router", async () => {
         expect.objectContaining({
           status: "SUCCEEDED",
           emailSent: true,
+        }),
+      )
+    })
+    it("does not send a success email to toppan users", async () => {
+      // Arrange
+      const toppanUser = await setupUser({
+        email: `toppan-user${TOPPAN_EMAIL_DOMAIN}`,
+      })
+      const { codebuildJob } = await setupCodeBuildJob({
+        userId: toppanUser.id,
+        arn: "build/test-id",
+        startedAt: FIXED_NOW,
+        isScheduled: true,
+      })
+      const caller = getCallerWithMockGrowthbook(session)
+
+      // Act
+      await caller.updateCodebuildWebhook({
+        projectName: "test-project",
+        arn: "build/test-id", // saved in the db
+        status: "SUCCEEDED",
+      })
+
+      // Assert
+      expect(sendSuccessfulPublishEmail).not.toHaveBeenCalled()
+      // the build status should still be updated, but no email should be sent
+      const job = await db
+        .selectFrom("CodeBuildJobs")
+        .where("buildId", "=", codebuildJob.buildId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(job).toEqual(
+        expect.objectContaining({
+          status: "SUCCEEDED",
+          emailSent: false, // emailSent should remain false
         }),
       )
     })

--- a/apps/studio/src/server/modules/webhook/webhook.utils.ts
+++ b/apps/studio/src/server/modules/webhook/webhook.utils.ts
@@ -119,7 +119,12 @@ const sendEmails = async (
             // they cannot view. Suppress the email for them (Toppan users only
             // ever publish gazettes).
             if (info.email?.endsWith(TOPPAN_EMAIL_DOMAIN)) {
-              return // skip sending; this build is effectively not emailed
+              // Skip sending. This job's id is intentionally NOT added to
+              // `codebuildJobIdsForSentEmails`, so its `emailSent` stays `false` —
+              // no email was sent. This is deliberate, not a pending notification:
+              // the suppression is idempotent on every webhook retry, so a Toppan
+              // job is never emailed.
+              return
             }
             return {
               id: info.codeBuildJobId, // codebuild job id

--- a/apps/studio/src/server/modules/webhook/webhook.utils.ts
+++ b/apps/studio/src/server/modules/webhook/webhook.utils.ts
@@ -1,6 +1,7 @@
 import type { GrowthBook } from "@growthbook/growthbook"
 import type { BuildStatusType } from "~prisma/generated/prisma/client"
 import { compact } from "lodash-es"
+import { TOPPAN_EMAIL_DOMAIN } from "~/constants/toppan"
 import {
   sendFailedPublishEmail,
   sendSuccessfulPublishEmail,
@@ -113,6 +114,13 @@ const sendEmails = async (
       .map((info) => {
         switch (buildStatus) {
           case "SUCCEEDED":
+            // Toppan users can only access gazettes in studio, and the
+            // successful publish email links to the raw studio resource which
+            // they cannot view. Suppress the email for them (Toppan users only
+            // ever publish gazettes).
+            if (info.email?.endsWith(TOPPAN_EMAIL_DOMAIN)) {
+              return // skip sending; this build is effectively not emailed
+            }
             return {
               id: info.codeBuildJobId, // codebuild job id
               promise: sendSuccessfulPublishEmail({


### PR DESCRIPTION
## Problem

Toppan users can only access gazettes in Studio and cannot view raw studio resources. The successful publish email links to raw studio resources, making it unhelpful for Toppan users. These emails should be suppressed for Toppan users while still updating the build status.

## Solution

Added a check in the `sendEmails` utility to skip sending successful publish emails to users with Toppan email domain addresses. The build status is still updated in the database, but no email is sent.

**Bug Fixes**:

- Toppan users no longer receive successful publish emails that link to resources they cannot access

## Tests

- Added unit test `"does not send a success email to toppan users"` in `webhook.router.test.ts` that verifies:
  - A Toppan user's successful build does not trigger `sendSuccessfulPublishEmail`
  - The build status is still updated to "SUCCEEDED" in the database
  - The `emailSent` flag remains `false`

Existing tests continue to pass, confirming backward compatibility for non-Toppan users.

https://claude.ai/code/session_01NVea8RS5LPD7USuozA2Zab

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR suppresses successful-publish notification emails for users with Toppan email domains (`@toppannext.com`), since those emails link to raw Studio resources that Toppan users cannot access. The build status DB update is unaffected; only the email dispatch is skipped.

- A guard is added in `sendEmails` inside `webhook.utils.ts` that returns early (before adding the job to `codebuildJobIdsForSentEmails`) when the recipient's email ends with `TOPPAN_EMAIL_DOMAIN`, leaving `emailSent = false` in the DB — documented inline as deliberate and idempotent on retries.
- A new integration test (`\"does not send a success email to toppan users\"`) verifies that `sendSuccessfulPublishEmail` is not called and that the job row is correctly updated to `SUCCEEDED` with `emailSent: false`.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a narrow, well-tested guard that only suppresses emails for a specific domain; all other code paths are untouched.

The guard is logically sound: endsWith('@toppannext.com') correctly isolates the Toppan domain without false positives, the build-status DB write is unaffected, and the idempotency-on-retry property is preserved. The integration test covers the new path end-to-end and is consistent with the existing test patterns.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/webhook/webhook.utils.ts | Adds a Toppan-domain guard in the SUCCEEDED branch of sendEmails; logic is correct and well-commented. The endsWith check with "@toppannext.com" is safe against false positives. The emailSent=false side-effect for skipped jobs is explicitly documented. |
| apps/studio/src/server/modules/webhook/__test__/webhook.router.test.ts | New integration test correctly verifies Toppan suppression: asserts email not sent, build status updated to SUCCEEDED, and emailSent remains false. Test setup is consistent with the existing pattern. |

</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Webhook: SUCCEEDED status] --> B[updateCurrentAndSupersededBuilds]
    B --> C[sendEmails called]
    C --> D{emailSent = false AND User.email NOT NULL?}
    D -- No --> E[Skip build entirely]
    D -- Yes --> F{isEmailFunctionalityActive?}
    F -- No --> E
    F -- Yes --> G{email ends with @toppannext.com?}
    G -- Yes --> H[return undefined - job id NOT added - emailSent stays false]
    G -- No --> I[sendSuccessfulPublishEmail - add id to codebuildJobIdsForSentEmails]
    I --> J[Promise.allSettled]
    J --> K[Update emailSent = true for fulfilled sends]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Webhook: SUCCEEDED status] --> B[updateCurrentAndSupersededBuilds]
    B --> C[sendEmails called]
    C --> D{emailSent = false AND User.email NOT NULL?}
    D -- No --> E[Skip build entirely]
    D -- Yes --> F{isEmailFunctionalityActive?}
    F -- No --> E
    F -- Yes --> G{email ends with @toppannext.com?}
    G -- Yes --> H[return undefined - job id NOT added - emailSent stays false]
    G -- No --> I[sendSuccessfulPublishEmail - add id to codebuildJobIdsForSentEmails]
    I --> J[Promise.allSettled]
    J --> K[Update emailSent = true for fulfilled sends]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/studio/src/server/modules/webhook/webhook.utils.ts`, line 132-143 ([link](https://github.com/opengovsg/isomer/blob/44bd3fd1a90be8e9fede1ed68c53ed74f4e4d03f/apps/studio/src/server/modules/webhook/webhook.utils.ts#L132-L143)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Failed-publish emails are not suppressed for Toppan users**

   The suppression only guards the `SUCCEEDED` branch. If the failed-publish email also contains links to raw Studio resources that Toppan users cannot access, they would still receive an unhelpful email. Given the rationale in the PR description — "the successful publish email links to the raw studio resource which they cannot view" — it's worth confirming whether the same resource URL appears in the failure template, and if so, adding the same guard to the `FAILED` case.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fwebhook%2Fwebhook.utils.ts%0ALine%3A%20132-143%0A%0AComment%3A%0A**Failed-publish%20emails%20are%20not%20suppressed%20for%20Toppan%20users**%0A%0AThe%20suppression%20only%20guards%20the%20%60SUCCEEDED%60%20branch.%20If%20the%20failed-publish%20email%20also%20contains%20links%20to%20raw%20Studio%20resources%20that%20Toppan%20users%20cannot%20access%2C%20they%20would%20still%20receive%20an%20unhelpful%20email.%20Given%20the%20rationale%20in%20the%20PR%20description%20%E2%80%94%20%22the%20successful%20publish%20email%20links%20to%20the%20raw%20studio%20resource%20which%20they%20cannot%20view%22%20%E2%80%94%20it's%20worth%20confirming%20whether%20the%20same%20resource%20URL%20appears%20in%20the%20failure%20template%2C%20and%20if%20so%2C%20adding%20the%20same%20guard%20to%20the%20%60FAILED%60%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer&pr=2578&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22claude%2Fslack-session-d47h8f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fslack-session-d47h8f%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fwebhook%2Fwebhook.utils.ts%0ALine%3A%20132-143%0A%0AComment%3A%0A**Failed-publish%20emails%20are%20not%20suppressed%20for%20Toppan%20users**%0A%0AThe%20suppression%20only%20guards%20the%20%60SUCCEEDED%60%20branch.%20If%20the%20failed-publish%20email%20also%20contains%20links%20to%20raw%20Studio%20resources%20that%20Toppan%20users%20cannot%20access%2C%20they%20would%20still%20receive%20an%20unhelpful%20email.%20Given%20the%20rationale%20in%20the%20PR%20description%20%E2%80%94%20%22the%20successful%20publish%20email%20links%20to%20the%20raw%20studio%20resource%20which%20they%20cannot%20view%22%20%E2%80%94%20it's%20worth%20confirming%20whether%20the%20same%20resource%20URL%20appears%20in%20the%20failure%20template%2C%20and%20if%20so%2C%20adding%20the%20same%20guard%20to%20the%20%60FAILED%60%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fwebhook%2Fwebhook.utils.ts%0ALine%3A%20132-143%0A%0AComment%3A%0A**Failed-publish%20emails%20are%20not%20suppressed%20for%20Toppan%20users**%0A%0AThe%20suppression%20only%20guards%20the%20%60SUCCEEDED%60%20branch.%20If%20the%20failed-publish%20email%20also%20contains%20links%20to%20raw%20Studio%20resources%20that%20Toppan%20users%20cannot%20access%2C%20they%20would%20still%20receive%20an%20unhelpful%20email.%20Given%20the%20rationale%20in%20the%20PR%20description%20%E2%80%94%20%22the%20successful%20publish%20email%20links%20to%20the%20raw%20studio%20resource%20which%20they%20cannot%20view%22%20%E2%80%94%20it's%20worth%20confirming%20whether%20the%20same%20resource%20URL%20appears%20in%20the%20failure%20template%2C%20and%20if%20so%2C%20adding%20the%20same%20guard%20to%20the%20%60FAILED%60%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2578&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22claude%2Fslack-session-d47h8f%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fslack-session-d47h8f%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fwebhook%2Fwebhook.utils.ts%0ALine%3A%20132-143%0A%0AComment%3A%0A**Failed-publish%20emails%20are%20not%20suppressed%20for%20Toppan%20users**%0A%0AThe%20suppression%20only%20guards%20the%20%60SUCCEEDED%60%20branch.%20If%20the%20failed-publish%20email%20also%20contains%20links%20to%20raw%20Studio%20resources%20that%20Toppan%20users%20cannot%20access%2C%20they%20would%20still%20receive%20an%20unhelpful%20email.%20Given%20the%20rationale%20in%20the%20PR%20description%20%E2%80%94%20%22the%20successful%20publish%20email%20links%20to%20the%20raw%20studio%20resource%20which%20they%20cannot%20view%22%20%E2%80%94%20it's%20worth%20confirming%20whether%20the%20same%20resource%20URL%20appears%20in%20the%20failure%20template%2C%20and%20if%20so%2C%20adding%20the%20same%20guard%20to%20the%20%60FAILED%60%20case.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer&pr=2578&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["docs(webhook): clarify emailSent stays f..."](https://github.com/opengovsg/isomer/commit/fa3934abfd2ea70094b4bdc00e6dae4f05c8c533) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39784157)</sub>

<!-- /greptile_comment -->