### PR TITLE
fix: await transaction execution in publish functions

### DIFF
--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1291,7 +1291,7 @@ export const publishResource = async (
         }),
     )
 
-  return db.transaction().execute(async (tx) => {
+  await db.transaction().execute(async (tx) => {
     await logPublishEvent(tx, {
       siteId: resource.siteId,
       by: byUser,
@@ -1299,9 +1299,9 @@ export const publishResource = async (
       eventType: AuditLogEvent.Publish,
       metadata: resource,
     })
-
-    await publishSite(logger, { siteId: resource.siteId })
   })
+
+  await publishSite(logger, { siteId: resource.siteId })
 }
 
 export const publishSiteConfig = async (
@@ -1324,7 +1324,7 @@ export const publishSiteConfig = async (
         }),
     )
 
-  return db.transaction().execute(async (tx) => {
+  await db.transaction().execute(async (tx) => {
     await logPublishEvent(tx, {
       siteId: site.id,
       by: byUser,
@@ -1332,9 +1332,9 @@ export const publishSiteConfig = async (
       eventType: AuditLogEvent.Publish,
       metadata: { site, ...rest },
     })
-
-    await publishSite(logger, { siteId: site.id })
   })
+
+  await publishSite(logger, { siteId: site.id })
 }
 
 export const getBatchAncestryWithSelfQuery = async ({

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -590,7 +590,7 @@ export const siteRouter = router({
           roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
         })
 
-        await db.transaction().execute(async (tx) => {
+        const { newSite, newNavbar, newFooter } = await db.transaction().execute(async (tx) => {
           const user = await tx
             .selectFrom("User")
             .where("id", "=", ctx.user.id)
@@ -724,13 +724,14 @@ export const siteRouter = router({
             delta: { before: oldFooter, after: newFooter },
             by: user,
           })
-
-          await publishSiteConfig(
-            ctx.user.id,
-            { site: newSite, navbar: newNavbar, footer: newFooter },
-            ctx.logger,
-          )
+          return { newSite, newNavbar, newFooter }
         })
+
+        await publishSiteConfig(
+          ctx.user.id,
+          { site: newSite, navbar: newNavbar, footer: newFooter },
+          ctx.logger,
+        )
       },
     ),
   create: protectedProcedure

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -763,7 +763,7 @@ export const siteRouter = router({
             }),
         )
 
-      return db.transaction().execute(async (tx) => {
+      await db.transaction().execute(async (tx) => {
         await logPublishEvent(tx, {
           by: byUser,
           eventType: AuditLogEvent.Publish,
@@ -771,7 +771,8 @@ export const siteRouter = router({
           metadata: {},
           siteId,
         })
-        await publishSite(ctx.logger, { siteId: siteId })
       })
+
+      await publishSite(ctx.logger, { siteId: siteId })
     }),
 })


### PR DESCRIPTION
This PR ensures that the transaction is awaited in the publish functions to ensure
that the transaction is committed before proceeding.


##### Notes
[Disclaimer: text generated by `nemotron-3-super-120b-a12b`. Reproduced as-is as part of investigation into free agentic coding tools and LLM providers]
[This work has been done by `nemotron-3-super-120b-a12b` on [OB-1](https://github.com/Overbrilliant/ob-1), with a lot of manual intervention by @LoneRifle]
Closes #1958

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates publish flows so database transactions finish before publishing starts. The main changes are:

- Await audit-log transactions before calling `publishSite`.
- Move the admin site-config publish call outside the config update transaction.
- Return updated site, navbar, and footer records from the transaction before publishing.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk for the touched publish paths.

The changes are narrowly scoped to transaction sequencing and do not add new schema, authorization, or input-handling behavior.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the isomer-studio Vitest suite with SKIP\_ENV\_VALIDATION=true and a 300-second timeout; the run exited with code 0 and reported 1 test file and 2 tests passed.
- Validated the test path ordering across the tested scenarios, showing user-loaded -\> tx-begin -\> logPublishEvent -\> logPublishEvent-complete -\> tx-callback-complete -\> tx-commit-complete -\> publishSite, proving publishSite happens after the awaited transaction completes.
- Captured artifacts from the test run to support reviewer inspection, including two log files and two TypeScript source artifacts.
- Cataloged the uploaded artifacts with clear titles and descriptions to facilitate quick review of the test run outputs.

<a href="https://app.greptile.com/trex/runs/14238121/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/resource/resource.service.ts | Moves resource and site-config publish side effects to run after the helper's audit-log transaction has completed. |
| apps/studio/src/server/modules/site/site.router.ts | Returns updated site config records from the admin config transaction before invoking the publish helper, and awaits the standalone publish audit transaction before starting CodeBuild. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller as tRPC publish/update caller
participant DB as Kysely transaction
participant Audit as Audit log
participant Publish as publishSiteConfig/publishResource
participant CodeBuild as CodeBuild publish

Caller->>DB: execute site/resource mutation or publish audit transaction
DB->>Audit: write audit event(s)
DB-->>Caller: commit and return updated records
Caller->>Publish: await publish helper after commit
Publish->>CodeBuild: publishSite starts/records build when needed
CodeBuild-->>Caller: publish completes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller as tRPC publish/update caller
participant DB as Kysely transaction
participant Audit as Audit log
participant Publish as publishSiteConfig/publishResource
participant CodeBuild as CodeBuild publish

Caller->>DB: execute site/resource mutation or publish audit transaction
DB->>Audit: write audit event(s)
DB-->>Caller: commit and return updated records
Caller->>Publish: await publish helper after commit
Publish->>CodeBuild: publishSite starts/records build when needed
CodeBuild-->>Caller: publish completes
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(site/router): run \`publishSiteConfig..."](https://github.com/opengovsg/isomer/commit/6a6edcf554afa09a43756b2ec9bb5683e352aea3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43765739)</sub>

<!-- /greptile_comment -->