### PR TITLE
fix: exclude tooling/bruno from pnpm workspace packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
   - "tooling/build/amplify"
   - "tooling/build/1password"
   - "tooling/build/scripts/publishing"
+  # Bruno API collections, not an npm package
+  - "!tooling/bruno"
 
 linkWorkspacePackages: true
 


### PR DESCRIPTION
## Problem

`sherif` (our workspace linter) flags `tooling/bruno` as a workspace package missing a `package.json`:

```
⚠️ warning All packages matching the workspace should have a package.json file. packages-without-package-json
   ./tooling/bruno/package.json doesn't exist.
```

`tooling/bruno` is a directory of Bruno API collections (`.bru` files) for the SearchSG Admin API, not an npm package, but it was still matched by the `tooling/*` glob in `pnpm-workspace.yaml`.

## Solution

Added `!tooling/bruno` to the `packages` list in `pnpm-workspace.yaml` to exclude it from the workspace glob, the same pattern already used to carve out standalone scripts under `tooling/build`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Excludes `tooling/bruno` from pnpm workspace packages so `sherif`/`pnpm exec sherif` no longer warns about a missing `package.json` there.

## Tests

- `pnpm exec sherif` now reports "No issues found".

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the pnpm workspace package list. The main changes are:

- Excludes `tooling/bruno` from the `tooling/*` workspace glob.
- Keeps Bruno API collection files out of workspace package checks.
- Prevents `sherif` from warning about a missing `tooling/bruno/package.json`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is a narrow workspace configuration exclusion for a non-package directory and does not alter application runtime behavior or dependencies.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the pre-change workspace Bruno exclusion baseline in workspace-bruno-exclusion-01-before.log to understand initial tooling patterns.
- Inspected the post-change workspace Bruno exclusion in workspace-bruno-exclusion-02-after.log, confirming the head includes - "!tooling/bruno" and that sherif checks report No issues found.
- Captured the two workspace exclusion logs as artifacts for review.

<a href="https://app.greptile.com/trex/runs/13162726/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Excludes `tooling/bruno` from pnpm workspace package globs; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: exclude tooling/bruno from pnpm wor..."](https://github.com/opengovsg/isomer/commit/c40727495d18a932cc7fab112410e0ac47488835) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41575625)</sub>

<!-- /greptile_comment -->