### PR TITLE
fix: gate Login/Logout audit log events to active collaborator windows

### DIFF
--- a/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
@@ -6,6 +6,7 @@ import { resetTables } from "../../../tests/integration/helpers/db"
 import {
   setupAdminPermissions,
   setupEditorPermissions,
+  setupIsomerAdmin,
   setupSite,
   setupUser,
 } from "../../../tests/integration/helpers/seed"
@@ -242,17 +243,18 @@ describe("getAuditLogQuery", () => {
       expect('"Date added"' in row).toBe(true)
     })
 
-    it("excludes @open.gov.sg emails", async () => {
+    it("excludes Isomer admins", async () => {
       // Arrange
-      const ogpUser = await setupUser({ email: "admin@open.gov.sg" })
-      await setupAdminPermissions({ userId: ogpUser.id, siteId })
+      const adminUser = await setupUser({ email: "admin@isomer.gov.sg" })
+      await setupAdminPermissions({ userId: adminUser.id, siteId })
+      await setupIsomerAdmin({ userId: adminUser.id })
 
       // Act
       const rows = await getUsersRows({ siteId, monthYear: TEST_MONTH })
 
       // Assert
       const emails = rows.map((r) => r.Email)
-      expect(emails).not.toContain("admin@open.gov.sg")
+      expect(emails).not.toContain("admin@isomer.gov.sg")
       expect(emails).toContain(user.email)
     })
 
@@ -749,15 +751,16 @@ describe("getAuditLogQuery", () => {
       expect(rows).toHaveLength(0)
     })
 
-    it("Logout by @open.gov.sg email is excluded", async () => {
+    it("Logout by Isomer admin is excluded", async () => {
       // Arrange
-      const ogpUser = await setupUser({ email: "admin@open.gov.sg" })
-      await setupAdminPermissions({ userId: ogpUser.id, siteId })
+      const adminUser = await setupUser({ email: "admin@isomer.gov.sg" })
+      await setupAdminPermissions({ userId: adminUser.id, siteId })
+      await setupIsomerAdmin({ userId: adminUser.id })
       await insertAuditLog({
         eventType: AuditLogEvent.Logout,
-        userId: ogpUser.id,
+        userId: adminUser.id,
         siteId: null,
-        delta: { before: { email: "admin@open.gov.sg" }, after: null },
+        delta: { before: { email: "admin@isomer.gov.sg" }, after: null },
         ipAddress: "1.2.3.4",
         createdAt: MID_MONTH,
       })
@@ -973,6 +976,63 @@ describe("getAuditLogQuery", () => {
       expect(times).toContain(T_05.getTime())
       expect(times).toContain(T_25.getTime())
       expect(times).not.toContain(MID_MONTH.getTime())
+    })
+
+    const insertLogoutFor = async (
+      collaborator: Awaited<ReturnType<typeof setupUser>>,
+      at: Date,
+    ) =>
+      insertAuditLog({
+        eventType: AuditLogEvent.Logout,
+        userId: collaborator.id,
+        siteId: null,
+        delta: { before: { email: collaborator.email }, after: null },
+        createdAt: at,
+      })
+
+    const logoutEmails = (rows: EventsQueryRow[]) =>
+      rows
+        .filter((r) => r['"Event type"'] === AuditLogEvent.Logout)
+        .map((r) => r.Email)
+
+    it("Logout at the exact moment of being granted is included", async () => {
+      // Arrange
+      const collaborator = await setupUser({
+        email: "logout-atgrant@agency.gov.sg",
+      })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: MID_MONTH,
+        revokedAt: null,
+      })
+      await insertLogoutFor(collaborator, MID_MONTH)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(logoutEmails(rows)).toContain(collaborator.email)
+    })
+
+    it("Logout at the exact moment of revocation is excluded", async () => {
+      // Arrange
+      const collaborator = await setupUser({
+        email: "logout-atrevoke@agency.gov.sg",
+      })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: GRANTED_BEFORE_MONTH,
+        revokedAt: MID_MONTH,
+      })
+      await insertLogoutFor(collaborator, MID_MONTH)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(logoutEmails(rows)).not.toContain(collaborator.email)
     })
   })
 

