### PR TITLE
feat(db): add AuditLogExportRequest model and migration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -46,6 +46,9 @@ _Avoid_: survey cooldown, quarter (the period is configurable, not fixed)
 **Isomer Admin**: A user with the Core or Migrator role. The only role that can manage taxonomy (create, edit, delete Tag Categories and Tag Options) via the Manage Filters panel.
 _Avoid_: admin, site admin (different concept — refers to site-level admin permissions)
 
+**Site Admin**: A user holding the `Admin` role on a specific site (`ResourcePermission.role = Admin`). Can manage that site's users and permissions. Distinct from Isomer Admin.
+_Avoid_: admin (ambiguous), Isomer Admin (a different, platform-level role)
+
 ### Redirects
 
 **Redirect**: A rule that sends a visitor from an old path on this site to another location. Created and published by a site admin; publishing rebuilds the site so the rule goes live.
@@ -65,3 +68,17 @@ _Avoid_: sample file, example CSV
 
 **Bulk upload**: Creating many Redirects at once by uploading a filled-in Redirects template — every row is validated, and the whole batch publishes in one step.
 _Avoid_: import, mass create, batch add
+
+### Audit and access logging
+
+**Audit Log** (`AuditLog`): The append-only record of site events — resource create/update/delete, publish, login/logout, permission and config changes — each carrying a `delta` (before/after) and `metadata`, scoped by `siteId` and `createdAt`.
+_Avoid_: access log (a derived view, not the raw record), history
+
+**Audit Log Export**: The Site-Admin-initiated, asynchronous workflow that produces a downloadable report of a site's audit/access data for a selected month and emails the requester a link. Comprises one or both report types below.
+_Avoid_: audit log (the underlying record, not the export), download
+
+**Access report** (`type: "users"`): The export view answering *who has access* to a site — derived from `ResourcePermission` joined with `User` (email, role, date added, last login).
+_Avoid_: user list, access log
+
+**Activity report** (`type: "events"`): The export view answering *what happened* on a site during the selected month — derived from `AuditLog` events.
+_Avoid_: event log (ambiguous with the table), audit report

--- a/docs/adr/0003-point-in-time-access-report.md
+++ b/docs/adr/0003-point-in-time-access-report.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# Access report reflects point-in-time access, not current access
+
+The Audit Log Export's **Access report** (`type: "users"`) answers *who had access to the site as of the end of the selected month*, reconstructed from `ResourcePermission.createdAt`/`deletedAt` (include rows where `createdAt <= monthEnd AND (deletedAt IS NULL OR deletedAt > monthEnd)`). For the current month, the as-of date collapses to "now". We chose this because the feature is framed around a selected month and the design calls for "time-in-point Access Logs" — an access *audit* must show who could access the site during the period under review, not who happens to hold access today.
+
+## Considered options
+
+- **Current access (ignore the month)** — what the original one-off script (`apps/studio/prisma/scripts/getAuditLogs.ts`) does: `WHERE rp.deletedAt IS NULL`, no date filter. Simpler and the obvious reading of the query, but it answers the wrong question for a monthly audit and contradicts the point-in-time design.
+- **List access changes within the month** — grants/revocations that occurred in the window. Rejected: that is really the Activity report's job (`PermissionCreate`/`PermissionDelete` events), not a snapshot.
+
+## Consequences
+
+A reader comparing this against the existing script will see the query reconstructing historical state from soft-delete timestamps rather than reading current permissions — this is deliberate, not an oversight. The reconstruction is only as accurate as the soft-delete history; hard-deleted or back-filled permission rows would not be represented faithfully.

--- a/docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md
+++ b/docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md
@@ -1,0 +1,16 @@
+---
+status: accepted
+---
+
+# Audit Log Exports are delivered as long-lived signed S3 URLs in email
+
+A completed Audit Log Export is delivered by emailing the requesting Site Admin a **signed S3 GET URL valid for 3 days**, after which the download link expires (the presigned URL is no longer usable). The link is a standalone bearer credential: anyone who receives the email can download the CSV — which contains sensitive data (user emails, roles, IP addresses, login/logout history) — with no re-authentication. We accepted this for simplicity over building an authenticated in-Studio download flow.
+
+## Considered options
+
+- **Link to an authenticated Studio route that mints a short-lived signed URL on click** — recipient must be a logged-in Admin of the site; access is re-checked at download time, so no bearer credential leaves Studio. Rejected for now in favour of a simpler email-only flow, despite being the stronger choice for sensitive data.
+- **Studio "Exports" page with history + auth-gated re-download** — most robust, but more UI than this iteration warrants.
+
+## Consequences
+
+This is a deliberate convenience-over-security trade-off and a reviewer will (rightly) question it. Mitigations: the presigned download URL expires after 3 days, bounding how long the emailed bearer credential works; exports are Site-Admin-only; and the default 5-minute signed-URL expiry in `src/lib/s3.ts` must be raised specifically for this path. Note that URL expiry does not delete the underlying S3 object — a separate object-lifecycle/deletion policy would be needed to bound data-at-rest exposure, which is not yet implemented. If the threat model tightens, switch to the authenticated-route option above without changing the rest of the workflow.

