### PR TITLE
fix: use transformedContent for table of contents in Database layout

### DIFF
--- a/packages/components/src/templates/next/layouts/Database/Database.tsx
+++ b/packages/components/src/templates/next/layouts/Database/Database.tsx
@@ -33,7 +33,7 @@ export const DatabaseLayout = ({
   )
   // auto-inject ids for heading level 2 blocks if does not exist
   const transformedContent = getTransformedPageContent(content)
-  const tableOfContents = getTableOfContents(site, content)
+  const tableOfContents = getTableOfContents(site, transformedContent)
 
   return (
     <Skeleton site={site} page={page} layout={layout}>


### PR DESCRIPTION
## Problem

Closes ISOM-2312

The `Database` page layout's table of contents was generated from the raw, untransformed page `content`, while the rendered page body used `transformedContent` (the output of `getTransformedPageContent`, which auto-injects anchor IDs for level-2 headings that don't already have one).

This mismatch meant that for any level-2 heading without an explicitly set `id`, the table of contents would link to `#undefined` (or a stale/incorrect anchor) instead of the ID actually rendered on the heading element, breaking that "jump to section" link.

## Solution

`getTableOfContents` is now called with `transformedContent` instead of `content`, so the anchor IDs it reads off headings and complex blocks (`infocards`, `infocols`, `infopic`, `keystatistics`) are the same auto-generated/preserved IDs that end up in the rendered DOM — matching the pattern already used in the `Content` and `IndexPage` layouts.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Fixed the `Database` layout's table of contents linking to broken/incorrect anchors for level-2 headings and complex blocks (infocards, infocols, infopic, keystatistics) that rely on auto-generated IDs.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] In Studio, create or open a `Database` layout page with body content containing at least two level-2 headings, and ensure at least one of those headings does not have a manually-set anchor ID
- [ ] Publish/preview the page and confirm the table of contents appears with an entry for each level-2 heading
- [ ] Click each table of contents entry and confirm the page scrolls to the correct corresponding heading (not to the top of the page or nowhere)
- [ ] Inspect the DOM to confirm each clicked heading's `id` attribute matches the `href` of the table of contents link that pointed to it

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes table-of-contents anchors in the Database layout. The main changes are:

- Uses `transformedContent` when generating Database page table-of-contents entries.
- Aligns Database layout behavior with the Content and IndexPage layouts.
- Keeps rendered heading and complex-block IDs in sync with the generated anchor links.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is a small template fix that reuses existing transformed content and matches parallel layouts.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Playwright run reported 2 table-of-contents links and exited with code 0.
- The DOM evidence confirms each TOC link targets an H2 with the same id and the expected heading text.
- Scroll evidence shows the first TOC click moved the scroll position from 0 to 873 and changed the hash to #section1, then the second click moved from 873 to 1869 with the long hash.
- The final poster view was captured after TOC interactions, illustrating the end-state of the Database Toc 02 UI.

<a href="https://app.greptile.com/trex/runs/14217989/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/layouts/Database/Database.tsx | Updates the Database layout to derive table-of-contents anchors from the same transformed content used for rendering; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Change database layout to use transforme..."](https://github.com/opengovsg/isomer/commit/e4a8efb08b4bdbe5d64092c59b1aca8eac3d2967) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43774325)</sub>

<!-- /greptile_comment -->