### PR TITLE
perf(publishing): resolve only referenced resources in redirects query

### DIFF
--- a/tooling/build/scripts/publishing/queries.ts
+++ b/tooling/build/scripts/publishing/queries.ts
@@ -63,26 +63,55 @@ SELECT name, config, theme FROM public."Site" WHERE "id" = $1;
 
 // Internal destinations are stored as "[resource:siteId:resourceId]" references
 // so a redirect follows the page when its permalink changes. At publish time we
-// resolve each reference to the target's current full permalink by walking the
-// resource tree. A Folder/Collection reference resolves via its published
-// IndexPage child (the container has no version of its own); the trailing
-// "_index" is stripped to match getConvertedPermalink in index.ts. Non-reference
+// resolve each reference to the target's current full permalink. Rather than
+// materialise every resource's permalink, we resolve only the resources a
+// redirect actually references and walk UP the tree from each to its root — so
+// cost scales with the number of referencing redirects, not the site's size
+// (and does no tree walk at all when no redirect references a resource).
+//
+// A Folder/Collection reference resolves via its published IndexPage child (the
+// container has no version of its own); the trailing "_index"/"_meta" is
+// stripped to match getConvertedPermalink in index.ts. Non-reference
 // destinations (literal paths, external https URLs) pass through untouched. A
 // reference resolves to NULL — and the redirect is dropped — when nothing live
-// matches (deleted/unpublished target), since that redirect would be broken.
+// matches (deleted/unpublished target, or a reference to another site).
 export const GET_REDIRECTS = `
-WITH RECURSIVE "resourcePath" (id, "publishedVersionId", "parentId", "fullPermalink", "type") AS (
-    SELECT r.id, r."publishedVersionId", r."parentId", r.permalink AS "fullPermalink", r.type AS "type"
-    FROM public."Resource" r
-    WHERE r."siteId" = $1 AND r."parentId" IS NULL
+WITH RECURSIVE
+    -- Distinct resourceIds referenced by this site's own redirects. The
+    -- embedded siteId must equal $1, else the reference can't resolve here.
+    "referenced" AS (
+        SELECT DISTINCT
+            CAST(substring(destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint) AS "resourceId"
+        FROM public."Redirect"
+        WHERE "siteId" = $1
+            AND "deletedAt" IS NULL
+            AND destination ~ '^\\[resource:\\d+:\\d+\\]$'
+            AND CAST(substring(destination from '\\[resource:(\\d+):\\d+\\]') AS bigint) = $1
+    ),
+    -- The published resource each reference resolves to: the referenced page
+    -- itself, or the published IndexPage child of a referenced container.
+    "target" AS (
+        SELECT ref."resourceId", r."parentId", r.permalink AS "fullPermalink"
+        FROM "referenced" ref
+        INNER JOIN public."Resource" r
+            ON r."siteId" = $1
+            AND r."publishedVersionId" IS NOT NULL
+            AND (
+                r.id = ref."resourceId"
+                OR (r."type" = 'IndexPage' AND r."parentId" = ref."resourceId")
+            )
+    ),
+    -- Walk UP from each target to its root, prepending ancestor permalinks so
+    -- the assembled "fullPermalink" matches the old top-down walk exactly.
+    "resolved" ("resourceId", "parentId", "fullPermalink") AS (
+        SELECT "resourceId", "parentId", "fullPermalink" FROM "target"
 
-    UNION ALL
+        UNION ALL
 
-    SELECT r.id, r."publishedVersionId", r."parentId", CONCAT(path."fullPermalink", '/', r.permalink), r.type AS "type"
-    FROM public."Resource" r
-    INNER JOIN "resourcePath" path ON r."parentId" = path.id
-    WHERE r."siteId" = $1
-)
+        SELECT res."resourceId", r."parentId", CONCAT(r.permalink, '/', res."fullPermalink")
+        FROM "resolved" res
+        INNER JOIN public."Resource" r ON r.id = res."parentId" AND r."siteId" = $1
+    )
 SELECT source, destination FROM (
     SELECT
         redirect.source AS source,
@@ -91,27 +120,19 @@ SELECT source, destination FROM (
             -- "||" (not CONCAT) so an unresolved reference stays NULL and is
             -- dropped below; CONCAT would coerce NULL to '' and emit "/".
             -- Strips a trailing "_index"/"_meta" to match getConvertedPermalink.
-            THEN '/' || regexp_replace(rp."fullPermalink", '(^|/)(_index|_meta)$', '')
+            THEN '/' || regexp_replace(root."fullPermalink", '(^|/)(_index|_meta)$', '')
             ELSE redirect.destination
         END AS destination
     FROM public."Redirect" redirect
-    LEFT JOIN "resourcePath" rp
+    LEFT JOIN (
+        SELECT "resourceId", "fullPermalink" FROM "resolved" WHERE "parentId" IS NULL
+    ) root
         ON redirect.destination ~ '^\\[resource:\\d+:\\d+\\]$'
         -- The reference's siteId must match this site ($1); a mismatched
-        -- reference can't resolve here and is dropped.
+        -- reference can't resolve here even if its resourceId exists locally.
         AND CAST(substring(redirect.destination from '\\[resource:(\\d+):\\d+\\]') AS bigint) = $1
-        AND rp."publishedVersionId" IS NOT NULL
-        AND (
-            -- A page reference resolves to the page itself.
-            rp.id = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
-            -- A Folder/Collection reference resolves via its published IndexPage
-            -- child; "_index" is stripped above to give the container's URL.
-            OR (
-                rp."type" = 'IndexPage'
-                AND rp."parentId" = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
-            )
-        )
+        AND root."resourceId" = CAST(substring(redirect.destination from '\\[resource:\\d+:(\\d+)\\]') AS bigint)
     WHERE redirect."siteId" = $1 AND redirect."deletedAt" IS NULL
-) resolved
-WHERE resolved.destination IS NOT NULL;
+) resolved_redirects
+WHERE resolved_redirects.destination IS NOT NULL;
 `


