### PR TITLE
fix: index gazettes into Algolia even when the publishing cron clears the draft blob first

### DIFF
--- a/.claude/skills/isomer-conventions/conventions/kysely-eb-fn-over-raw-sql.md
+++ b/.claude/skills/isomer-conventions/conventions/kysely-eb-fn-over-raw-sql.md
@@ -1,0 +1,56 @@
+---
+title: Prefer Kysely's expression builder over raw sql for supported functions
+category: Database
+type: best-practice
+---
+
+## Pattern
+
+When Kysely's expression builder has a typed equivalent for a SQL function,
+use it instead of a raw `` sql`...` `` template. The common case is
+`COALESCE` over columns:
+
+```ts
+.select([
+  (eb) =>
+    eb.fn.coalesce("DraftBlob.content", "PublishedBlob.content").as("content"),
+])
+```
+
+Raw `` sql`...` `` remains fine where the builder has no equivalent — e.g.
+JSON path extraction (`content->'page'->>'description'`) or `regexp_replace`,
+as in `apps/studio/src/server/modules/gazette/gazette.router.ts:135,147`.
+
+## Why
+
+The builder validates column references against the query's joined tables at
+compile time and infers the result type — a renamed column or alias breaks the
+build instead of failing (or silently misbehaving) at runtime. Raw strings
+also dodge Kysely's identifier quoting, so they're easier to get subtly wrong.
+
+## Bad
+
+```ts
+.select([
+  sql<unknown>`COALESCE("PublishedBlob"."content", "DraftBlob"."content")`.as(
+    "content",
+  ),
+])
+```
+
+## Good
+
+See `apps/studio/src/server/modules/gazette/gazette.router.ts:158-161`:
+
+```ts
+.select([
+  (eb) =>
+    eb.fn.coalesce("DraftBlob.content", "PublishedBlob.content").as("content"),
+])
+```
+
+## How to detect
+
+Flag `` sql` `` templates whose contents are a single function call over plain
+column references (`COALESCE`, `MAX`, `COUNT`, `SUM`, ...) with no JSON
+operators or Postgres-only functions — each has an `eb.fn` equivalent.

--- a/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
+++ b/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
@@ -444,6 +444,108 @@ describe("schedulePushDocumentJobHandler", async () => {
       expect(remaining).toHaveLength(0)
     })
 
+    it("dispatches a resource that was already published (publishing cron won the race)", async () => {
+      // Arrange — simulate the schedule-publishing cron having already run
+      // for this gazette: publishing promotes the draft blob into the
+      // published Version and clears draftBlobId (see publishPageResource /
+      // version.service.ts). Both crons fire on the same scheduledAt, so
+      // this ordering happens whenever schedule-publishing wins the tick.
+      const { resourceId, ref } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/2024/gazette/public/published-first.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const version = await db
+        .selectFrom("Version")
+        .where("resourceId", "=", String(resourceId))
+        .select("id")
+        .executeTakeFirstOrThrow()
+      await db
+        .updateTable("Resource")
+        .set({ publishedVersionId: version.id, draftBlobId: null })
+        .where("id", "=", String(resourceId))
+        .execute()
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — the gazette is indexed from the published Version's blob
+      // and its S3 object is untagged, even though no draft blob remains.
+      expect(algoliaLib.saveObjectsToSearchIndex).toHaveBeenCalledTimes(1)
+      const [records] = vi.mocked(algoliaLib.saveObjectsToSearchIndex).mock
+        .calls[0]!
+      expect(records[0]).toMatchObject({ objectGroup: ref.slice(1) })
+      expect(s3Lib.setAssetAsPublished).toHaveBeenCalledTimes(1)
+      const remainingAfterPublish = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .execute()
+      expect(remainingAfterPublish).toHaveLength(0)
+    })
+
+    it("indexes the published version's content, not a newer unpublished draft", async () => {
+      // Arrange — publish the gazette, then attach a NEW draft blob whose
+      // ref differs. The job must index what actually went live, not
+      // unpublished edits.
+      const publishedRef = "/2024/gazette/public/live.pdf"
+      const draftRef = "/2024/gazette/public/edited-draft.pdf"
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: publishedRef,
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const version = await db
+        .selectFrom("Version")
+        .where("resourceId", "=", String(resourceId))
+        .select("id")
+        .executeTakeFirstOrThrow()
+      const draftBlob = await db
+        .insertInto("Blob")
+        .values({ content: {} as never })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+      await setBlobContentForPushDocument(
+        draftBlob.id,
+        draftRef,
+        "Government Gazettes",
+        ["tag-1"],
+      )
+      await db
+        .updateTable("Resource")
+        .set({ publishedVersionId: version.id, draftBlobId: draftBlob.id })
+        .where("id", "=", String(resourceId))
+        .execute()
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — records are built from the published ref, not the draft's.
+      expect(algoliaLib.saveObjectsToSearchIndex).toHaveBeenCalledTimes(1)
+      const [records] = vi.mocked(algoliaLib.saveObjectsToSearchIndex).mock
+        .calls[0]!
+      expect(records[0]).toMatchObject({
+        objectGroup: publishedRef.slice(1),
+      })
+    })
+
     it("skips rows scheduled for the future", async () => {
       // Arrange
       const { resourceId } = await seedDocumentReadyForIngestion({

--- a/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
+++ b/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
@@ -160,18 +160,29 @@ export const schedulePushDocumentJobHandler = async () => {
   try {
     const useSearchSg = gb.isOn(ENABLE_SEARCHSG_GAZETTE_INGESTION)
 
-    // Pick the latest published Version per resource so we ingest the
-    // version that was just (or is being) published — distinctOn(Resource.id)
-    // + ordered by Version.id desc.
+    // Pick the content to index: prefer the published Version's blob, fall
+    // back to the draft blob. The schedule-publishing cron fires on the same
+    // scheduledAt as this job and publishing clears draftBlobId (the draft
+    // becomes the Version — see version.service.ts), so joining only on the
+    // draft blob silently drops any gazette whose publish won the race. The
+    // draft fallback covers the opposite ordering, where this job runs first
+    // and the identical content is published moments later. A row where both
+    // blobs are somehow missing yields null content, which fails the Zod
+    // parse below and is logged + skipped rather than silently dropped.
     const scheduledResources = await db
       .selectFrom("PushDocumentJob")
       .innerJoin("Resource", "Resource.id", "PushDocumentJob.resourceId")
-      .innerJoin("Blob", "Blob.id", "Resource.draftBlobId")
+      .leftJoin("Version", "Version.id", "Resource.publishedVersionId")
+      .leftJoin("Blob as PublishedBlob", "PublishedBlob.id", "Version.blobId")
+      .leftJoin("Blob as DraftBlob", "DraftBlob.id", "Resource.draftBlobId")
       .where("PushDocumentJob.scheduledAt", "<=", scheduledAtCutoff)
       .distinctOn("Resource.id")
       .orderBy("Resource.id")
       .select([
-        "Blob.content",
+        (eb) =>
+          eb.fn
+            .coalesce("PublishedBlob.content", "DraftBlob.content")
+            .as("content"),
         "Resource.title",
         "Resource.id as resourceId",
         "Resource.parentId",


### PR DESCRIPTION
## Problem

Some published gazettes were never pushed to the search index (Algolia) and their PDFs stayed hidden from the public, with no error logged.

Root cause is a race between two pg-boss crons that both fire every minute on the same `scheduledAt`:

1. `schedule-publishing` publishes the resource — which promotes the draft blob into a `Version` and **clears `Resource.draftBlobId`** (`version.service.ts`).
2. `schedule-push-document` selected due `PushDocumentJob` rows with an **inner join on `Resource.draftBlobId`**.

Whenever the publishing cron won the tick, the inner join silently dropped the gazette from the push job's select. The gazette was never indexed, `setAssetAsPublished` never removed the scheduling tag from the S3 object (so the PDF stayed un-viewable), and `deleteProcessedJobs` deleted the `PushDocumentJob` row anyway — permanent loss, no retry, no log line.

No tracked issue — diagnosed from production behaviour (gazettes intermittently missing from the index after publish).

## Solution

Make the push job's query independent of cron ordering: left-join both the published `Version`'s blob and the draft blob, and select `COALESCE(PublishedBlob.content, DraftBlob.content)` (via Kysely's `eb.fn.coalesce`, matching the existing idiom in `gazette.router.ts`).

- **Published blob wins**: it is what actually went live, and it protects against indexing unpublished edits if a new draft exists at push time.
- **Draft blob covers the opposite ordering**: if the push cron runs first, the draft holds the identical content that is published moments later.
- If both blobs are somehow missing, the null content fails the existing Zod parse and is logged + skipped — a diagnosable skip instead of an invisible join drop.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Documented a repo convention entry (`.claude/skills/isomer-conventions/conventions/kysely-eb-fn-over-raw-sql.md`): prefer Kysely's expression builder (`eb.fn.coalesce`) over raw `sql` templates when a typed equivalent exists

**Bug Fixes**:

- Gazettes are now indexed into Algolia (or SearchSG, flag-dependent) regardless of whether the publishing cron or the push-document cron runs first in a tick
- The push job now indexes the published version's content, not a newer unpublished draft, when both exist

## Before & After Screenshots

**BEFORE**:

N/A — backend cron behaviour. Symptom: gazette published, but absent from search and PDF not publicly viewable; no error logs for the affected `resourceId`.

**AFTER**:

N/A — gazette is indexed and its S3 object untagged in both cron orderings.

## Tests

Two regression tests added to `src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts` (both fail on the old query, pass with the fix):

- `dispatches a resource that was already published (publishing cron won the race)` — reproduces the race deterministically by clearing `draftBlobId` before running the handler; on old code Algolia was never called
- `indexes the published version's content, not a newer unpublished draft` — pins the COALESCE ordering

Run with:

```
cd apps/studio
pnpm exec dotenv -e .env.test -- vitest run src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
```

Full unit suite (66 files, 1527 tests), `pnpm typecheck`, oxlint and oxfmt all pass.

Note for ops: gazettes already lost to this race have no `PushDocumentJob` rows left — they need a one-off re-publish or manual backfill to appear in the index.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)