### PR TITLE
test(components): fix and extend Collection/CollectionBlock storybook coverage for tagCategories-based category

### DIFF
--- a/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.stories.tsx
@@ -34,12 +34,16 @@ const generateArgs = ({
     withImageFallback?: boolean
   }
 >): Partial<CollectionBlockProps> => {
+  // Category is now an ordinary tagCategories group — the option a card is
+  // tagged with is what CollectionBlock displays under its title.
+  const CATEGORY_OPTION_ID = "category-option-yes-i-am-a-category"
+
   const cards: IsomerSitemap[] = [
     {
       id: "3",
       title:
         "Date of Government Gazette Notification on Dissolution of Parliament",
-      category: "yes i am a category",
+      tagged: [CATEGORY_OPTION_ID],
       permalink: "/collection-1/item-1",
       layout: "article",
       summary: "",
@@ -58,7 +62,7 @@ const generateArgs = ({
     {
       id: "4",
       title: "Impact of Foreign Professionals on our Economy and Society",
-      category: "yes i am a category",
+      tagged: [CATEGORY_OPTION_ID],
       permalink: "/collection-1/item-2",
       layout: "article",
       summary: "",
@@ -73,7 +77,7 @@ const generateArgs = ({
     {
       id: "5",
       title: "Where does Government revenue come from?",
-      category: "yes i am a category",
+      tagged: [CATEGORY_OPTION_ID],
       permalink: "/collection-1/item-3",
       layout: "article",
       summary: "",
@@ -111,6 +115,18 @@ const generateArgs = ({
               "Clarifying widespread or common misperceptions of Government policy, or inaccurate assertions on matters of public concern that can harm Singapore's social fabric.",
             lastModified: "2021-01-01",
             children: cards.slice(0, numberOfCards),
+            collectionPagePageProps: {
+              tagCategories: [
+                {
+                  label: "Category",
+                  id: "category-group",
+                  isRequired: true,
+                  options: [
+                    { label: "yes i am a category", id: CATEGORY_OPTION_ID },
+                  ],
+                },
+              ],
+            },
           },
         ],
       },

--- a/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/ArticlePageHeader/ArticlePageHeader.stories.tsx
@@ -46,6 +46,13 @@ export const SingleSummaryItem: Story = {
   args: ARTICLE,
 }
 
+export const WithoutCategory: Story = {
+  args: {
+    ...ARTICLE,
+    category: undefined,
+  },
+}
+
 export const ArticleWithTags: Story = {
   args: {
     ...ARTICLE,

--- a/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/BlogCard/BlogCard.stories.tsx
@@ -92,6 +92,10 @@ export const CardWithoutImage: Story = {
   args: generateArgs({ image: undefined }),
 }
 
+export const CardWithoutCategory: Story = {
+  args: generateArgs({ category: undefined }),
+}
+
 export const ShortDescription: Story = {
   args: generateArgs({
     title: "Short title",

--- a/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
+++ b/packages/components/src/templates/next/components/internal/CollectionCard/CollectionCard.stories.tsx
@@ -92,6 +92,10 @@ export const CardWithoutImage: Story = {
   args: generateArgs({ image: undefined }),
 }
 
+export const CardWithoutCategory: Story = {
+  args: generateArgs({ category: undefined }),
+}
+
 export const ShortDescription: Story = {
   args: generateArgs({
     title: "Short title",

--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -86,9 +86,11 @@ const COLLECTION_ITEMS: IsomerSitemap[] = flatten(
 const generateArgs = ({
   collectionItems = COLLECTION_ITEMS,
   variant = "collection",
+  tagCategories,
 }: {
   collectionItems?: IsomerSitemap[]
   variant?: CollectionPageSchemaType["page"]["variant"]
+  tagCategories?: CollectionPageSchemaType["page"]["tagCategories"]
 } = {}): CollectionPageSchemaType => {
   return {
     layout: "collection",
@@ -140,6 +142,7 @@ const generateArgs = ({
       subtitle:
         "Since this page type supports text-heavy articles that are primarily for reading and absorbing information, the max content width on desktop is kept even smaller than its General Content Page counterpart.",
       variant,
+      tagCategories,
     },
     content: [],
   }
@@ -202,8 +205,23 @@ export const NoResults: Story = {
   },
 }
 
+// Category is now an ordinary tagCategories group — an item is tagged with
+// an option UUID rather than carrying a plain `category` string.
+const CATEGORY_NAME_2_OPTION_ID = "category-name-2"
+const CATEGORY_TAG_CATEGORY: NonNullable<
+  CollectionPageSchemaType["page"]["tagCategories"]
+> = [
+  {
+    label: "Category",
+    id: "category-group",
+    isRequired: true,
+    options: [{ label: "Category Name 2", id: CATEGORY_NAME_2_OPTION_ID }],
+  },
+]
+
 export const FilteredEmptyResults: Story = {
   args: generateArgs({
+    tagCategories: CATEGORY_TAG_CATEGORY,
     collectionItems: [
       ...COLLECTION_ITEMS,
       {
@@ -215,7 +233,7 @@ export const FilteredEmptyResults: Story = {
         summary:
           "This is supposed to be a description of the hero banner that Isomer uses on their official website.",
         date: "2025-05-07",
-        category: "Category Name 2",
+        tagged: [CATEGORY_NAME_2_OPTION_ID],
         ref: "https://www.isomer.gov.sg/images/Homepage/hero%20banner_10.png",
         fileDetails: {
           type: "png",
@@ -280,12 +298,24 @@ export const AllResultsNoDate: Story = {
   },
 }
 
+const THE_ONLY_CATEGORY_OPTION_ID = "the-only-category"
+
 export const AllResultsSameCategory: Story = {
   name: "Should show category filter even if all items have same category",
   args: generateArgs({
+    tagCategories: [
+      {
+        label: "Category",
+        id: "category-group",
+        isRequired: true,
+        options: [
+          { label: "The only category", id: THE_ONLY_CATEGORY_OPTION_ID },
+        ],
+      },
+    ],
     collectionItems: COLLECTION_ITEMS.map((item) => ({
       ...item,
-      category: "The only category",
+      tagged: [THE_ONLY_CATEGORY_OPTION_ID],
     })),
   }),
   play: async ({ canvasElement }) => {
@@ -310,6 +340,26 @@ export const AllResultsSameYear: Story = {
     const screen = within(canvasElement)
     const yearFilter = screen.queryByText(/Year/i)
     await expect(yearFilter).toBeInTheDocument()
+  },
+}
+
+const itemsWithNoFilterableAttributes = COLLECTION_ITEMS.map((item) => ({
+  ...item,
+  date: undefined,
+  tags: undefined,
+}))
+
+export const NoFiltersAvailable: Story = {
+  name: "Should show 'Nothing to filter by' when there is no year filter and no tag categories",
+  args: generateArgs({ collectionItems: itemsWithNoFilterableAttributes }),
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement)
+
+    const yearFilter = screen.queryByText(/Year/i)
+    await expect(yearFilter).not.toBeInTheDocument()
+
+    const nothingToFilterBy = await screen.findByText(/Nothing to filter by/i)
+    await expect(nothingToFilterBy).toBeInTheDocument()
   },
 }
 


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Stacked on #2683 (the category → tagCategories rendering cutover). Once that PR lands, several `packages/components` Storybook stories are stale or broken:

1. `Collection.stories.tsx`'s `FilteredEmptyResults` and `AllResultsSameCategory` stories have `play` functions that assert on the now-removed legacy category filter (`getByText(/Category Name 2 \(1\)/i)`, `queryByText(/Category/)`) — their fixtures only ever set the inert legacy `category` string, never `tagged`/`tagCategories`, so these interactions would fail once run (locally or via Chromatic CI).
2. `CollectionBlock.stories.tsx`'s fixtures set `category: "yes i am a category"` on each card, which is no longer read anywhere — the "With Image" etc. stories would silently stop showing any category text.
3. No story covered the new "no category" empty state (the `{category && (...)}` guards added in #2683) for `CollectionCard`, `BlogCard`, or `ArticlePageHeader`.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Storybook-only changes (stories + fixtures). No `src` production code outside of `*.stories.tsx` is touched.

**Features**:

- N/A

**Improvements**:

- `Collection.stories.tsx`: `FilteredEmptyResults` and `AllResultsSameCategory` now use a real `"Category"` `tagCategories` group + `tagged` on the relevant items, so their existing `play` assertions exercise the actual current filtering path instead of removed code.
- Added `NoFiltersAvailable`: a new story where every item has neither a `date` nor any `tags`, asserting the filter sidebar shows "Nothing to filter by" and no "Year" filter — covers the fully-empty-filters state that wasn't covered before.
- `CollectionBlock.stories.tsx`: fixtures now tag cards via `tagged` against a real `tagCategories` group on the parent Collection, so `displayCategory: true` stories actually render category text again.
- Added `CardWithoutCategory` stories to `CollectionCard.stories.tsx` and `BlogCard.stories.tsx`, and a `WithoutCategory` story to `ArticlePageHeader.stories.tsx`, covering the empty-category guard added in #2683.

**Bug Fixes**:

- N/A (the one real code bug found while doing this — `CollectionBlock`'s `getCollectionPages.ts` never threading `tagCategories` through — was moved into #2683 instead, since it's a production code fix, not a Storybook one).

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

<!-- What tests should be run to confirm functionality? -->

This PR only changes `*.stories.tsx` files (no `src` logic). `pnpm build`, `pnpm exec vitest run` (369 tests), `pnpm lint`, and `pnpm build-storybook` all pass. The `play`-function stories (`FilteredEmptyResults`, `AllResultsSameCategory`, `NoFiltersAvailable`) were verified by tracing their assertions against the actual `Filter`/`getTagFilters`/`getFilteredItems` rendering logic — there is no local Storybook interaction-test runner configured in this repo (no `test-storybook` script, no Vitest/Storybook test addon), so these `play` functions only execute in a browser (manual) or via Chromatic in CI. Please confirm they pass green in Chromatic once this PR builds.

No Manual Verification Steps needed beyond opening Storybook, since there's no user-facing production code change here.
