### PR TITLE
feat(components): show empty state on e-Gazette Algolia search when no results found

### DIFF
--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Hits.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Hits.tsx
@@ -19,9 +19,25 @@ const formatDate = (timestamp: number) => {
 }
 
 export const Hits = () => {
-  const { items } = useHits<EgazetteHit>()
+  const { items, results } = useHits<EgazetteHit>()
 
-  if (items.length === 0) return null
+  if (items.length === 0) {
+    // Artificial results are the placeholder response rendered before the
+    // first Algolia response arrives — showing "no results" then would flash
+    // the empty state on every page load.
+    if (results?.__isArtificial) return null
+
+    return (
+      <div className="flex flex-col gap-1 py-32 text-center">
+        <p className="prose-headline-lg-regular text-base-content-subtle">
+          We couldn’t find any results.
+        </p>
+        <p className="prose-body-base text-base-content">
+          Try different search terms or filters.
+        </p>
+      </div>
+    )
+  }
 
   return (
     <ul className="flex flex-col divide-y divide-base-divider-medium">

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -134,6 +134,25 @@ const withDeepLinkParams = (search: string): Decorator => {
   }
 }
 
+export const EgazetteAlgoliaNoResults: Story = {
+  args: EGAZETTE_ARGS,
+  parameters: liveAlgoliaParameters,
+  decorators: [withDeepLinkParams("?q=zzzzquerywithnoresultszzzz")],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await waitFor(
+      () =>
+        expect(
+          canvas.getByText("We couldn’t find any results."),
+        ).toBeInTheDocument(),
+      { timeout: 10000 },
+    )
+    await expect(
+      canvas.getByText("Try different search terms or filters."),
+    ).toBeInTheDocument()
+  },
+}
+
 export const EgazetteAlgoliaWithDeepLink: Story = {
   args: EGAZETTE_ARGS,
   parameters: liveAlgoliaParameters,


### PR DESCRIPTION
## Problem

On the e-Gazette Algolia search page, a query or filter combination that matches nothing renders a blank results area — the `Hits` widget returned `null` when there were no hits, leaving users with no feedback beyond the small stats line and no guidance on what to do next.

Closes N/A

## Solution

Render a proper empty state in the results area when a search returns no hits, following the copy and styling pattern already used by `CollectionResults` ("We couldn't find any results." / "Try different search terms or filters.").

The empty state is guarded by InstantSearch's `results.__isArtificial` flag so it does not flash during the placeholder render before the first Algolia response arrives.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- `Hits` widget (`EgazetteAlgoliaSearch`) now shows a "We couldn't find any results." empty state with a "Try different search terms or filters." hint when a query returns zero hits

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

Results area is completely blank when a query returns no hits (only the "No results found for <query>" stats line shows).

**AFTER**:

Results area shows a centered empty state: "We couldn't find any results." with "Try different search terms or filters." underneath. Verified live in Storybook against the staging Algolia index.

## Tests

- Added `EgazetteAlgoliaNoResults` Storybook story that deep-links a query with no matches (`?q=zzzzquerywithnoresultszzzz`) and asserts the empty state renders. Chromatic snapshots are disabled for it, consistent with the other live-Algolia stories.
- Verified manually in Storybook: the no-results story shows the empty state, and the regular `EgazetteAlgolia` story still renders hits and pagination with no empty state.
- `pnpm typecheck` and `pnpm lint` pass for `@opengovsg/isomer-components`.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an empty state for e-Gazette Algolia searches with no matches. The main changes are:

- Shows `We couldn’t find any results.` when a real Algolia response returns zero hits.
- Hides the empty state during InstantSearch’s artificial placeholder response.
- Adds a Storybook interaction story for the no-results query state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is small and UI-only, with Storybook coverage for the new empty state. No functional, security, schema, or data-contract issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the T-Rex capture for the e-Gazette Storybook Algolia scenario to collect proofs; the capture command exited successfully.
- Captured a no-results screenshot and video showing the empty-state copy in the Storybook story.
- Captured a regular-story screenshot and video showing live hits in the Storybook story.
- Reviewed Algolia network responses observed during the run to validate search behavior.
- Inspected the Storybook server log to confirm run status and timing.

<a href="https://app.greptile.com/trex/runs/13508080/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Hits.tsx | Adds empty-state rendering for zero-hit e-Gazette Algolia results while suppressing the initial artificial InstantSearch response. |
| packages/components/src/templates/next/layouts/Search/Search.stories.tsx | Adds a live Algolia Storybook story that deep-links to a no-results query and asserts the empty-state copy. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant SearchPage as e-Gazette search page
participant InstantSearch
participant Hits as Hits widget
participant Algolia

User->>SearchPage: Opens search with query or filters
SearchPage->>InstantSearch: Mounts search UI
InstantSearch->>Hits: Sends artificial placeholder results
Hits-->>SearchPage: Renders no empty-state message yet
InstantSearch->>Algolia: Runs search
Algolia-->>InstantSearch: Returns zero hits
InstantSearch->>Hits: Sends real empty result set
Hits-->>User: Shows no-results empty state
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant SearchPage as e-Gazette search page
participant InstantSearch
participant Hits as Hits widget
participant Algolia

User->>SearchPage: Opens search with query or filters
SearchPage->>InstantSearch: Mounts search UI
InstantSearch->>Hits: Sends artificial placeholder results
Hits-->>SearchPage: Renders no empty-state message yet
InstantSearch->>Algolia: Runs search
Algolia-->>InstantSearch: Returns zero hits
InstantSearch->>Hits: Sends real empty result set
Hits-->>User: Shows no-results empty state
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add no results page"](https://github.com/opengovsg/isomer/commit/4439ddf7a5d483cd0d9a5c3c7e343fcf1f1a3183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42290252)</sub>

<!-- /greptile_comment -->