### PR TITLE
chore(gazette): sort gazettes by scheduled date

### DIFF
--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -137,7 +137,9 @@ export const gazetteRouter = router({
         )
         // 4. Publish date descending
         .orderBy("Version.publishedAt", (ob) => ob.desc())
-        // 5. Toppan file ID descending — the last path segment of page.ref.
+        // 5. Scheuled date descending
+        .orderBy("Resource.scheduledAt", (ob) => ob.desc())
+        // 6. Toppan file ID descending — the last path segment of page.ref.
         //    e.g. "/2026/Government Gazette/Advertisements/26adv6175b.pdf"
         //    -> "26adv6175b.pdf". Strip everything up to the final slash so we
         //    sort on the file ID, not the full path.
@@ -145,7 +147,7 @@ export const gazetteRouter = router({
           sql`regexp_replace(COALESCE("DraftBlob"."content", "PublishedBlob"."content")->'page'->>'ref', '.*/', '')`,
           (ob) => ob.desc(),
         )
-        // 6. Updated at descending (tie-breaker)
+        // 7. Updated at descending (tie-breaker)
         .orderBy("Resource.updatedAt", "desc")
         .orderBy("Resource.id", "asc")
         .limit(limit)


### PR DESCRIPTION
## Problem

In the Government Gazettes dashboard, gazettes had no ordering by their **scheduled publish date**. Scheduled (not-yet-published) gazettes share a null publish date, so once the status and category tiers were applied they fell straight through to the file ID / updated-at tie-breakers — meaning gazettes queued for future publication were not surfaced in the order they are due to go live.

## Solution

Added `Resource.scheduledAt` (descending) as a sort key in the `gazette.list` tRPC procedure, placed after publish date and before Toppan file ID.

The ordering is now:

1. Status priority (Scheduled → Published)
2. Category (Government Gazette → Legislative Supplements → Other Supplements)
3. Notification number (descending)
4. Publish date (descending)
5. **Scheduled date (descending)** ← new
6. Toppan file ID (descending)
7. Updated-at, then resource ID (tie-breakers)

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Scheduled gazettes are now ordered by their scheduled publish date (most recent first), so entries queued for future publication appear in a predictable order rather than falling through to the file ID / updated-at tie-breakers.

## Tests

Verify against the Government Gazettes dashboard (`/sites/[siteId]/gazettes`):

- Scheduled gazettes appear ordered by their scheduled publish date, most recent first.
- Published gazettes continue to order by publish date, then file ID.
- Status and category ordering are unchanged.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the Government Gazettes list ordering. The main changes are:

- Adds `Resource.scheduledAt` as a descending sort key in `gazette.list`.
- Places scheduled date ordering after publish date and before Toppan file ID.
- Keeps the existing status, category, notification number, updated-at, and resource ID ordering intact.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is a small, contained ordering update in a read-only tRPC query. Auth, permission checks, filtering, selection, and response shaping remain unchanged. No correctness or security issues were identified.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the base gazette-scheduled-ordering test run and observed a failure: Could not find a working container runtime strategy (exit code 1).
- Ran the head run of the gazette-scheduled-ordering flow and encountered the same setup failure before the scenario could execute (exit code 1).

<a href="https://app.greptile.com/trex/runs/13155599/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/gazette/gazette.router.ts | Adds `Resource.scheduledAt` as a descending sort key in the gazette list query; no functional issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Dashboard as Gazettes Dashboard
participant Router as gazette.list tRPC
participant DB as PostgreSQL

Dashboard->>Router: Request gazettes(siteId, collectionId, limit, offset)
Router->>Router: Validate access and permissions
Router->>DB: Query Resource with blob/version joins
DB-->>Router: Rows ordered by status, category, notification, publishedAt, scheduledAt, file ID, tie-breakers
Router-->>Dashboard: Gazettes with file size and scheduled/published dates
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Dashboard as Gazettes Dashboard
participant Router as gazette.list tRPC
participant DB as PostgreSQL

Dashboard->>Router: Request gazettes(siteId, collectionId, limit, offset)
Router->>Router: Validate access and permissions
Router->>DB: Query Resource with blob/version joins
DB-->>Router: Rows ordered by status, category, notification, publishedAt, scheduledAt, file ID, tie-breakers
Router-->>Dashboard: Gazettes with file size and scheduled/published dates
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: sort by scheudled at"](https://github.com/opengovsg/isomer/commit/2be519453b5c164c7e363e0f6b45e80015a7b625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41560705)</sub>

<!-- /greptile_comment -->