### PR TITLE
feat(redirect): bulk-upload redirects modal and feature flag

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -49,3 +49,23 @@ _Avoid_: survey cooldown, quarter (the period is configurable, not fixed)
 
 **Isomer Admin**: A user with the Core or Migrator role. The only role that can manage taxonomy (create, edit, delete Tag Categories, Tag Options, and Category Options) via the Manage Filters panel.
 _Avoid_: admin, site admin (different concept — refers to site-level admin permissions)
+
+### Redirects
+
+**Redirect**: A rule that sends a visitor from an old path on this site to another location. Created and published by a site admin; publishing rebuilds the site so the rule goes live.
+_Avoid_: forward, rewrite, alias
+
+**Source**: The old on-site path a Redirect matches — what comes *behind* the domain (e.g. `/contact-us`). Always a path, never a full URL. Shown to editors as **"When someone visits"**.
+_Avoid_: from, origin, old URL (it is a path, not a URL)
+
+**Destination**: Where a Redirect sends the visitor — an on-site path, an external `https://` URL, or a Page reference. Shown to editors as **"Redirect them to"**.
+_Avoid_: to, target, new URL
+
+**Page reference**: A Destination that points at a specific page rather than a fixed path, so the Redirect keeps working when that page is moved or renamed. Used when the destination path matches a live published page.
+_Avoid_: internal link, resource link
+
+**Redirects template**: The downloadable `.csv` skeleton (header row: "When someone visits", "Redirect them to") an editor fills in for a Bulk upload. The errors file returned after validation is this same shape plus an explanation column, so it can be corrected and re-uploaded directly.
+_Avoid_: sample file, example CSV
+
+**Bulk upload**: Creating many Redirects at once by uploading a filled-in Redirects template — every row is validated, and the whole batch publishes in one step.
+_Avoid_: import, mass create, batch add

--- a/apps/studio/src/features/settings/Redirects/api.ts
+++ b/apps/studio/src/features/settings/Redirects/api.ts
@@ -62,3 +62,26 @@ export function useDeleteRedirect() {
   })
   return { mutate, isPending }
 }
+
+// Validates an uploaded CSV without writing. Uses the mutation (not a query) so
+// the large CSV travels in the POST body — a query serialises its input into the
+// request URL, which the server rejects near the size cap (connection reset).
+// Read-only server-side; mutateAsync just gives us a one-shot call returning the
+// verdicts.
+export function useBulkValidateRedirects(siteId: number) {
+  const { mutateAsync } = trpc.redirect.bulkValidate.useMutation()
+  return (csv: string) => mutateAsync({ siteId, csv })
+}
+
+// Publishes a validated batch. Invalidates the router only when a publish
+// actually happened (ok === true); a re-validation failure returns ok: false
+// with fresh row verdicts and writes nothing.
+export function useBulkCreateRedirects() {
+  const utils = trpc.useUtils()
+  const { mutateAsync, isPending } = trpc.redirect.bulkCreate.useMutation({
+    onSuccess: (result) => {
+      if (result.ok) void utils.redirect.invalidate()
+    },
+  })
+  return { mutateAsync, isPending }
+}

--- a/apps/studio/src/features/settings/Redirects/api.ts
+++ b/apps/studio/src/features/settings/Redirects/api.ts
@@ -66,11 +66,15 @@ export function useDeleteRedirect() {
 // Validates an uploaded CSV without writing. Uses the mutation (not a query) so
 // the large CSV travels in the POST body — a query serialises its input into the
 // request URL, which the server rejects near the size cap (connection reset).
-// Read-only server-side; mutateAsync just gives us a one-shot call returning the
-// verdicts.
+// Read-only server-side; `validate` is a one-shot call returning the verdicts,
+// and `isPending` drives the Process button's inline spinner (validation is
+// quick, so it does not warrant a full-screen loading state).
 export function useBulkValidateRedirects(siteId: number) {
-  const { mutateAsync } = trpc.redirect.bulkValidate.useMutation()
-  return (csv: string) => mutateAsync({ siteId, csv })
+  const { mutateAsync, isPending } = trpc.redirect.bulkValidate.useMutation()
+  return {
+    validate: (csv: string) => mutateAsync({ siteId, csv }),
+    isPending,
+  }
 }
 
 // Publishes a validated batch. Invalidates the router only when a publish

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Center,
+  Flex,
   FormControl,
   HStack,
   Icon,
@@ -14,19 +15,22 @@ import {
   Button,
   FormErrorMessage,
   FormLabel,
+  Link,
   useToast,
 } from "@opengovsg/design-system-react"
 import { useState } from "react"
-import { BiPlus, BiRightArrowAlt, BiSearch } from "react-icons/bi"
+import { BiBulb, BiPlus, BiRightArrowAlt, BiSearch } from "react-icons/bi"
 import { REDIRECT_MESSAGES } from "~/constants/redirect"
 import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
 } from "~/constants/toast"
+import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useZodForm } from "~/lib/form"
 
 import { useCreateRedirect } from "../api"
 import { addRedirectSchema, type AddRedirectInput } from "../types"
