### PR TITLE
chore: enable Intercom on staging environment

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -44,3 +44,4 @@ jobs:
       app-s3-assets-bucket-name: "isomer-next-infra-stg-assets-private-b18ec1f"
       app-s3-assets-domain-name: "isomer-user-content-stg.by.gov.sg"
       app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
+      app-intercom-app-id: "jv2tjc3g"


### PR DESCRIPTION
## Problem

Intercom was removed from the staging deployment workflow, but Studio now relies on Intercom for in-product support and feedback flows (e.g. the Intercom messenger widget and CSAT surveys triggered after collection tag actions). Without Intercom enabled on staging, these features cannot be verified in a production-like environment before release, making pre-release testing harder and increasing the risk of regressions reaching production.

## Solution

Re-add `app-intercom-app-id` to `.github/workflows/deploy_staging.yml`, matching the configuration already used in UAT and production.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Staging deploys now pass `NEXT_PUBLIC_INTERCOM_APP_ID` to the Studio build, enabling the Intercom messenger on `https://staging-studio.isomer.gov.sg`
- Brings staging in line with UAT and production Intercom configuration (`jv2tjc3g`)

**Bug Fixes**:

- N/A

## Before & After Screenshots

N/A (deployment configuration change)

## Tests

- Deploy to staging and confirm the Intercom messenger widget loads for a logged-in user
- Trigger a collection tag CSAT survey flow and confirm the Intercom survey appears (clear `localStorage` for the survey key if retesting)

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores Intercom configuration for staging deployments. The main change is:

- Adds `app-intercom-app-id` to `.github/workflows/deploy_staging.yml` with the same app ID used by UAT and production.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is a single additive workflow input that matches UAT and production. No runtime logic, secret handling, or data paths are changed.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The base commit was evaluated and showed that jobs.deploy\_staging.with.app-intercom-app-id=None, which resolved NEXT\_PUBLIC\_INTERCOM\_APP\_ID from staging input '' and resulted in passes\_expected\_contract being false.
- The head commit was evaluated and showed that jobs.deploy\_staging.with.app-intercom-app-id='jv2tjc3g', which resolved NEXT\_PUBLIC\_INTERCOM\_APP\_ID to 'jv2tjc3g' for the Docker build steps and resulted in passes\_expected\_contract being true.

<a href="https://app.greptile.com/trex/runs/12942825/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy_staging.yml | Adds the staging Intercom app ID input to the reusable AWS deploy workflow, matching UAT and production configuration; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enable Intercom on staging deploy"](https://github.com/opengovsg/isomer/commit/309d5f7e97b8a142db7eaa4e0bb8ba2e8bf1f757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41149803)</sub>

<!-- /greptile_comment -->