### PR TITLE
👨🏻‍💻 DX - fix(studio): fix flaky e2e tests and speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,11 +242,13 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
-      - name: Build Studio app
+      - name: Build Studio app and start test containers
         # Loose env mode required for env vars to be passed to the run
-        run: pnpm exec turbo build --filter=isomer-studio --env-mode=loose
-      - name: Start test containers
-        run: pnpm run setup:test
+        run: |
+          pnpm run setup:test &
+          SETUP_PID=$!
+          pnpm exec turbo build --filter=isomer-studio --env-mode=loose
+          wait $SETUP_PID
       - name: Configure Datadog Test Visibility
         uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
+      - name: Install Playwright (Chromium)
+        run: pnpm --filter isomer-studio exec playwright install chromium
       - name: Load .env file
         uses: opengovsg/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0 # v2
         with:
@@ -240,16 +242,13 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
-      - name: Build Studio app, install Playwright and start test containers
+      - name: Build Studio app and start test containers
         # Loose env mode required for env vars to be passed to the run
         run: |
           pnpm run setup:test &
           SETUP_PID=$!
-          pnpm --filter isomer-studio exec playwright install chromium &
-          PLAYWRIGHT_PID=$!
           pnpm exec turbo build --filter=isomer-studio --env-mode=loose
           wait $SETUP_PID
-          wait $PLAYWRIGHT_PID
       - name: Configure Datadog Test Visibility
         uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
-            ${{ github.workspace }}/.next/cache
+            ${{ github.workspace }}/apps/studio/.next/cache
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,9 @@ jobs:
         with:
           path: |
             ${{ github.workspace }}/apps/studio/.next/cache
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('**/*.js', '**/*.jsx', '**/*.ts', '**/*.tsx') }}
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
+            ${{ runner.os }}-nextjs-
       - name: Build Studio app
         # Loose env mode required for env vars to be passed to the run
         run: pnpm exec turbo build --filter=isomer-studio --env-mode=loose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,6 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Install Playwright (Chromium)
-        run: pnpm --filter isomer-studio exec playwright install chromium
       - name: Load .env file
         uses: opengovsg/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0 # v2
         with:
@@ -242,13 +240,16 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
-      - name: Build Studio app and start test containers
+      - name: Build Studio app, install Playwright and start test containers
         # Loose env mode required for env vars to be passed to the run
         run: |
           pnpm run setup:test &
           SETUP_PID=$!
+          pnpm --filter isomer-studio exec playwright install chromium &
+          PLAYWRIGHT_PID=$!
           pnpm exec turbo build --filter=isomer-studio --env-mode=loose
           wait $SETUP_PID
+          wait $PLAYWRIGHT_PID
       - name: Configure Datadog Test Visibility
         uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,13 +242,11 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
-      - name: Build Studio app and start test containers
+      - name: Build Studio app
         # Loose env mode required for env vars to be passed to the run
-        run: |
-          pnpm run setup:test &
-          SETUP_PID=$!
-          pnpm exec turbo build --filter=isomer-studio --env-mode=loose
-          wait $SETUP_PID
+        run: pnpm exec turbo build --filter=isomer-studio --env-mode=loose
+      - name: Start test containers
+        run: pnpm run setup:test
       - name: Configure Datadog Test Visibility
         uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
         with:

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -44,7 +44,7 @@
     "storybook": "storybook dev -p 6007",
     "teardown": "docker compose down",
     "test": "run-s test:e2e test:load:build test:unit",
-    "test-ci:e2e": "dotenv -e .env.test start-server-and-test dev http://127.0.0.1:3000 test:e2e",
+    "test-ci:e2e": "dotenv -e .env.test start-server-and-test start http://127.0.0.1:3000 test:e2e",
     "test-ci:unit": "dotenv -e .env.test vitest run --coverage",
     "test-dev": "start-server-and-test dev http://127.0.0.1:3000 test",
     "test-dev:unit": "dotenv -e .env.test vitest",

