### PR TITLE
feat: upload file-like redirect sources without appending /index.html

### DIFF
--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -33,12 +33,18 @@ const EMPTY_FILE = path.join(os.tmpdir(), "isomer-redirect-empty")
 
 function uploadOne(source: string, destination: string): Promise<void> {
   return new Promise((resolve, reject) => {
+    // Mirror the CloudFront redirect function's assumption (see
+    // generateRedirectFnCode in isomer-next-infra): if the last 5 characters
+    // contain a ".", the source is treated as a file path and used as-is.
+    // Otherwise it is a directory path and resolves to its "/index.html" object.
+    const isPotentialFilePath = source.slice(-5).includes(".")
+    const key = isPotentialFilePath ? source : `${source}/index.html`
     const proc = spawn("aws", [
       "s3",
       "cp",
       "--only-show-errors",
       EMPTY_FILE,
-      `s3://${S3_BUCKET}/${SITE_NAME}/${BUILD_NUMBER}/latest/${source}/index.html`,
+      `s3://${S3_BUCKET}/${SITE_NAME}/${BUILD_NUMBER}/latest/${key}`,
       "--content-type",
       "text/html",
       "--cache-control",


### PR DESCRIPTION
## Problem

When redirect sources are uploaded to S3, `uploadRedirects.ts` unconditionally appended `/index.html` to every source's object key. This mismatches the hidden assumption in the CloudFront viewer-request function (`generateRedirectFnCode` in `isomer-next-infra/src/publishing/common.ts`): when the last 5 characters of the request URI contain a `.`, the function treats it as a file path and resolves the object **as-is** (no `/index.html` appended).

As a result, redirects whose source looks like a file (e.g. `some/page.html`) were written to the wrong S3 key (`some/page.html/index.html`), so CloudFront — which fetches `some/page.html` — would not find the redirect object.

## Solution

Mirror the CloudFront function's `slice(-5).includes(".")` check in the upload script. If the source's last 5 characters contain a `.`, upload the object directly at that key; otherwise keep appending `/index.html` as before.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- Redirect sources that resemble file paths (a `.` within the last 5 characters, e.g. `.html`, `.pdf`) are now uploaded to the exact S3 key CloudFront resolves, so those redirects resolve correctly instead of 404-ing. Directory-style sources are unaffected.

## Tests

**Manual Verification Steps**:

- [ ] In Studio, open one of the sites and create a redirect whose source is a file-like path (i.e. has a `.` within the last 5 characters, e.g. `docs/report.pdf`), pointing to a valid destination.
- [ ] Let the site's build run to completion.
- [ ] Visit the file-like source URL on the published site and confirm it redirects to the configured destination (this previously did not work).
- [ ] Create a redirect with a directory-style source (e.g. `old-page`), let the build run, and confirm it still redirects correctly (no regression).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates redirect uploads so file-like sources are stored at the same S3 key CloudFront requests. The main changes are:

- File-like redirect sources now upload directly to `latest/{source}`.
- Directory-style redirect sources continue to upload to `latest/{source}/index.html`.
- The upload script now mirrors the CloudFront `slice(-5).includes(".")` path check.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge after normal human review for the high-risk `tooling/**` path.

The change is narrow and matches the documented CloudFront key-resolution rule. Existing directory-style redirect behavior is preserved. No correctness or security issues were identified.

No files require special attention beyond normal review of `tooling/build/scripts/publishing/uploadRedirects.ts`.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The upload command completed with exit status 0 and reported two redirects were handled, confirming both target files were uploaded.
- The destinations were confirmed as s3://stub-bucket/stub-site/123/latest/docs/report.pdf for docs/report.pdf and s3://stub-bucket/stub-site/123/latest/old-page/index.html for old-page.
- Artifacts were collected to support verification, including a textual manifest, a JSON manifest, and three log artifacts with review URLs.

<a href="https://app.greptile.com/trex/runs/14211570/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publishing/uploadRedirects.ts | Updates redirect upload key selection to match CloudFront file-path handling while preserving directory-style `/index.html` uploads. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant RedirectJSON as Redirects JSON
participant UploadScript as uploadRedirects.ts
participant S3 as S3 redirect objects
participant CloudFront as CloudFront viewer request

RedirectJSON->>UploadScript: source, destination
UploadScript->>UploadScript: normalize source
alt last 5 chars contain "."
    UploadScript->>S3: "upload latest/{source}"
    CloudFront->>S3: "fetch latest/{uri}"
else directory-style source
    UploadScript->>S3: "upload latest/{source}/index.html"
    CloudFront->>S3: "fetch latest/{uri}/index.html"
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant RedirectJSON as Redirects JSON
participant UploadScript as uploadRedirects.ts
participant S3 as S3 redirect objects
participant CloudFront as CloudFront viewer request

RedirectJSON->>UploadScript: source, destination
UploadScript->>UploadScript: normalize source
alt last 5 chars contain "."
    UploadScript->>S3: "upload latest/{source}"
    CloudFront->>S3: "fetch latest/{uri}"
else directory-style source
    UploadScript->>S3: "upload latest/{source}/index.html"
    CloudFront->>S3: "fetch latest/{uri}/index.html"
end
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: upload file-like redirect sources ..."](https://github.com/opengovsg/isomer/commit/a7b11b304cf8a30333932c15356fdacd192d7417) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43761550)</sub>

<!-- /greptile_comment -->