### PR TITLE
feat(studio): add audit log export request endpoint and cron

### DIFF
--- a/apps/studio/src/features/mail/templates/__tests__/auditLogExport.test.ts
+++ b/apps/studio/src/features/mail/templates/__tests__/auditLogExport.test.ts
@@ -103,17 +103,17 @@ describe("auditLogExportReady template", () => {
     )
   })
 
-  it("escapes HTML in the site name", () => {
-    // Act: the site name is interpolated into the subject
+  it("keeps the site name unescaped in the subject", () => {
+    // Act: the site name is interpolated into the subject, which isn't HTML
     const template = templates.auditLogExportReady({
       ...baseData,
       siteName: `Evil <b>&</b> Co`,
       link: { label: "access", url: "https://s3.example/x" },
     })
 
-    // Assert: special chars escaped, no raw injection
-    expect(template.subject).toContain("Evil &lt;b&gt;&amp;&lt;/b&gt; Co")
-    expect(template.subject).not.toContain("<b>&</b>")
+    // Assert: the raw site name renders as-is; escaped entities never leak in
+    expect(template.subject).toContain("Evil <b>&</b> Co")
+    expect(template.subject).not.toContain("&lt;b&gt;&amp;&lt;/b&gt;")
   })
 
   it("escapes a multi-parameter signed URL exactly once", () => {
@@ -163,15 +163,16 @@ describe("auditLogExportFailed template", () => {
     expect(template.body).toContain("support@isomer.gov.sg")
   })
 
-  it("escapes HTML in the site name", () => {
+  it("keeps the site name unescaped in the subject but escapes it in the body", () => {
     // Act
     const template = templates.auditLogExportFailed({
       ...data,
       siteName: `Evil <b>&</b> Co`,
     })
 
-    // Assert
-    expect(template.subject).toContain("Evil &lt;b&gt;&amp;&lt;/b&gt; Co")
+    // Assert: the subject isn't HTML, so the raw site name renders as-is;
+    // the body is HTML, so it stays escaped there.
+    expect(template.subject).toContain("Evil <b>&</b> Co")
     expect(template.body).not.toContain("<b>&</b>")
   })
 })

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -301,9 +301,9 @@ const auditLogExportReadyTemplate = (
   return {
     subject: `[Isomer] ${logName} logs for ${month} for your site (${siteName}) is ready`,
     body: `<p>Hi ${recipientEmail},</p>
-<p>You requested for audit logs for your site(s) for (${month}). This link will expire after ${AUDIT_LOG_EXPORT_URL_EXPIRY_DAYS} days.</p>
-<br/>
+<p>You requested for audit logs for your site(s) for ${month}. This link will expire after ${AUDIT_LOG_EXPORT_URL_EXPIRY_DAYS} days.</p>
 <p>${downloadLink}</p>
+<br/>
 <p>Best,</p>
 <p>Isomer team</p>`,
   }

--- a/apps/studio/src/features/mail/templates/templates.ts
+++ b/apps/studio/src/features/mail/templates/templates.ts
@@ -299,7 +299,7 @@ const auditLogExportReadyTemplate = (
   const downloadLink = `<a href="${link.url}">${getDownloadLinkLabel(link.label, month)}</a>`
 
   return {
-    subject: `[Isomer] ${logName} logs for ${month} for your site (${siteName}) is ready`,
+    subject: `[Isomer] ${logName} logs for ${month} for your site (${unescapeHtml(siteName)}) is ready`,
     body: `<p>Hi ${recipientEmail},</p>
 <p>You requested for audit logs for your site(s) for ${month}. This link will expire after ${AUDIT_LOG_EXPORT_URL_EXPIRY_DAYS} days.</p>
 <p>${downloadLink}</p>
@@ -317,10 +317,11 @@ const auditLogExportFailedTemplate = (
   const { recipientEmail, siteName, month } = data
 
   return {
-    subject: `[Isomer Studio] Your audit log export for ${siteName} (${month}) could not be generated`,
+    subject: `[Isomer Studio] Your audit log export for ${unescapeHtml(siteName)} (${month}) could not be generated`,
     body: `<p>Hi ${recipientEmail},</p>
 <p>We're sorry — we couldn't generate your audit log export for ${siteName} (${month}).</p>
 <p>Please try again later. If the problem persists, contact <a href="${ISOMER_SUPPORT_LINK}">${ISOMER_SUPPORT_EMAIL}</a>.</p>
+<br/>
 <p>Best,</p>
 <p>Isomer team</p>`,
   }

--- a/apps/studio/src/schemas/audit.ts
+++ b/apps/studio/src/schemas/audit.ts
@@ -34,7 +34,7 @@ export const validateIsNotFutureMonth = (
 
 export const validateIsMonthInPastYear = (
   requestedMonth: string,
-): boolean | MonthRangeError => {
+): true | MonthRangeError => {
   const parsed = parseISO(`${requestedMonth}-01`)
   const earliest = parseISO(
     `${getEarliestExportableMonth(getCurrentSingaporeMonth())}-01`,

--- a/apps/studio/src/schemas/audit.ts
+++ b/apps/studio/src/schemas/audit.ts
@@ -8,9 +8,44 @@ import {
 } from "date-fns"
 import { formatInTimeZone } from "date-fns-tz"
 import { z } from "zod"
+import {
+  FutureMonthError,
+  MonthRangeError,
+} from "~/server/modules/audit/audit.errors"
 import { AuditLogExportReportType } from "~prisma/generated/generatedEnums"
 
 const SINGAPORE_TIME_ZONE = "Asia/Singapore"
+
+export const validateIsNotFutureMonth = (
+  requestedMonth: string,
+): FutureMonthError | true => {
+  const currentMonth = getCurrentSingaporeMonth()
+  const requestedMonthDate = parseISO(`${requestedMonth}-01`)
+  const currentMonthDate = parseISO(`${currentMonth}-01`)
+  if (
+    !isSameMonth(requestedMonthDate, currentMonthDate) &&
+    isAfter(requestedMonthDate, currentMonthDate)
+  ) {
+    return new FutureMonthError(requestedMonth)
+  }
+
+  return true
+}
+
+export const validateIsMonthInPastYear = (
+  requestedMonth: string,
+): boolean | MonthRangeError => {
+  const parsed = parseISO(`${requestedMonth}-01`)
+  const earliest = parseISO(
+    `${getEarliestExportableMonth(getCurrentSingaporeMonth())}-01`,
+  )
+
+  if (!isSameMonth(parsed, earliest) && isBefore(parsed, earliest)) {
+    return new MonthRangeError(requestedMonth)
+  }
+
+  return true
+}
 
 // What the user may ask for. `Both` is UX vocabulary only — the service
 // fans it out into two AuditLogExportRequest rows (Access + Activity);
@@ -112,9 +147,8 @@ export const createAuditLogExportRequestSchema = z.object({
     })
     .refine(
       (month) => {
-        const parsed = parseISO(`${month}-01`)
-        const current = parseISO(`${getCurrentSingaporeMonth()}-01`)
-        return isSameMonth(parsed, current) || isBefore(parsed, current)
+        const possibleError = validateIsNotFutureMonth(month)
+        return possibleError === true
       },
       {
         message:
@@ -123,11 +157,8 @@ export const createAuditLogExportRequestSchema = z.object({
     )
     .refine(
       (month) => {
-        const parsed = parseISO(`${month}-01`)
-        const earliest = parseISO(
-          `${getEarliestExportableMonth(getCurrentSingaporeMonth())}-01`,
-        )
-        return isSameMonth(parsed, earliest) || isAfter(parsed, earliest)
+        const possibleError = validateIsMonthInPastYear(month)
+        return possibleError === true
       },
       { message: "You can only export audit logs from the past 12 months" },
     )

--- a/apps/studio/src/server/CLAUDE.md
+++ b/apps/studio/src/server/CLAUDE.md
@@ -40,7 +40,7 @@ Never write your own auth middleware in a router. If you need a new auth shape, 
 - Define the Zod schema in `apps/studio/src/schemas/<area>.ts` and import it in the router.
 - Routers should not declare ad-hoc inline schemas. If a schema is router-internal and tiny, keep it inline; otherwise lift it.
 
-### Permission checks belong in the router 
+### Permission checks belong in the router
 
 - Routers wire input → service. The router performs the permission check (`bulkValidateUserPermissionsForResources` and friends) **before** mutating and calling services.
 - Do not gate purely on the existence of a session — that only proves the caller is logged in, not authorised for the resource.

--- a/apps/studio/src/server/CLAUDE.md
+++ b/apps/studio/src/server/CLAUDE.md
@@ -42,7 +42,7 @@ Never write your own auth middleware in a router. If you need a new auth shape, 
 
 ### Permission checks belong in the service
 
-- Routers wire input → service. The service performs the permission check (`bulkValidateUserPermissionsForResources` and friends) **before** mutating.
+- Routers wire input → service. The router performs the permission check (`bulkValidateUserPermissionsForResources` and friends) **before** mutating and calling services.
 - Do not gate purely on the existence of a session — that only proves the caller is logged in, not authorised for the resource.
 
 ### Audit-log every state change

--- a/apps/studio/src/server/CLAUDE.md
+++ b/apps/studio/src/server/CLAUDE.md
@@ -40,7 +40,7 @@ Never write your own auth middleware in a router. If you need a new auth shape, 
 - Define the Zod schema in `apps/studio/src/schemas/<area>.ts` and import it in the router.
 - Routers should not declare ad-hoc inline schemas. If a schema is router-internal and tiny, keep it inline; otherwise lift it.
 
-### Permission checks belong in the service
+### Permission checks belong in the router 
 
 - Routers wire input → service. The router performs the permission check (`bulkValidateUserPermissionsForResources` and friends) **before** mutating and calling services.
 - Do not gate purely on the existence of a session — that only proves the caller is logged in, not authorised for the resource.

--- a/apps/studio/src/server/cron/index.ts
+++ b/apps/studio/src/server/cron/index.ts
@@ -1,4 +1,5 @@
 import { createBaseLogger } from "../../lib/logger"
+import { auditLogExportJob } from "./jobs/auditLogExportJob"
 import { deactivateInactiveUsersJob } from "./jobs/deactivateInactiveUsersJob"
 import { schedulePublishingJob } from "./jobs/schedulePublishingJob"
 import { schedulePushDocumentJob } from "./jobs/schedulePushDocumentJob"
@@ -20,6 +21,7 @@ export const initializeCronJobs = async () => {
     await sendAccountDeactivationWarningEmailsJob({ inHowManyDays: 1 }),
     await sendAccountDeactivationWarningEmailsJob({ inHowManyDays: 7 }),
     await sendAccountDeactivationWarningEmailsJob({ inHowManyDays: 14 }),
+    await auditLogExportJob(),
   )
 
   logger.info("Cron jobs initialized successfully")

--- a/apps/studio/src/server/cron/jobs/auditLogExportJob.ts
+++ b/apps/studio/src/server/cron/jobs/auditLogExportJob.ts
@@ -1,0 +1,23 @@
+import { createBaseLogger } from "~/lib/logger"
+import { processPendingAuditLogExports } from "~/server/modules/audit/auditLogExport.service"
+
+import { registerPgbossJob } from "@isomer/pgboss"
+
+const JOB_NAME = "audit-log-export"
+const CRON_SCHEDULE = "* * * * *" // every minute
+
+const logger = createBaseLogger({ path: "cron:auditLogExportJob" })
+
+export const auditLogExportJobHandler = async () => {
+  await processPendingAuditLogExports()
+}
+
+export const auditLogExportJob = async () => {
+  return await registerPgbossJob(
+    logger,
+    JOB_NAME,
+    CRON_SCHEDULE,
+    auditLogExportJobHandler,
+    { retryLimit: 3, singletonKey: JOB_NAME },
+  )
+}

--- a/apps/studio/src/server/modules/_app.ts
+++ b/apps/studio/src/server/modules/_app.ts
@@ -4,6 +4,7 @@
 
 import { publicProcedure, router } from "../trpc"
 import { assetRouter } from "./asset/asset.router"
+import { auditRouter } from "./audit/audit.router"
 import { authRouter } from "./auth/auth.router"
 import { collectionRouter } from "./collection/collection.router"
 import { folderRouter } from "./folder/folder.router"
@@ -22,6 +23,7 @@ export const appRouter = router({
   me: meRouter,
   auth: authRouter,
   asset: assetRouter,
+  audit: auditRouter,
   page: pageRouter,
   folder: folderRouter,
   collection: collectionRouter,

--- a/apps/studio/src/server/modules/audit/__tests__/audit.router.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/audit.router.test.ts
@@ -1,0 +1,327 @@
+import { TRPCError } from "@trpc/server"
+import { auth } from "tests/integration/helpers/auth"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  applySession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupAdminPermissions,
+  setupEditorPermissions,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { getCurrentSingaporeMonth } from "~/schemas/audit"
+import { createCallerFactory } from "~/server/trpc"
+
+import type { User } from "../../database"
+import { db } from "../../database"
+import { auditRouter } from "../audit.router"
+import { getMonthDateRange } from "../auditLogExport.query"
+
+const createCaller = createCallerFactory(auditRouter)
+
+// A month inside the allowed export window. The current Singapore-time month
+// is always valid: never in the future, and within the 12-month window — so
+// the happy-path tests don't rot as real time advances.
+const VALID_MONTH = getCurrentSingaporeMonth()
+
+// All AuditLogExportRequest rows for a (site, user), oldest-id first. Tables
+// are reset per test, so this is every row the test created — including the
+// fan-out rows a `Both` request produces. Deliberately not filtered by the
+// stored daterange: rejected inputs (e.g. a future month) must leave ZERO rows
+// of any shape behind.
+const getRequestRows = async ({
+  siteId,
+  userId,
+}: {
+  siteId: number
+  userId: string
+}) => {
+  return db
+    .selectFrom("AuditLogExportRequest")
+    .where("siteId", "=", siteId)
+    .where("userId", "=", userId)
+    .orderBy("id", "asc")
+    .selectAll()
+    .execute()
+}
+
+describe("audit.router", async () => {
+  let caller: ReturnType<typeof createCaller>
+  const session = await applyAuthedSession()
+  let user: User
+
+  beforeAll(() => {
+    caller = createCaller(createMockRequest(session))
+  })
+
+  beforeEach(async () => {
+    await resetTables(
+      "AuditLogExportRequest",
+      "ResourcePermission",
+      "Site",
+      "User",
+    )
+    user = await setupUser({
+      userId: session.userId,
+      email: "test@mock.com",
+    })
+    await auth(user)
+    caller = createCaller(createMockRequest(session))
+  })
+
+  describe("createExportRequest", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+      const { site } = await setupSite()
+
+      // Act
+      const result = unauthedCaller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should create a single Pending request for a concrete report type", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Assert: one inserted row, stored as the daterange derived from the
+      // picked month, and returned as an array (the fan-out contract).
+      const auditLogDateRange = getMonthDateRange(VALID_MONTH, new Date())
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        siteId: site.id,
+        userId: session.userId,
+        auditLogDateRange,
+        reportType: "Access",
+        status: "Pending",
+        attempts: 0,
+      })
+      expect(result[0]?.id).toBeDefined()
+
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(1)
+    })
+
+    it("should fan a Both request out into two Pending rows (Access + Activity)", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Both",
+      })
+
+      // Assert: `Both` is UX vocabulary only — it becomes two independent
+      // rows, one per concrete DB report type, sharing the same range.
+      const auditLogDateRange = getMonthDateRange(VALID_MONTH, new Date())
+      expect(result).toHaveLength(2)
+      expect(result.map((row) => row.reportType).sort()).toEqual([
+        "Access",
+        "Activity",
+      ])
+      for (const row of result) {
+        expect(row).toMatchObject({
+          siteId: site.id,
+          userId: session.userId,
+          auditLogDateRange,
+          status: "Pending",
+          attempts: 0,
+        })
+      }
+
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(2)
+    })
+
+    it("should throw FORBIDDEN when the caller is only an Editor", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "FORBIDDEN" })
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(0)
+    })
+
+    it("should throw FORBIDDEN when the caller has no permission on the site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+
+      // Act
+      const result = caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Activity",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "FORBIDDEN" })
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(0)
+    })
+
+    it("should throw CONFLICT and not create a duplicate for an in-flight request", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act — first request succeeds
+      await caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Act — second identical request is rejected
+      const result = caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "CONFLICT" })
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(1)
+    })
+
+    it("should throw CONFLICT for a Both request when one of its report types is already in flight, committing nothing", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act — an Access request is already in flight
+      await caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Act — a Both request for the same range overlaps it on Access
+      const result = caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Both",
+      })
+
+      // Assert: all-or-nothing — the Activity half is NOT committed either.
+      await expect(result).rejects.toMatchObject({ code: "CONFLICT" })
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.reportType).toBe("Access")
+    })
+
+    it("should throw BAD_REQUEST when the month is in the future", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.createExportRequest({
+        siteId: site.id,
+        month: "2999-12",
+        reportType: "Both",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(0)
+    })
+
+    it("should throw BAD_REQUEST when the month is older than the 12-month window", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      const tooOldMonth = "2000-01"
+
+      // Act
+      const result = caller.createExportRequest({
+        siteId: site.id,
+        month: tooOldMonth,
+        reportType: "Both",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
+      const rows = await getRequestRows({
+        siteId: site.id,
+        userId: session.userId!,
+      })
+      expect(rows).toHaveLength(0)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/audit/__tests__/auditLogExport.dedupe.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/auditLogExport.dedupe.test.ts
@@ -1,0 +1,258 @@
+import { TRPCError } from "@trpc/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getCurrentSingaporeMonth } from "~/schemas/audit"
+
+// This file deliberately mocks the DB (unlike the sibling integration tests) so
+// it can drive the ONE code path that a real-Postgres test cannot deterministic-
+// ally reach: the race-loser. The in-flight dedupe SELECT and the partial unique
+// index share the same predicate, so any row that would trip the index would
+// also be seen by the SELECT — meaning the INSERT's unique-violation catch is
+// only exercised when a concurrent request slips in between our SELECT and
+// INSERT. We simulate exactly that: SELECT returns "no in-flight row", then an
+// INSERT throws a Postgres unique-violation (23505), as the DB would under a
+// true race. Vitest isolates module mocks per test file, so mocking `../database`
+// here does not affect the real-DB integration tests in audit.router.test.ts.
+//
+// It also pins the `Both` fan-out contract: TWO inserts (Access + Activity)
+// issued through the SAME transaction, and a rethrow out of the transaction
+// callback when any of them loses the race (kysely rolls the transaction back
+// on a rejected callback, so nothing is committed — all-or-nothing).
+
+const { mockDb, mockValidatePermissions } = vi.hoisted(() => ({
+  mockDb: { transaction: vi.fn() },
+  mockValidatePermissions: vi.fn(),
+}))
+
+vi.mock("~/env.mjs", () => ({
+  env: {
+    // oxlint-disable-next-line node/no-process-env
+    NODE_ENV: process.env.NODE_ENV ?? "test",
+    // oxlint-disable-next-line node/no-process-env
+    NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV ?? "test",
+    S3_STUDIO_ASSETS_BUCKET_NAME: "test-audit-bucket",
+  },
+}))
+
+// Keep the real database module (its `AuditLogEvent`, `sql`, types and utils
+// are used across the audit module) and override only `db` with our fake.
+vi.mock("../../database", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../database")>()),
+  db: mockDb,
+}))
+
+vi.mock("../../permissions/permissions.service", () => ({
+  validatePermissionsForManagingUsers: mockValidatePermissions,
+}))
+
+// Import after mocks are registered so the service binds to the mocked modules.
+const { createAuditLogExportRequest } =
+  await import("../auditLogExport.service")
+
+// A Postgres unique_violation, shaped like the `pg` driver's error (Error with a
+// string `code`), which is what the partial unique index raises on the losing
+// INSERT of a race.
+const makeUniqueViolation = () => {
+  const error = new Error(
+    'duplicate key value violates unique constraint "AuditLogExportRequest_siteId_userId_dateRange_reportType_idx"',
+  )
+  ;(error as Error & { code: string }).code = "23505"
+  return error
+}
+
+const VALID_MONTH = getCurrentSingaporeMonth()
+
+const EXPECTED_CONFLICT = {
+  code: "CONFLICT",
+  message:
+    "An export for this period and report type is already being generated",
+}
+
+// One scripted outcome per INSERT the service issues, in order.
+type InsertStep = { ok: true } | { ok: false; error: Error }
+
+interface TxScript {
+  // What the in-flight fast-path SELECT resolves with (default: no row).
+  existing?: { id: string }
+  inserts?: InsertStep[]
+}
+
+// Build a fake Kysely transaction. The fast-path SELECT resolves with
+// `script.existing`; each INSERT consumes the next entry of `script.inserts`
+// and either resolves with a fake row (recording the `values` payload in
+// `insertedValues`) or rejects with the scripted error.
+const makeTx = (script: TxScript) => {
+  const insertedValues: Record<string, unknown>[] = []
+  let insertCall = 0
+  const tx = {
+    insertedValues,
+    selectFrom: () => ({
+      where: function () {
+        return this
+      },
+      select: function () {
+        return this
+      },
+      executeTakeFirst: () => Promise.resolve(script.existing),
+    }),
+    insertInto: () => {
+      let values: Record<string, unknown> = {}
+      return {
+        values: function (v: Record<string, unknown>) {
+          values = v
+          return this
+        },
+        returningAll: function () {
+          return this
+        },
+        executeTakeFirstOrThrow: () => {
+          const step = script.inserts?.[insertCall]
+          insertCall += 1
+          if (!step) {
+            return Promise.reject(
+              new Error(`Unexpected INSERT #${insertCall} (not scripted)`),
+            )
+          }
+          if (!step.ok) {
+            return Promise.reject(step.error)
+          }
+          insertedValues.push(values)
+          return Promise.resolve({ id: `row-${insertCall}`, ...values })
+        },
+      }
+    },
+  }
+  return tx
+}
+
+// Wire `db.transaction().execute(cb)` to run the callback against `tx`. A
+// throwing callback simply rejects — mirroring kysely, which rolls the
+// transaction back (nothing committed) and re-surfaces the error.
+const useTx = (tx: ReturnType<typeof makeTx>) => {
+  mockDb.transaction.mockReturnValue({
+    execute: (cb: (tx: unknown) => unknown) =>
+      Promise.resolve().then(() => cb(tx)),
+  })
+}
+
+describe("createAuditLogExportRequest — atomic dedupe + fan-out", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockValidatePermissions.mockResolvedValue(undefined)
+  })
+
+  it("re-throws a Postgres unique-violation from the INSERT as CONFLICT (not a 500)", async () => {
+    // Arrange: SELECT sees no in-flight row, but the INSERT loses the race and
+    // the partial unique index rejects it with 23505.
+    useTx(makeTx({ inserts: [{ ok: false, error: makeUniqueViolation() }] }))
+
+    // Act
+    const result = createAuditLogExportRequest({
+      siteId: 1,
+      userId: "user-1",
+      month: VALID_MONTH,
+      reportType: "Access",
+    })
+
+    // Assert: the caller gets the friendly CONFLICT, identical to the fast-path.
+    await expect(result).rejects.toMatchObject(EXPECTED_CONFLICT)
+    await expect(result).rejects.toBeInstanceOf(TRPCError)
+  })
+
+  it("re-throws a non-unique-violation INSERT error unchanged", async () => {
+    // Arrange: a different DB error must not be masked as CONFLICT.
+    const otherError = new Error("connection reset")
+    useTx(makeTx({ inserts: [{ ok: false, error: otherError }] }))
+
+    // Act
+    const result = createAuditLogExportRequest({
+      siteId: 1,
+      userId: "user-1",
+      month: VALID_MONTH,
+      reportType: "Access",
+    })
+
+    // Assert: surfaced as-is, not swallowed by the unique-violation catch.
+    await expect(result).rejects.toBe(otherError)
+  })
+
+  it("fans a Both request out into exactly two inserts (Access + Activity) in one transaction", async () => {
+    // Arrange: both inserts succeed.
+    const tx = makeTx({ inserts: [{ ok: true }, { ok: true }] })
+    useTx(tx)
+
+    // Act
+    const result = await createAuditLogExportRequest({
+      siteId: 1,
+      userId: "user-1",
+      month: VALID_MONTH,
+      reportType: "Both",
+    })
+
+    // Assert: one transaction, two rows — one per concrete DB report type,
+    // sharing the same (siteId, userId, auditLogDateRange).
+    expect(mockDb.transaction).toHaveBeenCalledTimes(1)
+    expect(tx.insertedValues).toHaveLength(2)
+    expect(tx.insertedValues.map((v) => v.reportType)).toEqual([
+      "Access",
+      "Activity",
+    ])
+    for (const values of tx.insertedValues) {
+      expect(values).toMatchObject({
+        siteId: 1,
+        userId: "user-1",
+        status: "Pending",
+        attempts: 0,
+      })
+      expect(values.auditLogDateRange).toMatch(
+        /^\[\d{4}-\d{2}-\d{2},\d{4}-\d{2}-\d{2}\)$/,
+      )
+    }
+    // The service returns every inserted row.
+    expect(result).toHaveLength(2)
+  })
+
+  it("throws CONFLICT when the SECOND insert of a Both request hits 23505, rethrowing out of the transaction so nothing commits", async () => {
+    // Arrange: the Access insert wins but the Activity insert loses a race
+    // against a concurrent in-flight Activity request.
+    const tx = makeTx({
+      inserts: [{ ok: true }, { ok: false, error: makeUniqueViolation() }],
+    })
+    useTx(tx)
+
+    // Act
+    const result = createAuditLogExportRequest({
+      siteId: 1,
+      userId: "user-1",
+      month: VALID_MONTH,
+      reportType: "Both",
+    })
+
+    // Assert: the CONFLICT propagates out of the transaction callback — that
+    // rethrow is what makes kysely roll back the already-issued Access insert
+    // (all-or-nothing). Only the first insert ever succeeded in-transaction.
+    await expect(result).rejects.toMatchObject(EXPECTED_CONFLICT)
+    await expect(result).rejects.toBeInstanceOf(TRPCError)
+    expect(tx.insertedValues).toHaveLength(1)
+    expect(tx.insertedValues[0]).toMatchObject({ reportType: "Access" })
+  })
+
+  it("throws CONFLICT from the fast-path SELECT for a single report type without attempting any insert", async () => {
+    // Arrange: the SELECT already sees an in-flight row for the same
+    // (siteId, userId, range, reportType).
+    const tx = makeTx({ existing: { id: "existing-row" }, inserts: [] })
+    useTx(tx)
+
+    // Act
+    const result = createAuditLogExportRequest({
+      siteId: 1,
+      userId: "user-1",
+      month: VALID_MONTH,
+      reportType: "Activity",
+    })
+
+    // Assert: friendly CONFLICT, and no INSERT was ever issued.
+    await expect(result).rejects.toMatchObject(EXPECTED_CONFLICT)
+    await expect(result).rejects.toBeInstanceOf(TRPCError)
+    expect(tx.insertedValues).toHaveLength(0)
+  })
+})

