### PR TITLE
feat(studio): fire intercom events at editing survey measuring points

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,17 @@ _Avoid_: tag, filter option, tag value
 **Tagged** (`tagged`): The array of Tag Option UUIDs stored on a Collection Item representing the editor's selections across all Tag Categories.
 _Avoid_: tags (the legacy resolved format using string labels), selected tags
 
+### Page editing survey
+
+**Content Edit**: Any change an editor makes to a page's content blocks in the page editor — adding, deleting, reordering, or modifying a block (including hero and prose). Counts the moment the change is made, whether or not it is later saved or discarded. Excludes changes made via raw JSON mode, and excludes page metadata, siderail ordering, database configuration, and collection settings — those edit page properties, not content blocks.
+_Avoid_: edit (ambiguous — could mean any interaction), saved edit (a Content Edit need not be saved)
+
+**Measuring Point**: The moment a user who has made at least one Content Edit ends that editing burst by either (a) successfully publishing or scheduling the page for publication, or (b) navigating anywhere else within Studio. Each burst of Content Edits produces exactly one Measuring Point — reaching one re-arms only after a fresh Content Edit. Closing the window or tab is not a Measuring Point.
+_Avoid_: trigger point (overloaded), exit (window close is not a Measuring Point)
+
+**Measuring Period**: The recurrence window within which a given user is shown the editing survey at most once. Defined and enforced in the survey tool's frequency settings, not by Studio.
+_Avoid_: survey cooldown, quarter (the period is configurable, not fixed)
+
 ### Roles and surfaces
 
 **Isomer Admin**: A user with the Core or Migrator role. The only role that can manage taxonomy (create, edit, delete Tag Categories, Tag Options, and Category Options) via the Manage Filters panel.

