### PR TITLE
fix: type fix for ImageClientProps

### DIFF
--- a/packages/components/src/interfaces/internal/Image.ts
+++ b/packages/components/src/interfaces/internal/Image.ts
@@ -1,3 +1,5 @@
+import type { ReactEventHandler } from "react"
+
 export interface ImageClientProps {
   src: string
   alt: string
@@ -5,5 +7,5 @@ export interface ImageClientProps {
   className: string
   assetsBaseUrl?: string
   lazyLoading?: boolean
-  onLoad?: React.ReactEventHandler<HTMLImageElement>
+  onLoad?: ReactEventHandler<HTMLImageElement>
 }


### PR DESCRIPTION
## Problem

FIx type for `ImageClientProps`

Closes #2360

## Solution

**Breaking Changes**

- [ ]  Yes - this PR contains breaking changes
    - Details ...
- [x]  No - this PR is backwards compatible

**Features**:

- NIL

**Improvements**:

- FIx type for ImageClientProps

**Bug Fixes**:

- NIL

## Before & After Screenshots

**BEFORE**:

NIL

**AFTER**:

NIL

## Tests

**Manual Verification Steps**:

- [ ]  NIL

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the image client prop type for React load handlers. The main change is:

- Imports `ReactEventHandler` from React as a type-only import.
- Updates `ImageClientProps.onLoad` to use `ReactEventHandler<HTMLImageElement>` directly.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to a single type-only import and type reference in an internal interface. No runtime behavior, schema shape, or data flow changes were introduced.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The run-type-validation.sh wrapper script was used to generate both proof logs with the exact commands and exit codes.
- The package typecheck step ran using tsgo and exited with code 0, according to the typecheck log.
- The module tsconfig compile check ran and exited with code 0, according to the module tsconfig log.

<a href="https://app.greptile.com/trex/runs/13324592/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/interfaces/internal/Image.ts | Updates `ImageClientProps.onLoad` to use an imported React event handler type without changing runtime behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: type fix for ImageClientProps"](https://github.com/opengovsg/isomer/commit/ab5b3fb73a20fbf2d39df5009e9fa8b8f6ddb16a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41917320)</sub>

<!-- /greptile_comment -->