### PR TITLE
fix: remove ssg.gov.sg from audit logs script

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -12,7 +12,6 @@ const __dirname = dirname(__filename)
 // Sites requiring audit logs
 const SITES_WITH_AUDIT_LOGS = [
   1, // stb.gov.sg
-  41, // ssg.gov.sg
   46, // sportsingapore.gov.sg
   48, // muis.gov.sg
   50, // knowledgehub.clc.gov.sg


### PR DESCRIPTION
Remove site 41 (ssg.gov.sg) from `SITES_WITH_AUDIT_LOGS` in `getAuditLogs.ts`.

Site is decommed alr

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the manual audit-log export script. The main change is:

- Removed `ssg.gov.sg` / site ID 41 from the hardcoded audit-log site list.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

The change is narrow, but the manual export list now omits a site that operators may still expect in compliance exports.

Only one script changed, and the risk is localized to missing generated CSV output rather than broader application behavior.

apps/studio/prisma/scripts/getAuditLogs.ts
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fprisma%2Fscripts%2FgetAuditLogs.ts%3A15%0A**Silent%20Site%20Export%20Omission**%0A%0AWhen%20an%20operator%20runs%20this%20script%20expecting%20the%20full%20audit-log%20export%20set%2C%20site%2041%20is%20now%20skipped%20with%20no%20warning%20or%20runtime%20override.%20The%20script%20still%20finishes%20with%20the%20normal%20success%20message%2C%20so%20the%20%60ssg.gov.sg%60%20CSVs%20can%20be%20missing%20from%20a%20compliance%20handoff%20without%20the%20operator%20noticing.%0A%0A&repo=opengovsg%2Fisomer&pr=2629&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fprisma%2Fscripts%2FgetAuditLogs.ts%3A15%0A**Silent%20Site%20Export%20Omission**%0A%0AWhen%20an%20operator%20runs%20this%20script%20expecting%20the%20full%20audit-log%20export%20set%2C%20site%2041%20is%20now%20skipped%20with%20no%20warning%20or%20runtime%20override.%20The%20script%20still%20finishes%20with%20the%20normal%20success%20message%2C%20so%20the%20%60ssg.gov.sg%60%20CSVs%20can%20be%20missing%20from%20a%20compliance%20handoff%20without%20the%20operator%20noticing.%0A%0A&pr=2629&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22fix-remove-ssg-audit-logs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix-remove-ssg-audit-logs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fprisma%2Fscripts%2FgetAuditLogs.ts%3A15%0A**Silent%20Site%20Export%20Omission**%0A%0AWhen%20an%20operator%20runs%20this%20script%20expecting%20the%20full%20audit-log%20export%20set%2C%20site%2041%20is%20now%20skipped%20with%20no%20warning%20or%20runtime%20override.%20The%20script%20still%20finishes%20with%20the%20normal%20success%20message%2C%20so%20the%20%60ssg.gov.sg%60%20CSVs%20can%20be%20missing%20from%20a%20compliance%20handoff%20without%20the%20operator%20noticing.%0A%0A&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=4"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/studio/prisma/scripts/getAuditLogs.ts:15
**Silent Site Export Omission**

When an operator runs this script expecting the full audit-log export set, site 41 is now skipped with no warning or runtime override. The script still finishes with the normal success message, so the `ssg.gov.sg` CSVs can be missing from a compliance handoff without the operator noticing.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove ssg.gov.sg (site 41) from au..."](https://github.com/opengovsg/isomer/commit/89b924f7e6546eb9f1e2b066e20f5d449e70ffa7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41045389)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - apps/studio/prisma/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=511e297b-11a8-4965-aa9a-a7db76a58b1c))

<!-- /greptile_comment -->