### PR TITLE
fix(studio): defer asset deletion until page save succeeds

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
@@ -171,6 +171,8 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
   const handleSave = useCallback(async () => {
     let newPageState = previewPageState
 
+    let assetsToDelete: string[] = []
+
     if (modifiedAssets.length > 0) {
       const updatedBlocks = Array.from(previewPageState.content)
       const newBlock = cloneDeep(updatedBlocks[currActiveIdx])
@@ -211,24 +213,15 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
         return
       }
 
-      // Delete the original assets for those that have been modified
-      // This is done by deleting the file key stored in the src attribute, as
-      // it would have been replaced by new file keys after uploading
-      const assetsToDelete = modifiedAssets
-        .map(({ src }) => src?.slice(1))
-        .filter((src) => src !== PLACEHOLDER_IMAGE_FILENAME)
-        .reduce<string[]>((acc, curr) => {
-          if (curr !== undefined) {
-            acc.push(curr)
-          }
-          return acc
-        }, [])
-
-      deleteAssets({
-        siteId,
-        resourceId: String(pageId),
-        fileKeys: assetsToDelete,
-      })
+      // Collect the original asset keys so they can be deleted after the page
+      // save succeeds.
+      assetsToDelete = modifiedAssets.reduce<string[]>((acc, { src }) => {
+        const fileKey = src?.slice(1)
+        if (fileKey !== undefined && fileKey !== PLACEHOLDER_IMAGE_FILENAME) {
+          acc.push(fileKey)
+        }
+        return acc
+      }, [])
     }
 
     savePage(
@@ -244,6 +237,13 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
           setSavedPageState(newPageState)
           setDrawerState({ state: "root" })
           setAddedBlockIndex(null)
+          if (assetsToDelete.length > 0) {
+            deleteAssets({
+              siteId,
+              resourceId: String(pageId),
+              fileKeys: assetsToDelete,
+            })
+          }
         },
       },
     )

--- a/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
@@ -68,6 +68,8 @@ export default function HeroEditorDrawer(): JSX.Element {
   const handleSaveChanges = useCallback(async () => {
     let newPageState = previewPageState
 
+    let assetsToDelete: string[] = []
+
     if (modifiedAssets.length > 0) {
       const updatedBlocks = Array.from(previewPageState.content)
       const newBlock = cloneDeep(updatedBlocks[currActiveIdx])
@@ -108,24 +110,15 @@ export default function HeroEditorDrawer(): JSX.Element {
         return
       }
 
-      // Delete the original assets for those that have been modified
-      // This is done by deleting the file key stored in the src attribute, as
-      // it would have been replaced by new file keys after uploading
-      const assetsToDelete = modifiedAssets
-        .map(({ src }) => src?.slice(1))
-        .filter((src) => src !== PLACEHOLDER_IMAGE_FILENAME)
-        .reduce<string[]>((acc, curr) => {
-          if (curr !== undefined) {
-            acc.push(curr)
-          }
-          return acc
-        }, [])
-
-      deleteAssets({
-        siteId,
-        resourceId: String(pageId),
-        fileKeys: assetsToDelete,
-      })
+      // Collect the original asset keys so they can be deleted after the page
+      // save succeeds.
+      assetsToDelete = modifiedAssets.reduce<string[]>((acc, { src }) => {
+        const fileKey = src?.slice(1)
+        if (fileKey !== undefined && fileKey !== PLACEHOLDER_IMAGE_FILENAME) {
+          acc.push(fileKey)
+        }
+        return acc
+      }, [])
     }
 
     mutate(
@@ -140,6 +133,13 @@ export default function HeroEditorDrawer(): JSX.Element {
           setPreviewPageState(newPageState)
           setSavedPageState(newPageState)
           setDrawerState({ state: "root" })
+          if (assetsToDelete.length > 0) {
+            deleteAssets({
+              siteId,
+              resourceId: String(pageId),
+              fileKeys: assetsToDelete,
+            })
+          }
         },
       },
     )


### PR DESCRIPTION
## Problem

Old assets were soft-deleted before the updated page blob was saved. If `updatePageBlob` failed after upload, the database could still point at the old asset keys while those keys had already been tagged for deletion.

Closes #2381
Closes #2382

## Solution

Collect the original asset keys during save, but only call `asset.deleteAssets` after `updatePageBlob` succeeds.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Skips `deleteAssets` when there are no old asset keys to delete.

**Bug Fixes**:

- Defers old hero and complex block asset deletion until the page save succeeds.

## Before & After Screenshots

**BEFORE**:

N/A

**AFTER**:

N/A

## Tests

**Manual Verification Steps**:

- [ ] Open a page with an existing saved hero image, replace the image, and save the page.
- [ ] In DevTools Network, filter by `/api/trpc` and confirm `page.updatePageBlob` succeeds before `asset.deleteAssets` is called.
- [ ] Repeat the same check for an existing saved image in a non-hero block, such as an Image block.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes asset cleanup timing in the editor save flow. The main changes are:

- Collects original hero and complex block asset keys during save.
- Calls `asset.deleteAssets` only after `page.updatePageBlob` succeeds.
- Skips asset deletion when there are no old asset keys.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrow and keeps the existing upload and editor state update paths intact while moving irreversible asset deletion behind the successful page save callback.

No files need special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Hero Order Storybook run was attempted to surface the app, but the process was killed before readiness.
- A static validation pass was executed over the changed files for Hero Order, and the output shows the drawers configured with uploadBeforeCollect: true, saveBeforeDelete: true, and deleteInsidePerCallOnSuccess: true.
- It was determined that no HAR or video could be produced because the real browser flow never became available.

<a href="https://app.greptile.com/trex/runs/13320074/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx | Defers complex block old-asset deletion until the page blob mutation succeeds and skips empty delete requests. |
| apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx | Defers hero old-asset deletion until the page blob mutation succeeds and skips empty delete requests. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Drawer as Hero/Complex Drawer
participant Upload as uploadModifiedAssets
participant Page as page.updatePageBlob
participant Asset as asset.deleteAssets

User->>Drawer: Save edited block
alt modified assets exist
    Drawer->>Upload: Upload replacement assets
    Upload-->>Drawer: Updated block with new asset keys
    Drawer->>Drawer: Collect original asset keys
end
Drawer->>Page: Save updated page blob
Page-->>Drawer: Save succeeds
Drawer->>Drawer: Update editor saved/preview state
opt original asset keys collected
    Drawer->>Asset: Soft-delete old asset keys
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Drawer as Hero/Complex Drawer
participant Upload as uploadModifiedAssets
participant Page as page.updatePageBlob
participant Asset as asset.deleteAssets

User->>Drawer: Save edited block
alt modified assets exist
    Drawer->>Upload: Upload replacement assets
    Upload-->>Drawer: Updated block with new asset keys
    Drawer->>Drawer: Collect original asset keys
end
Drawer->>Page: Save updated page blob
Page-->>Drawer: Save succeeds
Drawer->>Drawer: Update editor saved/preview state
opt original asset keys collected
    Drawer->>Asset: Soft-delete old asset keys
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): defer asset deletion until ..."](https://github.com/opengovsg/isomer/commit/f71953bd2d18c0536d0cce890bd91b8e1d1547a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41907227)</sub>

<!-- /greptile_comment -->