--- a/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
+++ b/apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts
@@ -1,5 +1,6 @@
 import { addMilliseconds, endOfMonth, parse, startOfMonth } from "date-fns"
 import { AuditLogEvent, db, jsonb } from "~/server/modules/database"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { resetTables } from "../../../tests/integration/helpers/db"
 import {
@@ -86,6 +87,35 @@ const insertAuditLog = async ({
       .returningAll()
       .executeTakeFirstOrThrow()
   )
+}
+
+// Inserts a ResourcePermission as one collaboration window (granted at
+// grantedAt, revoked at revokedAt — null means still active), for exercising
+// the per-event active-collaborator gating of Login/Logout events.
+const setupPermissionWindow = async ({
+  userId,
+  siteId,
+  grantedAt,
+  revokedAt,
+}: {
+  userId: string
+  siteId: number
+  grantedAt: Date
+  revokedAt: Date | null
+}) => {
+  return db
+    .insertInto("ResourcePermission")
+    .values({
+      userId,
+      siteId,
+      role: RoleType.Editor,
+      resourceId: null,
+      deletedAt: revokedAt,
+      createdAt: grantedAt,
+      updatedAt: grantedAt,
+    })
+    .returningAll()
+    .executeTakeFirstOrThrow()
 }
 
 // Group A: pure unit tests — no DB required
@@ -790,6 +820,159 @@ describe("getAuditLogQuery", () => {
         (r) => r['"Event type"'] === AuditLogEvent.Logout,
       )
       expect(logoutRow).toBeUndefined()
+    })
+  })
+
+  // Group E2: Login/Logout only appear while the user was an active collaborator
+  describe("active-collaborator gating of Login/Logout", () => {
+    const GRANTED_BEFORE_MONTH = new Date("2025-12-01T00:00:00.000Z")
+    const T_05 = new Date("2026-01-05T00:00:00.000Z")
+    const T_10 = new Date("2026-01-10T00:00:00.000Z")
+    const T_20 = new Date("2026-01-20T00:00:00.000Z")
+    const T_25 = new Date("2026-01-25T00:00:00.000Z")
+
+    const insertLoginFor = async (
+      collaborator: Awaited<ReturnType<typeof setupUser>>,
+      at: Date,
+    ) =>
+      insertAuditLog({
+        eventType: AuditLogEvent.Login,
+        userId: collaborator.id,
+        siteId: null,
+        delta: {
+          before: { identifier: `${collaborator.email}|1.2.3.4` },
+          after: null,
+        },
+        createdAt: at,
+      })
+
+    const loginEmails = (rows: EventsQueryRow[]) =>
+      rows
+        .filter((r) => r['"Event type"'] === AuditLogEvent.Login)
+        .map((r) => r.Email)
+
+    it("Login before the collaborator was revoked is included", async () => {
+      // Arrange
+      const collaborator = await setupUser({ email: "active@agency.gov.sg" })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: GRANTED_BEFORE_MONTH,
+        revokedAt: T_20,
+      })
+      await insertLoginFor(collaborator, T_10)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(loginEmails(rows)).toContain(collaborator.email)
+    })
+
+    it("Login at the exact moment of revocation is excluded", async () => {
+      // Arrange
+      const collaborator = await setupUser({ email: "atrevoke@agency.gov.sg" })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: GRANTED_BEFORE_MONTH,
+        revokedAt: MID_MONTH,
+      })
+      await insertLoginFor(collaborator, MID_MONTH)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(loginEmails(rows)).not.toContain(collaborator.email)
+    })
+
+    it("Login after revocation (same month) is excluded", async () => {
+      // Arrange
+      const collaborator = await setupUser({
+        email: "postrevoke@agency.gov.sg",
+      })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: GRANTED_BEFORE_MONTH,
+        revokedAt: T_20,
+      })
+      await insertLoginFor(collaborator, T_25)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(loginEmails(rows)).not.toContain(collaborator.email)
+    })
+
+    it("Login before the collaborator was granted is excluded", async () => {
+      // Arrange
+      const collaborator = await setupUser({ email: "pregrant@agency.gov.sg" })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: MID_MONTH,
+        revokedAt: null,
+      })
+      await insertLoginFor(collaborator, T_10)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(loginEmails(rows)).not.toContain(collaborator.email)
+    })
+
+    it("Login at the exact moment of being granted is included", async () => {
+      // Arrange
+      const collaborator = await setupUser({ email: "atgrant@agency.gov.sg" })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: MID_MONTH,
+        revokedAt: null,
+      })
+      await insertLoginFor(collaborator, MID_MONTH)
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert
+      expect(loginEmails(rows)).toContain(collaborator.email)
+    })
+
+    it("removed then re-added: events in the active windows show, the gap does not", async () => {
+      // Arrange — window 1: [GRANTED_BEFORE_MONTH, T_10), window 2: [T_20, ∞)
+      const collaborator = await setupUser({ email: "readded@agency.gov.sg" })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: GRANTED_BEFORE_MONTH,
+        revokedAt: T_10,
+      })
+      await setupPermissionWindow({
+        userId: collaborator.id,
+        siteId,
+        grantedAt: T_20,
+        revokedAt: null,
+      })
+      await insertLoginFor(collaborator, T_05) // in window 1
+      await insertLoginFor(collaborator, MID_MONTH) // in the gap
+      await insertLoginFor(collaborator, T_25) // in window 2
+
+      // Act
+      const rows = await getEventsRows({ siteId, monthYear: TEST_MONTH })
+
+      // Assert — two logins survive (window 1 + window 2), the gap login is dropped
+      const times = rows
+        .filter((r) => r['"Event type"'] === AuditLogEvent.Login)
+        .map((r) => r['"Date and time"'].getTime())
+      expect(times).toHaveLength(2)
+      expect(times).toContain(T_05.getTime())
+      expect(times).toContain(T_25.getTime())
+      expect(times).not.toContain(MID_MONTH.getTime())
     })
   })
 

