### PR TITLE
👨🏻‍💻 DX: ci: add turborepo remote caching with actions/cache

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,9 +16,9 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
-        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-turbo-${{ github.job }}-
+          ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-
 
     - shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,12 @@
 name: "Setup and install"
 description: "Common setup steps for Actions"
 
+inputs:
+  job-index:
+    description: "Index of the current job within its matrix, if any. Composite actions can't read the caller's strategy context directly, so matrixed callers must pass it in explicitly to disambiguate their turbo cache key."
+    required: false
+    default: "0"
+
 runs:
   using: composite
   steps:
@@ -16,12 +22,12 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
-        # strategy.job-index disambiguates matrix legs sharing the same github.job (e.g. test-studio's
-        # shards), which would otherwise race to reserve the same cache key. It's always 0 on non-matrix
+        # inputs.job-index disambiguates matrix legs sharing the same github.job (e.g. test-studio's
+        # shards), which would otherwise race to reserve the same cache key. Defaults to 0 on non-matrix
         # jobs, so the key there is unaffected.
-        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ inputs.job-index }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-
+          ${{ runner.os }}-turbo-${{ github.job }}-${{ inputs.job-index }}-
 
     - shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,9 +16,9 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
-        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-turbo-
+          ${{ runner.os }}-turbo-${{ github.job }}-
 
     - shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,5 +12,13 @@ runs:
         cache: pnpm
         cache-dependency-path: pnpm-lock.yaml
 
+    - name: Cache turbo build setup
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
     - shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -16,6 +16,9 @@ runs:
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: .turbo
+        # strategy.job-index disambiguates matrix legs sharing the same github.job (e.g. test-studio's
+        # shards), which would otherwise race to reserve the same cache key. It's always 0 on non-matrix
+        # jobs, so the key there is unaffected.
         key: ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
+        with:
+          job-index: ${{ matrix.shard }}
       - parallel:
           - name: Install Playwright (Chromium)
             # Required by the vitest "browser" project (Vitest Browser Mode).


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +19 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

CI jobs (build, lint, format, typecheck, and the various test/e2e jobs) get zero cache reuse between runs — every job recomputes turbo tasks from scratch even when the underlying inputs haven't changed, since we have no Turborepo remote cache configured.

## Solution

Adds Turborepo remote caching backed by `actions/cache` (no external service or tokens required), following the official guidance at https://turborepo.dev/docs/guides/ci-vendors/github-actions#remote-caching-with-github-actionscache. This mirrors the approach shipped in [opengovsg/starter-kit#637](https://github.com/opengovsg/starter-kit/pull/637) and its follow-up fix in [opengovsg/starter-kit#638](https://github.com/opengovsg/starter-kit/pull/638).

The cache step is added to the shared `.github/actions/setup/action.yml` composite action (the equivalent of starter-kit's `tooling/github/setup/action.yml`), which every CI job already uses — so all jobs pick up the `.turbo` cache without duplicating the step. `actions/cache` is pinned to the same commit SHA already used elsewhere in `ci.yml` (Next.js cache step) to keep action pinning consistent across the repo.

Since all CI jobs run this shared setup action in parallel, an initial version using a single shared cache key (`${{ runner.os }}-turbo-${{ github.sha }}`) would hit GitHub's per-key exclusive cache reservation and cause every job but the first to finish to fail with `Unable to reserve cache with key ..., another job may be creating this cache.` (the same issue starter-kit#638 fixed). The key is scoped per job via `${{ github.job }}`.

That alone isn't sufficient for `test-studio`, though: it runs as a 2-way matrix (sharded unit tests), and `github.job` is the job *id* from the workflow — it doesn't vary per matrix leg, so both shards would still resolve to the same key and race each other. Added `${{ strategy.job-index }}` to the key (`0` for non-matrixed jobs, unique per matrix leg otherwise) so each shard gets its own cache lane.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- CI jobs now cache and restore `.turbo` build output via `actions/cache`, keyed per-job (and per-matrix-leg) on `${{ runner.os }}-turbo-${{ github.job }}-${{ strategy.job-index }}-${{ github.sha }}` with a matching restore-key fallback, so turbo can produce cache hits across CI runs instead of recomputing every task from scratch.
- Observed CI runtime with a warm cache: the end-to-end test job went from ~5 minutes to ~1 minute 40 seconds (a ~67% reduction, roughly 3x faster). `format`, `lint`, and `typecheck` now all complete in under 1 minute.

**Bug Fixes**:

- N/A

## Tests

CI-only change — no production code paths affected.

- On this PR's own CI run, confirm the new "Cache turbo build setup" step appears in each job (build, lint, format, typecheck, test-*, end-to-end-tests) — including both `test-studio` matrix shards — and reports a successful cache save (no "Unable to reserve cache" errors) on first run.
- On any subsequent commit/rerun, confirm the step reports a cache restore (via `restore-keys`) and turbo output shows cache hits (e.g. `>>> FULL TURBO` or "cache hit" lines) for tasks like `lint`, `typecheck`, `format`.
- Confirm both `test-studio` shard jobs save/restore independently (no reservation conflicts between shard 1 and shard 2).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds Turborepo caching to GitHub Actions CI. The main changes are:

- Adds an optional `job-index` input to the shared setup composite action.
- Restores and saves the local `.turbo` cache with `actions/cache`.
- Keys the cache by runner OS, GitHub job, job index, and commit SHA.
- Passes the `test-studio` matrix shard into the setup action to avoid cache-key collisions between shards.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal runtime risk.

The change is limited to CI cache setup and uses distinct cache lanes for the only matrixed setup caller.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The turbo-cache CI validation results show all assertions passing, including the .turbo cache path, the computed key, the restore prefix, the default job-index, and unique shard keys for test-studio indexes 1 and 2.
- The log explicitly records that the real actions/cache reserve/save/restore steps could not be exercised on the GitHub Actions runner because the cache service is unavailable.
- Uploaded artifacts include a Python validation artifact and two linked logs that document the outcome of the validation and the environment limitation.

<a href="https://app.greptile.com/trex/runs/16556984/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/actions/setup/action.yml | Adds an optional matrix disambiguator input and restores/saves the Turborepo `.turbo` cache in the shared CI setup action; no issues found. |
| .github/workflows/ci.yml | Passes the `test-studio` shard value into the setup action so matrix legs use separate turbo cache keys; no issues found. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Job as CI job
participant Setup as .github/actions/setup
participant Cache as actions/cache
participant Turbo as Turborepo tasks

Job->>Setup: Invoke shared setup
alt test-studio matrix shard
    Job->>Setup: "Pass job-index = matrix.shard"
else non-matrix job
    Job->>Setup: "Use default job-index = 0"
end
Setup->>Cache: Restore .turbo with runner/job/index restore key
Setup->>Job: Install pnpm dependencies
Job->>Turbo: Run build/lint/typecheck/test task
Turbo->>Job: Reuse restored local cache when inputs match
Cache->>Cache: Save .turbo under runner/job/index/sha key
```
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: pass job-index as input instead of r..."](https://github.com/opengovsg/isomer/commit/9c808823327dbdfc53107ae71cb27bec3d9ed61c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45675985)</sub>

<!-- /greptile_comment -->