### PR TITLE
docs: add GrowthBook feature flag conventions for risky changes

### DIFF
--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -60,7 +60,7 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 
 ### Feature flags
 
-- [Gate risky changes behind a GrowthBook flag; canary via enabledSites](conventions/growthbook-flag-risky-changes.md) — best practice: risky changes ship behind a GrowthBook flag (key constant + safe fallback); canary to chosen agencies via `enabledSites`, the only canary we have
+- [Gate risky changes behind a GrowthBook flag; canary via enabledSites](conventions/growthbook-flag-risky-changes.md) — best practice: risky changes ship behind a GrowthBook flag (key constant + safe fallback); canary to chosen agencies via `enabledSites`, or to individuals via GrowthBook's native `email` targeting
 
 ### Dependencies
 

--- a/.claude/skills/isomer-conventions/SKILL.md
+++ b/.claude/skills/isomer-conventions/SKILL.md
@@ -58,6 +58,10 @@ Keep SKILL.md lean: detail lives in the entry files, never inline here.
 ### Testing
 - [Structure tests as Arrange / Act / Assert](conventions/tests-arrange-act-assert.md) — best practice: mark AAA phases (collapse adjacent markers when trivial), one Act per test
 
+### Feature flags
+
+- [Gate risky changes behind a GrowthBook flag; canary via enabledSites](conventions/growthbook-flag-risky-changes.md) — best practice: risky changes ship behind a GrowthBook flag (key constant + safe fallback); canary to chosen agencies via `enabledSites`, the only canary we have
+
 ### Dependencies
 
 - [Reference catalog packages via "catalog:" not direct version strings](conventions/pnpm-catalog-references.md) — smell: direct version strings in package.json for packages defined in pnpm-workspace.yaml catalog

--- a/.claude/skills/isomer-conventions/conventions/growthbook-flag-risky-changes.md
+++ b/.claude/skills/isomer-conventions/conventions/growthbook-flag-risky-changes.md
@@ -16,9 +16,16 @@ gracefully.
 
 To **canary to specific agencies**, use a `{ enabledSites: string[] }` flag value
 and gate on `enabledSites.includes(siteId.toString())`, widening the list over
-time. This is the *only* canary we have — Studio is one multi-tenant app, so
-there is no infrastructure-level (traffic-percentage) canary; that would hit
-random agencies, not chosen ones.
+time. Studio is one multi-tenant app, so there is no infrastructure-level
+(traffic-percentage) canary; that would hit random agencies, not chosen ones.
+
+To **canary to specific individuals** such as internal testers instead of a whole agency, set GrowthBook's `email` targeting
+condition in the dashboard. No hand-rolled check needed. `email` is already
+a GrowthBook attribute on every request. Client-side,
+`gb.setAttributes({ email })` runs in
+`apps/studio/src/components/AvatarMenu.tsx`. Server-side, it is set in
+`apps/studio/src/server/modules/auth/email/email.router.ts` and cleared on
+logout.
 
 ## Why
 
@@ -27,16 +34,19 @@ random agencies, not chosen ones.
   small, which is the whole point of shipping without certainty.
 - **Canary limits exposure to chosen agencies.** `enabledSites` lets one pilot
   agency exercise the change before it reaches everyone.
-- **Boundary — two classes this does *not* fully cover.**
+- **`email` targeting needs no app code.** Because the SDK already carries the
+  `email` attribute, gating individual testers is a dashboard-only change —
+  one less place for the check to drift or be implemented wrong.
+- **Boundary — two classes this does _not_ fully cover.**
   1. **Can't be canaried, but can be kill-switched.** Global/shared behavior,
      cross-cutting refactors, and shared-component changes reach every agency at
-     once, so `enabledSites` doesn't apply — but a *global boolean* flag still
+     once, so `enabledSites` doesn't apply — but a _global boolean_ flag still
      buys an instant on/off recovery. Prefer that over no flag.
   2. **Can't be partially rolled out at all.** Some changes are all-or-nothing by
      nature — auth/login (e.g. **2FA**), session/security flows, and irreversible
      data migrations. You cannot run some users on the new login and some on the
