### PR TITLE
fix(studio): align spacing and description colour in toggle

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -32,15 +32,16 @@ function JsonFormsBooleanControl({
   }
 
   return (
-    <Box>
+    <Box pt="0.5rem">
       <FormControl>
         <Flex justifyContent="space-between" alignItems="start">
           <FormLabel
             isRequired
             description={description}
             htmlFor={id}
-            mb={!description ? "0px" : "0.75rem"}
             gap="0.25rem"
+            mt="0.25rem"
+            mb="0.25rem"
           >
             {label}
           </FormLabel>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx
@@ -40,6 +40,7 @@ function JsonFormsBooleanControl({
             description={description}
             htmlFor={id}
             mb={!description ? "0px" : "0.75rem"}
+            gap="0.25rem"
           >
             {label}
           </FormLabel>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx
@@ -82,7 +82,7 @@ function JsonFormsObjectControl({
                 </Text>
 
                 {description && (
-                  <Text textStyle="body-2" textColor="base.content.strong">
+                  <Text textStyle="body-2" textColor="base.content.medium">
                     {description}
                   </Text>
                 )}


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [insert issue #]

Minor visual inconsistencies in the JSON Forms editor between the boolean toggle controls (e.g. "Show date on all items") and object toggle controls (e.g. "Set a thumbnail"):

1. The description text under "Set a thumbnail" was rendered in `base.content.strong` instead of the muted `base.content.medium` used by the OGP `FormLabel` description, making it appear darker than intended.
2. The boolean control lacked the `pt="0.5rem"` top padding that the object control had, causing misaligned vertical spacing.
3. The boolean control used a conditional `mb` that didn't produce a consistent gap between label and description text.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixed description text colour in `JsonFormsObjectControl` from `base.content.strong` → `base.content.medium` to match the colour used by OGP Design System's `FormLabel` description (which resolves to Chakra's `helperText` style).
- Added `pt="0.5rem"` to the outer `Box` in `JsonFormsBooleanControl` to match the object control's top padding.
- Replaced the conditional `mb` on `FormLabel` with `gap="0.25rem"` and a fixed `mt="0.25rem"` / `mb="0.25rem"` for consistent spacing between label and description regardless of whether a description is present.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Open a Collection page in the editor and navigate to the page settings panel.
- [ ] Verify that "Show date on all items" and "Set a thumbnail" toggle rows have consistent top padding.
- [ ] Verify that the description text under "Show date on all items" ("If an item doesn't have a date, we'll display a dash (-)") and under "Set a thumbnail" ("When this page is linked elsewhere on your site, this thumbnail may appear alongside it.") appear the same muted colour.
- [ ] Verify there is a small gap between each toggle label and its description text.

**New scripts**: N/A

**New dependencies**: N/A

**New dev dependencies**: N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects three visual inconsistencies between `JsonFormsBooleanControl` and `JsonFormsObjectControl` in the JSON Forms editor: it aligns top padding, normalises label/description spacing, and fixes the description text colour in the object control to use the muted `base.content.medium` token instead of the stronger `base.content.strong`.

- `JsonFormsObjectControl`: single-token change to description `textColor` (`base.content.strong` → `base.content.medium`) to match the OGP design system's `FormLabel` helper-text style.
- `JsonFormsBooleanControl`: adds `pt=\"0.5rem\"` to the outer `Box` and replaces the old conditional `mb` with `gap=\"0.25rem\"` + fixed `mt`/`mb` on `FormLabel` for uniform spacing regardless of whether a description is present.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Both changes are isolated style-prop adjustments with no data-flow or logic impact; safe to merge.

The diff touches only Chakra/OGP style props — a colour token swap and box-model tweaks. No business logic, state management, or data paths are affected, and the changes are fully self-contained within two leaf components.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsBooleanControl.tsx | Adds pt="0.5rem" to outer Box and replaces conditional mb on FormLabel with gap="0.25rem" + fixed mt/mb for consistent spacing; straightforward visual alignment fix. |
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsObjectControl.tsx | Changes description text colour from base.content.strong to base.content.medium to match the muted colour used by the OGP design system's FormLabel description; single-token change with no logic impact. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[JSON Forms editor renders a field] --> B{Field type?}
    B -->|boolean| C[JsonFormsBooleanControl]
    B -->|object| D[JsonFormsObjectControl]
    C --> C1["Box pt=0.5rem (NEW)"]
    C1 --> C2["FormLabel gap=0.25rem mt=0.25rem mb=0.25rem (NEW)"]
    C2 --> C3[label text]
    C2 --> C4[description text via OGP FormLabel prop]
    D --> D1["VStack pt=0.5rem (existing)"]
    D1 --> D2["Text label — base.content.strong (unchanged)"]
    D1 --> D3["Text description base.content.medium (FIXED from strong)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[JSON Forms editor renders a field] --> B{Field type?}
    B -->|boolean| C[JsonFormsBooleanControl]
    B -->|object| D[JsonFormsObjectControl]
    C --> C1["Box pt=0.5rem (NEW)"]
    C1 --> C2["FormLabel gap=0.25rem mt=0.25rem mb=0.25rem (NEW)"]
    C2 --> C3[label text]
    C2 --> C4[description text via OGP FormLabel prop]
    D --> D1["VStack pt=0.5rem (existing)"]
    D1 --> D2["Text label — base.content.strong (unchanged)"]
    D1 --> D3["Text description base.content.medium (FIXED from strong)"]
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(components): adjust spacing in JsonF..."](https://github.com/opengovsg/isomer/commit/0ef124327cb07b6e96e9d28a6a5f1b522ba6c6ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40779459)</sub>

<!-- /greptile_comment -->