--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -177,18 +177,23 @@ export const getAuditLogQuery = ({
 
   switch (type) {
     case "users":
-      return db
-        .selectFrom("User as u")
-        .innerJoin("ResourcePermission as rp", "u.id", "rp.userId")
-        .select([
-          "u.email as Email",
-          'u.lastLoginAt as "Last login"',
-          "rp.role as Role",
-          'rp.createdAt as "Date added"',
-        ])
-        .where("rp.siteId", "=", siteId)
-        .where("u.email", "not like", "%@open.gov.sg")
-        .where("rp.deletedAt", "is", null)
+      return (
+        db
+          .selectFrom("User as u")
+          .innerJoin("ResourcePermission as rp", "u.id", "rp.userId")
+          .select([
+            "u.email as Email",
+            'u.lastLoginAt as "Last login"',
+            "rp.role as Role",
+            'rp.createdAt as "Date added"',
+          ])
+          .where("rp.siteId", "=", siteId)
+          // Exclude internal Isomer admins from agency-facing reports
+          .where("u.id", "not in", (eb) =>
+            eb.selectFrom("IsomerAdmin").select("IsomerAdmin.userId"),
+          )
+          .where("rp.deletedAt", "is", null)
+      )
     case "events":
       return db
         .with("emailsFromPermissionChanges", (eb) =>
@@ -218,15 +223,30 @@ export const getAuditLogQuery = ({
         )
         .with("collaboratorWindows", (eb) =>
           eb
-            .selectFrom("ResourcePermission as rp")
-            .innerJoin("User as cu", "cu.id", "rp.userId")
+            .selectFrom("ResourcePermission as permission")
+            .innerJoin(
+              "User as collaboratorUser",
+              "collaboratorUser.id",
+              "permission.userId",
+            )
             .select([
-              "cu.email",
-              "rp.createdAt as grantedAt",
-              "rp.deletedAt as revokedAt",
+              "collaboratorUser.email",
+              "permission.createdAt as grantedAt",
+              "permission.deletedAt as revokedAt",
             ])
-            .where("rp.siteId", "=", siteId)
-            .where("cu.email", "not like", "%@open.gov.sg"),
+            .where("permission.siteId", "=", siteId)
+            // Exclude internal Isomer admins from agency-facing reports
+            .where("collaboratorUser.id", "not in", (ieb) =>
+              ieb.selectFrom("IsomerAdmin").select("IsomerAdmin.userId"),
+            )
+            // Restrict to windows that could overlap the queried month
+            .where("permission.createdAt", "<=", endDate)
+            .where((eb) =>
+              eb.or([
+                eb("permission.deletedAt", "is", null),
+                eb("permission.deletedAt", ">", startDate),
+              ]),
+            ),
         )
         .selectFrom("AuditLog as al")
         .leftJoin("User as u", "al.userId", "u.id")
@@ -324,10 +344,10 @@ export const getAuditLogQuery = ({
                     .select("cw.email")
                     // Only while the user was an active collaborator at event time
                     .where("cw.grantedAt", "<=", sql<Date>`al."createdAt"`)
-                    .where((web) =>
-                      web.or([
-                        web("cw.revokedAt", "is", null),
-                        web("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
+                    .where((eb) =>
+                      eb.or([
+                        eb("cw.revokedAt", "is", null),
+                        eb("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
                       ]),
                     )
                     .union(
@@ -345,10 +365,10 @@ export const getAuditLogQuery = ({
                   .select("cw.email")
                   // Only while the user was an active collaborator at event time
                   .where("cw.grantedAt", "<=", sql<Date>`al."createdAt"`)
-                  .where((web) =>
-                    web.or([
-                      web("cw.revokedAt", "is", null),
-                      web("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
+                  .where((eb) =>
+                    eb.or([
+                      eb("cw.revokedAt", "is", null),
+                      eb("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
                     ]),
                   )
                   .union(

--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -216,17 +216,17 @@ export const getAuditLogQuery = ({
             .where("AuditLog.createdAt", ">=", startDate)
             .where("AuditLog.createdAt", "<=", endDate),
         )
-        .with("emailsFromUsers", (eb) =>
+        .with("collaboratorWindows", (eb) =>
           eb
-            .selectFrom("User")
-            .select(["User.email", "User.id"])
-            .where("User.email", "not like", "%@open.gov.sg")
-            .where("User.id", "in", (fb) =>
-              fb
-                .selectFrom("ResourcePermission")
-                .select("ResourcePermission.userId")
-                .where("ResourcePermission.siteId", "=", siteId),
-            ),
+            .selectFrom("ResourcePermission as rp")
+            .innerJoin("User as cu", "cu.id", "rp.userId")
+            .select([
+              "cu.email",
+              "rp.createdAt as grantedAt",
+              "rp.deletedAt as revokedAt",
+            ])
+            .where("rp.siteId", "=", siteId)
+            .where("cu.email", "not like", "%@open.gov.sg"),
         )
         .selectFrom("AuditLog as al")
         .leftJoin("User as u", "al.userId", "u.id")
@@ -320,8 +320,16 @@ export const getAuditLogQuery = ({
                 "in",
                 (fb) =>
                   fb
-                    .selectFrom("emailsFromUsers")
-                    .select("emailsFromUsers.email")
+                    .selectFrom("collaboratorWindows as cw")
+                    .select("cw.email")
+                    // Only while the user was an active collaborator at event time
+                    .where("cw.grantedAt", "<=", sql<Date>`al."createdAt"`)
+                    .where((web) =>
+                      web.or([
+                        web("cw.revokedAt", "is", null),
+                        web("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
+                      ]),
+                    )
                     .union(
                       fb
                         .selectFrom("emailsFromPermissionChanges")
@@ -333,8 +341,16 @@ export const getAuditLogQuery = ({
               eb("al.eventType", "=", AuditLogEvent.Logout),
               eb(sql<string>`al.delta -> 'before' ->> 'email'`, "in", (fb) =>
                 fb
-                  .selectFrom("emailsFromUsers")
-                  .select("emailsFromUsers.email")
+                  .selectFrom("collaboratorWindows as cw")
+                  .select("cw.email")
+                  // Only while the user was an active collaborator at event time
+                  .where("cw.grantedAt", "<=", sql<Date>`al."createdAt"`)
+                  .where((web) =>
+                    web.or([
+                      web("cw.revokedAt", "is", null),
+                      web("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
+                    ]),
+                  )
                   .union(
                     fb
                       .selectFrom("emailsFromPermissionChanges")

--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -196,31 +196,6 @@ export const getAuditLogQuery = ({
       )
     case "events":
       return db
-        .with("emailsFromPermissionChanges", (eb) =>
-          eb
-            .selectFrom("AuditLog")
-            .select((fb) => [
-              fb
-                .case()
-                .when("AuditLog.eventType", "=", AuditLogEvent.PermissionCreate)
-                .then(sql<string>`"AuditLog".delta -> 'after' ->> 'userId'`)
-                .else(
-                  fb.fn<string>("coalesce", [
-                    sql<string>`"AuditLog".delta -> 'before' ->> 'userId'`,
-                    sql<string>`"AuditLog".delta -> 'after' ->> 'userId'`,
-                  ]),
-                )
-                .end()
-                .as("email"),
-            ])
-            .where("AuditLog.eventType", "in", [
-              AuditLogEvent.PermissionCreate,
-              AuditLogEvent.PermissionDelete,
-            ])
-            .where("AuditLog.siteId", "=", siteId)
-            .where("AuditLog.createdAt", ">=", startDate)
-            .where("AuditLog.createdAt", "<=", endDate),
-        )
         .with("collaboratorWindows", (eb) =>
           eb
             .selectFrom("ResourcePermission as permission")
@@ -349,11 +324,6 @@ export const getAuditLogQuery = ({
                         eb("cw.revokedAt", "is", null),
                         eb("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
                       ]),
-                    )
-                    .union(
-                      fb
-                        .selectFrom("emailsFromPermissionChanges")
-                        .select("emailsFromPermissionChanges.email"),
                     ),
               ),
             ]),
@@ -370,11 +340,6 @@ export const getAuditLogQuery = ({
                       eb("cw.revokedAt", "is", null),
                       eb("cw.revokedAt", ">", sql<Date>`al."createdAt"`),
                     ]),
-                  )
-                  .union(
-                    fb
-                      .selectFrom("emailsFromPermissionChanges")
-                      .select("emailsFromPermissionChanges.email"),
                   ),
               ),
             ]),


### PR DESCRIPTION
## Problem

The monthly audit log export (`prisma/scripts/getAuditLogs.ts`) included `Login` and `Logout` events for collaborators based on whether they *currently* hold any permission on the site — with no regard for **when** the permission existed.

As a result:

- A collaborator who has since been **removed** still had all of their historical `Login`/`Logout` events surfaced in the report.
- A collaborator's `Login`/`Logout` events that occurred **before they were ever granted access** (or **after their access was revoked**) were attributed to the site, even though they were not an active collaborator at that time.

This produces inaccurate access reports, which matter for the audit/compliance use case these exports serve.

## Solution

`Login`/`Logout` events are now gated **per event** against the collaborator's actual grant/revoke window, instead of against present-day membership.

The old `emailsFromUsers` CTE (any user with a `ResourcePermission` row for the site, regardless of `deletedAt`) is replaced by a `collaboratorWindows` CTE that carries each permission's `createdAt` (granted) and `deletedAt` (revoked) timestamps. A `Login`/`Logout` event is included only when its `createdAt` falls within an active window for that collaborator:

- `grantedAt <= event time`, and
- `revokedAt IS NULL` **or** `revokedAt > event time`.

Because the window is evaluated per `ResourcePermission` row, the **removed-then-re-added** case works correctly: events that occurred during either active window are kept, while events that fall in the gap between windows are dropped.

The `emailsFromPermissionChanges` union (which surfaces collaborators referenced by `PermissionCreate`/`PermissionDelete` events in the same period) is unchanged.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `Login`/`Logout` events are excluded for collaborators at times when they were not actively granted access to the site (before grant, at/after revocation).
- Removed collaborators no longer have their historical login activity attributed to the site after their access ends.
- Re-added collaborators correctly show login activity for each active window while excluding the inactive gap in between.

**Improvements**:

- Boundary semantics are now well-defined and tested: an event exactly at grant time is **included**; an event exactly at revocation time is **excluded**.

## Tests

Adds an integration test group (`active-collaborator gating of Login/Logout`) in `getAuditLogs.test.ts` covering: login before revocation (included), login exactly at revocation (excluded), login after revocation (excluded), login before grant (excluded), login exactly at grant (included), and the removed-then-re-added window case.

Run from `apps/studio`:

```bash
pnpm test:unit -- prisma/scripts/__tests__/getAuditLogs.test.ts
```

**Manual Verification Steps**:

- [ ] Identify a site (in `SITES_WITH_AUDIT_LOGS`) and a month where a collaborator was **removed** during or before that month and had `Login`/`Logout` activity after their removal.
- [ ] Run the audit log export for that month, e.g. `MONTH_YEAR=YYYY-MM tsx prisma/scripts/getAuditLogs.ts` from `apps/studio`.
- [ ] Open the generated `auditlogs_<siteId>_<YYYY-MM>.csv` and confirm the removed collaborator's `Login`/`Logout` events **after** their revocation no longer appear.
- [ ] Confirm that `Login`/`Logout` events for that same collaborator that occurred **while they were still active** are still present.
- [ ] For a collaborator who was removed and later re-added, confirm login activity appears for both active windows but not for the gap between them.
- [ ] Confirm the export for currently-active collaborators is unchanged (no events incorrectly dropped).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a correctness bug in the monthly audit log export by replacing a present-membership-based collaborator lookup with a time-windowed one. `Login`/`Logout` events now appear in the audit log only when the actor was an active collaborator at the exact moment the event occurred, handling removed, re-added, and never-yet-added collaborators correctly. The `@open.gov.sg` email-domain filter for internal Isomer admin exclusion is also replaced with a proper `IsomerAdmin` table lookup.

- **`collaboratorWindows` CTE** replaces the old `emailsFromUsers` (present-day membership) and `emailsFromPermissionChanges` CTEs; each `Login`/`Logout` event is now matched against the permission's `createdAt`/`deletedAt` window with grant-inclusive, revoke-exclusive semantics.
- **Integration tests** (Group E2) cover every boundary case: login exactly at grant (included), login exactly at revocation (excluded), login before grant (excluded), and the re-added-collaborator multi-window scenario.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The change is narrowly scoped to the audit log export script with no effect on runtime application behaviour.

The core rewrite is correct: the window pre-filter cannot exclude any window that could match an event inside the queried month, the per-event boundary semantics are well-defined and validated by the new test group, and the removed emailsFromPermissionChanges CTE was already a no-op. No data-loss or correctness regressions were identified.

No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/prisma/scripts/getAuditLogs.ts | Core fix: replaces present-membership CTEs with a per-permission time-window CTE for Login/Logout gating; also upgrades Isomer admin exclusion from email-domain pattern to IsomerAdmin table lookup. Logic and boundary semantics are correct. |
| apps/studio/prisma/scripts/__tests__/getAuditLogs.test.ts | New E2 test group covers all active-window boundary cases for Login and Logout. Test helpers and isolation via resetTables look correct. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/studio/prisma/scripts/getAuditLogs.ts`, line 333-337 ([link](https://github.com/opengovsg/isomer/blob/06385351c98f3a1b53aa7cf1f893d9eac9db3064/apps/studio/prisma/scripts/getAuditLogs.ts#L333-L337)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Union with `emailsFromPermissionChanges` conceptually bypasses the active-window gating**

   The comment on line 325/346 says "Only while the user was an active collaborator at event time," but the `.union(emailsFromPermissionChanges)` immediately below it would let any Login/Logout through if that CTE produced a matching email. In practice this never fires — `emailsFromPermissionChanges` extracts `delta -> 'after'/'before' ->> 'userId'` (a UUID/CUID), which can never equal an email string — so the window gating is the sole effective filter. However, the union's presence next to the active-collaborator comment is a latent trap: a future change to the delta schema or to `emailsFromPermissionChanges` that accidentally starts producing real email strings would silently re-introduce the original bug. The same pattern appears in the Logout branch (line ~354). Consider adding an inline comment clarifying that the union is intentionally limited to `PermissionCreate`/`PermissionDelete` audit-row surfacing and is inert for Login/Logout matching.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/prisma/scripts/getAuditLogs.ts
   Line: 333-337

   Comment:
   **Union with `emailsFromPermissionChanges` conceptually bypasses the active-window gating**

   The comment on line 325/346 says "Only while the user was an active collaborator at event time," but the `.union(emailsFromPermissionChanges)` immediately below it would let any Login/Logout through if that CTE produced a matching email. In practice this never fires — `emailsFromPermissionChanges` extracts `delta -> 'after'/'before' ->> 'userId'` (a UUID/CUID), which can never equal an email string — so the window gating is the sole effective filter. However, the union's presence next to the active-collaborator comment is a latent trap: a future change to the delta schema or to `emailsFromPermissionChanges` that accidentally starts producing real email strings would silently re-introduce the original bug. The same pattern appears in the Logout branch (line ~354). Consider adding an inline comment clarifying that the union is intentionally limited to `PermissionCreate`/`PermissionDelete` audit-row surfacing and is inert for Login/Logout matching.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fprisma%2Fscripts%2FgetAuditLogs.ts%0ALine%3A%20333-337%0A%0AComment%3A%0A**Union%20with%20%60emailsFromPermissionChanges%60%20conceptually%20bypasses%20the%20active-window%20gating**%0A%0AThe%20comment%20on%20line%20325%2F346%20says%20%22Only%20while%20the%20user%20was%20an%20active%20collaborator%20at%20event%20time%2C%22%20but%20the%20%60.union%28emailsFromPermissionChanges%29%60%20immediately%20below%20it%20would%20let%20any%20Login%2FLogout%20through%20if%20that%20CTE%20produced%20a%20matching%20email.%20In%20practice%20this%20never%20fires%20%E2%80%94%20%60emailsFromPermissionChanges%60%20extracts%20%60delta%20-%3E%20'after'%2F'before'%20-%3E%3E%20'userId'%60%20%28a%20UUID%2FCUID%29%2C%20which%20can%20never%20equal%20an%20email%20string%20%E2%80%94%20so%20the%20window%20gating%20is%20the%20sole%20effective%20filter.%20However%2C%20the%20union's%20presence%20next%20to%20the%20active-collaborator%20comment%20is%20a%20latent%20trap%3A%20a%20future%20change%20to%20the%20delta%20schema%20or%20to%20%60emailsFromPermissionChanges%60%20that%20accidentally%20starts%20producing%20real%20email%20strings%20would%20silently%20re-introduce%20the%20original%20bug.%20The%20same%20pattern%20appears%20in%20the%20Logout%20branch%20%28line%20~354%29.%20Consider%20adding%20an%20inline%20comment%20clarifying%20that%20the%20union%20is%20intentionally%20limited%20to%20%60PermissionCreate%60%2F%60PermissionDelete%60%20audit-row%20surfacing%20and%20is%20inert%20for%20Login%2FLogout%20matching.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer&pr=2612&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fprisma%2Fscripts%2FgetAuditLogs.ts%0ALine%3A%20333-337%0A%0AComment%3A%0A**Union%20with%20%60emailsFromPermissionChanges%60%20conceptually%20bypasses%20the%20active-window%20gating**%0A%0AThe%20comment%20on%20line%20325%2F346%20says%20%22Only%20while%20the%20user%20was%20an%20active%20collaborator%20at%20event%20time%2C%22%20but%20the%20%60.union%28emailsFromPermissionChanges%29%60%20immediately%20below%20it%20would%20let%20any%20Login%2FLogout%20through%20if%20that%20CTE%20produced%20a%20matching%20email.%20In%20practice%20this%20never%20fires%20%E2%80%94%20%60emailsFromPermissionChanges%60%20extracts%20%60delta%20-%3E%20'after'%2F'before'%20-%3E%3E%20'userId'%60%20%28a%20UUID%2FCUID%29%2C%20which%20can%20never%20equal%20an%20email%20string%20%E2%80%94%20so%20the%20window%20gating%20is%20the%20sole%20effective%20filter.%20However%2C%20the%20union's%20presence%20next%20to%20the%20active-collaborator%20comment%20is%20a%20latent%20trap%3A%20a%20future%20change%20to%20the%20delta%20schema%20or%20to%20%60emailsFromPermissionChanges%60%20that%20accidentally%20starts%20producing%20real%20email%20strings%20would%20silently%20re-introduce%20the%20original%20bug.%20The%20same%20pattern%20appears%20in%20the%20Logout%20branch%20%28line%20~354%29.%20Consider%20adding%20an%20inline%20comment%20clarifying%20that%20the%20union%20is%20intentionally%20limited%20to%20%60PermissionCreate%60%2F%60PermissionDelete%60%20audit-row%20surfacing%20and%20is%20inert%20for%20Login%2FLogout%20matching.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2612&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22fix%2Fsuppress-removed-collaborators%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fsuppress-removed-collaborators%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fprisma%2Fscripts%2FgetAuditLogs.ts%0ALine%3A%20333-337%0A%0AComment%3A%0A**Union%20with%20%60emailsFromPermissionChanges%60%20conceptually%20bypasses%20the%20active-window%20gating**%0A%0AThe%20comment%20on%20line%20325%2F346%20says%20%22Only%20while%20the%20user%20was%20an%20active%20collaborator%20at%20event%20time%2C%22%20but%20the%20%60.union%28emailsFromPermissionChanges%29%60%20immediately%20below%20it%20would%20let%20any%20Login%2FLogout%20through%20if%20that%20CTE%20produced%20a%20matching%20email.%20In%20practice%20this%20never%20fires%20%E2%80%94%20%60emailsFromPermissionChanges%60%20extracts%20%60delta%20-%3E%20'after'%2F'before'%20-%3E%3E%20'userId'%60%20%28a%20UUID%2FCUID%29%2C%20which%20can%20never%20equal%20an%20email%20string%20%E2%80%94%20so%20the%20window%20gating%20is%20the%20sole%20effective%20filter.%20However%2C%20the%20union's%20presence%20next%20to%20the%20active-collaborator%20comment%20is%20a%20latent%20trap%3A%20a%20future%20change%20to%20the%20delta%20schema%20or%20to%20%60emailsFromPermissionChanges%60%20that%20accidentally%20starts%20producing%20real%20email%20strings%20would%20silently%20re-introduce%20the%20original%20bug.%20The%20same%20pattern%20appears%20in%20the%20Logout%20branch%20%28line%20~354%29.%20Consider%20adding%20an%20inline%20comment%20clarifying%20that%20the%20union%20is%20intentionally%20limited%20to%20%60PermissionCreate%60%2F%60PermissionDelete%60%20audit-row%20surfacing%20and%20is%20inert%20for%20Login%2FLogout%20matching.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["refactor(redirect): remove dead emailsFr..."](https://github.com/opengovsg/isomer/commit/0a816061a905bdfc97cefd14a5f9b4be27c4a4ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40749550)</sub>

<!-- /greptile_comment -->