### PR TITLE
feat(redirect): flag unpublished destinations on the redirects table

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -12,6 +12,7 @@ const __dirname = dirname(__filename)
 // Sites requiring audit logs
 const SITES_WITH_AUDIT_LOGS = [
   1, // stb.gov.sg
+  41, // ssg.gov.sg
   46, // sportsingapore.gov.sg
   48, // muis.gov.sg
   50, // knowledgehub.clc.gov.sg

--- a/apps/studio/src/constants/redirect.ts
+++ b/apps/studio/src/constants/redirect.ts
@@ -9,30 +9,28 @@
 export const RESERVED_SOURCE_PREFIXES = ["/_next"] as const
 
 // Codes returned by the redirect.validate preflight so the client can render a
-// specific message (and styling) per issue. Errors block creation; warnings do
-// not, but are surfaced so users can reconsider before the redirect goes live.
+// specific message per blocking issue. All of these block creation — advisory
+// destination-liveness is surfaced on the table row instead.
 export const RedirectValidationCode = {
   AlreadyExists: "ALREADY_EXISTS",
   RedirectLoop: "REDIRECT_LOOP",
   SourceIsExistingPage: "SOURCE_IS_EXISTING_PAGE",
-  DestinationIsRedirectSource: "DESTINATION_IS_REDIRECT_SOURCE",
-  DestinationNotFound: "DESTINATION_NOT_FOUND",
-  DestinationNotPublished: "DESTINATION_NOT_PUBLISHED",
 } as const
 export type RedirectValidationCode =
   (typeof RedirectValidationCode)[keyof typeof RedirectValidationCode]
 
-// User-facing copy shared between the validate preflight, the create-time
-// guards, and the add-redirect form, so the server and client can't drift.
-// Messages that interpolate the path (the loop detail and the chain warning)
-// are produced in the service since they aren't reused by the client.
+// User-facing copy shared between the validate preflight and the create-time
+// guards, so the server and client can't drift. Messages that interpolate the
+// path (the loop detail) are produced in the service since they aren't reused.
 export const REDIRECT_MESSAGES = {
   alreadyExists: "This page is already being redirected.",
   loop: "This will trap visitors in a never-ending loop.",
-  destinationNotLive:
-    "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
   sourceIsExistingPage:
     "A live page already uses this URL. The redirect would hide it. Move or unpublish that page first.",
+  // Shown on a table row whose destination points at a page/folder that isn't
+  // published yet, so the redirect currently leads nowhere.
+  destinationNotPublished:
+    "This page or folder you're redirecting to hasn't been published yet.",
 } as const
 
 export interface RedirectValidationIssue {
@@ -45,5 +43,4 @@ export interface RedirectValidationIssue {
 
 export interface RedirectValidationResult {
   errors: RedirectValidationIssue[]
-  warnings: RedirectValidationIssue[]
 }

--- a/apps/studio/src/features/settings/Redirects/__tests__/utils.test.ts
+++ b/apps/studio/src/features/settings/Redirects/__tests__/utils.test.ts
@@ -1,7 +1,9 @@
+import type { ResolvedDestination } from "../utils"
 import {
   formatAddedAt,
   getDestinationDisplay,
   isReferenceDestination,
+  shouldWarnDestination,
 } from "../utils"
 
 describe("formatAddedAt", () => {
@@ -99,18 +101,50 @@ describe("getDestinationDisplay", () => {
   })
 
   it("resolves a reference to the page's current permalink", () => {
-    const permalinkByReference = new Map([["[resource:1:2]", "/about/contact"]])
-    expect(
-      getDestinationDisplay("[resource:1:2]", permalinkByReference),
-    ).toEqual({ status: "resolved", label: "/about/contact" })
+    const infoByDestination = new Map<string, ResolvedDestination>([
+      ["[resource:1:2]", { permalink: "/about/contact", warn: false }],
+    ])
+    expect(getDestinationDisplay("[resource:1:2]", infoByDestination)).toEqual({
+      status: "resolved",
+      label: "/about/contact",
+    })
   })
 
   it("flags a reference whose page no longer exists as missing", () => {
-    const permalinkByReference = new Map<string, string | null>([
-      ["[resource:1:2]", null],
+    const infoByDestination = new Map<string, ResolvedDestination>([
+      ["[resource:1:2]", { permalink: null, warn: true }],
     ])
-    expect(
-      getDestinationDisplay("[resource:1:2]", permalinkByReference),
-    ).toEqual({ status: "missing" })
+    expect(getDestinationDisplay("[resource:1:2]", infoByDestination)).toEqual({
+      status: "missing",
+    })
+  })
+})
+
+describe("shouldWarnDestination", () => {
+  it("warns when the server flagged the destination as leading nowhere", () => {
+    const infoByDestination = new Map<string, ResolvedDestination>([
+      ["[resource:1:2]", { permalink: null, warn: true }],
+      ["/unpublished", { permalink: null, warn: true }],
+    ])
+    expect(shouldWarnDestination("[resource:1:2]", infoByDestination)).toBe(
+      true,
+    )
+    expect(shouldWarnDestination("/unpublished", infoByDestination)).toBe(true)
+  })
+
+  it("does not warn for a published destination", () => {
+    const infoByDestination = new Map<string, ResolvedDestination>([
+      ["[resource:1:2]", { permalink: "/about/contact", warn: false }],
+    ])
+    expect(shouldWarnDestination("[resource:1:2]", infoByDestination)).toBe(
+      false,
+    )
+  })
+
+  it("does not warn for a destination that is still resolving or external", () => {
+    expect(shouldWarnDestination("https://example.gov.sg", new Map())).toBe(
+      false,
+    )
+    expect(shouldWarnDestination("[resource:1:2]", new Map())).toBe(false)
   })
 })

--- a/apps/studio/src/features/settings/Redirects/api.ts
+++ b/apps/studio/src/features/settings/Redirects/api.ts
@@ -25,25 +25,6 @@ export function useCountRedirects(siteId: number) {
   return { data: data ?? 0, isLoading }
 }
 
-// Preflight a would-be redirect for non-blocking warnings (e.g. the
-// destination doesn't exist or isn't published yet). Only enabled once the
-// caller has a sync-valid source + destination, since validate shares the
-// create input schema and would otherwise reject the half-typed values.
-export function useValidateRedirect(
-  siteId: number,
-  input: { source: string; destination: string } | null,
-) {
-  const { data } = trpc.redirect.validate.useQuery(
-    {
-      siteId,
-      source: input?.source ?? "",
-      destination: input?.destination ?? "",
-    },
-    { enabled: input !== null },
-  )
-  return { warnings: data?.warnings ?? [] }
-}
-
 // Resolves stored [resource:...] destinations to the page's current permalink
 // for display. Kept separate from the list query so the read path stays plain;
 // the table calls this once with the references on the visible page.

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -7,8 +7,10 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
+  ListItem,
   Stack,
   Text,
+  UnorderedList,
   useDisclosure,
 } from "@chakra-ui/react"
 import {

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -7,10 +7,8 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
-  ListItem,
   Stack,
   Text,
-  UnorderedList,
   useDisclosure,
 } from "@chakra-ui/react"
 import {

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -7,7 +7,6 @@ import {
   Input,
   InputGroup,
   InputLeftAddon,
-  Stack,
   Text,
   useDisclosure,
 } from "@chakra-ui/react"
@@ -15,7 +14,6 @@ import {
   Button,
   FormErrorMessage,
   FormLabel,
-  Infobox,
   useToast,
 } from "@opengovsg/design-system-react"
 import { useState } from "react"
@@ -27,7 +25,7 @@ import {
 } from "~/constants/toast"
 import { useZodForm } from "~/lib/form"
 
-import { useCreateRedirect, useValidateRedirect } from "../api"
+import { useCreateRedirect } from "../api"
 import { addRedirectSchema, type AddRedirectInput } from "../types"
 import { SelectDestinationPageModal } from "./SelectDestinationPageModal"
 
@@ -45,7 +43,6 @@ export const AddRedirectCard = ({
     setError,
     clearErrors,
     watch,
-    getValues,
     setValue,
     formState: { errors },
   } = useZodForm<typeof addRedirectSchema>({
@@ -67,27 +64,11 @@ export const AddRedirectCard = ({
   // destination field is focused (per the design).
   const [isDestinationFocused, setIsDestinationFocused] = useState(false)
 
-  // Non-blocking warnings (e.g. the destination doesn't exist / isn't
-  // published) are fetched on blur once the inputs are sync-valid.
-  const [validateInput, setValidateInput] = useState<AddRedirectInput | null>(
-    null,
-  )
-  const { warnings } = useValidateRedirect(siteId, validateInput)
-
-  const checkForWarnings = () => {
-    const parsed = addRedirectSchema.safeParse(getValues())
-    setValidateInput(parsed.success ? parsed.data : null)
-  }
-  // Drop any shown warning the moment a field changes, so it never lingers
-  // against edited input. (reset() doesn't fire onChange, so a successful add
-  // clears it explicitly in onSuccess below.)
-  const clearWarnings = () => setValidateInput(null)
-  // On edit, also clear any server-set error on that field — otherwise an
-  // inline "already redirected" / "loop" error (set via setError, which the
+  // On edit, clear any server-set error on that field — otherwise an inline
+  // "already redirected" / "loop" error (set via setError, which the
   // onSubmit-mode form doesn't revalidate) would linger over freshly-typed
   // input.
   const clearFieldFeedback = (field: keyof AddRedirectInput) => () => {
-    clearWarnings()
     clearErrors(field)
   }
 
@@ -100,7 +81,6 @@ export const AddRedirectCard = ({
       {
         onSuccess: () => {
           reset()
-          clearWarnings()
           toast({ ...SETTINGS_TOAST_MESSAGES.success, status: "success" })
         },
         // The inputs are left untouched on error so the user can fix the
@@ -170,7 +150,6 @@ export const AddRedirectCard = ({
             <Input
               placeholder="redirect-from"
               {...register("source", {
-                onBlur: checkForWarnings,
                 onChange: clearFieldFeedback("source"),
               })}
             />
@@ -204,10 +183,7 @@ export const AddRedirectCard = ({
               size="sm"
               onFocus={() => setIsDestinationFocused(true)}
               {...register("destination", {
-                onBlur: () => {
-                  setIsDestinationFocused(false)
-                  checkForWarnings()
-                },
+                onBlur: () => setIsDestinationFocused(false),
                 onChange: clearFieldFeedback("destination"),
               })}
             />
@@ -254,16 +230,6 @@ export const AddRedirectCard = ({
             )}
           </Box>
           <FormErrorMessage>{errors.destination?.message}</FormErrorMessage>
-
-          {warnings.length > 0 && (
-            <Stack spacing="0.5rem" mt="0.5rem">
-              {warnings.map((warning) => (
-                <Infobox key={warning.code} variant="warning" size="sm">
-                  {warning.message}
-                </Infobox>
-              ))}
-            </Stack>
-          )}
         </FormControl>
 
         <Box flexShrink={0} ml="0.5rem">

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -93,6 +93,10 @@ function DestinationCell({
   const label = isMissing ? MISSING_PAGE_LABEL : display.label
   const color = isMissing ? "utility.feedback.critical" : "base.content.strong"
   const { head, tail } = splitForMiddleTruncation(label)
+  // A missing reference already reads as "Page no longer exists" in red — the
+  // not-yet-published icon would contradict that, so only warn when the label
+  // itself isn't already flagging the problem.
+  const showWarningIcon = showWarning && !isMissing
   return (
     <HStack spacing="0.5rem" align="center" overflow="hidden" w="full">
       <Tooltip
@@ -129,7 +133,7 @@ function DestinationCell({
           </Text>
         </HStack>
       </Tooltip>
-      {showWarning && (
+      {showWarningIcon && (
         <Tooltip
           label={REDIRECT_MESSAGES.destinationNotPublished}
           placement="top"

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -20,12 +20,14 @@ import {
 import { useEffect, useMemo, useState } from "react"
 import {
   BiDownArrowAlt,
+  BiSolidErrorCircle,
   BiSortAlt2,
   BiTrash,
   BiUpArrowAlt,
 } from "react-icons/bi"
 import { TableHeader } from "~/components/Datatable"
 import { Datatable } from "~/components/Datatable/Datatable"
+import { REDIRECT_MESSAGES } from "~/constants/redirect"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
@@ -34,7 +36,7 @@ import { useIsTruncated } from "~/hooks/useIsTruncated"
 import { useTablePagination } from "~/hooks/useTablePagination"
 
 import type { RedirectRow, RedirectSortField } from "../types"
-import type { DestinationDisplay } from "../utils"
+import type { DestinationDisplay, ResolvedDestination } from "../utils"
 import {
   REDIRECTS_PAGE_SIZE,
   useCountRedirects,
@@ -46,6 +48,7 @@ import {
   formatAddedAt,
   getDestinationDisplay,
   isReferenceDestination,
+  shouldWarnDestination,
 } from "../utils"
 import { DeleteRedirectModal } from "./DeleteRedirectModal"
 import { RedirectsEmptyPlaceholder } from "./RedirectsEmptyPlaceholder"
@@ -70,11 +73,15 @@ const splitForMiddleTruncation = (value: string) => {
 // Renders a pre-resolved redirect destination. Reference destinations arrive as
 // the page's current permalink; while that resolution is in flight we show a
 // skeleton, and a reference whose page no longer exists is flagged rather than
-// leaking the raw "[resource:...]" string.
+// leaking the raw "[resource:...]" string. When the destination has no published
+// page behind it (missing or not-yet-published), a warning icon is pinned to the
+// end of the column.
 function DestinationCell({
   display,
+  showWarning,
 }: {
   display: DestinationDisplay
+  showWarning: boolean
 }): JSX.Element {
   const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>()
 
@@ -87,34 +94,63 @@ function DestinationCell({
   const color = isMissing ? "utility.feedback.critical" : "base.content.strong"
   const { head, tail } = splitForMiddleTruncation(label)
   return (
-    <Tooltip
-      label={label}
-      openDelay={500}
-      placement="top"
-      isDisabled={!isTruncated}
-    >
-      <HStack spacing="0" align="center" overflow="hidden">
-        <Text
-          ref={ref}
-          textStyle="body-2"
-          color={color}
-          minW={0}
+    <HStack spacing="0.5rem" align="center" overflow="hidden" w="full">
+      <Tooltip
+        label={label}
+        openDelay={500}
+        placement="top"
+        isDisabled={!isTruncated}
+      >
+        <HStack
+          spacing="0"
+          align="center"
           overflow="hidden"
-          whiteSpace="nowrap"
-          textOverflow="ellipsis"
+          minW={0}
+          flexShrink={1}
         >
-          {head}
-        </Text>
-        <Text
-          textStyle="body-2"
-          color={color}
-          flexShrink={0}
-          whiteSpace="nowrap"
+          <Text
+            ref={ref}
+            textStyle="body-2"
+            color={color}
+            minW={0}
+            overflow="hidden"
+            whiteSpace="nowrap"
+            textOverflow="ellipsis"
+          >
+            {head}
+          </Text>
+          <Text
+            textStyle="body-2"
+            color={color}
+            flexShrink={0}
+            whiteSpace="nowrap"
+          >
+            {tail}
+          </Text>
+        </HStack>
+      </Tooltip>
+      {showWarning && (
+        <Tooltip
+          label={REDIRECT_MESSAGES.destinationNotPublished}
+          placement="top"
         >
-          {tail}
-        </Text>
-      </HStack>
-    </Tooltip>
+          <Box
+            as="span"
+            ml="auto"
+            flexShrink={0}
+            display="inline-flex"
+            lineHeight="0"
+          >
+            <Icon
+              as={BiSolidErrorCircle}
+              boxSize="1rem"
+              color="utility.feedback.warning"
+              aria-label={REDIRECT_MESSAGES.destinationNotPublished}
+            />
+          </Box>
+        </Tooltip>
+      )}
+    </HStack>
   )
 }
 
@@ -191,7 +227,13 @@ function SourceCell({ source }: { source: string }): JSX.Element {
       placement="top"
       isDisabled={!isTextTruncated && !isRowTruncated}
     >
-      <HStack ref={rowRef} spacing="0" align="center" overflow="hidden">
+      <HStack
+        ref={rowRef}
+        spacing="0"
+        align="center"
+        overflow="hidden"
+        minW={0}
+      >
         <Text
           ref={textRef}
           textStyle="body-2"
@@ -243,7 +285,7 @@ function SourceCell({ source }: { source: string }): JSX.Element {
 
 const getColumns = (
   onDeleteClick: (row: RedirectRow) => void,
-  permalinkByReference: Map<string, string | null>,
+  infoByDestination: Map<string, ResolvedDestination>,
 ) => [
   columnsHelper.accessor("source", {
     minSize: 250,
@@ -255,7 +297,7 @@ const getColumns = (
         onClick={column.getToggleSortingHandler()}
       />
     ),
-    cell: ({ getValue }) => <SourceCell source={getValue()} />,
+    cell: ({ row }) => <SourceCell source={row.original.source} />,
   }),
   columnsHelper.accessor("destination", {
     minSize: 250,
@@ -269,7 +311,8 @@ const getColumns = (
     ),
     cell: ({ getValue }) => (
       <DestinationCell
-        display={getDestinationDisplay(getValue(), permalinkByReference)}
+        display={getDestinationDisplay(getValue(), infoByDestination)}
+        showWarning={shouldWarnDestination(getValue(), infoByDestination)}
       />
     ),
   }),
@@ -347,34 +390,41 @@ export const RedirectsTable = ({
     sortDirection: (sorting[0]?.desc ?? true) ? "desc" : "asc",
   })
 
-  // Resolve the reference destinations on the visible page to permalinks for
-  // display, in one batched request rather than per row
-  const referenceDestinations = useMemo(
+  // Resolve the internal destinations on the visible page in one batched
+  // request rather than per row — references resolve to their current permalink
+  // for display, and every internal destination reports whether it currently
+  // leads to a published page (for the not-yet-published warning). External
+  // URLs need neither, so they're left out.
+  const internalDestinations = useMemo(
     () =>
       Array.from(
         new Set(
           redirects
             .map((redirect) => redirect.destination)
-            .filter(isReferenceDestination),
+            .filter(
+              (destination) =>
+                isReferenceDestination(destination) ||
+                destination.startsWith("/"),
+            ),
         ),
       ),
     [redirects],
   )
-  const { data: resolvedReferences } = useResolveRedirectReferences(
+  const { data: resolvedDestinations } = useResolveRedirectReferences(
     siteId,
-    referenceDestinations,
+    internalDestinations,
   )
-  const permalinkByReference = useMemo(() => {
-    const map = new Map<string, string | null>()
-    resolvedReferences.forEach(({ reference, permalink }) =>
-      map.set(reference, permalink),
+  const infoByDestination = useMemo(() => {
+    const map = new Map<string, ResolvedDestination>()
+    resolvedDestinations.forEach(({ reference, permalink, warn }) =>
+      map.set(reference, { permalink, warn }),
     )
     return map
-  }, [resolvedReferences])
+  }, [resolvedDestinations])
 
   const columns = useMemo(
-    () => getColumns(setRedirectToDelete, permalinkByReference),
-    [permalinkByReference],
+    () => getColumns(setRedirectToDelete, infoByDestination),
+    [infoByDestination],
   )
 
   // Changing the sort order reshuffles rows across pages, so jump back to
@@ -440,7 +490,7 @@ export const RedirectsTable = ({
             ? destinationLabelFor(
                 getDestinationDisplay(
                   redirectToDelete.destination,
-                  permalinkByReference,
+                  infoByDestination,
                 ),
               )
             : ""

--- a/apps/studio/src/features/settings/Redirects/utils.ts
+++ b/apps/studio/src/features/settings/Redirects/utils.ts
@@ -20,6 +20,14 @@ const REFERENCE_DESTINATION_REGEX = new RegExp(
 export const isReferenceDestination = (destination: string): boolean =>
   REFERENCE_DESTINATION_REGEX.test(destination)
 
+// Resolved info for a stored internal destination: a reference's current
+// permalink for display (null once the page is gone), and `warn` — true when the
+// destination has no published page behind it (missing or not-yet-published).
+export interface ResolvedDestination {
+  permalink: string | null
+  warn: boolean
+}
+
 // Resolution state of a stored destination for display. The status is a stable
 // sentinel — user-facing copy for the "missing" case lives at the render site,
 // so the wording can change without touching this logic.
@@ -33,16 +41,24 @@ export type DestinationDisplay =
 // "resolving" until the lookup lands; non-references show verbatim.
 export const getDestinationDisplay = (
   destination: string,
-  permalinkByReference: Map<string, string | null>,
+  infoByDestination: Map<string, ResolvedDestination>,
 ): DestinationDisplay => {
   if (!isReferenceDestination(destination)) {
     return { status: "resolved", label: destination }
   }
-  if (!permalinkByReference.has(destination)) {
+  const info = infoByDestination.get(destination)
+  if (!info) {
     return { status: "resolving" }
   }
-  const permalink = permalinkByReference.get(destination) ?? null
-  return permalink === null
+  return info.permalink === null
     ? { status: "missing" }
-    : { status: "resolved", label: permalink }
+    : { status: "resolved", label: info.permalink }
 }
+
+// Whether the table should flag this destination as leading nowhere (missing or
+// not-yet-published). Driven by the server's resolved `warn`; external URLs and
+// still-resolving references don't warn.
+export const shouldWarnDestination = (
+  destination: string,
+  infoByDestination: Map<string, ResolvedDestination>,
+): boolean => infoByDestination.get(destination)?.warn ?? false

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2349,12 +2349,13 @@ describe("page.router", async () => {
         site.id,
         Number(page.id),
       )
+      const literalDestination = normalizeRedirectPath(fullPermalink!)
       await db
         .insertInto("Redirect")
         .values({
           siteId: site.id,
           source: "/old-url",
-          destination: normalizeRedirectPath(fullPermalink!),
+          destination: literalDestination,
         })
         .execute()
 
@@ -2369,6 +2370,40 @@ describe("page.router", async () => {
         .where("source", "=", "/old-url")
         .executeTakeFirstOrThrow()
       expect(redirect.destination).toEqual(`[resource:${site.id}:${page.id}]`)
+
+      // Assert — a RedirectDelete entry records the literal form being retired
+      const deleteEntry = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .where("siteId", "=", site.id)
+        .where("eventType", "=", "RedirectDelete")
+        .executeTakeFirstOrThrow()
+      expect(deleteEntry.userId).toBe(session.userId)
+      const deleteDelta = deleteEntry.delta as {
+        before: { destination: string; deletedAt: string | null }
+        after: { destination: string; deletedAt: string | null }
+      }
+      expect(deleteDelta.before.destination).toBe(literalDestination)
+      expect(deleteDelta.before.deletedAt).toBeNull()
+      expect(deleteDelta.after.destination).toBe(literalDestination)
+      expect(deleteDelta.after.deletedAt).not.toBeNull()
+
+      // Assert — a RedirectCreate entry records the reference form being adopted
+      const createEntry = await db
+        .selectFrom("AuditLog")
+        .selectAll()
+        .where("siteId", "=", site.id)
+        .where("eventType", "=", "RedirectCreate")
+        .executeTakeFirstOrThrow()
+      expect(createEntry.userId).toBe(session.userId)
+      const createDelta = createEntry.delta as {
+        before: null
+        after: { destination: string }
+      }
+      expect(createDelta.before).toBeNull()
+      expect(createDelta.after.destination).toBe(
+        `[resource:${site.id}:${page.id}]`,
+      )
     })
 
     it("should leave a literal redirect to a different path untouched on publish", async () => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -400,7 +400,7 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result).toEqual({ errors: [], warnings: [] })
+      expect(result).toEqual({ errors: [] })
     })
 
     it("should report no issues for a redirect to a published page", async () => {
@@ -415,7 +415,7 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result).toEqual({ errors: [], warnings: [] })
+      expect(result).toEqual({ errors: [] })
     })
 
     it("should error when a live redirect already exists for the source", async () => {
@@ -488,7 +488,7 @@ describe("redirect.router", async () => {
     it("should not flag a multi-hop cycle as a loop (only one hop is checked)", async () => {
       // Arrange — /b -> /c and /c -> /a already exist. Adding /a -> /b closes a
       // three-redirect cycle, but loop detection only looks one hop deep by
-      // design, so this surfaces as a chain warning rather than a loop error.
+      // design, so it is allowed rather than flagged as a loop error.
       await db
         .insertInto("Redirect")
         .values([
@@ -508,16 +508,11 @@ describe("redirect.router", async () => {
       expect(result.errors).not.toContainEqual(
         expect.objectContaining({ code: "REDIRECT_LOOP" }),
       )
-      expect(result.warnings).toContainEqual({
-        code: "DESTINATION_IS_REDIRECT_SOURCE",
-        message:
-          "This page already redirects to /c. Visitors will end up there instead.",
-      })
     })
 
     it("should not flag a multi-hop chain that never returns to the source", async () => {
       // Arrange — /b -> /c -> /d terminates at /d, so adding /a -> /b chains but
-      // does not loop; it is a warning, not an error.
+      // does not loop, so it is allowed.
       await db
         .insertInto("Redirect")
         .values([
@@ -560,187 +555,6 @@ describe("redirect.router", async () => {
 
       // Assert
       expect(result.errors).toEqual([])
-    })
-
-    it("should warn when the destination is itself a separate redirect source", async () => {
-      // Arrange
-      // /b redirects to /c, so /a -> /b would chain through /b to /c
-      await db
-        .insertInto("Redirect")
-        .values({ siteId, source: "/b", destination: "/c" })
-        .execute()
-
-      // Act
-      const result = await caller.validate({
-        siteId,
-        source: "/a",
-        destination: "/b",
-      })
-
-      // Assert
-      expect(result.errors).toEqual([])
-      expect(result.warnings).toContainEqual({
-        code: "DESTINATION_IS_REDIRECT_SOURCE",
-        message:
-          "This page already redirects to /c. Visitors will end up there instead.",
-      })
-    })
-
-    it("should warn when the internal destination does not exist", async () => {
-      // Arrange / Act
-      const result = await caller.validate({
-        siteId,
-        source: "/old",
-        destination: "/missing",
-      })
-
-      // Assert
-      expect(result.warnings).toContainEqual({
-        code: "DESTINATION_NOT_FOUND",
-        message:
-          "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
-      })
-    })
-
-    it("should warn when the internal destination exists but is not published", async () => {
-      // Arrange
-      await seedPageAtRoot({ permalink: "draft-page", published: false })
-
-      // Act
-      const result = await caller.validate({
-        siteId,
-        source: "/old",
-        destination: "/draft-page",
-      })
-
-      // Assert
-      expect(result.warnings).toContainEqual({
-        code: "DESTINATION_NOT_PUBLISHED",
-        message:
-          "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
-      })
-    })
-
-    it("should not warn for a published page nested under a folder", async () => {
-      // Arrange — /folder/leaf, where leaf is a published page under a folder.
-      // This exercises the multi-segment walk past depth 1.
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.RootPage,
-        parentId: null,
-      })
-      const { folder } = await setupFolder({
-        siteId,
-        permalink: "folder",
-        parentId: null,
-      })
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.Page,
-        parentId: folder.id,
-        permalink: "leaf",
-        state: ResourceState.Published,
-        userId,
-      })
-
-      // Act
-      const result = await caller.validate({
-        siteId,
-        source: "/old",
-        destination: "/folder/leaf",
-      })
-
-      // Assert
-      expect(result.warnings).toEqual([])
-    })
-
-    it("should not warn for a folder whose index page is published", async () => {
-      // Arrange — "/folder" is served by the folder's published IndexPage, so
-      // it must resolve as published (exercises the folder->IndexPage branch).
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.RootPage,
-        parentId: null,
-      })
-      const { folder } = await setupFolder({
-        siteId,
-        permalink: "folder",
-        parentId: null,
-      })
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.IndexPage,
-        parentId: folder.id,
-        state: ResourceState.Published,
-        userId,
-      })
-
-      // Act
-      const result = await caller.validate({
-        siteId,
-        source: "/old",
-        destination: "/folder",
-      })
-
-      // Assert
-      expect(result.warnings).toEqual([])
-    })
-
-    it("should not warn for a published destination that carries a #fragment", async () => {
-      // Arrange — an internal destination may keep a literal "#fragment"; it must
-      // still resolve to the underlying published page rather than 404-ing.
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.RootPage,
-        parentId: null,
-      })
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.Page,
-        parentId: null,
-        permalink: "leaf",
-        state: ResourceState.Published,
-        userId,
-      })
-
-      // Act
-      const result = await caller.validate({
-        siteId,
-        source: "/old",
-        destination: "/leaf#section",
-      })
-
-      // Assert
-      expect(result.warnings).toEqual([])
-    })
-
-    it("should warn NOT_PUBLISHED for a folder with no index page", async () => {
-      // Arrange — a folder with no IndexPage has no live page at its URL, so
-      // resolution falls back to the (unpublished) container.
-      await setupPageResource({
-        siteId,
-        resourceType: ResourceType.RootPage,
-        parentId: null,
-      })
-      await setupFolder({
-        siteId,
-        permalink: "folder",
-        parentId: null,
-      })
-
-      // Act
-      const result = await caller.validate({
-        siteId,
-        source: "/old",
-        destination: "/folder",
-      })
-
-      // Assert
-      expect(result.warnings).toContainEqual({
-        code: "DESTINATION_NOT_PUBLISHED",
-        message:
-          "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
-      })
     })
 
     it("should error when the source is the URL of a published page", async () => {
@@ -1427,6 +1241,8 @@ describe("redirect.router", async () => {
         siteId,
         resourceType: ResourceType.Page,
         permalink: "target-page",
+        state: ResourceState.Published,
+        userId: session.userId,
       })
       const reference = `[resource:${siteId}:${page.id}]`
 
@@ -1437,7 +1253,31 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result).toEqual([{ reference, permalink: "/target-page" }])
+      expect(result).toEqual([
+        { reference, permalink: "/target-page", warn: false },
+      ])
+    })
+
+    it("should warn for a reference whose page exists but is not published", async () => {
+      // Arrange — a draft page resolves to its permalink for display, but has no
+      // live page behind it yet, so the redirect currently leads nowhere.
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "draft-page",
+      })
+      const reference = `[resource:${siteId}:${page.id}]`
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference, permalink: "/draft-page", warn: true },
+      ])
     })
 
     it("should resolve a nested reference to its full permalink", async () => {
@@ -1464,7 +1304,7 @@ describe("redirect.router", async () => {
 
       // Assert
       expect(result).toEqual([
-        { reference, permalink: "/parent-folder/child-page" },
+        { reference, permalink: "/parent-folder/child-page", warn: false },
       ])
     })
 
@@ -1477,6 +1317,8 @@ describe("redirect.router", async () => {
         resourceType: ResourceType.IndexPage,
         permalink: "_index",
         parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId,
       })
       const reference = `[resource:${siteId}:${indexPage.id}]`
 
@@ -1487,10 +1329,10 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result).toEqual([{ reference, permalink: "/info" }])
+      expect(result).toEqual([{ reference, permalink: "/info", warn: false }])
     })
 
-    it("should resolve a deleted page's reference to null", async () => {
+    it("should resolve a deleted page's reference to null and warn", async () => {
       // Arrange — a reference to a resource that doesn't exist
       const reference = `[resource:${siteId}:999999]`
 
@@ -1501,10 +1343,10 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result).toEqual([{ reference, permalink: null }])
+      expect(result).toEqual([{ reference, permalink: null, warn: true }])
     })
 
-    it("should resolve a reference whose embedded siteId is not this site to null", async () => {
+    it("should resolve a reference whose embedded siteId is not this site to null and warn", async () => {
       // Arrange — the resourceId exists on this site, but the reference claims a
       // different site, so it must not resolve here.
       const { page } = await setupPageResource({
@@ -1521,7 +1363,182 @@ describe("redirect.router", async () => {
       })
 
       // Assert
-      expect(result).toEqual([{ reference, permalink: null }])
+      expect(result).toEqual([{ reference, permalink: null, warn: true }])
+    })
+
+    it("should not resolve or warn for an external URL destination", async () => {
+      // Arrange — external URLs aren't internal destinations; they never warn.
+      const reference = "https://www.example.gov.sg/page"
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [reference],
+      })
+
+      // Assert
+      expect(result).toEqual([{ reference, permalink: null, warn: false }])
+    })
+
+    it("should not warn for a literal path to a published page (no permalink echoed)", async () => {
+      // Arrange — a literal "/path" destination shows as typed (permalink stays
+      // null), and only warns when it has no published page behind it.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: null,
+        permalink: "leaf",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/leaf"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/leaf", permalink: null, warn: false },
+      ])
+    })
+
+    it("should not warn for a literal path to a published page carrying a #fragment", async () => {
+      // Arrange — a literal destination may keep a "#fragment"; resolution must
+      // strip it and still find the underlying published page.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: null,
+        permalink: "leaf",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/leaf#section"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/leaf#section", permalink: null, warn: false },
+      ])
+    })
+
+    it("should warn for a literal path to an unpublished page", async () => {
+      // Arrange
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: null,
+        permalink: "draft-leaf",
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/draft-leaf"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/draft-leaf", permalink: null, warn: true },
+      ])
+    })
+
+    it("should warn for a literal path that matches no page", async () => {
+      // Arrange / Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/missing"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/missing", permalink: null, warn: true },
+      ])
+    })
+
+    it("should not warn for a folder whose index page is published", async () => {
+      // Arrange — "/folder" is served by the folder's published IndexPage, so it
+      // resolves as published (exercises the folder -> IndexPage branch).
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/folder"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/folder", permalink: null, warn: false },
+      ])
+    })
+
+    it("should warn for a folder whose index page is not published", async () => {
+      // Arrange — a folder with an unpublished IndexPage has no live page at its
+      // URL, so it warns.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/folder"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/folder", permalink: null, warn: true },
+      ])
     })
   })
 

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -26,6 +26,7 @@ import {
   normalizeRedirectSource,
 } from "~/schemas/redirect"
 import { getReferenceLink } from "~/utils/link"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { Logger } from "@isomer/logging"
 
@@ -117,33 +118,127 @@ const resolveDestinationForStorage = async (
   }
 }
 
-// Resolves stored [resource:...] destinations back to current permalinks for
-// display, batched into one query. A reference to a missing page resolves to null.
+// Batch publish-state for a set of resource ids. A Page/CollectionPage is live
+// when it has a published version; a Folder/Collection is served by its
+// IndexPage, so it's live when that index page is published (mirrors
+// getResourceByFullPermalink's container handling).
+const getPublishedStateByResourceIds = async (
+  siteId: number,
+  resourceIds: number[],
+): Promise<Map<number, boolean>> => {
+  const result = new Map<number, boolean>()
+  if (resourceIds.length === 0) {
+    return result
+  }
+  const ids = resourceIds.map(String)
+  const resources = await db
+    .selectFrom("Resource")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.id", "in", ids)
+    .select(["Resource.id", "Resource.type", "Resource.publishedVersionId"])
+    .execute()
+
+  const containerIds = resources
+    .filter(
+      (r) =>
+        r.type === ResourceType.Folder || r.type === ResourceType.Collection,
+    )
+    .map((r) => String(r.id))
+  const publishedByContainerId = new Map<string, boolean>()
+  if (containerIds.length > 0) {
+    const indexPages = await db
+      .selectFrom("Resource")
+      .where("Resource.siteId", "=", siteId)
+      .where("Resource.parentId", "in", containerIds)
+      .where("Resource.type", "=", ResourceType.IndexPage)
+      .select(["Resource.parentId", "Resource.publishedVersionId"])
+      .execute()
+    for (const indexPage of indexPages) {
+      publishedByContainerId.set(
+        String(indexPage.parentId),
+        indexPage.publishedVersionId !== null,
+      )
+    }
+  }
+
+  for (const resource of resources) {
+    const isContainer =
+      resource.type === ResourceType.Folder ||
+      resource.type === ResourceType.Collection
+    result.set(
+      Number(resource.id),
+      isContainer
+        ? (publishedByContainerId.get(String(resource.id)) ?? false)
+        : resource.publishedVersionId !== null,
+    )
+  }
+  return result
+}
+
+// Resolves stored internal destinations (both [resource:...] references and
+// literal "/paths") for the table. For references it returns the destination
+// page's current permalink for display (null if the page is gone). `warn` is
+// true when the destination doesn't resolve to a published page — i.e. it's
+// missing (no such page/folder) or exists but isn't published yet — so the
+// table can flag redirects that currently lead nowhere. External URLs never
+// warn. Input keeps the `references` name but accepts any internal destination.
 export const resolveRedirectReferences = async ({
   siteId,
   references,
 }: ResolveRedirectReferencesInput): Promise<
-  { reference: string; permalink: string | null }[]
+  { reference: string; permalink: string | null; warn: boolean }[]
 > => {
-  // Resolve only references that are anchored AND belong to this site — a
-  // reference to another site can't resolve here, so it stays unresolved.
-  const parsed = references.map((reference) => {
-    const match = REFERENCE_DESTINATION_REGEX.exec(reference)
-    return {
-      reference,
-      resourceId:
-        match && Number(match[1]) === siteId ? Number(match[2]) : null,
-    }
-  })
+  // A literal path may carry a "?query"/"#fragment" that isn't part of the
+  // resource path — resolve against the bare path.
+  const stripQueryFragment = (value: string) => value.split(/[?#]/)[0] ?? value
+
+  // Classify each destination and resolve literal paths to a resource id.
+  // References are anchored AND must belong to this site; a cross-site
+  // reference can't resolve here.
+  const parsed = await Promise.all(
+    references.map(async (reference) => {
+      const match = REFERENCE_DESTINATION_REGEX.exec(reference)
+      if (match) {
+        const resourceId = Number(match[1]) === siteId ? Number(match[2]) : null
+        return { reference, kind: "reference" as const, resourceId }
+      }
+      if (reference.startsWith("/")) {
+        const resourceId = await getResourceIdByPermalink(
+          siteId,
+          stripQueryFragment(reference),
+        )
+        return { reference, kind: "literal" as const, resourceId }
+      }
+      return { reference, kind: "external" as const, resourceId: null }
+    }),
+  )
+
   const resourceIds = parsed
     .map(({ resourceId }) => resourceId)
     .filter((id): id is number => id !== null)
-  const permalinks = await getResourceFullPermalinks(siteId, resourceIds)
-  return parsed.map(({ reference, resourceId }) => ({
-    reference,
-    permalink:
-      resourceId === null ? null : (permalinks.get(resourceId) ?? null),
-  }))
+  const [permalinks, publishedState] = await Promise.all([
+    getResourceFullPermalinks(siteId, resourceIds),
+    getPublishedStateByResourceIds(siteId, resourceIds),
+  ])
+
+  return parsed.map(({ reference, kind, resourceId }) => {
+    if (kind === "external") {
+      return { reference, permalink: null, warn: false }
+    }
+    // Only references render the resolved permalink; a literal path shows as
+    // typed, so its display permalink stays null.
+    const permalink =
+      kind === "reference" && resourceId !== null
+        ? (permalinks.get(resourceId) ?? null)
+        : null
+    // Warn when the internal destination has no published page behind it: the
+    // resource is missing (no id, or a reference whose page was deleted) or it
+    // exists but isn't published yet.
+    const isMissing =
+      resourceId === null || (kind === "reference" && permalink === null)
+    const warn = isMissing || !(publishedState.get(resourceId ?? -1) ?? false)
+    return { reference, permalink, warn }
+  })
 }
 
 const getByUser = async (byUserId: string) =>
@@ -245,15 +340,15 @@ const getChainedRedirect = async (
   return { redirect, normalizedDestination, target, isLoop }
 }
 
-// Preflight for redirect.create: returns blocking errors and non-blocking
-// warnings without mutating. Advisory only — create re-enforces every error.
+// Preflight for redirect.create: returns blocking errors without mutating.
+// Advisory only — create re-enforces every error. Destination-liveness is no
+// longer warned here; the table flags not-yet-published destinations instead.
 export const validateRedirect = async ({
   siteId,
   source,
   destination,
 }: CreateRedirectInput): Promise<RedirectValidationResult> => {
   const errors: RedirectValidationIssue[] = []
-  const warnings: RedirectValidationIssue[] = []
 
   // Recreating a live redirect for the same source is not allowed — the user
   // must delete the existing one first.
@@ -288,33 +383,9 @@ export const validateRedirect = async ({
       message: REDIRECT_MESSAGES.loop,
       description: `${chained.normalizedDestination} already redirects to ${source}. Visitors will get stuck in between pages. Delete existing redirects or direct to a different page.`,
     })
-  } else if (chained) {
-    warnings.push({
-      code: RedirectValidationCode.DestinationIsRedirectSource,
-      message: `This page already redirects to ${chained.target}. Visitors will end up there instead.`,
-    })
-  } else if (destination.startsWith("/")) {
-    // An internal destination with no redirect of its own should point at a
-    // real, published page.
-    const normalizedDestination = normalizeRedirectPath(destination)
-    const resource = await getResourceByFullPermalink({
-      siteId,
-      fullPermalink: normalizedDestination,
-    })
-    if (!resource) {
-      warnings.push({
-        code: RedirectValidationCode.DestinationNotFound,
-        message: REDIRECT_MESSAGES.destinationNotLive,
-      })
-    } else if (resource.publishedVersionId === null) {
-      warnings.push({
-        code: RedirectValidationCode.DestinationNotPublished,
-        message: REDIRECT_MESSAGES.destinationNotLive,
-      })
-    }
   }
 
-  return { errors, warnings }
+  return { errors }
 }
 
 export const listRedirects = async ({

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -39,6 +39,7 @@ import {
   getResourceByFullPermalink,
   getResourceFullPermalinks,
   getResourceIdByPermalink,
+  getResourceIdsByPermalinks,
 } from "../resource/resource.service"
 
 // Sort field → column. `publishedAt` maps to `createdAt`; `satisfies` keeps the
@@ -192,26 +193,42 @@ export const resolveRedirectReferences = async ({
   // resource path — resolve against the bare path.
   const stripQueryFragment = (value: string) => value.split(/[?#]/)[0] ?? value
 
-  // Classify each destination and resolve literal paths to a resource id.
-  // References are anchored AND must belong to this site; a cross-site
-  // reference can't resolve here.
-  const parsed = await Promise.all(
-    references.map(async (reference) => {
-      const match = REFERENCE_DESTINATION_REGEX.exec(reference)
-      if (match) {
-        const resourceId = Number(match[1]) === siteId ? Number(match[2]) : null
-        return { reference, kind: "reference" as const, resourceId }
+  // Classify each destination synchronously. References are anchored AND must
+  // belong to this site; a cross-site reference can't resolve here. Literal
+  // paths carry their bare path so they can be resolved together in one batch
+  // (rather than a DB round-trip each).
+  const classified = references.map((reference) => {
+    const match = REFERENCE_DESTINATION_REGEX.exec(reference)
+    if (match) {
+      const resourceId = Number(match[1]) === siteId ? Number(match[2]) : null
+      return { reference, kind: "reference" as const, resourceId, path: null }
+    }
+    if (reference.startsWith("/")) {
+      return {
+        reference,
+        kind: "literal" as const,
+        resourceId: null,
+        path: stripQueryFragment(reference),
       }
-      if (reference.startsWith("/")) {
-        const resourceId = await getResourceIdByPermalink(
-          siteId,
-          stripQueryFragment(reference),
-        )
-        return { reference, kind: "literal" as const, resourceId }
-      }
-      return { reference, kind: "external" as const, resourceId: null }
-    }),
+    }
+    return {
+      reference,
+      kind: "external" as const,
+      resourceId: null,
+      path: null,
+    }
+  })
+
+  const idByPath = await getResourceIdsByPermalinks(
+    siteId,
+    classified.flatMap(({ path }) => (path !== null ? [path] : [])),
   )
+
+  const parsed = classified.map(({ reference, kind, resourceId, path }) => ({
+    reference,
+    kind,
+    resourceId: path !== null ? (idByPath.get(path) ?? null) : resourceId,
+  }))
 
   const resourceIds = parsed
     .map(({ resourceId }) => resourceId)

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -26,6 +26,7 @@ import type { Logger } from "@isomer/logging"
 import type {
   Footer,
   Navbar,
+  Redirect,
   Resource,
   SafeKysely,
   Site,
@@ -1210,12 +1211,21 @@ export const publishPageResource = async ({
         if (backfilled.length > 0) {
           const byUser = await getUserById(userId)
           for (const rewritten of backfilled) {
-            const literal = { ...rewritten, destination: literalDestination }
+            const literalBefore: Redirect = {
+              ...rewritten,
+              destination: literalDestination,
+              deletedAt: null,
+            }
+            const literalAfter: Redirect = {
+              ...rewritten,
+              destination: literalDestination,
+              deletedAt: new Date(),
+            }
             await logRedirectEvent(tx, {
               siteId,
               by: byUser,
               eventType: AuditLogEvent.RedirectDelete,
-              delta: { before: literal, after: literal },
+              delta: { before: literalBefore, after: literalAfter },
             })
             await logRedirectEvent(tx, {
               siteId,

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1034,6 +1034,81 @@ export const getResourceIdByPermalink = async (
   return Number(leaf.id)
 }
 
+// Batched variant of getResourceIdByPermalink: resolves many full-permalink
+// paths to the resource sitting at each path in a single pair of queries rather
+// than one walk (and round-trip) per path. Returns each path's leaf resource id
+// — a folder/collection resolves to its own id — regardless of publish state; a
+// path matching no resource maps to null. Liveness (including whether a
+// container has a published index page) is left to the caller's publish-state
+// lookup, so this is used to resolve the literal-path redirect destinations on
+// the visible page without an N+1.
+export const getResourceIdsByPermalinks = async (
+  siteId: number,
+  fullPermalinks: string[],
+): Promise<Map<string, number | null>> => {
+  const result = new Map<string, number | null>()
+  const uniquePaths = [...new Set(fullPermalinks)]
+  if (uniquePaths.length === 0) {
+    return result
+  }
+
+  const segmentsByPath = new Map(
+    uniquePaths.map((path) => [path, path.split("/").filter(Boolean)]),
+  )
+  const needsRoot = [...segmentsByPath.values()].some(
+    (segments) => segments.length === 0,
+  )
+  const allSegments = [...new Set([...segmentsByPath.values()].flat())]
+
+  // One query for every candidate segment across all paths, plus the root page
+  // only when a bare "/" path is present — two round-trips regardless of N.
+  const [root, candidates] = await Promise.all([
+    needsRoot
+      ? db
+          .selectFrom("Resource")
+          .where("Resource.siteId", "=", siteId)
+          .where("Resource.type", "=", ResourceType.RootPage)
+          .where("Resource.parentId", "is", null)
+          .select("Resource.id")
+          .executeTakeFirst()
+      : Promise.resolve(undefined),
+    allSegments.length > 0
+      ? db
+          .selectFrom("Resource")
+          .where("Resource.siteId", "=", siteId)
+          .where("Resource.permalink", "in", allSegments)
+          .select(["Resource.id", "Resource.permalink", "Resource.parentId"])
+          .execute()
+      : Promise.resolve([]),
+  ])
+
+  for (const [path, segments] of segmentsByPath) {
+    if (segments.length === 0) {
+      result.set(path, root ? Number(root.id) : null)
+      continue
+    }
+    // Walk the (parentId, permalink) chain in memory — the same unambiguous
+    // step the singular helper makes, resolved against the shared candidate set.
+    let parentId: string | null = null
+    let leafId: number | null = null
+    let resolved = true
+    for (const segment of segments) {
+      const match = candidates.find(
+        (candidate) =>
+          candidate.permalink === segment && candidate.parentId === parentId,
+      )
+      if (!match) {
+        resolved = false
+        break
+      }
+      leafId = Number(match.id)
+      parentId = String(match.id)
+    }
+    result.set(path, resolved ? leafId : null)
+  }
+  return result
+}
+
 interface PublishPageResourceArgs {
   logger: Logger<string>
   userId: string

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -50,7 +50,6 @@ export const Default: Story = {
       handlers: [
         redirectHandlers.list.default(),
         redirectHandlers.count.default(),
-        redirectHandlers.validate.noIssues(),
         ...COMMON_HANDLERS,
       ],
     },
@@ -64,7 +63,6 @@ export const Empty: Story = {
       handlers: [
         redirectHandlers.list.empty(),
         redirectHandlers.count.empty(),
-        redirectHandlers.validate.noIssues(),
         ...COMMON_HANDLERS,
       ],
     },
@@ -96,7 +94,6 @@ export const AlreadyExistsError: Story = {
         redirectHandlers.list.default(),
         redirectHandlers.count.default(),
         redirectHandlers.create.alreadyExists(),
-        redirectHandlers.validate.noIssues(),
         ...COMMON_HANDLERS,
       ],
     },
@@ -118,7 +115,6 @@ export const RedirectLoopError: Story = {
         redirectHandlers.list.default(),
         redirectHandlers.count.default(),
         redirectHandlers.create.loop(),
-        redirectHandlers.validate.noIssues(),
         ...COMMON_HANDLERS,
       ],
     },
@@ -133,39 +129,5 @@ export const RedirectLoopError: Story = {
     // The loop error is inline only — the generic failure toast must not also
     // fire (regression guard for the error switch falling through to default).
     await expect(screen.queryByText("Failed to add redirect")).toBeNull()
-  },
-}
-
-// Typing a destination that doesn't resolve to a page and blurring the field
-// surfaces a (non-blocking) warning beneath the row.
-export const DestinationNotFoundWarning: Story = {
-  parameters: {
-    growthbook: [createRedirectionsEnabledGbParameters(true)],
-    msw: {
-      handlers: [
-        redirectHandlers.list.default(),
-        redirectHandlers.count.default(),
-        redirectHandlers.validate.destinationNotFound(),
-        ...COMMON_HANDLERS,
-      ],
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const screen = within(canvasElement.ownerDocument.body)
-    await userEvent.type(
-      await screen.findByPlaceholderText("redirect-from"),
-      "old-page",
-    )
-    await userEvent.type(
-      screen.getByPlaceholderText("/path-to-page or https://www.google.com"),
-      "/no-page",
-    )
-    // Blur the destination to trigger the on-blur validate call.
-    await userEvent.tab()
-    await expect(
-      await screen.findByText(
-        "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
-      ),
-    ).toBeVisible()
   },
 }

--- a/apps/studio/tests/msw/handlers/redirect.ts
+++ b/apps/studio/tests/msw/handlers/redirect.ts
@@ -44,21 +44,6 @@ export const redirectHandlers = {
         throw new TRPCError({ code: "UNPROCESSABLE_CONTENT" })
       }),
   },
-  validate: {
-    noIssues: () =>
-      trpcMsw.redirect.validate.query(() => ({ errors: [], warnings: [] })),
-    destinationNotFound: () =>
-      trpcMsw.redirect.validate.query(() => ({
-        errors: [],
-        warnings: [
-          {
-            code: "DESTINATION_NOT_FOUND",
-            message:
-              "This page doesn't exist on your site yet. Make sure the page is live before publishing this redirect.",
-          },
-        ],
-      })),
-  },
   getBySource: {
     // The URL is not a redirect source — no settings warning shown.
     none: () => trpcMsw.redirect.getBySource.query(() => null),


### PR DESCRIPTION
## Problem

When adding a redirect, we used to run a create-time preflight that produced **non-blocking warnings** if the destination didn't point at a live, published page (missing page, unpublished page, or a destination that was itself a redirect source). These warnings appeared only in the add-redirect form at the moment of creation. Once a redirect was in the table, there was no ongoing signal that its destination had since been deleted or was never published — so the list could silently contain redirects that lead nowhere.

## Solution

Move destination-liveness feedback out of the create-time form and onto the redirects **table**, where it stays accurate over time.

- The `redirect.resolveReferences` resolver now classifies **every** internal destination — both `[resource:...]` references and literal `/paths` — and reports, per destination, its current display permalink and a `warn` flag. `warn` is true when the destination has no published page behind it: it's missing (no such page/folder, or a reference whose page was deleted) or it exists but isn't published yet. External URLs never warn.
- Publish-state is computed in one batched query. A Page/CollectionPage is live when it has a published version; a Folder/Collection is served by its IndexPage, so it's live when that index page is published (mirroring `getResourceByFullPermalink`'s container handling).
- The table shows an amber warning icon pinned to the end of the **destination** column for any row whose destination currently leads nowhere. Hovering it explains the destination hasn't been published yet.
- The create-time warning path is removed from `validateRedirect` (it now returns `{ errors }` only). Blocking errors (already-exists, redirect loop, source-is-existing-page) are unchanged — creation still re-enforces every error.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Destination-liveness is surfaced continuously in the redirects table instead of only once at creation time, so redirects that break later (destination deleted or unpublished) are now visible.
- The warning covers literal `/path` destinations too, not just internal page references.
- Removes the advisory warnings from the add-redirect form, simplifying the create flow.

## Before & After Screenshots

**BEFORE**:

No signal in the table when a redirect's destination is missing or unpublished; warnings only appeared transiently in the add-redirect form.

**AFTER**:

An amber warning icon appears at the end of the destination column for rows whose destination points at a missing or not-yet-published page/folder. Published destinations remain unmarked.

## Tests

**Manual Verification Steps**:

- [ ] Go to **Site settings → Redirects** for a site that has redirects.
- [ ] Confirm rows whose destination is a **missing** page/folder (e.g. a path that no longer resolves) show an amber warning icon at the end of the "Redirect them to" column.
- [ ] Confirm rows whose destination exists but is **not published yet** also show the warning icon.
- [ ] Hover the icon and confirm the tooltip reads that the page/folder hasn't been published yet.
- [ ] Confirm rows pointing at a **published** page/folder show **no** icon.
- [ ] Add a new redirect whose destination is an unpublished/missing internal path and confirm creation is **not blocked** by a warning (only the genuine blocking errors — already-redirected source, redirect loop, source-is-an-existing-page — still block).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves redirect destination liveness feedback from the add form to the redirects table. The main changes are:

- Resolves visible internal redirect destinations with `permalink` and `warn` metadata.
- Shows an amber warning icon when a destination has no published page or folder behind it.
- Removes create-time non-blocking destination warnings from redirect validation.
- Adds batched literal-path resource resolution to avoid per-row lookups.
- Updates tests, stories, and MSW fixtures for the new table-driven warning flow.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

No correctness or security issues were found in the changed redirect table, validation, or resource-resolution flow. The server-side behavior is covered by targeted tests for references, literal paths, missing resources, and publish state.

No files require special attention.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated TREX API contract: after-state includes warn flags and current permalinks.
- Documented blockers preventing UI flow: Storybook startup failures captured in redirects table logs, blocking UI capture.
- Recorded environment/test-run blockers: initial dependency install killed by SIGKILL, and later container-runtime setup error prevented tests from running.

<a href="https://app.greptile.com/trex/runs/13256105/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/redirect/redirect.service.ts | Moves destination liveness classification into `resolveReferences` with batched publish-state checks; no issues found. |
| apps/studio/src/server/modules/resource/resource.service.ts | Adds batched permalink-to-resource resolution for redirect table literal paths; no issues found. |
| apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx | Resolves visible internal destinations and displays warning icons for unpublished literal or reference destinations; no issues found. |
| apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx | Removes non-blocking warning fetching and rendering from the add redirect form; no issues found. |
| apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts | Updates validation expectations and adds resolveReferences coverage for publish-state warnings; no issues found. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Table as RedirectsTable
  participant API as tRPC redirect.resolveReferences
  participant Redirect as redirect.service
  participant Resource as resource.service
  participant DB as Database

  Table->>API: visible internal destinations
  API->>Redirect: resolveRedirectReferences(siteId, references)
  Redirect->>Resource: getResourceIdsByPermalinks(literal paths)
  Resource->>DB: batch fetch path segment candidates
  DB-->>Resource: resource ids or null
  Resource-->>Redirect: idByPath
  Redirect->>Resource: getResourceFullPermalinks(reference ids)
  Redirect->>DB: batch fetch publish state/index pages
  Resource-->>Redirect: display permalinks
  DB-->>Redirect: published-state map
  Redirect-->>API: "{ reference, permalink, warn }[]"
  API-->>Table: resolved destinations
  Table->>Table: "render permalink/path and warning icon when warn=true"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Table as RedirectsTable
  participant API as tRPC redirect.resolveReferences
  participant Redirect as redirect.service
  participant Resource as resource.service
  participant DB as Database

  Table->>API: visible internal destinations
  API->>Redirect: resolveRedirectReferences(siteId, references)
  Redirect->>Resource: getResourceIdsByPermalinks(literal paths)
  Resource->>DB: batch fetch path segment candidates
  DB-->>Resource: resource ids or null
  Resource-->>Redirect: idByPath
  Redirect->>Resource: getResourceFullPermalinks(reference ids)
  Redirect->>DB: batch fetch publish state/index pages
  Resource-->>Redirect: display permalinks
  DB-->>Redirect: published-state map
  Redirect-->>API: "{ reference, permalink, warn }[]"
  API-->>Table: resolved destinations
  Table->>Table: "render permalink/path and warning icon when warn=true"
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `apps/studio/src/server/modules/redirect/redirect.service.ts`, line 109-110 ([link](https://github.com/opengovsg/isomer/blob/9dfdf72b180645f14471d7e76543b5d4bad73616/apps/studio/src/server/modules/redirect/redirect.service.ts#L109-L110)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Stale comment — the preflight no longer warns about destination liveness; that warning was removed in this PR. The comment should be updated to reflect that the literal path is kept as-is (no warning, the table will flag it instead).

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/redirect/redirect.service.ts
   Line: 109-110

   Comment:
   Stale comment — the preflight no longer warns about destination liveness; that warning was removed in this PR. The comment should be updated to reflect that the literal path is kept as-is (no warning, the table will flag it instead).

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%20109-110%0A%0AComment%3A%0AStale%20comment%20%E2%80%94%20the%20preflight%20no%20longer%20warns%20about%20destination%20liveness%3B%20that%20warning%20was%20removed%20in%20this%20PR.%20The%20comment%20should%20be%20updated%20to%20reflect%20that%20the%20literal%20path%20is%20kept%20as-is%20%28no%20warning%2C%20the%20table%20will%20flag%20it%20instead%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20No%20resource%20at%20this%20path%20%E2%80%94%20keep%20the%20literal%20path%3B%20the%20redirects%20table%0A%20%20%20%20%20%20%2F%2F%20will%20flag%20it%20as%20leading%20nowhere%20once%20it's%20been%20saved.%0A%20%20%20%20%20%20if%20%28resourceId%20%3D%3D%3D%20null%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer&pr=2652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%20109-110%0A%0AComment%3A%0AStale%20comment%20%E2%80%94%20the%20preflight%20no%20longer%20warns%20about%20destination%20liveness%3B%20that%20warning%20was%20removed%20in%20this%20PR.%20The%20comment%20should%20be%20updated%20to%20reflect%20that%20the%20literal%20path%20is%20kept%20as-is%20%28no%20warning%2C%20the%20table%20will%20flag%20it%20instead%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20No%20resource%20at%20this%20path%20%E2%80%94%20keep%20the%20literal%20path%3B%20the%20redirects%20table%0A%20%20%20%20%20%20%2F%2F%20will%20flag%20it%20as%20leading%20nowhere%20once%20it's%20been%20saved.%0A%20%20%20%20%20%20if%20%28resourceId%20%3D%3D%3D%20null%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%2206-23-redirect-destination-warning-on-table%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2206-23-redirect-destination-warning-on-table%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%20109-110%0A%0AComment%3A%0AStale%20comment%20%E2%80%94%20the%20preflight%20no%20longer%20warns%20about%20destination%20liveness%3B%20that%20warning%20was%20removed%20in%20this%20PR.%20The%20comment%20should%20be%20updated%20to%20reflect%20that%20the%20literal%20path%20is%20kept%20as-is%20%28no%20warning%2C%20the%20table%20will%20flag%20it%20instead%29.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%2F%2F%20No%20resource%20at%20this%20path%20%E2%80%94%20keep%20the%20literal%20path%3B%20the%20redirects%20table%0A%20%20%20%20%20%20%2F%2F%20will%20flag%20it%20as%20leading%20nowhere%20once%20it's%20been%20saved.%0A%20%20%20%20%20%20if%20%28resourceId%20%3D%3D%3D%20null%29%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=4"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=4"></picture></a>

2. `apps/studio/src/server/modules/redirect/redirect.service.ts`, line 491-493 ([link](https://github.com/opengovsg/isomer/blob/9dfdf72b180645f14471d7e76543b5d4bad73616/apps/studio/src/server/modules/redirect/redirect.service.ts#L491-L493)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Stale comment — the preflight no longer produces warnings, so "the preflight already warned" is no longer accurate after this PR.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/redirect/redirect.service.ts
   Line: 491-493

   Comment:
   Stale comment — the preflight no longer produces warnings, so "the preflight already warned" is no longer accurate after this PR.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%20491-493%0A%0AComment%3A%0AStale%20comment%20%E2%80%94%20the%20preflight%20no%20longer%20produces%20warnings%2C%20so%20%22the%20preflight%20already%20warned%22%20is%20no%20longer%20accurate%20after%20this%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Resolve%20an%20internal-path%20destination%20to%20a%20%5Bresource%3A...%5D%20reference%20%28so%20it%0A%20%20%20%20%2F%2F%20follows%20page%20renames%29%3B%20a%20path%20with%20no%20live%20page%20yet%20is%20kept%20literal.%0A%20%20%20%20%2F%2F%20Never%20blocks%20the%20create.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer&pr=2652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%20491-493%0A%0AComment%3A%0AStale%20comment%20%E2%80%94%20the%20preflight%20no%20longer%20produces%20warnings%2C%20so%20%22the%20preflight%20already%20warned%22%20is%20no%20longer%20accurate%20after%20this%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Resolve%20an%20internal-path%20destination%20to%20a%20%5Bresource%3A...%5D%20reference%20%28so%20it%0A%20%20%20%20%2F%2F%20follows%20page%20renames%29%3B%20a%20path%20with%20no%20live%20page%20yet%20is%20kept%20literal.%0A%20%20%20%20%2F%2F%20Never%20blocks%20the%20create.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=2652&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%2206-23-redirect-destination-warning-on-table%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%2206-23-redirect-destination-warning-on-table%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%20491-493%0A%0AComment%3A%0AStale%20comment%20%E2%80%94%20the%20preflight%20no%20longer%20produces%20warnings%2C%20so%20%22the%20preflight%20already%20warned%22%20is%20no%20longer%20accurate%20after%20this%20PR.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Resolve%20an%20internal-path%20destination%20to%20a%20%5Bresource%3A...%5D%20reference%20%28so%20it%0A%20%20%20%20%2F%2F%20follows%20page%20renames%29%3B%20a%20path%20with%20no%20live%20page%20yet%20is%20kept%20literal.%0A%20%20%20%20%2F%2F%20Never%20blocks%20the%20create.%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=4"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=4"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(redirect): address review on destina..."](https://github.com/opengovsg/isomer/commit/da6cff7d8ba0f482cec1075e6a3f4dc102a6c339) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41310256)</sub>

<!-- /greptile_comment -->