### PR TITLE
👨🏻‍💻 DX - chore(ci): parallelise unit tests with sharding and split jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
         run: bash "$RUNNER_TEMP/comment-template-bundle-size.sh"
 
   test-studio:
-    name: Test Studio (${{ matrix.shard }}/{{ matrix.total_shards }})
+    name: Test Studio (${{ matrix.shard }}/${{ matrix.total_shards }})
     needs: optimize_ci
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
@@ -158,7 +158,7 @@ jobs:
       fail-fast: false # so that we can run all shards and one shard can fail without failing the entire job
       matrix:
         shard: [1, 2] # extend this if we need to run more shards concurrently
-        total_shards: 2
+        total_shards: [2]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,11 +149,14 @@ jobs:
           BASE_TOTAL: ${{ steps.base.outputs.total }}
         run: bash "$RUNNER_TEMP/comment-template-bundle-size.sh"
 
-  unit-integration-tests:
-    name: Unit & integration tests
+  test-studio:
+    name: Test Studio (${{ matrix.shard }}/4)
     needs: optimize_ci
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
+    strategy:
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup
@@ -169,12 +172,64 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
-        run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose
+        run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose -- --reporter=blob --shard=${{ matrix.shard }}/4
         env:
           # Required to allow Datadog to trace Vitest tests
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
           # Set timezone to Singapore to ensure that the tests are run in the correct timezone
           TZ: Asia/Singapore
+      - name: Upload coverage blob
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-studio-shard-${{ matrix.shard }}
+          path: apps/studio/.vitest-reports/
+          retention-days: 1
+          if-no-files-found: error
+
+  test-studio-coverage:
+    name: Test Studio coverage (merged)
+    needs: [optimize_ci, test-studio]
+    runs-on: ubuntu-latest
+    if: needs.optimize_ci.outputs.skip == 'false'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Install dependencies
+        run: pnpm exec turbo run generate --filter=isomer-studio
+      - name: Download coverage blobs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: coverage-studio-shard-*
+          path: apps/studio/.vitest-reports/
+          merge-multiple: true
+      - name: Merge coverage reports
+        working-directory: apps/studio
+        run: pnpm exec vitest --merge-reports .vitest-reports --coverage
+        env:
+          TZ: Asia/Singapore
+      - name: Upload merged coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-studio
+          path: apps/studio/coverage/
+          retention-days: 7
+
+  test-components:
+    name: Test Components
+    needs: optimize_ci
+    runs-on: ubuntu-latest
+    if: needs.optimize_ci.outputs.skip == 'false'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Configure Datadog Test Visibility
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+        with:
+          languages: js
+          service: isomer-studio
+          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Components
         run: pnpm exec turbo test-ci:unit --filter=@opengovsg/isomer-components --env-mode=loose
         env:
@@ -182,10 +237,49 @@ jobs:
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
           # Set timezone to Singapore to ensure that the tests are run in the correct timezone
           TZ: Asia/Singapore
+
+  test-validators:
+    name: Test Validators
+    needs: optimize_ci
+    runs-on: ubuntu-latest
+    if: needs.optimize_ci.outputs.skip == 'false'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Configure Datadog Test Visibility
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+        with:
+          languages: js
+          service: isomer-studio
+          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Validators
         run: pnpm exec turbo test-ci:unit --filter=@isomer/validators --env-mode=loose
         env:
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+
+  test-pgboss:
+    name: Test pgboss
+    needs: optimize_ci
+    runs-on: ubuntu-latest
+    if: needs.optimize_ci.outputs.skip == 'false'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Start test containers
+        run: pnpm exec turbo run setup:test --filter=@isomer/pgboss
+      - name: Configure Datadog Test Visibility
+        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+        with:
+          languages: js
+          service: isomer-pgboss
+          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
+      - name: Test pgboss
+        run: pnpm exec turbo test-ci:unit --filter=@isomer/pgboss --env-mode=loose
+        env:
+          NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+          TZ: Asia/Singapore
 
   publishing-script-tests:
     name: Publishing script tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,14 +150,15 @@ jobs:
         run: bash "$RUNNER_TEMP/comment-template-bundle-size.sh"
 
   test-studio:
