### PR TITLE
feat(studio): block DGS datasets over 4MB in database page editor

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDgsDatasetIdControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDgsDatasetIdControl.tsx
@@ -25,6 +25,7 @@ import {
 } from "@opengovsg/design-system-react"
 import {
   DGS_DATASET_ID_FORMAT,
+  DGS_REQUEST_MAX_BYTES,
   useDgsMetadata,
 } from "@opengovsg/isomer-components"
 import { useDebounce } from "@uidotdev/usehooks"
@@ -76,7 +77,12 @@ const DgsDatasetIdModal = ({
     enabled: !!datasetId,
   })
   const format = metadata?.format
-  const isValidDataset = format === "CSV"
+  // Datasets above 4MB require server-side search via the DGS "q" parameter,
+  // but not all datasets support "q". Disable until DGS rolls out OR filters
+  // or an equivalent that works universally.
+  const isDatasetTooLarge =
+    metadata?.size !== undefined && metadata.size > DGS_REQUEST_MAX_BYTES
+  const isValidDataset = format === "CSV" && !isDatasetTooLarge
 
   const isLoading = isValidatingDataset || isDebouncing
 
@@ -111,13 +117,16 @@ const DgsDatasetIdModal = ({
 
     setError("datasetId", {
       type: "manual",
-      message: format
-        ? "You can only link CSV datasets. Please check the dataset ID and try again."
-        : "This doesn’t look like a valid link from data.gov.sg. Check that you have the correct link and try again.",
+      message: isDatasetTooLarge
+        ? "This dataset exceeds the 4MB size limit and cannot be used. Please use a smaller dataset."
+        : format
+          ? "You can only link CSV datasets. Please check the dataset ID and try again."
+          : "This doesn’t look like a valid link from data.gov.sg. Check that you have the correct link and try again.",
     })
   }, [
     datasetId,
     isValidDataset,
+    isDatasetTooLarge,
     format,
     isValidatingDataset,
     setError,

--- a/apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
+import { http, HttpResponse } from "msw"
 import { expect, userEvent, waitFor, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
@@ -155,6 +156,44 @@ export const DatabaseModalValidDatasetId: Story = {
     await waitFor(() => screen.findByText(/Valid CSV dataset/), {
       timeout: 3000,
     })
+  },
+}
+
+export const DatabaseModalLargeDataset: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...COMMON_HANDLERS,
+        http.get(
+          "https://api-production.data.gov.sg/v2/public/api/datasets/:resourceId/metadata",
+          () =>
+            HttpResponse.json({
+              data: {
+                name: "Large dataset",
+                format: "CSV",
+                // 5MB — exceeds the 4MB limit
+                datasetSize: 5 * 1024 * 1024,
+                columnMetadata: { metaMapping: {} },
+              },
+            }),
+        ),
+      ],
+    },
+  },
+  play: async ({ canvasElement, ...rest }) => {
+    await DatabaseModalEmptyString.play?.({ canvasElement, ...rest })
+    const screen = within(canvasElement.ownerDocument.body)
+
+    const input = await screen.findByPlaceholderText("Paste dataset URL here")
+    await userEvent.type(input, "d_3f960c10fed6145404ca7b821f263b87")
+
+    await waitFor(
+      () =>
+        screen.findByText(
+          "This dataset exceeds the 4MB size limit and cannot be used. Please use a smaller dataset.",
+        ),
+      { timeout: 3000 },
+    )
   },
 }
 

