### PR TITLE
fix(storybook): disable rolldown strictExecutionOrder to fix runtime ReferenceError

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -17,6 +17,34 @@ const config: StorybookConfig = {
   },
 
   staticDirs: ["../public", "./assets"],
+
+  viteFinal: (config) => {
+    // Workaround for a rolldown (Vite 8 bundler) codegen bug: with
+    // strictExecutionOrder (force-enabled by @storybook/builder-vite),
+    // circular value-imports among src/{types,interfaces,schemas} make
+    // rolldown emit lazily-initialised (__esm-wrapped) modules whose
+    // cross-chunk bindings (e.g. typebox's `Type`) are never imported,
+    // throwing "ReferenceError: Type is not defined" at runtime. Disable it
+    // via a post-enforced plugin (builder-vite re-enables it in a pre plugin
+    // config hook, which runs after viteFinal). Only affects the Storybook
+    // build; the published package build uses tsc and is unaffected.
+    config.plugins ??= []
+    config.plugins.push({
+      name: "isomer:disable-strict-execution-order",
+      enforce: "post",
+      config: (cfg) => {
+        const output = (
+          cfg.build as
+            | { rolldownOptions?: { output?: Record<string, unknown> } }
+            | undefined
+        )?.rolldownOptions?.output
+        if (output && !Array.isArray(output)) {
+          output.strictExecutionOrder = false
+        }
+      },
+    })
+    return config
+  },
 }
 
 export default config


### PR DESCRIPTION
> [!WARNING]
>
> I have **not** checked this code yet, purely clauded

## Problem

The Chromatic `ui` check fails on full Storybook builds with `ReferenceError: Type is not defined` during story extraction. This is pre-existing on `main` — it only surfaces when Chromatic can't use TurboSnap (e.g. after a rebase/force-push loses the baseline) and does a full build.

The built Storybook throws at runtime when a story module loads: `@storybook/builder-vite` force-enables rolldown's `output.strictExecutionOrder` on Vite 8. Combined with this package's circular value-imports among `src/{types,interfaces,schemas}`, that mode's lazy (`__esm`-wrapped) module codegen emits chunks that reference cross-chunk bindings (e.g. typebox's `Type`) without importing them — hence the `ReferenceError`.

## Solution

Override `strictExecutionOrder` back to `false` for the Storybook build via a `viteFinal` post-enforced Vite plugin. The `post` enforcement matters: builder-vite re-enables the option inside a `pre`-plugin `config` hook that runs *after* `viteFinal`, so a plain `viteFinal` mutation gets clobbered.

This is a **Storybook-only** change. The published package build uses `tsc` and is unaffected, which is why every other CI job already passes.

The underlying `types` ↔ `interfaces` ↔ `schemas` circular dependencies (29 remaining per `madge`) are left as a separate hygiene task — this PR is the minimal fix to unblock CI.

## Tests

- Reproduced the baseline `ReferenceError` on `next-internal-components-childrenpages--default`.
- After the fix, swept **all 362 built stories** in a headless browser: **0 uncaught errors**.
- `pnpm typecheck`, `pnpm lint`, and `pnpm build` all pass.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a Storybook-only workaround for the components build. The main changes are:

- Adds a `viteFinal` hook in `packages/components/.storybook/main.ts`.
- Appends a post-enforced Vite plugin after Storybook builder configuration.
- Sets rolldown `strictExecutionOrder` to `false` for Storybook builds.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal runtime risk.

The change is limited to Storybook build configuration and does not affect published package output, schemas, or application runtime paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The team reviewed the before-state by inspecting the base build log and the browser console capture, which showed a ReferenceError and an empty root.
- The post-enforcement configuration was applied to enable the strictExecutionOrder workaround, and the build was re-run to generate updated artifacts.
- The after-state was verified to have a successful head build and a clean browser probe exit, with no uncaught runtime errors and the story content rendered.
- The after-state configuration evidence showed the Storybook Vite plugin in effect and the head build producing a separate type-\*.js chunk.

<a href="https://app.greptile.com/trex/runs/13251651/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/.storybook/main.ts | Adds a Storybook-only Vite post plugin that disables rolldown `strictExecutionOrder` after builder-vite config hooks. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant SB as Storybook config
participant BV as builder-vite pre config hook
participant IP as isomer post plugin
participant RB as Rolldown build

SB->>SB: viteFinal appends post plugin
BV->>BV: enables output.strictExecutionOrder
IP->>BV: post config hook mutates rolldownOptions.output
IP->>RB: "sets strictExecutionOrder = false"
RB->>RB: builds Storybook without lazy cross-chunk ReferenceError
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant SB as Storybook config
participant BV as builder-vite pre config hook
participant IP as isomer post plugin
participant RB as Rolldown build

SB->>SB: viteFinal appends post plugin
BV->>BV: enables output.strictExecutionOrder
IP->>BV: post config hook mutates rolldownOptions.output
IP->>RB: "sets strictExecutionOrder = false"
RB->>RB: builds Storybook without lazy cross-chunk ReferenceError
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(storybook): disable rolldown strictE..."](https://github.com/opengovsg/isomer/commit/a619690a12feb803080e288894ce774ed6676c0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41601837)</sub>

<!-- /greptile_comment -->