### PR TITLE
feat(intercom): fall back to console.log when app id is absent

### DIFF
--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -58,6 +58,10 @@
                   "FormHelperText"
                 ],
                 "message": "Please use FormLabel, FormErrorMessage, and FormHelperText from @opengovsg/design-system-react instead."
+              },
+              {
+                "name": "@intercom/messenger-js-sdk",
+                "message": "Use `~/lib/intercom` instead so calls fall back to a console.log when NEXT_PUBLIC_INTERCOM_APP_ID is absent (e.g. on staging)."
               }
             ]
           }
@@ -74,6 +78,12 @@
         "node/no-process-env": "off"
       },
       "plugins": ["node"]
+    },
+    {
+      "files": ["src/lib/intercom.ts"],
+      "rules": {
+        "no-restricted-imports": "off"
+      }
     },
     {
       "files": [

--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -82,7 +82,32 @@
     {
       "files": ["src/lib/intercom.ts"],
       "rules": {
-        "no-restricted-imports": "off"
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "process",
+                "importNames": ["env"],
+                "message": "Use `import { env } from '~/env'` instead to ensure validated types."
+              },
+              {
+                "name": "@chakra-ui/react",
+                "importNames": ["useToast"],
+                "message": "Please use useToast from @opengovsg/design-system-react instead."
+              },
+              {
+                "name": "@chakra-ui/react",
+                "importNames": [
+                  "FormLabel",
+                  "FormErrorMessage",
+                  "FormHelperText"
+                ],
+                "message": "Please use FormLabel, FormErrorMessage, and FormHelperText from @opengovsg/design-system-react instead."
+              }
+            ]
+          }
+        ]
       }
     },
     {

--- a/apps/studio/.oxlintrc.json
+++ b/apps/studio/.oxlintrc.json
@@ -80,37 +80,6 @@
       "plugins": ["node"]
     },
     {
-      "files": ["src/lib/intercom.ts"],
-      "rules": {
-        "no-restricted-imports": [
-          "error",
-          {
-            "paths": [
-              {
-                "name": "process",
-                "importNames": ["env"],
-                "message": "Use `import { env } from '~/env'` instead to ensure validated types."
-              },
-              {
-                "name": "@chakra-ui/react",
-                "importNames": ["useToast"],
-                "message": "Please use useToast from @opengovsg/design-system-react instead."
-              },
-              {
-                "name": "@chakra-ui/react",
-                "importNames": [
-                  "FormLabel",
-                  "FormErrorMessage",
-                  "FormHelperText"
-                ],
-                "message": "Please use FormLabel, FormErrorMessage, and FormHelperText from @opengovsg/design-system-react instead."
-              }
-            ]
-          }
-        ]
-      }
-    },
-    {
       "files": [
         "playwright.config.ts",
         "vitest.config.ts",

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -16,7 +16,7 @@ export const Intercom = () => {
       email: me.email,
       created_at: convertDateToUnixTimestamp(me.createdAt),
     })
-  }, [me.id, me.email, me.name, me.createdAt])
+  }, [me])
 
   return <></>
 }

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -1,7 +1,6 @@
-import { Intercom as IntercomSDK } from "@intercom/messenger-js-sdk"
 import { useCallback } from "react"
-import { env } from "~/env.mjs"
 import { useMe } from "~/features/me/api"
+import { bootIntercom } from "~/lib/intercom"
 
 const convertDateToUnixTimestamp = (date: Date): number => {
   return Math.floor(date.getTime() / 1000)
@@ -14,15 +13,12 @@ export const Intercom = () => {
     return me.name || me.email.split("@")[0]
   }, [me])
 
-  if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-    IntercomSDK({
-      app_id: env.NEXT_PUBLIC_INTERCOM_APP_ID,
-      user_id: me.id,
-      name: getIntercomName(),
-      email: me.email,
-      created_at: convertDateToUnixTimestamp(me.createdAt),
-    })
-  }
+  bootIntercom({
+    user_id: me.id,
+    name: getIntercomName(),
+    email: me.email,
+    created_at: convertDateToUnixTimestamp(me.createdAt),
+  })
 
   return <></>
 }

--- a/apps/studio/src/components/Intercom.tsx
+++ b/apps/studio/src/components/Intercom.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react"
+import { useEffect } from "react"
 import { useMe } from "~/features/me/api"
 import { bootIntercom } from "~/lib/intercom"
 
@@ -9,16 +9,14 @@ const convertDateToUnixTimestamp = (date: Date): number => {
 export const Intercom = () => {
   const { me } = useMe()
 
-  const getIntercomName = useCallback(() => {
-    return me.name || me.email.split("@")[0]
-  }, [me])
-
-  bootIntercom({
-    user_id: me.id,
-    name: getIntercomName(),
-    email: me.email,
-    created_at: convertDateToUnixTimestamp(me.createdAt),
-  })
+  useEffect(() => {
+    bootIntercom({
+      user_id: me.id,
+      name: me.name || me.email.split("@")[0],
+      email: me.email,
+      created_at: convertDateToUnixTimestamp(me.createdAt),
+    })
+  }, [me.id, me.email, me.name, me.createdAt])
 
   return <></>
 }

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -4,7 +4,6 @@ import type {
 } from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Flex, Text, useDisclosure } from "@chakra-ui/react"
