### PR TITLE
fix(site): remove redundant outer transaction in setNotification

### DIFF
--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -565,12 +565,10 @@ export const siteRouter = router({
         action: "update",
       })
 
-      const site = await db.transaction().execute(async () => {
-        return await setSiteNotification({
-          siteId,
-          userId: ctx.user.id,
-          notification,
-        })
+      const site = await setSiteNotification({
+        siteId,
+        userId: ctx.user.id,
+        notification,
       })
 
       await publishSiteConfig(ctx.user.id, { site }, ctx.logger)


### PR DESCRIPTION
## Problem

Closes ISOM-2316

The `setNotification` tRPC mutation wrapped its call to `setSiteNotification(...)` in an outer `db.transaction().execute(...)`, even though `setSiteNotification` already opens and manages its own transaction internally.

Because the outer call used the module-level `db` (not the `tx` handle passed into the callback), it did not nest as a savepoint on the same connection — it opened a second, entirely independent top-level transaction on a second connection checked out from the pool. The two transactions had no atomicity relationship with each other, and the outer transaction always committed before `publishSiteConfig` ran, so it provided no rollback protection for that side effect either. The net effect was two pooled connections held per `setNotification` call instead of one, with no functional benefit.

## Solution

Remove the redundant outer `db.transaction()` wrapper in `site.router.ts` and call `setSiteNotification(...)` directly, since it already owns its own transaction boundary end-to-end.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- `setNotification` now checks out one DB connection per call instead of two, reducing pressure on the connection pool (default max of 10) under concurrent load.

**Bug Fixes**:

- Removed a no-op outer transaction in `setNotification` that provided no atomicity or rollback guarantees.

## Tests

Existing tests in `apps/studio/src/server/modules/site/__tests__/site.router.test.ts` (`describe("setNotification")`) cover auth, permissions, add/update/remove notification behavior, and audit log side effects. These assert only on final DB/audit-log state via the tRPC caller, so they are unaffected by this change and should continue to pass unmodified.

**Manual Verification Steps**:

- [ ] As a site admin, open a site's notification banner settings and add a new notification; confirm it saves and appears on the published site.
- [ ] Edit an existing notification's content and save; confirm the update persists and the site republishes.
- [ ] Disable/remove an existing notification; confirm it is removed from the site config and no longer shown on the published site.
- [ ] Confirm a non-admin/editor-only user still receives a 403 when attempting to call `setNotification`.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes an extra transaction wrapper from the notification update path. The main changes are:

- `setNotification` now calls `setSiteNotification` directly.
- The service-owned transaction remains responsible for the site update and audit log.
- Permission validation, publishing, and the returned notification value stay unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is a small transaction-boundary simplification. `setSiteNotification` still owns the database transaction for the update and audit log, while the router keeps the same permission check, publish step, and response shape.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex validated the pre-change state by restoring the router file from HEAD^ and attempting the requested wrapper command, which encountered the container runtime environment blocker and exited with code 1.
- T-Rex re-ran the wrapper command against the changed code to produce the after-state result, which again hit the same environment blocker and exited with code 1.
- T-Rex examined the fallback path using the apps/studio fallback command, which also failed due to the same environment blocker and exit code 1.
- T-Rex compiled and linked the three key artifacts (before, after, and fallback logs) to enable reviewers to inspect the environment blocker and exit statuses.

<a href="https://app.greptile.com/trex/runs/14222651/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/site/site.router.ts | Removes a redundant outer transaction around `setSiteNotification`, leaving permission validation, the service-owned transaction, publishing, and return behavior unchanged. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Client
participant Router as siteRouter.setNotification
participant Permissions as validateUserPermissionsForSite
participant Service as setSiteNotification
participant DB as Database transaction
participant Publisher as publishSiteConfig

Client->>Router: setNotification(siteId, notification)
Router->>Permissions: validate update permission
Permissions-->>Router: authorized
Router->>Service: setSiteNotification(siteId, userId, notification)
Service->>DB: begin service-owned transaction
DB-->>Service: update Site + write audit log
Service-->>Router: updated site
Router->>Publisher: "publishSiteConfig(userId, { site })"
Publisher-->>Router: published
Router-->>Client: site.config.notification
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Client
participant Router as siteRouter.setNotification
participant Permissions as validateUserPermissionsForSite
participant Service as setSiteNotification
participant DB as Database transaction
participant Publisher as publishSiteConfig

Client->>Router: setNotification(siteId, notification)
Router->>Permissions: validate update permission
Permissions-->>Router: authorized
Router->>Service: setSiteNotification(siteId, userId, notification)
Service->>DB: begin service-owned transaction
DB-->>Service: update Site + write audit log
Service-->>Router: updated site
Router->>Publisher: "publishSiteConfig(userId, { site })"
Publisher-->>Router: published
Router-->>Client: site.config.notification
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Remove extra transaction in setNotificat..."](https://github.com/opengovsg/isomer/commit/bdf5f01afafb1a7d9c8fdbb7c0315313f2202091) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43785438)</sub>

<!-- /greptile_comment -->