### PR TITLE
fix(gazette): address dogfooding findings on egazette search page

### DIFF
--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Pagination.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Pagination.tsx
@@ -16,7 +16,15 @@ export const Pagination = () => {
         totalItems={nbPages}
         itemsPerPage={1}
         currPage={currentRefinement + 1}
-        setCurrPage={(page) => refine(page - 1)}
+        setCurrPage={(page) => {
+          refine(page - 1)
+          // Pagination sits below the results, so paging otherwise leaves the
+          // viewport at the bottom of the previous page's list. Jump back to the
+          // top so the new page starts in view, matching the legacy eGazette.
+          if (typeof window !== "undefined") {
+            window.scrollTo({ top: 0 })
+          }
+        }}
       />
     </div>
   )

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/RangeInput.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/RangeInput.tsx
@@ -11,7 +11,7 @@ interface RangeInputProps {
 }
 
 const inputStyles = tv({
-  base: "h-10 w-full rounded border bg-white px-2",
+  base: "h-10 w-full rounded border bg-white px-2 disabled:cursor-not-allowed",
   variants: {
     hasError: {
       true: "border-utility-feedback-alert",
@@ -63,6 +63,14 @@ export const RangeInput = ({
   })
   const [minRaw, maxRaw] = start
 
+  // Validate against the range Algolia derived from the attribute's facet stats
+  // when no explicit `bound` was passed. Without this a visitor can submit a
+  // year/month outside the data's range — a filter that matches nothing.
+  const effectiveBound = {
+    min: bound?.min ?? range.min,
+    max: bound?.max ?? range.max,
+  }
+
   const [min, setMin] = useState(toInputValue(minRaw))
   const [max, setMax] = useState(toInputValue(maxRaw))
   const [error, setError] = useState<string>()
@@ -91,7 +99,7 @@ export const RangeInput = ({
       setError("Please enter a valid number")
       return
     }
-    const validationError = validate(minNum, maxNum, bound)
+    const validationError = validate(minNum, maxNum, effectiveBound)
     if (validationError) {
       setError(validationError)
       return
@@ -142,7 +150,7 @@ export const RangeInput = ({
         <button
           type="submit"
           disabled={!canRefine}
-          className="prose-headline-base-medium h-10 rounded border border-base-content-strong bg-white px-3 text-base-content disabled:opacity-50"
+          className="prose-headline-base-medium h-10 rounded border border-base-content-strong bg-white px-3 text-base-content disabled:cursor-not-allowed disabled:opacity-50"
         >
           Go
         </button>

--- a/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SearchBox.tsx
+++ b/packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SearchBox.tsx
@@ -46,7 +46,7 @@ export const SearchBox = () => {
           if (timerRef.current) clearTimeout(timerRef.current)
           timerRef.current = setTimeout(() => refine(next), DEBOUNCE_MS)
         }}
-        className="prose-body-base h-12 w-full rounded border border-base-content-strong bg-white pl-10 pr-3 text-base-content placeholder:text-base-content-medium focus:outline-none focus:ring-2 focus:ring-utility-highlight"
+        className="prose-body-base h-12 w-full rounded border border-base-content-strong bg-white pl-10 pr-3 text-base-content placeholder:text-base-content-medium focus:outline-none focus:ring-2 focus:ring-utility-highlight [&::-webkit-search-cancel-button]:cursor-pointer"
       />
     </label>
   )

--- a/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Search/Search.stories.tsx
@@ -116,6 +116,26 @@ export const EgazetteAlgoliaWithYearRange: Story = {
   },
 }
 
+// A year beyond the index's derived range must be rejected with an inline error
+// instead of applying a filter that matches nothing. 3000 is safely past any
+// gazette's publish year, so it always exceeds the index's max.
+export const EgazetteAlgoliaYearOutOfRange: Story = {
+  args: EGAZETTE_ARGS,
+  parameters: liveAlgoliaParameters,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // The year "To" field is the first "To" input (year precedes month).
+    const yearToInput = canvas.getAllByLabelText("To")[0]
+    if (!yearToInput) throw new Error("Year range input not found")
+    await waitFor(() => expect(yearToInput).toBeEnabled(), { timeout: 10000 })
+    await userEvent.type(yearToInput, "3000")
+    const goButton = canvas.getAllByRole("button", { name: "Go" })[0]
+    if (!goButton) throw new Error("Year range submit button not found")
+    await userEvent.click(goButton)
+    await expect(await canvas.findByText(/or earlier/i)).toBeInTheDocument()
+  },
+}
+
 // Seeds the URL with egazette deep-link params before <InstantSearch> mounts,
 // then restores the original URL on unmount so other stories are unaffected.
 const withDeepLinkParams = (search: string): Decorator => {


### PR DESCRIPTION
## Problem

The egazette dogfooding session surfaced several UX issues on the search page. Three were tagged **Not started**, and this PR addresses all three:

1. **Pagination doesn't scroll to top** — paging through results leaves the viewport at the bottom of the previous page's list, so the next page opens off-screen. Legacy eGazette scrolls back to the top.
2. **[Nit] Field interactions** — the search box clear "✕" shows a text/arrow cursor instead of a pointer, and the disabled year/month range fields show a normal cursor instead of `not-allowed`.
3. **[Nit] Year can be set outside the available range** — the year/month range inputs accept values outside the data's range and apply a filter that matches nothing, with no feedback to the user.

No linked GitHub issue — findings are tracked in the [egazette dogfooding session](https://app.notion.com/p/opengov/egazette-dogfooding-session-39677dbba788808ca81fd3b5f61e7e7b) Notion database. The remaining findings there are already **Fixed**, **In progress**, or marked **NOT DOING**, so they are out of scope here.

Closes N/A (tracked in Notion — see link above)

## Solution

All changes are scoped to the egazette Algolia search widgets in `packages/components` (`templates/next/layouts/Search/EgazetteAlgoliaSearch/`). No schema, interface, or Studio-facing contract changes.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- **Pagination scroll-to-top** (`widgets/Pagination.tsx`): after `refine()`, the widget calls `window.scrollTo({ top: 0 })` (SSR-guarded) so the new page starts in view, matching legacy eGazette. Kept in the egazette widget rather than overloading the shared `PaginationControls`.
- **Clear-button cursor** (`widgets/SearchBox.tsx`): added `[&::-webkit-search-cancel-button]:cursor-pointer` to the native `type="search"` clear "✕". This is the same pseudo-element variant already used in `internal/Search.tsx`, and applies on WebKit/Blink where the native clear button renders.
- **Disabled-field cursor** (`widgets/RangeInput.tsx`): added `disabled:cursor-not-allowed` to the From/To inputs and the "Go" button.

**Bug Fixes**:

- **Out-of-range range input** (`widgets/RangeInput.tsx`): validation now checks against the range Algolia derives from the attribute's facet stats — `effectiveBound = explicit bound ?? facet range`. Out-of-range years/months are rejected through the component's existing inline `role="alert"` error instead of applying an empty-result filter. Deliberately routed through the existing custom validation (not native `min`/`max` attributes) so a browser validation bubble doesn't preempt the component's own error UI.

## Before & After Screenshots

These are cursor / scroll / validation behaviours rather than static-layout changes, so no static screenshots are attached. Behavioural summary:

**BEFORE**:

- Paging opens the next page with the viewport still at the bottom of the previous list.
- Hovering the search "✕" shows a text/arrow cursor; hovering disabled range fields shows a normal cursor.
- Typing e.g. `3000` in the year "To" field and clicking Go applies a zero-result filter with no feedback.

**AFTER**:

- Paging scrolls back to the top of the page.
- The "✕" shows a pointer cursor; disabled range fields show the `not-allowed` cursor.
- Out-of-range values show an inline error (e.g. "To must be 2026 or earlier") and the filter is not applied.

## Tests

- `pnpm --filter @opengovsg/isomer-components typecheck` — clean.
- `pnpm --filter @opengovsg/isomer-components test:unit` — 368/368 pass.
- `pnpm --filter @opengovsg/isomer-components lint` and `format` — clean.
- Added Storybook story `EgazetteAlgoliaYearOutOfRange` (`Search.stories.tsx`), mirroring the existing `EgazetteAlgoliaWithYearRange` story, which types an out-of-range year and asserts the inline error appears.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the eGazette search page UX. The main changes are:

- Scrolls back to the top after changing result pages.
- Shows pointer and not-allowed cursors for the affected search and range controls.
- Validates year and month range inputs against Algolia-derived bounds before applying filters.
- Adds a Storybook interaction story for out-of-range year validation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

Changes are scoped to eGazette published-site search widgets and a Storybook interaction test. No schema, dependency, server, or persistence behavior changes were introduced. No correctness or security issues were found in the changed files.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/Pagination.tsx | Adds an SSR-guarded scroll-to-top after Algolia pagination refinement; no issues found. |
| packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/RangeInput.tsx | Adds disabled cursor styling and validates submitted range values against explicit or Algolia-derived bounds; no issues found. |
| packages/components/src/templates/next/layouts/Search/EgazetteAlgoliaSearch/widgets/SearchBox.tsx | Adds cursor styling for the native WebKit/Blink search clear button; no issues found. |
| packages/components/src/templates/next/layouts/Search/Search.stories.tsx | Adds a Storybook interaction story covering out-of-range eGazette year validation; no issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant SearchWidget as eGazette Search Widgets
participant Algolia as React InstantSearch / Algolia
participant Page as Browser Viewport

User->>SearchWidget: Click pagination control
SearchWidget->>Algolia: refine(page - 1)
SearchWidget->>Page: "window.scrollTo({ top: 0 })"

User->>SearchWidget: Submit year/month range
SearchWidget->>Algolia: Read facet-derived range
SearchWidget->>SearchWidget: Validate against effective bound
alt Value is in range
    SearchWidget->>Algolia: refine([min, max])
else Value is out of range
    SearchWidget->>User: Show inline alert error
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant SearchWidget as eGazette Search Widgets
participant Algolia as React InstantSearch / Algolia
participant Page as Browser Viewport

User->>SearchWidget: Click pagination control
SearchWidget->>Algolia: refine(page - 1)
SearchWidget->>Page: "window.scrollTo({ top: 0 })"

User->>SearchWidget: Submit year/month range
SearchWidget->>Algolia: Read facet-derived range
SearchWidget->>SearchWidget: Validate against effective bound
alt Value is in range
    SearchWidget->>Algolia: refine([min, max])
else Value is out of range
    SearchWidget->>User: Show inline alert error
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gazette): address dogfooding finding..."](https://github.com/opengovsg/isomer/commit/ac2582ff767a60857952755287a3cbddb0b6eb38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43757912)</sub>

<!-- /greptile_comment -->