### PR TITLE
test(studio): add site admin config route e2e coverage

### DIFF
--- a/apps/studio/tests/e2e/site/admin.test.ts
+++ b/apps/studio/tests/e2e/site/admin.test.ts
@@ -33,9 +33,20 @@ for (const role of deniedRoles) {
     test("is redirected away from the site admin config page", async ({
       page,
     }) => {
-      await page.goto(`/sites/${getSeedSiteId()}/admin`)
+      const siteId = getSeedSiteId()
+      const adminResponsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url())
+        return (
+          url.pathname === `/sites/${siteId}/admin` &&
+          response.request().isNavigationRequest()
+        )
+      })
 
-      await expect(page).toHaveURL(new RegExp(`/sites/${getSeedSiteId()}$`))
+      await page.goto(`/sites/${siteId}/admin`)
+      const adminResponse = await adminResponsePromise
+
+      expect(adminResponse.status()).toBe(307)
+      await expect(page).toHaveURL(new RegExp(`/sites/${siteId}$`))
       await expect(
         page.getByText("Manage site configurations"),
       ).not.toBeVisible()

--- a/apps/studio/tests/e2e/site/admin.test.ts
+++ b/apps/studio/tests/e2e/site/admin.test.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test"
+
+import { storageStateFor } from "../fixtures/auth"
+import { getSeedSiteId } from "../fixtures/seed"
+
+const allowedRoles = ["core", "migrator"] as const
+const deniedRoles = ["editor", "publisher", "admin", "nomember"] as const
+
+for (const role of allowedRoles) {
+  test.describe(role, () => {
+    test.use({ storageState: storageStateFor(role) })
+
+    test("can view the site admin config page", async ({ page }) => {
+      await page.goto(`/sites/${getSeedSiteId()}/admin`)
+      await page.waitForURL(/\/admin$/)
+
+      await expect(page.getByText("Manage site configurations")).toBeVisible()
+      await expect(page.getByText("Site config", { exact: true })).toBeVisible()
+      await expect(page.getByText("Site theme", { exact: true })).toBeVisible()
+      await expect(page.getByText("Site navbar", { exact: true })).toBeVisible()
+      await expect(page.getByText("Site footer", { exact: true })).toBeVisible()
+      await expect(
+        page.getByRole("button", { name: "Save settings" }),
+      ).toBeVisible()
+    })
+  })
+}
+
+for (const role of deniedRoles) {
+  test.describe(role, () => {
+    test.use({ storageState: storageStateFor(role) })
+
+    test("is redirected away from the site admin config page", async ({
+      page,
+    }) => {
+      await page.goto(`/sites/${getSeedSiteId()}/admin`)
+
+      await expect(page).toHaveURL(new RegExp(`/sites/${getSeedSiteId()}$`))
+      await expect(
+        page.getByText("Manage site configurations"),
+      ).not.toBeVisible()
+    })
+  })
+}


### PR DESCRIPTION
## Problem

Follow-up to #2584 to add E2E coverage for the `/sites/:siteId/admin` access control behavior.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Adds Playwright coverage for the site admin config route:
  - `core` and `migrator` users can view the page
  - `editor`, `publisher`, regular site `admin`, and `nomember` users are redirected away

**Bug Fixes**:

- None

## Before & After Screenshots

**BEFORE**:

N/A

**AFTER**:

N/A

## Tests

- `pnpm --filter isomer-studio dev:e2e`

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds E2E coverage for the site admin config route. The main changes are:

- Adds Playwright checks for `core` and `migrator` users viewing `/sites/:siteId/admin`.
- Adds redirect checks for `editor`, `publisher`, site `admin`, and `nomember` users.
- Verifies the admin page content is hidden after denied users are redirected.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

Test-only change scoped to one new Playwright spec. Uses existing E2E storage-state and seed-site fixtures. No application behavior, data model, or security boundary code is modified.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A changed-file Playwright run was executed, and its command, working directory, timestamps, exit code 1, and the DB setup failure stack were captured in admin-e2e-01-run.log.
- A Playwright discovery run was performed successfully, and all six expected role scenarios were captured in admin-e2e-02-list.log.
- An executed-command summary was generated, noting that no HTML report or traces were produced before the global setup failed, in admin-e2e-summary.log.
- A JSON-formatted summary artifact was prepared to enable programmatic inspection of the run results, referenced as admin-e2e-summary.json.

<a href="https://app.greptile.com/trex/runs/13375069/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/tests/e2e/site/admin.test.ts | Adds Playwright E2E coverage for `/sites/:siteId/admin`, verifying core/migrator access and redirects for non-privileged roles. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Test as Playwright admin.test.ts
participant Browser as Browser Page
participant Studio as Studio /sites/:siteId/admin

Test->>Browser: Load storage state for role
Test->>Browser: "goto /sites/{seedSiteId}/admin"
Browser->>Studio: Navigation request
alt role is core or migrator
    Studio-->>Browser: Render admin config page
    Test->>Browser: Assert admin headings and Save settings visible
else role is editor, publisher, admin, or nomember
    Studio-->>Browser: "307 redirect to /sites/{seedSiteId}"
    Test->>Browser: Assert redirected URL and admin heading hidden
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Test as Playwright admin.test.ts
participant Browser as Browser Page
participant Studio as Studio /sites/:siteId/admin

Test->>Browser: Load storage state for role
Test->>Browser: "goto /sites/{seedSiteId}/admin"
Browser->>Studio: Navigation request
alt role is core or migrator
    Studio-->>Browser: Render admin config page
    Test->>Browser: Assert admin headings and Save settings visible
else role is editor, publisher, admin, or nomember
    Studio-->>Browser: "307 redirect to /sites/{seedSiteId}"
    Test->>Browser: Assert redirected URL and admin heading hidden
end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test(studio): assert site admin config r..."](https://github.com/opengovsg/isomer/commit/8813ece2e98d5601114fbd9e8d1b3835ad388f9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42022774)</sub>

<!-- /greptile_comment -->