### PR TITLE
fix(editor): stabilise JsonForms schema identity to stop dropped hero image writes

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
@@ -4,7 +4,7 @@ import { Box, Flex, HStack, useDisclosure } from "@chakra-ui/react"
 import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { cloneDeep, isEmpty, isEqual } from "lodash-es"
-import { useCallback } from "react"
+import { useCallback, useMemo } from "react"
 import { BiTrash } from "react-icons/bi"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -266,23 +266,36 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
 
   const isLoading = isSavingPage || isUploadingAsset || isDeletingAssets
 
+  const component = previewPageState.content[currActiveIdx]
+  const componentType = component?.type
+  const pageLayout = previewPageState.layout
+  // NOTE: Memoised so the schema identity is stable across renders.
+  // getComponentSchema returns a fresh object per call; passing a new schema
+  // to JsonForms on every render makes its internal resync effect fire on each
+  // parent re-render, replacing in-progress form state with the (stale) data
+  // prop. Async writes (e.g. uploaded image src, which arrives ~10ms later via
+  // JsonForms' debounced onChange) get silently erased before reaching us.
+  const { subSchema, validateFn } = useMemo(() => {
+    if (!componentType) return { subSchema: undefined, validateFn: undefined }
+    const schema = getComponentSchema({
+      component: componentType,
+      layout: pageLayout,
+    })
+    return {
+      subSchema: schema,
+      validateFn: ajv.compile<IsomerComponent>(schema),
+    }
+  }, [componentType, pageLayout])
+
   if (currActiveIdx === -1 || currActiveIdx > previewPageState.content.length) {
     return <></>
   }
 
