### PR TITLE
🔖 Feat: make collection default filter label editable

### DIFF
--- a/apps/studio/src/constants/formBuilder.ts
+++ b/apps/studio/src/constants/formBuilder.ts
@@ -4,6 +4,7 @@ export const JSON_FORMS_RANKING = {
   TagCategoryControl: 5,
   TagCategoryOptionsControl: 5,
   CategoryOptionsControl: 5,
+  CategoryLabelControl: 2,
   TaggedControl: 4,
   BooleanControl: 2,
   ConstControl: 2,

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -83,10 +83,20 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     if (isUserIsomerAdmin) {
       return drawerStateType === "display"
         ? {
-            exclude: ["tagCategories", "tags", "categoryOptions", "categoryLabel"],
+            exclude: [
+              "tagCategories",
+              "tags",
+              "categoryOptions",
+              "categoryLabel",
+            ],
           }
         : {
-            include: ["tagCategories", "tags", "categoryOptions", "categoryLabel"],
+            include: [
+              "tagCategories",
+              "tags",
+              "categoryOptions",
+              "categoryLabel",
+            ],
           }
     }
     return {

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -83,14 +83,14 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     if (isUserIsomerAdmin) {
       return drawerStateType === "display"
         ? {
-            exclude: ["tagCategories", "tags", "categoryOptions"],
+            exclude: ["tagCategories", "tags", "categoryOptions", "categoryLabel"],
           }
         : {
-            include: ["tagCategories", "tags", "categoryOptions"],
+            include: ["tagCategories", "tags", "categoryOptions", "categoryLabel"],
           }
     }
     return {
-      exclude: ["tagCategories", "tags", "categoryOptions"],
+      exclude: ["tagCategories", "tags", "categoryOptions", "categoryLabel"],
     }
   }, [drawerStateType, isUserIsomerAdmin])
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/FormBuilder.tsx
@@ -79,6 +79,8 @@ import {
   jsonFormsTagCategoriesControlTester,
   JsonFormsCategoryOptionsControl,
   jsonFormsCategoryOptionsControlTester,
+  JsonFormsCategoryLabelControl,
+  jsonFormsCategoryLabelControlTester,
   JsonFormsTagCategoryOptionsControl,
   jsonFormsTagCategoryOptionsControlTester,
   JsonFormsTaggedControl,
@@ -119,6 +121,10 @@ export const renderers: JsonFormsRendererRegistryEntry[] = [
   {
     tester: jsonFormsCategoryOptionsControlTester,
     renderer: JsonFormsCategoryOptionsControl,
+  },
+  {
+    tester: jsonFormsCategoryLabelControlTester,
+    renderer: JsonFormsCategoryLabelControl,
   },
   {
     tester: jsonFormsTagCategoryOptionsControlTester,

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryLabelControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryLabelControl.tsx
@@ -1,0 +1,72 @@
+import type { ControlProps, RankedTester } from "@jsonforms/core"
+import type { JsonFormsCellRendererRegistryEntry, JsonFormsRendererRegistryEntry } from "@jsonforms/core"
+import type { PropsWithChildren } from "react"
+import { rankWith, schemaMatches } from "@jsonforms/core"
+import { JsonFormsDispatch, withJsonFormsControlProps } from "@jsonforms/react"
+import { Box } from "@chakra-ui/react"
+import { CollectionPageCategoriesSchema } from "@opengovsg/isomer-components"
+import { createContext, useContext } from "react"
+import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+
+import { JsonFormsTextControl } from "./JsonFormsTextControl"
+
+const CATEGORY_LABEL_PATH = "categoryLabel"
+
+const CategoryLabelRenderContext = createContext(false)
+
+export function CategoryLabelRenderProvider({
+  children,
+}: PropsWithChildren): JSX.Element {
+  return (
+    <CategoryLabelRenderContext.Provider value={true}>
+      {children}
+    </CategoryLabelRenderContext.Provider>
+  )
+}
+
+export const jsonFormsCategoryLabelControlTester: RankedTester = rankWith(
+  JSON_FORMS_RANKING.CategoryLabelControl,
+  schemaMatches((schema) => schema.format === "category-label"),
+)
+
+function JsonFormsCategoryLabelControl(props: ControlProps): JSX.Element | null {
+  const show = useContext(CategoryLabelRenderContext)
+  if (!show) {
+    return null
+  }
+
+  return <JsonFormsTextControl {...props} />
+}
+
+export default withJsonFormsControlProps(JsonFormsCategoryLabelControl)
+
+export function CategoryLabelEditor({
+  enabled,
+  renderers,
+  cells,
+  visible,
+}: {
+  enabled?: boolean
+  renderers?: JsonFormsRendererRegistryEntry[]
+  cells?: JsonFormsCellRendererRegistryEntry[]
+  visible?: boolean
+}): JSX.Element {
+  return (
+    <CategoryLabelRenderProvider>
+      <Box w="full" mb="1.25rem">
+        <JsonFormsDispatch
+          renderers={renderers}
+          cells={cells}
+          visible={visible}
+          enabled={enabled}
+          schema={CollectionPageCategoriesSchema}
+          uischema={{
+            type: "Control",
+            scope: `#/properties/${CATEGORY_LABEL_PATH}`,
+          }}
+          path=""
+        />
+      </Box>
+    </CategoryLabelRenderProvider>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryLabelControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryLabelControl.tsx
@@ -1,9 +1,12 @@
 import type { ControlProps, RankedTester } from "@jsonforms/core"
-import type { JsonFormsCellRendererRegistryEntry, JsonFormsRendererRegistryEntry } from "@jsonforms/core"
+import type {
+  JsonFormsCellRendererRegistryEntry,
+  JsonFormsRendererRegistryEntry,
+} from "@jsonforms/core"
 import type { PropsWithChildren } from "react"
+import { Box } from "@chakra-ui/react"
 import { rankWith, schemaMatches } from "@jsonforms/core"
 import { JsonFormsDispatch, withJsonFormsControlProps } from "@jsonforms/react"
-import { Box } from "@chakra-ui/react"
 import { CollectionPageCategoriesSchema } from "@opengovsg/isomer-components"
 import { createContext, useContext } from "react"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
@@ -29,7 +32,9 @@ export const jsonFormsCategoryLabelControlTester: RankedTester = rankWith(
   schemaMatches((schema) => schema.format === "category-label"),
 )
 
-function JsonFormsCategoryLabelControl(props: ControlProps): JSX.Element | null {
+function JsonFormsCategoryLabelControl(
+  props: ControlProps,
+): JSX.Element | null {
   const show = useContext(CategoryLabelRenderContext)
   if (!show) {
     return null

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
@@ -13,7 +13,7 @@ import {
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
 import { composePaths, rankWith, schemaMatches } from "@jsonforms/core"
 import { useJsonForms, withJsonFormsArrayLayoutProps } from "@jsonforms/react"
-import { Button } from "@opengovsg/design-system-react"
+import { Button, Infobox } from "@opengovsg/design-system-react"
 import {
   resolveCategoryFilterLabel,
   type CollectionPagePageProps,
@@ -168,6 +168,21 @@ function CategoryOptionsExpandedEditor({
   return (
     <NestedDrawerSwitch {...props} {...arrayResult}>
       <VStack align="stretch" spacing={0} w="full">
+        <Infobox
+          width="100%"
+          size="sm"
+          variant="warning"
+          mb="1.25rem"
+          border="1px solid"
+          borderColor="utility.feedback.warning"
+          borderRadius="0.25rem"
+          px="0.625rem"
+          py="0.5rem"
+        >
+          <Text textStyle="body-2" color="base.content.strong">
+            This is the default filter, so you can't make it optional.
+          </Text>
+        </Infobox>
         <VStack spacing={0} align="start">
           <VStack align="start" spacing="0.25rem" w="full">
             <HStack w="full" justifyContent="space-between" align="center">

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
@@ -1,9 +1,5 @@
 import type { ArrayLayoutProps, RankedTester } from "@jsonforms/core"
 import {
-  resolveCategoryFilterLabel,
-  type CollectionPagePageProps,
-} from "@opengovsg/isomer-components"
-import {
   Box,
   chakra,
   Flex,
@@ -18,6 +14,10 @@ import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
 import { composePaths, rankWith, schemaMatches } from "@jsonforms/core"
 import { useJsonForms, withJsonFormsArrayLayoutProps } from "@jsonforms/react"
 import { Button } from "@opengovsg/design-system-react"
+import {
+  resolveCategoryFilterLabel,
+  type CollectionPagePageProps,
+} from "@opengovsg/isomer-components"
 import { get } from "lodash-es"
 import { Suspense, useMemo, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
@@ -42,7 +42,10 @@ import { useArray } from "../../hooks/useArray"
 import { useDeleteTarget } from "../../hooks/useDeleteTarget"
 import { useDuplicateLabels } from "../../hooks/useDuplicateLabels"
 import { createDefaultCategoryOption } from "./constants"
+import { CategoryLabelEditor } from "./JsonFormsCategoryLabelControl"
 import { hasBlankOptionLabel } from "./utils/hasBlankOptionLabel"
+
+const CATEGORY_LABEL_PATH = "categoryLabel"
 
 /** Matches category option rows from JsonForms (`categoryOptions` array on collection index). */
 type CategoryOptionItem = Partial<{
@@ -96,6 +99,9 @@ function CategoryOptionsExpandedEditor({
     uischemas,
     uischema,
     description,
+    renderers,
+    cells,
+    visible,
   } = props
   const { hasErrorAt } = useBuilderErrors()
   const { core } = useJsonForms()
@@ -183,6 +189,12 @@ function CategoryOptionsExpandedEditor({
             This is the default filter, so you can't make it optional.
           </Text>
         </Infobox>
+        <CategoryLabelEditor
+          enabled={enabled}
+          renderers={renderers}
+          cells={cells}
+          visible={visible}
+        />
         <VStack spacing={0} align="start">
           <VStack align="start" spacing="0.25rem" w="full">
             <HStack w="full" justifyContent="space-between" align="center">
@@ -348,7 +360,8 @@ function JsonFormsCategoryOptionsArrayLayoutInner(props: ArrayLayoutProps) {
     () =>
       hasBlankOptionLabel(items) ||
       duplicateOptionIndices.size > 0 ||
-      hasErrorAt(path),
+      hasErrorAt(path) ||
+      hasErrorAt(CATEGORY_LABEL_PATH),
     [items, path, duplicateOptionIndices, hasErrorAt],
   )
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryOptionsControl.tsx
@@ -1,5 +1,9 @@
 import type { ArrayLayoutProps, RankedTester } from "@jsonforms/core"
 import {
+  resolveCategoryFilterLabel,
+  type CollectionPagePageProps,
+} from "@opengovsg/isomer-components"
+import {
   Box,
   chakra,
   Flex,
@@ -13,7 +17,7 @@ import {
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
 import { composePaths, rankWith, schemaMatches } from "@jsonforms/core"
 import { useJsonForms, withJsonFormsArrayLayoutProps } from "@jsonforms/react"
-import { Button, Infobox } from "@opengovsg/design-system-react"
+import { Button } from "@opengovsg/design-system-react"
 import { get } from "lodash-es"
 import { Suspense, useMemo, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
@@ -164,22 +168,6 @@ function CategoryOptionsExpandedEditor({
   return (
     <NestedDrawerSwitch {...props} {...arrayResult}>
       <VStack align="stretch" spacing={0} w="full">
-        <Infobox
-          width="100%"
-          size="sm"
-          variant="warning"
-          mb="1.25rem"
-          border="1px solid"
-          borderColor="utility.feedback.warning"
-          borderRadius="0.25rem"
-          px="0.625rem"
-          py="0.5rem"
-        >
-          <Text textStyle="body-2" color="base.content.strong">
-            This is the default filter, so you can't change its name or make it
-            optional.
-          </Text>
-        </Infobox>
         <VStack spacing={0} align="start">
           <VStack align="start" spacing="0.25rem" w="full">
             <HStack w="full" justifyContent="space-between" align="center">
@@ -331,6 +319,9 @@ function JsonFormsCategoryOptionsArrayLayoutInner(props: ArrayLayoutProps) {
   const { hasErrorAt } = useBuilderErrors()
   const [expandedOpen, setExpandedOpen] = useState(false)
 
+  const page = core?.data as CollectionPagePageProps | undefined
+  const categoryFilterLabel = resolveCategoryFilterLabel(page?.categoryLabel)
+
   const items = useMemo(
     () => get(core?.data, path) as { label?: string }[] | undefined,
     [core?.data, path],
@@ -364,11 +355,11 @@ function JsonFormsCategoryOptionsArrayLayoutInner(props: ArrayLayoutProps) {
         gap={0}
       >
         <DrawerHeader
-          label="Edit Category"
+          label={`Edit ${categoryFilterLabel}`}
           isDisabled={cannotLeaveExpandedCategoryOptions}
           onBackClick={handleCloseExpandedCategoryOptions}
           textStyle="subhead-1"
-          backAriaLabel="Return to Category"
+          backAriaLabel={`Return to ${categoryFilterLabel}`}
         />
         <Box w="100%" flex={1} minH={0} px="1.5rem" py="1rem" overflow="auto">
           <CategoryOptionsExpandedEditor
@@ -481,7 +472,7 @@ function JsonFormsCategoryOptionsArrayLayoutInner(props: ArrayLayoutProps) {
                         flexWrap="wrap"
                       >
                         <Text textStyle="subhead-2" textAlign="start">
-                          Category
+                          {categoryFilterLabel}
                         </Text>
                       </HStack>
                       <Text textStyle="caption-2" color="base.content.medium">

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/index.ts
@@ -117,6 +117,10 @@ export {
   jsonFormsCategoryOptionsControlTester,
 } from "./JsonFormsCategoryOptionsControl"
 export {
+  default as JsonFormsCategoryLabelControl,
+  jsonFormsCategoryLabelControlTester,
+} from "./JsonFormsCategoryLabelControl"
+export {
   default as JsonFormsNavbarControl,
   jsonFormsNavbarControlTester,
 } from "./JsonFormsNavbarControl"

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,6 +12,8 @@ export {
   createChildrenPagesComparator,
   formatBytes,
   DGS_REQUEST_MAX_BYTES,
+  DEFAULT_CATEGORY_FILTER_LABEL,
+  resolveCategoryFilterLabel,
 } from "./utils"
 export * from "./schemas"
 export * from "./types"

--- a/packages/components/src/templates/next/layouts/Collection/Collection.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.tsx
@@ -22,6 +22,7 @@ export const CollectionLayout = ({
     defaultSortDirection,
     tagCategories,
     categoryOptions,
+    categoryLabel,
     showDate,
     showThumbnail,
   } = page
@@ -53,6 +54,7 @@ export const CollectionLayout = ({
           processedItems,
           tagCategories,
           categoryOptions,
+          categoryLabel,
         )}
         shouldShowDate={shouldShowDate(processedItems)}
         siteAssetsBaseUrl={site.assetsBaseUrl}

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
@@ -204,4 +204,34 @@ describe("getCategoryFilter", () => {
       "Zebra",
     ])
   })
+
+  it("uses a custom categoryLabel when provided", () => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "News" } as ProcessedCollectionCardProps,
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, undefined, "Topic")
+
+    // Assert
+    expect(result.label).toBe("Topic")
+  })
+
+  it.each([
+    ["omitted", undefined],
+    ["empty string", ""],
+    ["whitespace", "   "],
+  ] as const)("falls back to Category when categoryLabel is %s", (_, label) => {
+    // Arrange
+    const items: ProcessedCollectionCardProps[] = [
+      { category: "News" } as ProcessedCollectionCardProps,
+    ]
+
+    // Act
+    const result = getCategoryFilter(items, undefined, label)
+
+    // Assert
+    expect(result.label).toBe("Category")
+  })
 })

--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getCategoryFilter.test.ts
@@ -10,7 +10,7 @@ describe("getCategoryFilter", () => {
     const items: ProcessedCollectionCardProps[] = []
 
     // Act
-    const result = getCategoryFilter(items)
+    const result = getCategoryFilter({ items })
 
     // Assert
     expect(result).toEqual({
@@ -41,7 +41,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items)
+    const result = getCategoryFilter({ items })
 
     // Assert
     expect(result).toEqual({
@@ -65,7 +65,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items)
+    const result = getCategoryFilter({ items })
 
     // Assert
     expect(result.items.map((i) => i.label)).toEqual([
@@ -91,7 +91,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, categoryOptions)
+    const result = getCategoryFilter({ items, categoryOptions })
 
     // Assert
     expect(result).toEqual({
@@ -119,7 +119,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, categoryOptions)
+    const result = getCategoryFilter({ items, categoryOptions })
 
     // Assert
     expect(result.items.map((i) => i.label)).toEqual(["Policy", "News"])
@@ -143,7 +143,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, categoryOptions)
+    const result = getCategoryFilter({ items, categoryOptions })
 
     // Assert — order must follow categoryOptions, not fall back to alphabetical
     expect(result.items.map((i) => i.id)).toEqual([
@@ -168,7 +168,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, categoryOptions)
+    const result = getCategoryFilter({ items, categoryOptions })
 
     // Assert
     expect(result.items.map((i) => i.label)).toEqual([
@@ -194,7 +194,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, categoryOptions)
+    const result = getCategoryFilter({ items, categoryOptions })
 
     // Assert — known items first in editor order, unknown items alphabetically after
     expect(result.items.map((i) => i.label)).toEqual([
@@ -212,7 +212,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, undefined, "Topic")
+    const result = getCategoryFilter({ items, categoryLabel: "Topic" })
 
     // Assert
     expect(result.label).toBe("Topic")
@@ -229,7 +229,7 @@ describe("getCategoryFilter", () => {
     ]
 
     // Act
-    const result = getCategoryFilter(items, undefined, label)
+    const result = getCategoryFilter({ items, categoryLabel: label })
 
     // Assert
     expect(result.label).toBe("Category")

--- a/packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts
@@ -11,11 +11,12 @@ export const getAvailableFilters = (
   items: ProcessedCollectionCardProps[],
   tagCategories?: CollectionPageSchemaType["page"]["tagCategories"],
   categoryOptions?: CollectionPageCategoryOption[],
+  categoryLabel?: string,
 ): Filter[] => {
   // TODO: Allow user to pass in order of filters to be shown
   return [
     ...getTagFilters(items, tagCategories),
-    getCategoryFilter(items, categoryOptions),
+    getCategoryFilter(items, categoryOptions, categoryLabel),
     getYearFilter(items),
   ].filter((filter) => filter.items.length >= 1)
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getAvailableFilters.ts
@@ -11,12 +11,12 @@ export const getAvailableFilters = (
   items: ProcessedCollectionCardProps[],
   tagCategories?: CollectionPageSchemaType["page"]["tagCategories"],
   categoryOptions?: CollectionPageCategoryOption[],
-  categoryLabel?: string,
+  categoryLabel?: CollectionPageSchemaType["page"]["categoryLabel"],
 ): Filter[] => {
   // TODO: Allow user to pass in order of filters to be shown
   return [
     ...getTagFilters(items, tagCategories),
-    getCategoryFilter(items, categoryOptions, categoryLabel),
+    getCategoryFilter({ items, categoryOptions, categoryLabel }),
     getYearFilter(items),
   ].filter((filter) => filter.items.length >= 1)
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -3,10 +3,12 @@ import type { Filter } from "~/templates/next/types/Filter"
 import type { CollectionPageCategoryOption } from "~/types/page"
 
 import { FILTER_ID_CATEGORY } from "./constants"
+import { resolveCategoryFilterLabel } from "~/utils/resolveCategoryFilterLabel"
 
 export const getCategoryFilter = (
   items: ProcessedCollectionCardProps[],
   categoryOptions?: CollectionPageCategoryOption[],
+  categoryLabel?: string,
 ): Filter => {
   const categories: Record<string, number> = {}
 
@@ -52,7 +54,7 @@ export const getCategoryFilter = (
 
     return {
       id: FILTER_ID_CATEGORY,
-      label: "Category",
+      label: resolveCategoryFilterLabel(categoryLabel),
       items: [...known, ...unknown],
     }
   }
@@ -63,7 +65,7 @@ export const getCategoryFilter = (
 
   return {
     id: FILTER_ID_CATEGORY,
-    label: "Category",
+    label: resolveCategoryFilterLabel(categoryLabel),
     items: categoryFilterItems,
   }
 }

--- a/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getCategoryFilter.ts
@@ -1,15 +1,24 @@
 import type { ProcessedCollectionCardProps } from "~/interfaces"
 import type { Filter } from "~/templates/next/types/Filter"
-import type { CollectionPageCategoryOption } from "~/types/page"
-
-import { FILTER_ID_CATEGORY } from "./constants"
+import type {
+  CollectionPageCategoryLabel,
+  CollectionPageCategoryOption,
+} from "~/types/page"
 import { resolveCategoryFilterLabel } from "~/utils/resolveCategoryFilterLabel"
 
-export const getCategoryFilter = (
-  items: ProcessedCollectionCardProps[],
-  categoryOptions?: CollectionPageCategoryOption[],
-  categoryLabel?: string,
-): Filter => {
+import { FILTER_ID_CATEGORY } from "./constants"
+
+export interface GetCategoryFilterProps {
+  items: ProcessedCollectionCardProps[]
+  categoryOptions?: CollectionPageCategoryOption[]
+  categoryLabel?: CollectionPageCategoryLabel
+}
+
+export const getCategoryFilter = ({
+  items,
+  categoryOptions,
+  categoryLabel,
+}: GetCategoryFilterProps): Filter => {
   const categories: Record<string, number> = {}
 
   items.forEach(({ category }) => {

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -141,8 +141,9 @@ export type CollectionPageCategoryOption = NonNullable<
   Static<typeof CategoriesSchema>["categoryOptions"]
 >[number]
 
-export type CollectionPageCategoryLabel =
-  Static<typeof CategoriesSchema>["categoryLabel"]
+export type CollectionPageCategoryLabel = Static<
+  typeof CategoriesSchema
+>["categoryLabel"]
 
 const TaggedSchema = Type.Optional(
   // NOTE: This stores the `uuid` of the tag option

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -100,6 +100,18 @@ const TagCategoriesSchema = Type.Object({
  * not under Collection display.
  */
 const CategoriesSchema = Type.Object({
+  categoryLabel: Type.Optional(
+    Type.String({
+      title: "Filter name",
+      description:
+        "The label visitors see for the default filter on your collection page.",
+      pattern: TRIMMED_NON_EMPTY_STRING_REGEX,
+      errorMessage: {
+        pattern: "cannot be empty or have leading/trailing spaces",
+      },
+      default: "Category", // default value for backward compatibility and auto backfilling
+    }),
+  ),
   categoryOptions: Type.Optional(
     Type.Array(
       Type.Object({

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -141,6 +141,9 @@ export type CollectionPageCategoryOption = NonNullable<
   Static<typeof CategoriesSchema>["categoryOptions"]
 >[number]
 
+export type CollectionPageCategoryLabel =
+  Static<typeof CategoriesSchema>["categoryLabel"]
+
 const TaggedSchema = Type.Optional(
   // NOTE: This stores the `uuid` of the tag option
   Type.Array(TagOptionUuidSchema, {

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -97,7 +97,8 @@ const TagCategoriesSchema = Type.Object({
  *
  * Display vs "Manage filters" in Studio is not encoded here: `getScopedSchema` in
  * CollectionEditorStateDrawer includes this field only in the Filters drawer (with tag filters),
- * not under Collection display.
+ * not under Collection display. The `category-label` format hides it from the top-level filters
+ * list; Studio renders it inside the default filter editor instead.
  */
 const CategoriesSchema = Type.Object({
   categoryLabel: Type.Optional(
@@ -105,6 +106,7 @@ const CategoriesSchema = Type.Object({
       title: "Filter name",
       description:
         "The label visitors see for the default filter on your collection page.",
+      format: "category-label",
       pattern: TRIMMED_NON_EMPTY_STRING_REGEX,
       errorMessage: {
         pattern: "cannot be empty or have leading/trailing spaces",
@@ -136,6 +138,9 @@ const CategoriesSchema = Type.Object({
     ),
   ),
 })
+
+/** Categories filter fields on a collection index page (`categoryLabel`, `categoryOptions`). */
+export const CollectionPageCategoriesSchema = CategoriesSchema
 
 export type CollectionPageCategoryOption = NonNullable<
   Static<typeof CategoriesSchema>["categoryOptions"]

--- a/packages/components/src/types/page.ts
+++ b/packages/components/src/types/page.ts
@@ -105,7 +105,7 @@ const CategoriesSchema = Type.Object({
     Type.String({
       title: "Filter name",
       description:
-        "The label visitors see for the default filter on your collection page.",
+        "The label visitors see for the default filter. It defaults to 'Category'.",
       format: "category-label",
       pattern: TRIMMED_NON_EMPTY_STRING_REGEX,
       errorMessage: {

--- a/packages/components/src/utils/__tests__/resolveCategoryFilterLabel.test.ts
+++ b/packages/components/src/utils/__tests__/resolveCategoryFilterLabel.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  DEFAULT_CATEGORY_FILTER_LABEL,
+  resolveCategoryFilterLabel,
+} from "../resolveCategoryFilterLabel"
+
+describe("resolveCategoryFilterLabel", () => {
+  it("returns the custom label when provided", () => {
+    // Arrange / Act
+    const result = resolveCategoryFilterLabel("Topic")
+
+    // Assert
+    expect(result).toBe("Topic")
+  })
+
+  it("trims leading and trailing whitespace from the label", () => {
+    // Arrange / Act
+    const result = resolveCategoryFilterLabel("  Topic  ")
+
+    // Assert
+    expect(result).toBe("Topic")
+  })
+
+  it.each([
+    ["omitted", undefined],
+    ["empty string", ""],
+    ["whitespace", "   "],
+  ] as const)(
+    "falls back to DEFAULT_CATEGORY_FILTER_LABEL when categoryLabel is %s",
+    (_, categoryLabel) => {
+      // Arrange / Act
+      const result = resolveCategoryFilterLabel(categoryLabel)
+
+      // Assert
+      expect(result).toBe(DEFAULT_CATEGORY_FILTER_LABEL)
+    },
+  )
+})

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -39,3 +39,7 @@ export {
 } from "./validation"
 
 export { createChildrenPagesComparator } from "./createChildrenPagesComparator"
+export {
+  DEFAULT_CATEGORY_FILTER_LABEL,
+  resolveCategoryFilterLabel,
+} from "./resolveCategoryFilterLabel"

--- a/packages/components/src/utils/resolveCategoryFilterLabel.ts
+++ b/packages/components/src/utils/resolveCategoryFilterLabel.ts
@@ -1,0 +1,4 @@
+export const DEFAULT_CATEGORY_FILTER_LABEL = "Category"
+
+export const resolveCategoryFilterLabel = (categoryLabel?: string) =>
+  categoryLabel?.trim() || DEFAULT_CATEGORY_FILTER_LABEL

--- a/packages/components/src/utils/resolveCategoryFilterLabel.ts
+++ b/packages/components/src/utils/resolveCategoryFilterLabel.ts
@@ -1,4 +1,7 @@
+import type { CollectionPageCategoryLabel } from "~/types/page"
+
 export const DEFAULT_CATEGORY_FILTER_LABEL = "Category"
 
-export const resolveCategoryFilterLabel = (categoryLabel?: string) =>
-  categoryLabel?.trim() || DEFAULT_CATEGORY_FILTER_LABEL
+export const resolveCategoryFilterLabel = (
+  categoryLabel?: CollectionPageCategoryLabel,
+) => categoryLabel?.trim() || DEFAULT_CATEGORY_FILTER_LABEL


### PR DESCRIPTION
## Problem

The default category filter on collection index pages is hardcoded as "Category" in both the public filter sidebar and Studio's Manage filters UI. Site admins cannot customise this label to match their content taxonomy (e.g. "Topic", "Type").

## Solution

Add an optional `categoryLabel` field to the collection index page blob. Admins edit it via a "Filter name" field in Manage filters (Isomer Admin). The public site and Studio card/drawer labels read from this field, with a runtime fallback to `"Category"` for already-published blobs that omit it. JSON Schema `default: "Category"` pre-fills the Studio form via AJV `useDefaults`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Admins can rename the default collection filter group label in Manage filters
- Custom label appears on the public collection filter sidebar after publish
- Legacy collections without `categoryLabel` continue to display "Category"

**Improvements**:

- Removed the infobox stating the default filter name cannot be changed
- Default filter card and drawer headers in Studio reflect the configured label dynamically
- Shared `resolveCategoryFilterLabel` helper exported from `@opengovsg/isomer-components`

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- Filter sidebar and Manage filters always show "Category" as the default filter group name -->

**AFTER**:

<!-- Manage filters shows editable "Filter name" field; public sidebar reflects custom label -->

## Tests

**Manual Verification Steps**:

- [ ] Log in as an Isomer Admin and open a collection index page in Studio
- [ ] Open **Manage filters** and confirm a **Filter name** text field appears above the Default Filter card, pre-filled with "Category"
- [ ] Change Filter name to a custom value (e.g. "Topic"), save, and publish the collection
- [ ] On the live collection page, confirm the filter sidebar group heading shows the custom label (e.g. "Topic") instead of "Category"
- [ ] Confirm collection item cards still show their assigned category option labels (e.g. "News", "Policy") unchanged
- [ ] Open a legacy collection that has never had `categoryLabel` saved and confirm the public site still shows "Category" until republished

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Made with [Cursor](https://cursor.com)