### PR DESCRIPTION
## Problem

The `GET_REDIRECTS` query, run once per site on every publish, built the **full permalink of every resource in the site** via a recursive CTE that walked the entire resource tree top-down, then left-joined the site's redirects against that materialised set.

This made the query cost `O(site size)` regardless of how many redirects exist — a large site paid to walk its whole tree even when only a handful of redirects (or none) actually reference an internal resource. Only redirects whose destination is an internal `[resource:siteId:resourceId]` reference need any tree resolution at all; literal and external destinations pass through untouched.

## Solution

Resolve only the resources a redirect actually references, and walk **up** the tree from each target instead of materialising the whole tree:

1. `referenced` — the distinct `resourceId`s referenced by this site's own redirects (with the embedded-siteId guard).
2. `target` — the published resource each reference resolves to: the referenced page itself, or the published `IndexPage` child of a referenced Folder/Collection.
3. `resolved` — walk up from each target to its root, prepending ancestor permalinks so the assembled `fullPermalink` is byte-for-byte identical to the previous top-down walk.

Cost now scales with the **number of referencing redirects × tree depth** rather than site size, and no recursive tree walk happens at all when no redirect references a resource.

The query's inputs, output columns (`source`, `destination`), and semantics are unchanged. All existing behaviour is preserved: literal/external destinations pass through; unpublished, dangling-folder, deleted, and cross-site references are dropped.

Based on 3030 redirects, time taken dropped from **85 seconds to 9 seconds**.

**BEFORE:**
<img width="1176" height="219" alt="image" src="https://github.com/user-attachments/assets/9b1e6a77-753e-4740-bce5-670b1f54137c" />


**AFTER:**
<img width="1180" height="222" alt="image" src="https://github.com/user-attachments/assets/21b0c335-f2db-4396-83e5-642312443605" />


**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- `GET_REDIRECTS` no longer materialises every resource's permalink on publish; it resolves only referenced resources by walking up the tree, so publish-time cost scales with referencing redirects instead of total site size.

## Tests

The existing publishing integration suite (`tooling/build/scripts/publishing/tests/publishing.test.ts`) passes unchanged — 20/20. It covers literal destinations, page/index/folder/root references, an unpublished-target reference, a dangling folder with no published index, a deleted redirect, and a cross-site reference, all against a real Postgres via testcontainers.

**Manual Verification Steps**:

- [ ] Pick a site that has redirects configured, including at least one internal redirect whose destination points to a page/folder (a `[resource:...]` reference) and one literal-path redirect.
- [ ] Publish the site.
- [ ] Confirm the publish job completes without error and produces `redirects.json`.
- [ ] Verify `redirects.json` contains the literal redirect unchanged, and the internal reference resolved to the target's current live permalink (e.g. an internal redirect to a folder resolves to that folder's index URL).
- [ ] Confirm redirects pointing to unpublished/deleted targets are absent from `redirects.json`.
- [ ] Visit a redirect source URL on the published site and confirm it redirects to the expected destination.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR optimizes redirect generation during publishing. The main changes are:

- Extracts distinct same-site internal resource references from redirects before resolving targets.
- Resolves only referenced published resources or their published `IndexPage` children.
- Walks upward through ancestors to rebuild full permalinks for resolved redirect destinations.
- Keeps literal and external redirect destinations unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The single changed file updates the publishing redirects query while preserving the existing output columns and redirect resolution behavior for pages, container index pages, same-site checks, deleted redirects, and unresolved targets.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Inspected the canonical publishing test run log to capture the command, working directory, exit code, and the testcontainers runtime error.
- Reviewed additional direct publishing invocations and confirmed they encountered the same container-runtime blocker as the canonical run.
- Concluded that no test reached the publishing script or the GET\_REDIRECTS query, leaving the overall result inconclusive.

<a href="https://app.greptile.com/trex/runs/14334338/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publishing/queries.ts | Reworks `GET_REDIRECTS` to resolve only referenced internal resources via an upward recursive CTE while preserving literal and external destinations. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Publish as Publish job
participant Redirect as public.Redirect
participant Resource as public.Resource
participant Output as redirects.json

Publish->>Redirect: Fetch non-deleted redirects for site
Redirect-->>Publish: literal/external destinations and internal [resource] refs
Publish->>Redirect: Extract distinct same-site referenced resourceIds
Publish->>Resource: Resolve published target page or IndexPage child
Resource-->>Publish: target permalink + parentId
loop For each resolved target ancestor
    Publish->>Resource: Load parent resource for same site
    Resource-->>Publish: prepend ancestor permalink
end
Publish->>Output: Write source + literal destination or resolved permalink
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Publish as Publish job
participant Redirect as public.Redirect
participant Resource as public.Resource
participant Output as redirects.json

Publish->>Redirect: Fetch non-deleted redirects for site
Redirect-->>Publish: literal/external destinations and internal [resource] refs
Publish->>Redirect: Extract distinct same-site referenced resourceIds
Publish->>Resource: Resolve published target page or IndexPage child
Resource-->>Publish: target permalink + parentId
loop For each resolved target ancestor
    Publish->>Resource: Load parent resource for same site
    Resource-->>Publish: prepend ancestor permalink
end
Publish->>Output: Write source + literal destination or resolved permalink
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["perf(publishing): resolve only reference..."](https://github.com/opengovsg/isomer/commit/64d2edffbb274b1ee996cbff2a0c5b5745274bb5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44019352)</sub>

<!-- /greptile_comment -->