-     old, and flipping a flag off mid-flight can leave users *locked out or
-     half-migrated* — so a flag is not a clean undo here, and sometimes not
+     old, and flipping a flag off mid-flight can leave users _locked out or
+     half-migrated_ — so a flag is not a clean undo here, and sometimes not
      appropriate at all. These are inherently high-stakes: ship them as a
      **deliberate, isolated release** (never batched), lean on strong pre-merge
      acceptance tests, and plan to **fix forward** — the 5xx auto-rollback is a
@@ -84,3 +94,7 @@ const isNewThingEnabled = useFeatureValue<boolean>(SOME_FEATURE_KEY, false)
   `apps/studio/src/lib/growthbook.ts` where `true` is intentional.
 - Canary pattern reference: `enabledSites.includes(siteId.toString())` in
   `apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx:66`.
+- A hand-rolled `enabledEmails`/allowlist check in application code — `email`
+  is already a live GrowthBook attribute (`apps/studio/src/components/AvatarMenu.tsx`,
+  `apps/studio/src/server/modules/auth/email/email.router.ts`), so this belongs
+  in a GrowthBook targeting condition instead.

--- a/.claude/skills/isomer-conventions/conventions/growthbook-flag-risky-changes.md
+++ b/.claude/skills/isomer-conventions/conventions/growthbook-flag-risky-changes.md
@@ -1,0 +1,86 @@
+---
+title: Gate risky changes behind a GrowthBook flag; canary via enabledSites
+category: Feature flags
+type: best-practice
+---
+
+## Pattern
+
+Ship risky or rollout-sensitive changes behind a GrowthBook flag **by default**,
+so approval no longer requires certainty — if it's wrong, you flip the flag
+instead of redeploying. Declare the flag key as a constant in
+`apps/studio/src/lib/growthbook.ts`, read it via `useFeatureValue<T>(KEY,
+fallback)` (client) or `gb.getFeatureValue(KEY, fallback)` (server), and always
+give a **safe fallback** (the old/off behavior) so a GrowthBook outage degrades
+gracefully.
+
+To **canary to specific agencies**, use a `{ enabledSites: string[] }` flag value
+and gate on `enabledSites.includes(siteId.toString())`, widening the list over
+time. This is the *only* canary we have — Studio is one multi-tenant app, so
+there is no infrastructure-level (traffic-percentage) canary; that would hit
+random agencies, not chosen ones.
+
+## Why
+
+- **Rollback = flag flip, not redeploy.** The scary part of approving a PR is
+  "what if it breaks in prod" — a flag makes recovery instant and blast-radius
+  small, which is the whole point of shipping without certainty.
+- **Canary limits exposure to chosen agencies.** `enabledSites` lets one pilot
+  agency exercise the change before it reaches everyone.
+- **Boundary — two classes this does *not* fully cover.**
+  1. **Can't be canaried, but can be kill-switched.** Global/shared behavior,
+     cross-cutting refactors, and shared-component changes reach every agency at
+     once, so `enabledSites` doesn't apply — but a *global boolean* flag still
+     buys an instant on/off recovery. Prefer that over no flag.
+  2. **Can't be partially rolled out at all.** Some changes are all-or-nothing by
+     nature — auth/login (e.g. **2FA**), session/security flows, and irreversible
+     data migrations. You cannot run some users on the new login and some on the
+     old, and flipping a flag off mid-flight can leave users *locked out or
+     half-migrated* — so a flag is not a clean undo here, and sometimes not
+     appropriate at all. These are inherently high-stakes: ship them as a
+     **deliberate, isolated release** (never batched), lean on strong pre-merge
+     acceptance tests, and plan to **fix forward** — the 5xx auto-rollback is a
+     backstop for crashes, not a safe undo for a half-applied auth change.
+
+## Bad
+
+```tsx
+// Risky new feature shipped with no flag — reaches all agencies at once,
+// and the only way back is a redeploy.
+export function CategoryDropdown({ siteId }: Props) {
+  return <NewDropdown siteId={siteId} />
+}
+
+// Or: flag read with a hard-coded key and an unsafe default that turns the
+// new (risky) behavior ON when GrowthBook is unreachable.
+const enabled = useFeatureValue<boolean>("category-dropdown", true)
+```
+
+## Good
+
+```tsx
+// Key declared once as a constant (apps/studio/src/lib/growthbook.ts).
+import { CATEGORY_DROPDOWN_FEATURE_KEY } from "~/lib/growthbook"
+
+// Canary by agency: default to no sites, widen enabledSites over time.
+const { enabledSites } = useFeatureValue<{ enabledSites: string[] }>(
+  CATEGORY_DROPDOWN_FEATURE_KEY,
+  { enabledSites: [] }, // safe fallback: off everywhere
+)
+const isDropdownEnabled = enabledSites.includes(siteId.toString())
+
+// Simple on/off risky change: default OFF (old behavior) as the safe fallback.
+const isNewThingEnabled = useFeatureValue<boolean>(SOME_FEATURE_KEY, false)
+```
+
+## How to detect
+
+- A new risky/rollout-sensitive feature merged with **no** GrowthBook flag.
+- `useFeatureValue` / `getFeatureValue` called with a **hard-coded string** key
+  instead of a `*_FEATURE_KEY` constant from `lib/growthbook.ts`.
+- A rollout-sensitive flag defaulting to `true` (unsafe fallback) — new behavior
+  should default off, so an outage falls back to the known-good path. See the
+  deliberate exception `IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE` in
+  `apps/studio/src/lib/growthbook.ts` where `true` is intentional.
+- Canary pattern reference: `enabledSites.includes(siteId.toString())` in
+  `apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsCategoryControl.tsx:66`.


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +104 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |

