### PR TITLE
👨🏻‍💻 DX - Test: Add post-deploy Playwright smoke tests to CI

### DIFF
--- a/.github/workflows/aws_deploy.yml
+++ b/.github/workflows/aws_deploy.yml
@@ -385,3 +385,22 @@ jobs:
           payload: |
             channel: ${{ secrets.SLACK_CHANNEL_ID }}
             text: "<!subteam^${{ secrets.SLACK_NOTIFY_TEAM_ID }}> Deployment of *${{ inputs.app-name }}* to *${{ inputs.environment }}* environment has *failed* :warning: \n> Version: *${{ inputs.app-version }}*\n> Attempted by: ${{ github.actor }}"
+
+  # Post-deploy smoke against the deployed environment (all environments).
+  # Runs AFTER the CodeDeploy blue/green shift completes, so it detects a bad deploy
+  # but does not gate traffic pre-shift. To gate BEFORE live traffic, move this to a
+  # CodeDeploy AfterAllowTestTraffic lifecycle hook against the green task set; to
+  # auto-recover on failure, wire rollback here (tag-rollback workflow, or
+  # `aws deploy stop-deployment --auto-rollback-enabled` during the bake window).
+  smoke:
+    name: Smoke test deployed environment
+    needs: deploy
+    if: ${{ inputs.app-url != '' }}
+    uses: ./.github/workflows/smoke.yml
+    with:
+      app-url: ${{ inputs.app-url }}
+      environment: ${{ inputs.environment }}
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+      SLACK_NOTIFY_TEAM_ID: ${{ secrets.SLACK_NOTIFY_TEAM_ID }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -15,7 +15,7 @@ on:
         required: true
         type: string
       environment:
-        description: "Deployment environment (for env-scoped secrets)"
+        description: "Deployment environment label (for job name and notifications)"
         required: true
         type: string
     secrets:
@@ -33,7 +33,6 @@ jobs:
   smoke:
     name: Smoke (${{ inputs.environment }})
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,55 @@
+name: 🚬 Smoke test
+
+# Reusable: verifies a DEPLOYED environment is alive and correctly wired (app boots,
+# routing + auth reachable, real integrations serving) by running the smoke suite
+# against its public URL. It does NOT verify that any change is correct.
+#
+# Called from aws_deploy.yml after every deploy, so it runs on all environments.
+# Can also be called on a schedule for ongoing synthetic monitoring of production.
+
+on:
+  workflow_call:
+    inputs:
+      app-url:
+        description: "Public URL of the deployed environment to smoke test"
+        required: true
+        type: string
+      environment:
+        description: "Deployment environment (for env-scoped secrets)"
+        required: true
+        type: string
+    secrets:
+      SLACK_BOT_TOKEN:
+        description: "Slack bot token with permissions to post messages"
+      SLACK_CHANNEL_ID:
+        description: "Slack channel ID to post smoke failures to"
+      SLACK_NOTIFY_TEAM_ID:
+        description: "Slack team ID to mention on smoke failure"
+
+permissions:
+  contents: read
+
+jobs:
+  smoke:
+    name: Smoke (${{ inputs.environment }})
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Install Playwright (Chromium)
+        run: pnpm --filter isomer-studio exec playwright install chromium
+      - name: Run smoke tests against ${{ inputs.environment }}
+        env:
+          PLAYWRIGHT_TEST_BASE_URL: ${{ inputs.app-url }}
+        run: pnpm --filter isomer-studio run test:smoke
+      - name: Notify smoke failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "<!subteam^${{ secrets.SLACK_NOTIFY_TEAM_ID }}> :warning: Post-deploy smoke tests FAILED against *${{ inputs.environment }}* (${{ inputs.app-url }}) — the deployed environment may be broken. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Install Playwright (Chromium)
-        run: pnpm --filter isomer-studio exec playwright install chromium
+        run: pnpm --filter isomer-studio exec playwright install chromium --with-deps
       - name: Run smoke tests against ${{ inputs.environment }}
         env:
           PLAYWRIGHT_TEST_BASE_URL: ${{ inputs.app-url }}

--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -78,6 +78,7 @@
     {
       "files": [
         "playwright.config.ts",
+        "playwright.smoke.config.ts",
         "tests/**/*.ts",
         "tests/**/*.tsx",
         ".storybook/**/*.ts",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -50,6 +50,7 @@
     "test-dev:unit": "dotenv -e .env.test -- vitest",
     "test:e2e": "dotenv -e .env.test pnpm exec playwright test",
     "test:load:build": "webpack-cli --config tests/load/webpack.config.cjs",
+    "test:smoke": "pnpm exec playwright test --config playwright.smoke.config.ts",
     "test:unit": "dotenv -e .env.test -- vitest run",
     "test:watch": "dotenv -e .env.test -- pnpm exec vitest watch",
     "typecheck": "tsgo --noEmit"

--- a/apps/studio/playwright.smoke.config.ts
+++ b/apps/studio/playwright.smoke.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig } from "@playwright/test"
+
+import baseConfig from "./playwright.config"
+
+// Smoke config for running against a DEPLOYED, remote environment (e.g. staging
+// ECS after a deploy). It EXTENDS playwright.config.ts and changes only what a
+// remote run requires, so the shared settings (reporter, timeout, browser, etc.)
+// never drift. The differences:
+//   - NO globalSetup: the e2e globalSetup writes directly to a local DB and does
+//     a Mockpass login; it must never run against a real environment.
+//   - selects only the smoke suite (by path), which is unauthenticated + read-only
+//   - retries + trace, because a live shared environment is inherently less stable
+//   - requires PLAYWRIGHT_TEST_BASE_URL (no localhost default)
+//
+// Point it at the target with PLAYWRIGHT_TEST_BASE_URL, e.g.
+//   PLAYWRIGHT_TEST_BASE_URL=https://staging-studio.isomer.gov.sg pnpm test:smoke
+const baseUrl = process.env.PLAYWRIGHT_TEST_BASE_URL
+
+if (!baseUrl) {
+  throw new Error(
+    "PLAYWRIGHT_TEST_BASE_URL must be set for the smoke suite (the deployed URL to hit).",
+  )
+}
+
+const baseProject = baseConfig.projects?.[0]
+
+export default defineConfig({
+  ...baseConfig,
+  globalSetup: undefined,
+  testMatch: /smoke\.test\.ts$/,
+  retries: 2,
+  forbidOnly: !!process.env.CI,
+  projects: [
+    {
+      ...baseProject,
+      name: "smoke",
+      outputDir: "./tests/e2e/smoke-results",
+      use: {
+        ...baseProject?.use,
+        baseURL: baseUrl,
+        // Smoke is an unattended deploy gate — always headless.
+        // Pass `--headed` on the CLI when debugging a failure locally.
+        headless: true,
+        trace: "retain-on-failure",
+      },
+    },
+  ],
+})

--- a/apps/studio/tests/e2e/smoke.test.ts
+++ b/apps/studio/tests/e2e/smoke.test.ts
@@ -1,6 +1,16 @@
 import { expect, test } from "@playwright/test"
 
-test("go to /sign-in", async ({ page }) => {
+// This is the smoke suite: unauthenticated, read-only, idempotent checks that are
+// safe to run against a LIVE, SHARED environment (e.g. staging ECS after a deploy).
+// It verifies the deployment is alive and correctly wired — NOT that any specific
+// change behaves correctly. Keep it fast and few.
+//
+// It is selected by file path (playwright.smoke.config.ts) and runs WITHOUT the
+// e2e globalSetup, which seeds a local DB and must never touch a real environment.
+
+test("sign-in page renders (app boots + serves HTML/CSS/JS)", async ({
+  page,
+}) => {
   await page.goto("/sign-in")
 
   const text = page.getByText(`Isomer Studio`).first()
@@ -8,7 +18,14 @@ test("go to /sign-in", async ({ page }) => {
   await expect(text).toBeVisible()
 })
 
-test("test 404", async ({ page }) => {
+test("unknown route returns 404 (routing wired)", async ({ page }) => {
   const res = await page.goto("/not-found")
   expect(res?.status()).toBe(404)
+})
+
+test("root redirects unauthenticated users to sign-in (auth wired)", async ({
+  page,
+}) => {
+  await page.goto("/")
+  await expect(page).toHaveURL(/\/sign-in/)
 })


### PR DESCRIPTION
## Problem

After every AWS deploy we had no automated check that the deployed environment was alive and correctly wired (app boots, routing, auth). Release confidence still relied on manual staging verification, and a bad deploy could go unnoticed until someone tried the environment by hand.

## Solution

Introduce a reusable post-deploy smoke workflow that runs unauthenticated, read-only Playwright checks against the deployed public URL immediately after CodeDeploy completes.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- New reusable `.github/workflows/smoke.yml` workflow that runs the smoke suite against a deployed environment URL, with Slack notification on failure
- `aws_deploy.yml` invokes smoke automatically after deploy when `app-url` is provided (staging, UAT, and production deploys)
- Dedicated `playwright.smoke.config.ts` for remote runs: no local `globalSetup`, requires `PLAYWRIGHT_TEST_BASE_URL`, retries and trace-on-failure for CI stability

**Improvements**:

- Expanded smoke test suite with clearer scenarios: sign-in page renders, unknown routes return 404, unauthenticated root redirects to sign-in
- Added `test:smoke` npm script for running the suite locally against any deployed URL

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- Deploy completes with no automated post-deploy health check -->

**AFTER**:

<!-- Deploy workflow includes a "Smoke test deployed environment" job that runs Playwright against the public app URL -->

## Tests

**New scripts**:

- `pnpm --filter isomer-studio run test:smoke` : runs the smoke Playwright suite against `PLAYWRIGHT_TEST_BASE_URL` (e.g. `PLAYWRIGHT_TEST_BASE_URL=https://staging-studio.isomer.gov.sg pnpm --filter isomer-studio run test:smoke`)

**New dependencies**:

- None

**New dev dependencies**:

- None

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds post-deploy smoke tests for deployed Studio environments. The main changes are:

- A reusable `.github/workflows/smoke.yml` workflow for remote Playwright smoke checks.
- AWS deploy workflow wiring that runs smoke tests after deployment when `app-url` is provided.
- A dedicated `playwright.smoke.config.ts` that requires `PLAYWRIGHT_TEST_BASE_URL` and skips local e2e setup.
- Expanded smoke tests for sign-in rendering, 404 routing, and unauthenticated root redirects.
- A `test:smoke` package script and lint override for the new smoke config.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low functional risk.

The changes are limited to CI workflow wiring and smoke-test configuration. The reusable workflow avoids the prior environment approval gate issue. Chromium is installed with system dependencies. The smoke config disables local global setup for remote runs.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the smoke workflow validation for both base and head using the shared validation script and captured before/after logs that record the validation runs.
- T-Rex inspected the smoke-suite state before and after execution, noting base limitations such as missing test:smoke and config gaps, the command used for the run, the resulting test list, and the runtime blockage caused by missing browser binaries.

<a href="https://app.greptile.com/trex/runs/13205667/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/aws_deploy.yml | Adds a post-deploy reusable smoke-test job gated on `app-url`; no blocking issues found. |
| .github/workflows/smoke.yml | Introduces the reusable smoke workflow with setup, Playwright browser installation, remote test execution, and Slack failure notification; previous concerns appear addressed. |
| apps/studio/playwright.smoke.config.ts | Adds a remote-only Playwright config requiring `PLAYWRIGHT_TEST_BASE_URL`, disabling local global setup, and selecting only the smoke suite. |
| apps/studio/tests/e2e/smoke.test.ts | Expands unauthenticated read-only smoke checks for sign-in rendering, 404 routing, and auth redirect behavior. |
| apps/studio/package.json | Adds a `test:smoke` script that runs Playwright with the dedicated remote smoke config. |
| apps/studio/.oxlintrc.json | Extends the Playwright/test lint override to the new smoke config file. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Deploy as AWS Deploy workflow
participant Smoke as Reusable smoke workflow
participant PW as Playwright smoke suite
participant App as Deployed Studio URL
participant Slack as Slack notification

Deploy->>Deploy: Complete CodeDeploy deployment
alt app-url provided
    Deploy->>Smoke: Call smoke.yml with app-url + environment
    Smoke->>Smoke: Checkout + setup dependencies
    Smoke->>PW: Run test:smoke with PLAYWRIGHT_TEST_BASE_URL
    PW->>App: GET /sign-in
    App-->>PW: Sign-in page HTML
    PW->>App: GET /not-found
    App-->>PW: 404 response
    PW->>App: GET /
    App-->>PW: Redirect to /sign-in
    alt smoke failure
        Smoke->>Slack: Post failure notification
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Deploy as AWS Deploy workflow
participant Smoke as Reusable smoke workflow
participant PW as Playwright smoke suite
participant App as Deployed Studio URL
participant Slack as Slack notification

Deploy->>Deploy: Complete CodeDeploy deployment
alt app-url provided
    Deploy->>Smoke: Call smoke.yml with app-url + environment
    Smoke->>Smoke: Checkout + setup dependencies
    Smoke->>PW: Run test:smoke with PLAYWRIGHT_TEST_BASE_URL
    PW->>App: GET /sign-in
    App-->>PW: Sign-in page HTML
    PW->>App: GET /not-found
    App-->>PW: 404 response
    PW->>App: GET /
    App-->>PW: Redirect to /sign-in
    alt smoke failure
        Smoke->>Slack: Post failure notification
    end
end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: update smoke.yml to clarify en..."](https://github.com/opengovsg/isomer/commit/8f5a494d5c065d82404c9d4e8c76448dec7938b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41610542)</sub>

<!-- /greptile_comment -->