### PR TITLE
feat(isomer-admin): add publish-site-resources script for pre-launch assistance

### DIFF
--- a/tooling/scripts/isomer-admin/README.md
+++ b/tooling/scripts/isomer-admin/README.md
@@ -58,6 +58,12 @@ Imports JSON files from `./input` to update existing resources in the database. 
 
 **NOTE:** This requires you to place the files inside `./input` first before running.
 
+### Publish Site Resources
+
+Publishes all draft resources for a given site ID in the database. Lists matching resources for review before confirming. For each resource, creates a new Version record and transitions the resource state from Draft to Published.
+
+**Use case:** Pre-launch assistance — when an agency needs all their content published live at once and requires admin help to do so.
+
 ### Rebuild All CodeBuild Projects
 
 Lists all AWS CodeBuild projects in a selected region, sorts them alphabetically, and starts a build for each project. The script can be run as a dry run to show project indexes first, then resumed from a specific index if a previous run stops midway.

--- a/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
+++ b/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
@@ -99,10 +99,12 @@ export const publishSiteResources = async () => {
           [newVersionRow.id, resource.id],
         );
 
-        console.log(`Published resource ${resource.id} (${resource.title})`);
       }
 
       await client.query("COMMIT");
+      for (const resource of resources) {
+        console.log(`Published resource ${resource.id} (${resource.title})`);
+      }
       console.log(`\nDone. ${resources.length} resource(s) published.`);
     } catch (err) {
       await client.query("ROLLBACK");

--- a/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
+++ b/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
@@ -1,0 +1,115 @@
+import { input, confirm } from "@inquirer/prompts";
+import { withDbClient } from "../utils/db";
+
+export const publishSiteResources = async () => {
+  const publisherEmail = await input({
+    message: "Enter your email address (e.g. adriangoh@open.gov.sg)",
+  });
+
+  const siteId = Number(await input({ message: "Enter the site ID to publish" }));
+
+  if (isNaN(siteId)) {
+    console.error("Invalid site ID provided");
+    return;
+  }
+
+  await withDbClient(async (client) => {
+    const userResult = await client.query<{ id: string }>(
+      `SELECT id FROM "User" WHERE email = $1`,
+      [publisherEmail.toLowerCase()],
+    );
+    const user = userResult.rows[0];
+    if (!user) {
+      console.error(`User with email ${publisherEmail} not found`);
+      return;
+    }
+    const publisherUserId = user.id;
+
+    const draftResources = await client.query<{
+      id: string;
+      type: string;
+      title: string;
+      draftBlobId: string;
+      publishedVersionId: string | null;
+    }>(
+      `SELECT id, type, title, "draftBlobId", "publishedVersionId"
+       FROM "Resource"
+       WHERE "siteId" = $1
+         AND "draftBlobId" IS NOT NULL
+         AND state = 'Draft'`,
+      [siteId],
+    );
+
+    const resources = draftResources.rows;
+
+    if (resources.length === 0) {
+      console.log("No draft resources found for this site.");
+      return;
+    }
+
+    console.log(
+      `Found ${resources.length} draft resource(s) to publish for site ${siteId}:`,
+    );
+    for (const r of resources) {
+      console.log(`  [${r.id}] ${r.type} — ${r.title}`);
+    }
+
+    const confirmed = await confirm({
+      message: `Publish all ${resources.length} resource(s)?`,
+      default: false,
+    });
+
+    if (!confirmed) {
+      console.log("Aborted.");
+      return;
+    }
+
+    let successCount = 0;
+    let errorCount = 0;
+
+    for (const resource of resources) {
+      try {
+        const currentVersion = await client.query<{ versionNum: number }>(
+          `SELECT "versionNum" FROM "Version" WHERE id = $1`,
+          [resource.publishedVersionId],
+        );
+        const latestVersionNumber = currentVersion.rows[0]?.versionNum ?? 0;
+
+        const newVersion = await client.query<{ id: string }>(
+          `INSERT INTO "Version" ("blobId", "versionNum", "resourceId", "publishedBy")
+           VALUES ($1, $2, $3, $4) RETURNING id`,
+          [
+            resource.draftBlobId,
+            latestVersionNumber + 1,
+            resource.id,
+            publisherUserId,
+          ],
+        );
+
+        const newVersionRow = newVersion.rows[0];
+        if (!newVersionRow) {
+          console.error(`Failed to create version for resource ${resource.id}`);
+          errorCount++;
+          continue;
+        }
+
+        await client.query(
+          `UPDATE "Resource"
+           SET "draftBlobId" = NULL, "publishedVersionId" = $1, state = 'Published', "updatedAt" = NOW()
+           WHERE id = $2`,
+          [newVersionRow.id, resource.id],
+        );
+
+        console.log(`Published resource ${resource.id} (${resource.title})`);
+        successCount++;
+      } catch (err) {
+        console.error(`Error publishing resource ${resource.id}:`, err);
+        errorCount++;
+      }
+    }
+
+    console.log(
+      `\nDone. ${successCount} published, ${errorCount} failed.`,
+    );
+  });
+};

--- a/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
+++ b/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
@@ -15,7 +15,7 @@ export const publishSiteResources = async () => {
 
   await withDbClient(async (client) => {
     const userResult = await client.query<{ id: string }>(
-      `SELECT id FROM "User" WHERE email = $1`,
+      `SELECT id FROM "User" WHERE email = $1 AND "deletedAt" IS NULL`,
       [publisherEmail.toLowerCase()],
     );
     const user = userResult.rows[0];

--- a/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
+++ b/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
@@ -64,11 +64,10 @@ export const publishSiteResources = async () => {
       return;
     }
 
-    let successCount = 0;
-    let errorCount = 0;
+    await client.query("BEGIN");
 
-    for (const resource of resources) {
-      try {
+    try {
+      for (const resource of resources) {
         const currentVersion = await client.query<{ versionNum: number }>(
           `SELECT "versionNum" FROM "Version" WHERE id = $1`,
           [resource.publishedVersionId],
@@ -88,9 +87,9 @@ export const publishSiteResources = async () => {
 
         const newVersionRow = newVersion.rows[0];
         if (!newVersionRow) {
-          console.error(`Failed to create version for resource ${resource.id}`);
-          errorCount++;
-          continue;
+          throw new Error(
+            `Failed to create version for resource ${resource.id}`,
+          );
         }
 
         await client.query(
@@ -101,15 +100,13 @@ export const publishSiteResources = async () => {
         );
 
         console.log(`Published resource ${resource.id} (${resource.title})`);
-        successCount++;
-      } catch (err) {
-        console.error(`Error publishing resource ${resource.id}:`, err);
-        errorCount++;
       }
-    }
 
-    console.log(
-      `\nDone. ${successCount} published, ${errorCount} failed.`,
-    );
+      await client.query("COMMIT");
+      console.log(`\nDone. ${resources.length} resource(s) published.`);
+    } catch (err) {
+      await client.query("ROLLBACK");
+      console.error("Transaction rolled back. No resources were published.", err);
+    }
   });
 };

--- a/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
+++ b/tooling/scripts/isomer-admin/apps/publish-site-resources.ts
@@ -106,6 +106,9 @@ export const publishSiteResources = async () => {
         console.log(`Published resource ${resource.id} (${resource.title})`);
       }
       console.log(`\nDone. ${resources.length} resource(s) published.`);
+      console.log(
+        "\nIMPORTANT: The static site has NOT been rebuilt. You must manually trigger a CodeBuild rebuild for the changes to go live.",
+      );
     } catch (err) {
       await client.query("ROLLBACK");
       console.error("Transaction rolled back. No resources were published.", err);

--- a/tooling/scripts/isomer-admin/index.ts
+++ b/tooling/scripts/isomer-admin/index.ts
@@ -7,6 +7,7 @@ import { exportSiteJsons } from "./apps/export-site-jsons"
 import { extractFolderJsons } from "./apps/extract-folder-jsons"
 import { findInvalidSchema } from "./apps/find-invalid-schema"
 import { importFolderJsons } from "./apps/import-folder-jsons"
+import { publishSiteResources } from "./apps/publish-site-resources"
 import { rebuildAllCodebuildProjects } from "./apps/rebuild-all-codebuild-projects"
 
 const main = async () => {
@@ -49,6 +50,12 @@ const main = async () => {
         value: "import-folder-jsons",
       },
       {
+        name: "Publish site resources",
+        description:
+          "Publish all draft resources for a given site ID in the database.",
+        value: "publish-site-resources",
+      },
+      {
         name: "Rebuild all CodeBuild projects",
         description:
           "List AWS CodeBuild projects and start builds for each project with resumable batching.",
@@ -75,6 +82,9 @@ const main = async () => {
       break
     case "import-folder-jsons":
       await importFolderJsons()
+      break
+    case "publish-site-resources":
+      await publishSiteResources()
       break
     case "rebuild-all-codebuild-projects":
       await rebuildAllCodebuildProjects()

--- a/tooling/scripts/isomer-admin/types.ts
+++ b/tooling/scripts/isomer-admin/types.ts
@@ -24,4 +24,5 @@ export type IsomerAdminScriptType =
   | "extract-folder-jsons"
   | "find-invalid-schema"
   | "import-folder-jsons"
+  | "publish-site-resources"
   | "rebuild-all-codebuild-projects"


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

There was no admin script to bulk-publish all draft resources for a given site. During pre-launch, agencies sometimes need all their content published live at once and require admin assistance to do so.

## Solution

<!-- How did you solve the problem? -->

Added a new `publish-site-resources` script to the `isomer-admin` CLI.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- New `publish-site-resources` admin script that publishes all draft resources for a given site ID in one go
  - Prompts for publisher email and site ID
  - Queries all `Draft` resources with a `draftBlobId` for the site and displays them for review before confirming
  - For each resource: creates a new `Version` record (incrementing `versionNum`) and transitions the resource to `Published` with `draftBlobId` cleared
  - Reports a success/failure count on completion

**Improvements**:

- Updated `isomer-admin` README to document the new script and its pre-launch use case

## Before & After Screenshots

N/A — admin CLI tooling, no UI changes.

## Tests

**Manual Verification Steps**:

- [ ] Run `pnpm run isomer-admin` from `tooling/scripts`
- [ ] Select **"Publish site resources"** from the menu
- [ ] Enter a publisher email and a site ID that has draft resources
- [ ] Confirm the listed resources look correct, then confirm publishing
- [ ] Verify the targeted resources are now in `Published` state in the database (`state = 'Published'`, `draftBlobId = NULL`, `publishedVersionId` populated)

**New scripts**:

- N/A (extends existing `isomer-admin` CLI, no new top-level scripts)

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `publish-site-resources` admin script to the `isomer-admin` CLI that bulk-publishes all draft resources for a given site, intended for pre-launch assistance when agencies need all content published at once.

- The core logic correctly mirrors the production `incrementVersion` flow in `version.service.ts`: looks up the current `publishedVersionId`'s `versionNum`, inserts a new `Version` record, and updates the `Resource` row to `Published` with `draftBlobId` cleared — all inside a single transaction.
- User lookup now guards against soft-deleted accounts (`deletedAt IS NULL`), the post-commit logs correctly avoid false positives on rollback, and the terminal output includes an explicit warning reminding the operator to manually trigger a CodeBuild rebuild.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the bulk-publish logic correctly replicates the production incrementVersion flow and all database mutations are wrapped in a single rolled-back-on-error transaction.

The transaction logic matches the production version.service.ts incrementVersion path exactly: fetches current versionNum from publishedVersionId, inserts a new Version row, then clears draftBlobId and sets state to Published. The soft-delete guard on User lookup is in place, success logs are emitted only after COMMIT, and the IMPORTANT rebuild reminder is printed at the end. The one minor gap — Number("") = 0 silently passes the siteId guard — has no risk of data corruption since the query would simply return no resources.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/scripts/isomer-admin/apps/publish-site-resources.ts | Core script implementing bulk publish; logic correctly matches the production incrementVersion flow. Minor siteId validation gap (Number("") = 0 passes isNaN check). |
| tooling/scripts/isomer-admin/index.ts | Adds menu entry and switch case for publish-site-resources; change is mechanical and correct. |
| tooling/scripts/isomer-admin/types.ts | Adds "publish-site-resources" to the IsomerAdminScriptType union; correct and complete. |
| tooling/scripts/isomer-admin/README.md | Documents the new script and its pre-launch use case; clear and accurate. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Operator (CLI)
    participant DB as PostgreSQL

    Admin->>DB: "SELECT id FROM User WHERE email = $1 AND deletedAt IS NULL"
    DB-->>Admin: publisherUserId

    Admin->>DB: "SELECT id, type, title, draftBlobId, publishedVersionId FROM Resource WHERE siteId = $1 AND state = 'Draft' AND draftBlobId IS NOT NULL"
    DB-->>Admin: draftResources[]

    Admin->>Admin: Display resource list, await confirmation

    Admin->>DB: BEGIN
    loop For each draftResource
        Admin->>DB: "SELECT versionNum FROM Version WHERE id = publishedVersionId"
        DB-->>Admin: latestVersionNum (or 0 if never published)
        Admin->>DB: INSERT INTO Version (blobId, versionNum+1, resourceId, publishedBy) RETURNING id
        DB-->>Admin: newVersionId
        Admin->>DB: "UPDATE Resource SET draftBlobId=NULL, publishedVersionId=newVersionId, state='Published', updatedAt=NOW() WHERE id = resourceId"
    end
    Admin->>DB: COMMIT
    Admin->>Admin: Print success summary + CodeBuild rebuild reminder
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Operator (CLI)
    participant DB as PostgreSQL

    Admin->>DB: "SELECT id FROM User WHERE email = $1 AND deletedAt IS NULL"
    DB-->>Admin: publisherUserId

    Admin->>DB: "SELECT id, type, title, draftBlobId, publishedVersionId FROM Resource WHERE siteId = $1 AND state = 'Draft' AND draftBlobId IS NOT NULL"
    DB-->>Admin: draftResources[]

    Admin->>Admin: Display resource list, await confirmation

    Admin->>DB: BEGIN
    loop For each draftResource
        Admin->>DB: "SELECT versionNum FROM Version WHERE id = publishedVersionId"
        DB-->>Admin: latestVersionNum (or 0 if never published)
        Admin->>DB: INSERT INTO Version (blobId, versionNum+1, resourceId, publishedBy) RETURNING id
        DB-->>Admin: newVersionId
        Admin->>DB: "UPDATE Resource SET draftBlobId=NULL, publishedVersionId=newVersionId, state='Published', updatedAt=NOW() WHERE id = resourceId"
    end
    Admin->>DB: COMMIT
    Admin->>Admin: Print success summary + CodeBuild rebuild reminder
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["Enhance publish-site-resources script to..."](https://github.com/opengovsg/isomer/commit/43d08cb2f223915e1600ff697323532dbc7a6332) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40759798)</sub>

<!-- /greptile_comment -->