--- a/apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx
@@ -181,8 +181,11 @@ export const DatabaseModalLargeDataset: Story = {
     },
   },
   play: async ({ canvasElement, ...rest }) => {
-    await DatabaseModalEmptyString.play?.({ canvasElement, ...rest })
+    await EditFixedBlockDatabase.play?.({ canvasElement, ...rest })
     const screen = within(canvasElement.ownerDocument.body)
+
+    const editButton = await screen.findByRole("button", { name: /edit/i })
+    await userEvent.click(editButton)
 
     const input = await screen.findByPlaceholderText("Paste dataset URL here")
     await userEvent.type(input, "d_3c55210de27fcccda2ed0c63fdd2b352")

--- a/apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx
@@ -151,7 +151,7 @@ export const DatabaseModalValidDatasetId: Story = {
     const screen = within(canvasElement.ownerDocument.body)
 
     const input = await screen.findByPlaceholderText("Paste dataset URL here")
-    await userEvent.type(input, "d_3f960c10fed6145404ca7b821f263b87")
+    await userEvent.type(input, "d_3c55210de27fcccda2ed0c63fdd2b352")
 
     await waitFor(() => screen.findByText(/Valid CSV dataset/), {
       timeout: 3000,
@@ -185,7 +185,7 @@ export const DatabaseModalLargeDataset: Story = {
     const screen = within(canvasElement.ownerDocument.body)
 
     const input = await screen.findByPlaceholderText("Paste dataset URL here")
-    await userEvent.type(input, "d_3f960c10fed6145404ca7b821f263b87")
+    await userEvent.type(input, "d_3c55210de27fcccda2ed0c63fdd2b352")
 
     await waitFor(
       () =>

--- a/packages/components/src/hooks/useDgsMetadata.ts
+++ b/packages/components/src/hooks/useDgsMetadata.ts
@@ -22,21 +22,33 @@ export const useDgsMetadata = ({
       return
     }
 
+    const controller = new AbortController()
+
     const fetchMetadata = async () => {
       setIsLoading(true)
       setMetadata(undefined)
       try {
-        const metadata = await fetchDgsMetadata({ resourceId })
+        const metadata = await fetchDgsMetadata({
+          resourceId,
+          signal: controller.signal,
+        })
         setMetadata(metadata)
         setIsError(false)
-      } catch {
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") {
+          return
+        }
         setIsError(true)
       } finally {
-        setIsLoading(false)
+        if (!controller.signal.aborted) setIsLoading(false)
       }
     }
 
     void fetchMetadata()
+
+    return () => {
+      controller.abort()
+    }
   }, [resourceId, enabled])
 
   return {

--- a/packages/components/src/hooks/useDgsMetadata.ts
+++ b/packages/components/src/hooks/useDgsMetadata.ts
@@ -24,6 +24,7 @@ export const useDgsMetadata = ({
 
     const fetchMetadata = async () => {
       setIsLoading(true)
+      setMetadata(undefined)
       try {
         const metadata = await fetchDgsMetadata({ resourceId })
         setMetadata(metadata)

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -11,6 +11,7 @@ export {
   TRIMMED_NON_EMPTY_STRING_REGEX,
   createChildrenPagesComparator,
   formatBytes,
+  DGS_REQUEST_MAX_BYTES,
 } from "./utils"
 export * from "./schemas"
 export * from "./types"

--- a/packages/components/src/utils/dgs/fetchDgsMetadata.ts
+++ b/packages/components/src/utils/dgs/fetchDgsMetadata.ts
@@ -2,6 +2,7 @@ import { isCkanInternalColumn } from "./isCkanInternalColumn"
 
 interface FetchDgsMetadataProps {
   resourceId: string
+  signal?: AbortSignal
 }
 
 interface MetaMappingType {
@@ -37,10 +38,12 @@ export type FetchDgsMetadataOutput = Pick<
 
 export const fetchDgsMetadata = async ({
   resourceId,
+  signal,
 }: FetchDgsMetadataProps): Promise<FetchDgsMetadataOutput> => {
   // For simplicity sake, we will always use data.gov.sg production API
   const response = await fetch(
     `https://api-production.data.gov.sg/v2/public/api/datasets/${resourceId}/metadata`,
+    { signal },
   )
 
   if (!response.ok) {

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -19,6 +19,7 @@ export {
   fetchDgsFileDownloadUrl,
   fetchDgsMetadata,
   getDgsIdFromDgsLink,
+  DGS_REQUEST_MAX_BYTES,
 } from "./dgs"
 export { fetchFileMetadata } from "./fetchFileMetadata"
 export { formatBytes } from "./formatBytes"


### PR DESCRIPTION
## Problem

Closes #

The database page editor allowed linking any CSV dataset from data.gov.sg, including those over 4MB. Datasets above 4MB require server-side search via the DGS \`q\` parameter, but not all datasets support \`q\`. This caused broken search behaviour for large datasets.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Validates dataset size when linking a dataset in the Database page editor modal — datasets exceeding 4MB are rejected with a clear error message: _"This dataset exceeds the 4MB size limit and cannot be used. Please use a smaller dataset."_
- Exports `DGS_REQUEST_MAX_BYTES` from `@opengovsg/isomer-components` so Studio can reference the same threshold constant used by the renderer.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Navigate to a Database page in Studio and open the database editor drawer.
- [ ] Click **Edit** on the dataset field to open the "Link a dataset" modal.
- [ ] Paste a data.gov.sg dataset URL for a CSV dataset whose size exceeds 4MB and confirm the error _"This dataset exceeds the 4MB size limit and cannot be used. Please use a smaller dataset."_ appears and the **Save Dataset ID** button remains disabled.
- [ ] Paste a data.gov.sg dataset URL for a CSV dataset under 4MB and confirm it validates successfully and the dataset can be saved.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR blocks oversized data.gov.sg CSV datasets in the database page editor. The main changes are:

- Adds a 4MB size check to the DGS dataset modal.
- Shows a clear error when a linked dataset is too large.
- Cancels stale metadata requests when the dataset ID changes.
- Exports the shared DGS request-size constant from the components package.
- Adds Storybook coverage for the large-dataset modal state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsDgsDatasetIdControl.tsx | Adds the dataset size validation and large-dataset error state in the editor modal. |
| packages/components/src/hooks/useDgsMetadata.ts | Clears old metadata and aborts obsolete metadata requests when the resource changes. |
| packages/components/src/utils/dgs/fetchDgsMetadata.ts | Accepts an optional abort signal for DGS metadata fetches. |
| packages/components/src/index.ts | Exports the DGS request-size constant from the public package entrypoint. |
| packages/components/src/utils/index.ts | Re-exports the DGS request-size constant through the utils barrel. |
| apps/studio/src/stories/Page/EditPage/EditDatabasePage.stories.tsx | Adds a Storybook scenario for the oversized DGS dataset warning. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: enhance DGS metadata fetching with ..."](https://github.com/opengovsg/isomer/commit/0f6aec4ec8b1af025452a541568fc4f219ab2b5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40979054)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - packages/components/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=8900a543-c1f2-41a7-a138-bcabc7c23b94))
- Context used - apps/studio/src/features/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=8ebd2c03-f007-45a9-87b4-39f408e532a6))
- Context used - risk taxonomy for Isomer to figure out blast radiu... ([source](https://app.greptile.com/opengovsg/-/custom-context?memory=2456b749-4c79-46ad-bf7c-e3922c4909ec))
</details>

<!-- /greptile_comment -->