### PR TITLE
fix(components): remove <br /> and empty entries from table of contents (ISOM-2323)

### DIFF
--- a/packages/components/src/utils/__tests__/getTableOfContents.test.ts
+++ b/packages/components/src/utils/__tests__/getTableOfContents.test.ts
@@ -124,6 +124,41 @@ describe("getTableOfContents", () => {
     expect(toc[0]?.content).not.toContain("<br")
   })
 
+  it("skips empty level-2 headings (e.g. containing only a hard break)", () => {
+    // Arrange
+    const site = generateSiteConfig()
+    const transformedContent = getTransformedPageContent([
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [
+              { type: "hardBreak" } as unknown as {
+                type: "text"
+                text: string
+              },
+            ],
+          },
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Real heading" }],
+          },
+        ],
+      },
+    ])
+
+    // Act
+    const toc = getTableOfContents(site, transformedContent)
+
+    // Assert
+    expect(toc).toHaveLength(1)
+    expect(toc.map((t) => t.content)).toEqual(["Real heading"])
+    expect(toc[0]?.anchorLink).toEqual(expect.stringMatching(anchorPattern))
+  })
+
   it("preserves order of toc entries across prose and blocks", () => {
     // Arrange
     const content: IsomerComponent[] = [

--- a/packages/components/src/utils/__tests__/getTableOfContents.test.ts
+++ b/packages/components/src/utils/__tests__/getTableOfContents.test.ts
@@ -92,6 +92,38 @@ describe("getTableOfContents", () => {
     ])
   })
 
+  it("strips hard breaks from level-2 heading toc entries", () => {
+    // Arrange
+    const site = generateSiteConfig()
+    const transformedContent = getTransformedPageContent([
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [
+              { type: "text", text: "Line one" },
+              { type: "hardBreak" } as unknown as {
+                type: "text"
+                text: string
+              },
+              { type: "text", text: "Line two" },
+            ],
+          },
+        ],
+      },
+    ])
+
+    // Act
+    const toc = getTableOfContents(site, transformedContent)
+
+    // Assert
+    expect(toc).toHaveLength(1)
+    expect(toc[0]?.content).toBe("Line one Line two")
+    expect(toc[0]?.content).not.toContain("<br")
+  })
+
   it("preserves order of toc entries across prose and blocks", () => {
     // Arrange
     const content: IsomerComponent[] = [

--- a/packages/components/src/utils/__tests__/getTableOfContents.test.ts
+++ b/packages/components/src/utils/__tests__/getTableOfContents.test.ts
@@ -159,6 +159,41 @@ describe("getTableOfContents", () => {
     expect(toc[0]?.anchorLink).toEqual(expect.stringMatching(anchorPattern))
   })
 
+  it("skips whitespace-only level-2 headings (spaces, tabs, non-breaking space)", () => {
+    // Arrange
+    const site = generateSiteConfig()
+    const transformedContent = getTransformedPageContent([
+      {
+        type: "prose",
+        content: [
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "   \t " }],
+          },
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: " " }],
+          },
+          {
+            type: "heading",
+            attrs: { level: 2 },
+            content: [{ type: "text", text: "Real heading" }],
+          },
+        ],
+      },
+    ])
+
+    // Act
+    const toc = getTableOfContents(site, transformedContent)
+
+    // Assert
+    expect(toc).toHaveLength(1)
+    expect(toc.map((t) => t.content)).toEqual(["Real heading"])
+    expect(toc[0]?.anchorLink).toEqual(expect.stringMatching(anchorPattern))
+  })
+
   it("preserves order of toc entries across prose and blocks", () => {
     // Arrange
     const content: IsomerComponent[] = [

--- a/packages/components/src/utils/getTableOfContents.ts
+++ b/packages/components/src/utils/getTableOfContents.ts
@@ -29,13 +29,17 @@ export const getTableOfContents = (
 
       for (const component of block.content) {
         if (component.type === "heading" && component.attrs.level === 2) {
-          result.push({
-            content: getTextAsHtml({ site, content: component.content })
-              .replace(/<br\s*\/?>/gi, " ")
-              .replace(/\s+/g, " ")
-              .trim(),
-            anchorLink: "#" + component.attrs.id,
-          })
+          const content = getTextAsHtml({ site, content: component.content })
+            .replace(/<br\s*\/?>/gi, " ")
+            .replace(/\s+/g, " ")
+            .trim()
+
+          if (content) {
+            result.push({
+              content,
+              anchorLink: "#" + component.attrs.id,
+            })
+          }
         }
       }
 

--- a/packages/components/src/utils/getTableOfContents.ts
+++ b/packages/components/src/utils/getTableOfContents.ts
@@ -30,7 +30,10 @@ export const getTableOfContents = (
       for (const component of block.content) {
         if (component.type === "heading" && component.attrs.level === 2) {
           result.push({
-            content: getTextAsHtml({ site, content: component.content }),
+            content: getTextAsHtml({ site, content: component.content })
+              .replace(/<br\s*\/?>/gi, " ")
+              .replace(/\s+/g, " ")
+              .trim(),
             anchorLink: "#" + component.attrs.id,
           })
         }


### PR DESCRIPTION
## Problem

The auto-generated Table of Contents rendered a literal `<br />` as visible text whenever a level-2 heading contained a line break. The TOC label is built from `getTextAsHtml()`, which emits the literal string `"<br />"` for `hardBreak` nodes; the TOC component renders that value as a plain (escaped) React text child, so the raw `<br />` appeared in the list.

Reported via Slack: https://opengovproducts.slack.com/archives/C06R4DX966P/p1782795528001259?thread_ts=1782488292.958179&cid=C06R4DX966P
Example page: https://www.publicservicefestival.gov.sg/discover-more/deals-promo/

Closes [ISOM-2323](https://linear.app/ogp/issue/ISOM-2323/remove-br-from-table-of-contents)

## Solution

In `getTableOfContents.ts`, the level-2 heading branch now post-processes the `getTextAsHtml()` output before using it as a TOC label:

- Replaces `<br />` markup with a single space (so `"Line one<br />Line two"` reads as `"Line one Line two"` instead of running the words together), then collapses whitespace and trims.
- Only pushes a TOC entry when the resulting text is non-empty, so empty / line-break-only / whitespace-only headings no longer add a blank bullet.

The `<br />` output of `getTextAsHtml()` is intentional for its other consumers (real headings, paragraphs) that render the value as HTML, so this change is scoped to the TOC path only.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Table of contents no longer displays a literal `<br />` for headings that contain line breaks.
- Empty, line-break-only, and whitespace-only (including non-breaking space) headings are no longer added as blank entries in the table of contents.

## Before & After Screenshots

**BEFORE**: Table of contents entry showed the literal text `<br />` for a heading with a line break.

**AFTER**: The entry shows the heading text on a single line with no `<br />`; empty/whitespace-only headings produce no entry.

## Tests

Added regression tests in `packages/components/src/utils/__tests__/getTableOfContents.test.ts`:

- A level-2 heading with a `hardBreak` between two text nodes renders as `"Line one Line two"` (no `<br>`).
- An empty (hardBreak-only) heading is skipped from the TOC.
- Whitespace-only and non-breaking-space headings are skipped from the TOC.

All `getTableOfContents` unit tests pass (6/6); `pnpm typecheck` and `oxlint` are clean for the changed files.

**Manual Verification Steps**:

- [ ] Create a page with a level-2 heading containing a line break (Shift+Enter) and confirm the TOC entry shows the text on one line with no literal `<br />`.
- [ ] Confirm an empty or whitespace-only level-2 heading produces no TOC bullet.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a rendering bug where level-2 headings containing line breaks (`hardBreak` nodes) would display a literal `<br />` string in the auto-generated Table of Contents. It also prevents empty, whitespace-only, and `hardBreak`-only headings from producing blank TOC entries.

- **`getTableOfContents.ts`**: Post-processes the `getTextAsHtml()` output for level-2 headings — replaces `<br …/>` patterns with a space, collapses internal whitespace, trims, and only pushes an entry when the result is non-empty.
- **`getTableOfContents.test.ts`**: Adds three regression tests covering hard-break stripping, hardBreak-only (empty) heading skipping, and whitespace/NBSP-only heading skipping.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is narrowly scoped to TOC label post-processing and cannot affect page rendering or other consumers of getTextAsHtml.

The fix is a small, well-contained post-processing step applied only inside the TOC path. It correctly handles all the documented edge cases (hard breaks, whitespace-only, NBSP, empty headings), and the regex chain is sound. Three new regression tests cover each new code path. No existing tests were modified and no other callsites are touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/utils/getTableOfContents.ts | Targeted fix: post-processes getTextAsHtml() output for level-2 headings to strip br tags, collapse whitespace, and skip empty results. Logic is correct and well-scoped. |
| packages/components/src/utils/__tests__/getTableOfContents.test.ts | Adds three well-structured regression tests covering hard-break stripping, empty heading skipping, and whitespace-only heading skipping; uses as-unknown-as cast to inject hardBreak nodes into typed test content. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[getTableOfContents called] --> B{block.type?}
    B -- prose --> C[iterate block.content]
    B -- infocards/infocols/infopic/keystatistics --> D[push block.title as TOC entry]
    B -- other --> E[return empty]
    C --> F{component.type === heading && level === 2?}
    F -- No --> C
    F -- Yes --> G[getTextAsHtml component.content]
    G --> H[replace br tags with space]
    H --> I[collapse whitespace]
    I --> J[trim]
    J --> K{non-empty?}
    K -- Yes --> L[push content + anchorLink to result]
    K -- No --> M[skip — empty/whitespace-only heading]
    L --> C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[getTableOfContents called] --> B{block.type?}
    B -- prose --> C[iterate block.content]
    B -- infocards/infocols/infopic/keystatistics --> D[push block.title as TOC entry]
    B -- other --> E[return empty]
    C --> F{component.type === heading && level === 2?}
    F -- No --> C
    F -- Yes --> G[getTextAsHtml component.content]
    G --> H[replace br tags with space]
    H --> I[collapse whitespace]
    I --> J[trim]
    J --> K{non-empty?}
    K -- Yes --> L[push content + anchorLink to result]
    K -- No --> M[skip — empty/whitespace-only heading]
    L --> C
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(components): cover whitespace-only ..."](https://github.com/opengovsg/isomer/commit/0e31e3d4cc7db8daaf675aa3b56f7337939e6761) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40728463)</sub>

<!-- /greptile_comment -->