-    name: Test Studio (${{ matrix.shard }}/4)
+    name: Test Studio (${{ matrix.shard }}/{{ matrix.total_shards }})
     needs: optimize_ci
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
     strategy:
       fail-fast: false # so that we can run all shards and one shard can fail without failing the entire job
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2] # extend this if we need to run more shards concurrently
+        total_shards: 2
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup
@@ -173,7 +174,7 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
-        run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose -- --shard=${{ matrix.shard }}/4
+        run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose -- --shard=${{ matrix.shard }}/${{ matrix.total_shards }}
         env:
           # Required to allow Datadog to trace Vitest tests
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.optimize_ci.outputs.skip == 'false'
     strategy:
+      fail-fast: false # so that we can run all shards and one shard can fail without failing the entire job
       matrix:
         shard: [1, 2, 3, 4]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,48 +172,12 @@ jobs:
           api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
-        run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose -- --reporter=blob --shard=${{ matrix.shard }}/4
+        run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose -- --shard=${{ matrix.shard }}/4
         env:
           # Required to allow Datadog to trace Vitest tests
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
           # Set timezone to Singapore to ensure that the tests are run in the correct timezone
           TZ: Asia/Singapore
-      - name: Upload coverage blob
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-studio-shard-${{ matrix.shard }}
-          path: apps/studio/.vitest-reports/
-          retention-days: 1
-          if-no-files-found: error
-
-  test-studio-coverage:
-    name: Test Studio coverage (merged)
-    needs: [optimize_ci, test-studio]
-    runs-on: ubuntu-latest
-    if: needs.optimize_ci.outputs.skip == 'false'
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-      - name: Setup
-        uses: ./.github/actions/setup
-      - name: Install dependencies
-        run: pnpm exec turbo run generate --filter=isomer-studio
-      - name: Download coverage blobs
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          pattern: coverage-studio-shard-*
-          path: apps/studio/.vitest-reports/
-          merge-multiple: true
-      - name: Merge coverage reports
-        working-directory: apps/studio
-        run: pnpm exec vitest --merge-reports .vitest-reports --coverage
-        env:
-          TZ: Asia/Singapore
-      - name: Upload merged coverage
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-studio
-          path: apps/studio/coverage/
-          retention-days: 7
 
   test-components:
     name: Test Components

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,7 @@ jobs:
         run: pnpm exec turbo test-ci:unit --filter=@isomer/validators --env-mode=loose
         env:
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
+          TZ: Asia/Singapore
 
   test-pgboss:
     name: Test pgboss

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -45,13 +45,13 @@
     "teardown": "docker compose down",
     "test": "run-s test:e2e test:load:build test:unit",
     "test-ci:e2e": "dotenv -e .env.test start-server-and-test dev http://127.0.0.1:3000 test:e2e",
-    "test-ci:unit": "dotenv -e .env.test vitest run --coverage",
+    "test-ci:unit": "dotenv -e .env.test -- vitest run --coverage",
     "test-dev": "start-server-and-test dev http://127.0.0.1:3000 test",
-    "test-dev:unit": "dotenv -e .env.test vitest",
+    "test-dev:unit": "dotenv -e .env.test -- vitest",
     "test:e2e": "dotenv -e .env.test pnpm exec playwright test",
     "test:load:build": "webpack-cli --config tests/load/webpack.config.cjs",
-    "test:unit": "dotenv -e .env.test vitest run",
-    "test:watch": "dotenv -e .env.test pnpm exec vitest watch",
+    "test:unit": "dotenv -e .env.test -- vitest run",
+    "test:watch": "dotenv -e .env.test -- pnpm exec vitest watch",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Problem

Studio unit tests previously ran in a single monolithic CI job alongside components and validators tests. As the suite grows (~1500 tests), this creates a CI bottleneck. Sharding was also attempted but had no effect on runtime because Vitest flags were not reaching the test runner.

## Solution

Refactored the monolithic `unit-integration-tests` job into separate, parallel CI jobs and added Vitest sharding for Studio tests to reduce wall-clock time.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Split the single `unit-integration-tests` job into dedicated jobs: `test-studio`, `test-components`, `test-validators`, and `test-pgboss`
- Added a 2-shard matrix strategy for Studio unit tests (`--shard=N/total_shards`), with `total_shards` defined alongside the shard index so the count is easy to extend
- Added a dedicated `test-pgboss` job with test container setup (`setup:test`) and Datadog Test Visibility

**Improvements**:

- Components, validators, and pgboss jobs each run independently, allowing GitHub Actions to parallelise them across runners
- Datadog Test Visibility is configured per job for better test execution monitoring
- Set `fail-fast: false` on the Studio shard matrix so all shards run to completion even if one fails