-import { trackEvent } from "@intercom/messenger-js-sdk"
 import { Button, Infobox, useToast } from "@opengovsg/design-system-react"
 import {
   getScopedSchema,
@@ -14,11 +13,10 @@ import { isEmpty, isEqual } from "lodash-es"
 import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import { env } from "~/env.mjs"
 import { useMe } from "~/features/me/api"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
+import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
 import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
@@ -118,11 +116,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
       {
         onSuccess: () => {
           setDrawerState({ state: "root" })
-          if (
-            env.NEXT_PUBLIC_INTERCOM_APP_ID &&
-            hadNoTagsBefore &&
-            hasTagsNow
-          ) {
+          if (hadNoTagsBefore && hasTagsNow) {
             trackEvent("first_tag_added")
             triggerCollectionTagCsatSurveyOnce({ userId: me.id })
           }

--- a/apps/studio/src/features/editing-experience/hooks/useContentEditSurvey.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useContentEditSurvey.ts
@@ -1,10 +1,9 @@
-import { trackEvent } from "@intercom/messenger-js-sdk"
 import { useStore } from "jotai"
 import { isEqual } from "lodash-es"
 import { useRouter } from "next/router"
 import { useCallback, useEffect, useRef } from "react"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import { env } from "~/env.mjs"
+import { trackEvent } from "~/lib/intercom"
 
 import type { ContentEditSurveyEvent } from "../constants"
 import { hasContentEditAtom } from "../atoms"
@@ -19,9 +18,7 @@ export const useFireContentEditSurveyEvent = (): ((
     (eventName: ContentEditSurveyEvent) => {
       if (!store.get(hasContentEditAtom)) return
       store.set(hasContentEditAtom, false)
-      if (env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-        trackEvent(eventName)
-      }
+      trackEvent(eventName)
     },
     [store],
   )

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -1,4 +1,29 @@
-import { startSurvey } from "@intercom/messenger-js-sdk"
+import {
+  Intercom as bootIntercomSdk,
+  startSurvey,
+  trackEvent as trackEventSdk,
+} from "@intercom/messenger-js-sdk"
+import { env } from "~/env.mjs"
+
+type BootIntercomProps = Omit<Parameters<typeof bootIntercomSdk>[0], "app_id">
+
+export const bootIntercom = (props: BootIntercomProps): void => {
+  if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+    console.log("[Intercom mock] bootIntercom", props)
+    return
+  }
+
+  bootIntercomSdk({ app_id: env.NEXT_PUBLIC_INTERCOM_APP_ID, ...props })
+}
+
+export const trackEvent = (eventName: string): void => {
+  if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+    console.log("[Intercom mock] trackEvent", eventName)
+    return
+  }
+
+  trackEventSdk(eventName)
+}
 
 interface TriggerSurveyOnceProps {
   surveyId: string
@@ -10,10 +35,14 @@ const triggerSurveyOnce = ({
   userId,
 }: TriggerSurveyOnceProps): void => {
   const key = `intercom_survey_${surveyId}_${userId}_shown`
-  if (!localStorage.getItem(key)) {
+  if (localStorage.getItem(key)) return
+
+  if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+    console.log("[Intercom mock] startSurvey", surveyId)
+  } else {
     startSurvey(surveyId)
-    localStorage.setItem(key, "1")
   }
+  localStorage.setItem(key, "1")
 }
 
 export const triggerCollectionTagCsatSurveyOnce = ({

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -1,3 +1,4 @@
+// oxlint-disable-next-line no-restricted-imports
 import {
   Intercom as bootIntercomSdk,
   startSurvey,


### PR DESCRIPTION
## Problem

All Intercom calls (boot, event tracking, survey triggers) were guarded ad hoc at each call site with `if (env.NEXT_PUBLIC_INTERCOM_APP_ID)`. When the app id is absent — e.g. on staging after the companion PR "chore(deploy): remove Intercom app id from staging deploy", or in local dev — those calls silently no-op, so there's no way to verify an event actually fired or a survey would have triggered.

## Solution

Consolidates every Intercom SDK call behind `apps/studio/src/lib/intercom.ts`:

- `bootIntercom(...)` wraps the SDK's boot call
- `trackEvent(...)` wraps event tracking
- `triggerCollectionTagCsatSurveyOnce(...)` wraps the CSAT survey trigger (unchanged public API)

Each function checks `NEXT_PUBLIC_INTERCOM_APP_ID` internally. When it's present, the real SDK call is made as before. When it's absent, the call logs `console.log("[Intercom mock] <call>", payload)` to the browser console instead, so testers can verify in devtools that the right event/survey would have fired.

Call sites (`Intercom.tsx`, `useContentEditSurvey.ts`, `CollectionEditorStateDrawer.tsx`) now call these wrappers unconditionally instead of duplicating the env-var guard.

An `.oxlintrc.json` `no-restricted-imports` rule blocks importing `@intercom/messenger-js-sdk` directly anywhere except `lib/intercom.ts`, so future code can't bypass the fallback.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Intercom boot, event tracking, and survey triggers now log a visible, verifiable message in the browser console whenever `NEXT_PUBLIC_INTERCOM_APP_ID` is unset, instead of silently no-oping.
- A lint rule prevents future code from importing the Intercom SDK directly and bypassing the fallback.

**Bug Fixes**:

- None

## Tests

**Manual Verification Steps**:

- [ ] With `NEXT_PUBLIC_INTERCOM_APP_ID` unset locally (or on a deploy without it, e.g. staging), log in to Studio, open the browser devtools console, and confirm `[Intercom mock] bootIntercom {...}` is logged on page load instead of the Intercom messenger widget appearing.
- [ ] Edit a page's content, then navigate away from the editor — confirm the console logs `[Intercom mock] trackEvent left-editor-after-editing`.
- [ ] On a Collection page, add its first tag and save changes — confirm the console logs both `[Intercom mock] trackEvent first_tag_added` and `[Intercom mock] startSurvey 65029624` (clear the `intercom_survey_65029624_<userId>_shown` localStorage key first if it was already set from a previous test run).
- [ ] With `NEXT_PUBLIC_INTERCOM_APP_ID` set to a real app id, repeat the steps above and confirm the real Intercom messenger boots and no `[Intercom mock]` logs appear — behavior is unchanged from before this PR.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes Studio’s Intercom calls behind a shared wrapper. The main changes are:

- Adds `~/lib/intercom` wrappers for boot, event tracking, and one-shot survey triggers.
- Falls back to `[Intercom mock]` browser console logs when `NEXT_PUBLIC_INTERCOM_APP_ID` is unset.
- Updates Studio call sites to use the wrapper without local app-id guards.
- Adds an Oxlint restricted import rule to prevent direct Intercom SDK imports.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is small, client-side, and preserves the existing SDK path when an app id is configured. The absent-app-id path now logs the same call intent instead of silently skipping it. No functional or security bugs were identified.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Intercom fallback general contract validation tests and confirmed all tests passed.
- Compared the before-state log with a real app id against the after-state log with the app id unset to verify the TREX\_BEFORE and TREX\_AFTER sequences.
- Verified that the SDK boot function was not called with an app id in the after-state.

<a href="https://app.greptile.com/trex/runs/15187341/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/lib/intercom.ts | Centralizes Intercom boot, event tracking, and one-shot survey behavior with console-log fallbacks when no app id is configured. |
| apps/studio/src/components/Intercom.tsx | Moves Intercom booting through the shared wrapper and triggers it from an effect tied to the current user data. |
| apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx | Routes first-tag Intercom tracking and CSAT survey triggering through the shared wrapper without duplicating environment checks. |
| apps/studio/src/features/editing-experience/hooks/useContentEditSurvey.ts | Routes content-edit survey event tracking through the shared wrapper after the existing edit-state gate. |
| apps/studio/.oxlintrc.json | Adds a restricted import entry requiring Intercom SDK usage to go through the local wrapper. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant UI as Studio call sites
participant Wrapper as ~/lib/intercom
participant Env as NEXT_PUBLIC_INTERCOM_APP_ID
participant SDK as Intercom SDK
participant Console as Browser console

UI->>Wrapper: bootIntercom / trackEvent / triggerSurveyOnce
Wrapper->>Env: Check app id
alt App id configured
    Wrapper->>SDK: Call real Intercom SDK
else App id absent
    Wrapper->>Console: Log [Intercom mock] message
end
opt Survey trigger
    Wrapper->>Wrapper: Store localStorage shown key
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant UI as Studio call sites
participant Wrapper as ~/lib/intercom
participant Env as NEXT_PUBLIC_INTERCOM_APP_ID
participant SDK as Intercom SDK
participant Console as Browser console

UI->>Wrapper: bootIntercom / trackEvent / triggerSurveyOnce
Wrapper->>Env: Check app id
alt App id configured
    Wrapper->>SDK: Call real Intercom SDK
else App id absent
    Wrapper->>Console: Log [Intercom mock] message
end
opt Survey trigger
    Wrapper->>Wrapper: Store localStorage shown key
end
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(intercom): address human review nits..."](https://github.com/opengovsg/isomer/commit/16ad9434e66be20cd5f9d0273560399920446fd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44083050)</sub>

<!-- /greptile_comment -->