### PR TITLE
fix(storybook): fix flaky Profile Modal Required story

### DIFF
--- a/apps/studio/src/stories/Page/ProfileModal.stories.tsx
+++ b/apps/studio/src/stories/Page/ProfileModal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { expect, userEvent, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -67,9 +67,9 @@ export const Required: Story = {
       "Welcome to Studio! Tell us about yourself.",
     )
 
-    await expect(modalHeader).toBeVisible()
+    await waitFor(() => expect(modalHeader).toBeVisible())
     await userEvent.keyboard("{Escape}")
-    await expect(modalHeader).toBeVisible()
+    await waitFor(() => expect(modalHeader).toBeVisible())
   },
 }
 


### PR DESCRIPTION
## Problem

The `Profile Modal Required` Storybook story was intermittently failing with:

```
Error: expect(element).toBeVisible()
Received element is not visible: <header class="chakra-modal__header" />
```

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Wrapped `toBeVisible()` assertions in `waitFor` in the `Required` story play function. Chakra UI's modal entrance animation starts at `opacity: 0` and transitions to `opacity: 1`. The `findByText` query resolves as soon as the `<header>` element appears in the DOM — before the animation completes — causing `toBeVisible()` to intermittently fail. Using `waitFor` retries the assertion until the animation finishes and the element is fully visible.

## Before & After Screenshots

N/A — Storybook test fix only.

## Tests

No manual verification steps needed — this is a test-only change with no production code modifications.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates a flaky Storybook interaction test for the required profile modal. The main changes are:

- Imports `waitFor` from `storybook/test`.
- Wraps the initial modal header visibility assertion in `waitFor`.
- Wraps the post-`Escape` visibility assertion in `waitFor`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to a low-risk Storybook story and matches the flaky assertion described in the PR.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Storybook server started with real repository config and advanced to webpack progress around 92% before being killed with exit code 137.
- A Playwright navigation attempt to the required story URL was made, but the browser reported ERR\_CONNECTION\_REFUSED, indicating the server was not accepting connections.
- Blocker evidence was captured with screenshots showing the browser displaying a connection error page due to the server termination prior to readiness.

<a href="https://app.greptile.com/trex/runs/13311231/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/stories/Page/ProfileModal.stories.tsx | Updates the `Required` Storybook play function to wait for Chakra modal visibility assertions after the modal enters the DOM; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(storybook): wrap toBeVisible asserti..."](https://github.com/opengovsg/isomer/commit/9102bc9a3969392e58277207ee2cf83966a00a36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41890119)</sub>

<!-- /greptile_comment -->