### PR TITLE
fix(publishing): percent-decode redirect source when building S3 key

### DIFF
--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeSource } from "../uploadRedirects"
+
+// A redirect `source` is stored percent-encoded (the source schema forbids a
+// raw space, so a space is persisted as "%20"). CloudFront percent-decodes the
+// request path before it fetches from S3, so the object must be keyed by the
+// DECODED path — otherwise the request 404s against a "%20" key that no
+// incoming request ever reaches.
+describe("normalizeSource", () => {
+  it("percent-decodes a %20 source so the S3 key matches the decoded path CloudFront fetches", () => {
+    // Arrange / Act
+    const key = normalizeSource(
+      "/files/conserved-buildings/trinity%20church11.4.05.pdf",
+    )
+
+    // Assert
+    expect(key).toBe("files/conserved-buildings/trinity church11.4.05.pdf")
+  })
+
+  it("percent-decodes other encoded octets in the source", () => {
+    // Arrange / Act / Assert
+    expect(normalizeSource("/a%28b%29c")).toBe("a(b)c")
+  })
+
+  it("leaves an already-decoded source unchanged", () => {
+    // Arrange / Act / Assert
+    expect(normalizeSource("/-/media/corporate/list.pdf")).toBe(
+      "-/media/corporate/list.pdf",
+    )
+  })
+
+  it("trims and collapses slashes", () => {
+    // Arrange / Act / Assert
+    expect(normalizeSource("//foo//bar//")).toBe("foo/bar")
+  })
+
+  it("rejects a traversal segment smuggled in via percent-encoding", () => {
+    // Arrange / Act / Assert — "%2e%2e" decodes to ".."
+    expect(normalizeSource("/foo/%2e%2e/bar")).toBeNull()
+  })
+
+  it("rejects a control character smuggled in via percent-encoding", () => {
+    // Arrange / Act / Assert — "%00" decodes to NUL
+    expect(normalizeSource("/foo%00bar")).toBeNull()
+  })
+
+  it("rejects malformed percent-encoding", () => {
+    // Arrange / Act / Assert — a lone "%" is not a valid escape sequence
+    expect(normalizeSource("/foo%bar")).toBeNull()
+  })
+})

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -2,6 +2,8 @@ import { spawn } from "child_process"
 import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
+import { argv } from "process"
+import { pathToFileURL } from "url"
 
 const REDIRECTS_JSON = process.env.REDIRECTS_JSON
 const S3_BUCKET = process.env.S3_BUCKET_NAME
@@ -15,11 +17,24 @@ interface Redirect {
 }
 
 // Returns the normalised S3 key segment, or null if the source is unsafe/empty.
