### PR TITLE
chore: replace vite-tsconfig-paths plugin with native Vite 8 support

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -212,7 +212,6 @@
     "tsx": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:vitest",
-    "vite-tsconfig-paths": "catalog:vitest",
     "vitest": "catalog:vitest",
     "webpack-cli": "catalog:",
     "webpack-glob-entries": "catalog:"

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -1,8 +1,9 @@
-import tsconfigPaths from "vite-tsconfig-paths"
 import { configDefaults, defineConfig } from "vitest/config"
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     include: ["src/**/*.test.{ts,tsx}", "prisma/scripts/**/*.test.ts"],
     retry: 0,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -114,7 +114,6 @@
     "tsc-alias": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:vitest",
-    "vite-tsconfig-paths": "catalog:vitest",
     "vitest": "catalog:vitest"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,9 +624,6 @@ catalogs:
     vite:
       specifier: ^8.1.0
       version: 8.1.1
-    vite-tsconfig-paths:
-      specifier: ^6.1.1
-      version: 6.1.1
     vitest:
       specifier: ^4.1.9
       version: 4.1.9
@@ -1122,9 +1119,6 @@ importers:
       vite:
         specifier: catalog:vitest
         version: 8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3)
-      vite-tsconfig-paths:
-        specifier: catalog:vitest
-        version: 6.1.1(typescript@6.0.3)(vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3))
       vitest:
         specifier: catalog:vitest
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3))
@@ -1324,9 +1318,6 @@ importers:
       vite:
         specifier: catalog:vitest
         version: 8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3)
-      vite-tsconfig-paths:
-        specifier: catalog:vitest
-        version: 6.1.1(typescript@6.0.3)(vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3))
       vitest:
         specifier: catalog:vitest
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/coverage-istanbul@4.1.9)(happy-dom@20.10.6)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@25.9.3)(typescript@6.0.3))(vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3))
@@ -8819,9 +8810,6 @@ packages:
     resolution: {integrity: sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==}
     engines: {node: '>=0.10.0'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -11972,17 +11960,6 @@ packages:
     engines: {node: '>=16.20.2'}
     hasBin: true
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    deprecated: unmaintained
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
     engines: {node: '>=10.13.0'}
@@ -12233,11 +12210,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@8.1.1:
     resolution: {integrity: sha512-X/05/cT+VITy2AeDc1der6smvGWWREtL4hPbPTaVbjSBuuWkmNOjR6HP3NzqcQA2nF6VHGUPaFRJyft/2AE9Kg==}
@@ -19911,8 +19883,6 @@ snapshots:
       pify: 2.3.0
       pinkie-promise: 2.0.1
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   got@12.6.1:
@@ -23548,10 +23518,6 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
-  tsconfck@3.1.6(typescript@6.0.3):
-    optionalDependencies:
-      typescript: 6.0.3
-
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
       chalk: 4.1.2
@@ -23808,26 +23774,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
-  vite-tsconfig-paths@6.1.1(typescript@6.0.3)(vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3)):
-    dependencies:
-      debug: 4.4.3
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@6.0.3)
-      vite: 8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@8.1.1(@types/node@25.9.3)(esbuild@0.28.0)(jiti@1.21.7)(sass@1.101.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.8.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -278,5 +278,4 @@ catalogs:
     "@vitejs/plugin-react": ^6.0.3
     "@vitest/coverage-istanbul": ^4.1.9
     vite: ^8.1.0
-    vite-tsconfig-paths: ^6.1.1
     vitest: ^4.1.9


### PR DESCRIPTION
## Problem

`apps/studio` uses the `vite-tsconfig-paths` plugin in its Vitest config to resolve TypeScript path aliases (e.g. `~/*`) during tests. Vite 8 (already in use via the `vitest` catalog) now natively supports tsconfig paths resolution, making the third-party plugin redundant.

`packages/components` also declared `vite-tsconfig-paths` as a dependency, but never actually imported or used it — its Vitest config resolves the `~/` alias manually via `vitest`'s `alias` option instead.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Replaced the `vite-tsconfig-paths` plugin in `apps/studio/vitest.config.ts` with Vite 8's native `resolve.tsconfigPaths: true` option, which resolves the same `~/*` and other tsconfig path aliases used in tests.
- Removed the now-unused `vite-tsconfig-paths` dependency from `apps/studio/package.json` and `packages/components/package.json` (the latter never referenced it in source), and dropped the corresponding entry from the `vitest` catalog in `pnpm-workspace.yaml`.

**Bug Fixes**:

- None

## Before & After Screenshots

Not applicable — this is a test tooling/dependency change with no UI impact.

## Tests

- Ran `apps/studio`'s full unit test suite (`pnpm test:unit`) — 1501 tests passed (one unrelated, pre-existing flaky DB-hook-timeout test passed on retry), confirming `~/*`, `~prisma/*`, and `~server/*` path aliases still resolve correctly under the native Vite resolver.
- Ran `packages/components`'s unit test suite — 368 tests passed.
- Ran `pnpm typecheck` in `apps/studio` — no errors.

No production code paths are affected, so no manual verification steps are needed.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None (removed `vite-tsconfig-paths`)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the third-party tsconfig path resolver with Vite's native support for Studio tests. The main changes are:

- Enables `resolve.tsconfigPaths` in `apps/studio/vitest.config.ts`.
- Removes `vite-tsconfig-paths` from Studio and Components dev dependencies.
- Updates the workspace catalog and lockfile to drop the unused package and its transitive entries.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to test tooling dependency cleanup and a Vite-supported config option. The dependency removal is consistent across package manifests, workspace catalog, and lockfile. No review issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I examined the Studio alias test and confirmed it failed without native tsconfig path resolution, showing a Cannot find module '~/utils/safeJsonParse' error.
- I verified that enabling resolve.tsconfigPaths makes the Studio alias test pass, with 1 test passed.
- I reviewed the harness and configuration files used for the Studio alias tests, including studio-alias-smoke.test.ts, studio-alias-vitest.config.ts, and studio-alias-vitest-before.config.ts.
- I inspected the supporting artifacts that capture the lockfile sanity and components smoke command outputs.

<a href="https://app.greptile.com/trex/runs/13348209/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/vitest.config.ts | Replaced the `vite-tsconfig-paths` plugin with Vite 8's native `resolve.tsconfigPaths: true` setting for Vitest path alias resolution. |
| apps/studio/package.json | Removed the unused `vite-tsconfig-paths` dev dependency from Studio while keeping Vite/Vitest catalog usage intact. |
| packages/components/package.json | Removed the unused `vite-tsconfig-paths` dev dependency from the components package without changing scripts or runtime dependencies. |
| pnpm-workspace.yaml | Removed the `vite-tsconfig-paths` entry from the `vitest` catalog after all workspace references were deleted. |
| pnpm-lock.yaml | Lockfile updates consistently remove `vite-tsconfig-paths` and its now-orphaned transitive dependencies from the affected importers and catalog. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: replace vite-tsconfig-paths plugi..."](https://github.com/opengovsg/isomer/commit/288207efe912e72a5acc06ad34109f85572850fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41969141)</sub>

<!-- /greptile_comment -->