--- a/packages/db/prisma/generate.cts
+++ b/packages/db/prisma/generate.cts
@@ -6,6 +6,63 @@ const TYPE_FOLDER = "../src/generated"
 // THIS MUST BE PREFIXED WITH A DOT
 const TYPE_FILE = "./generatedTypes.ts"
 const GENERATED_FILE = "./selectableTypes.ts"
+const SCHEMA_FILE = "./schema.prisma"
+
+// prisma-kysely drops `Unsupported(...)` columns entirely (it skips fields of
+// kind "unsupported" before applying `@kyselyType` doc-comment overrides), so
+// we re-inject those fields into the generated Kysely types here, using each
+// field's `/// @kyselyType(X)` doc comment in schema.prisma as the emitted
+// type. Fields of type `Unsupported(...)` without a `/// @kyselyType(...)`
+// doc comment stay omitted, matching prisma-kysely's default behaviour.
+const patchUnsupportedColumns = async () => {
+  const schema = await fs.readFile(path.join(__dirname, SCHEMA_FILE), "utf8")
+  const typesPath = path.join(__dirname, TYPE_FOLDER, TYPE_FILE)
+  let types = await fs.readFile(typesPath, "utf8")
+
+  const modelPattern = /model\s+(\w+)\s+\{([\s\S]*?)\n\}/g
+  const fieldPattern =
+    /\/\/\/\s*@kyselyType\(([^)]+)\)\s*\n\s*(\w+)\s+Unsupported\("[^"]+"\)(\?)?/g
+
+  for (const [, modelName, modelBody] of schema.matchAll(modelPattern)) {
+    if (!modelName || !modelBody) {
+      continue
+    }
+    for (const [, kyselyType, fieldName, nullable] of modelBody.matchAll(
+      fieldPattern,
+    )) {
+      if (!kyselyType || !fieldName) {
+        continue
+      }
+      const fieldType = `${kyselyType}${nullable ? " | null" : ""}`
+      // prisma-kysely emits `export type X = {...};` (later rewritten to
+      // `export interface X {...}` by oxlint's --fix), so handle both forms.
+      const headers = [
+        {
+          header: `export type ${modelName} = {\n`,
+          property: `    ${fieldName}: ${fieldType};\n`,
+        },
+        {
+          header: `export interface ${modelName} {\n`,
+          property: `  ${fieldName}: ${fieldType}\n`,
+        },
+      ]
+      const match = headers.find(({ header }) => types.includes(header))
+      if (!match) {
+        throw new Error(
+          `Could not find generated type for model ${modelName} while injecting Unsupported column ${fieldName}`,
+        )
+      }
+      // Idempotency guard: `prisma generate` rewrites the file before this
+      // script runs, but skip re-injection if the script is run standalone.
+      if (new RegExp(`\\b${fieldName}\\s*[?:]`).test(types)) {
+        continue
+      }
+      types = types.replace(match.header, match.header + match.property)
+    }
+  }
+
+  await fs.writeFile(typesPath, types)
+}
 
 const KYSELY_IMPORT = ts.factory.createImportDeclaration(
   undefined,
@@ -87,6 +144,8 @@ const extractTableTypes = (source: ts.SourceFile) => {
 }
 
 export const generate = async () => {
+  await patchUnsupportedColumns()
+
   const file = await fs.readFile(path.join(__dirname, TYPE_FOLDER, TYPE_FILE))
   const source = ts.createSourceFile(
     TYPE_FILE,

--- a/packages/db/prisma/migrations/20260630031102_add_audit_log_export_request/migration.sql
+++ b/packages/db/prisma/migrations/20260630031102_add_audit_log_export_request/migration.sql
@@ -1,0 +1,62 @@
+-- CreateEnum
+CREATE TYPE "AuditLogExportReportType" AS ENUM ('Access', 'Activity');
+
+-- CreateEnum
+CREATE TYPE "AuditLogExportStatus" AS ENUM ('Pending', 'Processing', 'Done', 'Failed');
+
+-- CreateTable
+-- "auditLogDateRange" bounds are SGT calendar dates, half-open [) (Postgres
+-- canonicalizes daterange to this form); a full month is e.g.
+-- [2026-04-01,2026-05-01). Current-month requests are clamped to today+1 at
+-- insert time.
+CREATE TABLE "AuditLogExportRequest" (
+    "id" BIGSERIAL NOT NULL,
+    "siteId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "auditLogDateRange" daterange NOT NULL,
+    "reportType" "AuditLogExportReportType" NOT NULL,
+    "status" "AuditLogExportStatus" NOT NULL DEFAULT 'Pending',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "errorMessage" TEXT,
+    "objectKey" TEXT,
+    -- set when the request reaches Done; a completed row whose "completedAt" >=
+    -- the end of its "auditLogDateRange" holds a Complete Artifact eligible for reuse
+    "completedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "AuditLogExportRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- AddCheckConstraint
+-- The export range must be non-empty and bounded on both sides: an unbounded
+-- or empty range is never a valid audit log export request.
+ALTER TABLE "AuditLogExportRequest"
+    ADD CONSTRAINT "AuditLogExportRequest_auditLogDateRange_bounded_check"
+    CHECK (
+        NOT isempty("auditLogDateRange")
+        AND lower("auditLogDateRange") IS NOT NULL
+        AND upper("auditLogDateRange") IS NOT NULL
+    );
+
+-- CreateIndex
+CREATE INDEX "AuditLogExportRequest_status_idx" ON "AuditLogExportRequest"("status");
+
+-- CreateIndex
+-- Partial UNIQUE index: prevents duplicate in-flight export requests for the same
+-- (site, user, range, reportType) while one is still Pending/Processing, closing the
+-- SELECT-then-INSERT race in the service layer. Once a request reaches Done/Failed the
+-- row drops out of the index, so the same range can be re-requested later.
+-- Dedupe is by range EQUALITY (not overlap); Postgres canonicalizes daterange to
+-- half-open [) form, so equality is representation-proof (e.g. [a,b] and [a,b+1)
+-- store identically).
+-- Prisma cannot express a partial unique index, so this is hand-written SQL and the
+-- Prisma schema keeps a plain @@index (expect migrate-dev drift on this index).
+-- (Index name kept under Postgres's 63-char identifier limit.)
+CREATE UNIQUE INDEX "AuditLogExportRequest_siteId_userId_dateRange_reportType_idx" ON "AuditLogExportRequest"("siteId", "userId", "auditLogDateRange", "reportType") WHERE "status" IN ('Pending', 'Processing');
+
+-- AddForeignKey
+ALTER TABLE "AuditLogExportRequest" ADD CONSTRAINT "AuditLogExportRequest_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "AuditLogExportRequest" ADD CONSTRAINT "AuditLogExportRequest_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -135,13 +135,14 @@ model User {
   deletedAt   DateTime?
   lastLoginAt DateTime?
 
-  ResourcePermission ResourcePermission[]
-  IsomerAdmin        IsomerAdmin[]
-  versions           Version[]
-  AuditLog           AuditLog[]
-  CodeBuildJobs      CodeBuildJobs[]
-  ScheduledResources Resource[]
-  pushDocumentJobs   PushDocumentJob[]
+  ResourcePermission    ResourcePermission[]
+  IsomerAdmin           IsomerAdmin[]
+  versions              Version[]
+  AuditLog              AuditLog[]
+  CodeBuildJobs         CodeBuildJobs[]
+  ScheduledResources    Resource[]
+  pushDocumentJobs      PushDocumentJob[]
+  AuditLogExportRequest AuditLogExportRequest[]
 
   // This unique index is subsequently replaced with a custom index that
   // treats nulls as not distinct.
@@ -168,18 +169,19 @@ model Site {
   footer      Footer?
   codeBuildId String?
 
-  createdAt          DateTime             @default(now())
-  updatedAt          DateTime             @default(now()) @updatedAt
-  ResourcePermission ResourcePermission[]
-  AuditLog           AuditLog[]
-  CodeBuildJobs      CodeBuildJobs[]
-  Redirect           Redirect[]
+  createdAt             DateTime                @default(now())
+  updatedAt             DateTime                @default(now()) @updatedAt
+  ResourcePermission    ResourcePermission[]
+  AuditLog              AuditLog[]
+  CodeBuildJobs         CodeBuildJobs[]
+  Redirect              Redirect[]
+  AuditLogExportRequest AuditLogExportRequest[]
 }
 
 model Redirect {
-  id          BigInt   @id @default(autoincrement())
+  id          BigInt    @id @default(autoincrement())
   siteId      Int
-  site        Site     @relation(fields: [siteId], references: [id])
+  site        Site      @relation(fields: [siteId], references: [id])
   source      String
   destination String
   createdAt   DateTime  @default(now())
@@ -365,4 +367,49 @@ model PushDocumentJob {
 
   @@index([scheduledAt])
   @@index([resourceId])
+}
+
+enum AuditLogExportReportType {
+  Access // who had access (point-in-time)
+  Activity // what happened (events)
+  // NOTE: a "both" user request is fanned out by the service into two rows
+  // (one Access, one Activity), so there is no `Both` variant here.
+}
+
+enum AuditLogExportStatus {
+  Pending
+  Processing
+  Done
+  Failed
+}
+
+model AuditLogExportRequest {
+  id                BigInt                   @id @default(autoincrement())
+  site              Site                     @relation(fields: [siteId], references: [id], onDelete: Restrict)
+  siteId            Int
+  user              User                     @relation(fields: [userId], references: [id], onDelete: Restrict)
+  userId            String
+  // Export range: bounds are SGT calendar dates, half-open [) (Postgres
+  // canonicalizes daterange to this form). A full month is e.g.
+  // [2026-04-01,2026-05-01); current-month requests are clamped to today+1
+  // at insert time.
+  /// @kyselyType(string)
+  auditLogDateRange Unsupported("daterange")
+  reportType        AuditLogExportReportType
+  status            AuditLogExportStatus     @default(Pending)
+  attempts          Int                      @default(0)
+  errorMessage      String?
+  objectKey         String? // S3 key of the generated CSV (one job produces exactly one CSV)
+  completedAt       DateTime? // set when the request reaches Done; a completed row whose completedAt >= the end of its auditLogDateRange holds a Complete Artifact eligible for reuse
+  createdAt         DateTime                 @default(now())
+  updatedAt         DateTime                 @default(now()) @updatedAt
+
+  @@index([status])
+  // NOTE: the migration promotes this to a PARTIAL UNIQUE index
+  // (`WHERE status IN ('Pending', 'Processing')`) to prevent duplicate
+  // in-flight requests for the same range. Prisma's schema DSL cannot express
+  // a partial unique index, so it is defined as raw SQL in the migration and
+  // this stays a plain `@@index`. As a result `prisma migrate dev` against an
+  // existing DB will report drift here; that divergence is expected.
+  @@index([siteId, userId, auditLogDateRange, reportType])
 }

--- a/packages/db/src/generated/generatedEnums.ts
+++ b/packages/db/src/generated/generatedEnums.ts
@@ -57,3 +57,17 @@ export const BuildStatusType = {
 } as const
 export type BuildStatusType =
   (typeof BuildStatusType)[keyof typeof BuildStatusType]
+export const AuditLogExportReportType = {
+  Access: "Access",
+  Activity: "Activity",
+} as const
+export type AuditLogExportReportType =
+  (typeof AuditLogExportReportType)[keyof typeof AuditLogExportReportType]
+export const AuditLogExportStatus = {
+  Pending: "Pending",
+  Processing: "Processing",
+  Done: "Done",
+  Failed: "Failed",
+} as const
+export type AuditLogExportStatus =
+  (typeof AuditLogExportStatus)[keyof typeof AuditLogExportStatus]

--- a/packages/db/src/generated/generatedTypes.ts
+++ b/packages/db/src/generated/generatedTypes.ts
@@ -12,6 +12,8 @@ import type {
   IsomerAdminRole,
   AuditLogEvent,
   BuildStatusType,
+  AuditLogExportReportType,
+  AuditLogExportStatus,
 } from "./generatedEnums"
 
 export interface AuditLog {
@@ -28,6 +30,20 @@ export interface AuditLog {
    */
   delta: PrismaJson.AuditLogDeltaJsonContent
   ipAddress: string | null
+}
+export interface AuditLogExportRequest {
+  auditLogDateRange: string
+  id: GeneratedAlways<string>
+  siteId: number
+  userId: string
+  reportType: AuditLogExportReportType
+  status: Generated<AuditLogExportStatus>
+  attempts: Generated<number>
+  errorMessage: string | null
+  objectKey: string | null
+  completedAt: Timestamp | null
+  createdAt: Generated<Timestamp>
+  updatedAt: Generated<Timestamp>
 }
 export interface Blob {
   id: GeneratedAlways<string>
@@ -182,6 +198,7 @@ export interface Whitelist {
 }
 export interface DB {
   AuditLog: AuditLog
+  AuditLogExportRequest: AuditLogExportRequest
   Blob: Blob
   CodeBuildJobs: CodeBuildJobs
   Footer: Footer

--- a/packages/db/src/generated/selectableTypes.ts
+++ b/packages/db/src/generated/selectableTypes.ts
@@ -3,6 +3,7 @@ import { type Selectable } from "kysely"
 
 import type * as T from "./generatedTypes"
 export type AuditLog = Selectable<T.AuditLog>
+export type AuditLogExportRequest = Selectable<T.AuditLogExportRequest>
 export type Blob = Selectable<T.Blob>
 export type CodeBuildJobs = Selectable<T.CodeBuildJobs>
 export type Footer = Selectable<T.Footer>


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +183 | -15 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 3 | +49 | -0 |
| 🚫 Ignore | 3 | +32 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The async Audit Log Export feature lets a Site Admin request a downloadable report of a site's audit/access data for a selected month and receive it by email. That workflow needs durable, queryable per-request state — who requested what, the lifecycle status, retry count, and the resulting object key — but no such table exists.

No linked issue (stacked feature work). This is the base of a 6-PR stack:

1. **#2603 (this PR)** — schema: `AuditLogExportRequest` model + migration
2. #2604 — Zod input schema
3. #2605 — report queries + CSV
4. #2606 — S3 + email delivery plumbing
5. #2607 — request endpoint + cron orchestrator
6. #2608 — Settings UI

## Solution

Add an **additive, backward-compatible** Prisma model and two enums for the export workflow, plus the architectural decision records and glossary entries that explain the non-obvious choices.

**Breaking Changes**

- [ ] Yes
- [x] No — this PR is backwards compatible. The migration only adds new types, a new table, indexes, and foreign keys; no existing object is altered or dropped.

**Features**:

- `AuditLogExportRequest` table — `id`, `siteId`, `userId`, `auditLogDateRange` (native Postgres `daterange`: SGT calendar dates, half-open, canonical `[YYYY-MM-DD,YYYY-MM-DD)` — e.g. `[2026-04-01,2026-05-01)` for April; current-month requests are clamped to SGT-today + 1 at insert time), `reportType`, `status` (default `Pending`), `attempts`, `errorMessage`, `objectKey` (nullable — each job produces exactly one CSV), timestamps. A named CHECK constraint rejects empty or unbounded ranges. Indexed on `status` (cron sweep), plus a partial unique index on `(siteId, userId, auditLogDateRange, reportType) WHERE status IN ('Pending','Processing')` (in-flight dedupe by range **equality** — Postgres canonicalizes `daterange`, so equality is representation-proof).
- `AuditLogExportReportType` enum — `Access` | `Activity`. `Both` is deliberately **not** a DB value: it is input vocabulary only, which the service (#2607) fans out into two rows, one per report.
- `AuditLogExportStatus` enum — `Pending` | `Processing` | `Done` | `Failed`.

**Improvements**:

- `docs/adr/0003-point-in-time-access-report.md` — records why the Access report reconstructs *historical* access (as-of month end) instead of reading current permissions.
- `docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md` — records the emailed long-lived signed-URL delivery trade-off and its mitigations.
- `CONTEXT.md` — glossary entries: **Site Admin**, **Audit Log**, **Audit Log Export**, **Access report**, **Activity report**.

**Bug Fixes**:

- None.

## Tests

Schema-only PR; no runtime behaviour yet. Verified that:

- `pnpm --filter @isomer/db migrate` applies `20260630031102_add_audit_log_export_request` cleanly (additive SQL only).
- `pnpm generate` refreshes the Prisma + Kysely types with no errors.
- `pnpm typecheck` is green.

**New dependencies**: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds the `AuditLogExportRequest` Prisma model and its migration as the schema foundation for the async Audit Log Export feature. The change is purely additive — two new enums, one new table with appropriate indexes, FK constraints, and a bounded-range CHECK constraint.

- **Schema**: `AuditLogExportRequest` table with a native Postgres `daterange` column (`auditLogDateRange`), a `status` sweep index, and a hand-written partial UNIQUE index `WHERE status IN ('Pending','Processing')` for in-flight deduplication; the plain `@@index` / partial-UNIQUE drift is explicitly acknowledged in both the schema and migration comments.
- **Code generation**: `patchUnsupportedColumns` in `generate.cts` re-injects `Unsupported(\"daterange\")` fields (annotated with `/// @kyselyType(...)`) into the prisma-kysely output, correctly producing `auditLogDateRange: string` in the Kysely types.
- **Docs**: Two new ADRs (point-in-time access reconstruction, emailed signed-URL delivery trade-off) and glossary entries in `CONTEXT.md`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — purely additive schema change with no modifications to existing tables, indexes, or types.

Every change is additive: new enums, a new table, new indexes, and new generated type files. Existing tables are untouched. The migration is backward-compatible and the Kysely type injection is correctly guarded for idempotency. The only non-trivial concern is that `generate().catch` logs but does not exit non-zero on failure, which would hide a broken generation step in CI — but this does not affect the correctness of the committed generated files.

**Files Needing Attention:** packages/db/prisma/generate.cts — the new `patchUnsupportedColumns` code path throws on mismatch but the top-level error handler exits 0.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/db/prisma/generate.cts | Adds `patchUnsupportedColumns` to inject `Unsupported("...")`-typed fields (annotated with `/// @kyselyType(...)`) into the prisma-kysely output; logic is sound but the top-level `.catch` silently swallows errors (exits 0), which can hide injection failures. |
| packages/db/prisma/migrations/20260630031102_add_audit_log_export_request/migration.sql | Clean additive migration: two enums, one table, a bounded-range CHECK constraint, a status sweep index, and a partial UNIQUE index for in-flight deduplication; index names are within Postgres's 63-char limit and both FKs carry ON DELETE RESTRICT. |
| packages/db/prisma/schema.prisma | Adds `AuditLogExportRequest` model with `daterange` column typed as `Unsupported` + `/// @kyselyType(string)` annotation; both FK relations carry explicit `onDelete: Restrict`; the plain `@@index` vs. migration's partial UNIQUE index drift is clearly documented inline. |
| packages/db/src/generated/generatedTypes.ts | Correctly adds the `AuditLogExportRequest` interface and registers it in the `DB` map; `auditLogDateRange` appears first (injected by `patchUnsupportedColumns`) while the DB column is 4th — cosmetic inconsistency, not a runtime issue. |
| packages/db/src/generated/generatedEnums.ts | Generates `AuditLogExportReportType` and `AuditLogExportStatus` const-enums matching the Prisma schema values exactly. |
| packages/db/src/generated/selectableTypes.ts | Adds `AuditLogExportRequest` selectable type, consistent with the rest of the file. |
| docs/adr/0003-point-in-time-access-report.md | New ADR documenting the point-in-time access reconstruction approach; clearly explains why the query uses `createdAt`/`deletedAt` instead of reading current permissions. |
| docs/adr/0004-emailed-signed-url-delivery-for-audit-exports.md | New ADR documenting the emailed signed-URL delivery trade-off and its mitigations; the security implications are candidly acknowledged. |
| CONTEXT.md | Adds glossary entries for Site Admin, Audit Log, Audit Log Export, Access report, and Activity report; consistent with the new schema concepts. |

</details>

<details open><summary><h3>Entity Relationship Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
erDiagram
    Site {
        int id PK
        string name
    }
    User {
        string id PK
        string email
    }
    AuditLogExportRequest {
        bigint id PK
        int siteId FK
        string userId FK
        daterange auditLogDateRange
        AuditLogExportReportType reportType
        AuditLogExportStatus status
        int attempts
        string errorMessage
        string objectKey
        timestamp completedAt
        timestamp createdAt
        timestamp updatedAt
    }
    AuditLogExportReportType {
        string Access
        string Activity
    }
    AuditLogExportStatus {
        string Pending
        string Processing
        string Done
        string Failed
    }
    Site ||--o{ AuditLogExportRequest : "siteId (RESTRICT)"
    User ||--o{ AuditLogExportRequest : "userId (RESTRICT)"
    AuditLogExportRequest }o--|| AuditLogExportReportType : "reportType"
    AuditLogExportRequest }o--|| AuditLogExportStatus : "status"
```
</details>

<sub>Reviews (18): Last reviewed commit: ["feat(db): add AuditLogExportRequest mode..."](https://github.com/opengovsg/isomer/commit/f5b3593765cba011cfe260c9c7ee50fe066a1183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40759279)</sub>

<!-- /greptile_comment -->