### PR TITLE
chore(deploy): remove Intercom app id from staging deploy

### DIFF
--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -44,3 +44,9 @@ jobs:
       app-s3-assets-bucket-name: "isomer-next-infra-stg-assets-private-b18ec1f"
       app-s3-assets-domain-name: "isomer-user-content-stg.by.gov.sg"
       app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
+      # NOTE: app-intercom-app-id is intentionally omitted here. Staging is
+      # used for internal self-testing, and booting Intercom with the same
+      # app id as production/UAT would pollute their data with test traffic.
+      # Leaving this unset makes NEXT_PUBLIC_INTERCOM_APP_ID empty on staging,
+      # which the Intercom wrapper (apps/studio/src/lib/intercom.ts) treats
+      # as "not configured" and logs to the console instead.

--- a/.github/workflows/deploy_staging.yml
+++ b/.github/workflows/deploy_staging.yml
@@ -44,4 +44,3 @@ jobs:
       app-s3-assets-bucket-name: "isomer-next-infra-stg-assets-private-b18ec1f"
       app-s3-assets-domain-name: "isomer-user-content-stg.by.gov.sg"
       app-growthbook-client-key: "sdk-x4jkIJGr4TizR8qK"
-      app-intercom-app-id: "jv2tjc3g"


### PR DESCRIPTION
## Problem

Staging currently boots Intercom with the same app id as production and UAT. Staging is used for internal self-testing, so this pollutes production/UAT Intercom data with test traffic (dogfooding events, surveys, etc. from staff testing, not real users).

## Solution

Removes the `app-intercom-app-id` input from `.github/workflows/deploy_staging.yml`. This input is `required: false` in the shared `aws_deploy.yml` workflow, so omitting it simply builds staging with `NEXT_PUBLIC_INTERCOM_APP_ID` empty — which the app's Intercom wrapper (see companion PR "feat(intercom): fall back to console.log when app id is absent") already treats as "Intercom not configured."

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Staging deploys no longer boot Intercom or fire real Intercom events/surveys, so production/UAT data is no longer polluted by internal self-testing on staging.

**Bug Fixes**:

- None

## Tests

CI/CD config-only change — no production code behavior changes in this PR by itself.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the staging deployment so Intercom is not configured there. The main changes are:

- Removes the `app-intercom-app-id` input from `.github/workflows/deploy_staging.yml`.
- Leaves `NEXT_PUBLIC_INTERCOM_APP_ID` empty during staging builds.
- Documents that staging should not send Intercom events to the shared production/UAT app.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to one staging workflow input. The shared deploy workflow marks the Intercom app id optional. The app checks `NEXT_PUBLIC_INTERCOM_APP_ID` before booting or firing Intercom events.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The validator reviewed deploy\_staging.yml, aws\_deploy.yml, and the Docker build-arg mappings to app-intercom-app-id, confirming that deploy\_staging.yml omits a concrete app-id input while aws\_deploy.yml marks app-intercom-app-id as optional and of type string, and both Docker build-arg blocks map NEXT\_PUBLIC\_INTERCOM\_APP\_ID to inputs.app-intercom-app-id.
- pnpm exec sherif was run to validate the contract; the results are captured in the log.

<a href="https://app.greptile.com/trex/runs/14363022/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy_staging.yml | Removes the optional staging Intercom app id input so staging builds with an empty `NEXT_PUBLIC_INTERCOM_APP_ID`; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(deploy): explain why staging omits ..."](https://github.com/opengovsg/isomer/commit/9746a37f68ee4f704993b23edd74fd81d3d4ec6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44082450)</sub>

<!-- /greptile_comment -->