### PR TITLE
fix(permissions): correct @casl/react v7 Can render-prop destructuring

### DIFF
--- a/apps/studio/src/components/AuthWrappers/PermissionsBoundary.tsx
+++ b/apps/studio/src/components/AuthWrappers/PermissionsBoundary.tsx
@@ -81,8 +81,8 @@ export const PermissionsBoundary = ({
   return (
     <PermissionsProvider siteId={siteId}>
       <Can do="read" on={{ parentId: null }} passThrough>
-        {(allowed) => {
-          return allowed ? (
+        {({ isAllowed }) => {
+          return isAllowed ? (
             page
           ) : (
             <DefaultLayout>

--- a/apps/studio/src/features/editing-experience/components/PublishButton.stories.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { expect, waitFor, within } from "storybook/test"
+import { meHandlers } from "tests/msw/handlers/me"
+import { pageHandlers } from "tests/msw/handlers/page"
+import { resourceHandlers } from "tests/msw/handlers/resource"
+import { PermissionsProvider } from "~/features/permissions"
+
+import PublishButton from "./PublishButton"
+
+// PublishButton renders its own <Can> gate, which reads the ability built by
+// PermissionsProvider from the user's roles. Each story below swaps the
+// `getRolesFor` handler to demonstrate what every role sees.
+const COMMON_HANDLERS = [meHandlers.me(), pageHandlers.readPage.content()]
+
+const meta: Meta<typeof PublishButton> = {
+  title: "Components/PublishButton",
+  component: PublishButton,
+  args: { pageId: 1, siteId: 1 },
+  decorators: [
+    (Story) => (
+      <PermissionsProvider siteId={1} resourceId="1">
+        <Story />
+      </PermissionsProvider>
+    ),
+  ],
+  parameters: {
+    msw: { handlers: COMMON_HANDLERS },
+    nextjs: {
+      router: {
+        query: { siteId: "1", pageId: "1" },
+        pathname: "/sites/[siteId]/pages/[pageId]",
+      },
+    },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const handlersForRole = (
+  roleHandler: ReturnType<typeof resourceHandlers.getRolesFor.admin>,
+) => ({ msw: { handlers: [...COMMON_HANDLERS, roleHandler] } })
+
+// Admins have full permissions, including publish.
+export const Admin: Story = {
+  parameters: handlersForRole(resourceHandlers.getRolesFor.admin()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(async () =>
+      expect(
+        await canvas.findByRole("button", { name: "Publish" }),
+      ).toBeVisible(),
+    )
+  },
+}
+
+// Publishers are the dedicated publish role.
+export const Publisher: Story = {
+  parameters: handlersForRole(resourceHandlers.getRolesFor.publisher()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(async () =>
+      expect(
+        await canvas.findByRole("button", { name: "Publish" }),
+      ).toBeVisible(),
+    )
+  },
+}
+
+// Editors cannot publish — the button must not render for them.
+export const Editor: Story = {
+  parameters: handlersForRole(resourceHandlers.getRolesFor.editor()),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(() =>
+      expect(
+        canvas.queryByRole("button", { name: "Publish" }),
+      ).not.toBeInTheDocument(),
+    )
+  },
+}

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -83,12 +83,12 @@ const SuspendablePublishButton = ({
 
   return (
     <Can do="publish" on="Resource" passThrough>
-      {(allowed) => (
+      {({ isAllowed }) => (
         <TouchableTooltip
           hidden={isChangesPendingPublish}
           label="All changes have been published"
         >
-          {allowed && (
+          {isAllowed && (
             <>
               {/* Render the modal conditionally to ensure the schema resets when the modal is opened/closed */}
               {scheduledPublishingDisclosure.isOpen && (

--- a/apps/studio/src/features/editing-experience/components/__tests__/PublishButton.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/__tests__/PublishButton.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import type { ResourceAbility } from "~/server/modules/permissions/permissions.type"
+import { AbilityBuilder, createMongoAbility } from "@casl/ability"
+import { AbilityProvider } from "@casl/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { buildPermissionsForResource } from "~/server/modules/permissions/permissions.util"
+import { theme } from "~/theme"
+import { RoleType } from "~prisma/generated/generatedEnums"
+
+import PublishButton from "../PublishButton"
+
+// The "Schedule for later" dropdown relies on Chakra's Menu context, which does
+// not initialise under jsdom. It is unrelated to the permission gate under test,
+// so stub the menu primitives to plain passthroughs.
+vi.mock("@chakra-ui/react", async (importActual) => {
+  const actual = (await importActual()) as Record<string, unknown>
+  return {
+    ...actual,
+    Menu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    MenuButton: ({ "aria-label": ariaLabel }: { "aria-label"?: string }) => (
+      <button aria-label={ariaLabel} />
+    ),
+    MenuList: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    MenuItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  }
+})
+
+// PublishButton is wrapped in withSuspense, whose Suspense wrapper waits for the
+// Next.js router to be ready before mounting children. Provide a ready router.
+vi.mock("next/router", () => ({
+  useRouter: () => ({ isReady: true }),
+}))
+
+// PublishButton reads the current page (to decide the enabled/pending state) and
+// owns the publish mutation. Neither is what we are testing here — the regression
+// is purely about whether the <Can> permission gate shows the button — so stub
+// the tRPC surface with the minimum the component touches on render.
+vi.mock("~/utils/trpc", () => {
+  const noop = vi.fn()
+  return {
+    trpc: {
+      page: {
+        readPage: {
+          useSuspenseQuery: () => [
+            { draftBlobId: "draft-1", scheduledAt: null },
+          ],
+        },
+        publishPage: {
+          useMutation: () => ({ mutate: noop, isPending: false }),
+        },
+      },
+      useUtils: () => ({
+        page: {
+          readPage: { refetch: noop },
+          getCategories: { invalidate: noop },
+          getCategoryOptions: { invalidate: noop },
+        },
+        collection: { getCategoryOptionUsageCount: { invalidate: noop } },
+        site: { getLocalisedSitemap: { invalidate: noop } },
+      }),
+    },
+  }
+})
+
+// Build the client ability exactly the way PermissionsProvider does, so this test
+// exercises the real CASL rules + the real <Can> render-prop contract.
+const abilityFor = (role: RoleType) => {
+  const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
+  buildPermissionsForResource(role, builder)
+  return builder.build({ detectSubjectType: () => "Resource" })
+}
+
+const renderForRole = (role: RoleType) =>
+  render(
+    <ThemeProvider theme={theme}>
+      <AbilityProvider value={abilityFor(role)}>
+        <PublishButton pageId={1} siteId={1} />
+      </AbilityProvider>
+    </ThemeProvider>,
+  )
+
+describe("PublishButton permission gating", () => {
+  it("renders the Publish button for publishers", () => {
+    renderForRole(RoleType.Publisher)
+    expect(screen.queryByRole("button", { name: "Publish" })).not.toBeNull()
+  })
+
+  it("renders the Publish button for admins", () => {
+    renderForRole(RoleType.Admin)
+    expect(screen.queryByRole("button", { name: "Publish" })).not.toBeNull()
+  })
+
+  // Regression: @casl/react v7 changed the render-prop to receive a single
+  // `{ isAllowed }` object instead of a positional boolean. Destructuring it as a
+  // positional boolean made `allowed` an always-truthy object, leaking the button
+  // to editors regardless of their permissions.
+  it("does NOT render the Publish button for editors", () => {
+    renderForRole(RoleType.Editor)
+    expect(screen.queryByRole("button", { name: "Publish" })).toBeNull()
+  })
+})

--- a/apps/studio/src/features/permissions/__tests__/Can.test.tsx
+++ b/apps/studio/src/features/permissions/__tests__/Can.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import type { ResourceAbility } from "~/server/modules/permissions/permissions.type"
+import { AbilityBuilder, createMongoAbility } from "@casl/ability"
+import { AbilityProvider } from "@casl/react"
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Can } from "~/features/permissions"
+
+// These tests lock the @casl/react <Can> contract that our permission gates rely
+// on. @casl/react v7 changed the render-prop from a positional boolean
+// `(isAllowed, ability) => ...` to a single object `({ isAllowed, ... }) => ...`;
+// consuming it the old way made the argument always truthy and silently leaked
+// gated UI. If a future upgrade changes the shape again, these tests fail loudly
+// instead of every <Can passThrough> gate failing open in production.
+const buildAbility = () => {
+  const builder = new AbilityBuilder<ResourceAbility>(createMongoAbility)
+  // Allow publish, deny everything else (e.g. delete).
+  builder.can("publish", "Resource")
+  return builder.build({ detectSubjectType: () => "Resource" })
+}
+
+const renderWithAbility = (ui: React.ReactNode) =>
+  render(<AbilityProvider value={buildAbility()}>{ui}</AbilityProvider>)
+
+describe("<Can> render-prop contract", () => {
+  it("passes a single object exposing `isAllowed`, not a positional boolean", () => {
+    let received: unknown
+    renderWithAbility(
+      <Can do="publish" on="Resource" passThrough>
+        {(arg) => {
+          received = arg
+          return null
+        }}
+      </Can>,
+    )
+
+    expect(typeof received).toBe("object")
+    expect(received).toMatchObject({ isAllowed: true })
+  })
+
+  it("reports `isAllowed: false` for a denied action", () => {
+    let received: unknown
+    renderWithAbility(
+      <Can do="delete" on="Resource" passThrough>
+        {(arg) => {
+          received = arg
+          return null
+        }}
+      </Can>,
+    )
+
+    expect(received).toMatchObject({ isAllowed: false })
+  })
+})
+
+describe("<Can> node-child gating", () => {
+  it("renders children when the action is allowed", () => {
+    renderWithAbility(
+      <Can do="publish" on="Resource">
+        <span>allowed content</span>
+      </Can>,
+    )
+
+    expect(screen.queryByText("allowed content")).not.toBeNull()
+  })
+
+  it("hides children when the action is denied", () => {
+    renderWithAbility(
+      <Can do="delete" on="Resource">
+        <span>denied content</span>
+      </Can>,
+    )
+
+    expect(screen.queryByText("denied content")).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

Editors (and anyone, regardless of role) could see the **Publish** button in the page/link editor.

## Root cause

`@casl/react` was upgraded to **v7** (catalog `casl`, applied during the npm→pnpm migration #1943). In v7 the `<Can passThrough>` render-prop changed shape:

```diff
- {(isAllowed, ability) => ...}              // pre-v7: positional args
+ {({ isAllowed, ability, reason }) => ...}  // v7: single object
```

Two call sites still destructured the old positional form, so the variable held the **always-truthy object** and the permission gate never evaluated:

- **`PublishButton.tsx`** — `{(allowed) => ... {allowed && <button/>}}` always rendered the button.
- **`PermissionsBoundary.tsx`** — `{(allowed) => allowed ? page : <error>}` silently let users without `read`-on-root through the page boundary instead of showing the permission error.

The underlying CASL rules were correct all along (an editor's ability returns `can("publish", "Resource") === false`); only the v7 API consumption was wrong.

## Fix

Destructure the v7 object (`{ isAllowed }`) at both call sites.

## Codebase audit

Checked every `<Can>` usage in `apps/studio` (none exist elsewhere):

| Usage | Child | Affected? |
|---|---|---|
| `PublishButton.tsx` | function | ✅ fixed |
| `PermissionsBoundary.tsx` | function | ✅ fixed |
| `SettingsHeader.tsx` | node | unaffected |
| `NavbarEditor.tsx` | node | unaffected |
| `FooterEditor.tsx` | node | unaffected |
| `ResourceTableMenu.tsx` (move / delete) | node | unaffected |
| `pages/sites/[siteId]/index.tsx` | node (`<Menu>`; the `{({ isOpen }) => ...}` is Menu's own render-prop) | unaffected |

The two fixed call sites were the **only** render-prop consumers. Node-child `<Can>` usages were unaffected — their rendering contract (render iff allowed) did not change in v7.

## Tests / Stories

- **`PublishButton.test.tsx`** — renders the real `PublishButton` per role with the real CASL ability (built exactly as `PermissionsProvider` does). Asserts editors don't see the button; publishers/admins do. Verified **failing on the old code** and passing on the fix.
- **`PublishButton.stories.tsx`** — `Admin`, `Publisher`, `Editor` stories (swapping the `getRolesFor` MSW handler) with play-function visibility assertions.
- **`permissions/__tests__/Can.test.tsx`** — contract test on the re-exported `<Can>` that pins both modes (function-child yields a `{ isAllowed }` object; node children render iff allowed). Guards the whole bug class against a future CASL bump silently failing gates open.

## Verification

- `pnpm test:unit` on the new files → all pass; PublishButton test confirmed to fail when the fix is reverted.
- `oxlint --type-aware` on all changed files → clean.
- `pnpm typecheck` → no errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a silent permission gate regression introduced when `@casl/react` was upgraded to v7. The v7 `<Can passThrough>` render-prop changed from positional arguments `(isAllowed, ability) => …` to a single object `({ isAllowed, ability, reason }) => …`; two call sites still destructured the old form, making the variable hold an always-truthy object so the gate never evaluated.

- **`PublishButton.tsx` and `PermissionsBoundary.tsx`**: destructuring updated from `(allowed)` to `({ isAllowed })` — the minimal, correct fix.
- **New tests** (`PublishButton.test.tsx`, `Can.test.tsx`): unit test the per-role publish-button visibility and pin the CASL render-prop contract so a future upgrade breaking the shape fails loudly.
- **New Storybook stories** (`PublishButton.stories.tsx`): provide visual regression coverage for Admin, Publisher, and Editor roles.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the fix is minimal and surgical, correcting the exact API mismatch at both affected call sites with no other logic changes.

Both changes are single-line destructuring corrections that restore the intended permission gating. The new tests exercise the real CASL rules per role, were verified to fail before the fix, and a contract test guards the render-prop shape against future regressions. The audit documented in the PR description confirms no other render-prop call sites exist.

No files require special attention. The PermissionsBoundary fix has no dedicated component-level test (noted in a prior review), but the generic Can.test.tsx contract test covers the same destructuring pattern.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/components/AuthWrappers/PermissionsBoundary.tsx | One-line fix: destructures `{ isAllowed }` from the v7 render-prop object instead of treating the whole object as a boolean; the gate now correctly shows the error page for unauthorised users. |
| apps/studio/src/features/editing-experience/components/PublishButton.tsx | Matching one-line fix at the publish-button render-prop; editors will no longer see the Publish button. |
| apps/studio/src/features/editing-experience/components/__tests__/PublishButton.test.tsx | New unit test that builds real CASL abilities per role and asserts publish-button visibility; exercises the exact regression path and was verified to fail before the fix. |
| apps/studio/src/features/permissions/__tests__/Can.test.tsx | Contract test locking the v7 render-prop shape (`{ isAllowed }` object) and node-child gate behaviour; will catch any future CASL API breakage early. |
| apps/studio/src/features/editing-experience/components/PublishButton.stories.tsx | Storybook stories with play-function assertions for Admin, Publisher, and Editor roles; complements the unit test with visual and interaction-level coverage. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["User navigates to page/editor"] --> B["PermissionsProvider builds CASL ability\n(from user role via buildPermissionsForResource)"]
    B --> C{"<Can passThrough>\nrender-prop arg"}
    
    C -- "Pre-fix (v7 bug):\n`(allowed)` = always-truthy object" --> D["Gate always open\nAll roles see protected UI"]
    C -- "Post-fix (v7 correct):\n`({ isAllowed })` = boolean" --> E{"isAllowed?"}
    
    E -- "true (admin/publisher)" --> F["Show Publish Button\nor Protected Page"]
    E -- "false (editor)" --> G["Hide button\nor Show Error Boundary"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["User navigates to page/editor"] --> B["PermissionsProvider builds CASL ability\n(from user role via buildPermissionsForResource)"]
    B --> C{"<Can passThrough>\nrender-prop arg"}
    
    C -- "Pre-fix (v7 bug):\n`(allowed)` = always-truthy object" --> D["Gate always open\nAll roles see protected UI"]
    C -- "Post-fix (v7 correct):\n`({ isAllowed })` = boolean" --> E{"isAllowed?"}
    
    E -- "true (admin/publisher)" --> F["Show Publish Button\nor Protected Page"]
    E -- "false (editor)" --> G["Hide button\nor Show Error Boundary"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["test(permissions): lock the @casl/react ..."](https://github.com/opengovsg/isomer/commit/795826a08be9cdab1542c727659bdc650a7ae7ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40009057)</sub>

<!-- /greptile_comment -->