-function normalizeSource(source: string): string | null {
+export function normalizeSource(source: string): string | null {
   if (typeof source !== "string") return null
+  // A stored source keeps its percent-encoding (the source schema forbids a raw
+  // space, so a space is persisted as "%20"). CloudFront percent-decodes the
+  // request path before it fetches from S3, so the object must be keyed by the
+  // DECODED path — otherwise it sits at a "%20" key that no request ever reaches.
+  // Decode first, then run the safety checks below on the decoded value so an
+  // encoded "%2e%2e" or "%00" can't smuggle a traversal / control char past them.
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(source)
+  } catch {
+    // Malformed percent-encoding (e.g. a lone "%") can't be keyed correctly.
+    return null
+  }
   // Reject control chars and backslashes
-  if (/[\x00-\x1f\\]/.test(source)) return null
-  const trimmed = source
+  if (/[\x00-\x1f\x7f\\]/.test(decoded)) return null
+  const trimmed = decoded
     .replace(/^\/+/, "")
     .replace(/\/+$/, "")
     .replace(/\/+/g, "/")
@@ -135,7 +150,11 @@ async function main(): Promise<void> {
   if (failed > 0) process.exit(1)
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+// Run only when executed directly (`tsx uploadRedirects.ts`), not when the file
+// is imported — e.g. by the unit tests for normalizeSource.
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Problem

Redirects whose `source` contains a percent-encoded character — most commonly a space stored as `%20` (the source schema forbids a raw space) — return **404 instead of redirecting** on the published site.

When redirects are uploaded to S3, `normalizeSource` kept the literal `%20` in the object key, so the redirect object was stored at `…/trinity%20church.pdf/index.html`. CloudFront percent-decodes the request path *before* it looks up the S3 origin, so it fetched `…/trinity church.pdf/index.html` (a real space) — a key that does not exist — and served a 404. Redirects without encoded characters (e.g. a plain `.pdf` path) were unaffected, which is why the bug only showed up for `%20` sources.

Closes ISOM-2358.

## Solution

Percent-decode the source when building the S3 key in `tooling/build/scripts/publishing/uploadRedirects.ts`, so the object is keyed by the same decoded path CloudFront fetches. The database `source` still keeps its `%20` (the browser-URL form) — only the S3 key is decoded, matching the intended design.

The existing control-character, backslash, and path-traversal checks now run on the **decoded** value, so decoding cannot smuggle anything past them; this also closed two latent holes (encoded `%2e%2e` traversal and encoded `%00` control chars). Malformed percent-encoding (e.g. a lone `%`) is rejected rather than uploaded to a key no request can reach.

`normalizeSource` is now exported and `main()` is guarded to run only on direct execution, so the function can be unit-tested without executing the upload script on import. The sole production caller (`publisher.sh` → `tsx uploadRedirects.ts`) is unaffected.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Redirect sources containing percent-encoded characters (e.g. `%20`) now resolve correctly on the published site instead of 404-ing, because the S3 key is written in the decoded form CloudFront requests.
- Encoded path-traversal (`%2e%2e`), encoded control characters (`%00`), and malformed percent-encoding in a redirect source are now rejected during upload.

## Tests

Added `tooling/build/scripts/publishing/tests/uploadRedirects.test.ts` covering `normalizeSource`: `%20` and general percent-decoding, already-decoded paths, slash trimming/collapsing, and rejection of encoded traversal, encoded control chars, and malformed encoding. Verified the suite fails against the pre-fix code and passes with the fix.

**Manual Verification Steps**:

- [ ] In Studio, open a site's **Settings → Redirects** and add a redirect with an encoded space in the source, e.g. source `/files/test-redirect%20page.pdf`, destination `/` (or any valid page).
- [ ] Publish the site and wait for the build to complete.
- [ ] Visit the source path on the live site, e.g. `https://<site-domain>/files/test-redirect%20page.pdf` — confirm it returns a **301** to the destination (before this fix it returned a 404).
- [ ] (Optional) Confirm the published S3 object key for the redirect contains a literal space rather than `%20`.
- [ ] Confirm an existing redirect with no encoded characters still redirects correctly (no regression).

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes redirect publishing for percent-encoded source paths. The main changes are:

- Decode redirect `source` values before building S3 redirect object keys.
- Run control-character, backslash, and path-traversal checks on the decoded source.
- Reject malformed percent-encoding instead of uploading unreachable redirect keys.
- Export `normalizeSource` and guard script execution so the function can be unit-tested.
- Add unit tests for decoding, slash normalization, and unsafe encoded inputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low implementation risk.

The change is narrowly scoped to redirect source normalization during publishing. Decoded values are validated before upload, and focused tests cover the reported bug and unsafe encoded inputs.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The uploadRedirects test suite was executed with the exact command and working directory recorded in the log, including verbose per-test output.
- All seven normalizeSource test cases under tests/uploadRedirects.test.ts passed.
- The run completed with an EXIT\_CODE of 0, indicating success.
- A Vitest unresolved-import warning was emitted for vitest/config, but it did not block execution and the tests finished successfully.

<a href="https://app.greptile.com/trex/runs/14337159/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publishing/uploadRedirects.ts | Exports and updates `normalizeSource` to decode redirect sources before validation and S3 key construction. |
| tooling/build/scripts/publishing/tests/uploadRedirects.test.ts | Adds unit coverage for decoded redirect keys, existing normalization behavior, and rejected unsafe encoded sources. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant JSON as Redirects JSON
participant Script as uploadRedirects.ts
participant Norm as normalizeSource
participant S3 as S3 redirect object
participant CF as CloudFront

JSON->>Script: source with percent-encoding
Script->>Norm: normalizeSource(source)
Norm->>Norm: decodeURIComponent(source)
Norm->>Norm: validate decoded control chars / traversal
Norm-->>Script: decoded S3 key segment or null
Script->>S3: "upload latest/{decoded source}/index.html"
CF->>S3: fetch decoded request path/index.html
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant JSON as Redirects JSON
participant Script as uploadRedirects.ts
participant Norm as normalizeSource
participant S3 as S3 redirect object
participant CF as CloudFront

JSON->>Script: source with percent-encoding
Script->>Norm: normalizeSource(source)
Norm->>Norm: decodeURIComponent(source)
Norm->>Norm: validate decoded control chars / traversal
Norm-->>Script: decoded S3 key segment or null
Script->>S3: "upload latest/{decoded source}/index.html"
CF->>S3: fetch decoded request path/index.html
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(publishing): percent-decode redirect..."](https://github.com/opengovsg/isomer/commit/e2c8b82015216dfd38e7b845c569b25ef6a3c961) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44025472)</sub>

<!-- /greptile_comment -->