### PR TITLE
fix(gazette): avoid tombstoning live file when re-upload lands on the same S3 key

### DIFF
--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -445,6 +445,10 @@ describe("gazette.router", async () => {
         scheduledAt: PAST_DATE,
       })
 
+      const markFileAsDeleted = vi
+        .spyOn(gazetteService, "markFileAsDeleted")
+        .mockResolvedValue(undefined)
+
       // Act
       await caller.update({
         siteId: site.id,
@@ -486,6 +490,60 @@ describe("gazette.router", async () => {
       expect(page?.category).toBe("Other Supplements")
       expect(page?.description).toBe("new-desc")
       expect(page?.tagged).toEqual(["sub-2"])
+
+      // The superseded file (a different key) is soft-deleted after commit.
+      expect(markFileAsDeleted).toHaveBeenCalledExactlyOnceWith({
+        key: "1/abc/notice.pdf",
+      })
+    })
+
+    it("does not soft-delete the S3 object when the new ref matches the existing ref", async () => {
+      // Arrange: S3 keys are deterministic (year/category/subcategory/filename),
+      // so re-uploading a replacement file without changing its metadata lands
+      // on the SAME key — cleanup must be skipped or it tombstones the live file.
+      const { site, collection } = await seedToppanWithCollection()
+      const { gazetteId } = await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "Original",
+        permalink: crypto.randomUUID(),
+        ref: "/2026/Government Gazette/sub-1/notice.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+      const markFileAsDeleted = vi
+        .spyOn(gazetteService, "markFileAsDeleted")
+        .mockResolvedValue(undefined)
+
+      // Act: re-upload to the same key
+      await caller.update({
+        siteId: site.id,
+        gazetteId: Number(gazetteId),
+        title: "Original",
+        newRef: "/2026/Government Gazette/sub-1/notice.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+
+      // Assert: the gazette still points at the ref, and it was never tombstoned
+      expect(markFileAsDeleted).not.toHaveBeenCalled()
+      const resource = await db
+        .selectFrom("Resource")
+        .where("id", "=", String(gazetteId))
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      const blob = await db
+        .selectFrom("Blob")
+        .where("id", "=", resource.draftBlobId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(
+        (blob.content as { page?: { ref?: string } } | null)?.page?.ref,
+      ).toBe("/2026/Government Gazette/sub-1/notice.pdf")
     })
 
     it("accepts a past scheduledAt on update (mirrors create's contract)", async () => {

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -445,7 +445,12 @@ export const gazetteRouter = router({
         if (newRef) {
           newFilename = newRef.split("/").pop()
           finalRef = newRef
-          if (existingRef) oldRefToCleanUp = existingRef.replace(/^\//, "")
+          // S3 keys are deterministic (year/category/subcategory/filename), so
+          // a re-upload that keeps the same metadata lands on the SAME key as
+          // the existing ref — cleaning up would tombstone the live file.
+          if (existingRef && existingRef !== newRef) {
+            oldRefToCleanUp = existingRef.replace(/^\//, "")
+          }
         } else if (
           desiredFileName &&
           existingRef &&


### PR DESCRIPTION
## Problem

When editing a gazette, uploading a replacement file (`newRef`) causes the router to soft-delete (tombstone) the old S3 object after the DB transaction commits. However, gazette S3 keys are deterministic — built from `year/category/subcategory/filename` — so re-uploading a file **without changing any of its metadata** lands on the exact same key as the existing ref. The cleanup step then tombstones the very key the gazette now points at, deleting the live file the user just uploaded.

## Solution

Only schedule the old ref for cleanup when the key actually changed (`existingRef !== newRef`). When a re-upload lands on the same key, the object has simply been overwritten in place and there is nothing to clean up.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- `gazette.update`: skip soft-deleting the previous S3 object when the newly uploaded ref resolves to the same key as the existing ref, so a same-metadata re-upload no longer tombstones the live file. A comment documents why the guard exists (deterministic S3 keys).

## Before & After Screenshots

**BEFORE**:

N/A — backend-only change.

**AFTER**:

N/A — backend-only change.

## Tests

- `pnpm test:unit -- src/server/modules/gazette/__tests__/gazette.router.test.ts`
  - New test: `does not soft-delete the S3 object when the new ref matches the existing ref` — re-uploads to the same key and asserts `markFileAsDeleted` is never called while the gazette still points at the ref.
  - Existing key-change test now also asserts `markFileAsDeleted` is called exactly once with the superseded key.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the gazette file cleanup path for replacement uploads. The main changes are:

- Skips soft-deleting the old S3 object when `newRef` is the same as the existing ref.
- Keeps the existing soft-delete behavior when the replacement upload uses a different S3 key.
- Adds tests for both changed-key cleanup and same-key re-upload preservation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to the gazette cleanup guard and matches the same-key re-upload failure mode. Existing cleanup behavior for changed keys is preserved. Tests cover both the skipped-cleanup path and the superseded-key cleanup path.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof that documents the three log artifacts and their roles in validating command execution, test invocation, and Docker runtime checks.
- Verified Gazette-router-unit-01-exact.log shows the exact requested command and the root-level test:unit not-found result.
- Verified Gazette-router-unit-02-filter.log shows the isomer-studio Vitest invocation and the Testcontainers runtime failure.
- Verified Gazette-router-unit-03-runtime-check.log shows the missing Docker runtime check.

<a href="https://app.greptile.com/trex/runs/14372010/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/gazette/gazette.router.ts | Adds a guard so `gazette.update` only soft-deletes the previous S3 key when the replacement ref differs from the existing ref; no issues found. |
| apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts | Extends update tests to cover both superseded-key cleanup and same-key re-upload behavior; no issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Router as gazette.update
participant DB
participant S3 as S3 cleanup

User->>Router: Submit update with newRef
Router->>DB: Read existing gazette blob ref
alt newRef equals existingRef
    Router->>DB: Commit updated gazette pointing to same ref
    Router-->>S3: Skip markFileAsDeleted
else newRef differs from existingRef
    Router->>DB: Commit updated gazette pointing to newRef
    Router->>S3: markFileAsDeleted(old key)
end
Router-->>User: Return gazetteId
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Router as gazette.update
participant DB
participant S3 as S3 cleanup

User->>Router: Submit update with newRef
Router->>DB: Read existing gazette blob ref
alt newRef equals existingRef
    Router->>DB: Commit updated gazette pointing to same ref
    Router-->>S3: Skip markFileAsDeleted
else newRef differs from existingRef
    Router->>DB: Commit updated gazette pointing to newRef
    Router->>S3: markFileAsDeleted(old key)
end
Router-->>User: Return gazetteId
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: avoid tombstoning when same key"](https://github.com/opengovsg/isomer/commit/38823795098ee4a02b2c5c347db55ccb64338034) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44098798)</sub>

<!-- /greptile_comment -->