**Bug Fixes**:

- Fixed Vitest sharding not taking effect: `dotenv-cli` was consuming flags like `--shard` and `--coverage` because the `--` separator was missing from test scripts in `apps/studio/package.json`. Added `--` so Turbo-appended args reach Vitest correctly.

## Before & After Screenshots

⚡️ **Before: ~5 min 10 sec (sequential) → After: ~3 min 20 sec longest parallel step — 1.55× faster, 35% reduction in wall-clock time**

**BEFORE**:

Single `Unit & integration tests` job running Studio, Components, and Validators sequentially. Sharded runs still executed the full suite (~1493 tests per shard).

**AFTER**:

Four parallel CI jobs: `Test Studio (1/2)` and `(2/2)`, plus `Test Components`, `Test Validators`, and `Test pgboss`. Each Studio shard runs ~half the test files.

## Tests

- Verify CI passes on this PR — all new jobs (`test-studio` shards, `test-components`, `test-validators`, `test-pgboss`) should complete successfully
- Confirm each Studio shard runs a subset of tests (not the full ~1493 count on every shard)
- Confirm total test count across shards matches the pre-sharding baseline (no tests dropped)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR parallelises Studio unit tests by splitting the monolithic `unit-integration-tests` job into four dedicated jobs (`test-studio` with a 2-shard matrix, `test-components`, `test-validators`, `test-pgboss`) and fixes the root cause of sharding not working by adding the `--` separator to all `dotenv-cli` invocations in `apps/studio/package.json`.

- `fail-fast: false` is set on the Studio shard matrix and `TZ: Asia/Singapore` is consistently applied across all new jobs, addressing the correctness concerns from earlier review rounds.
- Each Studio shard still executes `vitest run --coverage` (baked into the `test-ci:unit` script), producing two partial coverage reports that are discarded at job completion — worth revisiting if coverage tracking is desired.
- The `test-pgboss` job correctly starts test containers before running tests, and Datadog Test Visibility is configured per job.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactoring is mechanical (job split + -- fix), all existing correctness issues from prior rounds are addressed, and the only open question is whether partial per-shard coverage reports are acceptable.

The change correctly fixes Vitest sharding, sets timezone and fail-fast consistently, and introduces no new failure modes in the test execution path. The only remaining gap is that --coverage generates ephemeral partial reports with no merge step, which is a waste of compute but does not affect test correctness or CI reliability.

apps/studio/turbo.json is worth keeping in mind if Turbo remote caching is ever added — the test-ci:unit task has no cache: false, so both shards would share the same cache key and whichever finishes first could cause the other to skip.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Monolithic unit-integration-tests job split into four parallel jobs (test-studio with 2-shard matrix, test-components, test-validators, test-pgboss); fail-fast disabled and TZ set correctly on all jobs; each shard still runs --coverage with no merge step to produce a usable aggregate report |
| apps/studio/package.json | Added -- separator to all dotenv-cli invocations so flags like --shard and --coverage are forwarded to vitest instead of being consumed by dotenv-cli; the root bug fix that makes Vitest sharding work |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    OCI[optimize_ci] --> TS1[test-studio shard 1/2]
    OCI --> TS2[test-studio shard 2/2]
    OCI --> TC[test-components]
    OCI --> TV[test-validators]
    OCI --> TP[test-pgboss]

    TS1 --> |vitest --shard=1/2 --coverage| CR1[Partial coverage report discarded]
    TS2 --> |vitest --shard=2/2 --coverage| CR2[Partial coverage report discarded]

    TP --> |setup:test first| PG[(Postgres container)]
    PG --> TP2[pgboss tests]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    OCI[optimize_ci] --> TS1[test-studio shard 1/2]
    OCI --> TS2[test-studio shard 2/2]
    OCI --> TC[test-components]
    OCI --> TV[test-validators]
    OCI --> TP[test-pgboss]

    TS1 --> |vitest --shard=1/2 --coverage| CR1[Partial coverage report discarded]
    TS2 --> |vitest --shard=2/2 --coverage| CR2[Partial coverage report discarded]

    TP --> |setup:test first| PG[(Postgres container)]
    PG --> TP2[pgboss tests]
```

</a>
</details>

<sub>Reviews (6): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/concurren..."](https://github.com/opengovsg/isomer/commit/d6613c602eaaa4c0024b32a1e9492df236273d4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40876881)</sub>

<!-- /greptile_comment -->