### PR TITLE
feat(studio): add audit log export request input schema

### DIFF
--- a/apps/studio/src/schemas/__tests__/audit.test.ts
+++ b/apps/studio/src/schemas/__tests__/audit.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest"
+import { AuditLogExportReportType } from "~prisma/generated/generatedEnums"
+
+import {
+  AUDIT_LOG_EXPORT_MAX_MONTHS,
+  createAuditLogExportRequestSchema,
+  getCurrentSingaporeMonth,
+  getEarliestExportableMonth,
+} from "../audit"
+
+// The schema now enforces the export window relative to "now", so the valid
+// fixture month is the current Singapore month (always in-window) rather than a
+// fixed literal that would fall out of the window as real time advances.
+const CURRENT_MONTH = getCurrentSingaporeMonth()
+
+const VALID_INPUT = {
+  siteId: 1,
+  month: CURRENT_MONTH,
+  reportType: AuditLogExportReportType.Both,
+}
+
+describe("createAuditLogExportRequestSchema", () => {
+  it("should parse a known-good input", () => {
+    // Arrange / Act
+    const result = createAuditLogExportRequestSchema.safeParse(VALID_INPUT)
+
+    // Assert
+    expect(result.success).toBe(true)
+  })
+
+  describe("month", () => {
+    it.each(["2026-13", "2026-1", "26-01", "not-a-month", ""])(
+      "should reject the invalid month %j",
+      (month) => {
+        // Arrange / Act
+        const result = createAuditLogExportRequestSchema.safeParse({
+          ...VALID_INPUT,
+          month,
+        })
+
+        // Assert
+        expect(result.success).toBe(false)
+      },
+    )
+
+    it("should accept the current Singapore month (in window)", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        month: CURRENT_MONTH,
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should accept the earliest month in the window", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        month: getEarliestExportableMonth(CURRENT_MONTH),
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject a month in the future", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        month: "2999-12",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+
+    it("should reject a month older than the 12-month window", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        month: "2000-01",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe("reportType", () => {
+    it.each([
+      AuditLogExportReportType.Access,
+      AuditLogExportReportType.Activity,
+      AuditLogExportReportType.Both,
+    ])("should accept the valid report type %s", (reportType) => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        reportType,
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+    })
+
+    it("should reject an invalid report type", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        reportType: "users",
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe("getEarliestExportableMonth", () => {
+    it("should return the month 11 months before the current month", () => {
+      // 12 months inclusive of the current month.
+      expect(getEarliestExportableMonth("2026-06")).toBe("2025-07")
+    })
+
+    it.each([
+      ["2026-01", "2025-02"],
+      ["2026-12", "2026-01"],
+      ["2026-11", "2025-12"],
+    ])("should roll the year over correctly: %s -> %s", (current, earliest) => {
+      expect(getEarliestExportableMonth(current)).toBe(earliest)
+    })
+
+    it("should span exactly AUDIT_LOG_EXPORT_MAX_MONTHS months inclusive", () => {
+      expect(AUDIT_LOG_EXPORT_MAX_MONTHS).toBe(12)
+      // current month + earliest month, plus the 10 in between, is 12 months.
+      expect(getEarliestExportableMonth("2026-06")).toBe("2025-07")
+    })
+  })
+
+  describe("siteId", () => {
+    it("should reject a non-positive siteId", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        siteId: 0,
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+
+    it("should reject a negative siteId", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        siteId: -1,
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+
+    it("should reject a non-integer siteId", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        siteId: 1.5,
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/apps/studio/src/schemas/__tests__/audit.test.ts
+++ b/apps/studio/src/schemas/__tests__/audit.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { AuditLogExportReportType } from "~prisma/generated/generatedEnums"
 
+import type { IsoMonth } from "../audit"
 import {
   AUDIT_LOG_EXPORT_MAX_MONTHS,
+  AuditLogExportRequestedReportType,
   createAuditLogExportRequestSchema,
   getCurrentSingaporeMonth,
   getEarliestExportableMonth,
@@ -16,7 +17,7 @@ const CURRENT_MONTH = getCurrentSingaporeMonth()
 const VALID_INPUT = {
   siteId: 1,
   month: CURRENT_MONTH,
-  reportType: AuditLogExportReportType.Both,
+  reportType: AuditLogExportRequestedReportType.Both,
 }
 
 describe("createAuditLogExportRequestSchema", () => {
@@ -90,9 +91,9 @@ describe("createAuditLogExportRequestSchema", () => {
 
   describe("reportType", () => {
     it.each([
-      AuditLogExportReportType.Access,
-      AuditLogExportReportType.Activity,
-      AuditLogExportReportType.Both,
+      AuditLogExportRequestedReportType.Access,
+      AuditLogExportRequestedReportType.Activity,
+      AuditLogExportRequestedReportType.Both,
     ])("should accept the valid report type %s", (reportType) => {
       // Arrange / Act
       const result = createAuditLogExportRequestSchema.safeParse({
@@ -122,7 +123,9 @@ describe("createAuditLogExportRequestSchema", () => {
       expect(getEarliestExportableMonth("2026-06")).toBe("2025-07")
     })
 
-    it.each([
+    // `it.each` widens tuple literals to `string`, so type the cases
+    // explicitly to satisfy the `IsoMonth` parameter.
+    it.each<[IsoMonth, IsoMonth]>([
       ["2026-01", "2025-02"],
       ["2026-12", "2026-01"],
       ["2026-11", "2025-12"],
@@ -138,6 +141,49 @@ describe("createAuditLogExportRequestSchema", () => {
   })
 
   describe("siteId", () => {
+    it("should accept a plain number siteId", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        siteId: 1,
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+      expect(result.data?.siteId).toBe(1)
+    })
+
+    it("should coerce a numeric-string siteId (e.g. from a native form input)", () => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        siteId: "1",
+      })
+
+      // Assert
+      expect(result.success).toBe(true)
+      expect(result.data?.siteId).toBe(1)
+    })
+
+    // JS numeric coercion turns true -> 1, [1] -> 1, and "" / [] -> 0. The
+    // union guard must reject these non-ID JSON values rather than silently
+    // treating them as a valid site.
+    it.each([
+      ["boolean true", true],
+      ["single-element array", [1]],
+      ["empty object", {}],
+      ["non-numeric string", "abc"],
+    ])("should reject a non-ID siteId (%s)", (_label, siteId) => {
+      // Arrange / Act
+      const result = createAuditLogExportRequestSchema.safeParse({
+        ...VALID_INPUT,
+        siteId,
+      })
+
+      // Assert
+      expect(result.success).toBe(false)
+    })
+
     it("should reject a non-positive siteId", () => {
       // Arrange / Act
       const result = createAuditLogExportRequestSchema.safeParse({

--- a/apps/studio/src/schemas/audit.ts
+++ b/apps/studio/src/schemas/audit.ts
@@ -40,7 +40,10 @@ type IsoMonthSegment =
   | "10"
   | "11"
   | "12"
-export type IsoMonth = `${number}-${IsoMonthSegment}`
+type YearPrefix = "2"
+type YearSuffix = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+type IsoYear = `${YearPrefix}${YearSuffix}${YearSuffix}${YearSuffix}`
+export type IsoMonth = `${IsoYear}-${IsoMonthSegment}`
 
 // Matches a calendar month like "2026-03" — the runtime counterpart of
 // `IsoMonth`, used where values cross from untyped input into the type.

--- a/apps/studio/src/schemas/audit.ts
+++ b/apps/studio/src/schemas/audit.ts
@@ -1,10 +1,49 @@
+import {
+  format,
+  isAfter,
+  isBefore,
+  isSameMonth,
+  parseISO,
+  subMonths,
+} from "date-fns"
 import { formatInTimeZone } from "date-fns-tz"
 import { z } from "zod"
 import { AuditLogExportReportType } from "~prisma/generated/generatedEnums"
 
 const SINGAPORE_TIME_ZONE = "Asia/Singapore"
 
-// Matches a calendar month like "2026-03".
+// What the user may ask for. `Both` is UX vocabulary only — the service
+// fans it out into two AuditLogExportRequest rows (Access + Activity);
+// the DB enum has no Both member.
+export const AuditLogExportRequestedReportType = {
+  ...AuditLogExportReportType,
+  Both: "Both",
+} as const
+export type AuditLogExportRequestedReportType =
+  (typeof AuditLogExportRequestedReportType)[keyof typeof AuditLogExportRequestedReportType]
+
+// A calendar month in ISO `yyyy-MM` form, e.g. "2026-03". This is the shape
+// every month value in the audit-export flow is passed around in (picker →
+// zod input → service → query layer), so it gets a real type rather than a
+// bare `string`. The month segment is a closed union because TypeScript's
+// `${number}` does not match zero-padded strings like "03".
+type IsoMonthSegment =
+  | "01"
+  | "02"
+  | "03"
+  | "04"
+  | "05"
+  | "06"
+  | "07"
+  | "08"
+  | "09"
+  | "10"
+  | "11"
+  | "12"
+export type IsoMonth = `${number}-${IsoMonthSegment}`
+
+// Matches a calendar month like "2026-03" — the runtime counterpart of
+// `IsoMonth`, used where values cross from untyped input into the type.
 const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/
 
 // The export window: a Site Admin may request the current Singapore-time month
@@ -15,22 +54,28 @@ const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/
 // from the same constant — one source of truth across all three.
 export const AUDIT_LOG_EXPORT_MAX_MONTHS = 12
 
-// Given the current calendar month as "yyyy-MM", return the earliest month
-// (also "yyyy-MM") still exportable under the window. Pure: the caller passes
-// in the current month rather than reading the clock here.
-export const getEarliestExportableMonth = (currentMonth: string): string => {
+// Given the current calendar month, return the earliest month still
+// exportable under the window. Pure: the caller passes in the current month
+// rather than reading the clock here.
+export const getEarliestExportableMonth = (
+  currentMonth: IsoMonth,
+): IsoMonth => {
   const [year, month] = currentMonth.split("-").map(Number)
   if (year === undefined || month === undefined) {
     throw new Error(
       `Invalid month, expected "yyyy-MM" but got: ${currentMonth}`,
     )
   }
-  const earliest = new Date(
-    Date.UTC(year, month - 1 - (AUDIT_LOG_EXPORT_MAX_MONTHS - 1), 1),
+  // Subtract the window with date-fns, keeping the current month inclusive.
+  // Construct and format in the same (local) frame so the resulting calendar
+  // month is unaffected by the runtime's zone.
+  const earliest = subMonths(
+    new Date(year, month - 1, 1),
+    AUDIT_LOG_EXPORT_MAX_MONTHS - 1,
   )
-  // `earliest` is a UTC-anchored instant; read it back in UTC so the calendar
-  // month is unaffected by the runtime's local zone.
-  return formatInTimeZone(earliest, "UTC", "yyyy-MM")
+  // The "yyyy-MM" token always yields a zero-padded month, so the cast is
+  // sound; date-fns just types `format` as returning plain `string`.
+  return format(earliest, "yyyy-MM") as IsoMonth
 }
 
 // The current calendar month in Singapore time as "yyyy-MM". SGT is UTC+8 all
@@ -38,30 +83,55 @@ export const getEarliestExportableMonth = (currentMonth: string): string => {
 // correct wherever this runs — the server in any timezone, or the user's
 // browser. We use date-fns-tz's explicit "yyyy-MM" token rather than an
 // Intl locale trick (e.g. "en-CA"), which depends on ICU locale data and can
-// silently format differently on minimal-ICU runtimes. The zero-padded result
-// compares lexicographically the same as chronologically.
-export const getCurrentSingaporeMonth = (): string =>
-  formatInTimeZone(new Date(), SINGAPORE_TIME_ZONE, "yyyy-MM")
+// silently format differently on minimal-ICU runtimes.
+export const getCurrentSingaporeMonth = (): IsoMonth =>
+  // Same reasoning as above: "yyyy-MM" always zero-pads, so the cast is sound.
+  formatInTimeZone(new Date(), SINGAPORE_TIME_ZONE, "yyyy-MM") as IsoMonth
 
 export const createAuditLogExportRequestSchema = z.object({
+  // Accept a real number or a numeric form string (a native input yields e.g.
+  // "1"), then convert to the numeric site ID the database and service contract
+  // use. The union guards against JS numeric coercion quirks — a bare
+  // z.coerce.number() would turn non-ID values like true or [1] into 1.
   siteId: z
-    .number()
-    .int({ message: "Select a valid site" })
-    .positive({ message: "Select a valid site" }),
+    .union([z.number(), z.string().regex(/^\d+$/)])
+    .transform(Number)
+    .pipe(
+      z
+        .number()
+        .int({ message: "Select a valid site" })
+        .positive({ message: "Select a valid site" }),
+    ),
   month: z
     .string()
     .regex(MONTH_REGEX, {
       message: "Enter a month in the format YYYY-MM, e.g. 2026-03",
     })
-    .refine((month) => month <= getCurrentSingaporeMonth(), {
-      message: "You cannot export audit logs for a month that is in the future",
-    })
     .refine(
-      (month) =>
-        month >= getEarliestExportableMonth(getCurrentSingaporeMonth()),
+      (month) => {
+        const parsed = parseISO(`${month}-01`)
+        const current = parseISO(`${getCurrentSingaporeMonth()}-01`)
+        return isSameMonth(parsed, current) || isBefore(parsed, current)
+      },
+      {
+        message:
+          "You cannot export audit logs for a month that is in the future",
+      },
+    )
+    .refine(
+      (month) => {
+        const parsed = parseISO(`${month}-01`)
+        const earliest = parseISO(
+          `${getEarliestExportableMonth(getCurrentSingaporeMonth())}-01`,
+        )
+        return isSameMonth(parsed, earliest) || isAfter(parsed, earliest)
+      },
       { message: "You can only export audit logs from the past 12 months" },
-    ),
-  reportType: z.enum(AuditLogExportReportType, {
+    )
+    // The regex above guarantees the shape at runtime; narrow the inferred
+    // output from `string` to `IsoMonth` so consumers get the real type.
+    .transform((month) => month as IsoMonth),
+  reportType: z.enum(AuditLogExportRequestedReportType, {
     message: "Select a report type",
   }),
 })

--- a/apps/studio/src/schemas/audit.ts
+++ b/apps/studio/src/schemas/audit.ts
@@ -1,0 +1,71 @@
+import { formatInTimeZone } from "date-fns-tz"
+import { z } from "zod"
+import { AuditLogExportReportType } from "~prisma/generated/generatedEnums"
+
+const SINGAPORE_TIME_ZONE = "Asia/Singapore"
+
+// Matches a calendar month like "2026-03".
+const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/
+
+// The export window: a Site Admin may request the current Singapore-time month
+// plus the 11 months before it (12 months inclusive of the current month).
+// This schema enforces the window directly (so both the client form and the
+// server's input validation reject out-of-window months); the service keeps an
+// equivalent guard as defense-in-depth, and the month picker derives its range
+// from the same constant — one source of truth across all three.
+export const AUDIT_LOG_EXPORT_MAX_MONTHS = 12
+
+// Given the current calendar month as "yyyy-MM", return the earliest month
+// (also "yyyy-MM") still exportable under the window. Pure: the caller passes
+// in the current month rather than reading the clock here.
+export const getEarliestExportableMonth = (currentMonth: string): string => {
+  const [year, month] = currentMonth.split("-").map(Number)
+  if (year === undefined || month === undefined) {
+    throw new Error(
+      `Invalid month, expected "yyyy-MM" but got: ${currentMonth}`,
+    )
+  }
+  const earliest = new Date(
+    Date.UTC(year, month - 1 - (AUDIT_LOG_EXPORT_MAX_MONTHS - 1), 1),
+  )
+  // `earliest` is a UTC-anchored instant; read it back in UTC so the calendar
+  // month is unaffected by the runtime's local zone.
+  return formatInTimeZone(earliest, "UTC", "yyyy-MM")
+}
+
+// The current calendar month in Singapore time as "yyyy-MM". SGT is UTC+8 all
+// year (no DST); we format in that zone explicitly so the window check is
+// correct wherever this runs — the server in any timezone, or the user's
+// browser. We use date-fns-tz's explicit "yyyy-MM" token rather than an
+// Intl locale trick (e.g. "en-CA"), which depends on ICU locale data and can
+// silently format differently on minimal-ICU runtimes. The zero-padded result
+// compares lexicographically the same as chronologically.
+export const getCurrentSingaporeMonth = (): string =>
+  formatInTimeZone(new Date(), SINGAPORE_TIME_ZONE, "yyyy-MM")
+
+export const createAuditLogExportRequestSchema = z.object({
+  siteId: z
+    .number()
+    .int({ message: "Select a valid site" })
+    .positive({ message: "Select a valid site" }),
+  month: z
+    .string()
+    .regex(MONTH_REGEX, {
+      message: "Enter a month in the format YYYY-MM, e.g. 2026-03",
+    })
+    .refine((month) => month <= getCurrentSingaporeMonth(), {
+      message: "You cannot export audit logs for a month that is in the future",
+    })
+    .refine(
+      (month) =>
+        month >= getEarliestExportableMonth(getCurrentSingaporeMonth()),
+      { message: "You can only export audit logs from the past 12 months" },
+    ),
+  reportType: z.enum(AuditLogExportReportType, {
+    message: "Select a report type",
+  }),
+})
+
+export type CreateAuditLogExportRequestInput = z.infer<
+  typeof createAuditLogExportRequestSchema
+>


### PR DESCRIPTION
## Problem

The Audit Log Export endpoint needs validated, type-safe input — a site, a calendar month, and which report(s) to produce — with user-facing error messages, before any server logic runs.

No linked issue (stacked feature work). Part of the stack starting at #2603 (depends on the schema PR for the `AuditLogExportReportType` enum).

## Solution

Add a Zod schema for the create-export-request input under `~/schemas/`, following the area conventions (one file per domain, `<action><Entity>Schema` naming, user-facing messages on every constraint, inferred type exported alongside).

**Breaking Changes**

- [ ] Yes
- [x] No — additive, no existing schema changed.

**Features**:

- `createAuditLogExportRequestSchema` in `apps/studio/src/schemas/audit.ts`:
  - `siteId` — positive integer.
  - `month` — string matching `^\d{4}-(0[1-9]|1[0-2])$` (e.g. `2026-03`), **plus** two refinements enforcing the export window: not in the future, and not older than the 12-month window — both relative to the current Singapore month. Because the client form derives from this schema, the window is now validated client-side (zodResolver) and server-side (router input) as well as in the service guard.
  - `reportType` — `z.enum(AuditLogExportRequestedReportType)` (`Access` | `Activity` | `Both`). `AuditLogExportRequestedReportType` is **input vocabulary**, defined in this file by spreading the Prisma `AuditLogExportReportType` enum (`Access` | `Activity`) plus `Both` — so it still fails type-check if the DB enum changes. `Both` never reaches the DB: the service (#2607) fans a `Both` request out into two rows (one `Access`, one `Activity`).
- Exported inferred type `CreateAuditLogExportRequestInput`.
- `AUDIT_LOG_EXPORT_MAX_MONTHS` (= 12), `getEarliestExportableMonth(currentMonth)`, and `getCurrentSingaporeMonth()` — the shared export-window policy, consumed by the schema refinements, the server guard (#2607), and the client month picker (#2608) so they can't drift. Note: adding the refinements makes this schema time-dependent by design (its tests use dynamic months).

**Improvements**:

- Uses the zod 4 `z.enum(EnumObject)` form (not the deprecated `z.nativeEnum`).

**Bug Fixes**:

- None.

## Tests

- `apps/studio/src/schemas/__tests__/audit.test.ts` — 22 cases: valid input parses; invalid month formats rejected (`2026-13`, `2026-1`, `26-01`, non-month, empty); window cases (current month and the earliest in-window month accepted; a future month and a month older than the window rejected); each valid `reportType` accepted and an invalid one rejected; non-positive / non-integer `siteId` rejected; plus `getEarliestExportableMonth` arithmetic + year rollover.
- `pnpm test:unit -- src/schemas/__tests__/audit.test.ts` → 22/22 passing. Typecheck green.

**New dependencies**: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds shared validation for audit log export requests. The main changes are:

- New `createAuditLogExportRequestSchema` for `siteId`, `month`, and `reportType`.
- Singapore-month helpers for the current and earliest exportable months.
- Input report vocabulary that supports `Access`, `Activity`, and `Both`.
- Unit tests for valid input, invalid months, export-window limits, report types, and site ID handling.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after the non-blocking validation-message gap is addressed.

The change is additive, covered by focused unit tests, and does not add persisted side effects. The remaining issue is limited to the form-facing error message for invalid numeric-string `siteId` input.

**Files Needing Attention:** apps/studio/src/schemas/audit.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base harness failed because the audit schema module was absent.
- The direct tsx harness was executed against head and all requested checks passed with exit code 0.
- The excluded siteId='abc' missing-message finding was not tested or reported.

<a href="https://app.greptile.com/trex/runs/17201511/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/schemas/audit.ts | Adds the shared audit log export request schema, Singapore-month window helpers, and report type input vocabulary; one validation message should be added for the site ID string regex. |
| apps/studio/src/schemas/__tests__/audit.test.ts | Adds unit coverage for export request parsing, month boundaries, report types, site ID coercion, and earliest-month arithmetic. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant User as User/Form
participant Schema as createAuditLogExportRequestSchema
participant Time as Singapore month helpers
participant Service as Audit export service
participant DB as AuditLogExportRequest rows

User->>Schema: siteId, month, reportType
Schema->>Schema: normalize and validate siteId
Schema->>Time: getCurrentSingaporeMonth()
Schema->>Time: getEarliestExportableMonth(current)
Time-->>Schema: current + earliest exportable months
Schema->>Schema: reject future/out-of-window month
Schema->>Schema: validate Access/Activity/Both
Schema-->>Service: typed CreateAuditLogExportRequestInput
Service->>DB: create Access/Activity rows
```
</details>

<sub>Reviews (23): Last reviewed commit: ["chore: add year typoe"](https://github.com/opengovsg/isomer/commit/d5712b3471e1ae8594a6a293fe5bb742f5efefc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41007950)</sub>

**Context used:**

- Context used - apps/studio/src/schemas/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=4ceb4df8-b228-4a23-9c80-f6e26b2fc036))

<!-- /greptile_comment -->