2 file(s) changed. Buckets derived from [`docs/risk-taxonomy.md`](../blob/main/docs/risk-taxonomy.md) conventions.
<!-- pr-diff-breakdown:end -->

## Problem

Agents and reviewers lack a documented Isomer convention for when and how to gate risky changes behind GrowthBook flags. Without this guidance, rollout-sensitive features may ship without flags, use unsafe fallbacks, or miss the `enabledSites` canary pattern that is our only agency-scoped rollout mechanism.

## Solution

Added a new isomer-conventions entry documenting GrowthBook flag best practices for risky changes, and linked it from the skill index.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- New convention doc `growthbook-flag-risky-changes.md` covering:
  - Default pattern: declare flag keys in `lib/growthbook.ts`, read via `useFeatureValue` / `getFeatureValue`, always use a safe fallback (old/off behavior)
  - Canary pattern: `{ enabledSites: string[] }` with `enabledSites.includes(siteId.toString())` as the only agency-scoped canary available in our multi-tenant Studio app
  - Boundaries: global kill-switch flags for changes that cannot be canaried; deliberate isolated releases for all-or-nothing changes (auth, migrations) where flag rollback is not a safe undo
  - Detection heuristics for code review (missing flags, hard-coded keys, unsafe `true` defaults)
- Registered the convention under a new **Feature flags** section in `isomer-conventions/SKILL.md`

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

N/A — documentation-only change.

**AFTER**:

N/A — documentation-only change.

## Tests

No production code changes. Convention docs are consumed by agents and reviewers at development time; no runtime verification required.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds GrowthBook feature flag guidance to the Isomer conventions docs. The main changes are:

- A new Feature flags entry in the `isomer-conventions` skill catalog.
- A new convention for gating risky changes behind GrowthBook flags.
- Guidance for safe fallbacks, `enabledSites` agency canaries, GrowthBook `email` targeting, and cases where flags are not a safe rollback path.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to Markdown convention documentation and a skill index link. No runtime code, configuration, or production behavior changes were introduced. No correctness or security issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran a git diff --check across the isomer-conventions path for the specified commit range and confirmed there were no whitespace or formatting errors.
- I executed sherif via pnpm to validate conventions and it reported no issues found.
- I saved the full command transcript to the docs-validation.log artifact for review.

<a href="https://app.greptile.com/trex/runs/15350827/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .claude/skills/isomer-conventions/SKILL.md | Adds a Feature flags catalog entry pointing reviewers to the new GrowthBook risky-change convention. |
| .claude/skills/isomer-conventions/conventions/growthbook-flag-risky-changes.md | Adds documentation for GrowthBook flag usage, safe fallbacks, enabledSites canaries, email targeting, and detection heuristics for risky changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: update GrowthBook flag guidelines ..."](https://github.com/opengovsg/isomer/commit/87da63e2c8b27a53e4be13f877aa5f0315628d63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41671809)</sub>

<!-- /greptile_comment -->