--- a/apps/studio/src/server/modules/audit/__tests__/auditLogExport.dedupe.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/auditLogExport.dedupe.test.ts
@@ -61,18 +61,23 @@ const makeUniqueViolation = () => {
 
 const VALID_MONTH = getCurrentSingaporeMonth()
 
-const EXPECTED_CONFLICT = {
+// The CONFLICT message names the specific report type that's already in
+// flight, so a partially-conflicting `Both` request tells the user which
+// half — see getInFlightConflictMessage in the service.
+const conflictFor = (reportType: "Access" | "Activity") => ({
   code: "CONFLICT",
   message:
-    "An export for this period and report type is already being generated",
-}
+    reportType === "Access"
+      ? "An access log export for this period is already being generated"
+      : "An audit log export for this period is already being generated",
+})
 
 // One scripted outcome per INSERT the service issues, in order.
 type InsertStep = { ok: true } | { ok: false; error: Error }
 
 interface TxScript {
   // What the in-flight fast-path SELECT resolves with (default: no row).
-  existing?: { id: string }
+  existing?: { id: string; reportType: "Access" | "Activity" }
   inserts?: InsertStep[]
 }
 
@@ -154,7 +159,7 @@ describe("createAuditLogExportRequest — atomic dedupe + fan-out", () => {
     })
 
     // Assert: the caller gets the friendly CONFLICT, identical to the fast-path.
-    await expect(result).rejects.toMatchObject(EXPECTED_CONFLICT)
+    await expect(result).rejects.toMatchObject(conflictFor("Access"))
     await expect(result).rejects.toBeInstanceOf(TRPCError)
   })
 
