### PR TITLE
chore(gazette): prioritise file ID over publish date for advertisements

### DIFF
--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -89,6 +89,15 @@ export const gazetteRouter = router({
         userId: ctx.user.id,
       })
 
+      // Toppan file ID — the last path segment of page.ref.
+      //   e.g. "/2026/Government Gazette/Advertisements/26adv6175b.pdf"
+      //   -> "26adv6175b.pdf". Strip everything up to the final slash so we
+      //   sort on the file ID, not the full path.
+      const fileId = sql`regexp_replace(COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref', '.*/', '')`
+      // Advertisements are a subcategory of Government Gazette, identified by
+      // the "/Advertisements/" segment in their file ref path.
+      const isAdvertisement = sql<boolean>`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref' ILIKE '%/Advertisements/%'`
+
       const results = await db
         .selectFrom("Resource")
         .leftJoin("Blob as DraftBlob", "Resource.draftBlobId", "DraftBlob.id")
@@ -135,14 +144,28 @@ export const gazetteRouter = router({
           sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'description'`,
           (ob) => ob.desc(),
         )
-        // 4. Publish date descending
-        .orderBy("Version.publishedAt", (ob) => ob.desc())
-        // 5. Toppan file ID descending — the last path segment of page.ref.
-        //    e.g. "/2026/Government Gazette/Advertisements/26adv6175b.pdf"
-        //    -> "26adv6175b.pdf". Strip everything up to the final slash so we
-        //    sort on the file ID, not the full path.
+        // 4. Advertisements form their own block within the category tier.
+        //    They need the opposite file-ID/publish-date priority to every
+        //    other gazette, so we separate the two groups here — a single sort
+        //    can't compare an advertisement against a non-advertisement when
+        //    each wants a different key to dominate. Non-advertisements first,
+        //    advertisements last.
+        .orderBy(isAdvertisement, "asc")
+        // 5a. Advertisements: Toppan file ID descending, then publish date.
+        .orderBy(sql`CASE WHEN ${isAdvertisement} THEN ${fileId} END`, (ob) =>
+          ob.desc(),
+        )
         .orderBy(
-          sql`regexp_replace(COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref', '.*/', '')`,
+          sql`CASE WHEN ${isAdvertisement} THEN "Version"."publishedAt" END`,
+          (ob) => ob.desc(),
+        )
+        // 5b. All other gazettes: publish date descending, then Toppan file ID.
+        .orderBy(
+          sql`CASE WHEN NOT ${isAdvertisement} THEN "Version"."publishedAt" END`,
+          (ob) => ob.desc(),
+        )
+        .orderBy(
+          sql`CASE WHEN NOT ${isAdvertisement} THEN ${fileId} END`,
           (ob) => ob.desc(),
         )
         // 6. Updated at descending (tie-breaker)

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -135,7 +135,9 @@ export const gazetteRouter = router({
           sql`COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'description'`,
           (ob) => ob.desc(),
         )
-        // 4. Toppan file ID descending — the last path segment of page.ref.
+        // 4. Publish date descending
+        .orderBy("Version.publishedAt", (ob) => ob.desc())
+        // 5. Toppan file ID descending — the last path segment of page.ref.
         //    e.g. "/2026/Government Gazette/Advertisements/26adv6175b.pdf"
         //    -> "26adv6175b.pdf". Strip everything up to the final slash so we
         //    sort on the file ID, not the full path.
@@ -143,8 +145,6 @@ export const gazetteRouter = router({
           sql`regexp_replace(COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref', '.*/', '')`,
           (ob) => ob.desc(),
         )
-        // 5. Publish date descending
-        .orderBy("Version.publishedAt", (ob) => ob.desc())
         // 6. Updated at descending (tie-breaker)
         .orderBy("Resource.updatedAt", "desc")
         .orderBy("Resource.id", "asc")


### PR DESCRIPTION
## Problem

Advertisements are a subcategory of Government Gazette, but they need the **opposite** sort priority to every other gazette in the Government Gazettes dashboard:

- **Advertisements** — Toppan file ID should outrank publish date.
- **All other gazettes** — publish date should outrank Toppan file ID (the ordering set in #2650).

A single fixed ordering can't express both. Priority in SQL is determined by the sequence of `ORDER BY` clauses, and the sorter can't compare an advertisement against a non-advertisement when each wants a different key to dominate.

## Solution

In the `gazette.list` tRPC procedure, advertisements are separated into their own block within the category tier, and each block is then given its own file-ID/publish-date priority.

Full ordering:

1. Status priority (Scheduled → Published)
2. Category (Government Gazette → Legislative Supplements → Other Supplements)
3. Notification number (descending)
4. **Advertisement discriminator** — non-advertisements first, advertisements last
5a. **Advertisements**: Toppan file ID desc, then publish date desc
5b. **All other gazettes**: publish date desc, then Toppan file ID desc
6. Updated-at, then resource ID (tie-breakers)

Technical notes:

- `isAdvertisement` is detected from the file ref path (`… ILIKE '%/Advertisements/%'`), since the subcategory itself is stored as a per-site tag UUID rather than a stable literal.
- The discriminator clause (`orderBy(isAdvertisement, "asc")`) separates advertisements and non-advertisements into contiguous blocks so their conflicting orderings never need to be compared against each other.
- Each block's ordering is applied through conditional `CASE` clauses; the clause that does not apply to a block evaluates to `NULL` (a constant within that block), so it has no effect there.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Advertisements are now ordered by Toppan file ID ahead of publish date, while every other gazette continues to be ordered by publish date ahead of file ID.

## Tests

Verify against the Government Gazettes dashboard (`/sites/[siteId]/gazettes`):

- Advertisements (ref path containing `/Advertisements/`) appear ordered by Toppan file ID descending, with publish date as the secondary key.
- All other gazettes appear ordered by publish date descending, with Toppan file ID as the secondary key.
- Advertisements form a contiguous block within the Government Gazette category rather than intermixing with non-advertisement entries.
- Status and category ordering are unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates `gazette.list` sorting for Government Gazette advertisements. The main changes are:

- Detects advertisements from the `page.ref` path segment.
- Separates advertisements from other gazettes inside the category tier.
- Applies file-ID-first ordering for advertisements and publish-date-first ordering for other gazettes.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR needs a targeted ordering fix before the dashboard behavior matches the intended advertisement grouping.

A single contained query-ordering issue remains: `page.description` has higher priority than the new advertisement discriminator, so advertisements without notification numbers can be placed before non-advertisements.

`apps/studio/src/server/modules/gazette/gazette.router.ts`
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The PostgreSQL harness for gazette advertisement ordering was attempted, but Docker was unavailable in the environment, so the container could not start.
- The harness run traces were reviewed, showing the exact commands attempted and error outputs; no gazette.list ordering result was produced, so no contract verdict could be reported.
- The before/after comparisons showed base ordering by file ID and head ordering by publish date, with both views returning 200 OK.
- The tests were blocked by a Testcontainers runtime blocker in Vitest, preventing any requests from being captured for base-router and head-router runs.

<a href="https://app.greptile.com/trex/runs/13027566/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/gazette/gazette.router.ts | Updates gazette list ordering to split advertisements and apply conditional file-ID/publish-date priority, but the notification-number sort still precedes the advertisement discriminator and can break the intended block order. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client as Gazette dashboard
participant Router as gazette.list tRPC
participant DB as PostgreSQL
Client->>Router: list(siteId, collectionId, limit, offset)
Router->>Router: validate gazette access and resource permissions
Router->>DB: Query Resource with blob/version joins
DB-->>Router: Rows ordered by status, category, notification, advertisement block, conditional keys
Router->>Router: Fetch S3 file sizes for returned refs
Router-->>Client: Gazette rows with fileSize and schedule/publish dates
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client as Gazette dashboard
participant Router as gazette.list tRPC
participant DB as PostgreSQL
Client->>Router: list(siteId, collectionId, limit, offset)
Router->>Router: validate gazette access and resource permissions
Router->>DB: Query Resource with blob/version joins
DB-->>Router: Rows ordered by status, category, notification, advertisement block, conditional keys
Router->>Router: Fetch S3 file sizes for returned refs
Router-->>Client: Gazette rows with fileSize and schedule/publish dates
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/studio/src/server/modules/gazette/gazette.router.ts`, line 142-153 ([link](https://github.com/opengovsg/isomer/blob/dd807be6f426cb181d959709da8573d6f8e5f0fc/apps/studio/src/server/modules/gazette/gazette.router.ts#L142-L153)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Advertisement block is split**
   `page.description` is sorted before `isAdvertisement`, so advertisements without notification numbers are ordered by the notification-number key before the discriminator runs. In PostgreSQL, `DESC` sorts `NULL` values first, and this module's context notes advertisements are published without a notification number, so those ads can appear ahead of non-advertisements instead of forming the intended non-advertisement-first contiguous block. Move the advertisement discriminator before the notification-number ordering or make the notification sort conditional per block.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/gazette/gazette.router.ts
   Line: 142-153

   Comment:
   **Advertisement block is split**
   `page.description` is sorted before `isAdvertisement`, so advertisements without notification numbers are ordered by the notification-number key before the discriminator runs. In PostgreSQL, `DESC` sorts `NULL` values first, and this module's context notes advertisements are published without a notification number, so those ads can appear ahead of non-advertisements instead of forming the intended non-advertisement-first contiguous block. Move the advertisement discriminator before the notification-number ordering or make the notification sort conditional per block.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fgazette%2Fgazette.router.ts%0ALine%3A%20142-153%0A%0AComment%3A%0A**Advertisement%20block%20is%20split**%0A%60page.description%60%20is%20sorted%20before%20%60isAdvertisement%60%2C%20so%20advertisements%20without%20notification%20numbers%20are%20ordered%20by%20the%20notification-number%20key%20before%20the%20discriminator%20runs.%20In%20PostgreSQL%2C%20%60DESC%60%20sorts%20%60NULL%60%20values%20first%2C%20and%20this%20module's%20context%20notes%20advertisements%20are%20published%20without%20a%20notification%20number%2C%20so%20those%20ads%20can%20appear%20ahead%20of%20non-advertisements%20instead%20of%20forming%20the%20intended%20non-advertisement-first%20contiguous%20block.%20Move%20the%20advertisement%20discriminator%20before%20the%20notification-number%20ordering%20or%20make%20the%20notification%20sort%20conditional%20per%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer&pr=2651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fgazette%2Fgazette.router.ts%0ALine%3A%20142-153%0A%0AComment%3A%0A**Advertisement%20block%20is%20split**%0A%60page.description%60%20is%20sorted%20before%20%60isAdvertisement%60%2C%20so%20advertisements%20without%20notification%20numbers%20are%20ordered%20by%20the%20notification-number%20key%20before%20the%20discriminator%20runs.%20In%20PostgreSQL%2C%20%60DESC%60%20sorts%20%60NULL%60%20values%20first%2C%20and%20this%20module's%20context%20notes%20advertisements%20are%20published%20without%20a%20notification%20number%2C%20so%20those%20ads%20can%20appear%20ahead%20of%20non-advertisements%20instead%20of%20forming%20the%20intended%20non-advertisement-first%20contiguous%20block.%20Move%20the%20advertisement%20discriminator%20before%20the%20notification-number%20ordering%20or%20make%20the%20notification%20sort%20conditional%20per%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22chore%2Fgazette-advertisement-ordering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fgazette-advertisement-ordering%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fgazette%2Fgazette.router.ts%0ALine%3A%20142-153%0A%0AComment%3A%0A**Advertisement%20block%20is%20split**%0A%60page.description%60%20is%20sorted%20before%20%60isAdvertisement%60%2C%20so%20advertisements%20without%20notification%20numbers%20are%20ordered%20by%20the%20notification-number%20key%20before%20the%20discriminator%20runs.%20In%20PostgreSQL%2C%20%60DESC%60%20sorts%20%60NULL%60%20values%20first%2C%20and%20this%20module's%20context%20notes%20advertisements%20are%20published%20without%20a%20notification%20number%2C%20so%20those%20ads%20can%20appear%20ahead%20of%20non-advertisements%20instead%20of%20forming%20the%20intended%20non-advertisement-first%20contiguous%20block.%20Move%20the%20advertisement%20discriminator%20before%20the%20notification-number%20ordering%20or%20make%20the%20notification%20sort%20conditional%20per%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=4"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=4"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fgazette%2Fgazette.router.ts%3A142-153%0A**Advertisement%20block%20is%20split**%0A%60page.description%60%20is%20sorted%20before%20%60isAdvertisement%60%2C%20so%20advertisements%20without%20notification%20numbers%20are%20ordered%20by%20the%20notification-number%20key%20before%20the%20discriminator%20runs.%20In%20PostgreSQL%2C%20%60DESC%60%20sorts%20%60NULL%60%20values%20first%2C%20and%20this%20module's%20context%20notes%20advertisements%20are%20published%20without%20a%20notification%20number%2C%20so%20those%20ads%20can%20appear%20ahead%20of%20non-advertisements%20instead%20of%20forming%20the%20intended%20non-advertisement-first%20contiguous%20block.%20Move%20the%20advertisement%20discriminator%20before%20the%20notification-number%20ordering%20or%20make%20the%20notification%20sort%20conditional%20per%20block.%0A%0A&repo=opengovsg%2Fisomer&pr=2651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fgazette%2Fgazette.router.ts%3A142-153%0A**Advertisement%20block%20is%20split**%0A%60page.description%60%20is%20sorted%20before%20%60isAdvertisement%60%2C%20so%20advertisements%20without%20notification%20numbers%20are%20ordered%20by%20the%20notification-number%20key%20before%20the%20discriminator%20runs.%20In%20PostgreSQL%2C%20%60DESC%60%20sorts%20%60NULL%60%20values%20first%2C%20and%20this%20module's%20context%20notes%20advertisements%20are%20published%20without%20a%20notification%20number%2C%20so%20those%20ads%20can%20appear%20ahead%20of%20non-advertisements%20instead%20of%20forming%20the%20intended%20non-advertisement-first%20contiguous%20block.%20Move%20the%20advertisement%20discriminator%20before%20the%20notification-number%20ordering%20or%20make%20the%20notification%20sort%20conditional%20per%20block.%0A%0A&pr=2651&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22chore%2Fgazette-advertisement-ordering%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fgazette-advertisement-ordering%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fgazette%2Fgazette.router.ts%3A142-153%0A**Advertisement%20block%20is%20split**%0A%60page.description%60%20is%20sorted%20before%20%60isAdvertisement%60%2C%20so%20advertisements%20without%20notification%20numbers%20are%20ordered%20by%20the%20notification-number%20key%20before%20the%20discriminator%20runs.%20In%20PostgreSQL%2C%20%60DESC%60%20sorts%20%60NULL%60%20values%20first%2C%20and%20this%20module's%20context%20notes%20advertisements%20are%20published%20without%20a%20notification%20number%2C%20so%20those%20ads%20can%20appear%20ahead%20of%20non-advertisements%20instead%20of%20forming%20the%20intended%20non-advertisement-first%20contiguous%20block.%20Move%20the%20advertisement%20discriminator%20before%20the%20notification-number%20ordering%20or%20make%20the%20notification%20sort%20conditional%20per%20block.%0A%0A&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=4"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=4"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/studio/src/server/modules/gazette/gazette.router.ts:142-153
**Advertisement block is split**
`page.description` is sorted before `isAdvertisement`, so advertisements without notification numbers are ordered by the notification-number key before the discriminator runs. In PostgreSQL, `DESC` sorts `NULL` values first, and this module's context notes advertisements are published without a notification number, so those ads can appear ahead of non-advertisements instead of forming the intended non-advertisement-first contiguous block. Move the advertisement discriminator before the notification-number ordering or make the notification sort conditional per block.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(gazette): prioritise file ID over ..."](https://github.com/opengovsg/isomer/commit/dd807be6f426cb181d959709da8573d6f8e5f0fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41305894)</sub>

<!-- /greptile_comment -->