+import { BulkUploadRedirectsModal } from "./BulkUploadRedirectsModal"
 import { SelectDestinationPageModal } from "./SelectDestinationPageModal"
 
 interface AddRedirectCardProps {
@@ -51,10 +55,16 @@ export const AddRedirectCard = ({
   })
   const toast = useToast(BRIEF_TOAST_SETTINGS)
   const { mutate: createRedirect, isPending } = useCreateRedirect()
+  const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
   const {
     isOpen: isPageModalOpen,
     onOpen: onPageModalOpen,
     onClose: onPageModalClose,
+  } = useDisclosure()
+  const {
+    isOpen: isBulkUploadOpen,
+    onOpen: onBulkUploadOpen,
+    onClose: onBulkUploadClose,
   } = useDisclosure()
 
   const [source, destination] = watch(["source", "destination"])
@@ -131,6 +141,39 @@ export const AddRedirectCard = ({
         New redirects publish right away, but can take a few minutes to take
         effect on your live site.
       </Text>
+
+      {isAdvancedRedirectsEnabled && (
+        <Flex
+          align="center"
+          gap="0.5rem"
+          bg="utility.feedback.info-subtle"
+          borderRadius="4px"
+          p="0.75rem"
+          mb="1.25rem"
+        >
+          <Icon
+            as={BiBulb}
+            boxSize="1.25rem"
+            color="base.content.default"
+            flexShrink={0}
+          />
+          <Flex wrap="wrap" columnGap="0.25rem" rowGap="0.25rem">
+            <Text textStyle="subhead-2" color="base.content.default">
+              Have more than 10 redirects to add? You can
+            </Text>
+            <Link
+              as="button"
+              type="button"
+              variant="inline"
+              textStyle="subhead-2"
+              color="interaction.links.default"
+              onClick={onBulkUploadOpen}
+            >
+              bulk upload with a .csv instead.
+            </Link>
+          </Flex>
+        </Flex>
+      )}
 
       <HStack as="form" align="flex-start" onSubmit={handleSubmit(onSubmit)}>
         <FormControl
@@ -258,6 +301,12 @@ export const AddRedirectCard = ({
             shouldDirty: true,
           })
         }
+      />
+
+      <BulkUploadRedirectsModal
+        siteId={siteId}
+        isOpen={isBulkUploadOpen}
+        onClose={onBulkUploadClose}
       />
     </Box>
   )

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -303,11 +303,13 @@ export const AddRedirectCard = ({
         }
       />
 
-      <BulkUploadRedirectsModal
-        siteId={siteId}
-        isOpen={isBulkUploadOpen}
-        onClose={onBulkUploadClose}
-      />
+      {isAdvancedRedirectsEnabled && (
+        <BulkUploadRedirectsModal
+          siteId={siteId}
+          isOpen={isBulkUploadOpen}
+          onClose={onBulkUploadClose}
+        />
+      )}
     </Box>
   )
 }

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -324,7 +324,7 @@ const BulkUploadModalBody = ({
       )
     case "success":
       return (
-        <Stack spacing="1rem">
+        <Stack spacing="1.5rem">
           <Flex gap="0.5rem">
             <Icon
               as={BiSolidCheckCircle}
@@ -333,11 +333,11 @@ const BulkUploadModalBody = ({
               mt="0.125rem"
             />
             <Stack spacing="0.25rem">
-              <Text textStyle="subhead-2">
+              <Text textStyle="subhead-2" color="utility.feedback.success">
                 All {validRows.length} redirect
                 {validRows.length === 1 ? " is" : "s are"} good to go.
               </Text>
-              <Text textStyle="body-2" color="base.content.medium">
+              <Text textStyle="body-2" color="base.content.default">
                 Clicking &lsquo;Publish {validRows.length} redirect
                 {validRows.length === 1 ? "" : "s"}&rsquo; will publish them
                 immediately.
@@ -349,9 +349,15 @@ const BulkUploadModalBody = ({
               border="1px solid"
               borderColor="base.divider.medium"
               borderRadius="0.25rem"
+              background="base.canvas.alt"
             >
               <AccordionButton>
-                <Text flex="1" textAlign="left" textStyle="subhead-2">
+                <Text
+                  flex="1"
+                  textAlign="left"
+                  paddingY="1"
+                  textStyle="subhead-2"
+                >
                   Redirects to be added
                 </Text>
                 <AccordionIcon />
@@ -362,7 +368,7 @@ const BulkUploadModalBody = ({
                     <Flex
                       key={row.rowNumber}
                       align="center"
-                      gap="0.5rem"
+                      gap="1rem"
                       textStyle="body-2"
                     >
                       <Text flex="1" noOfLines={1} title={row.source}>
@@ -385,17 +391,16 @@ const BulkUploadModalBody = ({
       // "upload" and "errors" share the same picker; the error banner and
       // template-vs-errors-file download are the only differences.
       return (
-        <Stack spacing="1rem">
+        <Stack spacing="2rem">
           {stage === "errors" && validation ? (
             <Flex gap="0.5rem">
               <Icon
                 as={BiSolidError}
                 color="utility.feedback.critical"
                 boxSize="1.25rem"
-                mt="0.125rem"
               />
-              <Stack spacing="0.5rem" align="flex-start">
-                <Text textStyle="body-2" color="utility.feedback.critical">
+              <Stack spacing="1rem" align="flex-start">
+                <Text textStyle="subhead-2" color="utility.feedback.critical">
                   {errorBannerText(validation)}
                 </Text>
                 {validation.fileError === null && (
@@ -413,14 +418,15 @@ const BulkUploadModalBody = ({
           ) : (
             <Stack spacing="0.75rem" align="flex-start">
               <Text textStyle="body-2">
-                To make sure your redirects are formatted properly, list your
-                redirects on the redirects template:
+                To make sure your redirects are formatted properly, download and
+                use the template:
               </Text>
               <Button
                 as="a"
                 href={TEMPLATE_HREF}
                 download
                 variant="outline"
+                size="xs"
                 leftIcon={<BiDownload fontSize="1.25rem" />}
               >
                 Download redirects template (.csv)
@@ -428,11 +434,12 @@ const BulkUploadModalBody = ({
             </Stack>
           )}
 
-          {stage === "errors" && (
-            <Text textStyle="subhead-2">Re-upload the file with fixes</Text>
-          )}
-
           <Stack spacing="0.5rem">
+            {stage === "errors" && (
+              <Text textStyle="subhead-2" textColor="base.content.strong">
+                Re-upload the file with fixes
+              </Text>
+            )}
             <Attachment
               name="redirects-csv"
               multiple={false}
@@ -448,12 +455,12 @@ const BulkUploadModalBody = ({
               <br />
               Accepted file type: .csv
             </Text>
+            {fileError && (
+              <Text textStyle="body-2" color="utility.feedback.critical">
+                {fileError}
+              </Text>
+            )}
           </Stack>
-          {fileError && (
-            <Text textStyle="body-2" color="utility.feedback.critical">
-              {fileError}
-            </Text>
-          )}
         </Stack>
       )
   }

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -32,7 +32,6 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { buildRedirectErrorsCsv, parseRedirectCsv } from "~/lib/redirectCsv"
 import { MAX_BULK_REDIRECT_CSV_BYTES } from "~/schemas/redirect"
 import { formatFileSizeLimit } from "~/utils/formatFileSizeLimit"
-import { trpc } from "~/utils/trpc"
 
 import { useBulkCreateRedirects, useBulkValidateRedirects } from "../api"
 
@@ -66,18 +65,6 @@ const triggerCsvDownload = (filename: string, contents: string) => {
   setTimeout(() => URL.revokeObjectURL(url), 0)
 }
 
-// A site name can contain characters that are invalid or surprising in a
-// download filename (slashes, colons, newlines), so reduce it to a safe slug.
-const toFilenameSlug = (value: string) =>
-  value
-    // Collapse every run of characters outside [A-Za-z0-9._-] into a single "-",
-    // so only filename-safe characters remain.
-    .replace(/[^a-zA-Z0-9._-]+/g, "-")
-    // Trim leading/trailing "-" left by that collapse (e.g. from a leading slash).
-    .replace(/^-+|-+$/g, "")
-    // Cap the length, and fall back to "site" if nothing usable is left.
-    .slice(0, 64) || "site"
-
 export const BulkUploadRedirectsModal = ({
   siteId,
   isOpen,
@@ -86,13 +73,6 @@ export const BulkUploadRedirectsModal = ({
   const toast = useToast(BRIEF_TOAST_SETTINGS)
   const { validate, isPending: isValidating } = useBulkValidateRedirects(siteId)
   const { mutateAsync: publish } = useBulkCreateRedirects()
-  // Site display name (Site config `siteName`), used to name the errors file.
-  // Only needed once the modal is open, so don't fetch it on the settings page
-  // behind a closed modal.
-  const { data: site } = trpc.site.getSiteName.useQuery(
-    { siteId },
-    { enabled: isOpen },
-  )
 
   const [stage, setStage] = useState<Stage>("upload")
   const [file, setFile] = useState<File | null>(null)
@@ -240,7 +220,7 @@ export const BulkUploadRedirectsModal = ({
   const handleDownloadErrors = () => {
     if (!validation) return
     triggerCsvDownload(
-      `redirects_errors_${toFilenameSlug(site?.name ?? "site")}.csv`,
+      `redirects_errors_${siteId}.csv`,
       buildRedirectErrorsCsv(validation.rows),
     )
   }
@@ -355,8 +335,8 @@ const BulkUploadModalBody = ({
                 {validRows.length === 1 ? " is" : "s are"} good to go.
               </Text>
               <Text textStyle="body-2" color="base.content.default">
-                Clicking &lsquo;Publish {validRows.length} redirect
-                {validRows.length === 1 ? "" : "s"}&rsquo; will publish them
+                Clicking ‘Publish {validRows.length} redirect
+                {validRows.length === 1 ? "" : "s"}’ will publish them
                 immediately.
               </Text>
             </Stack>

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -1,0 +1,466 @@
+import type { AttachmentProps } from "@opengovsg/design-system-react"
+import type { RouterOutput } from "~/utils/trpc"
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Center,
+  Flex,
+  Icon,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spinner,
+  Stack,
+  Text,
+} from "@chakra-ui/react"
+import { Attachment, Button, useToast } from "@opengovsg/design-system-react"
+import { useEffect, useState } from "react"
+import {
+  BiDownload,
+  BiRightArrowAlt,
+  BiSolidCheckCircle,
+  BiSolidError,
+} from "react-icons/bi"
+import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
+import { buildRedirectErrorsCsv, parseRedirectCsv } from "~/lib/redirectCsv"
+import { MAX_BULK_REDIRECT_CSV_BYTES } from "~/schemas/redirect"
+import { formatFileSizeLimit } from "~/utils/formatFileSizeLimit"
+import { trpc } from "~/utils/trpc"
+
+import { useBulkCreateRedirects, useBulkValidateRedirects } from "../api"
+
+type BulkValidation = RouterOutput["redirect"]["bulkValidate"]
+
+// Path to the header-only template shipped as a static public asset.
+const TEMPLATE_HREF = "/redirects-template.csv"
+
+interface BulkUploadRedirectsModalProps {
+  siteId: number
+  isOpen: boolean
+  onClose: () => void
+}
+
+// The modal walks through: pick a file → process (validate) → either fix errors
+// and re-upload, or review and publish the whole batch. `stage` tracks which of
+// those the user is on; validation holds the server's per-row verdicts.
+type Stage = "upload" | "processing" | "errors" | "success"
+
+const triggerCsvDownload = (filename: string, contents: string) => {
+  const blob = new Blob([contents], { type: "text/csv;charset=utf-8;" })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement("a")
+  anchor.href = url
+  anchor.download = filename
+  anchor.click()
+  URL.revokeObjectURL(url)
+}
+
+// A site name can contain characters that are invalid or surprising in a
+// download filename (slashes, colons, newlines), so reduce it to a safe slug.
+const toFilenameSlug = (value: string) =>
+  value
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "site"
+
+export const BulkUploadRedirectsModal = ({
+  siteId,
+  isOpen,
+  onClose,
+}: BulkUploadRedirectsModalProps): JSX.Element => {
+  const toast = useToast(BRIEF_TOAST_SETTINGS)
+  const validate = useBulkValidateRedirects(siteId)
+  const { mutateAsync: publish, isPending: isPublishing } =
+    useBulkCreateRedirects()
+  // Site display name (Site config `siteName`), used to name the errors file.
+  const { data: site } = trpc.site.getSiteName.useQuery({ siteId })
+
+  const [stage, setStage] = useState<Stage>("upload")
+  const [file, setFile] = useState<File | null>(null)
+  const [csv, setCsv] = useState<string | null>(null)
+  // A file-level problem caught in the browser (empty / missing column), shown
+  // inline under the chip before the user can process.
+  const [fileError, setFileError] = useState<string | null>(null)
+  const [validation, setValidation] = useState<BulkValidation | null>(null)
+  const [showSlowMessage, setShowSlowMessage] = useState(false)
+  // Oversize / wrong-type files rejected by the dropzone; surfaced by Attachment.
+  const [rejections, setRejections] = useState<
+    AttachmentProps<false>["rejections"]
+  >([])
+
+  const resetState = () => {
+    setStage("upload")
+    setFile(null)
+    setCsv(null)
+    setFileError(null)
+    setValidation(null)
+    setShowSlowMessage(false)
+    setRejections([])
+  }
+
+  // Start fresh every time the modal opens, so a previous run's file or errors
+  // never linger.
+  useEffect(() => {
+    if (isOpen) resetState()
+  }, [isOpen])
+
+  // Only show the "this might take a while" line once processing runs long, per
+  // the design ("if processing time is short, don't show the second message").
+  useEffect(() => {
+    if (stage !== "processing") {
+      setShowSlowMessage(false)
+      return
+    }
+    const timer = setTimeout(() => setShowSlowMessage(true), 3000)
+    return () => clearTimeout(timer)
+  }, [stage])
+
+  const handleClose = () => {
+    resetState()
+    onClose()
+  }
+
+  const handleFileChange = async (selected: File | undefined) => {
+    if (!selected) {
+      setFile(null)
+      setCsv(null)
+      setFileError(null)
+      return
+    }
+    setFile(selected)
+    try {
+      const text = await selected.text()
+      setCsv(text)
+      const parsed = parseRedirectCsv(text)
+      setFileError(parsed.fileError ?? null)
+    } catch {
+      setCsv(null)
+      setFileError("We couldn't read this file. Upload a valid .csv file.")
+    }
+  }
+
+  // Show the errors screen with a fresh, empty re-upload zone (the design's
+  // "re-upload the file with fixes"), so the corrected file can be dropped in.
+  const enterErrorsStage = (result: BulkValidation) => {
+    setValidation(result)
+    setFile(null)
+    setCsv(null)
+    setFileError(null)
+    setRejections([])
+    setStage("errors")
+  }
+
+  const handleProcess = async () => {
+    if (!csv) return
+    setStage("processing")
+    try {
+      const result = await validate(csv)
+      if (result.fileError !== null || result.errorCount > 0) {
+        enterErrorsStage(result)
+        return
+      }
+      setValidation(result)
+      setStage("success")
+    } catch {
+      toast({
+        title: "We couldn't check your redirects",
+        description: "Please try again.",
+        status: "error",
+      })
+      setStage("upload")
+    }
+  }
+
+  const handlePublish = async () => {
+    if (!csv) return
+    try {
+      const result = await publish({ siteId, csv })
+      if (result.ok) {
+        toast({
+          title: `${result.publishedCount} redirect${result.publishedCount === 1 ? "" : "s"} published`,
+          status: "success",
+        })
+        handleClose()
+        return
+      }
+      // A race since the preview made the batch invalid — show the errors screen
+      // with the fresh verdicts.
+      enterErrorsStage(result.validation)
+    } catch {
+      toast({
+        title: "We couldn't publish your redirects",
+        description: "Please try again.",
+        status: "error",
+      })
+    }
+  }
+
+  const handleDownloadErrors = () => {
+    if (!validation) return
+    triggerCsvDownload(
+      `redirects_errors_${toFilenameSlug(site?.name ?? "site")}.csv`,
+      buildRedirectErrorsCsv(validation.rows),
+    )
+  }
+
+  const isProcessDisabled = !file || !!fileError || !csv
+  const validRows = validation?.rows.filter((row) => row.error === null) ?? []
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{modalTitle(stage)}</ModalHeader>
+        <ModalCloseButton />
+
+        <ModalBody>
+          <BulkUploadModalBody
+            stage={stage}
+            showSlowMessage={showSlowMessage}
+            validation={validation}
+            validRows={validRows}
+            file={file}
+            fileError={fileError}
+            rejections={rejections}
+            onFileChange={handleFileChange}
+            onRejection={setRejections}
+            onDownloadErrors={handleDownloadErrors}
+          />
+        </ModalBody>
+
+        {stage !== "processing" && (
+          <ModalFooter>
+            {stage === "success" ? (
+              <Button
+                onClick={() => void handlePublish()}
+                isLoading={isPublishing}
+              >
+                Publish {validRows.length} redirect
+                {validRows.length === 1 ? "" : "s"}
+              </Button>
+            ) : (
+              <Button
+                onClick={() => void handleProcess()}
+                isDisabled={isProcessDisabled}
+              >
+                {isProcessDisabled
+                  ? "Upload file to continue"
+                  : "Process redirects"}
+              </Button>
+            )}
+          </ModalFooter>
+        )}
+      </ModalContent>
+    </Modal>
+  )
+}
+
+interface BulkUploadModalBodyProps {
+  stage: Stage
+  showSlowMessage: boolean
+  validation: BulkValidation | null
+  validRows: BulkValidation["rows"]
+  file: File | null
+  fileError: string | null
+  rejections: AttachmentProps<false>["rejections"]
+  onFileChange: (selected: File | undefined) => void
+  onRejection: (rejections: AttachmentProps<false>["rejections"]) => void
+  onDownloadErrors: () => void
+}
+
+// Renders the body for the modal's current stage. A switch (not a ternary
+// chain) so each stage reads as its own branch and the union stays exhaustive.
+const BulkUploadModalBody = ({
+  stage,
+  showSlowMessage,
+  validation,
+  validRows,
+  file,
+  fileError,
+  rejections,
+  onFileChange,
+  onRejection,
+  onDownloadErrors,
+}: BulkUploadModalBodyProps): JSX.Element => {
+  switch (stage) {
+    case "processing":
+      return (
+        <Center flexDir="column" py="2.5rem" gap="1rem">
+          <Spinner />
+          <Stack spacing="0.25rem" textAlign="center">
+            <Text textStyle="body-2">
+              Checking your redirects for loops, errors, or any missing
+              pieces...
+            </Text>
+            {showSlowMessage && (
+              <Text textStyle="body-2" color="base.content.medium">
+                This might take a while.
+              </Text>
+            )}
+          </Stack>
+        </Center>
+      )
+    case "success":
+      return (
+        <Stack spacing="1rem">
+          <Flex gap="0.5rem">
+            <Icon
+              as={BiSolidCheckCircle}
+              color="utility.feedback.success"
+              boxSize="1.25rem"
+              mt="0.125rem"
+            />
+            <Stack spacing="0.25rem">
+              <Text textStyle="subhead-2">
+                All {validRows.length} redirect
+                {validRows.length === 1 ? " is" : "s are"} good to go.
+              </Text>
+              <Text textStyle="body-2" color="base.content.medium">
+                Clicking &lsquo;Publish {validRows.length} redirect
+                {validRows.length === 1 ? "" : "s"}&rsquo; will publish them
+                immediately.
+              </Text>
+            </Stack>
+          </Flex>
+          <Accordion allowToggle reduceMotion>
+            <AccordionItem
+              border="1px solid"
+              borderColor="base.divider.medium"
+              borderRadius="0.25rem"
+            >
+              <AccordionButton>
+                <Text flex="1" textAlign="left" textStyle="subhead-2">
+                  Redirects to be added
+                </Text>
+                <AccordionIcon />
+              </AccordionButton>
+              <AccordionPanel maxH="12rem" overflowY="auto">
+                <Stack spacing="0.5rem">
+                  {validRows.map((row) => (
+                    <Flex
+                      key={row.rowNumber}
+                      align="center"
+                      gap="0.5rem"
+                      textStyle="body-2"
+                    >
+                      <Text flex="1" noOfLines={1} title={row.source}>
+                        {row.source}
+                      </Text>
+                      <Icon as={BiRightArrowAlt} flexShrink={0} />
+                      <Text flex="1" noOfLines={1} title={row.destination}>
+                        {row.destination}
+                      </Text>
+                    </Flex>
+                  ))}
+                </Stack>
+              </AccordionPanel>
+            </AccordionItem>
+          </Accordion>
+        </Stack>
+      )
+    case "upload":
+    case "errors":
+      // "upload" and "errors" share the same picker; the error banner and
+      // template-vs-errors-file download are the only differences.
+      return (
+        <Stack spacing="1rem">
+          {stage === "errors" && validation ? (
+            <Flex gap="0.5rem">
+              <Icon
+                as={BiSolidError}
+                color="utility.feedback.critical"
+                boxSize="1.25rem"
+                mt="0.125rem"
+              />
+              <Stack spacing="0.5rem" align="flex-start">
+                <Text textStyle="body-2" color="utility.feedback.critical">
+                  {errorBannerText(validation)}
+                </Text>
+                {validation.fileError === null && (
+                  <Button
+                    variant="outline"
+                    size="xs"
+                    leftIcon={<BiDownload fontSize="1rem" />}
+                    onClick={onDownloadErrors}
+                  >
+                    Download errors file (.csv)
+                  </Button>
+                )}
+              </Stack>
+            </Flex>
+          ) : (
+            <Stack spacing="0.75rem" align="flex-start">
+              <Text textStyle="body-2">
+                To make sure your redirects are formatted properly, list your
+                redirects on the redirects template:
+              </Text>
+              <Button
+                as="a"
+                href={TEMPLATE_HREF}
+                download
+                variant="outline"
+                leftIcon={<BiDownload fontSize="1.25rem" />}
+              >
+                Download redirects template (.csv)
+              </Button>
+            </Stack>
+          )}
+
+          {stage === "errors" && (
+            <Text textStyle="subhead-2">Re-upload the file with fixes</Text>
+          )}
+
+          <Stack spacing="0.5rem">
+            <Attachment
+              name="redirects-csv"
+              multiple={false}
+              value={file ?? undefined}
+              onChange={(selected) => void onFileChange(selected)}
+              rejections={rejections}
+              onRejection={onRejection}
+              accept={[".csv", "text/csv"]}
+              maxSize={MAX_BULK_REDIRECT_CSV_BYTES}
+            />
+            <Text textStyle="body-2" color="base.content.medium">
+              {`Maximum file size: ${formatFileSizeLimit({ bytes: MAX_BULK_REDIRECT_CSV_BYTES })}`}
+              <br />
+              Accepted file type: .csv
+            </Text>
+          </Stack>
+          {fileError && (
+            <Text textStyle="body-2" color="utility.feedback.critical">
+              {fileError}
+            </Text>
+          )}
+        </Stack>
+      )
+  }
+}
+
+const modalTitle = (stage: Stage): string => {
+  switch (stage) {
+    case "processing":
+      return "Processing your redirects"
+    case "errors":
+      return "There are errors in your redirects"
+    case "success":
+      return "Redirects are ready to publish"
+    case "upload":
+      return "Bulk upload redirects"
+  }
+}
+
+const errorBannerText = (validation: BulkValidation): string => {
+  if (validation.fileError !== null) {
+    return validation.fileError
+  }
+  const count = validation.errorCount
+  return `${count} redirect${count === 1 ? " has" : "s have"} errors. Download the errors file and correct them before re-uploading:`
+}

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -21,7 +21,7 @@ import {
   Text,
 } from "@chakra-ui/react"
 import { Attachment, Button, useToast } from "@opengovsg/design-system-react"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import {
   BiDownload,
   BiRightArrowAlt,
@@ -96,6 +96,12 @@ export const BulkUploadRedirectsModal = ({
     AttachmentProps<false>["rejections"]
   >([])
 
+  // Tracks the most recently picked file. `file.text()` is async, so if the user
+  // picks A then B before A finishes reading, A could resolve last — this lets
+  // the handler drop the stale read instead of committing A's contents while the
+  // chip shows B.
+  const latestFileRef = useRef<File | null>(null)
+
   const resetState = () => {
     setStage("upload")
     setFile(null)
@@ -104,6 +110,7 @@ export const BulkUploadRedirectsModal = ({
     setValidation(null)
     setShowSlowMessage(false)
     setRejections([])
+    latestFileRef.current = null
   }
 
   // Start fresh every time the modal opens, so a previous run's file or errors
@@ -130,18 +137,23 @@ export const BulkUploadRedirectsModal = ({
 
   const handleFileChange = async (selected: File | undefined) => {
     if (!selected) {
+      latestFileRef.current = null
       setFile(null)
       setCsv(null)
       setFileError(null)
       return
     }
+    latestFileRef.current = selected
     setFile(selected)
     try {
       const text = await selected.text()
+      // A newer file was picked while this one was being read — drop the stale
+      // result so the parsed csv can't disagree with the chip.
+      if (latestFileRef.current !== selected) return
       setCsv(text)
-      const parsed = parseRedirectCsv(text)
-      setFileError(parsed.fileError ?? null)
+      setFileError(parseRedirectCsv(text).fileError ?? null)
     } catch {
+      if (latestFileRef.current !== selected) return
       setCsv(null)
       setFileError("We couldn't read this file. Upload a valid .csv file.")
     }

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -61,7 +61,9 @@ const triggerCsvDownload = (filename: string, contents: string) => {
   anchor.href = url
   anchor.download = filename
   anchor.click()
-  URL.revokeObjectURL(url)
+  // Revoke on the next tick, not synchronously after click(): some browsers
+  // abort the download if the blob URL is freed before it has started.
+  setTimeout(() => URL.revokeObjectURL(url), 0)
 }
 
 // A site name can contain characters that are invalid or surprising in a

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -50,7 +50,9 @@ interface BulkUploadRedirectsModalProps {
 // The modal walks through: pick a file → process (validate) → either fix errors
 // and re-upload, or review and publish the whole batch. `stage` tracks which of
 // those the user is on; validation holds the server's per-row verdicts.
-type Stage = "upload" | "processing" | "errors" | "success"
+// Validation is quick, so its spinner rides on the Process button; publishing
+// the batch is the slow step, so it gets the full-screen "publishing" stage.
+type Stage = "upload" | "publishing" | "errors" | "success"
 
 const triggerCsvDownload = (filename: string, contents: string) => {
   const blob = new Blob([contents], { type: "text/csv;charset=utf-8;" })
@@ -76,9 +78,8 @@ export const BulkUploadRedirectsModal = ({
   onClose,
 }: BulkUploadRedirectsModalProps): JSX.Element => {
   const toast = useToast(BRIEF_TOAST_SETTINGS)
-  const validate = useBulkValidateRedirects(siteId)
-  const { mutateAsync: publish, isPending: isPublishing } =
-    useBulkCreateRedirects()
+  const { validate, isPending: isValidating } = useBulkValidateRedirects(siteId)
+  const { mutateAsync: publish } = useBulkCreateRedirects()
   // Site display name (Site config `siteName`), used to name the errors file.
   const { data: site } = trpc.site.getSiteName.useQuery({ siteId })
 
@@ -111,10 +112,10 @@ export const BulkUploadRedirectsModal = ({
     if (isOpen) resetState()
   }, [isOpen])
 
-  // Only show the "this might take a while" line once processing runs long, per
-  // the design ("if processing time is short, don't show the second message").
+  // Only show the "this might take a while" line once publishing runs long, per
+  // the design ("if it's quick, don't show the second message").
   useEffect(() => {
-    if (stage !== "processing") {
+    if (stage !== "publishing") {
       setShowSlowMessage(false)
       return
     }
@@ -159,7 +160,8 @@ export const BulkUploadRedirectsModal = ({
 
   const handleProcess = async () => {
     if (!csv) return
-    setStage("processing")
+    // Validation is quick, so the Process button's inline spinner (isValidating)
+    // is enough — no full-screen stage. Stay put so a failure keeps the file.
     try {
       const result = await validate(csv)
       if (result.fileError !== null || result.errorCount > 0) {
@@ -174,12 +176,14 @@ export const BulkUploadRedirectsModal = ({
         description: "Please try again.",
         status: "error",
       })
-      setStage("upload")
     }
   }
 
   const handlePublish = async () => {
     if (!csv) return
+    // Creating the batch and republishing the site is the slow step, so switch
+    // to the full-screen spinner once the user commits.
+    setStage("publishing")
     try {
       const result = await publish({ siteId, csv })
       if (result.ok) {
@@ -199,6 +203,8 @@ export const BulkUploadRedirectsModal = ({
         description: "Please try again.",
         status: "error",
       })
+      // Back to the review screen so the user can retry the publish.
+      setStage("success")
     }
   }
 
@@ -235,13 +241,10 @@ export const BulkUploadRedirectsModal = ({
           />
         </ModalBody>
 
-        {stage !== "processing" && (
+        {stage !== "publishing" && (
           <ModalFooter>
             {stage === "success" ? (
-              <Button
-                onClick={() => void handlePublish()}
-                isLoading={isPublishing}
-              >
+              <Button onClick={() => void handlePublish()}>
                 Publish {validRows.length} redirect
                 {validRows.length === 1 ? "" : "s"}
               </Button>
@@ -249,6 +252,7 @@ export const BulkUploadRedirectsModal = ({
               <Button
                 onClick={() => void handleProcess()}
                 isDisabled={isProcessDisabled}
+                isLoading={isValidating}
               >
                 {isProcessDisabled
                   ? "Upload file to continue"
@@ -290,14 +294,13 @@ const BulkUploadModalBody = ({
   onDownloadErrors,
 }: BulkUploadModalBodyProps): JSX.Element => {
   switch (stage) {
-    case "processing":
+    case "publishing":
       return (
         <Center flexDir="column" py="2.5rem" gap="1rem">
           <Spinner />
           <Stack spacing="0.25rem" textAlign="center">
             <Text textStyle="body-2">
-              Checking your redirects for loops, errors, or any missing
-              pieces...
+              Publishing your redirects to your site...
             </Text>
             {showSlowMessage && (
               <Text textStyle="body-2" color="base.content.medium">
@@ -446,8 +449,8 @@ const BulkUploadModalBody = ({
 
 const modalTitle = (stage: Stage): string => {
   switch (stage) {
-    case "processing":
-      return "Processing your redirects"
+    case "publishing":
+      return "Publishing your redirects"
     case "errors":
       return "There are errors in your redirects"
     case "success":

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -68,8 +68,12 @@ const triggerCsvDownload = (filename: string, contents: string) => {
 // download filename (slashes, colons, newlines), so reduce it to a safe slug.
 const toFilenameSlug = (value: string) =>
   value
+    // Collapse every run of characters outside [A-Za-z0-9._-] into a single "-",
+    // so only filename-safe characters remain.
     .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    // Trim leading/trailing "-" left by that collapse (e.g. from a leading slash).
     .replace(/^-+|-+$/g, "")
+    // Cap the length, and fall back to "site" if nothing usable is left.
     .slice(0, 64) || "site"
 
 export const BulkUploadRedirectsModal = ({
@@ -81,7 +85,12 @@ export const BulkUploadRedirectsModal = ({
   const { validate, isPending: isValidating } = useBulkValidateRedirects(siteId)
   const { mutateAsync: publish } = useBulkCreateRedirects()
   // Site display name (Site config `siteName`), used to name the errors file.
-  const { data: site } = trpc.site.getSiteName.useQuery({ siteId })
+  // Only needed once the modal is open, so don't fetch it on the settings page
+  // behind a closed modal.
+  const { data: site } = trpc.site.getSiteName.useQuery(
+    { siteId },
+    { enabled: isOpen },
+  )
 
   const [stage, setStage] = useState<Stage>("upload")
   const [file, setFile] = useState<File | null>(null)
@@ -145,6 +154,12 @@ export const BulkUploadRedirectsModal = ({
     }
     latestFileRef.current = selected
     setFile(selected)
+    // Clear the previous file's parsed csv, error, and any dropzone rejections
+    // synchronously, so nothing stale is shown or processed during the async
+    // read below (Process stays disabled until the new csv is parsed).
+    setCsv(null)
+    setFileError(null)
+    setRejections([])
     try {
       const text = await selected.text()
       // A newer file was picked while this one was being read — drop the stale

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
@@ -1,32 +1,10 @@
-import {
-  Center,
-  Flex,
-  Icon,
-  Stack,
-  Text,
-  useDisclosure,
-} from "@chakra-ui/react"
-import { Button, Link } from "@opengovsg/design-system-react"
-import { BiUpload, BiWrench } from "react-icons/bi"
-import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
+import { Center, Flex, Icon, Stack, Text } from "@chakra-ui/react"
+import { Link } from "@opengovsg/design-system-react"
+import { BiWrench } from "react-icons/bi"
 
-import { BulkUploadRedirectsModal } from "./BulkUploadRedirectsModal"
 import { REDIRECTS_SUPPORT_LINK } from "../constants"
 
-interface RedirectsHeaderProps {
-  siteId: number
-}
-
-export const RedirectsHeader = ({
-  siteId,
-}: RedirectsHeaderProps): JSX.Element => {
-  const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
-  const {
-    isOpen: isBulkUploadOpen,
-    onOpen: onBulkUploadOpen,
-    onClose: onBulkUploadClose,
-  } = useDisclosure()
-
+export const RedirectsHeader = (): JSX.Element => {
   return (
     <Flex justifyContent="space-between" align="center" gap="1rem" w="full">
       <Stack spacing="0.5rem">
@@ -52,25 +30,6 @@ export const RedirectsHeader = ({
           .
         </Text>
       </Stack>
-
-      {/* Placement is intentionally temporary (top-right of the page) — a home
-          for the bulk-upload entry point until the final location is decided. */}
-      {isAdvancedRedirectsEnabled && (
-        <>
-          <Button
-            variant="outline"
-            leftIcon={<BiUpload fontSize="1.25rem" />}
-            onClick={onBulkUploadOpen}
-          >
-            Bulk upload redirects
-          </Button>
-          <BulkUploadRedirectsModal
-            siteId={siteId}
-            isOpen={isBulkUploadOpen}
-            onClose={onBulkUploadClose}
-          />
-        </>
-      )}
     </Flex>
   )
 }

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
@@ -1,12 +1,34 @@
-import { Center, Flex, Icon, Stack, Text } from "@chakra-ui/react"
-import { Link } from "@opengovsg/design-system-react"
-import { BiWrench } from "react-icons/bi"
+import {
+  Center,
+  Flex,
+  Icon,
+  Stack,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react"
+import { Button, Link } from "@opengovsg/design-system-react"
+import { BiUpload, BiWrench } from "react-icons/bi"
+import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 
+import { BulkUploadRedirectsModal } from "./BulkUploadRedirectsModal"
 import { REDIRECTS_SUPPORT_LINK } from "../constants"
 
-export const RedirectsHeader = (): JSX.Element => {
+interface RedirectsHeaderProps {
+  siteId: number
+}
+
+export const RedirectsHeader = ({
+  siteId,
+}: RedirectsHeaderProps): JSX.Element => {
+  const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
+  const {
+    isOpen: isBulkUploadOpen,
+    onOpen: onBulkUploadOpen,
+    onClose: onBulkUploadClose,
+  } = useDisclosure()
+
   return (
-    <Flex justifyContent="space-between" align="center" w="full">
+    <Flex justifyContent="space-between" align="center" gap="1rem" w="full">
       <Stack spacing="0.5rem">
         <Flex align="center" gap="0.75rem">
           <Center
@@ -30,6 +52,25 @@ export const RedirectsHeader = (): JSX.Element => {
           .
         </Text>
       </Stack>
+
+      {/* Placement is intentionally temporary (top-right of the page) — a home
+          for the bulk-upload entry point until the final location is decided. */}
+      {isAdvancedRedirectsEnabled && (
+        <>
+          <Button
+            variant="outline"
+            leftIcon={<BiUpload fontSize="1.25rem" />}
+            onClick={onBulkUploadOpen}
+          >
+            Bulk upload redirects
+          </Button>
+          <BulkUploadRedirectsModal
+            siteId={siteId}
+            isOpen={isBulkUploadOpen}
+            onClose={onBulkUploadClose}
+          />
+        </>
+      )}
     </Flex>
   )
 }

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -138,13 +138,7 @@ function DestinationCell({
           label={REDIRECT_MESSAGES.destinationNotPublished}
           placement="top"
         >
-          <Box
-            as="span"
-            ml="auto"
-            flexShrink={0}
-            display="inline-flex"
-            lineHeight="0"
-          >
+          <Box as="span" flexShrink={0} display="inline-flex" lineHeight="0">
             <Icon
               as={BiSolidErrorCircle}
               boxSize="1rem"

--- a/apps/studio/src/features/settings/Redirects/index.tsx
+++ b/apps/studio/src/features/settings/Redirects/index.tsx
@@ -12,7 +12,7 @@ export const RedirectsSettings = ({
   siteId,
 }: RedirectsSettingsProps): JSX.Element => (
   <Stack spacing="1.5rem" px="2rem" py="1.5rem" w="full">
-    <RedirectsHeader />
+    <RedirectsHeader siteId={siteId} />
 
     <Stack spacing="1.25rem">
       <AddRedirectCard siteId={siteId} />

--- a/apps/studio/src/features/settings/Redirects/index.tsx
+++ b/apps/studio/src/features/settings/Redirects/index.tsx
@@ -12,7 +12,7 @@ export const RedirectsSettings = ({
   siteId,
 }: RedirectsSettingsProps): JSX.Element => (
   <Stack spacing="1.5rem" px="2rem" py="1.5rem" w="full">
-    <RedirectsHeader siteId={siteId} />
+    <RedirectsHeader />
 
     <Stack spacing="1.25rem">
       <AddRedirectCard siteId={siteId} />

--- a/apps/studio/src/features/settings/Redirects/types.ts
+++ b/apps/studio/src/features/settings/Redirects/types.ts
@@ -1,9 +1,6 @@
+import type { RedirectRowInput } from "~/schemas/redirect"
 import type { RouterOutput } from "~/utils/trpc"
-import { z } from "zod"
-import {
-  createRedirectObjectSchema,
-  refineSourceDestinationDiffer,
-} from "~/schemas/redirect"
+import { redirectRowSchema } from "~/schemas/redirect"
 
 // A live redirect row as returned by the server, so the table type can never
 // drift from what `redirect.list` actually responds with
@@ -11,37 +8,9 @@ export type RedirectRow = RouterOutput["redirect"]["list"][number]
 
 export type { RedirectSortField } from "~/schemas/redirect"
 
-// Client-side convenience applied just before validation, so users don't have
-// to type the scheme the published site serves over:
-//   - an "http://" destination is upgraded to "https://"
-//   - a leading "www." host gets "https://" prefixed
-// A "www." prefix unambiguously signals an external host (an internal path
-// starts with "/"), so it's safe to infer. A schemeless host WITHOUT "www."
-// ("google.com") is left untouched — it's ambiguous against an internal path
-// ("/test.zip" vs "test.zip") — and fails validation as an invalid URL.
-// This lives only on the form; the shared server schema is unchanged.
-const normalizeDestinationScheme = (value: string): string => {
-  if (value.startsWith("http://")) {
-    return `https://${value.slice("http://".length)}`
-  }
-  if (value.startsWith("www.")) {
-    return `https://${value}`
-  }
-  return value
-}
-
-// The add form collects everything except siteId, which comes from the route.
-// Reusing the server schema's field rules keeps client and server validation
-// identical; the destination first runs through the scheme fix-up (piped into
-// the shared rules so the field's input type stays a plain string for the form).
-export const addRedirectSchema = z
-  .object({
-    source: createRedirectObjectSchema.shape.source,
-    destination: z
-      .string()
-      .trim()
-      .transform(normalizeDestinationScheme)
-      .pipe(createRedirectObjectSchema.shape.destination),
-  })
-  .superRefine(refineSourceDestinationDiffer)
-export type AddRedirectInput = z.infer<typeof addRedirectSchema>
+// The add form collects exactly one redirect minus siteId (from the route) —
+// the same shape a bulk-upload CSV row has, so both reuse the shared row schema
+// (scheme fix-up + create-schema field rules). Aliased here so form code keeps
+// referring to `addRedirectSchema`.
+export const addRedirectSchema = redirectRowSchema
+export type AddRedirectInput = RedirectRowInput

--- a/apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts
+++ b/apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts
@@ -1,0 +1,5 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+
+export const useIsAdvancedRedirectsEnabled = () =>
+  useFeatureValue<boolean>(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, false)

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -16,6 +16,10 @@ export const IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY =
   "homepage-antiscam-banner-enabled"
 export const EGAZETTE_INFO_FEATURE_KEY = "egazette-info"
 export const IS_REDIRECTIONS_ENABLED_FEATURE_KEY = "is-redirections-enabled"
+// Gates the "advanced redirects" surface (bulk CSV upload) separately from the
+// base redirects feature, which is already fully enabled pending flag removal.
+export const IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY =
+  "is-advanced-redirects-enabled"
 // When OFF (default): gazette ingestion targets Algolia directly.
 // When ON: gazette ingestion is routed to SearchSG instead.
 export const ENABLE_SEARCHSG_GAZETTE_INGESTION =

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -5,7 +5,10 @@ import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import RedirectsSettingsPage from "~/pages/sites/[siteId]/settings/redirects"
 import { ADMIN_HANDLERS } from "~/stories/handlers"
-import { createRedirectionsEnabledGbParameters } from "~/stories/utils/growthbook"
+import {
+  createAdvancedRedirectsEnabledGbParameters,
+  createRedirectionsEnabledGbParameters,
+} from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   ...ADMIN_HANDLERS,
@@ -102,6 +105,116 @@ export const AlreadyExistsError: Story = {
     const screen = await submitNewRedirect(canvasElement)
     await expect(
       await screen.findByText("This page is already being redirected."),
+    ).toBeVisible()
+  },
+}
+
+// Opens the bulk-upload modal, uploads a valid CSV, and clicks "Process
+// redirects" so the mocked validation drives the next screen.
+const VALID_CSV =
+  "When someone visits,Redirect them to\n/old-one,/new-one\n/old-two,https://www.example.gov.sg"
+
+const openModalAndUpload = async (canvasElement: HTMLElement) => {
+  const body = canvasElement.ownerDocument.body
+  const screen = within(body)
+  await userEvent.click(
+    await screen.findByRole("button", { name: "Bulk upload redirects" }),
+  )
+  // The dropzone's file input has no stable accessible label, so grab it
+  // directly once the modal has mounted.
+  const fileInput = await waitFor(() => {
+    const input = body.querySelector<HTMLInputElement>("input[type='file']")
+    if (!input) throw new Error("file input not found")
+    return input
+  })
+  await userEvent.upload(
+    fileInput,
+    new File([VALID_CSV], "redirects.csv", { type: "text/csv" }),
+  )
+  const processButton = await screen.findByRole("button", {
+    name: "Process redirects",
+  })
+  await waitFor(() => expect(processButton).toBeEnabled())
+  await userEvent.click(processButton, { pointerEventsCheck: 0 })
+  return screen
+}
+
+// Clicking the top-right button opens the modal at its initial upload state.
+export const BulkUploadModal: Story = {
+  parameters: {
+    growthbook: [
+      createRedirectionsEnabledGbParameters(true),
+      createAdvancedRedirectsEnabledGbParameters(true),
+    ],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement.ownerDocument.body)
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Bulk upload redirects" }),
+    )
+    // Finding the template download confirms the modal opened. Presence (not a
+    // one-shot toBeVisible) is used deliberately: asserting visibility during
+    // the modal's enter animation is flaky.
+    await screen.findByText("Download redirects template (.csv)")
+  },
+}
+
+// A fully valid file lands on the ready-to-publish screen.
+export const BulkUploadReadyToPublish: Story = {
+  parameters: {
+    growthbook: [
+      createRedirectionsEnabledGbParameters(true),
+      createAdvancedRedirectsEnabledGbParameters(true),
+    ],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        redirectHandlers.bulkValidate.allValid(),
+        redirectHandlers.bulkCreate.success(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = await openModalAndUpload(canvasElement)
+    await expect(
+      await screen.findByText("All 2 redirects are good to go."),
+    ).toBeVisible()
+    await expect(
+      screen.getByRole("button", { name: "Publish 2 redirects" }),
+    ).toBeVisible()
+  },
+}
+
+// A file with a bad row lands on the errors screen with the download affordance.
+export const BulkUploadWithErrors: Story = {
+  parameters: {
+    growthbook: [
+      createRedirectionsEnabledGbParameters(true),
+      createAdvancedRedirectsEnabledGbParameters(true),
+    ],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        redirectHandlers.bulkValidate.withErrors(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = await openModalAndUpload(canvasElement)
+    await expect(await screen.findByText(/1 redirect has errors/)).toBeVisible()
+    await expect(
+      screen.getByRole("button", { name: "Download errors file (.csv)" }),
     ).toBeVisible()
   },
 }

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -118,7 +118,7 @@ const openModalAndUpload = async (canvasElement: HTMLElement) => {
   const body = canvasElement.ownerDocument.body
   const screen = within(body)
   await userEvent.click(
-    await screen.findByRole("button", { name: "Bulk upload redirects" }),
+    await screen.findByRole("button", { name: /bulk upload with a \.csv/i }),
   )
   // The dropzone's file input has no stable accessible label, so grab it
   // directly once the modal has mounted.
@@ -139,7 +139,7 @@ const openModalAndUpload = async (canvasElement: HTMLElement) => {
   return screen
 }
 
-// Clicking the top-right button opens the modal at its initial upload state.
+// Clicking the inline bulk-upload CTA opens the modal at its initial upload state.
 export const BulkUploadModal: Story = {
   parameters: {
     growthbook: [
@@ -157,7 +157,7 @@ export const BulkUploadModal: Story = {
   play: async ({ canvasElement }) => {
     const screen = within(canvasElement.ownerDocument.body)
     await userEvent.click(
-      await screen.findByRole("button", { name: "Bulk upload redirects" }),
+      await screen.findByRole("button", { name: /bulk upload with a \.csv/i }),
     )
     // Finding the template download confirms the modal opened. Presence (not a
     // one-shot toBeVisible) is used deliberately: asserting visibility during

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -121,9 +121,12 @@ const openModalAndUpload = async (canvasElement: HTMLElement) => {
     await screen.findByRole("button", { name: /bulk upload with a \.csv/i }),
   )
   // The dropzone's file input has no stable accessible label, so grab it
-  // directly once the modal has mounted.
+  // directly once the modal has mounted. Scope to the modal dialog so an
+  // unrelated file input elsewhere on the page can't be picked up by mistake.
   const fileInput = await waitFor(() => {
-    const input = body.querySelector<HTMLInputElement>("input[type='file']")
+    const input = body.querySelector<HTMLInputElement>(
+      "[role='dialog'] input[type='file']",
+    )
     if (!input) throw new Error("file input not found")
     return input
   })

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -5,6 +5,7 @@ import {
   CATEGORY_DROPDOWN_FEATURE_KEY,
   CATEGORY_ID_DROPDOWN_FEATURE_KEY,
   EGAZETTE_INFO_FEATURE_KEY,
+  IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY,
   IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
   IS_REDIRECTIONS_ENABLED_FEATURE_KEY,
   IS_SINGPASS_ENABLED_FEATURE_KEY,
@@ -47,6 +48,12 @@ export const createSingpassEnabledGbParameters = (isEnabled: boolean) => {
 
 export const createRedirectionsEnabledGbParameters = (isEnabled: boolean) => {
   return [IS_REDIRECTIONS_ENABLED_FEATURE_KEY, isEnabled]
+}
+
+export const createAdvancedRedirectsEnabledGbParameters = (
+  isEnabled: boolean,
+) => {
+  return [IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, isEnabled]
 }
 
 export const createAntiScamBannerEnabledGbParameters = (isEnabled: boolean) => {

--- a/apps/studio/tests/msw/handlers/redirect.ts
+++ b/apps/studio/tests/msw/handlers/redirect.ts
@@ -44,6 +44,52 @@ export const redirectHandlers = {
         throw new TRPCError({ code: "UNPROCESSABLE_CONTENT" })
       }),
   },
+  bulkValidate: {
+    // Every row passes — drives the ready-to-publish preview.
+    allValid: () =>
+      trpcMsw.redirect.bulkValidate.mutation(() => ({
+        fileError: null,
+        rows: [
+          {
+            rowNumber: 2,
+            source: "/old-one",
+            destination: "/new-one",
+            error: null,
+          },
+          {
+            rowNumber: 3,
+            source: "/old-two",
+            destination: "https://www.example.gov.sg",
+            error: null,
+          },
+        ],
+        validCount: 2,
+        errorCount: 0,
+      })),
+    // A mix of a failing and a passing row — drives the errors screen.
+    withErrors: () =>
+      trpcMsw.redirect.bulkValidate.mutation(() => ({
+        fileError: null,
+        rows: [
+          {
+            rowNumber: 2,
+            source: "/loop-a",
+            destination: "/loop-b",
+            error: "This will trap visitors in a never-ending loop.",
+          },
+          { rowNumber: 3, source: "/ok", destination: "/fine", error: null },
+        ],
+        validCount: 1,
+        errorCount: 1,
+      })),
+  },
+  bulkCreate: {
+    success: (publishedCount = 2) =>
+      trpcMsw.redirect.bulkCreate.mutation(() => ({
+        ok: true as const,
+        publishedCount,
+      })),
+  },
   getBySource: {
     // The URL is not a redirect source — no settings warning shown.
     none: () => trpcMsw.redirect.getBySource.query(() => null),


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 8 | +583 | -48 |
| 🧪 Test | 3 | +170 | -1 |
| 📄 Doc | 1 | +20 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

> **📚 Top of a 3-PR stack** — bulk upload redirects, split from this PR's original single-PR form. Review and merge bottom-up:
> 1. #2805 — CSV parsing + validation schema
> 2. #2806 — bulk validate/create endpoints
> 3. **#2778 — modal UI + feature flag ← _this PR_**
>
> This PR now contains only the **frontend layer**; the CSV parser/schema is in #2805 and the server endpoints are in #2806.

## Problem

Closes ISOM-2271

Editors could only add redirects one at a time through the inline form on the redirects settings page. Setting up or migrating many redirects at once was slow and error-prone, with no way to validate a whole set before publishing.

## Solution

Adds the **Bulk upload redirects** UI: an editor downloads a CSV template, fills it in, and uploads it. The file is parsed in the browser for instant feedback, validated authoritatively on the server (#2806), and — only if every row is clean — published in one step. The entry point is gated behind the `is-advanced-redirects-enabled` GrowthBook flag for staged rollout.

Design reference: [Figma — Bulk upload redirects](https://www.figma.com/design/g7LnLn4IUcUC9dYxgsHEJM/Isomer-Studio-working-file?node-id=22241-11950&m=dev).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- **Inline "bulk upload with a .csv instead." CTA** in the add-redirect card on the redirects settings page, gated behind `is-advanced-redirects-enabled` via `useIsAdvancedRedirectsEnabled`.
- **Multi-step modal**: download template → upload CSV → client-parse for instant file-level feedback → server `bulkValidate` → fix errors / review preview → `bulkCreate` → publish.
- **Errors flow**: when any row fails, the modal shows the count and offers a downloadable errors file (failures listed first) with plain-language reasons, in the same column shape as the template so it re-uploads directly after fixes.
- **Ready-to-publish preview**: an "All N redirects are good to go" screen with an expandable list of the rows to be added.
- File-size limit (1 MB) shown under the upload dropzone; `.csv` only.
- Client hooks `useBulkValidateRedirects` / `useBulkCreateRedirects`, MSW handlers, and Storybook stories for the modal's initial / ready-to-publish / errors states.

**Improvements**:

- Records the redirects glossary (Redirect, Source, Destination, Page reference, Redirects template, Bulk upload) in `CONTEXT.md`.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

Redirects settings page with only the inline single-add form; no way to add redirects in bulk.

**AFTER**:

The modal states (initial upload, ready-to-publish preview, errors) are captured as Storybook stories under `Pages/Site Management/Agency Settings Page/Redirects`. (No live app screenshots attached — the browser-rendered states live in Storybook; design reference is the Figma link above.)

## Tests

Storybook stories cover the modal's initial upload, ready-to-publish, and errors states (with the feature flag on) and back the Chromatic UI review. The parser unit tests live in #2805 and the backend integration tests in #2806.

**Manual Verification Steps** (end-to-end for the full stack):

- [ ] Enable the `is-advanced-redirects-enabled` flag for a test site, open **Site settings → Redirects**, and confirm the inline "bulk upload with a .csv instead." CTA appears in the add-redirect card.
- [ ] Open the modal, click "Download redirects template (.csv)", and confirm the file's header row is `When someone visits,Redirect them to`.
- [ ] Upload a CSV with 2–3 valid redirects (include one `path → /path` and one `path → https://…` row); click "Process redirects" and confirm the "All N redirects are good to go" screen, then expand "Redirects to be added" to see the rows.
- [ ] Upload a CSV containing bad rows (e.g. `/a,/b` and `/b,/a` to force a loop, a duplicated source, and a malformed destination); confirm the errors screen shows the count and that "Download errors file (.csv)" produces a file listing the failing rows first with plain-language reasons.
- [ ] Correct the errors file and re-upload it; confirm it reaches the ready-to-publish screen, click "Publish N redirects", and confirm the new redirects appear in the table below and the site republishes.
- [ ] With the flag OFF, confirm the CTA is hidden; as a non-admin user, confirm the bulk publish is not permitted.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a feature-flagged frontend flow for bulk uploading redirects. The main changes are:

- Adds an inline bulk-upload CTA in the add-redirect card.
- Adds a multi-step CSV modal for template download, upload, validation, error download, preview, and publish.
- Adds tRPC client hooks for bulk validation and bulk creation.
- Adds a false-default GrowthBook flag for advanced redirects.
- Adds Storybook stories and MSW handlers for the new modal states.
- Adds redirects glossary terms to `CONTEXT.md`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low rollout risk.

No verified issues remain in the reviewed frontend changes. The new UI is gated behind a false-default GrowthBook flag. The added GrowthBook change is limited to a new flag key constant.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Storybook bulk upload modal tests and captured the initial state with the advanced bulk upload CTA, template download, and CSV upload affordance.
- Validated the ready-to-publish state by confirming all redirects are good to go and the publish button is available.
- Validated the error state by confirming that one redirect has errors and the download errors file button is shown.
- Inspected the evidence log, confirming the Playwright run completed with exit code 0 and MSW mocked API activity including /redirect.bulkValidate.

<a href="https://app.greptile.com/trex/runs/15513769/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx | Introduces the multi-step CSV upload, validation, error download, preview, and publish modal. |
| apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx | Adds a GrowthBook-gated CTA and mounts the bulk-upload modal from the existing add-redirect card. |
| apps/studio/src/features/settings/Redirects/api.ts | Adds tRPC mutation hooks for bulk validation and creation, invalidating redirect queries after successful publish. |
| apps/studio/src/features/settings/Redirects/types.ts | Reuses the shared redirect row schema for the add form so single-add and bulk rows share validation. |
| apps/studio/src/lib/growthbook.ts | Adds the advanced redirects feature flag key constant. |
| apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx | Adds Storybook interactions covering initial, ready-to-publish, and validation-error modal states. |
| apps/studio/tests/msw/handlers/redirect.ts | Adds MSW handlers for mocked bulk validation and successful bulk creation responses. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Editor
  participant AddRedirectCard
  participant BulkUploadRedirectsModal
  participant RedirectTRPC
  participant RedirectList

  Editor->>AddRedirectCard: Click gated bulk CSV CTA
  AddRedirectCard->>BulkUploadRedirectsModal: Open modal
  Editor->>BulkUploadRedirectsModal: Download template / upload CSV
  BulkUploadRedirectsModal->>BulkUploadRedirectsModal: Read file and parse file-level errors
  Editor->>BulkUploadRedirectsModal: Process redirects
  BulkUploadRedirectsModal->>RedirectTRPC: bulkValidate(siteId, csv)
  RedirectTRPC-->>BulkUploadRedirectsModal: Row verdicts
  alt Validation errors
    BulkUploadRedirectsModal-->>Editor: Show errors and downloadable errors CSV
  else All rows valid
    BulkUploadRedirectsModal-->>Editor: Show ready-to-publish preview
    Editor->>BulkUploadRedirectsModal: Publish redirects
    BulkUploadRedirectsModal->>RedirectTRPC: bulkCreate(siteId, csv)
    RedirectTRPC-->>BulkUploadRedirectsModal: ok / fresh validation
    alt Publish succeeds
      BulkUploadRedirectsModal->>RedirectList: Invalidate redirect queries
      BulkUploadRedirectsModal-->>Editor: Success toast and close
    else Race validation fails
      BulkUploadRedirectsModal-->>Editor: Show errors for corrected re-upload
    end
  end
```
</details>

<sub>Reviews (20): Last reviewed commit: ["refactor(redirect): name the errors file..."](https://github.com/opengovsg/isomer/commit/9dbb6b8b9375b118822723f082410003d8ac3e9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44018545)</sub>

<!-- /greptile_comment -->