### PR TITLE
fix(studio): show category required error on collection item editors

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/LinkEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/LinkEditorDrawer.tsx
@@ -14,6 +14,7 @@ import { safeJsonParse } from "~/utils/safeJsonParse"
 import { trpc } from "~/utils/trpc"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
+import { useIsCategorySelectionValid } from "../../hooks/useIsCategorySelectionValid"
 import { ActivateRawJsonEditorMode } from "../ActivateRawJsonEditorMode"
 import { ErrorProvider, useBuilderErrors } from "../form-builder/ErrorProvider"
 import FormBuilder from "../form-builder/FormBuilder"
@@ -44,7 +45,15 @@ const InnerDrawer = ({
   handleSaveChanges,
   setDrawerState,
 }: LinkEditorDrawerStateProps) => {
+  const { linkId, siteId } = useQueryParse(editLinkSchema)
   const { errors } = useBuilderErrors()
+  const isCategoryValid = useIsCategorySelectionValid({
+    resourceId: linkId,
+    siteId,
+    categoryId: previewPageState.categoryId,
+    category: previewPageState.category,
+    enabled: true,
+  })
   const { isAdmin: isUserIsomerAdmin } = useIsUserIsomerAdmin({
     roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
   })
@@ -84,7 +93,9 @@ const InnerDrawer = ({
           w="full"
           alignSelf="flex-start"
           onClick={handleSaveChanges}
-          isDisabled={!isEmpty(errors) || !previewPageState.ref}
+          isDisabled={
+            !isEmpty(errors) || !previewPageState.ref || !isCategoryValid
+          }
           isLoading={isLoading}
         >
           Save

--- a/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
@@ -1,4 +1,7 @@
-import type { IsomerSchema } from "@opengovsg/isomer-components"
+import type {
+  ArticlePagePageProps,
+  IsomerSchema,
+} from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Flex, Text, useDisclosure } from "@chakra-ui/react"
 import { Button, Infobox, useToast } from "@opengovsg/design-system-react"
@@ -14,7 +17,9 @@ import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
+import { ResourceType } from "~prisma/generated/generatedEnums"
 
+import { useIsCategorySelectionValid } from "../../hooks/useIsCategorySelectionValid"
 import { pageSchema } from "../../schema"
 import { CHANGES_SAVED_PLEASE_PUBLISH_MESSAGE } from "../constants"
 import { DiscardChangesModal } from "../DiscardChangesModal"
@@ -36,6 +41,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
     onClose: onDiscardChangesModalClose,
   } = useDisclosure()
   const {
+    type,
     setDrawerState,
     savedPageState,
     setSavedPageState,
@@ -44,6 +50,16 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { pageId, siteId } = useQueryParse(pageSchema)
+  const isCollectionItem =
+    type === ResourceType.CollectionPage || type === ResourceType.CollectionLink
+  const pageProps = previewPageState.page as ArticlePagePageProps
+  const isCategoryValid = useIsCategorySelectionValid({
+    resourceId: pageId,
+    siteId,
+    categoryId: pageProps.categoryId,
+    category: pageProps.category,
+    enabled: isCollectionItem,
+  })
   const toast = useToast()
   const utils = trpc.useUtils()
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
@@ -183,7 +199,11 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
             py="1.5rem"
             px="2rem"
           >
-            <SaveButton isLoading={isPending} onClick={handleSaveChanges} />
+            <SaveButton
+              isLoading={isPending}
+              isCategoryValid={isCategoryValid}
+              onClick={handleSaveChanges}
+            />
           </Box>
         </ErrorProvider>
       </Flex>
@@ -194,9 +214,11 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
 const SaveButton = ({
   onClick,
   isLoading,
+  isCategoryValid = true,
 }: {
   onClick: () => void
   isLoading: boolean
+  isCategoryValid?: boolean
 }) => {
   const { errors } = useBuilderErrors()
 
@@ -204,7 +226,7 @@ const SaveButton = ({
     <Button
       w="100%"
       isLoading={isLoading}
-      isDisabled={!isEmpty(errors)}
+      isDisabled={!isEmpty(errors) || !isCategoryValid}
       onClick={onClick}
     >
       Save changes

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx
@@ -3,10 +3,18 @@ import { FormControl, Skeleton } from "@chakra-ui/react"
 import { useFeatureValue } from "@growthbook/growthbook-react"
 import { and, rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
-import { FormLabel, SingleSelect } from "@opengovsg/design-system-react"
+import {
+  FormErrorMessage,
+  FormLabel,
+  SingleSelect,
+} from "@opengovsg/design-system-react"
 import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { collectionItemSchema } from "~/features/editing-experience/schema"
+import {
+  CATEGORY_SELECTION_ERROR_MESSAGE,
+  isCategorySelectionValid,
+} from "~/features/editing-experience/utils/validateCategorySelection"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import {
   CATEGORY_DROPDOWN_FEATURE_KEY,
@@ -29,6 +37,7 @@ function SuspendableJsonFormsCategoryControl({
   handleChange,
   path,
   label,
+  description,
 }: JsonFormsCategoryControlProps) {
   const { siteId, pageId, linkId } = useQueryParse(collectionItemSchema)
 
@@ -41,18 +50,30 @@ function SuspendableJsonFormsCategoryControl({
     pageId: pageId || linkId || -1,
   })
 
+  const isInvalid = !isCategorySelectionValid({
+    hasConfigurableOptions: categories.length > 0,
+    category: data,
+    useCategoryId: false,
+  })
+
   return (
-    <SingleSelect
-      value={data}
-      name={label}
-      items={categories.map((category) => {
-        return { label: category, value: category }
-      })}
-      isClearable={false}
-      onChange={(value) => {
-        handleChange(path, value)
-      }}
-    />
+    <FormControl isRequired isInvalid={isInvalid} gap="0.5rem">
+      <FormLabel description={description}>{label}</FormLabel>
+      <SingleSelect
+        value={data}
+        name={label}
+        items={categories.map((category) => {
+          return { label: category, value: category }
+        })}
+        isClearable={false}
+        onChange={(value) => {
+          handleChange(path, value)
+        }}
+      />
+      {isInvalid && (
+        <FormErrorMessage>{CATEGORY_SELECTION_ERROR_MESSAGE}</FormErrorMessage>
+      )}
+    </FormControl>
   )
 }
 
@@ -75,12 +96,13 @@ export function JsonFormsCategoryControl({
 
   const isDropdownEnabled = enabledSites.includes(siteId.toString())
   return isDropdownEnabled ? (
-    <FormControl isRequired={required} gap="0.5rem">
-      <FormLabel description={description}>{label}</FormLabel>
-      <Suspense fallback={<Skeleton />}>
-        <SuspendableJsonFormsCategoryControl {...props} label={label} />
-      </Suspense>
-    </FormControl>
+    <Suspense fallback={<Skeleton />}>
+      <SuspendableJsonFormsCategoryControl
+        {...props}
+        description={description}
+        label={label}
+      />
+    </Suspense>
   ) : (
     <JsonFormsTextControl
       {...props}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryIdControl.tsx
@@ -3,12 +3,20 @@ import { FormControl, Skeleton } from "@chakra-ui/react"
 import { useFeatureValue } from "@growthbook/growthbook-react"
 import { and, rankWith, schemaMatches } from "@jsonforms/core"
 import { withJsonFormsControlProps } from "@jsonforms/react"
-import { FormLabel, SingleSelect } from "@opengovsg/design-system-react"
+import {
+  FormErrorMessage,
+  FormLabel,
+  SingleSelect,
+} from "@opengovsg/design-system-react"
 import { useRouter } from "next/router"
 import { ErrorBoundary } from "react-error-boundary"
 import Suspense from "~/components/Suspense"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { collectionItemSchema } from "~/features/editing-experience/schema"
+import {
+  CATEGORY_SELECTION_ERROR_MESSAGE,
+  isCategorySelectionValid,
+} from "~/features/editing-experience/utils/validateCategorySelection"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { CATEGORY_ID_DROPDOWN_FEATURE_KEY } from "~/lib/growthbook"
 import { trpc } from "~/utils/trpc"
@@ -27,6 +35,7 @@ function SuspendableJsonFormsCategoryIdSelect({
   handleChange,
   path,
   label,
+  description,
   resourceId,
 }: JsonFormsCategoryIdControlProps & { resourceId: number }) {
   const { siteId } = useQueryParse(collectionItemSchema)
@@ -36,42 +45,49 @@ function SuspendableJsonFormsCategoryIdSelect({
     pageId: resourceId,
   })
 
+  const isInvalid = !isCategorySelectionValid({
+    hasConfigurableOptions: categoryOptions.length > 0,
+    categoryId: data,
+    useCategoryId: true,
+  })
+
   return (
-    <SingleSelect
-      value={data}
-      name={label}
-      items={categoryOptions.map(({ id, label: optionLabel }) => ({
-        label: optionLabel,
-        value: id,
-      }))}
-      // Hardcoded false (not derived from `required`) because categoryId is still
-      // Type.Optional in the schema pending the category migration. Using `!required`
-      // would be true in the gap between "migration ran" and "schema updated",
-      // letting editors clear backfilled categoryIds. Correct behaviour across all states:
-      //
-      //   State                                 | isClearable=false
-      //   --------------------------------------|------------------------------------------
-      //   Pre-migration, old item (no categoryId) | nothing to clear — harmless
-      //   Pre-migration, new item (has categoryId) | can't clear — correct
-      //   Migration ran, schema not yet updated  | can't clear — protects migrated data
-      //   Migration ran + schema updated         | can't clear — correct
-      //
-      // Once migration is complete and categoryId is made required in the schema,
-      // replace with isClearable={!required}.
-      isClearable={false}
-      onChange={(value) => {
-        handleChange(path, value)
-      }}
-    />
+    <FormControl isRequired isInvalid={isInvalid} gap="0.5rem">
+      <FormLabel description={description}>{label}</FormLabel>
+      <SingleSelect
+        value={data}
+        name={label}
+        items={categoryOptions.map(({ id, label: optionLabel }) => ({
+          label: optionLabel,
+          value: id,
+        }))}
+        // Hardcoded false (not derived from `required`) because categoryId is still
+        // Type.Optional in the schema pending the category migration. Using `!required`
+        // would be true in the gap between "migration ran" and "schema updated",
+        // letting editors clear backfilled categoryIds. Correct behaviour across all states:
+        //
+        //   State                                 | isClearable=false
+        //   --------------------------------------|------------------------------------------
+        //   Pre-migration, old item (no categoryId) | nothing to clear — harmless
+        //   Pre-migration, new item (has categoryId) | can't clear — correct
+        //   Migration ran, schema not yet updated  | can't clear — protects migrated data
+        //   Migration ran + schema updated         | can't clear — correct
+        //
+        // Once migration is complete and categoryId is made required in the schema,
+        // replace with isClearable={!required}.
+        isClearable={false}
+        onChange={(value) => {
+          handleChange(path, value)
+        }}
+      />
+      {isInvalid && (
+        <FormErrorMessage>{CATEGORY_SELECTION_ERROR_MESSAGE}</FormErrorMessage>
+      )}
+    </FormControl>
   )
 }
 
-export function JsonFormsCategoryIdControl({
-  description,
-  required,
-  label,
-  ...props
-}: ControlProps) {
+export function JsonFormsCategoryIdControl({ label, ...props }: ControlProps) {
   const { query } = useRouter()
   // Safe-parse rather than throw: this control may match a `category-id` field
   // outside the collection-item route (e.g. Storybook without a router), where
@@ -91,18 +107,15 @@ export function JsonFormsCategoryIdControl({
   if (resourceId === undefined) return null
 
   return enabledSites.includes(parsedQuery.data.siteId.toString()) ? (
-    <FormControl isRequired={required} gap="0.5rem">
-      <FormLabel description={description}>{label}</FormLabel>
-      <ErrorBoundary fallbackRender={() => null}>
-        <Suspense fallback={<Skeleton />}>
-          <SuspendableJsonFormsCategoryIdSelect
-            {...props}
-            label={label}
-            resourceId={resourceId}
-          />
-        </Suspense>
-      </ErrorBoundary>
-    </FormControl>
+    <ErrorBoundary fallbackRender={() => null}>
+      <Suspense fallback={<Skeleton />}>
+        <SuspendableJsonFormsCategoryIdSelect
+          {...props}
+          label={label}
+          resourceId={resourceId}
+        />
+      </Suspense>
+    </ErrorBoundary>
   ) : null
 }
 

--- a/apps/studio/src/features/editing-experience/hooks/useIsCategorySelectionValid.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useIsCategorySelectionValid.ts
@@ -1,0 +1,72 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import {
+  CATEGORY_DROPDOWN_FEATURE_KEY,
+  CATEGORY_ID_DROPDOWN_FEATURE_KEY,
+} from "~/lib/growthbook"
+import { trpc } from "~/utils/trpc"
+
+import { isCategorySelectionValid } from "../utils/validateCategorySelection"
+
+export function useIsCategorySelectionValid({
+  resourceId,
+  siteId,
+  categoryId,
+  category,
+  enabled,
+}: {
+  resourceId: number
+  siteId: number
+  categoryId?: string
+  category?: string
+  enabled: boolean
+}): boolean {
+  const { enabledSites: categoryIdEnabledSites } = useFeatureValue<{
+    enabledSites: string[]
+  }>(CATEGORY_ID_DROPDOWN_FEATURE_KEY, { enabledSites: [] })
+  const { enabledSites: categoryDropdownEnabledSites } = useFeatureValue<{
+    enabledSites: string[]
+  }>(CATEGORY_DROPDOWN_FEATURE_KEY, { enabledSites: [] })
+
+  const useCategoryId = categoryIdEnabledSites.includes(siteId.toString())
+  const useLegacyDropdown =
+    !useCategoryId && categoryDropdownEnabledSites.includes(siteId.toString())
+  const shouldValidate = enabled && (useCategoryId || useLegacyDropdown)
+
+  const { data: categoryOptionsData, isLoading: isCategoryOptionsLoading } =
+    trpc.page.getCategoryOptions.useQuery(
+      { siteId, pageId: resourceId },
+      { enabled: shouldValidate && useCategoryId },
+    )
+
+  const { data: categoriesData, isLoading: isCategoriesLoading } =
+    trpc.page.getCategories.useQuery(
+      { siteId, pageId: resourceId },
+      { enabled: shouldValidate && useLegacyDropdown },
+    )
+
+  if (!shouldValidate) {
+    return true
+  }
+
+  if (
+    (useCategoryId && isCategoryOptionsLoading) ||
+    (useLegacyDropdown && isCategoriesLoading)
+  ) {
+    return false
+  }
+
+  if (useCategoryId) {
+    return isCategorySelectionValid({
+      hasConfigurableOptions:
+        (categoryOptionsData?.categoryOptions.length ?? 0) > 0,
+      categoryId,
+      useCategoryId: true,
+    })
+  }
+
+  return isCategorySelectionValid({
+    hasConfigurableOptions: (categoriesData?.categories.length ?? 0) > 0,
+    category,
+    useCategoryId: false,
+  })
+}

--- a/apps/studio/src/features/editing-experience/utils/__tests__/validateCategorySelection.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/validateCategorySelection.test.ts
@@ -1,0 +1,73 @@
+import {
+  CATEGORY_SELECTION_ERROR_MESSAGE,
+  isCategorySelectionValid,
+} from "../validateCategorySelection"
+
+describe("validateCategorySelection", () => {
+  it("exports the expected error message", () => {
+    expect(CATEGORY_SELECTION_ERROR_MESSAGE).toBe("Please select an option.")
+  })
+
+  it("returns valid when there are no configurable options", () => {
+    expect(
+      isCategorySelectionValid({
+        hasConfigurableOptions: false,
+        categoryId: undefined,
+        category: undefined,
+        useCategoryId: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("returns invalid when categoryId is required but missing", () => {
+    expect(
+      isCategorySelectionValid({
+        hasConfigurableOptions: true,
+        categoryId: undefined,
+        category: "Legacy",
+        useCategoryId: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("returns invalid when categoryId is only whitespace", () => {
+    expect(
+      isCategorySelectionValid({
+        hasConfigurableOptions: true,
+        categoryId: "   ",
+        useCategoryId: true,
+      }),
+    ).toBe(false)
+  })
+
+  it("returns valid when categoryId is selected", () => {
+    expect(
+      isCategorySelectionValid({
+        hasConfigurableOptions: true,
+        categoryId: "cat-uuid-1",
+        useCategoryId: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("returns invalid when legacy category is required but missing", () => {
+    expect(
+      isCategorySelectionValid({
+        hasConfigurableOptions: true,
+        category: undefined,
+        categoryId: "cat-uuid-1",
+        useCategoryId: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("returns valid when legacy category is selected", () => {
+    expect(
+      isCategorySelectionValid({
+        hasConfigurableOptions: true,
+        category: "Policy",
+        useCategoryId: false,
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/validateCategorySelection.ts
+++ b/apps/studio/src/features/editing-experience/utils/validateCategorySelection.ts
@@ -1,0 +1,23 @@
+export const CATEGORY_SELECTION_ERROR_MESSAGE = "Please select an option."
+
+export function isCategorySelectionValid({
+  hasConfigurableOptions,
+  categoryId,
+  category,
+  useCategoryId,
+}: {
+  hasConfigurableOptions: boolean
+  categoryId?: string
+  category?: string
+  useCategoryId: boolean
+}): boolean {
+  if (!hasConfigurableOptions) {
+    return true
+  }
+
+  if (useCategoryId) {
+    return !!categoryId?.trim()
+  }
+
+  return !!category?.trim()
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Category is a required field when editing collection pages and collection links, but selecting nothing from the dropdown did not show any validation feedback. Required tag categories already show **"At least one option must be selected"** when empty.

## Root cause

`JsonFormsCategoryIdControl` and `JsonFormsCategoryControl` marked the field as required visually (`isRequired`) but did not set `isInvalid` or render a `FormErrorMessage`. Because `categoryId` remains `Type.Optional` in the JSON schema pending migration, AJV validation also does not catch a missing selection.

## Fix

- Show **"Please select an option."** on the category dropdown when options exist but nothing is selected (both `categoryId` and legacy `category` dropdown paths).
- Extract shared validation into `validateCategorySelection` and `useIsCategorySelectionValid`.
- Disable **Save** in the metadata editor (collection pages) and link editor drawers until a category is selected, consistent with required tag category behaviour.

## Verification

- Added unit tests for `validateCategorySelection`
- `pnpm typecheck` passes
- `pnpm lint` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8808ed8-85fb-4dbb-a36b-39d4a033ca6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8808ed8-85fb-4dbb-a36b-39d4a033ca6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