--- a/apps/studio/playwright.config.ts
+++ b/apps/studio/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         baseURL: baseUrl,
         headless: opts.headless,
-        video: "on",
+        video: "retain-on-failure",
       },
     },
   ],


### PR DESCRIPTION
## Problem

E2E tests were flaky (~50% failure rate) for subfolder create-page tests, and the CI pipeline had several inefficiencies adding unnecessary time to each run.

⚡️ **Before: 7m 30s → After: 5m 00s (~33% faster, 1.5x)** on cache hit (i.e. `pnpm-lock.yaml` unchanged)

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `apps/studio/package.json`: Change `test-ci:e2e` to use `next start` instead of `next dev`. CI already runs `next build` first; the dev server lazily compiles routes, causing the folder page route to intermittently return 404 before compilation finished (~50% flake rate on subfolder tests).
- `.github/workflows/ci.yml`: Fix Next.js cache path from `${{ github.workspace }}/.next/cache` to `${{ github.workspace }}/apps/studio/.next/cache` — the cache was never populated or restored because the path pointed at the repo root instead of where Next.js actually writes it.

**Improvements**:

- `.github/workflows/ci.yml`: Remove the per-source-file hash (`hashFiles('**/*.js', ...')`) from the Next.js cache key. This was scanning and hashing every JS/TS file in the monorepo on every run (~40s overhead, twice per job). The `.next/cache` directory is Next.js's own SWC/webpack cache which handles internal invalidation itself — the GHA cache only needs to bust when dependencies change (`pnpm-lock.yaml`). Also fixes `restore-keys` which previously never matched anything.
- `apps/studio/playwright.config.ts`: Change `video` from `"on"` to `"retain-on-failure"` so video artifacts are only kept for failing tests, reducing CI storage usage and runtime.

## Before & After Screenshots

N/A — CI configuration changes only.

## Tests

No production code changes — no manual verification steps required.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a ~50% flake rate in subfolder e2e tests and speeds up CI by ~33% (7m30s → 5m00s) through three targeted configuration changes: correcting the Next.js cache path in CI, switching e2e tests from `next dev` to `next start`, and reducing Playwright video recording to failures only.

- **Root-cause fix for flaky tests**: `test-ci:e2e` now uses `next start` instead of `next dev`. Since CI already runs `next build` first, the dev server's lazy route compilation was causing the folder route to intermittently 404 before it compiled, causing ~50% test failure rate.
- **Cache path and key fixes**: The Next.js GHA cache path was pointing at the repo root (`.next/cache`) rather than the app directory (`apps/studio/.next/cache`), so the cache was never populated or restored; the per-source-file hash in the key added ~40s overhead twice per job and has been replaced with just the lockfile hash.
- **Artifact optimization**: Playwright video recording changed from `"on"` to `"retain-on-failure"`, reducing CI storage usage and runtime.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

All changes are CI/DX configuration only with no production code impact; each fix is well-targeted and correct.

The three changes each address a clearly identified and well-explained defect in CI configuration — wrong cache path, unnecessarily expensive cache key hash, and a non-deterministic dev server used where a production server was needed. No application logic is touched.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Fixes two bugs: the Next.js cache path (was repo root, now correctly `apps/studio/.next/cache`) and a cache-key redundancy (removes costly per-source-file hash); broadens `restore-keys` fallback which is an accepted trade-off as Next.js handles internal invalidation itself. |
| apps/studio/package.json | Changes `test-ci:e2e` to use `next start` instead of `next dev`, fixing flaky e2e tests; `next start` serves the already-built output deterministically without lazy route compilation. |
| apps/studio/playwright.config.ts | Switches Playwright video recording from `"on"` (always record) to `"retain-on-failure"` (only keep for failing tests), reducing CI artifact storage and runtime overhead. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;main&#39; into chore/e2e-test-..."](https://github.com/opengovsg/isomer/commit/79f1a7e137279facbd6f8ee7e1fee88bdf3a565a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40887627)</sub>

<!-- /greptile_comment -->