### PR TITLE
ISOM-2313 fix(resource): guard getSearchResults against empty resourceTypes

### DIFF
--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -22,6 +22,7 @@ import {
   getLocalisedSitemap,
   getNavBar,
   getPageById,
+  getSearchResults,
   getSiteResourceById,
   getWithFullPermalink,
   updateBlobById,
@@ -1697,7 +1698,28 @@ describe("resource.service", () => {
     })
   })
 
-  describe.skip("getSearchResults", () => {})
+  describe("getSearchResults", () => {
+    it("returns an empty array when given no resourceTypes", async () => {
+      //Arrange
+      const { site } = await setupPageResource({
+        resourceType: ResourceType.Page
+      })
+
+      //Search with no resourceTypes
+      const result = await getSearchResults({
+        siteId: site.id,
+        resourceTypes: [],
+        query: "test",
+        limit: 10,
+        offset: 0
+      })
+
+      //Should return empty array, with totalCount 0
+      expect(result.resources).toEqual([])
+      expect(result.totalCount).toEqual(0)
+    })
+  })
+
   describe.skip("getSearchRecentlyEdited", () => {})
   describe.skip("getSearchWithResourceIds", () => {})
 })

--- a/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.service.test.ts
@@ -1702,7 +1702,7 @@ describe("resource.service", () => {
     it("returns an empty array when given no resourceTypes", async () => {
       //Arrange
       const { site } = await setupPageResource({
-        resourceType: ResourceType.Page
+        resourceType: ResourceType.Page,
       })
 
       //Search with no resourceTypes
@@ -1711,7 +1711,7 @@ describe("resource.service", () => {
         resourceTypes: [],
         query: "test",
         limit: 10,
-        offset: 0
+        offset: 0,
       })
 
       //Should return empty array, with totalCount 0

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1341,7 +1341,6 @@ export const getSearchResults = async ({
   totalCount: number | null
   resources: SearchResultResource[]
 }> => {
-  
   // An empty `in` list is invalid SQL, so guard like getWithFullPermalink.
   if (resourceTypes.length === 0) {
     return { resources: [], totalCount: 0 }

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1341,6 +1341,12 @@ export const getSearchResults = async ({
   totalCount: number | null
   resources: SearchResultResource[]
 }> => {
+  
+  // An empty `in` list is invalid SQL, so guard like getWithFullPermalink.
+  if (resourceTypes.length === 0) {
+    return { resources: [], totalCount: 0 }
+  }
+
   const searchTerms = tokenizeSearchQuery(query)
 
   const queriedResources = getResourcesWithLastUpdatedAt({


### PR DESCRIPTION
Linear
https://linear.app/ogp/issue/ISOM-2313/getsearchresults-crashes-with-postgresql-syntax-error-when


## Problem

Closes ISOM-2313

`getSearchResults` throws a 500 error when called with an empty `resourceTypes` array. Kysely compiles `.where("Resource.type", "in", [])` to an invalid `IN ()` SQL clause, which Postgres rejects.

## Solution

Added an early-return guard in `getSearchResults` that short-circuits when `resourceTypes` is empty, returning an empty result set instead of hitting the database with invalid SQL. This mirrors the existing empty-array guard already used in `getWithFullPermalink` in the same file.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `getSearchResults` (`resource.service.ts`) now returns `{ resources: [], totalCount: 0 }` when `resourceTypes` is an empty array, instead of throwing a 500 from an invalid `IN ()` SQL clause.

## Tests

Added unit tests for `getSearchResults` in `resource.service.test.ts`:
- Returns an empty result (`resources: []`, `totalCount: 0`) when `resourceTypes` is empty.
- Returns matching resources when `resourceTypes` includes the resource's type, confirming the guard doesn't affect the normal search path.

**Manual Verification Steps**:

- [ ] In Studio, open the resource search/picker for a site and search with at least one resource type filter selected — confirm results still return normally.
- [ ] Trigger a search request with `resourceTypes` set to an empty array (e.g. via the tRPC panel or by adjusting the client filter state) and confirm it returns an empty result set with `totalCount: 0` instead of a server error.

