### PR TITLE
fix(studio): guard godmode routes server-side

### DIFF
--- a/apps/studio/src/features/godmode/serverSideProps.ts
+++ b/apps/studio/src/features/godmode/serverSideProps.ts
@@ -1,0 +1,75 @@
+import type { GetServerSidePropsContext, GetServerSidePropsResult } from "next"
+import type { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+import { getIronSession } from "iron-session"
+import { DASHBOARD } from "~/lib/routes"
+import { type SessionData } from "~/lib/types/session"
+import { generateSessionOptions } from "~/server/modules/auth/session"
+import { isActiveIsomerAdmin } from "~/server/modules/permissions/permissions.service"
+
+export interface GodModeAdminRoleProps {
+  userGodModeRoles: IsomerAdminRole[]
+}
+
+export const requireGodModeAdmin = async (
+  { req, res }: GetServerSidePropsContext,
+  allowedRoles: readonly IsomerAdminRole[],
+): Promise<GetServerSidePropsResult<Record<string, never>>> => {
+  const session = await getIronSession<SessionData>(
+    req,
+    res,
+    generateSessionOptions(),
+  )
+
+  const isUserGodModeAdmin =
+    !!session.userId &&
+    (await isActiveIsomerAdmin(session.userId, [...allowedRoles]))
+
+  if (!isUserGodModeAdmin) {
+    return {
+      redirect: {
+        destination: DASHBOARD,
+        permanent: false,
+      },
+    }
+  }
+
+  return {
+    props: {},
+  }
+}
+
+export const requireGodModeAdminWithRoleProps = async (
+  { req, res }: GetServerSidePropsContext,
+  allowedRoles: readonly IsomerAdminRole[],
+): Promise<GetServerSidePropsResult<GodModeAdminRoleProps>> => {
+  const session = await getIronSession<SessionData>(
+    req,
+    res,
+    generateSessionOptions(),
+  )
+
+  const userGodModeRoles: IsomerAdminRole[] = []
+
+  if (session.userId) {
+    for (const role of allowedRoles) {
+      if (await isActiveIsomerAdmin(session.userId, [role])) {
+        userGodModeRoles.push(role)
+      }
+    }
+  }
+
+  if (userGodModeRoles.length === 0) {
+    return {
+      redirect: {
+        destination: DASHBOARD,
+        permanent: false,
+      },
+    }
+  }
+
+  return {
+    props: {
+      userGodModeRoles,
+    },
+  }
+}

--- a/apps/studio/src/features/godmode/serverSideProps.ts
+++ b/apps/studio/src/features/godmode/serverSideProps.ts
@@ -13,34 +13,6 @@ export interface GodModeAdminRoleProps {
 export const requireGodModeAdmin = async (
   { req, res }: GetServerSidePropsContext,
   allowedRoles: readonly IsomerAdminRole[],
-): Promise<GetServerSidePropsResult<Record<string, never>>> => {
-  const session = await getIronSession<SessionData>(
-    req,
-    res,
-    generateSessionOptions(),
-  )
-
-  const isUserGodModeAdmin =
-    !!session.userId &&
-    (await isActiveIsomerAdmin(session.userId, [...allowedRoles]))
-
-  if (!isUserGodModeAdmin) {
-    return {
-      redirect: {
-        destination: DASHBOARD,
-        permanent: false,
-      },
-    }
-  }
-
-  return {
-    props: {},
-  }
-}
-
-export const requireGodModeAdminWithRoleProps = async (
-  { req, res }: GetServerSidePropsContext,
-  allowedRoles: readonly IsomerAdminRole[],
 ): Promise<GetServerSidePropsResult<GodModeAdminRoleProps>> => {
   const session = await getIronSession<SessionData>(
     req,

--- a/apps/studio/src/features/godmode/serverSideProps.ts
+++ b/apps/studio/src/features/godmode/serverSideProps.ts
@@ -51,11 +51,15 @@ export const requireGodModeAdminWithRoleProps = async (
   const userGodModeRoles: IsomerAdminRole[] = []
 
   if (session.userId) {
-    for (const role of allowedRoles) {
-      if (await isActiveIsomerAdmin(session.userId, [role])) {
-        userGodModeRoles.push(role)
-      }
-    }
+    const userId = session.userId
+    const roles = await Promise.all(
+      allowedRoles.map(async (role) =>
+        (await isActiveIsomerAdmin(userId, [role])) ? role : null,
+      ),
+    )
+    userGodModeRoles.push(
+      ...roles.filter((role): role is IsomerAdminRole => role !== null),
+    )
   }
 
   if (userGodModeRoles.length === 0) {

--- a/apps/studio/src/pages/godmode/create-site.tsx
+++ b/apps/studio/src/pages/godmode/create-site.tsx
@@ -1,3 +1,4 @@
+import type { GetServerSideProps } from "next"
 import {
   Box,
   Breadcrumb,
@@ -20,7 +21,7 @@ import {
 import NextLink from "next/link"
 import { useRouter } from "next/router"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
-import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { requireGodModeAdmin } from "~/features/godmode/serverSideProps"
 import { useZodForm } from "~/lib/form"
 import { type NextPageWithLayout } from "~/lib/types"
 import { createSiteSchema } from "~/schemas/site"
@@ -28,21 +29,12 @@ import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { trpc } from "~/utils/trpc"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
+export const getServerSideProps: GetServerSideProps = (context) =>
+  requireGodModeAdmin(context, [IsomerAdminRole.Core])
+
 const GodModeCreateSitePage: NextPageWithLayout = () => {
   const toast = useToast()
   const router = useRouter()
-  const { isAdmin: isUserIsomerAdmin, isLoading } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core],
-  })
-
-  if (!isLoading && !isUserIsomerAdmin) {
-    toast({
-      title: "You do not have permission to access this page.",
-      status: "error",
-      ...BRIEF_TOAST_SETTINGS,
-    })
-    void router.push(`/`)
-  }
 
   const createSiteMutation = trpc.site.create.useMutation({
     onSuccess: ({ siteId, siteName }) => {

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -8,7 +8,7 @@ import {
 } from "@chakra-ui/react"
 import NextLink from "next/link"
 import {
-  requireGodModeAdminWithRoleProps,
+  requireGodModeAdmin,
   type GodModeAdminRoleProps,
 } from "~/features/godmode/serverSideProps"
 import { type NextPageWithLayout } from "~/lib/types"
@@ -43,10 +43,7 @@ const GODMODE_LINKS: readonly GodModeLink[] = [
 export const getServerSideProps: GetServerSideProps<GodModeAdminRoleProps> = (
   context,
 ) =>
-  requireGodModeAdminWithRoleProps(context, [
-    IsomerAdminRole.Core,
-    IsomerAdminRole.Migrator,
-  ])
+  requireGodModeAdmin(context, [IsomerAdminRole.Core, IsomerAdminRole.Migrator])
 
 const GodModePage: NextPageWithLayout<GodModeAdminRoleProps> = ({
   userGodModeRoles,

--- a/apps/studio/src/pages/godmode/index.tsx
+++ b/apps/studio/src/pages/godmode/index.tsx
@@ -1,3 +1,4 @@
+import type { GetServerSideProps } from "next"
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -5,23 +6,23 @@ import {
   Flex,
   Text,
 } from "@chakra-ui/react"
-import { useToast } from "@opengovsg/design-system-react"
 import NextLink from "next/link"
-import { useRouter } from "next/router"
-import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
-import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import {
+  requireGodModeAdminWithRoleProps,
+  type GodModeAdminRoleProps,
+} from "~/features/godmode/serverSideProps"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
-interface GodmodeLink {
+interface GodModeLink {
   href: string
   label: string
   /** Isomer admin roles that may see this hub link */
   roles: readonly IsomerAdminRole[]
 }
 
-const GODMODE_LINKS: readonly GodmodeLink[] = [
+const GODMODE_LINKS: readonly GodModeLink[] = [
   {
     href: "/godmode/create-site",
     label: "Create a new site",
@@ -39,39 +40,21 @@ const GODMODE_LINKS: readonly GodmodeLink[] = [
   },
 ]
 
-const GodModePage: NextPageWithLayout = () => {
-  const toast = useToast()
-  const router = useRouter()
-  const { isAdmin: isCoreIsomerAdmin, isLoading: isCoreRoleLoading } =
-    useIsUserIsomerAdmin({
-      roles: [IsomerAdminRole.Core],
-    })
-  const { isAdmin: isMigratorIsomerAdmin, isLoading: isMigratorRoleLoading } =
-    useIsUserIsomerAdmin({
-      roles: [IsomerAdminRole.Migrator],
-    })
+export const getServerSideProps: GetServerSideProps<GodModeAdminRoleProps> = (
+  context,
+) =>
+  requireGodModeAdminWithRoleProps(context, [
+    IsomerAdminRole.Core,
+    IsomerAdminRole.Migrator,
+  ])
 
-  const isLoading = isCoreRoleLoading || isMigratorRoleLoading
-  const userGodmodeRoles = new Set<IsomerAdminRole>()
-  if (isCoreIsomerAdmin) {
-    userGodmodeRoles.add(IsomerAdminRole.Core)
-  }
-  if (isMigratorIsomerAdmin) {
-    userGodmodeRoles.add(IsomerAdminRole.Migrator)
-  }
-
-  const visibleGodmodeLinks = GODMODE_LINKS.filter((link) =>
-    link.roles.some((role) => userGodmodeRoles.has(role)),
+const GodModePage: NextPageWithLayout<GodModeAdminRoleProps> = ({
+  userGodModeRoles,
+}) => {
+  const userGodModeRoleSet = new Set(userGodModeRoles)
+  const visibleGodModeLinks = GODMODE_LINKS.filter((link) =>
+    link.roles.some((role) => userGodModeRoleSet.has(role)),
   )
-
-  if (!isLoading && visibleGodmodeLinks.length === 0) {
-    toast({
-      title: "You do not have permission to access this page.",
-      status: "error",
-      ...BRIEF_TOAST_SETTINGS,
-    })
-    void router.push(`/`)
-  }
 
   return (
     <Flex flexDir="column" py="2rem" maxW="57rem" mx="auto" width="100%">
@@ -88,24 +71,23 @@ const GodModePage: NextPageWithLayout = () => {
       </Text>
 
       <Flex flexDirection="column" mt="1.5rem" gap="1rem">
-        {!isLoading &&
-          visibleGodmodeLinks.map((link) => (
-            <Flex
-              key={link.href}
-              as={NextLink}
-              href={link.href}
-              p="1rem"
-              borderWidth="1px"
-              alignItems="center"
-              bg="base.canvas.default"
-              border="1px solid"
-              borderColor="base.divider.medium"
-              borderRadius="0.5rem"
-              _hover={{ background: "interaction.muted.main.hover" }}
-            >
-              <Text textStyle="subhead-2">{link.label}</Text>
-            </Flex>
-          ))}
+        {visibleGodModeLinks.map((link) => (
+          <Flex
+            key={link.href}
+            as={NextLink}
+            href={link.href}
+            p="1rem"
+            borderWidth="1px"
+            alignItems="center"
+            bg="base.canvas.default"
+            border="1px solid"
+            borderColor="base.divider.medium"
+            borderRadius="0.5rem"
+            _hover={{ background: "interaction.muted.main.hover" }}
+          >
+            <Text textStyle="subhead-2">{link.label}</Text>
+          </Flex>
+        ))}
       </Flex>
     </Flex>
   )

--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -1,3 +1,4 @@
+import type { GetServerSideProps } from "next"
 import {
   Box,
   Breadcrumb,
@@ -15,30 +16,18 @@ import {
 } from "@chakra-ui/react"
 import { useToast } from "@opengovsg/design-system-react"
 import NextLink from "next/link"
-import { useRouter } from "next/router"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
-import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { requireGodModeAdmin } from "~/features/godmode/serverSideProps"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { trpc } from "~/utils/trpc"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
+export const getServerSideProps: GetServerSideProps = (context) =>
+  requireGodModeAdmin(context, [IsomerAdminRole.Core])
+
 const GodModePublishingPage: NextPageWithLayout = () => {
   const toast = useToast()
-  const router = useRouter()
-  const { isAdmin: isUserIsomerAdmin, isLoading: isAdminCheckLoading } =
-    useIsUserIsomerAdmin({
-      roles: [IsomerAdminRole.Core],
-    })
-
-  if (!isAdminCheckLoading && !isUserIsomerAdmin) {
-    toast({
-      title: "You do not have permission to access this page.",
-      status: "error",
-      ...BRIEF_TOAST_SETTINGS,
-    })
-    void router.push(`/`)
-  }
 
   const { data: sites = [] } = trpc.site.listAllSites.useQuery()
 

--- a/apps/studio/src/pages/godmode/whitelist.tsx
+++ b/apps/studio/src/pages/godmode/whitelist.tsx
@@ -1,3 +1,4 @@
+import type { GetServerSideProps } from "next"
 import {
   Box,
   Breadcrumb,
@@ -9,21 +10,19 @@ import {
 } from "@chakra-ui/react"
 import { Textarea, useToast } from "@opengovsg/design-system-react"
 import NextLink from "next/link"
-import { useRouter } from "next/router"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
-import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
+import { requireGodModeAdmin } from "~/features/godmode/serverSideProps"
 import { type NextPageWithLayout } from "~/lib/types"
 import { AuthenticatedLayout } from "~/templates/layouts/AuthenticatedLayout"
 import { trpc } from "~/utils/trpc"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
+export const getServerSideProps: GetServerSideProps = (context) =>
+  requireGodModeAdmin(context, [IsomerAdminRole.Core, IsomerAdminRole.Migrator])
+
 const GodModeWhitelistPage: NextPageWithLayout = () => {
   const toast = useToast()
-  const router = useRouter()
-  const { isAdmin: isUserIsomerAdmin, isLoading } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
-  })
 
   const [vendorEmails, setVendorEmails] = useState<string[]>([])
   const [adminEmails, setAdminEmails] = useState<string[]>([])
@@ -46,21 +45,6 @@ const GodModeWhitelistPage: NextPageWithLayout = () => {
       })
     },
   })
-
-  useEffect(() => {
-    if (!isLoading && !isUserIsomerAdmin) {
-      toast({
-        title: "You do not have permission to access this page.",
-        status: "error",
-        ...BRIEF_TOAST_SETTINGS,
-      })
-      void router.push(`/`)
-    }
-  }, [isUserIsomerAdmin, isLoading, router, toast])
-
-  if (!isUserIsomerAdmin) {
-    return null
-  }
 
   return (
     <Flex flexDir="column" py="2rem" maxW="57rem" mx="auto" width="100%">

--- a/apps/studio/tests/e2e/fixtures/auth.ts
+++ b/apps/studio/tests/e2e/fixtures/auth.ts
@@ -1,7 +1,14 @@
 import path from "path"
 import { fileURLToPath } from "url"
 
-export const ROLES = ["editor", "publisher", "admin", "nomember"] as const
+export const ROLES = [
+  "editor",
+  "publisher",
+  "admin",
+  "nomember",
+  "core",
+  "migrator",
+] as const
 export type Role = (typeof ROLES)[number]
 
 export const TEST_EMAILS: Record<Role, string> = {
@@ -9,6 +16,8 @@ export const TEST_EMAILS: Record<Role, string> = {
   publisher: "publisher@open.gov.sg",
   admin: "admin-e2e@open.gov.sg",
   nomember: "nomember-e2e@open.gov.sg",
+  core: "core-e2e@open.gov.sg",
+  migrator: "migrator-e2e@open.gov.sg",
 }
 
 const STORAGE_DIR = fileURLToPath(new URL("../storage-state", import.meta.url))

--- a/apps/studio/tests/e2e/fixtures/seed.ts
+++ b/apps/studio/tests/e2e/fixtures/seed.ts
@@ -1,6 +1,6 @@
 import { createId } from "@paralleldrive/cuid2"
 import { db } from "~/server/modules/database"
-import { RoleType } from "~prisma/generated/generatedEnums"
+import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS } from "./auth"
 
@@ -69,10 +69,27 @@ const ensureUserWithRole = async (
   return user
 }
 
+const ensureGodModeAdmin = async (
+  email: string,
+  role: (typeof IsomerAdminRole)[keyof typeof IsomerAdminRole],
+) => {
+  const user = await ensureUserWithRole(email, null)
+
+  await db
+    .insertInto("IsomerAdmin")
+    .values({ userId: user.id, role, expiry: null })
+    .onConflict((oc) =>
+      oc.columns(["userId", "role"]).doUpdateSet({ expiry: null }),
+    )
+    .execute()
+}
+
 export const seedRolesForE2E = async () => {
   await ensureUserWithRole(TEST_EMAILS.admin, RoleType.Admin)
   await ensureUserWithRole(TEST_EMAILS.nomember, null)
   // editor + publisher are seeded by prisma/seed.ts; ensure they're still active
   await ensureUserWithRole(TEST_EMAILS.editor, RoleType.Editor)
   await ensureUserWithRole(TEST_EMAILS.publisher, RoleType.Publisher)
+  await ensureGodModeAdmin(TEST_EMAILS.core, IsomerAdminRole.Core)
+  await ensureGodModeAdmin(TEST_EMAILS.migrator, IsomerAdminRole.Migrator)
 }

--- a/apps/studio/tests/e2e/godmode/access.test.ts
+++ b/apps/studio/tests/e2e/godmode/access.test.ts
@@ -1,0 +1,93 @@
+import { expect, test, type Browser, type Page } from "@playwright/test"
+
+import { storageStateFor, type Role } from "../fixtures/auth"
+
+const GODMODE_ROUTES = [
+  { path: "/godmode/create-site", heading: "Create a new site" },
+  { path: "/godmode/publishing", heading: "Publishing" },
+  { path: "/godmode/whitelist", heading: "Whitelist" },
+] as const
+
+const openAs = async (
+  browser: Browser,
+  baseURL: string | undefined,
+  role: Role,
+) => {
+  const ctx = await browser.newContext({
+    baseURL,
+    storageState: storageStateFor(role),
+  })
+  const page = await ctx.newPage()
+  return { ctx, page }
+}
+
+const expectRedirectToDashboard = async (page: Page, path: string) => {
+  await page.goto(path)
+  await page.waitForURL("/")
+  await expect(page).toHaveURL(/\/$/)
+}
+
+test.describe("godmode access", () => {
+  test("core admin can access all godmode routes", async ({
+    browser,
+    baseURL,
+  }) => {
+    const { ctx, page } = await openAs(browser, baseURL, "core")
+
+    await page.goto("/godmode")
+    await expect(page.getByRole("heading", { name: /God Mode/ })).toBeVisible()
+    await expect(
+      page.getByRole("link", { name: "Create a new site" }),
+    ).toBeVisible()
+    await expect(page.getByRole("link", { name: "Publishing" })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Whitelist" })).toBeVisible()
+
+    for (const route of GODMODE_ROUTES) {
+      await page.goto(route.path)
+      await expect(
+        page.getByRole("heading", { name: route.heading }),
+      ).toBeVisible()
+    }
+
+    await ctx.close()
+  })
+
+  test("migrator can only access whitelist godmode routes", async ({
+    browser,
+    baseURL,
+  }) => {
+    const { ctx, page } = await openAs(browser, baseURL, "migrator")
+
+    await page.goto("/godmode")
+    await expect(page.getByRole("heading", { name: /God Mode/ })).toBeVisible()
+    await expect(page.getByRole("link", { name: "Whitelist" })).toBeVisible()
+    await expect(
+      page.getByRole("link", { name: "Create a new site" }),
+    ).not.toBeVisible()
+    await expect(
+      page.getByRole("link", { name: "Publishing" }),
+    ).not.toBeVisible()
+
+    await page.goto("/godmode/whitelist")
+    await expect(page.getByRole("heading", { name: "Whitelist" })).toBeVisible()
+
+    await expectRedirectToDashboard(page, "/godmode/create-site")
+    await expectRedirectToDashboard(page, "/godmode/publishing")
+
+    await ctx.close()
+  })
+
+  test("site admin without godmode access is redirected", async ({
+    browser,
+    baseURL,
+  }) => {
+    const { ctx, page } = await openAs(browser, baseURL, "admin")
+
+    await expectRedirectToDashboard(page, "/godmode")
+    for (const route of GODMODE_ROUTES) {
+      await expectRedirectToDashboard(page, route.path)
+    }
+
+    await ctx.close()
+  })
+})


### PR DESCRIPTION
## Problem

Godmode routes are reserved for Isomer admins, but their access checks were handled client-side. This could briefly render reserved pages and trigger page-specific requests before redirecting unauthorized users.

This follows up on #2584, which moved `/sites/[siteId]/admin` to server-side guarding.

## Solution

Adds shared server-side guards for godmode routes and applies them across the godmode pages.

This removes the previous client-side permission error toast for unauthorized users.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Adds reusable godmode `getServerSideProps` guards for role-based access.
- Keeps `/godmode` link visibility based on the user’s Isomer admin role.
- Removes duplicated client-side redirect logic from godmode pages.

**Bug Fixes**:

- Prevents unauthorized users from rendering reserved godmode pages before redirect.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

**Non-Isomer admin**

- [ ] Visit `/godmode`, `/godmode/create-site`, `/godmode/publishing`, and `/godmode/whitelist`. Verify each redirects to `/` without making page-specific tRPC calls.

**Isomer Core admin**

- [ ] Visit `/godmode`. Verify Create Site, Publishing, and Whitelist are shown.
- [ ] Visit `/godmode/create-site` and `/godmode/publishing`. Verify both pages load.

**Isomer Migrator admin**

- [ ] Visit `/godmode`. Verify only Whitelist is shown.
- [ ] Visit `/godmode/whitelist`. Verify the page loads.
- [ ] Visit `/godmode/create-site` and `/godmode/publishing`. Verify both redirect to `/` without making page-specific tRPC calls.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves godmode route access checks from client-side redirects to server-side guards. The main changes are:

- Adds a shared `requireGodModeAdmin` helper for role-based server-side access checks.
- Applies Core and Migrator role guards to the godmode hub and subpages.
- Keeps the godmode hub links filtered by the roles returned from the server.
- Extends E2E auth fixtures and tests for Core, Migrator, and non-godmode users.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low implementation risk.

No blocking issues were identified. The access control change uses existing session and permission helpers. E2E coverage checks allowed and denied godmode paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the test listing to confirm core admin, migrator, and non-godmode site admin scenarios are present.
- Assessed the full end-to-end run and observed that Playwright started the target spec but the global setup failed while inserting a user via Kysely and PostgreSQL.
- Examined the environment blockers and saw Docker is not found and PostgreSQL at localhost:5432 is refusing connections, explaining the setup failure.

<a href="https://app.greptile.com/trex/runs/13363618/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/godmode/serverSideProps.ts | Adds a shared server-side godmode role guard using the existing iron-session and active Isomer admin permission check. |
| apps/studio/src/pages/godmode/create-site.tsx | Replaces client-side Core admin redirect logic with the shared `getServerSideProps` guard before rendering the create-site page. |
| apps/studio/src/pages/godmode/index.tsx | Moves godmode hub access and link visibility to server-supplied Core/Migrator roles. |
| apps/studio/src/pages/godmode/publishing.tsx | Adds the Core-only server-side guard and removes the previous client-side permission redirect. |
| apps/studio/src/pages/godmode/whitelist.tsx | Adds the Core/Migrator server-side guard and removes client-only gating before whitelist tRPC usage. |
| apps/studio/tests/e2e/godmode/access.test.ts | Adds Playwright coverage for Core, Migrator, and non-godmode access to godmode routes. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Page as Godmode Page getServerSideProps
participant Session as Iron Session
participant Permissions as isActiveIsomerAdmin
participant Browser

User->>Page: Request /godmode route
Page->>Session: Read auth session from req/res
Session-->>Page: session.userId
alt userId present
    Page->>Permissions: Check allowed IsomerAdminRole(s)
    Permissions-->>Page: Active matching roles
else missing session
    Page->>Page: No godmode roles
end
alt at least one allowed role
    Page-->>Browser: Render page with userGodModeRoles props
else no allowed roles
    Page-->>Browser: 302 redirect to /
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Page as Godmode Page getServerSideProps
participant Session as Iron Session
participant Permissions as isActiveIsomerAdmin
participant Browser

User->>Page: Request /godmode route
Page->>Session: Read auth session from req/res
Session-->>Page: session.userId
alt userId present
    Page->>Permissions: Check allowed IsomerAdminRole(s)
    Permissions-->>Page: Active matching roles
else missing session
    Page->>Page: No godmode roles
end
alt at least one allowed role
    Page-->>Browser: Render page with userGodModeRoles props
else no allowed roles
    Page-->>Browser: 302 redirect to /
end
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["test(studio): add godmode route e2e cove..."](https://github.com/opengovsg/isomer/commit/80e5c76e17230dfff8b1c52c0fee788fc4e328f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41768609)</sub>

<!-- /greptile_comment -->