### PR TITLE
fix: use published version when deriving subcategory in push document job

### DIFF
--- a/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
+++ b/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
@@ -108,8 +108,10 @@ const seedDocumentReadyForIngestion = async ({
     .where("id", "=", String(indexBlob.id))
     .execute()
 
-  // A published Version for the IndexPage.
-  await db
+  // A published Version for the IndexPage. Publishing sets
+  // publishedVersionId on the Resource (see version.service.ts), and the
+  // handler resolves the index page blob through it.
+  const indexVersion = await db
     .insertInto("Version")
     .values({
       versionNum: 1,
@@ -117,6 +119,12 @@ const seedDocumentReadyForIngestion = async ({
       blobId: indexBlob.id,
       publishedBy,
     })
+    .returning("id")
+    .executeTakeFirstOrThrow()
+  await db
+    .updateTable("Resource")
+    .set({ publishedVersionId: indexVersion.id })
+    .where("id", "=", indexPage.id)
     .execute()
 
   // Child page that points at the PDF asset.

--- a/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
+++ b/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
@@ -93,7 +93,7 @@ const extractResourceData = async ({
   // as we need to derive the subcategory
   const { content: indexPageContent } = await db
     .selectFrom("Resource")
-    .innerJoin("Version", "Version.resourceId", "Resource.id")
+    .innerJoin("Version", "Version.id", "Resource.publishedVersionId")
     .innerJoin("Blob", "Blob.id", "Version.blobId")
     .where("type", "=", "IndexPage")
     .where("parentId", "=", parentId)


### PR DESCRIPTION
## Problem

In the scheduled push-document cron job, the query that fetches the collection index page's content joined `Version` on `Version.resourceId = Resource.id`. Since a resource accumulates one `Version` row per publish, this join matches **every** version of the index page, and `executeTakeFirstOrThrow` returns an arbitrary one — not necessarily the currently published version.

This means the subcategory for a pushed document could be derived from a stale index page blob. If a tag category or option was added or renamed in a newer publish, the job would either resolve the wrong subcategory or fail to find one, since the document's tag ID would not exist in the outdated `tagCategories` mapping.

## Solution

Join `Version` on `Resource.publishedVersionId = Version.id` instead, so the query always resolves to exactly one row: the blob of the index page's currently published version.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- `schedulePushDocumentJob`: the collection index page content used to derive a pushed document's subcategory is now always taken from the published version, instead of an arbitrary version of the resource

## Before & After Screenshots

**BEFORE**:

N/A — backend cron job change, no UI impact

**AFTER**:

N/A

## Tests

- Run the push document job against a collection whose index page has been published more than once (so multiple `Version` rows exist), and verify the derived subcategory matches the tag options in the **latest published** index page content

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes how the push-document cron job derives document subcategories. The main changes are:

- Reads the collection index page through `Resource.publishedVersionId`.
- Uses the published index page blob instead of an arbitrary historical `Version` row.
- Updates the test fixture to set `publishedVersionId` for seeded index pages.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to one database join in the push-document cron path and matches existing publish semantics. No runtime, data integrity, or security issues were identified in the changed files.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Vitest attempt for push\_document\_subcategory ran but hit a blocker indicating no working container runtime strategy.
- A fallback runtime path was exercised, and it completed with exit code 0, reporting historical join candidates \[null, "Latest Published Label"\] and a publishedVersionId-derived label.
- A fallback harness file push\_document\_subcategory\_fallback.mjs was generated and used to validate the runtime proof.

<a href="https://app.greptile.com/trex/runs/14232604/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts | Updates subcategory derivation to join the collection index page through `Resource.publishedVersionId`, ensuring the cron reads the currently published index blob. |
| apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts | Updates the push-document test fixture so seeded index pages mirror publish behavior by setting `Resource.publishedVersionId`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Cron as schedulePushDocumentJobHandler
participant DB as Database
participant S3 as Gazette S3
participant Index as Search Index

Cron->>DB: Fetch due PushDocumentJob resources
Cron->>DB: Load resource content from published version or draft fallback
Cron->>DB: "Load collection IndexPage via Resource.publishedVersionId -> Version.blobId"
Cron->>S3: Fetch PDF and clear scheduled tag
Cron->>Cron: Derive subcategory from published index page tagCategories
Cron->>Index: Push SearchSG or Algolia records
Cron->>DB: Delete processed PushDocumentJob rows
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Cron as schedulePushDocumentJobHandler
participant DB as Database
participant S3 as Gazette S3
participant Index as Search Index

Cron->>DB: Fetch due PushDocumentJob resources
Cron->>DB: Load resource content from published version or draft fallback
Cron->>DB: "Load collection IndexPage via Resource.publishedVersionId -> Version.blobId"
Cron->>S3: Fetch PDF and clear scheduled tag
Cron->>Cron: Derive subcategory from published index page tagCategories
Cron->>Index: Push SearchSG or Algolia records
Cron->>DB: Delete processed PushDocumentJob rows
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["test: set publishedVersionId on index pa..."](https://github.com/opengovsg/isomer/commit/4dd73ba53c195147b373f56eb4f54d3dd9c2550a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43784682)</sub>

<!-- /greptile_comment -->