### PR TITLE
Refactor admin role eligibility to use whitelist expiry instead of gov.sg domain

### DIFF
--- a/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
@@ -26,7 +26,6 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsSingpassEnabled } from "~/hooks/useIsSingpassEnabled"
 import { useZodForm } from "~/lib/form"
 import { createUserInputSchema } from "~/schemas/user"
-import { isGovEmail } from "~/utils/email"
 import { trpc } from "~/utils/trpc"
 import { RoleType } from "~prisma/generated/generatedEnums"
 
@@ -69,16 +68,11 @@ export const AddUserModal = () => {
   const email = watch("email")
   const debouncedEmail = useDebounce(email, 300)
 
-  const isNonGovEmailInput = useMemo(
-    () => !!(!errors.email && email && !isGovEmail(email.trim())),
-    [errors.email, email],
-  )
-
   // Reason we are not using zodForm build-in schema is because the checking of whitelist
   // is an async operation requiring an API call, and combining them will be less readable
   const additionalEmailError = useMemo(
-    () => isNonGovEmailInput && hasWhitelistError,
-    [isNonGovEmailInput, hasWhitelistError],
+    () => hasWhitelistError,
+    [hasWhitelistError],
   )
 
   const { mutate: createUser, isPending } = trpc.user.create.useMutation({
@@ -112,6 +106,19 @@ export const AddUserModal = () => {
     },
   )
 
+  const { data: isWhitelistedAsAdmin, refetch: checkAdminWhitelist } =
+    trpc.whitelist.isEmailWhitelistedAsAdmin.useQuery(
+      { siteId, email: (debouncedEmail || "").trim() },
+      {
+        enabled: false,
+      },
+    )
+
+  const isEmailNotWhitelistedAsAdmin = useMemo(
+    () => !!(!errors.email && email && !isWhitelistedAsAdmin),
+    [errors.email, email, isWhitelistedAsAdmin],
+  )
+
   useEffect(() => {
     // Run after the whitelist check is successful
     if (!isSuccess) {
@@ -142,11 +149,12 @@ export const AddUserModal = () => {
     if (!debouncedEmail || errors.email) return
 
     void checkWhitelist()
+    void checkAdminWhitelist()
   }, [
     debouncedEmail,
-    isNonGovEmailInput,
     errors.email,
     checkWhitelist,
+    checkAdminWhitelist,
     setAddUserModalState,
   ])
 
@@ -209,7 +217,8 @@ export const AddUserModal = () => {
               <FormControl
                 isRequired
                 isInvalid={
-                  watch("role") === RoleType.Admin && isNonGovEmailInput
+                  watch("role") === RoleType.Admin &&
+                  isEmailNotWhitelistedAsAdmin
                 }
               >
                 <FormLabel
@@ -235,17 +244,17 @@ export const AddUserModal = () => {
                       isSelected={watch("role") === role}
                       onClick={() => setValue("role", role)}
                       permissionLabels={permissionLabels}
-                      isDisabled={role === RoleType.Admin && isNonGovEmailInput}
+                      isDisabled={
+                        role === RoleType.Admin && isEmailNotWhitelistedAsAdmin
+                      }
                     />
                   ))}
                 </HStack>
               </FormControl>
-              {watch("role") === RoleType.Admin && !isNonGovEmailInput && (
-                <AddAdminWarning />
-              )}
-              {watch("role") === RoleType.Admin && isNonGovEmailInput && (
-                <NonGovEmailCannotBeAdmin />
-              )}
+              {watch("role") === RoleType.Admin &&
+                !isEmailNotWhitelistedAsAdmin && <AddAdminWarning />}
+              {watch("role") === RoleType.Admin &&
+                isEmailNotWhitelistedAsAdmin && <NonGovEmailCannotBeAdmin />}
             </VStack>
           </VStack>
         </ModalBody>
@@ -267,7 +276,8 @@ export const AddUserModal = () => {
                 email === "" ||
                 additionalEmailError ||
                 email !== debouncedEmail || // check if email has changed
-                (watch("role") === RoleType.Admin && isNonGovEmailInput) ||
+                (watch("role") === RoleType.Admin &&
+                  isEmailNotWhitelistedAsAdmin) ||
                 !isSingpassEnabled
               }
             >

--- a/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
@@ -106,17 +106,33 @@ export const AddUserModal = () => {
     },
   )
 
-  const { data: isWhitelistedAsAdmin, refetch: checkAdminWhitelist } =
-    trpc.whitelist.isEmailWhitelistedAsAdmin.useQuery(
-      { siteId, email: (debouncedEmail || "").trim() },
-      {
-        enabled: false,
-      },
-    )
+  const {
+    data: isWhitelistedAsAdmin,
+    refetch: checkAdminWhitelist,
+    isFetching: isCheckingAdminWhitelist,
+  } = trpc.whitelist.isEmailWhitelistedAsAdmin.useQuery(
+    { siteId, email: (debouncedEmail || "").trim() },
+    {
+      enabled: false,
+    },
+  )
 
   const isEmailNotWhitelistedAsAdmin = useMemo(
-    () => !!(!errors.email && email && !isWhitelistedAsAdmin),
-    [errors.email, email, isWhitelistedAsAdmin],
+    () =>
+      !!(
+        !errors.email &&
+        email &&
+        (email !== debouncedEmail ||
+          isCheckingAdminWhitelist ||
+          !isWhitelistedAsAdmin)
+      ),
+    [
+      errors.email,
+      email,
+      debouncedEmail,
+      isCheckingAdminWhitelist,
+      isWhitelistedAsAdmin,
+    ],
   )
 
   useEffect(() => {

--- a/apps/studio/src/features/users/components/UserPermissionModal/Banners/NonGovEmailCannotBeAdmin.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/Banners/NonGovEmailCannotBeAdmin.tsx
@@ -10,6 +10,6 @@ export const NonGovEmailCannotBeAdmin = () => (
     w="100%"
     border="none"
   >
-    Non-gov.sg emails cannot be added as admin. Select another role.
+    This email can't be added as an admin. Select another role.
   </Infobox>
 )

--- a/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
@@ -98,8 +98,10 @@ export const EditUserModal = () => {
       { enabled: !!siteId && !!userId && !!email },
     )
 
-  // Conservatively treat the email as not-admin-eligible until the check resolves
-  const isAdminRoleDisabled = !isEmailWhitelistedAsAdmin
+  // Only disable the Admin role once the whitelist check has resolved to
+  // ineligible; while it's still loading (undefined) leave it enabled so the
+  // warning doesn't flash for users who already hold the Admin role.
+  const isAdminRoleDisabled = isEmailWhitelistedAsAdmin === false
 
   return (
     <Modal isOpen={!!siteId && !!userId} onClose={onClose}>

--- a/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
@@ -15,13 +15,12 @@ import {
 } from "@chakra-ui/react"
 import { FormLabel, useToast } from "@opengovsg/design-system-react"
 import { useAtomValue, useSetAtom } from "jotai"
-import { useEffect, useMemo } from "react"
+import { useEffect } from "react"
 import { z as zod } from "zod"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useIsSingpassEnabled } from "~/hooks/useIsSingpassEnabled"
 import { useZodForm } from "~/lib/form"
 import { updateUserInputSchema } from "~/schemas/user"
-import { isGovEmail } from "~/utils/email"
 import { trpc } from "~/utils/trpc"
 import { RoleType } from "~prisma/generated/generatedEnums"
 
@@ -93,7 +92,14 @@ export const EditUserModal = () => {
 
   const selectedRole = watch("role")
 
-  const isNonGovEmailInput = useMemo(() => !isGovEmail(email), [email])
+  const { data: isEmailWhitelistedAsAdmin } =
+    trpc.whitelist.isEmailWhitelistedAsAdmin.useQuery(
+      { siteId, email },
+      { enabled: !!siteId && !!userId && !!email },
+    )
+
+  // Conservatively treat the email as not-admin-eligible until the check resolves
+  const isAdminRoleDisabled = !isEmailWhitelistedAsAdmin
 
   return (
     <Modal isOpen={!!siteId && !!userId} onClose={onClose}>
@@ -133,15 +139,17 @@ export const EditUserModal = () => {
                       isSelected={selectedRole === role}
                       onClick={() => setValue("role", role)}
                       permissionLabels={permissionLabels}
-                      isDisabled={role === RoleType.Admin && isNonGovEmailInput}
+                      isDisabled={
+                        role === RoleType.Admin && isAdminRoleDisabled
+                      }
                     />
                   ))}
                 </HStack>
               </FormControl>
-              {selectedRole === RoleType.Admin && !isNonGovEmailInput && (
+              {selectedRole === RoleType.Admin && !isAdminRoleDisabled && (
                 <AddAdminWarning />
               )}
-              {selectedRole === RoleType.Admin && isNonGovEmailInput && (
+              {selectedRole === RoleType.Admin && isAdminRoleDisabled && (
                 <NonGovEmailCannotBeAdmin />
               )}
             </VStack>

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -259,16 +259,20 @@ describe("user.router", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
-    it("should throw 403 if assigning a whitelisted non-gov.sg email with admin role", async () => {
+    it("should throw 403 if assigning admin role to an email whitelisted with a non-null expiry", async () => {
       // Arrange
-      const nonGovSgEmail = "test@coolvendor.com"
+      // A vendor entry (future, non-null expiry) satisfies the whitelist gate
+      // but is not eligible for the Admin role.
+      const vendorEmail = "test@coolvendor.com"
+      const oneYearFromNow = new Date()
+      oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1)
       await setupAdminPermissions({ userId: session.userId, siteId })
-      await setUpWhitelist({ email: nonGovSgEmail })
+      await setUpWhitelist({ email: vendorEmail, expiry: oneYearFromNow })
 
       // Act
       const result = caller.create({
         siteId,
-        users: [{ email: nonGovSgEmail, role: RoleType.Admin }],
+        users: [{ email: vendorEmail, role: RoleType.Admin }],
       })
 
       // Assert
@@ -276,7 +280,7 @@ describe("user.router", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "This email cannot be added as an admin. Select another role.",
         }),
       )
 
@@ -1542,7 +1546,7 @@ describe("user.router", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
-    it("should throw 403 if assigning a non-gov.sg email with admin role", async () => {
+    it("should throw 403 if assigning admin role to an email not whitelisted as admin", async () => {
       // Arrange
       await setupAdminPermissions({ userId: session.userId, siteId })
 
@@ -1564,7 +1568,7 @@ describe("user.router", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "This email cannot be added as an admin. Select another role.",
         }),
       )
 

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -263,16 +263,20 @@ describe("user.service", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
-    it("should throw 403 if assigning a non-gov.sg email with admin role", async () => {
+    it("should throw 403 if assigning admin role to an email whitelisted with a non-null expiry", async () => {
       // Arrange
-      const nonGovSgEmail = "test@coolvendor.com"
-      await setUpWhitelist({ email: nonGovSgEmail })
+      // A vendor entry has a future (non-null) expiry; it satisfies the
+      // whitelist gate but is NOT eligible for the Admin role.
+      const vendorEmail = "test@coolvendor.com"
+      const oneYearFromNow = new Date()
+      oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1)
+      await setUpWhitelist({ email: vendorEmail, expiry: oneYearFromNow })
 
       // Act
       const result = db.transaction().execute((tx) => {
         return createUserWithPermission({
           byUserId: creatorUserId,
-          email: nonGovSgEmail,
+          email: vendorEmail,
           role: RoleType.Admin,
           siteId,
           tx,
@@ -284,13 +288,82 @@ describe("user.service", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "This email cannot be added as an admin. Select another role.",
         }),
       )
 
       // Assert DB - audit logs
       const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLogs).toHaveLength(0)
+    })
+
+    it("should create a user with admin role if the email is whitelisted with a null expiry", async () => {
+      // Arrange
+      // A null-expiry whitelist entry is an admin entry, so the Admin role is
+      // allowed. TEST_EMAIL is whitelisted with a null expiry in beforeAll.
+      const role = RoleType.Admin
+
+      // Act
+      const { user, resourcePermission } = await db
+        .transaction()
+        .execute((tx) => {
+          return createUserWithPermission({
+            byUserId: creatorUserId,
+            email: TEST_EMAIL,
+            role,
+            siteId,
+            tx,
+          })
+        })
+
+      // Assert: Verify resource permission in database
+      const dbResourcePermissionResult = await db
+        .selectFrom("ResourcePermission")
+        .where("userId", "=", user.id)
+        .where("siteId", "=", siteId)
+        .selectAll()
+        .execute()
+
+      expect(dbResourcePermissionResult).toHaveLength(1)
+      expect(dbResourcePermissionResult[0]).toMatchObject({
+        userId: user.id,
+        siteId,
+        role: RoleType.Admin,
+      })
+
+      // Assert DB - audit logs (user)
+      const userAuditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "UserCreate")
+        .selectAll()
+        .execute()
+      expect(userAuditLogs).toHaveLength(1)
+      expect(userAuditLogs[0]).toMatchObject({
+        eventType: "UserCreate",
+        delta: expect.objectContaining({
+          before: null,
+          after: expect.objectContaining(
+            omit(user, ["createdAt", "updatedAt"]),
+          ),
+        }),
+      })
+
+      // Assert DB - audit logs (permission)
+      const permissionAuditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", "PermissionCreate")
+        .selectAll()
+        .execute()
+      expect(permissionAuditLogs).toHaveLength(1)
+      expect(permissionAuditLogs[0]).toMatchObject({
+        eventType: "PermissionCreate",
+        delta: expect.objectContaining({
+          before: null,
+          after: expect.objectContaining(
+            omit(resourcePermission, ["createdAt", "updatedAt"]),
+          ),
+        }),
+      })
     })
 
     it("should create a non-gov.sg email with non-admin role", async () => {

--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -306,7 +306,7 @@ export const userRouter = router({
         })
       }
 
-      validateEmailRoleCombination({ email: user.email, role })
+      await validateEmailRoleCombination({ email: user.email, role })
 
       const updatedUserPermission = await updateUserSitewidePermission({
         byUserId: ctx.user.id,

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -3,13 +3,15 @@ import type { ResourcePermission, User } from "~prisma/generated/generatedTypes"
 import { createId } from "@paralleldrive/cuid2"
 import { TRPCError } from "@trpc/server"
 import isEmail from "validator/lib/isEmail"
-import { isGovEmail } from "~/utils/email"
 import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 
 import type { DB, Transaction } from "../database"
 import { logPermissionEvent, logUserEvent } from "../audit/audit.service"
 import { db, RoleType } from "../database"
-import { isEmailWhitelisted } from "../whitelist/whitelist.service"
+import {
+  isEmailWhitelisted,
+  isEmailWhitelistedAsAdmin,
+} from "../whitelist/whitelist.service"
 
 export const isUserDeleted = async (email: string) => {
   const lowercaseEmail = email.toLowerCase()
@@ -23,18 +25,17 @@ export const isUserDeleted = async (email: string) => {
   return user?.deletedAt ? true : false
 }
 
-export const validateEmailRoleCombination = ({
+export const validateEmailRoleCombination = async ({
   email,
   role,
 }: {
   email: string
   role: ResourcePermission["role"]
 }) => {
-  if (!isGovEmail(email) && role === RoleType.Admin) {
+  if (role === RoleType.Admin && !(await isEmailWhitelistedAsAdmin(email))) {
     throw new TRPCError({
       code: "FORBIDDEN",
-      message:
-        "Non-gov.sg emails cannot be added as admin. Select another role.",
+      message: "This email cannot be added as an admin. Select another role.",
     })
   }
 }
@@ -65,7 +66,7 @@ export const createUserWithPermission = async ({
     })
   }
 
-  validateEmailRoleCombination({ email, role })
+  await validateEmailRoleCombination({ email, role })
 
   const isWhitelisted = await isEmailWhitelisted(email)
   if (!isWhitelisted) {

--- a/apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts
+++ b/apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts
@@ -1,7 +1,10 @@
 import { resetTables } from "tests/integration/helpers/db"
 import { setUpWhitelist } from "tests/integration/helpers/seed"
 
-import { isEmailWhitelisted } from "../whitelist.service"
+import {
+  isEmailWhitelisted,
+  isEmailWhitelistedAsAdmin,
+} from "../whitelist.service"
 
 describe("whitelist.service", () => {
   beforeAll(async () => {
@@ -121,5 +124,73 @@ describe("whitelist.service", () => {
 
     // Assert
     expect(result).toBe(true)
+  })
+
+  describe("isEmailWhitelistedAsAdmin", () => {
+    it("should return true if the exact email address is whitelisted with a null expiry", async () => {
+      // Arrange
+      const email = "whitelisted@example.com"
+
+      // Act
+      const result = await isEmailWhitelistedAsAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    it("should return true if the exact email domain is whitelisted with a null expiry", async () => {
+      // Arrange
+      const email = "user@vendor.com.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAsAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    it("should return true if the suffix of the email domain is whitelisted with a null expiry", async () => {
+      // Arrange
+      const email = "user@agency.gov.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAsAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    it("should return false if the exact email address is whitelisted only with a future (non-null) expiry", async () => {
+      // Arrange
+      const email = "vendor-whitelisted@example.com"
+
+      // Act
+      const result = await isEmailWhitelistedAsAdmin(email)
+
+      // Assert
+      expect(result).toBe(false)
+    })
+
+    it("should return false if the email domain is whitelisted only with a future (non-null) expiry", async () => {
+      // Arrange
+      const email = "user@whitelisted.com.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAsAdmin(email)
+
+      // Assert
+      expect(result).toBe(false)
+    })
+
+    it("should return false if the email is not whitelisted", async () => {
+      // Arrange
+      const email = "not-whitelisted@example.com"
+
+      // Act
+      const result = await isEmailWhitelistedAsAdmin(email)
+
+      // Assert
+      expect(result).toBe(false)
+    })
   })
 })

--- a/apps/studio/src/server/modules/whitelist/whitelist.router.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.router.ts
@@ -10,7 +10,11 @@ import {
   validatePermissionsForManagingUsers,
   validateUserIsIsomerAdmin,
 } from "../permissions/permissions.service"
-import { isEmailWhitelisted, whitelistEmails } from "./whitelist.service"
+import {
+  isEmailWhitelisted,
+  isEmailWhitelistedAsAdmin,
+  whitelistEmails,
+} from "./whitelist.service"
 
 export const whitelistRouter = router({
   isEmailWhitelisted: protectedProcedure
@@ -27,6 +31,18 @@ export const whitelistRouter = router({
       })
 
       return await isEmailWhitelisted(email)
+    }),
+  isEmailWhitelistedAsAdmin: protectedProcedure
+    .input(isEmailWhitelistedInputSchema)
+    .output(isEmailWhitelistedOutputSchema)
+    .query(async ({ ctx, input: { siteId, email } }) => {
+      await validatePermissionsForManagingUsers({
+        siteId,
+        userId: ctx.user.id,
+        action: "manage",
+      })
+
+      return await isEmailWhitelistedAsAdmin(email)
     }),
   whitelistEmails: protectedProcedure
     .input(whitelistEmailsInputSchema)

--- a/apps/studio/src/server/modules/whitelist/whitelist.service.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.service.ts
@@ -85,7 +85,10 @@ export const whitelistEmails = async ({
   })
 }
 
-export const isEmailWhitelisted = async (email: string) => {
+const isEmailWhitelistedWithFilter = async (
+  email: string,
+  nullExpiryOnly: boolean,
+) => {
   const lowercaseEmail = email.toLowerCase()
 
   // Extra guard even if Zod validation has already checked
@@ -97,11 +100,15 @@ export const isEmailWhitelisted = async (email: string) => {
   }
 
   // Step 1: Check if the exact email address is whitelisted
+  // Admin entries have a null expiry; vendor entries have a future expiry.
+  // The admin gate matches only null-expiry entries.
   const exactMatch = await db
     .selectFrom("Whitelist")
     .where("email", "=", lowercaseEmail)
     .where(({ eb }) =>
-      eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+      nullExpiryOnly
+        ? eb("expiry", "is", null)
+        : eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
     )
     .select(["id"])
     .executeTakeFirst()
@@ -124,7 +131,9 @@ export const isEmailWhitelisted = async (email: string) => {
     .selectFrom("Whitelist")
     .where("email", "=", emailDomain)
     .where(({ eb }) =>
-      eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+      nullExpiryOnly
+        ? eb("expiry", "is", null)
+        : eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
     )
     .select(["id"])
     .executeTakeFirst()
@@ -143,7 +152,9 @@ export const isEmailWhitelisted = async (email: string) => {
       .selectFrom("Whitelist")
       .where("email", "=", suffix)
       .where(({ eb }) =>
-        eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+        nullExpiryOnly
+          ? eb("expiry", "is", null)
+          : eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
       )
       .select(["id"])
       .executeTakeFirst()
@@ -155,3 +166,9 @@ export const isEmailWhitelisted = async (email: string) => {
 
   return false
 }
+
+export const isEmailWhitelisted = (email: string) =>
+  isEmailWhitelistedWithFilter(email, false)
+
+export const isEmailWhitelistedAsAdmin = (email: string) =>
+  isEmailWhitelistedWithFilter(email, true)

--- a/apps/studio/src/stories/Page/AddUserModal.stories.tsx
+++ b/apps/studio/src/stories/Page/AddUserModal.stories.tsx
@@ -97,6 +97,14 @@ export const AdminWarningBanner: Story = {
 }
 
 export const NonGovEmailCannotBeAdmin: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...COMMON_HANDLERS,
+        whitelistHandlers.isEmailWhitelistedAsAdmin.false(),
+      ],
+    },
+  },
   play: async (context) => {
     const { canvasElement } = context
     await Default.play?.(context)
@@ -115,7 +123,7 @@ export const NonGovEmailCannotBeAdmin: Story = {
     }
 
     const nonGovEmailCannotBeAdminText = await screen.findByText(
-      "Non-gov.sg emails cannot be added as admin. Select another role.",
+      "This email can't be added as an admin. Select another role.",
     )
     await expect(nonGovEmailCannotBeAdminText).toBeVisible()
   },

--- a/apps/studio/src/stories/handlers/index.ts
+++ b/apps/studio/src/stories/handlers/index.ts
@@ -2,6 +2,7 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import { userHandlers } from "tests/msw/handlers/user"
+import { whitelistHandlers } from "tests/msw/handlers/whitelist"
 
 export const ADMIN_HANDLERS = [
   meHandlers.me(),
@@ -10,4 +11,5 @@ export const ADMIN_HANDLERS = [
   userHandlers.count.default(),
   userHandlers.list.users(),
   userHandlers.isIsomerAdmin.default(),
+  whitelistHandlers.isEmailWhitelistedAsAdmin.true(),
 ]

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -146,7 +146,7 @@ test("admin cannot invite a vendor collaborator as Admin", async ({ page }) => {
   // shows, and Send stays blocked.
   await expect(page.getByRole("button", { name: /^Admin/ })).toBeDisabled()
   await expect(
-    page.getByText("Non-gov.sg emails cannot be added as admin"),
+    page.getByText("This email can't be added as an admin"),
   ).toBeVisible()
   await expect(page.getByRole("button", { name: "Send invite" })).toBeDisabled()
 })

--- a/apps/studio/tests/msw/handlers/whitelist.ts
+++ b/apps/studio/tests/msw/handlers/whitelist.ts
@@ -11,4 +11,14 @@ export const whitelistHandlers = {
         return false
       }),
   },
+  isEmailWhitelistedAsAdmin: {
+    true: () =>
+      trpcMsw.whitelist.isEmailWhitelistedAsAdmin.query(() => {
+        return true
+      }),
+    false: () =>
+      trpcMsw.whitelist.isEmailWhitelistedAsAdmin.query(() => {
+        return false
+      }),
+  },
 }


### PR DESCRIPTION
## Problem

The current implementation restricts the Admin role to gov.sg email addresses only, using a simple domain check. This approach is inflexible and doesn't account for the whitelist system's expiry mechanism, which distinguishes between permanent admin entries (null expiry) and temporary vendor entries (future expiry).

## Solution

Refactored the admin role eligibility logic to check the whitelist system directly:
- Admin role is now only available to emails whitelisted with a **null expiry** (permanent admin entries)
- Emails whitelisted with a **future expiry** (vendor entries) cannot be assigned the Admin role, even if whitelisted
- Removed the `isGovEmail()` utility function dependency from role validation

**Features**:
- Added `isEmailWhitelistedAsAdmin()` service function that filters whitelist entries by null expiry
- Added `isEmailWhitelistedAsAdmin` tRPC query endpoint for frontend validation
- Updated frontend to call the new endpoint and disable Admin role selection based on actual whitelist eligibility
- Updated error message from "Non-gov.sg emails cannot be added as admin" to "This email cannot be added as an admin" for clarity

**Improvements**:
- Refactored `isEmailWhitelisted()` to use a shared `isEmailWhitelistedWithFilter()` helper to reduce code duplication
- Frontend now performs real-time validation against the whitelist system rather than relying on domain heuristics
- Both `AddUserModal` and `EditUserModal` now use consistent whitelist-based validation

**Bug Fixes**:
- Fixed inconsistent admin eligibility checks between frontend and backend by using the same whitelist service

## Tests

- Added comprehensive unit tests for `isEmailWhitelistedAsAdmin()` covering exact email matches, domain matches, suffix matches, and non-whitelisted cases
- Added unit test verifying users can be created with Admin role when whitelisted with null expiry
- Updated existing tests to reflect new error message and validation logic
- Updated Storybook stories and MSW handlers to support the new `isEmailWhitelistedAsAdmin` endpoint
- E2E tests updated to reflect new error messaging

**Breaking Changes**:
- [ ] No - this PR is backwards compatible (internal validation logic change, same external behavior for gov.sg emails)

https://claude.ai/code/session_011wL9XjEfBWuJ9kgvkFMRad

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the `isGovEmail` domain heuristic with a whitelist-expiry check for admin role eligibility: only emails whitelisted with a **null expiry** (permanent admin entries) may be assigned the Admin role; vendor entries (future expiry) are explicitly excluded. The change is applied consistently across both the backend service/router layer and the `AddUserModal`/`EditUserModal` frontend components.

- `whitelist.service.ts` is refactored to share a `isEmailWhitelistedWithFilter(email, nullExpiryOnly)` helper, exposing `isEmailWhitelisted` (any valid entry) and the new `isEmailWhitelistedAsAdmin` (null-expiry only).
- A bug fix is included: `validateEmailRoleCombination` was not `await`-ed in `user.router.ts`'s `update` handler, meaning the FORBIDDEN check was silently skipped on every role update; this PR correctly adds `await`.
- Frontend modals now call the new `isEmailWhitelistedAsAdmin` tRPC endpoint for real-time validation, with `isCheckingAdminWhitelist` used to prevent stale-state flashes during in-flight requests.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the backend enforcement is sound and the previously-missing await on validateEmailRoleCombination is now fixed.

The core logic (whitelist null-expiry gate, backend FORBIDDEN, frontend disable state) is correctly implemented and well-tested. The missing await in the update handler was a real gap that is now closed. The only finding is a Storybook handler gap that does not affect production code or CI integration tests.

apps/studio/src/stories/Page/AddUserModal.stories.tsx — local COMMON_HANDLERS is missing the new isEmailWhitelistedAsAdmin handler, which leaves the Admin button in an incorrect disabled state for stories that type an email.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/whitelist/whitelist.service.ts | Core refactoring: extracts `isEmailWhitelistedWithFilter(email, nullExpiryOnly)` helper and exposes `isEmailWhitelisted` (any valid entry) and `isEmailWhitelistedAsAdmin` (null-expiry only). Logic is correct for all three lookup paths (exact, domain, suffix). |
| apps/studio/src/server/modules/user/user.service.ts | Replaces `isGovEmail` check with `await isEmailWhitelistedAsAdmin`; adds missing `await` to both call-sites of `validateEmailRoleCombination`. Logic is correct. |
| apps/studio/src/server/modules/user/user.router.ts | Adds missing `await` to the `validateEmailRoleCombination` call in the `update` handler — previously the async function was fire-and-forget, allowing forbidden role assignments to slip through server-side. |
| apps/studio/src/server/modules/whitelist/whitelist.router.ts | Adds `isEmailWhitelistedAsAdmin` tRPC query endpoint with the same `validatePermissionsForManagingUsers` authorization guard used by the sibling `isEmailWhitelisted` endpoint. |
| apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx | Replaces `isGovEmail` domain heuristic with a real-time `isEmailWhitelistedAsAdmin` query; uses `isCheckingAdminWhitelist` and `email !== debouncedEmail` flags to disable Admin while the check is in-flight. Logic is correct; base COMMON_HANDLERS in the stories file is missing a handler for this new query. |
| apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx | Switches to `isEmailWhitelistedAsAdmin` query with `isAdminRoleDisabled = (isEmailWhitelistedAsAdmin === false)` guard to avoid the loading-flash for existing admins. Save changes button remains gated only by `isSingpassEnabled`, relying on backend rejection for admin-role mismatches (noted in prior review). |
| apps/studio/src/stories/Page/AddUserModal.stories.tsx | Adds `isEmailWhitelistedAsAdmin.false()` handler to `NonGovEmailCannotBeAdmin` story; local `COMMON_HANDLERS` constant is not updated with the `.true()` default, leaving other stories that type an email without a handler for the new query. |
| apps/studio/src/stories/handlers/index.ts | Correctly adds `whitelistHandlers.isEmailWhitelistedAsAdmin.true()` to the shared `ADMIN_HANDLERS` export so all stories relying on it default to admin-eligible. |
| apps/studio/tests/msw/handlers/whitelist.ts | Adds `true()` and `false()` MSW handlers for the new `isEmailWhitelistedAsAdmin` tRPC query, mirroring the existing `isEmailWhitelisted` handler pattern. |
| apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts | Adds comprehensive unit tests for `isEmailWhitelistedAsAdmin` covering exact match, domain match, suffix match, and non-null-expiry (vendor) cases. |
| apps/studio/src/server/modules/user/__tests__/user.service.test.ts | Updates existing vendor-email FORBIDDEN test to use a future-expiry whitelist entry and adds a new passing test for null-expiry (admin) whitelisted emails creating with Admin role. |
| apps/studio/src/server/modules/user/__tests__/user.router.test.ts | Updates error messages and whitelist seed data in existing router tests to match the new validation behaviour and error text. |
| apps/studio/tests/e2e/user/invite-user.test.ts | Updates E2E assertion text to match the renamed banner copy. |
| apps/studio/src/features/users/components/UserPermissionModal/Banners/NonGovEmailCannotBeAdmin.tsx | Banner text updated from domain-specific wording to the generic 'This email can't be added as an admin' to reflect whitelist-based eligibility. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant UI as AddUserModal / EditUserModal
    participant WR as whitelist.router
    participant WS as whitelist.service
    participant UR as user.router
    participant US as user.service
    participant DB as Database

    Note over UI: User types email (debounced 300ms)
    UI->>WR: "isEmailWhitelistedAsAdmin({ siteId, email })"
    WR->>WR: validatePermissionsForManagingUsers
    WR->>WS: isEmailWhitelistedAsAdmin(email)
    WS->>WS: "isEmailWhitelistedWithFilter(email, nullExpiryOnly=true)"
    WS->>DB: SELECT exact match WHERE expiry IS NULL
    WS->>DB: SELECT domain match WHERE expiry IS NULL
    WS->>DB: SELECT suffix match WHERE expiry IS NULL
    DB-->>WS: match / no match
    WS-->>WR: true / false
    WR-->>UI: isWhitelistedAsAdmin
    Note over UI: isAdminRoleDisabled = (result === false)

    Note over UI: User submits (create / update)
    UI->>UR: "user.create / user.update({ role })"
    UR->>US: "validateEmailRoleCombination({ email, role })"
    US->>WS: isEmailWhitelistedAsAdmin(email)
    WS->>DB: "(same 3 queries, nullExpiryOnly=true)"
    DB-->>WS: match / no match
    WS-->>US: true / false
    alt "role=Admin AND not whitelisted as admin"
        US-->>UR: throw FORBIDDEN
        UR-->>UI: 403 This email cannot be added as an admin
    else
        US->>DB: INSERT/UPDATE permission
        DB-->>US: ok
        US-->>UR: result
        UR-->>UI: success
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant UI as AddUserModal / EditUserModal
    participant WR as whitelist.router
    participant WS as whitelist.service
    participant UR as user.router
    participant US as user.service
    participant DB as Database

    Note over UI: User types email (debounced 300ms)
    UI->>WR: "isEmailWhitelistedAsAdmin({ siteId, email })"
    WR->>WR: validatePermissionsForManagingUsers
    WR->>WS: isEmailWhitelistedAsAdmin(email)
    WS->>WS: "isEmailWhitelistedWithFilter(email, nullExpiryOnly=true)"
    WS->>DB: SELECT exact match WHERE expiry IS NULL
    WS->>DB: SELECT domain match WHERE expiry IS NULL
    WS->>DB: SELECT suffix match WHERE expiry IS NULL
    DB-->>WS: match / no match
    WS-->>WR: true / false
    WR-->>UI: isWhitelistedAsAdmin
    Note over UI: isAdminRoleDisabled = (result === false)

    Note over UI: User submits (create / update)
    UI->>UR: "user.create / user.update({ role })"
    UR->>US: "validateEmailRoleCombination({ email, role })"
    US->>WS: isEmailWhitelistedAsAdmin(email)
    WS->>DB: "(same 3 queries, nullExpiryOnly=true)"
    DB-->>WS: match / no match
    WS-->>US: true / false
    alt "role=Admin AND not whitelisted as admin"
        US-->>UR: throw FORBIDDEN
        UR-->>UI: 403 This email cannot be added as an admin
    else
        US->>DB: INSERT/UPDATE permission
        DB-->>US: ok
        US-->>UR: result
        UR-->>UI: success
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx`, line 167-172 ([link](https://github.com/opengovsg/isomer/blob/83e54546ebe1102cab3160e96bdfc60bbc0c3331/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx#L167-L172)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"Save changes" button not gated by admin role eligibility**

   `AddUserModal`'s submit button checks `isEmailNotWhitelistedAsAdmin` before allowing submission. `EditUserModal`'s "Save changes" button only checks `!isSingpassEnabled`. An admin editing their own role (or an admin-role being assigned to a non-admin-eligible user) relies solely on the backend `validateEmailRoleCombination` call for enforcement. The backend will reject with a FORBIDDEN error, but the user gets no UI-side indication before clicking. Consider mirroring `AddUserModal`'s pattern by also disabling the button when `watch("role") === RoleType.Admin && isAdminRoleDisabled`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(users): avoid admin warning flash wh..."](https://github.com/opengovsg/isomer/commit/e0eb52784a2a3016454d392bafcca1f1c2384dc8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40445133)</sub>

<!-- /greptile_comment -->