--- a/apps/studio/src/features/editing-experience/__tests__/useContentEditSurvey.test.tsx
+++ b/apps/studio/src/features/editing-experience/__tests__/useContentEditSurvey.test.tsx
@@ -1,0 +1,293 @@
+// @vitest-environment jsdom
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+import type { PropsWithChildren } from "react"
+import { act, render, renderHook } from "@testing-library/react"
+import { createStore, Provider } from "jotai"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  EditorDrawerProvider,
+  useEditorDrawerContext,
+} from "~/contexts/EditorDrawerContext"
+import { ResourceType } from "~prisma/generated/generatedEnums"
+
+import { hasContentEditAtom } from "../atoms"
+import {
+  LEFT_EDITOR_AFTER_EDITING_EVENT,
+  PUBLISHED_AFTER_EDITING_EVENT,
+} from "../constants"
+import {
+  useContentEditTracker,
+  useFireContentEditSurveyEvent,
+  useLeftEditorSurveyTracker,
+} from "../hooks/useContentEditSurvey"
+
+const trackEventMock = vi.hoisted(() => vi.fn())
+vi.mock("@intercom/messenger-js-sdk", () => ({ trackEvent: trackEventMock }))
+
+const mockEnv = vi.hoisted(() => ({
+  env: { NEXT_PUBLIC_INTERCOM_APP_ID: "test-app-id" as string | undefined },
+}))
+vi.mock("~/env.mjs", () => mockEnv)
+
+const routeChangeStartHandlers = vi.hoisted<(() => void)[]>(() => [])
+vi.mock("next/router", () => ({
+  useRouter: () => ({
+    events: {
+      on: (_event: string, handler: () => void) => {
+        routeChangeStartHandlers.push(handler)
+      },
+      off: (_event: string, handler: () => void) => {
+        const index = routeChangeStartHandlers.indexOf(handler)
+        if (index !== -1) routeChangeStartHandlers.splice(index, 1)
+      },
+    },
+  }),
+}))
+
+const BASE_PAGE: IsomerSchema = {
+  version: "0.1.0",
+  layout: "homepage",
+  page: {},
+  content: [{ type: "prose", content: [] }],
+}
+
+const jotaiWrapper = (store: ReturnType<typeof createStore>) => {
+  const Wrapper = ({ children }: PropsWithChildren) => (
+    <Provider store={store}>{children}</Provider>
+  )
+  return Wrapper
+}
+
+let drawerContext: ReturnType<typeof useEditorDrawerContext>
+
+const TrackerHarness = () => {
+  useContentEditTracker()
+  drawerContext = useEditorDrawerContext()
+  return null
+}
+
+const renderTracker = (store: ReturnType<typeof createStore>) =>
+  render(
+    <Provider store={store}>
+      <EditorDrawerProvider
+        initialPageState={BASE_PAGE}
+        type={ResourceType.Page}
+        permalink="/test-page"
+        siteId={1}
+        pageId={1}
+        updatedAt={new Date()}
+        title="Test page"
+      >
+        <TrackerHarness />
+      </EditorDrawerProvider>
+    </Provider>,
+  )
+
+beforeEach(() => {
+  trackEventMock.mockClear()
+  mockEnv.env.NEXT_PUBLIC_INTERCOM_APP_ID = "test-app-id"
+  routeChangeStartHandlers.length = 0
+})
+
+describe("useFireContentEditSurveyEvent", () => {
+  it("does nothing when no content edit has been made", () => {
+    // Arrange
+    const store = createStore()
+    const { result } = renderHook(() => useFireContentEditSurveyEvent(), {
+      wrapper: jotaiWrapper(store),
+    })
+
+    // Act
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Assert
+    expect(trackEventMock).not.toHaveBeenCalled()
+    expect(store.get(hasContentEditAtom)).toBe(false)
+  })
+
+  it("fires the event and resets the flag when a content edit has been made", () => {
+    // Arrange
+    const store = createStore()
+    store.set(hasContentEditAtom, true)
+    const { result } = renderHook(() => useFireContentEditSurveyEvent(), {
+      wrapper: jotaiWrapper(store),
+    })
+
+    // Act
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Assert
+    expect(trackEventMock).toHaveBeenCalledTimes(1)
+    expect(trackEventMock).toHaveBeenCalledWith(PUBLISHED_AFTER_EDITING_EVENT)
+    expect(store.get(hasContentEditAtom)).toBe(false)
+  })
+
+  it("is a no-op on a second call after the flag has been consumed", () => {
+    // Arrange
+    const store = createStore()
+    store.set(hasContentEditAtom, true)
+    const { result } = renderHook(() => useFireContentEditSurveyEvent(), {
+      wrapper: jotaiWrapper(store),
+    })
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Act
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Assert
+    expect(trackEventMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("resets the flag without firing when NEXT_PUBLIC_INTERCOM_APP_ID is unset", () => {
+    // Arrange
+    mockEnv.env.NEXT_PUBLIC_INTERCOM_APP_ID = undefined
+    const store = createStore()
+    store.set(hasContentEditAtom, true)
+    const { result } = renderHook(() => useFireContentEditSurveyEvent(), {
+      wrapper: jotaiWrapper(store),
+    })
+
+    // Act
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Assert
+    expect(trackEventMock).not.toHaveBeenCalled()
+    expect(store.get(hasContentEditAtom)).toBe(false)
+  })
+})
+
+describe("useContentEditTracker", () => {
+  it("sets the flag when content diverges", () => {
+    // Arrange
+    const store = createStore()
+    renderTracker(store)
+
+    // Act
+    // setPreviewPageState uses flushSync internally, so state changes must be
+    // wrapped in act() to flush the resulting effects deterministically
+    act(() =>
+      drawerContext.setPreviewPageState((previous) => ({
+        ...previous,
+        content: [...previous.content, { type: "prose", content: [] }],
+      })),
+    )
+
+    // Assert
+    expect(store.get(hasContentEditAtom)).toBe(true)
+  })
+
+  it("does not set the flag on a re-render with deep-equal content", () => {
+    // Arrange
+    const store = createStore()
+    renderTracker(store)
+
+    // Act
+    act(() =>
+      drawerContext.setPreviewPageState((previous) => ({
+        ...previous,
+        content: [...previous.content],
+      })),
+    )
+
+    // Assert
+    expect(store.get(hasContentEditAtom)).toBe(false)
+  })
+
+  it("does not set the flag when content diverges in raw JSON mode", () => {
+    // Arrange
+    const store = createStore()
+    renderTracker(store)
+    act(() => drawerContext.setDrawerState({ state: "rawJsonEditor" }))
+
+    // Act
+    act(() =>
+      drawerContext.setPreviewPageState((previous) => ({
+        ...previous,
+        content: [...previous.content, { type: "prose", content: [] }],
+      })),
+    )
+
+    // Assert
+    expect(store.get(hasContentEditAtom)).toBe(false)
+
+    // Act: leaving raw JSON mode must not retroactively arm the flag
+    // (docs/adr/0003-editing-survey-measuring-points.md) — pins that the
+    // baseline ref is advanced before the rawJsonEditor guard
+    act(() => drawerContext.setDrawerState({ state: "root" }))
+
+    // Assert
+    expect(store.get(hasContentEditAtom)).toBe(false)
+  })
+
+  it("re-arms after the flag is consumed, emitting one event per burst", () => {
+    // Arrange
+    const store = createStore()
+    renderTracker(store)
+    const { result } = renderHook(() => useFireContentEditSurveyEvent(), {
+      wrapper: jotaiWrapper(store),
+    })
+
+    // Act: first burst — diverge content, then fire
+    act(() =>
+      drawerContext.setPreviewPageState((previous) => ({
+        ...previous,
+        content: [...previous.content, { type: "prose", content: [] }],
+      })),
+    )
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Assert
+    expect(trackEventMock).toHaveBeenCalledTimes(1)
+    expect(store.get(hasContentEditAtom)).toBe(false)
+
+    // Act: second burst — a fresh divergence
+    act(() =>
+      drawerContext.setPreviewPageState((previous) => ({
+        ...previous,
+        content: [...previous.content, { type: "prose", content: [] }],
+      })),
+    )
+
+    // Assert: the consumed flag is re-armed
+    expect(store.get(hasContentEditAtom)).toBe(true)
+
+    // Act: fire the second burst
+    act(() => result.current(PUBLISHED_AFTER_EDITING_EVENT))
+
+    // Assert
+    expect(trackEventMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("useLeftEditorSurveyTracker", () => {
+  it("fires the left-editor event on route change when a content edit has been made", () => {
+    // Arrange
+    const store = createStore()
+    store.set(hasContentEditAtom, true)
+    renderHook(() => useLeftEditorSurveyTracker(), {
+      wrapper: jotaiWrapper(store),
+    })
+
+    // Act
+    act(() => routeChangeStartHandlers.forEach((handler) => handler()))
+
+    // Assert
+    expect(trackEventMock).toHaveBeenCalledTimes(1)
+    expect(trackEventMock).toHaveBeenCalledWith(LEFT_EDITOR_AFTER_EDITING_EVENT)
+    expect(store.get(hasContentEditAtom)).toBe(false)
+  })
+
+  it("unsubscribes from route changes on unmount", () => {
+    // Arrange
+    const store = createStore()
+    const { unmount } = renderHook(() => useLeftEditorSurveyTracker(), {
+      wrapper: jotaiWrapper(store),
+    })
+
+    // Act
+    unmount()
+
+    // Assert
+    expect(routeChangeStartHandlers).toHaveLength(0)
+  })
+})

--- a/apps/studio/src/features/editing-experience/atoms.ts
+++ b/apps/studio/src/features/editing-experience/atoms.ts
@@ -2,3 +2,5 @@ import type { ResourceItemContent } from "~/schemas/resource"
 import { atom } from "jotai"
 
 export const moveResourceAtom = atom<null | ResourceItemContent>(null)
+
+export const hasContentEditAtom = atom(false)

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -23,6 +23,8 @@ import { Can } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
 
+import { PUBLISHED_AFTER_EDITING_EVENT } from "../constants"
+import { useFireContentEditSurveyEvent } from "../hooks/useContentEditSurvey"
 import { PublishingModal, ScheduledPublishingModal } from "./PublishingModal"
 import { CancelSchedulePublishIndicator } from "./PublishingModal/CancelSchedulePublishIndicator"
 
@@ -38,6 +40,7 @@ const SuspendablePublishButton = ({
 }: PublishButtonProps): JSX.Element => {
   const toast = useToast()
   const utils = trpc.useUtils()
+  const fireContentEditSurveyEvent = useFireContentEditSurveyEvent()
   // the current disclosures for the publish modals
   const publishNowDisclosure = useDisclosure()
   const scheduledPublishingDisclosure = useDisclosure()
@@ -59,6 +62,7 @@ const SuspendablePublishButton = ({
       ])
     },
     onSuccess: () => {
+      fireContentEditSurveyEvent(PUBLISHED_AFTER_EDITING_EVENT)
       toast({
         status: "success",
         title: "Page published successfully",

--- a/apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishingModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishingModal.tsx
@@ -28,6 +28,8 @@ import { useZodForm } from "~/lib/form"
 import { schedulePublishClientSchema } from "~/schemas/schedule"
 import { trpc } from "~/utils/trpc"
 
+import { PUBLISHED_AFTER_EDITING_EVENT } from "../../constants"
+import { useFireContentEditSurveyEvent } from "../../hooks/useContentEditSurvey"
 import { SchedulePublishDetails } from "./ScheduledPublishDetails"
 
 interface ScheduledPublishingModalProps extends UseDisclosureReturn {
@@ -43,6 +45,7 @@ export const ScheduledPublishingModal = ({
 }: ScheduledPublishingModalProps): JSX.Element => {
   const toast = useToast()
   const utils = trpc.useUtils()
+  const fireContentEditSurveyEvent = useFireContentEditSurveyEvent()
   const [isScheduledPublishValid, setIsScheduledPublishValid] = useState(false)
 
   const methods = useZodForm<typeof schedulePublishClientSchema>({
@@ -71,6 +74,7 @@ export const ScheduledPublishingModal = ({
         onClose()
       },
       onSuccess: () => {
+        fireContentEditSurveyEvent(PUBLISHED_AFTER_EDITING_EVENT)
         toast({
           status: "success",
           title: "Page scheduled successfully",

--- a/apps/studio/src/features/editing-experience/constants.ts
+++ b/apps/studio/src/features/editing-experience/constants.ts
@@ -58,3 +58,9 @@ export const TYPE_TO_ICON: Record<
   dynamiccomponentlist: BiListUl,
   childrenpages: BiListUl,
 }
+
+export const PUBLISHED_AFTER_EDITING_EVENT = "published-after-editing"
+export const LEFT_EDITOR_AFTER_EDITING_EVENT = "left-editor-after-editing"
+export type ContentEditSurveyEvent =
+  | typeof PUBLISHED_AFTER_EDITING_EVENT
+  | typeof LEFT_EDITOR_AFTER_EDITING_EVENT

--- a/apps/studio/src/features/editing-experience/hooks/useContentEditSurvey.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useContentEditSurvey.ts
@@ -1,0 +1,68 @@
+import { trackEvent } from "@intercom/messenger-js-sdk"
+import { useStore } from "jotai"
+import { isEqual } from "lodash-es"
+import { useRouter } from "next/router"
+import { useCallback, useEffect, useRef } from "react"
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { env } from "~/env.mjs"
+
+import type { ContentEditSurveyEvent } from "../constants"
+import { hasContentEditAtom } from "../atoms"
+import { LEFT_EDITOR_AFTER_EDITING_EVENT } from "../constants"
+
+export const useFireContentEditSurveyEvent = (): ((
+  eventName: ContentEditSurveyEvent,
+) => void) => {
+  const store = useStore()
+
+  return useCallback(
+    (eventName: ContentEditSurveyEvent) => {
+      if (!store.get(hasContentEditAtom)) return
+      store.set(hasContentEditAtom, false)
+      if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+        trackEvent(eventName)
+      }
+    },
+    [store],
+  )
+}
+
+export const useContentEditTracker = (): void => {
+  const store = useStore()
+  const { previewPageState, drawerState } = useEditorDrawerContext()
+  const previousContentRef = useRef(previewPageState.content)
+
+  useEffect(() => {
+    const previousContent = previousContentRef.current
+    const nextContent = previewPageState.content
+    previousContentRef.current = nextContent
+
+    // Raw JSON mode is a staff-only surface excluded from the survey by design
+    // (docs/adr/0003-editing-survey-measuring-points.md)
+    if (drawerState.state === "rawJsonEditor") return
+    if (store.get(hasContentEditAtom)) return
+    if (previousContent === nextContent) return
+    if (isEqual(previousContent, nextContent)) return
+
+    store.set(hasContentEditAtom, true)
+  }, [previewPageState.content, drawerState, store])
+}
+
+export const useLeftEditorSurveyTracker = (): void => {
+  const router = useRouter()
+  const fireContentEditSurveyEvent = useFireContentEditSurveyEvent()
+
+  useEffect(() => {
+    // Assumes the editor route has no navigation guard, so routeChangeStart
+    // always means the user actually leaves; an unsaved-changes guard that
+    // cancels navigation would make this mis-fire.
+    const handleRouteChangeStart = () => {
+      fireContentEditSurveyEvent(LEFT_EDITOR_AFTER_EDITING_EVENT)
+    }
+
+    router.events.on("routeChangeStart", handleRouteChangeStart)
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChangeStart)
+    }
+  }, [router.events, fireContentEditSurveyEvent])
+}

--- a/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx
@@ -4,6 +4,10 @@ import { PermissionsBoundary } from "~/components/AuthWrappers"
 import { EditorDrawerProvider } from "~/contexts/EditorDrawerContext"
 import { EditPageDrawer } from "~/features/editing-experience/components/Drawer/EditPageDrawer"
 import { EditPagePreview } from "~/features/editing-experience/components/preview/EditPagePreview"
+import {
+  useContentEditTracker,
+  useLeftEditorSurveyTracker,
+} from "~/features/editing-experience/hooks/useContentEditSurvey"
 import { pageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useResourceLocalViewHistory } from "~/hooks/useResourceLocalViewHistory"
@@ -50,6 +54,9 @@ const EditPage: NextPageWithLayout = () => {
 }
 
 const PageEditingView = () => {
+  useContentEditTracker()
+  useLeftEditorSurveyTracker()
+
   return (
     <Grid h="full" w="100%" templateColumns="repeat(3, 1fr)" gap={0}>
       <GridItem colSpan={1} overflow="auto" minW="28rem">

--- a/docs/adr/0003-editing-survey-measuring-points.md
+++ b/docs/adr/0003-editing-survey-measuring-points.md
@@ -1,0 +1,11 @@
+# Editing CSAT survey: measuring points, edit definition, and Intercom-owned gating
+
+We show an editing-experience CSAT survey when a user who made at least one Content Edit (see CONTEXT.md) ends that editing burst — by successfully publishing/scheduling the page, or by navigating anywhere else within Studio. Three deliberate choices, made 2026-07, that would break period-over-period comparability if changed mid-measurement:
+
+1. **Discarded edits count.** A Content Edit registers the moment `previewPageState.content` diverges, even if the user later discards. We are measuring the *experience* of editing, not whether the artifact changed — users who tried and gave up are the most informative cohort. Rejected alternative: counting only persisted saves (`updatePageBlob` success), which reads cleaner but silently drops that cohort. Raw JSON mode is excluded in code (staff-only surface, not the experience under measurement).
+
+2. **Intercom owns "once per user per Measuring Period".** The client fires two events — `published-after-editing` (on successful publish or schedule mutation) and `left-editor-after-editing` (on in-app route change away from the editor) — and the Intercom survey's audience/frequency rules enforce display frequency. Rejected alternatives: the existing localStorage `triggerSurveyOnce` pattern (per-browser, period changes require a deploy) and a server-side flag (new infrastructure for no gain). The survey must be configured in Intercom to trigger on *either* event, and the Measuring Period lives only in Intercom's frequency settings.
+
+3. **Window/tab close is deliberately unmeasured.** No `beforeunload` tracking — users who edit then close the window fire no event, by design (conflicts with the other measuring points and is a hostile survey moment).
+
+Consequence: each editing burst emits exactly one event (the flag resets on fire and re-arms on the next Content Edit), so the publish and leave cohorts are disjoint per burst.


### PR DESCRIPTION
## Goal
Emit the Intercom events that drive the editing-experience CSAT survey: one event per editing burst, fired when a user who changed page content publishes/schedules or navigates away.

## Approach
One-shot per `docs/oneshot-vs-plan-threshold.md` (FE-only, additive, 34 source LOC). Design was resolved in a grilling session; decisions and rejected alternatives are recorded in `docs/adr/0003-editing-survey-measuring-points.md` and the new "Page editing survey" glossary section of `CONTEXT.md` (both included here).

## What this PR does
- `hasContentEditAtom` (jotai, feature-scoped) arms when `previewPageState.content` diverges — including edits later discarded — except while the drawer is in raw JSON mode (staff-only surface).
- `useFireContentEditSurveyEvent` consumes the flag exactly once per burst: resets it, then fires `trackEvent` guarded by `NEXT_PUBLIC_INTERCOM_APP_ID`.
- `published-after-editing` fires on successful `publishPage` or `schedulePage` mutation; `left-editor-after-editing` fires on `routeChangeStart` away from the editor. Window close deliberately fires nothing.
- Trackers mount in `PageEditingView` (inside `EditorDrawerProvider`); the flag crosses to the layout-mounted `PublishButton` via the shared default jotai store.

## Stack
Single PR — client-only change, no schema/server slices.

## Verification
- [x] typecheck / lint / unit pass (1503 tests, incl. 10 new for flag semantics: divergence arming, raw-JSON exclusion incl. the retroactive case, consume-once, burst re-arm, route-change unsubscribe)
- [x] Storybook story — N/A: no visual component added (state hooks + two one-line mutation-handler calls); hook behaviour covered by unit tests instead
- [ ] Intercom-side follow-up (not code): configure the survey to trigger on either event, set frequency to the measuring period, exclude @open.gov.sg staff from the audience

## Closes
No tracking ticket — implemented from a design handoff (see ADR 0003 for the decision record). Label note: `ai-authored` and `area:studio` labels do not exist in this repo, so only `risk:low` is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds client-side tracking for page-editing CSAT survey measuring points. The main changes are:

- Tracks when page content changes outside raw JSON mode.
- Fires one Intercom event per editing burst on successful publish or schedule.
- Fires a separate Intercom event when the user navigates away from the editor.
- Adds tests and documentation for the survey event semantics.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low runtime risk.

Changes are additive, client-only, and covered by focused unit tests. No blocking or non-blocking issues were identified. The external side effect is limited to guarded Intercom analytics events.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A pre-probe snapshot was captured, showing the initial repository state with base HEAD and TOTAL\_CONTRACT\_NEEDLE\_HITS=0.
- A focused Vitest run was executed and completed, reporting the current HEAD and that 1 test file with 10 tests passed.
- When the initial Vitest invocation was blocked by the repo's unrelated testcontainers globalSetup, a temporary, focused Vitest config was used to run the changed hook tests without that setup.

<a href="https://app.greptile.com/trex/runs/13175783/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/hooks/useContentEditSurvey.ts | Adds hooks for detecting content edits, consuming the edit flag once, and firing leave-editor events on route changes. |
| apps/studio/src/pages/sites/[siteId]/pages/[pageId]/index.tsx | Mounts the content-edit and route-leave survey trackers inside the editor drawer provider. |
| apps/studio/src/features/editing-experience/components/PublishButton.tsx | Fires the published-after-editing survey event after successful publish mutations. |
| apps/studio/src/features/editing-experience/components/PublishingModal/ScheduledPublishingModal.tsx | Fires the published-after-editing survey event after successful scheduled publish mutations. |
| apps/studio/src/features/editing-experience/__tests__/useContentEditSurvey.test.tsx | Adds hook tests covering content divergence, raw JSON exclusion, one-shot event consumption, re-arming, and route unsubscribe behavior. |
| docs/adr/0003-editing-survey-measuring-points.md | Documents the measuring-point decisions and Intercom-owned survey frequency model. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Editor as PageEditingView
participant Tracker as useContentEditTracker
participant Store as hasContentEditAtom
participant Publish as Publish/Schedule mutation
participant Router as Next router
participant Intercom as Intercom trackEvent

Editor->>Tracker: mount inside EditorDrawerProvider
Tracker->>Tracker: compare previous content with previewPageState.content
Tracker->>Store: set true when content diverges outside raw JSON mode
alt publish or schedule succeeds
    Publish->>Store: consume flag
    Store-->>Publish: content edit was present
    Publish->>Intercom: published-after-editing
else routeChangeStart after edit
    Router->>Store: consume flag
    Store-->>Router: content edit was present
    Router->>Intercom: left-editor-after-editing
end
Store->>Store: reset false until a fresh content edit re-arms
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Editor as PageEditingView
participant Tracker as useContentEditTracker
participant Store as hasContentEditAtom
participant Publish as Publish/Schedule mutation
participant Router as Next router
participant Intercom as Intercom trackEvent

Editor->>Tracker: mount inside EditorDrawerProvider
Tracker->>Tracker: compare previous content with previewPageState.content
Tracker->>Store: set true when content diverges outside raw JSON mode
alt publish or schedule succeeds
    Publish->>Store: consume flag
    Store-->>Publish: content edit was present
    Publish->>Intercom: published-after-editing
else routeChangeStart after edit
    Router->>Store: consume flag
    Store-->>Router: content edit was present
    Router->>Intercom: left-editor-after-editing
end
Store->>Store: reset false until a fresh content edit re-arms
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(studio): fire intercom events at ed..."](https://github.com/opengovsg/isomer/commit/af814aa2fc014b2833813dff9ed6604131f9d3ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41602225)</sub>

<!-- /greptile_comment -->