### PR TITLE
fix(studio): allow SVG uploads via correct schema validation

### DIFF
--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react"
 import { useAssetUpload } from "~/features/editing-experience/components/form-builder/hooks/useAssetUpload"
 import { RISKY_FILE_EXTENSIONS } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
-import { getPresignedPutUrlSchema } from "~/schemas/asset"
+import { getPresignedPutUrlSchema, uploadSvgSchema } from "~/schemas/asset"
 import { formatFileSizeLimit } from "~/utils/formatFileSizeLimit"
 import { getFileExtension } from "~/utils/getFileExtension"
 
@@ -100,9 +100,15 @@ export const FileAttachment = ({
               ...Object.values(acceptedFileTypes),
             ])}
             onFileValidation={(file) => {
-              const parseResult = getPresignedPutUrlSchema
-                .pick({ fileName: true })
-                .safeParse({ fileName: file.name })
+              // SVGs are validated and uploaded via the dedicated uploadSvg
+              // endpoint (not the presigned PUT path), so use uploadSvgSchema
+              // for filename validation to avoid the deliberate SVG rejection
+              // in getPresignedPutUrlSchema.
+              const isSvg = file.name.toLowerCase().endsWith(".svg")
+              const schema = isSvg
+                ? uploadSvgSchema.pick({ fileName: true })
+                : getPresignedPutUrlSchema.pick({ fileName: true })
+              const parseResult = schema.safeParse({ fileName: file.name })
 
               if (parseResult.success) return null
               // NOTE: safe assertion here because we're in error path and there's at least 1 error


### PR DESCRIPTION
## Problem

When uploading an SVG file in Studio, users see \"File type not allowed. Please upload a supported file type.\" even though SVG is a supported image type.

## Solution

The `FileAttachment` component's `onFileValidation` callback was validating all filenames against `getPresignedPutUrlSchema`, which deliberately rejects `.svg` extensions — SVGs must go through the dedicated `uploadSvg` endpoint (which sanitizes content server-side) rather than the presigned PUT path. However, `useUploadAssetMutation` already correctly routes SVG files to the `uploadSvg` endpoint. The client-side validation was simply using the wrong schema.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed SVG uploads being rejected with \"File type not allowed\" by validating `.svg` filenames against `uploadSvgSchema` instead of `getPresignedPutUrlSchema` in `FileAttachment.onFileValidation`.

## Before & After Screenshots

**BEFORE**: Uploading an SVG shows "File type not allowed. Please upload a supported file type."

**AFTER**: SVG files upload successfully.

## Tests

**Manual Verification Steps**:

- [ ] Open any page or block in Studio that has an image upload field (e.g. Hero image, Infopic image).
- [ ] Attempt to upload a `.svg` file — confirm no "File type not allowed" error appears and the upload succeeds.
- [ ] Upload a non-SVG image (e.g. `.png`) — confirm it still uploads successfully.
- [ ] Attempt to upload a disallowed file type (e.g. `.exe`) — confirm it is still rejected.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a client-side validation mismatch where `.svg` file uploads were rejected with "File type not allowed" because `onFileValidation` was using `getPresignedPutUrlSchema`, which deliberately blocks SVGs since they must go through a sanitizing endpoint. The fix branches the schema selection on whether the file is an SVG, consistent with how `useUploadAssetMutation` already routes SVG uploads to the dedicated `uploadSvg` endpoint.

- **Schema selection aligned with upload routing**: the `isSvg` check in `onFileValidation` (`file.name.toLowerCase().endsWith(".svg")`) is identical to the branch condition in `useUploadAssetMutation`, so validation and actual upload path are now in sync.
- **No change to security model**: SVG content sanitization still happens server-side via the `uploadSvg` tRPC procedure; the client-side change only fixes the filename-level pre-flight check.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — small, focused fix with no changes to security-sensitive upload or sanitization paths.

The change is three lines of logic that select the correct Zod schema for client-side filename validation based on file extension, exactly mirroring the already-correct routing in useUploadAssetMutation. The SVG sanitization path on the server is untouched. No regressions for non-SVG file types are possible since those still go through getPresignedPutUrlSchema as before.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/components/PageEditor/FileAttachment.tsx | Fixes SVG client-side validation by routing .svg filenames through uploadSvgSchema instead of getPresignedPutUrlSchema, mirroring the routing logic already present in useUploadAssetMutation. No logical issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant FileAttachment
    participant useUploadAssetMutation
    participant Server

    User->>FileAttachment: Select file (e.g. image.svg)
    FileAttachment->>FileAttachment: onFileValidation(file)
    alt file.name ends with .svg
        FileAttachment->>FileAttachment: "uploadSvgSchema.pick({fileName}).safeParse()"
    else other file type
        FileAttachment->>FileAttachment: "getPresignedPutUrlSchema.pick({fileName}).safeParse()"
    end
    FileAttachment-->>User: return null (valid) or error message

    User->>FileAttachment: onChange(file) [only reached if valid]
    FileAttachment->>useUploadAssetMutation: "uploadFile({ file })"
    alt effectiveName ends with .svg
        useUploadAssetMutation->>Server: trpc.asset.uploadSvg (sanitizes content)
    else other file type
        useUploadAssetMutation->>Server: trpc.asset.getPresignedPutUrl then S3 PUT
    end
    Server-->>useUploadAssetMutation: fileKey
    useUploadAssetMutation-->>FileAttachment: "{ path }"
    FileAttachment->>FileAttachment: setHref(src)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant FileAttachment
    participant useUploadAssetMutation
    participant Server

    User->>FileAttachment: Select file (e.g. image.svg)
    FileAttachment->>FileAttachment: onFileValidation(file)
    alt file.name ends with .svg
        FileAttachment->>FileAttachment: "uploadSvgSchema.pick({fileName}).safeParse()"
    else other file type
        FileAttachment->>FileAttachment: "getPresignedPutUrlSchema.pick({fileName}).safeParse()"
    end
    FileAttachment-->>User: return null (valid) or error message

    User->>FileAttachment: onChange(file) [only reached if valid]
    FileAttachment->>useUploadAssetMutation: "uploadFile({ file })"
    alt effectiveName ends with .svg
        useUploadAssetMutation->>Server: trpc.asset.uploadSvg (sanitizes content)
    else other file type
        useUploadAssetMutation->>Server: trpc.asset.getPresignedPutUrl then S3 PUT
    end
    Server-->>useUploadAssetMutation: fileKey
    useUploadAssetMutation-->>FileAttachment: "{ path }"
    FileAttachment->>FileAttachment: setHref(src)
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): allow SVG uploads in FileAt..."](https://github.com/opengovsg/isomer/commit/3554ded284633f2d9bcb9f2738d26a56cd574a5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40771974)</sub>

<!-- /greptile_comment -->