### PR TITLE
ci(e2e): fix PR comment posting for fork PRs using workflow_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,11 +216,8 @@ jobs:
     needs: optimize_ci
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
-    # pull-requests: write is needed to upsert a comment with the artifact URL
-    # after the test run; contents: read is the existing checkout default.
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup
@@ -270,28 +267,25 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
-      # On PR runs, post (or replace) a comment with a clickable link to the
-      # artifact zip so reviewers can play the per-test video.webm files
-      # without having to navigate to the workflow run UI.
-      - name: Find existing video-link comment
-        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
-        id: find-video-comment
-        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "<!-- e2e-video-link -->"
-
-      - name: Upsert PR comment with e2e video artifact link
+      # Posting a PR comment requires write access, but GitHub restricts
+      # GITHUB_TOKEN to read-only for `pull_request` events from forks — no
+      # `permissions:` declaration overrides this. The actual comment is posted
+      # by post-pr-comment.yml, which uses a `workflow_run` trigger and runs in
+      # the base-repo context where write access is available. We pass the PR
+      # number and artifact URL through a small artifact because the two
+      # workflows run in separate contexts and can't share environment variables.
+      - name: Save E2E comment metadata
         if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.upload-test-results.outputs.artifact-url != '' }}
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
-        with:
-          comment-id: ${{ steps.find-video-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body: |
-            <!-- e2e-video-link -->
-            🎥 **E2E test videos** — [Download artifact](${{ steps.upload-test-results.outputs.artifact-url }})
+        run: |
+          mkdir -p /tmp/e2e-metadata
+          echo "${{ github.event.pull_request.number }}" > /tmp/e2e-metadata/pr-number.txt
+          echo "${{ steps.upload-test-results.outputs.artifact-url }}" > /tmp/e2e-metadata/artifact-url.txt
 
-            Each test has its own directory under the zip; play `video.webm` to watch the run.
-            Workflow: [run #${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) — artifact expires in 7 days.
+      - name: Upload E2E comment metadata
+        if: ${{ !cancelled() && github.event_name == 'pull_request' && steps.upload-test-results.outputs.artifact-url != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-comment-metadata
+          path: /tmp/e2e-metadata/
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -21,6 +21,7 @@ on:
     types: [completed]
 
 permissions:
+  actions: read # needed by `gh run download` to access the Actions artifacts API
   pull-requests: write
   issues: write # GitHub routes PR comments through the issues API endpoint
 

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -1,0 +1,79 @@
+name: Post E2E video comment
+
+# Why a separate workflow instead of steps inside ci.yml?
+#
+# GitHub hard-restricts the GITHUB_TOKEN to read-only for `pull_request`
+# events triggered by a fork, regardless of what the `permissions:` block
+# declares. Posting a PR comment requires write access, so those steps would
+# always 403 on fork PRs.
+#
+# The `workflow_run` trigger is the official GitHub workaround: it fires after
+# the target workflow completes but runs in the BASE repo's context, so
+# GITHUB_TOKEN always has the permissions declared below — even when the
+# triggering PR came from a fork.
+#
+# The PR number and artifact URL can't be read from the triggering run's
+# environment (different context), so ci.yml writes them into a small artifact
+# ("e2e-comment-metadata") that this workflow downloads before posting.
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  pull-requests: write
+  issues: write # GitHub routes PR comments through the issues API endpoint
+
+jobs:
+  post-comment:
+    # Only run for PR triggers; push runs on main/staging/production don't have
+    # a PR to comment on.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download E2E comment metadata
+        id: download
+        # The artifact won't exist if the E2E job was skipped (Graphite
+        # optimizer) or if the test-results upload failed. continue-on-error
+        # lets subsequent steps gate on `steps.download.outcome` instead of
+        # failing the whole job.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ github.event.workflow_run.id }} \
+            --name e2e-comment-metadata \
+            --dir /tmp/e2e-metadata \
+            --repo ${{ github.repository }}
+
+      - name: Read metadata
+        if: steps.download.outcome == 'success'
+        id: metadata
+        run: |
+          echo "pr-number=$(cat /tmp/e2e-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
+          echo "artifact-url=$(cat /tmp/e2e-metadata/artifact-url.txt)" >> $GITHUB_OUTPUT
+
+      - name: Find existing video-link comment
+        if: steps.download.outcome == 'success'
+        id: find-video-comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ steps.metadata.outputs.pr-number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "<!-- e2e-video-link -->"
+
+      - name: Upsert PR comment with e2e video artifact link
+        if: steps.download.outcome == 'success'
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          comment-id: ${{ steps.find-video-comment.outputs.comment-id }}
+          issue-number: ${{ steps.metadata.outputs.pr-number }}
+          edit-mode: replace
+          body: |
+            <!-- e2e-video-link -->
+            🎥 **E2E test videos** — [Download artifact](${{ steps.metadata.outputs.artifact-url }})
+
+            Each test has its own directory under the zip; play `video.webm` to watch the run.
+            Workflow: [run #${{ github.event.workflow_run.id }}](${{ github.event.workflow_run.html_url }}) — artifact expires in 7 days.


### PR DESCRIPTION
> [!NOTE]
> disclaimer: i one-shot cluaded this 

## Problem

The E2E test artifact comment step was failing with a 403 on PRs opened from forks:

```
RequestError [HttpError]: Resource not accessible by integration
x-accepted-github-permissions: issues=write; pull_requests=write
```

GitHub hard-restricts `GITHUB_TOKEN` to read-only for `pull_request` events triggered by a fork, regardless of what the `permissions:` block declares. This meant the comment was silently dropped for any fork contributor.

Closes #2580 (if tracking) — observed on run [#28277487178](https://github.com/opengovsg/isomer/actions/runs/28277487178).

## Solution

Split comment posting out of `ci.yml` into a dedicated `post-pr-comment.yml` workflow that uses a `workflow_run` trigger. Unlike `pull_request`, `workflow_run` always runs in the **base repo's context**, so `GITHUB_TOKEN` has write access even when the triggering PR came from a fork.

Because the two workflows run in separate contexts and can't share environment variables, `ci.yml` now writes the PR number and artifact URL into a small `e2e-comment-metadata` artifact. `post-pr-comment.yml` downloads that artifact after CI completes and uses it to find and upsert the comment.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- PR comment with E2E video artifact link now posts correctly for **all** PRs, including those opened from forks
- `end-to-end-tests` job permissions narrowed to `contents: read` only (no write access needed in that job anymore)
- `post-pr-comment.yml` gracefully no-ops when the metadata artifact doesn't exist (e.g. E2E job skipped by Graphite optimizer, or artifact upload failed) via `continue-on-error: true` on the download step

## Before & After Screenshots

N/A — CI workflow change only.

## Tests

No production code changes — CI/CD config only. No Manual Verification Steps required.

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes E2E test artifact comment posting for fork PRs by splitting the comment step out of `ci.yml` into a new `post-pr-comment.yml` workflow that uses a `workflow_run` trigger, which always runs in the base repo's context and therefore has write access even for fork-originated PRs.

- **`ci.yml`**: Removes `pull-requests: write` and the inline comment steps; instead writes the PR number and artifact URL into a small `e2e-comment-metadata` artifact (retention: 1 day) that bridges the two workflow contexts.
- **`post-pr-comment.yml`**: New workflow triggered on CI completion; downloads the metadata artifact with `continue-on-error: true` to gracefully no-op when the artifact is absent (skipped E2E job, failed upload), then upserts the PR comment. The `actions: read` permission is correctly declared for the `gh run download` call.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the workflow_run pattern is correctly implemented, the fork-PR write-access problem is genuinely fixed, and the graceful no-op path works as designed.

The two-workflow design is the standard GitHub-recommended approach for this class of problem. The `actions: read` permission (previously missing) is now present, artifact scoping by run ID prevents cross-run collisions, and the `continue-on-error` + outcome-gate pattern correctly handles the skipped-E2E case.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Removed `pull-requests: write` from the end-to-end-tests job and replaced the inline PR comment steps with a small metadata artifact upload; permissions correctly narrowed to `contents: read` only. |
| .github/workflows/post-pr-comment.yml | New workflow_run-based workflow that downloads the metadata artifact and posts the E2E video comment; `issues: write` is included but not required — `pull-requests: write` alone covers PR comments. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Fork as Fork PR (contributor)
    participant CI as ci.yml (pull_request trigger)
    participant Art as GitHub Artifacts
    participant PPR as post-pr-comment.yml (workflow_run trigger)
    participant PR as Pull Request

    Fork->>CI: opens/updates PR
    CI->>CI: run E2E tests
    CI->>Art: upload e2e-test-results artifact
    CI->>Art: upload e2e-comment-metadata artifact (pr-number.txt + artifact-url.txt)
    CI-->>PPR: workflow completed event
    PPR->>Art: gh run download e2e-comment-metadata
    Note over PPR: continue-on-error: true (no-op if artifact missing)
    PPR->>PPR: read pr-number + artifact-url
    PPR->>PR: find existing video-link comment
    PPR->>PR: upsert comment with artifact link
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Fork as Fork PR (contributor)
    participant CI as ci.yml (pull_request trigger)
    participant Art as GitHub Artifacts
    participant PPR as post-pr-comment.yml (workflow_run trigger)
    participant PR as Pull Request

    Fork->>CI: opens/updates PR
    CI->>CI: run E2E tests
    CI->>Art: upload e2e-test-results artifact
    CI->>Art: upload e2e-comment-metadata artifact (pr-number.txt + artifact-url.txt)
    CI-->>PPR: workflow completed event
    PPR->>Art: gh run download e2e-comment-metadata
    Note over PPR: continue-on-error: true (no-op if artifact missing)
    PPR->>PPR: read pr-number + artifact-url
    PPR->>PR: find existing video-link comment
    PPR->>PR: upsert comment with artifact link
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Update .github/workflows/post-pr-comment..."](https://github.com/opengovsg/isomer/commit/e77d7903faba7131bb0c25ff705853df20fbf2a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40445682)</sub>

<!-- /greptile_comment -->