-  const component = previewPageState.content[currActiveIdx]
-
-  if (!component) {
+  if (!component || !subSchema || !validateFn) {
     return <></>
   }
 
-  const subSchema = getComponentSchema({
-    component: component.type,
-    layout: previewPageState.layout,
-  })
-  const { title } = subSchema
-  const validateFn = ajv.compile<IsomerComponent>(subSchema)
-  const componentName = title || "component"
+  const componentName = subSchema.title || "component"
 
   return (
     <>

--- a/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
@@ -23,6 +23,15 @@ import FormBuilder from "../form-builder/FormBuilder"
 import { uploadModifiedAssets } from "../utils"
 import { DrawerHeader } from "./DrawerHeader"
 
+// NOTE: Must be module-scoped so the schema identity is stable across renders.
+// getComponentSchema returns a fresh object per call; passing a new schema to
+// JsonForms on every render makes its internal resync effect fire on each
+// parent re-render, replacing in-progress form state with the (stale) data
+// prop. Async writes (e.g. uploaded image src, which arrives ~10ms later via
+// JsonForms' debounced onChange) get silently erased before reaching us.
+const heroSchema = getComponentSchema({ component: "hero" })
+const validateHeroFn = ajv.compile<IsomerComponent>(heroSchema)
+
 export default function HeroEditorDrawer(): JSX.Element {
   const {
     isOpen: isDiscardChangesModalOpen,
@@ -40,9 +49,6 @@ export default function HeroEditorDrawer(): JSX.Element {
     setModifiedAssets,
   } = useEditorDrawerContext()
   const toast = useToast()
-
-  const subSchema = getComponentSchema({ component: "hero" })
-  const validateFn = ajv.compile<IsomerComponent>(subSchema)
 
   const { pageId, siteId } = useQueryParse(pageSchema)
   const utils = trpc.useUtils()
@@ -206,8 +212,8 @@ export default function HeroEditorDrawer(): JSX.Element {
           <Box px="1.5rem" py="1rem" flex={1} overflow="auto">
             <Box mb="1rem">
               <FormBuilder<IsomerComponent>
-                schema={subSchema}
-                validateFn={validateFn}
+                schema={heroSchema}
+                validateFn={validateHeroFn}
                 data={previewPageState.content[0]}
                 handleChange={handleChange}
               />


### PR DESCRIPTION
## Problem

Uploading a hero banner image on GSIB (Menlo Security / Windows) appeared to succeed — the CDN verification passed and the image appeared in the form — but clicking Save wrote the old image URL to the page blob. The upload result was silently discarded.

Other image upload fields (meta image, inline images) were unaffected. The bug was GSIB-only.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- **Stabilise JsonForms schema identity in `HeroEditorDrawer` and `ComplexEditorStateDrawer`**

  Root cause, traced through `@jsonforms/react@3.8.0` source line-by-line:

  **Two facts from the installed source:**

  1. `onChange` is debounced by 10 ms (`debouncedEmit = debounce(..., 10)`, fired from an effect) — the parent hand-off *always* happens on a later macrotask, outside any synchronous flush window.
  2. The resync `useEffect` (`useEffect(..., [data, schema, uischema, ajv, ...])`) fires whenever the **`schema` prop identity** changes, and `UPDATE_CORE` **replaces internal form data with the `data` prop**.

  **Sequence of failure:**

  `HeroEditorDrawer` called `getComponentSchema()` + `ajv.compile()` in render scope, and `getComponentSchema` spreads a fresh object every call ([components.ts:104](packages/components/src/schemas/components.ts:104)):

  ```
  T+0     setHref(src) → JsonForms internal state gets the image
          (onChange scheduled for T+10ms via debounce)
  T+ε     Menlo focus/visibility event → RQ window-focus refetch → re-render cascade →
          HeroEditorDrawer re-renders → getComponentSchema() returns a FRESH object →
          JsonForms resync effect fires ([data, schema, …] dep array) →
          UPDATE_CORE: schema identity changed → internal core REPLACED with the
          stale parent block (no image) + ajv.compile(hero union) = long tasks in RUM
  T+10ms  debouncedEmit fires with now-STALE data → image never reaches parent
  ```

  Silent at every layer: `asset_upload_verified` fires (the image was written internally), but nothing persists.

  **Why hero-only:** the hero union schema (5 variants) is the only per-render-regenerated schema that is also expensive to recompile (slow compile = wide race window) *and* receives an async write that must survive the storm. Synchronous typing survives because each keystroke re-commits the current value; the async `setHref` does not.

  **Why GSIB-only:** Menlo Security injects synthetic `focus`/`visibilitychange` events that drive React Query window-focus refetches and cascade re-renders, supplying the fatal re-renders at T+ε. Non-GSIB browsers don't inject these events so the race window stays empty.

  **Why `flushSync` was ineffective (reverted):** `onChange` is debounced across a macrotask boundary — no synchronous flush can reach it. The defect is structural (schema identity churn per render), not a batching issue.

  **Fix:** hoist the hero schema/validator to module scope (mirroring `RootStateDrawer`); memoize the complex-editor schema/validator on `[componentType, layout]`. With a stable schema identity the resync effect only fires when the parent legitimately commits new data — the clobber window is structurally closed, not narrowed. This also eliminates the per-render recompilation of the 5-variant hero union schema (which showed as long tasks in the RUM waterfall).

## Before & After Screenshots

**BEFORE**: Hero image upload on GSIB appears to succeed (image shows in form) but clicking Save writes the old URL.

**AFTER**: Image write is preserved across re-renders; Save persists the newly uploaded image. Hero drawer long tasks disappear from RUM (no more per-render union recompile).

## Tests

**Manual Verification Steps**:

- [ ] On a GSIB machine (or any Windows + Menlo Security browser), open a page with a hero banner, upload a new image, and click Save — confirm the saved page shows the new image (check preview or publish)
- [ ] In Datadog RUM (service: isomer-next, env: staging), confirm `asset_upload_verified` is followed by an `updatePageBlob` call containing the matching `fileKey` (the exact signature that was missing in the original dogfooding session)
- [ ] Upload a hero image on a non-GSIB machine and confirm it saves correctly (regression check)
- [ ] Upload a meta image or any other image field and confirm those still work (no regression)

**New scripts**: None

**New dependencies**: None

**New dev dependencies**: None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a race condition in `HeroEditorDrawer` and `ComplexEditorStateDrawer` where an uploaded image URL was silently discarded on GSIB machines. The root cause was that `getComponentSchema` spreads a fresh object on every call (confirmed at `components.ts:104`), so passing its result directly as the `schema` prop to `JsonForms` caused the library's internal resync effect to fire on every parent re-render, replacing in-flight form state with stale props before the debounced `onChange` could propagate the new image src.

- **`HeroEditorDrawer`**: Schema and AJV validator hoisted to module scope, mirroring the existing `RootStateDrawer`/`EditPageDrawer` pattern, eliminating per-render recompilation of the 5-variant hero union schema.
- **`ComplexEditorStateDrawer`**: Schema and validator wrapped in `useMemo([componentType, pageLayout])` — both deps are primitive strings, so identity is stable as long as the component type and layout don't change, and the resync effect only fires on legitimate data commits.
- The memoisation moves the early-return guards slightly later in the render function (after hooks), but this is correct per React rules and the new `!subSchema || !validateFn` guard handles the undefined case safely.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is a targeted stabilisation of JsonForms schema props with no behaviour change on the happy path.

Both changed files apply well-understood React memoisation/hoisting to eliminate a structural race condition. The deps in the useMemo are primitive strings, hook ordering is correct (called before early returns), and the new guard handles the undefined-schema case without risk of a runtime crash. The pattern mirrors the existing RootStateDrawer and EditPageDrawer implementations. No new side-effects are introduced.

No files in the diff require special attention. The P2 note about CollectionEditorStateDrawer and MetadataEditorStateDrawer (not in this diff) is a follow-up suggestion, not a blocker.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx | Schema and AJV validator moved to module scope; mirrors RootStateDrawer/EditPageDrawer pattern. No issues introduced. |
| apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx | Schema/validator memoised on primitive deps [componentType, pageLayout]; hook ordering is correct (useMemo before early returns); new guard handles undefined schema gracefully. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Menlo as Menlo Security Event
    participant RQ as React Query
    participant HD as HeroEditorDrawer
    participant JF as JsonForms (internal)
    participant Parent as EditorDrawerContext

    Note over HD,JF: BEFORE fix — schema identity unstable
    JF->>Parent: setHref(src) [T+0, internal state updated]
    Note over JF: onChange debounced, fires at T+10ms
    Menlo->>RQ: focus/visibilitychange event
    RQ->>HD: window-focus refetch → re-render cascade
    HD->>HD: getComponentSchema() → NEW object reference
    HD->>JF: schema prop changed identity
    JF->>JF: resync effect fires (schema dep changed)
    JF->>JF: UPDATE_CORE: replace state with stale data prop
    Note over JF: image src lost from internal state
    JF->>Parent: debouncedEmit fires with STALE data [T+10ms]
    Note over Parent: uploaded image URL never reaches parent

    Note over HD,JF: AFTER fix — schema hoisted to module scope
    HD->>JF: "schema = heroSchema (stable module-level ref)"
    JF->>Parent: setHref(src) [T+0, internal state updated]
    Note over JF: onChange debounced, fires at T+10ms
    Menlo->>RQ: focus/visibilitychange event
    RQ->>HD: window-focus refetch → re-render cascade
    HD->>JF: schema prop identity UNCHANGED (same ref)
    Note over JF: resync effect does NOT fire
    JF->>Parent: debouncedEmit fires with NEW image src [T+10ms]
    Note over Parent: uploaded image URL preserved ✓
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Menlo as Menlo Security Event
    participant RQ as React Query
    participant HD as HeroEditorDrawer
    participant JF as JsonForms (internal)
    participant Parent as EditorDrawerContext

    Note over HD,JF: BEFORE fix — schema identity unstable
    JF->>Parent: setHref(src) [T+0, internal state updated]
    Note over JF: onChange debounced, fires at T+10ms
    Menlo->>RQ: focus/visibilitychange event
    RQ->>HD: window-focus refetch → re-render cascade
    HD->>HD: getComponentSchema() → NEW object reference
    HD->>JF: schema prop changed identity
    JF->>JF: resync effect fires (schema dep changed)
    JF->>JF: UPDATE_CORE: replace state with stale data prop
    Note over JF: image src lost from internal state
    JF->>Parent: debouncedEmit fires with STALE data [T+10ms]
    Note over Parent: uploaded image URL never reaches parent

    Note over HD,JF: AFTER fix — schema hoisted to module scope
    HD->>JF: "schema = heroSchema (stable module-level ref)"
    JF->>Parent: setHref(src) [T+0, internal state updated]
    Note over JF: onChange debounced, fires at T+10ms
    Menlo->>RQ: focus/visibilitychange event
    RQ->>HD: window-focus refetch → re-render cascade
    HD->>JF: schema prop identity UNCHANGED (same ref)
    Note over JF: resync effect does NOT fire
    JF->>Parent: debouncedEmit fires with NEW image src [T+10ms]
    Note over Parent: uploaded image URL preserved ✓
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2FDrawer%2FComplexEditorStateDrawer.tsx%3A278-288%0A**Follow-up%3A%20two%20sibling%20drawers%20still%20have%20the%20same%20schema-identity%20pattern**%0A%0A%60CollectionEditorStateDrawer%60%20calls%20%60getScopedSchema%28%7B...schemaFields%7D%29%60%20%28fresh%20spread%20object%20every%20render%29%20and%20passes%20the%20result%20directly%20as%20%60schema%60%20to%20%60FormBuilder%60%2C%20with%20%60ajv.compile%60%20also%20called%20bare%20in%20the%20render%20body.%20%60MetadataEditorStateDrawer%60%20has%20the%20same%20shape%20%E2%80%94%20%60getLayoutPageSchema%60%20returns%20a%20fresh%20object%20each%20render%2C%20and%20while%20%60filteredSchema%60%20is%20wrapped%20in%20%60useMemo%60%2C%20the%20dep%20%60metadataSchema%60%20itself%20is%20a%20fresh%20object%20every%20render%20so%20the%20memo%20recomputes%20every%20render%20anyway.%20Neither%20drawer%20currently%20handles%20async%20image%20writes%2C%20so%20the%20race%20window%20isn't%20exposed%20today%2C%20but%20the%20structural%20fragility%20is%20identical%20to%20what%20this%20PR%20fixed.%20Worth%20a%20follow-up%20to%20apply%20%60useMemo%60%20%28or%20module-scope%20hoisting%29%20to%20those%20two%20as%20well.%0A%0A&repo=opengovsg%2Fisomer&pr=2653&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2FDrawer%2FComplexEditorStateDrawer.tsx%3A278-288%0A**Follow-up%3A%20two%20sibling%20drawers%20still%20have%20the%20same%20schema-identity%20pattern**%0A%0A%60CollectionEditorStateDrawer%60%20calls%20%60getScopedSchema%28%7B...schemaFields%7D%29%60%20%28fresh%20spread%20object%20every%20render%29%20and%20passes%20the%20result%20directly%20as%20%60schema%60%20to%20%60FormBuilder%60%2C%20with%20%60ajv.compile%60%20also%20called%20bare%20in%20the%20render%20body.%20%60MetadataEditorStateDrawer%60%20has%20the%20same%20shape%20%E2%80%94%20%60getLayoutPageSchema%60%20returns%20a%20fresh%20object%20each%20render%2C%20and%20while%20%60filteredSchema%60%20is%20wrapped%20in%20%60useMemo%60%2C%20the%20dep%20%60metadataSchema%60%20itself%20is%20a%20fresh%20object%20every%20render%20so%20the%20memo%20recomputes%20every%20render%20anyway.%20Neither%20drawer%20currently%20handles%20async%20image%20writes%2C%20so%20the%20race%20window%20isn't%20exposed%20today%2C%20but%20the%20structural%20fragility%20is%20identical%20to%20what%20this%20PR%20fixed.%20Worth%20a%20follow-up%20to%20apply%20%60useMemo%60%20%28or%20module-scope%20hoisting%29%20to%20those%20two%20as%20well.%0A%0A&pr=2653&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22asset-upload-observability%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22asset-upload-observability%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2FDrawer%2FComplexEditorStateDrawer.tsx%3A278-288%0A**Follow-up%3A%20two%20sibling%20drawers%20still%20have%20the%20same%20schema-identity%20pattern**%0A%0A%60CollectionEditorStateDrawer%60%20calls%20%60getScopedSchema%28%7B...schemaFields%7D%29%60%20%28fresh%20spread%20object%20every%20render%29%20and%20passes%20the%20result%20directly%20as%20%60schema%60%20to%20%60FormBuilder%60%2C%20with%20%60ajv.compile%60%20also%20called%20bare%20in%20the%20render%20body.%20%60MetadataEditorStateDrawer%60%20has%20the%20same%20shape%20%E2%80%94%20%60getLayoutPageSchema%60%20returns%20a%20fresh%20object%20each%20render%2C%20and%20while%20%60filteredSchema%60%20is%20wrapped%20in%20%60useMemo%60%2C%20the%20dep%20%60metadataSchema%60%20itself%20is%20a%20fresh%20object%20every%20render%20so%20the%20memo%20recomputes%20every%20render%20anyway.%20Neither%20drawer%20currently%20handles%20async%20image%20writes%2C%20so%20the%20race%20window%20isn't%20exposed%20today%2C%20but%20the%20structural%20fragility%20is%20identical%20to%20what%20this%20PR%20fixed.%20Worth%20a%20follow-up%20to%20apply%20%60useMemo%60%20%28or%20module-scope%20hoisting%29%20to%20those%20two%20as%20well.%0A%0A&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx:278-288
**Follow-up: two sibling drawers still have the same schema-identity pattern**

`CollectionEditorStateDrawer` calls `getScopedSchema({...schemaFields})` (fresh spread object every render) and passes the result directly as `schema` to `FormBuilder`, with `ajv.compile` also called bare in the render body. `MetadataEditorStateDrawer` has the same shape — `getLayoutPageSchema` returns a fresh object each render, and while `filteredSchema` is wrapped in `useMemo`, the dep `metadataSchema` itself is a fresh object every render so the memo recomputes every render anyway. Neither drawer currently handles async image writes, so the race window isn't exposed today, but the structural fragility is identical to what this PR fixed. Worth a follow-up to apply `useMemo` (or module-scope hoisting) to those two as well.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(editor): stabilise JsonForms schema ..."](https://github.com/opengovsg/isomer/commit/d0f56c3c869a1d1d8e14a3525bf5063cd8532fcc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44993122)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->