### PR TITLE
fix(studio): surface asset CDN verification failures

### DIFF
--- a/apps/studio/src/components/PageEditor/FileAttachment.tsx
+++ b/apps/studio/src/components/PageEditor/FileAttachment.tsx
@@ -1,9 +1,10 @@
 import type { AttachmentProps } from "@opengovsg/design-system-react"
 import { FormControl, Skeleton, Text } from "@chakra-ui/react"
-import { Attachment } from "@opengovsg/design-system-react"
+import { Attachment, useToast } from "@opengovsg/design-system-react"
 import { uniq } from "lodash-es"
 import dynamic from "next/dynamic"
 import { useEffect, useState } from "react"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useAssetUpload } from "~/features/editing-experience/components/form-builder/hooks/useAssetUpload"
 import { RISKY_FILE_EXTENSIONS } from "~/features/editing-experience/components/form-builder/renderers/controls/constants"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
@@ -49,6 +50,7 @@ export const FileAttachment = ({
     resourceId,
   })
   const { handleAssetUpload, isLoading } = useAssetUpload({})
+  const toast = useToast()
 
   useEffect(() => {
     // NOTE: The outer link modal uses this to disable the button
@@ -62,7 +64,16 @@ export const FileAttachment = ({
         onSuccess: ({ path }) => {
           onUploadedFile?.(file)
           if (shouldFetchResource) {
-            void handleAssetUpload(path).then((src) => setHref(src))
+            void handleAssetUpload(path)
+              .then((src) => setHref(src))
+              .catch(() => {
+                toast({
+                  title: "Failed to upload file",
+                  description: "Please try again.",
+                  status: "error",
+                  ...BRIEF_TOAST_SETTINGS,
+                })
+              })
           } else setHref(path)
         },
       },

--- a/apps/studio/src/features/editing-experience/components/form-builder/hooks/useAssetUpload.ts
+++ b/apps/studio/src/features/editing-experience/components/form-builder/hooks/useAssetUpload.ts
@@ -42,6 +42,7 @@ export const useAssetUpload = ({
       return src
     } catch (e) {
       console.error(e)
+      throw e
     } finally {
       setIsLoading(false)
     }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsMetaImageControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsMetaImageControl.tsx
@@ -6,6 +6,7 @@ import {
   Attachment,
   FormErrorMessage,
   FormLabel,
+  useToast,
 } from "@opengovsg/design-system-react"
 import {
   IMAGE_ACCEPTED_MIME_TYPE_MAPPING,
@@ -13,6 +14,7 @@ import {
 } from "@opengovsg/isomer-components"
 import { uniq } from "lodash-es"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { pageSchema } from "~/features/editing-experience/schema"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useUploadAssetMutation } from "~/hooks/useUploadAssetMutation"
@@ -43,6 +45,7 @@ function JsonFormsMetaImageControl(props: JsonFormsMetaImageControlProps) {
   const { image } = useS3Image(data)
   const { handleAssetUpload, isLoading } = useAssetUpload({})
   const { siteId, pageId } = useQueryParse(pageSchema)
+  const toast = useToast()
   const { mutate: uploadFile } = useUploadAssetMutation({
     siteId,
     resourceId: String(pageId),
@@ -84,9 +87,18 @@ function JsonFormsMetaImageControl(props: JsonFormsMetaImageControlProps) {
               { file },
               {
                 onSuccess: ({ path: imagePath }) => {
-                  void handleAssetUpload(imagePath).then((src) => {
-                    handleChange(path, src)
-                  })
+                  void handleAssetUpload(imagePath)
+                    .then((src) => {
+                      handleChange(path, src)
+                    })
+                    .catch(() => {
+                      toast({
+                        title: "Failed to upload image",
+                        description: "Please try again.",
+                        status: "error",
+                        ...BRIEF_TOAST_SETTINGS,
+                      })
+                    })
                 },
               },
             )


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

CDN verification failures after S3 upload were being swallowed by `useAssetUpload`. Because the promise resolved with `undefined`, callers could clear the uploaded file/image field without showing any user-facing error.

Closes #2366
Closes #2374

## Solution

<!-- How did you solve the problem? -->

`useAssetUpload` now rethrows CDN verification failures after logging them, so callers can handle failed verification explicitly.

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Prevent `FileAttachment` from calling `setHref(undefined)` when CDN verification fails.
- Prevent `JsonFormsMetaImageControl` from calling `handleChange(path, undefined)` when CDN verification fails.
- Show an error toast when CDN verification fails.

## Before & After Screenshots

N/A.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Upload an image/file that uses CDN verification.
- [ ] Simulate or encounter CDN verification failure after S3 upload.
- [ ] Confirm the existing form value is not silently replaced with `undefined`.
- [ ] Confirm an error toast is shown.

**New scripts**:

N/A

**New dependencies**:

N/A

**New dev dependencies**:

N/A