@@ -212,8 +217,10 @@ describe("createAuditLogExportRequest — atomic dedupe + fan-out", () => {
   })
 
   it("throws CONFLICT when the SECOND insert of a Both request hits 23505, rethrowing out of the transaction so nothing commits", async () => {
-    // Arrange: the Access insert wins but the Activity insert loses a race
-    // against a concurrent in-flight Activity request.
+    // Arrange: the fan-out order for `Both` is [Activity, Access] (see
+    // REPORT_TYPES_BY_REQUESTED_TYPE), so the Activity insert wins but the
+    // Access insert loses a race against a concurrent in-flight Access
+    // request.
     const tx = makeTx({
       inserts: [{ ok: true }, { ok: false, error: makeUniqueViolation() }],
     })
@@ -228,18 +235,23 @@ describe("createAuditLogExportRequest — atomic dedupe + fan-out", () => {
     })
 
     // Assert: the CONFLICT propagates out of the transaction callback — that
-    // rethrow is what makes kysely roll back the already-issued Access insert
-    // (all-or-nothing). Only the first insert ever succeeded in-transaction.
-    await expect(result).rejects.toMatchObject(EXPECTED_CONFLICT)
+    // rethrow is what makes kysely roll back the already-issued Activity
+    // insert (all-or-nothing). Only the first insert ever succeeded
+    // in-transaction, and the message names Access — the report type that
+    // actually lost the race.
+    await expect(result).rejects.toMatchObject(conflictFor("Access"))
     await expect(result).rejects.toBeInstanceOf(TRPCError)
     expect(tx.insertedValues).toHaveLength(1)
-    expect(tx.insertedValues[0]).toMatchObject({ reportType: "Access" })
+    expect(tx.insertedValues[0]).toMatchObject({ reportType: "Activity" })
   })
 
   it("throws CONFLICT from the fast-path SELECT for a single report type without attempting any insert", async () => {
     // Arrange: the SELECT already sees an in-flight row for the same
     // (siteId, userId, range, reportType).
-    const tx = makeTx({ existing: { id: "existing-row" }, inserts: [] })
+    const tx = makeTx({
+      existing: { id: "existing-row", reportType: "Activity" },
+      inserts: [],
+    })
     useTx(tx)
 
     // Act
@@ -250,8 +262,9 @@ describe("createAuditLogExportRequest — atomic dedupe + fan-out", () => {
       reportType: "Activity",
     })
 
-    // Assert: friendly CONFLICT, and no INSERT was ever issued.
-    await expect(result).rejects.toMatchObject(EXPECTED_CONFLICT)
+    // Assert: friendly CONFLICT naming the conflicting report type, and no
+    // INSERT was ever issued.
+    await expect(result).rejects.toMatchObject(conflictFor("Activity"))
     await expect(result).rejects.toBeInstanceOf(TRPCError)
     expect(tx.insertedValues).toHaveLength(0)
   })

