### PR TITLE
chore: add cap, osir, and nsas sites to audit logs

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -113,14 +113,17 @@ const SITES_WITH_AUDIT_LOGS = [
   284, // www.ptc.gov.sg
   287, // www.mot.gov.sg
   289, // www.toteboard.gov.sg
+  301, // space.gov.sg
   334, // seab.gov.sg
   336, // www.caringcommuters.gov.sg
   343, // www.motawardsceremony.gov.sg
   357, // www.ago.gov.sg
+  378, // osir.gov.sg
   397, // www.rp.edu.sg
   409, // www.hsa.gov.sg
   484, // www.hpb.gov.sg
   492, // www.oneservice.gov.sg
+  512, // cap.gov.sg
 ]
 
 // Month and year to get audit logs for, in the format of YYYY-MM,


### PR DESCRIPTION
## Problem

Three sites need to be included in the monthly audit log export but were missing from the `getAuditLogs.ts` allowlist:

- Committee Against Profiteering (cap.gov.sg) — site 512
- Office of Significant Investments Review (osir.gov.sg) — site 378
- National Space Agency of Singapore / NSAS (space.gov.sg) — site 301

Without these entries, the audit log script does not generate user-access and event reports for these sites.

## Solution

Added the three site IDs to the `SITES_WITH_AUDIT_LOGS` array in `apps/studio/prisma/scripts/getAuditLogs.ts`, each inserted in its correct sorted-by-ID position with a domain comment matching the existing convention.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- The monthly audit log export script now generates user-access and event report CSVs for cap.gov.sg (512), osir.gov.sg (378), and space.gov.sg (301).

## Tests

This is a change to a manually-run data script (`prisma/scripts/`), not production application code. The script is executed manually by an operator, and the added entries follow the identical pattern as the existing ~100 site IDs already in the array.

**New scripts**:

- None (existing `getAuditLogs.ts` script updated only)

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds three sites to the monthly audit log export allowlist. The main changes are:

- Added `space.gov.sg` with site ID `301`.
- Added `osir.gov.sg` with site ID `378`.
- Added `cap.gov.sg` with site ID `512`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

Small additive update to a manually run export script allowlist. No query logic, schema, migration, or runtime application behavior changed.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the before audit-allowlist log to record allowlist\_count=110, sorted order true, and present=false for 301, 378, and 512.
- Inspected the after audit-allowlist log to confirm allowlist\_count increased to 113, sorted order true, and present=true for 301, 378, and 512 with matching comments.
- Verified that the after state implies generated target files for each site, such as useraccess\_301\_YYYY-MM.csv and auditlogs\_301\_YYYY-MM.csv, as well as corresponding files for 378 and 512.

<a href="https://app.greptile.com/trex/runs/13036245/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/prisma/scripts/getAuditLogs.ts | Adds three site IDs to the audit-log export allowlist in sorted order; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add cap, osir, and nsas sites to ..."](https://github.com/opengovsg/isomer/commit/5a850464b7d4334c928db65af5a017fd4ba1ce70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41322012)</sub>

<!-- /greptile_comment -->