### PR TITLE
chore(gazette): order published gazettes by publish date before file ID

### DIFF
--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -135,7 +135,9 @@ export const gazetteRouter = router({
           sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'description'`,
           (ob) => ob.desc(),
         )
-        // 4. Toppan file ID descending — the last path segment of page.ref.
+        // 4. Publish date descending
+        .orderBy("Version.publishedAt", (ob) => ob.desc())
+        // 5. Toppan file ID descending — the last path segment of page.ref.
         //    e.g. "/2026/Government Gazette/Advertisements/26adv6175b.pdf"
         //    -> "26adv6175b.pdf". Strip everything up to the final slash so we
         //    sort on the file ID, not the full path.
@@ -143,8 +145,6 @@ export const gazetteRouter = router({
           sql`regexp_replace(COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref', '.*/', '')`,
           (ob) => ob.desc(),
         )
-        // 5. Publish date descending
-        .orderBy("Version.publishedAt", (ob) => ob.desc())
         // 6. Updated at descending (tie-breaker)
         .orderBy("Resource.updatedAt", "desc")
         .orderBy("Resource.id", "asc")


### PR DESCRIPTION
## Problem

In the Government Gazettes dashboard, published gazettes were ordered by **Toppan file ID** before **publish date**. Following feedback from Toppan, this ordering is incorrect — within a given status, category, and notification-number tier, gazettes should surface by when they were published, not by the alphanumeric file ID of the underlying PDF.

## Solution

Swapped the relative priority of two `orderBy` clauses in the `gazette.list` tRPC procedure so that **publish date descending** is applied before **Toppan file ID descending**.

The full ordering is now:

1. Status priority (Scheduled → Published)
2. Category (Government Gazette → Legislative Supplements → Other Supplements)
3. Notification number (descending)
4. **Publish date (descending)** ← moved up
5. **Toppan file ID (descending)** ← moved down
6. Updated-at, then resource ID (tie-breakers)

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Gazettes in the dashboard are now ordered by publish date ahead of the Toppan file ID, matching the ordering Toppan expects. File ID remains as the secondary tie-breaker.

## Tests

Verify against the Government Gazettes dashboard (`/sites/[siteId]/gazettes`):

- Within the same category and notification-number group, gazettes appear ordered by most-recent publish date first.
- Where two gazettes share the same publish date, they fall back to Toppan file ID descending.
- Scheduled gazettes still sort ahead of published ones, and the existing category ordering is unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the ordering for published gazettes in the dashboard. The main changes are:

- Moves publish date sorting ahead of Toppan file ID sorting.
- Keeps Toppan file ID as the fallback sort after publish date.
- Preserves the existing status, category, notification number, updated-at, and resource ID ordering.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change only swaps two existing order priorities in a read-only gazette listing query. Authorization, filters, selected fields, pagination, and tie-breakers are unchanged, and no runtime or security issues were identified.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The initial test run attempted the base checkout and command execution, but failed due to a container runtime strategy error reported by testcontainers.
- A subsequent scoped execution was attempted against head, but it encountered the same environment blocker as before.
- The generated test file for the real tRPC fixture/path was included as evidence of the attempted fixture usage.

<a href="https://app.greptile.com/trex/runs/13026838/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/gazette/gazette.router.ts | Reorders the gazette list query so `Version.publishedAt` sorts before the derived Toppan file ID, with no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: fix ordering after call by toppan..."](https://github.com/opengovsg/isomer/commit/14b2f6d0894ed3fe25deacf1600d5d3336a4d439) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41304442)</sub>

<!-- /greptile_comment -->