--- a/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
@@ -22,14 +22,14 @@ interface FailedEmailArg {
 const {
   mockUploadAuditLogExport,
   mockGenerateSignedGetUrl,
-  mockGetAuditLogExportBucketName,
+  mockGetStudioAssetsBucketName,
   mockSendAuditLogExportReadyEmail,
   mockSendAuditLogExportFailedEmail,
 } = vi.hoisted(() => ({
   mockUploadAuditLogExport:
     vi.fn<(args: { key: string; body: unknown }) => Promise<void>>(),
   mockGenerateSignedGetUrl: vi.fn<() => Promise<string>>(),
-  mockGetAuditLogExportBucketName: vi.fn<() => string>(),
+  mockGetStudioAssetsBucketName: vi.fn<() => string>(),
   mockSendAuditLogExportReadyEmail:
     vi.fn<(data: ReadyEmailArg) => Promise<void>>(),
   mockSendAuditLogExportFailedEmail:
@@ -59,7 +59,7 @@ vi.mock("~/env.mjs", () => ({
 vi.mock("~/lib/s3", () => ({
   uploadAuditLogExport: mockUploadAuditLogExport,
   generateSignedGetUrl: mockGenerateSignedGetUrl,
-  getAuditLogExportBucketName: mockGetAuditLogExportBucketName,
+  getStudioAssetsBucketName: mockGetStudioAssetsBucketName,
   AUDIT_LOG_EXPORT_URL_EXPIRY_SECONDS: 60 * 60 * 24 * 3,
 }))
 
@@ -131,7 +131,7 @@ describe("auditLogExport processor", () => {
       "AuditLog",
     )
     vi.clearAllMocks()
-    mockGetAuditLogExportBucketName.mockReturnValue("test-audit-bucket")
+    mockGetStudioAssetsBucketName.mockReturnValue("test-audit-bucket")
     mockGenerateSignedGetUrl.mockResolvedValue("https://signed.example/url")
     mockUploadAuditLogExport.mockResolvedValue(undefined)
     mockSendAuditLogExportReadyEmail.mockResolvedValue(undefined)

--- a/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
@@ -353,6 +353,38 @@ describe("auditLogExport processor", () => {
     expect(updated.attempts).toBe(1)
   })
 
+  it("charges a stale re-claim that fails exactly one attempt, not two", async () => {
+    // Arrange: a stale Processing row that has already burned one attempt.
+    // The re-claim charges attempt 2 at claim time; when processing then
+    // fails, the catch must NOT add another increment — the row still has a
+    // retry left, so it is re-queued rather than Failed. (Regression: the
+    // catch used to add 1 to the post-claim value, jumping 1 → 3 and
+    // skipping the middle retry entirely.)
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "stalefail@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+    mockUploadAuditLogExport.mockRejectedValue(new Error("s3 down"))
+
+    const staleUpdatedAt = new Date(Date.now() - 30 * 60 * 1000) // 30 min ago
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+      status: "Processing",
+      attempts: 1,
+      updatedAt: staleUpdatedAt,
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert: one attempt charged (1 → 2), re-queued with a retry remaining.
+    const updated = await getRequest(request.id)
+    expect(updated.attempts).toBe(2)
+    expect(updated.status).toBe("Pending")
+    expect(mockSendAuditLogExportFailedEmail).not.toHaveBeenCalled()
+  })
+
   it("does not touch a fresh Processing row within the lease window", async () => {
     // Arrange: a row currently Processing whose `updatedAt` is recent (a live
     // worker is presumably still on it). A concurrent sweep must leave it alone.

--- a/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
@@ -1,0 +1,386 @@
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupAdminPermissions,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+interface ReadyEmailArg {
+  recipientEmail: string
+  siteName: string
+  month: string
+  link: { label: "access" | "audit"; url: string }
+}
+
+interface FailedEmailArg {
+  recipientEmail: string
+  siteName: string
+  month: string
+}
+
+const {
+  mockUploadAuditLogExport,
+  mockGenerateSignedGetUrl,
+  mockGetAuditLogExportBucketName,
+  mockSendAuditLogExportReadyEmail,
+  mockSendAuditLogExportFailedEmail,
+} = vi.hoisted(() => ({
+  mockUploadAuditLogExport:
+    vi.fn<(args: { key: string; body: unknown }) => Promise<void>>(),
+  mockGenerateSignedGetUrl: vi.fn<() => Promise<string>>(),
+  mockGetAuditLogExportBucketName: vi.fn<() => string>(),
+  mockSendAuditLogExportReadyEmail:
+    vi.fn<(data: ReadyEmailArg) => Promise<void>>(),
+  mockSendAuditLogExportFailedEmail:
+    vi.fn<(data: FailedEmailArg) => Promise<void>>(),
+}))
+
+// `~/lib/s3` (mocked below) is the only thing in this service's import chain
+// that requires `S3_STUDIO_ASSETS_BUCKET_NAME`, and `~/lib/logger` only
+// reads NODE_ENV / NEXT_PUBLIC_APP_ENV. The DB still needs the real connection
+// string, which dotenv-cli has already loaded into `process.env` from
+// `.env.test`. We bypass the validated env schema (which would reject the
+// missing audit-bucket var) and read what we need straight from `process.env`.
+vi.mock("~/env.mjs", () => ({
+  env: {
+    // oxlint-disable-next-line node/no-process-env
+    NODE_ENV: process.env.NODE_ENV ?? "test",
+    // oxlint-disable-next-line node/no-process-env
+    NEXT_PUBLIC_APP_ENV: process.env.NEXT_PUBLIC_APP_ENV ?? "test",
+    // oxlint-disable-next-line node/no-process-env
+    DATABASE_URL: process.env.DATABASE_URL,
+    S3_STUDIO_ASSETS_BUCKET_NAME: "test-audit-bucket",
+  },
+}))
+
+// Mock only the external boundaries (S3 + mail). The DB is NOT mocked — the
+// request rows, sites, users and permissions are seeded into a real Postgres.
+vi.mock("~/lib/s3", () => ({
+  uploadAuditLogExport: mockUploadAuditLogExport,
+  generateSignedGetUrl: mockGenerateSignedGetUrl,
+  getAuditLogExportBucketName: mockGetAuditLogExportBucketName,
+  AUDIT_LOG_EXPORT_URL_EXPIRY_SECONDS: 60 * 60 * 24 * 3,
+}))
+
+vi.mock("~/features/mail/service", () => ({
+  sendAuditLogExportReadyEmail: mockSendAuditLogExportReadyEmail,
+  sendAuditLogExportFailedEmail: mockSendAuditLogExportFailedEmail,
+}))
+
+import { db } from "../../database"
+import { getMonthDateRange } from "../auditLogExport.query"
+import { processPendingAuditLogExports } from "../auditLogExport.service"
+
+// A fixed past month, so the stored range is the full calendar month (the
+// current-month clamp is a no-op) and the expected S3 slug is deterministic.
+const MONTH = "2024-03"
+const AUDIT_LOG_DATE_RANGE = getMonthDateRange(MONTH, new Date()) // [2024-03-01,2024-04-01)
+
+// Each row produces exactly one report; `Both` no longer exists at the DB
+// layer (a "Both" user request is fanned out into one row per type).
+type ReportType = "Access" | "Activity"
+
+const seedRequest = async ({
+  siteId,
+  userId,
+  reportType,
+  status = "Pending",
+  attempts = 0,
+  updatedAt,
+}: {
+  siteId: number
+  userId: string
+  reportType: ReportType
+  status?: "Pending" | "Processing" | "Done" | "Failed"
+  attempts?: number
+  // Override the DB-managed `updatedAt` — used to simulate a stale (or fresh)
+  // `Processing` claim relative to the lease window.
+  updatedAt?: Date
+}) => {
+  return db
+    .insertInto("AuditLogExportRequest")
+    .values({
+      siteId,
+      userId,
+      auditLogDateRange: AUDIT_LOG_DATE_RANGE,
+      reportType,
+      status,
+      attempts,
+      ...(updatedAt ? { updatedAt } : {}),
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
+}
+
+const getRequest = async (id: string) => {
+  return db
+    .selectFrom("AuditLogExportRequest")
+    .where("id", "=", id)
+    .selectAll()
+    .executeTakeFirstOrThrow()
+}
+
+describe("auditLogExport processor", () => {
+  beforeEach(async () => {
+    await resetTables(
+      "AuditLogExportRequest",
+      "ResourcePermission",
+      "User",
+      "Site",
+      "AuditLog",
+    )
+    vi.clearAllMocks()
+    mockGetAuditLogExportBucketName.mockReturnValue("test-audit-bucket")
+    mockGenerateSignedGetUrl.mockResolvedValue("https://signed.example/url")
+    mockUploadAuditLogExport.mockResolvedValue(undefined)
+    mockSendAuditLogExportReadyEmail.mockResolvedValue(undefined)
+    mockSendAuditLogExportFailedEmail.mockResolvedValue(undefined)
+  })
+
+  it("processes an Access request: one upload with an inclusive-end key, one link, status Done", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "admin@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+    // A couple of permission rows so the access report is non-empty.
+    const memberA = await setupUser({ email: "alice@vendor.com.sg" })
+    const memberB = await setupUser({ email: "bob@vendor.com.sg" })
+    await setupAdminPermissions({ userId: memberA.id, siteId: site.id })
+    await setupAdminPermissions({ userId: memberB.id, siteId: site.id })
+
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert: the S3 key renders the half-open range [2024-03-01,2024-04-01)
+    // with an inclusive end — `2024-03-01-to-2024-03-31`.
+    const expectedKey = `audit-log-exports/${site.id}/${request.id}/access-2024-03-01-to-2024-03-31.csv`
+    expect(mockUploadAuditLogExport).toHaveBeenCalledTimes(1)
+    expect(mockUploadAuditLogExport.mock.calls[0]![0].key).toBe(expectedKey)
+
+    expect(mockSendAuditLogExportReadyEmail).toHaveBeenCalledTimes(1)
+    const emailArg = mockSendAuditLogExportReadyEmail.mock.calls[0]![0]
+    expect(emailArg.link).toEqual({
+      label: "access",
+      url: "https://signed.example/url",
+    })
+    expect(emailArg.recipientEmail).toBe("admin@vendor.com.sg")
+    expect(emailArg.month).toBe("March 2024")
+    expect(mockSendAuditLogExportFailedEmail).not.toHaveBeenCalled()
+
+    const updated = await getRequest(request.id)
+    expect(updated.status).toBe("Done")
+    expect(updated.objectKey).toBe(expectedKey)
+  })
+
+  it("processes a fanned-out Both request (two rows): two uploads, two single-link emails, both Done", async () => {
+    // Arrange: a "Both" user request is stored as two independent rows — one
+    // Access, one Activity — each fulfilled as its own job with its own email.
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "admin2@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+
+    const accessRequest = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+    })
+    const activityRequest = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Activity",
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert: two uploads and two independent ready emails, each with exactly
+    // one link (no cross-job coordination).
+    expect(mockUploadAuditLogExport).toHaveBeenCalledTimes(2)
+    expect(mockSendAuditLogExportReadyEmail).toHaveBeenCalledTimes(2)
+    const labels = mockSendAuditLogExportReadyEmail.mock.calls
+      .map(([arg]) => arg.link.label)
+      .sort()
+    expect(labels).toEqual(["access", "audit"])
+
+    const updatedAccess = await getRequest(accessRequest.id)
+    expect(updatedAccess.status).toBe("Done")
+    expect(updatedAccess.objectKey).toBe(
+      `audit-log-exports/${site.id}/${accessRequest.id}/access-2024-03-01-to-2024-03-31.csv`,
+    )
+
+    const updatedActivity = await getRequest(activityRequest.id)
+    expect(updatedActivity.status).toBe("Done")
+    expect(updatedActivity.objectKey).toBe(
+      `audit-log-exports/${site.id}/${activityRequest.id}/activity-2024-03-01-to-2024-03-31.csv`,
+    )
+  })
+
+  it("uploads a header-only CSV and sends the ready email when there are no results", async () => {
+    // Arrange: a site with no member permissions → empty access report.
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "admin3@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+    // Revoke the admin's own permission so the access report is empty for this
+    // site (note: @open.gov.sg is excluded anyway, but vendor emails are not).
+    await db
+      .updateTable("ResourcePermission")
+      .set({ deletedAt: new Date("2020-01-01") })
+      .where("userId", "=", admin.id)
+      .where("siteId", "=", site.id)
+      .execute()
+
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert
+    expect(mockUploadAuditLogExport).toHaveBeenCalledTimes(1)
+    expect(mockSendAuditLogExportReadyEmail).toHaveBeenCalledTimes(1)
+
+    const updated = await getRequest(request.id)
+    expect(updated.status).toBe("Done")
+  })
+
+  it("retries on failure and only fails (with email) after the third attempt", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "admin4@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+    mockUploadAuditLogExport.mockRejectedValue(new Error("s3 down"))
+
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+    })
+
+    // Act: first sweep → attempt 1, re-queued, no failed email.
+    await processPendingAuditLogExports()
+
+    // Assert
+    let updated = await getRequest(request.id)
+    expect(updated.attempts).toBe(1)
+    expect(updated.status).toBe("Pending")
+    expect(mockSendAuditLogExportFailedEmail).not.toHaveBeenCalled()
+
+    // Act: second sweep → attempt 2, still re-queued.
+    await processPendingAuditLogExports()
+    updated = await getRequest(request.id)
+    expect(updated.attempts).toBe(2)
+    expect(updated.status).toBe("Pending")
+    expect(mockSendAuditLogExportFailedEmail).not.toHaveBeenCalled()
+
+    // Act: third sweep → attempt 3, Failed + failed email sent.
+    await processPendingAuditLogExports()
+    updated = await getRequest(request.id)
+    expect(updated.attempts).toBe(3)
+    expect(updated.status).toBe("Failed")
+    expect(mockSendAuditLogExportFailedEmail).toHaveBeenCalledTimes(1)
+    const failedArg = mockSendAuditLogExportFailedEmail.mock.calls[0]![0]
+    expect(failedArg.recipientEmail).toBe("admin4@vendor.com.sg")
+    // The failure email's month label derives from the daterange lower bound.
+    expect(failedArg.month).toBe("March 2024")
+
+    // The ready email must never have been sent.
+    expect(mockSendAuditLogExportReadyEmail).not.toHaveBeenCalled()
+  })
+
+  it("does not reprocess a request that is not Pending", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "admin5@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+
+    const doneRequest = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+      status: "Done",
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert: a Done row is never claimed, so no S3/mail work happens for it.
+    expect(mockUploadAuditLogExport).not.toHaveBeenCalled()
+    expect(mockSendAuditLogExportReadyEmail).not.toHaveBeenCalled()
+
+    const updated = await getRequest(doneRequest.id)
+    expect(updated.status).toBe("Done")
+  })
+
+  it("re-claims and processes a stale Processing row (abandoned claim) to Done", async () => {
+    // Arrange: a row stuck in Processing with an `updatedAt` well past the
+    // 15-minute lease — simulating a worker that died after claiming it but
+    // before the ready email / mark-Done. A later sweep must recover it.
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "stale@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+
+    const staleUpdatedAt = new Date(Date.now() - 30 * 60 * 1000) // 30 min ago
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+      status: "Processing",
+      updatedAt: staleUpdatedAt,
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert: the stale row was re-claimed, processed, and finished.
+    expect(mockUploadAuditLogExport).toHaveBeenCalledTimes(1)
+    expect(mockSendAuditLogExportReadyEmail).toHaveBeenCalledTimes(1)
+    expect(mockSendAuditLogExportFailedEmail).not.toHaveBeenCalled()
+
+    const updated = await getRequest(request.id)
+    expect(updated.status).toBe("Done")
+    expect(updated.objectKey).not.toBeNull()
+    // Re-claiming a stale row counts as a fresh attempt.
+    expect(updated.attempts).toBe(1)
+  })
+
+  it("does not touch a fresh Processing row within the lease window", async () => {
+    // Arrange: a row currently Processing whose `updatedAt` is recent (a live
+    // worker is presumably still on it). A concurrent sweep must leave it alone.
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "fresh@vendor.com.sg" })
+    await setupAdminPermissions({ userId: admin.id, siteId: site.id })
+
+    const freshUpdatedAt = new Date(Date.now() - 60 * 1000) // 1 min ago
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+      status: "Processing",
+      updatedAt: freshUpdatedAt,
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert: no work happened and the row is untouched.
+    expect(mockUploadAuditLogExport).not.toHaveBeenCalled()
+    expect(mockSendAuditLogExportReadyEmail).not.toHaveBeenCalled()
+    expect(mockSendAuditLogExportFailedEmail).not.toHaveBeenCalled()
+
+    const updated = await getRequest(request.id)
+    expect(updated.status).toBe("Processing")
+    expect(updated.attempts).toBe(0)
+    // `updatedAt` must not have moved (not re-claimed).
+    expect(updated.updatedAt.getTime()).toBe(freshUpdatedAt.getTime())
+  })
+})

--- a/apps/studio/src/server/modules/audit/audit.errors.ts
+++ b/apps/studio/src/server/modules/audit/audit.errors.ts
@@ -1,0 +1,25 @@
+export class FutureMonthError extends Error {
+  requestedMonth: string
+
+  constructor(
+    requestedMonth: string,
+    message = "You cannot export audit logs for a month that is in the future",
+  ) {
+    super(message)
+    this.requestedMonth = requestedMonth
+    this.name = "FutureMonthError"
+  }
+}
+
+export class MonthRangeError extends Error {
+  requestedMonth: string
+
+  constructor(
+    requestedMonth: string,
+    message = "You can only export audit logs from the past 12 months",
+  ) {
+    super(message)
+    this.requestedMonth = requestedMonth
+    this.name = "MonthRangeError"
+  }
+}

--- a/apps/studio/src/server/modules/audit/audit.router.ts
+++ b/apps/studio/src/server/modules/audit/audit.router.ts
@@ -1,0 +1,44 @@
+import { TRPCError } from "@trpc/server"
+import { createAuditLogExportRequestSchema } from "~/schemas/audit"
+
+import { protectedProcedure, router } from "../../trpc"
+import { createAuditLogExportRequest } from "./auditLogExport.service"
+
+export const auditRouter = router({
+  createExportRequest: protectedProcedure
+    .input(createAuditLogExportRequestSchema)
+    // Rate-limited because each accepted request eventually triggers downstream
+    // work that hits external services (CSV generation, S3 upload, email).
+    // Arbitrary low limit to prevent abuse; tune if legitimate usage is blocked.
+    .meta({ rateLimitOptions: { max: 5, windowMs: 60_000 } })
+    .mutation(async ({ ctx, input: { siteId, month, reportType } }) => {
+      try {
+        return await createAuditLogExportRequest({
+          siteId,
+          userId: ctx.user.id,
+          month,
+          reportType,
+        })
+      } catch (error) {
+        // Permission / validation / dedupe failures are already typed
+        // TRPCErrors with safe, user-facing messages — let them through.
+        if (error instanceof TRPCError) {
+          throw error
+        }
+
+        // Anything else (e.g. a DB error) may leak request internals; log it
+        // with the request context and surface a generic error to the client.
+        ctx.logger.error({
+          error,
+          message: "Failed to create audit log export request",
+          siteId,
+          month,
+          reportType,
+        })
+        throw new TRPCError({
+          code: "INTERNAL_SERVER_ERROR",
+          message: "Failed to create audit log export request",
+        })
+      }
+    }),
+})

--- a/apps/studio/src/server/modules/audit/audit.router.ts
+++ b/apps/studio/src/server/modules/audit/audit.router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server"
 import { createAuditLogExportRequestSchema } from "~/schemas/audit"
 
 import { protectedProcedure, router } from "../../trpc"
+import { validateUserIsSiteAdmin } from "../permissions/permissions.service"
 import { createAuditLogExportRequest } from "./auditLogExport.service"
 
 export const auditRouter = router({
@@ -12,6 +13,13 @@ export const auditRouter = router({
     // Arbitrary low limit to prevent abuse; tune if legitimate usage is blocked.
     .meta({ rateLimitOptions: { max: 5, windowMs: 60_000 } })
     .mutation(async ({ ctx, input: { siteId, month, reportType } }) => {
+      // Permission check FIRST, before any mutation. Audit log export is a
+      // Site Admin-only capability so we reject any attempts if they are not an admin
+      await validateUserIsSiteAdmin({
+        siteId,
+        userId: ctx.user.id,
+      })
+
       try {
         return await createAuditLogExportRequest({
           siteId,

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -31,7 +31,6 @@ import type { BaseLogger } from "@isomer/logging"
 import type { AuditLogExportReportType } from "../database"
 import { db } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
-import { validatePermissionsForManagingUsers } from "../permissions/permissions.service"
 import {
   getAccessReportRows,
   getActivityReportRows,
@@ -68,17 +67,6 @@ export const createAuditLogExportRequest = async ({
   month,
   reportType,
 }: CreateAuditLogExportRequestProps) => {
-  // Permission check FIRST, before any mutation. Audit log export is a
-  // Site Admin-only capability — we reuse the same admin-only gate as the
-  // user-management surface (`manage` on `UserManagement`), which only grants
-  // the `manage` action to the `Admin` role. Editors/Publishers can `read`
-  // but not `manage`, so they are rejected here with FORBIDDEN.
-  await validatePermissionsForManagingUsers({
-    siteId,
-    userId,
-    action: "manage",
-  })
-
   // Reject months outside the allowed window (in Singapore time). This mirrors
   // the schema's window refinements as defense-in-depth, and uses the same
   // date-fns comparators (parseISO + isBefore/isAfter/isSameMonth) so the

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -20,7 +20,7 @@ import {
   uploadAuditLogExport,
 } from "~/lib/s3"
 import {
-  type AuditLogExportRequestedReportType,
+  AuditLogExportRequestedReportType,
   type CreateAuditLogExportRequestInput,
   getCurrentSingaporeMonth,
   getEarliestExportableMonth,
@@ -28,7 +28,7 @@ import {
 
 import type { BaseLogger } from "@isomer/logging"
 
-import type { AuditLogExportReportType } from "../database"
+import { AuditLogExportReportType } from "../database"
 import { AuditLogExportStatus, db } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
@@ -59,9 +59,14 @@ const REPORT_TYPES_BY_REQUESTED_TYPE: Record<
   AuditLogExportRequestedReportType,
   readonly AuditLogExportReportType[]
 > = {
-  Access: ["Access"],
-  Activity: ["Activity"],
-  Both: ["Access", "Activity"],
+  [AuditLogExportRequestedReportType.Access]: [AuditLogExportReportType.Access],
+  [AuditLogExportRequestedReportType.Activity]: [
+    AuditLogExportReportType.Activity,
+  ],
+  [AuditLogExportRequestedReportType.Both]: [
+    AuditLogExportReportType.Activity,
+    AuditLogExportReportType.Access,
+  ],
 }
 
 export const createAuditLogExportRequest = async ({
@@ -219,8 +224,14 @@ const PROCESSING_LEASE_MS = 15 * 60 * 1000
 // request time (see REPORT_TYPES_BY_REQUESTED_TYPE), so every row here maps to
 // exactly one report — one CSV, one download link, one email.
 const REPORT_BY_TYPE = {
-  Access: { kind: "Access", label: "access" },
-  Activity: { kind: "Activity", label: "audit" },
+  [AuditLogExportReportType.Access]: {
+    kind: AuditLogExportReportType.Access,
+    label: "access",
+  },
+  [AuditLogExportReportType.Activity]: {
+    kind: AuditLogExportReportType.Activity,
+    label: "audit",
+  },
 } as const
 
 /**

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -359,9 +359,7 @@ export const processAuditLogExportRequest = async (
             auditLogDateRange: request.auditLogDateRange,
           })
 
-    // The report row types are precise interfaces without an index
-    // signature; `toCsv` only needs string-keyed records, so widen here.
-    const csv = toCsv(rows as unknown as Record<string, unknown>[])
+    const csv = toCsv(rows)
     const rangeSlug = getRangeSlug(request.auditLogDateRange)
     const objectKey = `audit-log-exports/${request.siteId}/${requestId}/${report.kind.toLowerCase()}-${rangeSlug}.csv`
 

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -29,7 +29,7 @@ import {
 import type { BaseLogger } from "@isomer/logging"
 
 import type { AuditLogExportReportType } from "../database"
-import { db } from "../database"
+import { AuditLogExportStatus, db } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
   getAccessReportRows,
@@ -46,7 +46,10 @@ type CreateAuditLogExportRequestProps = CreateAuditLogExportRequestInput & {
 // Statuses that represent an export that is still in-flight; a duplicate
 // request for the same (site, user, range, report type) should be rejected
 // while one of these exists.
-const IN_FLIGHT_STATUSES = ["Pending", "Processing"] as const
+const IN_FLIGHT_STATUSES = [
+  AuditLogExportStatus.Pending,
+  AuditLogExportStatus.Processing,
+]
 
 // Fan-out from the requested (input) report type to the DB rows to insert.
 // `Both` is UX vocabulary only (see schemas/audit.ts): it becomes TWO

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -16,7 +16,7 @@ import { createBaseLogger } from "~/lib/logger"
 import {
   AUDIT_LOG_EXPORT_URL_EXPIRY_SECONDS,
   generateSignedGetUrl,
-  getAuditLogExportBucketName,
+  getStudioAssetsBucketName,
   uploadAuditLogExport,
 } from "~/lib/s3"
 import {
@@ -346,7 +346,7 @@ export const processAuditLogExportRequest = async (
     // URL. `Both` requests were fanned out into two rows at request time, so
     // one row is always exactly one report.
     const report = REPORT_BY_TYPE[request.reportType]
-    const bucket = getAuditLogExportBucketName()
+    const bucket = getStudioAssetsBucketName()
 
     const rows =
       report.kind === "Access"

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -202,8 +202,9 @@ const logger: BaseLogger = createBaseLogger({
   path: "modules/audit/auditLogExport.service",
 })
 
-// After this many failed attempts a request is marked Failed (and the
-// requester is emailed) rather than retried again on the next sweep.
+// After this many started attempts (charged at claim time) a failing request
+// is marked Failed (and the requester emailed) rather than retried again on
+// the next sweep.
 const MAX_ATTEMPTS = 3
 
 // Number of Pending requests claimed per cron sweep. Keeps each minute's run
@@ -267,14 +268,16 @@ const getRangeSlug = (auditLogDateRange: string): string => {
  * claim left behind by a killed/redeployed worker — see PROCESSING_LEASE_MS).
  * The `WHERE` guard plus `RETURNING` make the claim race-safe: if no row comes
  * back, another sweep already grabbed it (or it is freshly Processing) and we
- * skip. Re-claiming a stale row counts as a fresh attempt (attempts += 1) so a
- * repeatedly-crashing row still exhausts MAX_ATTEMPTS instead of looping
- * forever.
+ * skip. `attempts` counts processing attempts STARTED: every claim (fresh or
+ * stale re-claim) charges attempts + 1 atomically, so an attempt is counted
+ * exactly once whether it ends in a caught error, a dead worker, or success —
+ * a repeatedly-crashing row still exhausts MAX_ATTEMPTS instead of looping
+ * forever, and a stale re-claim that fails is never double-charged.
  *
  * Steps 2–6 (load site/user, generate CSVs, upload to S3, sign URLs, send the
  * ready email, mark Done) are wrapped in a try/catch: on any failure we
- * increment `attempts` and either re-queue the row (Pending) for the next
- * sweep or, once `attempts >= MAX_ATTEMPTS`, mark it Failed and best-effort
+ * either re-queue the row (Pending) for the next sweep or, once the
+ * already-charged `attempts >= MAX_ATTEMPTS`, mark it Failed and best-effort
  * email the requester. Raw errors are only ever logged, never surfaced to the
  * recipient.
  *
@@ -288,21 +291,15 @@ export const processAuditLogExportRequest = async (
 ): Promise<void> => {
   // Step 1: atomic claim. Claim a fresh `Pending` row, or re-claim a
   // `Processing` row whose lease has expired (abandoned by a dead worker).
-  // Re-claiming a stale row bumps `attempts` so it can't retry infinitely;
-  // a fresh Pending claim leaves `attempts` untouched (the catch owns that
-  // increment for genuine in-process failures).
+  // Every claim charges the attempt up front — the catch never increments, so
+  // a stale re-claim that fails again is charged once, not twice.
   const request = await db
     .updateTable("AuditLogExportRequest")
-    .set((eb) => ({
+    .set({
       status: "Processing",
       updatedAt: new Date(),
-      attempts: eb
-        .case()
-        .when("status", "=", "Processing")
-        .then(sql<number>`attempts + 1`)
-        .else(eb.ref("attempts"))
-        .end(),
-    }))
+      attempts: sql<number>`attempts + 1`,
+    })
     .where("id", "=", requestId)
     .where((eb) =>
       eb.or([
@@ -392,8 +389,9 @@ export const processAuditLogExportRequest = async (
       .where("id", "=", requestId)
       .execute()
   } catch (error) {
-    // Step 7: failure handling. Increment attempts; re-queue or fail.
-    const attempts = request.attempts + 1
+    // Step 7: failure handling. The claim already charged this attempt, so
+    // `request.attempts` (post-claim) is authoritative — re-queue or fail.
+    const { attempts } = request
     const errorMessage =
       error instanceof Error ? error.message : "Unknown error"
 
@@ -403,12 +401,11 @@ export const processAuditLogExportRequest = async (
     )
 
     if (attempts < MAX_ATTEMPTS) {
-      // Re-queue for the next sweep.
+      // Re-queue for the next sweep; `attempts` is already persisted.
       await db
         .updateTable("AuditLogExportRequest")
         .set({
           status: "Pending",
-          attempts,
           errorMessage,
           updatedAt: new Date(),
         })
@@ -422,7 +419,6 @@ export const processAuditLogExportRequest = async (
       .updateTable("AuditLogExportRequest")
       .set({
         status: "Failed",
-        attempts,
         errorMessage,
         updatedAt: new Date(),
       })

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -1,0 +1,504 @@
+import { TRPCError } from "@trpc/server"
+import {
+  addDays,
+  format,
+  isAfter,
+  isBefore,
+  isSameMonth,
+  parseISO,
+} from "date-fns"
+import { sql } from "kysely"
+import {
+  sendAuditLogExportFailedEmail,
+  sendAuditLogExportReadyEmail,
+} from "~/features/mail/service"
+import { createBaseLogger } from "~/lib/logger"
+import {
+  AUDIT_LOG_EXPORT_URL_EXPIRY_SECONDS,
+  generateSignedGetUrl,
+  getAuditLogExportBucketName,
+  uploadAuditLogExport,
+} from "~/lib/s3"
+import {
+  type AuditLogExportRequestedReportType,
+  type CreateAuditLogExportRequestInput,
+  getCurrentSingaporeMonth,
+  getEarliestExportableMonth,
+} from "~/schemas/audit"
+
+import type { BaseLogger } from "@isomer/logging"
+
+import type { AuditLogExportReportType } from "../database"
+import { db } from "../database"
+import { PG_ERROR_CODES } from "../database/constants"
+import { validatePermissionsForManagingUsers } from "../permissions/permissions.service"
+import {
+  getAccessReportRows,
+  getActivityReportRows,
+  getMonthDateRange,
+  parseAuditLogDateRange,
+  toCsv,
+} from "./auditLogExport.query"
+
+type CreateAuditLogExportRequestProps = CreateAuditLogExportRequestInput & {
+  userId: string
+}
+
+// Statuses that represent an export that is still in-flight; a duplicate
+// request for the same (site, user, range, report type) should be rejected
+// while one of these exists.
+const IN_FLIGHT_STATUSES = ["Pending", "Processing"] as const
+
+// Fan-out from the requested (input) report type to the DB rows to insert.
+// `Both` is UX vocabulary only (see schemas/audit.ts): it becomes TWO
+// AuditLogExportRequest rows — one Access, one Activity — each fulfilled as an
+// independent job. The DB enum has no `Both` member.
+const REPORT_TYPES_BY_REQUESTED_TYPE: Record<
+  AuditLogExportRequestedReportType,
+  readonly AuditLogExportReportType[]
+> = {
+  Access: ["Access"],
+  Activity: ["Activity"],
+  Both: ["Access", "Activity"],
+}
+
+export const createAuditLogExportRequest = async ({
+  siteId,
+  userId,
+  month,
+  reportType,
+}: CreateAuditLogExportRequestProps) => {
+  // Permission check FIRST, before any mutation. Audit log export is a
+  // Site Admin-only capability — we reuse the same admin-only gate as the
+  // user-management surface (`manage` on `UserManagement`), which only grants
+  // the `manage` action to the `Admin` role. Editors/Publishers can `read`
+  // but not `manage`, so they are rejected here with FORBIDDEN.
+  await validatePermissionsForManagingUsers({
+    siteId,
+    userId,
+    action: "manage",
+  })
+
+  // Reject months outside the allowed window (in Singapore time). This mirrors
+  // the schema's window refinements as defense-in-depth, and uses the same
+  // date-fns comparators (parseISO + isBefore/isAfter/isSameMonth) so the
+  // comparison style stays consistent with schemas/audit.ts.
+  const currentMonth = getCurrentSingaporeMonth()
+  const requestedMonthDate = parseISO(`${month}-01`)
+  const currentMonthDate = parseISO(`${currentMonth}-01`)
+  if (
+    !isSameMonth(requestedMonthDate, currentMonthDate) &&
+    isAfter(requestedMonthDate, currentMonthDate)
+  ) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "You cannot export audit logs for a month that is in the future",
+    })
+  }
+
+  const earliestMonthDate = parseISO(
+    `${getEarliestExportableMonth(currentMonth)}-01`,
+  )
+  if (
+    !isSameMonth(requestedMonthDate, earliestMonthDate) &&
+    isBefore(requestedMonthDate, earliestMonthDate)
+  ) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "You can only export audit logs from the past 12 months",
+    })
+  }
+
+  // The month picker is the user-facing input, but requests are stored as a
+  // half-open SGT calendar-date range, `[YYYY-MM-DD,YYYY-MM-DD)` (see
+  // getMonthDateRange — a current-month request is clamped to today + 1).
+  const auditLogDateRange = getMonthDateRange(month, new Date())
+
+  // The concrete DB report types this request fans out to: one row for
+  // Access/Activity, two rows for Both.
+  const reportTypes = REPORT_TYPES_BY_REQUESTED_TYPE[reportType]
+
+  // In-flight dedupe is atomic. The real guard is a PARTIAL UNIQUE INDEX on
+  // (siteId, userId, auditLogDateRange, reportType) WHERE status IN
+  // ('Pending','Processing') (defined in the PR #2603 migration): the database
+  // physically refuses a second in-flight row for the same range+report type,
+  // so two concurrent identical requests cannot both insert. The SELECT below
+  // is only a fast-path so the common (non-racing) duplicate returns a friendly
+  // CONFLICT without relying on an exception; the losing side of an actual race
+  // is caught from the INSERT's unique-violation and surfaced as the SAME
+  // CONFLICT rather than a raw 500. All inserts for one request run inside ONE
+  // transaction, all-or-nothing: if any insert of a `Both` fan-out loses the
+  // race, the thrown CONFLICT rolls back the whole transaction and neither row
+  // is committed.
+  return db.transaction().execute(async (tx) => {
+    const existing = await tx
+      .selectFrom("AuditLogExportRequest")
+      .where("siteId", "=", siteId)
+      .where("userId", "=", userId)
+      .where("auditLogDateRange", "=", auditLogDateRange)
+      .where("reportType", "in", [...reportTypes])
+      .where("status", "in", IN_FLIGHT_STATUSES)
+      .select("id")
+      .executeTakeFirst()
+
+    if (existing) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message:
+          "An export for this period and report type is already being generated",
+      })
+    }
+
+    try {
+      const inserted = []
+      for (const dbReportType of reportTypes) {
+        inserted.push(
+          await tx
+            .insertInto("AuditLogExportRequest")
+            .values({
+              siteId,
+              userId,
+              auditLogDateRange,
+              reportType: dbReportType,
+              status: "Pending",
+              attempts: 0,
+            })
+            .returningAll()
+            .executeTakeFirstOrThrow(),
+        )
+      }
+      // Return every inserted row (one for Access/Activity, two for Both).
+      // The UI ignores the payload, so the array shape is chosen purely to
+      // reflect the fan-out honestly.
+      return inserted
+    } catch (error) {
+      // Race-loser path: a concurrent request inserted an in-flight row
+      // between our SELECT and INSERT, so the partial unique index rejected
+      // ours. Translate that into the same friendly CONFLICT as the fast-path;
+      // throwing aborts the transaction, so earlier fan-out inserts roll back
+      // too (all-or-nothing). Any other error (and any TRPCError thrown above)
+      // is re-thrown as-is.
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === PG_ERROR_CODES.uniqueViolation
+      ) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message:
+            "An export for this period and report type is already being generated",
+        })
+      }
+      throw error
+    }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Fulfilment orchestrator (LAYER 4c)
+// ---------------------------------------------------------------------------
+
+const logger: BaseLogger = createBaseLogger({
+  path: "modules/audit/auditLogExport.service",
+})
+
+// After this many failed attempts a request is marked Failed (and the
+// requester is emailed) rather than retried again on the next sweep.
+const MAX_ATTEMPTS = 3
+
+// Number of Pending requests claimed per cron sweep. Keeps each minute's run
+// bounded so one large backlog cannot monopolise the worker.
+const BATCH_SIZE = 20
+
+// A row is moved to `Processing` the moment a sweep claims it, and only moved
+// back to `Pending` by the in-process `catch`. If the worker is killed or
+// redeployed after the claim but before that catch runs, the row would
+// otherwise stay `Processing` forever — never retried, requester never
+// emailed. We treat any `Processing` row whose `updatedAt` is older than this
+// lease as an abandoned claim and allow a later sweep to re-claim it.
+//
+// 15 minutes is comfortably longer than the worst-case time to process a
+// single request (query + CSV + S3 upload + email, all with short timeouts),
+// so a still-running worker's claim will never be stolen mid-flight, while a
+// genuinely dead worker's rows are recovered within a couple of sweeps.
+const PROCESSING_LEASE_MS = 15 * 60 * 1000
+
+// The single report each row produces. `Both` is fanned out into two rows at
+// request time (see REPORT_TYPES_BY_REQUESTED_TYPE), so every row here maps to
+// exactly one report — one CSV, one download link, one email.
+const REPORT_BY_TYPE = {
+  Access: { kind: "Access", label: "access" },
+  Activity: { kind: "Activity", label: "audit" },
+} as const
+
+/**
+ * Human-readable label for an export's period (e.g. "June 2026") for the email
+ * subject/body, derived from the stored daterange's inclusive lower bound
+ * (already an SGT calendar date). The picker is month-based, so the lower
+ * bound is the 1st of the month and the month name is an accurate label.
+ */
+const getExportPeriodLabel = (auditLogDateRange: string): string => {
+  const { lowerInclusive } = parseAuditLogDateRange(auditLogDateRange)
+  return format(parseISO(lowerInclusive), "MMMM yyyy")
+}
+
+/**
+ * Slug for the S3 object key, rendering the half-open stored range with an
+ * INCLUSIVE end for human readability: `[2026-04-01,2026-05-01)` →
+ * `2026-04-01-to-2026-04-30`. Plain calendar arithmetic on the date string —
+ * the bounds are SGT calendar dates and SGT has no DST.
+ */
+const getRangeSlug = (auditLogDateRange: string): string => {
+  const { lowerInclusive, upperExclusive } =
+    parseAuditLogDateRange(auditLogDateRange)
+  const upperInclusive = format(
+    addDays(parseISO(upperExclusive), -1),
+    "yyyy-MM-dd",
+  )
+  return `${lowerInclusive}-to-${upperInclusive}`
+}
+
+/**
+ * Process a single export request, identified by id.
+ *
+ * Step 1 claims the row atomically so that concurrent sweeps never
+ * double-process it. A row is claimable if it is `Pending`, OR if it is
+ * `Processing` but its `updatedAt` is older than `staleCutoff` (an abandoned
+ * claim left behind by a killed/redeployed worker — see PROCESSING_LEASE_MS).
+ * The `WHERE` guard plus `RETURNING` make the claim race-safe: if no row comes
+ * back, another sweep already grabbed it (or it is freshly Processing) and we
+ * skip. Re-claiming a stale row counts as a fresh attempt (attempts += 1) so a
+ * repeatedly-crashing row still exhausts MAX_ATTEMPTS instead of looping
+ * forever.
+ *
+ * Steps 2–6 (load site/user, generate CSVs, upload to S3, sign URLs, send the
+ * ready email, mark Done) are wrapped in a try/catch: on any failure we
+ * increment `attempts` and either re-queue the row (Pending) for the next
+ * sweep or, once `attempts >= MAX_ATTEMPTS`, mark it Failed and best-effort
+ * email the requester. Raw errors are only ever logged, never surfaced to the
+ * recipient.
+ *
+ * @param staleCutoff Rows that are `Processing` with `updatedAt < staleCutoff`
+ * are treated as abandoned and re-claimable. Passed in by the sweep so every
+ * row in one batch uses the same cutoff instant.
+ */
+export const processAuditLogExportRequest = async (
+  requestId: string,
+  staleCutoff: Date,
+): Promise<void> => {
+  // Step 1: atomic claim. Claim a fresh `Pending` row, or re-claim a
+  // `Processing` row whose lease has expired (abandoned by a dead worker).
+  // Re-claiming a stale row bumps `attempts` so it can't retry infinitely;
+  // a fresh Pending claim leaves `attempts` untouched (the catch owns that
+  // increment for genuine in-process failures).
+  const request = await db
+    .updateTable("AuditLogExportRequest")
+    .set((eb) => ({
+      status: "Processing",
+      updatedAt: new Date(),
+      attempts: eb
+        .case()
+        .when("status", "=", "Processing")
+        .then(sql<number>`attempts + 1`)
+        .else(eb.ref("attempts"))
+        .end(),
+    }))
+    .where("id", "=", requestId)
+    .where((eb) =>
+      eb.or([
+        eb("status", "=", "Pending"),
+        eb.and([
+          eb("status", "=", "Processing"),
+          eb("updatedAt", "<", staleCutoff),
+        ]),
+      ]),
+    )
+    .returningAll()
+    .executeTakeFirst()
+
+  if (!request) {
+    // Another sweep claimed it, it is no longer Pending, or it is a
+    // still-fresh Processing row within its lease — skip silently.
+    return
+  }
+
+  try {
+    // Step 2: load the site (for a display name) and the requesting user
+    // (for the recipient email).
+    const site = await db
+      .selectFrom("Site")
+      .where("id", "=", request.siteId)
+      .select(["id", "name", "config"])
+      .executeTakeFirstOrThrow()
+
+    const user = await db
+      .selectFrom("User")
+      .where("id", "=", request.userId)
+      .select(["id", "email"])
+      .executeTakeFirstOrThrow()
+
+    const siteConfig = site.config as { siteName?: string } | null
+    const siteName = siteConfig?.siteName || site.name
+    const recipientEmail = user.email
+
+    // Step 3 + 4: run the row's single report query, serialise to CSV
+    // (always — header-only CSV for zero rows), upload, and sign a download
+    // URL. `Both` requests were fanned out into two rows at request time, so
+    // one row is always exactly one report.
+    const report = REPORT_BY_TYPE[request.reportType]
+    const bucket = getAuditLogExportBucketName()
+
+    const rows =
+      report.kind === "Access"
+        ? await getAccessReportRows({
+            siteId: request.siteId,
+            auditLogDateRange: request.auditLogDateRange,
+          })
+        : await getActivityReportRows({
+            siteId: request.siteId,
+            auditLogDateRange: request.auditLogDateRange,
+          })
+
+    // The report row types are precise interfaces without an index
+    // signature; `toCsv` only needs string-keyed records, so widen here.
+    const csv = toCsv(rows as unknown as Record<string, unknown>[])
+    const rangeSlug = getRangeSlug(request.auditLogDateRange)
+    const objectKey = `audit-log-exports/${request.siteId}/${requestId}/${report.kind.toLowerCase()}-${rangeSlug}.csv`
+
+    await uploadAuditLogExport({ key: objectKey, body: csv })
+
+    const url = await generateSignedGetUrl(
+      { Bucket: bucket, Key: objectKey },
+      AUDIT_LOG_EXPORT_URL_EXPIRY_SECONDS,
+    )
+
+    // Step 5: one ready email with the single download link. A "Both" user
+    // request is two independent rows, so it yields two independent emails —
+    // no cross-job coordination.
+    await sendAuditLogExportReadyEmail({
+      recipientEmail,
+      siteName,
+      month: getExportPeriodLabel(request.auditLogDateRange),
+      link: { label: report.label, url },
+    })
+
+    // Step 6: mark Done.
+    await db
+      .updateTable("AuditLogExportRequest")
+      .set({
+        status: "Done",
+        objectKey,
+        errorMessage: null,
+        updatedAt: new Date(),
+      })
+      .where("id", "=", requestId)
+      .execute()
+  } catch (error) {
+    // Step 7: failure handling. Increment attempts; re-queue or fail.
+    const attempts = request.attempts + 1
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error"
+
+    logger.error(
+      { error, requestId, attempts },
+      "Failed to process audit log export request",
+    )
+
+    if (attempts < MAX_ATTEMPTS) {
+      // Re-queue for the next sweep.
+      await db
+        .updateTable("AuditLogExportRequest")
+        .set({
+          status: "Pending",
+          attempts,
+          errorMessage,
+          updatedAt: new Date(),
+        })
+        .where("id", "=", requestId)
+        .execute()
+      return
+    }
+
+    // Exhausted retries — mark Failed and notify the requester (best-effort).
+    await db
+      .updateTable("AuditLogExportRequest")
+      .set({
+        status: "Failed",
+        attempts,
+        errorMessage,
+        updatedAt: new Date(),
+      })
+      .where("id", "=", requestId)
+      .execute()
+
+    try {
+      const failed = await db
+        .selectFrom("AuditLogExportRequest")
+        .innerJoin("Site", "Site.id", "AuditLogExportRequest.siteId")
+        .innerJoin("User", "User.id", "AuditLogExportRequest.userId")
+        .where("AuditLogExportRequest.id", "=", requestId)
+        .select([
+          "User.email as recipientEmail",
+          "Site.name as siteName",
+          "Site.config as config",
+          "AuditLogExportRequest.auditLogDateRange as auditLogDateRange",
+        ])
+        .executeTakeFirstOrThrow()
+
+      const failedConfig = failed.config as { siteName?: string } | null
+      await sendAuditLogExportFailedEmail({
+        recipientEmail: failed.recipientEmail,
+        siteName: failedConfig?.siteName || failed.siteName,
+        month: getExportPeriodLabel(failed.auditLogDateRange),
+      })
+    } catch (emailError) {
+      // The row is already Failed; a failed failure-email must not throw.
+      logger.error(
+        { error: emailError, requestId },
+        "Failed to send audit log export failure email",
+      )
+    }
+  }
+}
+
+/**
+ * Cron entry point. Claims up to `BATCH_SIZE` requests (oldest first) and
+ * processes each. Candidates are rows that are `Pending`, plus rows stuck in
+ * `Processing` past their lease (PROCESSING_LEASE_MS) — abandoned claims from a
+ * worker that died between the claim and the in-process catch. Per-row errors
+ * are caught so a single bad row never aborts the rest of the batch.
+ */
+export const processPendingAuditLogExports = async (): Promise<void> => {
+  // A single cutoff instant for the whole sweep: the batch selector and the
+  // per-row atomic claim must agree on what counts as "stale".
+  const staleCutoff = new Date(Date.now() - PROCESSING_LEASE_MS)
+
+  const pending = await db
+    .selectFrom("AuditLogExportRequest")
+    .where((eb) =>
+      eb.or([
+        eb("status", "=", "Pending"),
+        eb.and([
+          eb("status", "=", "Processing"),
+          eb("updatedAt", "<", staleCutoff),
+        ]),
+      ]),
+    )
+    .orderBy("createdAt", "asc")
+    .limit(BATCH_SIZE)
+    .select("id")
+    .execute()
+
+  for (const { id } of pending) {
+    try {
+      await processAuditLogExportRequest(id, staleCutoff)
+    } catch (error) {
+      // processAuditLogExportRequest handles its own errors, but guard the
+      // batch loop defensively so one unexpected throw can't halt the sweep.
+      logger.error(
+        { error, requestId: id },
+        "Unexpected error processing audit log export request in batch",
+      )
+    }
+  }
+}

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -387,6 +387,7 @@ export const processAuditLogExportRequest = async (
         objectKey,
         errorMessage: null,
         updatedAt: new Date(),
+        completedAt: new Date(),
       })
       .where("id", "=", requestId)
       .execute()

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -156,7 +156,7 @@ export const createAuditLogExportRequest = async ({
               userId,
               auditLogDateRange,
               reportType: dbReportType,
-              status: "Pending",
+              status: AuditLogExportStatus.Pending,
               attempts: 0,
             })
             .returningAll()
@@ -321,25 +321,27 @@ export const processAuditLogExportRequest = async (
     return
   }
 
+  // Step 2: load the site (for a display name) and the requesting user (for the
+  // recipient email). Loaded before the try so the failure-email path below can
+  // reuse them instead of re-querying. The row was just claimed and both are
+  // FK-backed, so these never miss in practice.
+  const site = await db
+    .selectFrom("Site")
+    .where("id", "=", request.siteId)
+    .select(["id", "name", "config"])
+    .executeTakeFirstOrThrow()
+
+  const user = await db
+    .selectFrom("User")
+    .where("id", "=", request.userId)
+    .select(["id", "email"])
+    .executeTakeFirstOrThrow()
+
+  const siteConfig = site.config as { siteName?: string } | null
+  const siteName = siteConfig?.siteName || site.name
+  const recipientEmail = user.email
+
   try {
-    // Step 2: load the site (for a display name) and the requesting user
-    // (for the recipient email).
-    const site = await db
-      .selectFrom("Site")
-      .where("id", "=", request.siteId)
-      .select(["id", "name", "config"])
-      .executeTakeFirstOrThrow()
-
-    const user = await db
-      .selectFrom("User")
-      .where("id", "=", request.userId)
-      .select(["id", "email"])
-      .executeTakeFirstOrThrow()
-
-    const siteConfig = site.config as { siteName?: string } | null
-    const siteName = siteConfig?.siteName || site.name
-    const recipientEmail = user.email
-
     // Step 3 + 4: run the row's single report query, serialise to CSV
     // (always — header-only CSV for zero rows), upload, and sign a download
     // URL. `Both` requests were fanned out into two rows at request time, so
@@ -429,24 +431,11 @@ export const processAuditLogExportRequest = async (
       .execute()
 
     try {
-      const failed = await db
-        .selectFrom("AuditLogExportRequest")
-        .innerJoin("Site", "Site.id", "AuditLogExportRequest.siteId")
-        .innerJoin("User", "User.id", "AuditLogExportRequest.userId")
-        .where("AuditLogExportRequest.id", "=", requestId)
-        .select([
-          "User.email as recipientEmail",
-          "Site.name as siteName",
-          "Site.config as config",
-          "AuditLogExportRequest.auditLogDateRange as auditLogDateRange",
-        ])
-        .executeTakeFirstOrThrow()
-
-      const failedConfig = failed.config as { siteName?: string } | null
+      // Reuse the site/user already loaded above instead of re-querying.
       await sendAuditLogExportFailedEmail({
-        recipientEmail: failed.recipientEmail,
-        siteName: failedConfig?.siteName || failed.siteName,
-        month: getExportPeriodLabel(failed.auditLogDateRange),
+        recipientEmail,
+        siteName,
+        month: getExportPeriodLabel(request.auditLogDateRange),
       })
     } catch (emailError) {
       // The row is already Failed; a failed failure-email must not throw.

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -69,7 +69,7 @@ export const createAuditLogExportRequest = async ({
   reportType,
 }: CreateAuditLogExportRequestProps) => {
   const possibleError =
-    validateIsNotFutureMonth(month) ?? validateIsMonthInPastYear(month)
+    validateIsNotFutureMonth(month) || validateIsMonthInPastYear(month)
   if (possibleError !== true) {
     logger.warn(possibleError)
     throw new TRPCError({

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -1,12 +1,5 @@
 import { TRPCError } from "@trpc/server"
-import {
-  addDays,
-  format,
-  isAfter,
-  isBefore,
-  isSameMonth,
-  parseISO,
-} from "date-fns"
+import { addDays, format, parseISO } from "date-fns"
 import { sql } from "kysely"
 import {
   sendAuditLogExportFailedEmail,
@@ -22,8 +15,8 @@ import {
 import {
   AuditLogExportRequestedReportType,
   type CreateAuditLogExportRequestInput,
-  getCurrentSingaporeMonth,
-  getEarliestExportableMonth,
+  validateIsMonthInPastYear,
+  validateIsNotFutureMonth,
 } from "~/schemas/audit"
 
 import type { BaseLogger } from "@isomer/logging"
@@ -75,33 +68,13 @@ export const createAuditLogExportRequest = async ({
   month,
   reportType,
 }: CreateAuditLogExportRequestProps) => {
-  // Reject months outside the allowed window (in Singapore time). This mirrors
-  // the schema's window refinements as defense-in-depth, and uses the same
-  // date-fns comparators (parseISO + isBefore/isAfter/isSameMonth) so the
-  // comparison style stays consistent with schemas/audit.ts.
-  const currentMonth = getCurrentSingaporeMonth()
-  const requestedMonthDate = parseISO(`${month}-01`)
-  const currentMonthDate = parseISO(`${currentMonth}-01`)
-  if (
-    !isSameMonth(requestedMonthDate, currentMonthDate) &&
-    isAfter(requestedMonthDate, currentMonthDate)
-  ) {
+  const possibleError =
+    validateIsNotFutureMonth(month) ?? validateIsMonthInPastYear(month)
+  if (possibleError !== true) {
+    logger.warn(possibleError)
     throw new TRPCError({
       code: "BAD_REQUEST",
-      message: "You cannot export audit logs for a month that is in the future",
-    })
-  }
-
-  const earliestMonthDate = parseISO(
-    `${getEarliestExportableMonth(currentMonth)}-01`,
-  )
-  if (
-    !isSameMonth(requestedMonthDate, earliestMonthDate) &&
-    isBefore(requestedMonthDate, earliestMonthDate)
-  ) {
-    throw new TRPCError({
-      code: "BAD_REQUEST",
-      message: "You can only export audit logs from the past 12 months",
+      message: possibleError.message,
     })
   }
 

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -328,7 +328,22 @@ export const processAuditLogExportRequest = async (
   // NOTE: Early return - this is technically not a failure
   // because it means that the user has been removed from the site
   // as an admin between the job creation and fulfillment time
-  if (!user) return
+  if (!user) {
+    logger.warn(
+      { requestId, userId: request.userId },
+      "User no longer exists or is not an admin",
+    )
+    await db
+      .updateTable("AuditLogExportRequest")
+      .set({
+        status: AuditLogExportStatus.Failed,
+        errorMessage: "User no longer exists or is not an admin",
+        updatedAt: new Date(),
+      })
+      .where("id", "=", requestId)
+      .execute()
+    return
+  }
 
   const siteConfig = site.config
   const siteName = siteConfig?.siteName || site.name

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -319,9 +319,11 @@ export const processAuditLogExportRequest = async (
     .selectFrom("User")
     .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
     .where("User.id", "=", request.userId)
+    .where("User.deletedAt", "is", null)
     .where("ResourcePermission.userId", "=", request.userId)
     .where("ResourcePermission.role", "=", "Admin")
     .where("ResourcePermission.siteId", "=", site.id)
+    .where("ResourcePermission.deletedAt", "is", null)
     .select(["User.id", "User.email"])
     .executeTakeFirst()
 

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -62,6 +62,27 @@ const REPORT_TYPES_BY_REQUESTED_TYPE: Record<
   ],
 }
 
+// The single report each row produces. `Both` is fanned out into two rows at
+// request time (see REPORT_TYPES_BY_REQUESTED_TYPE), so every row here maps to
+// exactly one report — one CSV, one download link, one email. Also used to
+// name the specific report type in a CONFLICT error message.
+const REPORT_BY_TYPE = {
+  [AuditLogExportReportType.Access]: {
+    kind: AuditLogExportReportType.Access,
+    label: "access",
+  },
+  [AuditLogExportReportType.Activity]: {
+    kind: AuditLogExportReportType.Activity,
+    label: "audit",
+  },
+} as const
+
+// Named per report type so a `Both` request that partially conflicts (e.g.
+// access is already in flight but activity is not) tells the user which one,
+// rather than a generic message that leaves them guessing.
+const getInFlightConflictMessage = (reportType: AuditLogExportReportType) =>
+  `An ${REPORT_BY_TYPE[reportType].label} log export for this period is already being generated`
+
 export const createAuditLogExportRequest = async ({
   siteId,
   userId,
@@ -110,20 +131,19 @@ export const createAuditLogExportRequest = async ({
       .where("auditLogDateRange", "=", auditLogDateRange)
       .where("reportType", "in", [...reportTypes])
       .where("status", "in", IN_FLIGHT_STATUSES)
-      .select("id")
+      .select(["id", "reportType"])
       .executeTakeFirst()
 
     if (existing) {
       throw new TRPCError({
         code: "CONFLICT",
-        message:
-          "An export for this period and report type is already being generated",
+        message: getInFlightConflictMessage(existing.reportType),
       })
     }
 
-    try {
-      const inserted = []
-      for (const dbReportType of reportTypes) {
+    const inserted = []
+    for (const dbReportType of reportTypes) {
+      try {
         inserted.push(
           await tx
             .insertInto("AuditLogExportRequest")
@@ -138,31 +158,32 @@ export const createAuditLogExportRequest = async ({
             .returningAll()
             .executeTakeFirstOrThrow(),
         )
+      } catch (error) {
+        // Race-loser path: a concurrent request inserted an in-flight row for
+        // this exact (siteId, userId, range, dbReportType) between our SELECT
+        // and this INSERT, so the partial unique index rejected ours.
+        // Translate that into the same friendly CONFLICT as the fast-path,
+        // naming this specific report type; throwing aborts the transaction,
+        // so earlier fan-out inserts in this loop roll back too
+        // (all-or-nothing). Any other error (and any TRPCError thrown above)
+        // is re-thrown as-is.
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          error.code === PG_ERROR_CODES.uniqueViolation
+        ) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: getInFlightConflictMessage(dbReportType),
+          })
+        }
+        throw error
       }
-      // Return every inserted row (one for Access/Activity, two for Both).
-      // The UI ignores the payload, so the array shape is chosen purely to
-      // reflect the fan-out honestly.
-      return inserted
-    } catch (error) {
-      // Race-loser path: a concurrent request inserted an in-flight row
-      // between our SELECT and INSERT, so the partial unique index rejected
-      // ours. Translate that into the same friendly CONFLICT as the fast-path;
-      // throwing aborts the transaction, so earlier fan-out inserts roll back
-      // too (all-or-nothing). Any other error (and any TRPCError thrown above)
-      // is re-thrown as-is.
-      if (
-        error instanceof Error &&
-        "code" in error &&
-        error.code === PG_ERROR_CODES.uniqueViolation
-      ) {
-        throw new TRPCError({
-          code: "CONFLICT",
-          message:
-            "An export for this period and report type is already being generated",
-        })
-      }
-      throw error
     }
+    // Return every inserted row (one for Access/Activity, two for Both).
+    // The UI ignores the payload, so the array shape is chosen purely to
+    // reflect the fan-out honestly.
+    return inserted
   })
 }
 
@@ -195,20 +216,6 @@ const BATCH_SIZE = 20
 // so a still-running worker's claim will never be stolen mid-flight, while a
 // genuinely dead worker's rows are recovered within a couple of sweeps.
 const PROCESSING_LEASE_MS = 15 * 60 * 1000
-
-// The single report each row produces. `Both` is fanned out into two rows at
-// request time (see REPORT_TYPES_BY_REQUESTED_TYPE), so every row here maps to
-// exactly one report — one CSV, one download link, one email.
-const REPORT_BY_TYPE = {
-  [AuditLogExportReportType.Access]: {
-    kind: AuditLogExportReportType.Access,
-    label: "access",
-  },
-  [AuditLogExportReportType.Activity]: {
-    kind: AuditLogExportReportType.Activity,
-    label: "audit",
-  },
-} as const
 
 /**
  * Human-readable label for an export's period (e.g. "June 2026") for the email

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -271,16 +271,16 @@ export const processAuditLogExportRequest = async (
   const request = await db
     .updateTable("AuditLogExportRequest")
     .set({
-      status: "Processing",
+      status: AuditLogExportStatus.Processing,
       updatedAt: new Date(),
       attempts: sql<number>`attempts + 1`,
     })
     .where("id", "=", requestId)
     .where((eb) =>
       eb.or([
-        eb("status", "=", "Pending"),
+        eb("status", "=", AuditLogExportStatus.Pending),
         eb.and([
-          eb("status", "=", "Processing"),
+          eb("status", "=", AuditLogExportStatus.Processing),
           eb("updatedAt", "<", staleCutoff),
           eb("AuditLogExportRequest.attempts", "<", MAX_ATTEMPTS),
         ]),
@@ -359,7 +359,7 @@ export const processAuditLogExportRequest = async (
     await db
       .updateTable("AuditLogExportRequest")
       .set({
-        status: "Done",
+        status: AuditLogExportStatus.Done,
         objectKey,
         errorMessage: null,
         updatedAt: new Date(),
@@ -384,7 +384,7 @@ export const processAuditLogExportRequest = async (
       await db
         .updateTable("AuditLogExportRequest")
         .set({
-          status: "Pending",
+          status: AuditLogExportStatus.Pending,
           errorMessage,
           updatedAt: new Date(),
         })
@@ -397,7 +397,7 @@ export const processAuditLogExportRequest = async (
     await db
       .updateTable("AuditLogExportRequest")
       .set({
-        status: "Failed",
+        status: AuditLogExportStatus.Failed,
         errorMessage,
         updatedAt: new Date(),
       })
@@ -437,9 +437,9 @@ export const processPendingAuditLogExports = async (): Promise<void> => {
     .selectFrom("AuditLogExportRequest")
     .where((eb) =>
       eb.or([
-        eb("status", "=", "Pending"),
+        eb("status", "=", AuditLogExportStatus.Pending),
         eb.and([
-          eb("status", "=", "Processing"),
+          eb("status", "=", AuditLogExportStatus.Processing),
           eb("updatedAt", "<", staleCutoff),
         ]),
       ]),

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -68,8 +68,11 @@ export const createAuditLogExportRequest = async ({
   month,
   reportType,
 }: CreateAuditLogExportRequestProps) => {
+  const futureMonthCheck = validateIsNotFutureMonth(month)
   const possibleError =
-    validateIsNotFutureMonth(month) || validateIsMonthInPastYear(month)
+    futureMonthCheck !== true
+      ? futureMonthCheck
+      : validateIsMonthInPastYear(month)
   if (possibleError !== true) {
     logger.warn(possibleError)
     throw new TRPCError({
@@ -436,6 +439,13 @@ export const processAuditLogExportRequest = async (
  * `Processing` past their lease (PROCESSING_LEASE_MS) — abandoned claims from a
  * worker that died between the claim and the in-process catch. Per-row errors
  * are caught so a single bad row never aborts the rest of the batch.
+ *
+ * Stale `Processing` rows that have already exhausted `MAX_ATTEMPTS` are
+ * excluded here, mirroring the claim guard in `processAuditLogExportRequest`:
+ * such a row can never actually be claimed, so selecting it would only waste
+ * a batch slot on a guaranteed no-op — and with `BATCH_SIZE` candidates
+ * ordered oldest-first, enough exhausted rows would starve newer `Pending`
+ * exports out of every sweep.
  */
 export const processPendingAuditLogExports = async (): Promise<void> => {
   // A single cutoff instant for the whole sweep: the batch selector and the
@@ -450,6 +460,7 @@ export const processPendingAuditLogExports = async (): Promise<void> => {
         eb.and([
           eb("status", "=", AuditLogExportStatus.Processing),
           eb("updatedAt", "<", staleCutoff),
+          eb("attempts", "<", MAX_ATTEMPTS),
         ]),
       ]),
     )

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -307,11 +307,20 @@ export const processAuditLogExportRequest = async (
 
   const user = await db
     .selectFrom("User")
-    .where("id", "=", request.userId)
-    .select(["id", "email"])
-    .executeTakeFirstOrThrow()
+    .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
+    .where("User.id", "=", request.userId)
+    .where("ResourcePermission.userId", "=", request.userId)
+    .where("ResourcePermission.role", "=", "Admin")
+    .where("ResourcePermission.siteId", "=", site.id)
+    .select(["User.id", "User.email"])
+    .executeTakeFirst()
 
-  const siteConfig = site.config as { siteName?: string } | null
+  // NOTE: Early return - this is technically not a failure
+  // because it means that the user has been removed from the site
+  // as an admin between the job creation and fulfillment time
+  if (!user) return
+
+  const siteConfig = site.config
   const siteName = siteConfig?.siteName || site.name
   const recipientEmail = user.email
 

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -309,6 +309,7 @@ export const processAuditLogExportRequest = async (
         eb.and([
           eb("status", "=", "Processing"),
           eb("updatedAt", "<", staleCutoff),
+          eb("AuditLogExportRequest.attempts", "<", MAX_ATTEMPTS),
         ]),
       ]),
     )

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -333,3 +333,29 @@ export const validateUserIsIsomerAdmin = async ({
     })
   }
 }
+
+interface ValidateUserIsSiteAdminProps {
+  userId: string
+  siteId: number
+}
+export const validateUserIsSiteAdmin = async ({
+  userId,
+  siteId,
+}: ValidateUserIsSiteAdminProps) => {
+  const _ = await db
+    .selectFrom("ResourcePermission")
+    .where("role", "=", "Admin")
+    .where("ResourcePermission.userId", "=", userId)
+    .where("ResourcePermission.siteId", "=", siteId)
+    .where("ResourcePermission.deletedAt", "is", null)
+    .select(["role"])
+    .executeTakeFirstOrThrow(() => {
+      throw new TRPCError({
+        code: "FORBIDDEN",
+        message:
+          "You do not have sufficient permissions to perform this action",
+      })
+    })
+
+  return true
+}


### PR DESCRIPTION
## Problem

Site Admins need an endpoint to request an export, and the system needs to fulfil those requests asynchronously (a month of activity for a large site can be slow to generate), deliver the result by email, and survive transient failures — without blocking the request.

No linked issue (stacked feature work). Part of the stack starting at #2603 (depends on the schema, Zod, queries, and delivery PRs).

## Solution

Add the request-creation endpoint and the pg-boss cron that drains pending requests, following the repo's existing `PushDocumentJob` poll pattern (the wrapper is schedule-only; no ad-hoc queue).

**Breaking Changes**

- [ ] Yes
- [x] No — new module + new cron job registration; existing routers untouched.

**Features**:

- `audit.createExportRequest` mutation (registered in `_app.ts`):
  - **Admin-only** — reuses `validatePermissionsForManagingUsers({ action: "manage" })`, the same gate as `/sites/[siteId]/users`; Editors/Publishers are rejected.
  - **Month-window guard** (Asia/Singapore) → `BAD_REQUEST` for a future month, and for any month older than the 12-month window (current month + previous 11), using the shared `getEarliestExportableMonth` helper.
  - **In-flight dedupe** — rejects with `CONFLICT` if an identical `(siteId, userId, auditLogDateRange, reportType)` request is already `Pending`/`Processing` (backed by the partial unique index; `daterange` canonicalization makes the equality check representation-proof).
  - **`Both` fan-out** — a `Both` request is input vocabulary only: the service inserts **two** rows (one `Access`, one `Activity`) inside a single transaction, all-or-nothing — if either insert loses to the unique index, the whole transaction rolls back and the request fails with `CONFLICT`. The endpoint returns the array of inserted rows (1 or 2).
  - Rate-limited (`.meta({ rateLimitOptions: { max: 5, windowMs: 60_000 } })`) since it triggers downstream email/S3.
  - Inserts `Pending` row(s) with the month's `daterange` (a current-month request is clamped to SGT-today + 1 at insert time, so today's partial day is included); errors are logged via `ctx.logger` and never leaked.
- `audit-log-export` cron job (every minute) → `processPendingAuditLogExports()`:
  - Atomically claims a row (`UPDATE ... WHERE id = ? AND status = 'Pending' RETURNING`).
  - Each row is exactly one report: generates it, uploads **one** CSV (inclusive-end key slug, e.g. `access-2026-04-01-to-2026-04-30.csv`), signs a 3-day URL, sends a ready email with a **single** download link, marks `Done`. A `Both` request (two rows) therefore yields two independent emails.
  - **Bounded retry**: on error, `attempts++`; `< 3` → back to `Pending` (retried next sweep); `>= 3` → `Failed` + failure email.
  - Empty results still produce a (header-only) CSV and a link.

**Improvements**:

- Per-row error isolation so one bad request never aborts the sweep.

**Bug Fixes**:

- None.

## Tests

- `__tests__/audit.router.test.ts` — Admin happy path (one `Pending` row), Editor/no-permission → `FORBIDDEN`, duplicate → `CONFLICT`, future month → `BAD_REQUEST`, unauthed → 401.
- `__tests__/auditLogExport.processor.test.ts` — Access happy path (one upload with an inclusive-end key, one link, `Done`), fanned-out `Both` (two rows → two uploads + two single-link emails, both `Done`), empty results (header-only, still `Done`), retry-then-fail (attempts 1→2 stay `Pending`, attempt 3 → `Failed` + failure email, ready email never sent), and claiming (a `Done` row not reprocessed). DB is real; S3/mail mocked.
- `pnpm test:unit -- src/server/modules/audit/` → all passing. Typecheck + lint green.

**New dependencies**: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an audit log export request flow for Studio. The main changes are:

- A new admin-only `audit.createExportRequest` tRPC mutation with month validation, rate limiting, and in-flight dedupe.
- Fan-out from `Both` requests into separate `Access` and `Activity` export rows.
- A scheduled `audit-log-export` cron job that claims pending or stale requests and processes them asynchronously.
- CSV generation, S3 upload, signed download links, and ready/failure email delivery for each export row.
- Tests covering authorization, duplicate handling, fan-out, retries, stale claims, empty exports, and mail templates.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge based on the reviewed changed paths.

No new non-duplicative blocking issues were identified. The endpoint follows the reviewed authorization, validation, and rate-limit conventions. The processor has focused tests for retries, stale claims, fan-out, empty exports, and terminal states.

**Files Needing Attention:** `apps/studio/src/server/modules/audit/auditLogExport.service.ts` remains the highest-risk file because it owns claim/retry state transitions plus S3 and email side effects.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to run the audit create export request, but environment and setup failures blocked the execution.
- Tried the audit log export processor tests; the base invocation failed due to a missing container runtime, and the after state shows a blocked head invocation plus a passing cron-registration test with exit code 0.
- Ran the audit export persistence dedupe tests; the after state shows a partial unique index and service implementation with four tests passing, while the fan-out test failed due to an unexpected report type order.

<a href="https://app.greptile.com/trex/runs/17211980/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/audit/auditLogExport.service.ts | Implements request creation, in-flight dedupe, report fan-out, export processing, retry handling, S3 upload, and email delivery. |
| apps/studio/src/server/modules/audit/audit.router.ts | Adds the admin-only, rate-limited tRPC mutation for creating audit log export requests. |
| apps/studio/src/server/modules/permissions/permissions.service.ts | Adds an active Site Admin permission validator for the new audit export endpoint. |
| apps/studio/src/schemas/audit.ts | Adds audit export request validation and month-window helpers for the new endpoint. |
| apps/studio/src/server/cron/jobs/auditLogExportJob.ts | Adds a scheduled pg-boss wrapper that runs pending audit log export processing every minute. |
| apps/studio/src/features/mail/templates/templates.ts | Adds audit export ready/failed mail templates with escaped HTML bodies and raw text subjects. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  actor Admin as Site Admin
  participant Router as audit.createExportRequest
  participant Perm as validateUserIsSiteAdmin
  participant DB as AuditLogExportRequest
  participant Cron as audit-log-export cron
  participant Query as Report queries
  participant S3 as S3
  participant Mail as Email service

  Admin->>Router: request export(siteId, month, reportType)
  Router->>Perm: verify active Site Admin
  Perm-->>Router: allowed
  Router->>DB: transaction: dedupe + insert Pending row(s)
  DB-->>Router: inserted Access/Activity request(s)
  Router-->>Admin: accepted rows

  Cron->>DB: select Pending or stale Processing batch
  loop each request
    Cron->>DB: atomically claim Processing + attempts + 1
    Cron->>Query: build Access or Activity rows
    Query-->>Cron: report rows
    Cron->>S3: upload CSV
    S3-->>Cron: object stored
    Cron->>S3: generate signed URL
    S3-->>Cron: 3-day URL
    Cron->>Mail: send ready email
    Cron->>DB: mark Done
  end

  alt processing error
    Cron->>DB: "requeue Pending if attempts < 3"
    Cron->>DB: "mark Failed if attempts >= 3"
    Cron->>Mail: send failure email after final attempt
  end
```
</details>

<sub>Reviews (20): Last reviewed commit: ["chore: unescape the title of the emali"](https://github.com/opengovsg/isomer/commit/fd5166c44f4beda49ecbbe4d712cc7205fa96028) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41594814)</sub>

<!-- /greptile_comment -->