### PR TITLE
fix(components): drop unused display from collection Filter data

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getTagFilters.test.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/__tests__/getTagFilters.test.ts
@@ -35,7 +35,6 @@ describe("getTagFilters", () => {
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [
           { id: "Brain", label: "Brain", count: 2 },
           { id: "Heart", label: "Heart", count: 1 },
@@ -44,7 +43,6 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [
           { id: "Acute", label: "Acute", count: 1 },
           { id: "Chronic", label: "Chronic", count: 1 },
@@ -89,13 +87,11 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [{ id: "Acute", label: "Acute", count: 1 }],
       },
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [{ id: "Brain", label: "Brain", count: 1 }],
       },
     ])
@@ -152,7 +148,6 @@ describe("getTagFilters", () => {
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [
           { id: "Arm", label: "Arm", count: 1 }, // Unlisted; comes first
           { id: "Heart", label: "Heart", count: 1 },
@@ -162,7 +157,6 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [
           { id: "Chronic", label: "Chronic", count: 1 },
           { id: "Acute", label: "Acute", count: 1 },
@@ -199,7 +193,6 @@ describe("getTagFilters", () => {
       {
         id: "Fruits",
         label: "Fruits",
-        display: "pills",
         items: [
           { id: "Banana", label: "Banana", count: 2 },
           { id: "Apple", label: "Apple", count: 1 },
@@ -288,13 +281,11 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [{ id: "Acute", label: "Acute", count: 1 }],
       },
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [
           { id: "Heart", label: "Heart", count: 1 },
           { id: "Brain", label: "Brain", count: 1 },
@@ -303,7 +294,6 @@ describe("getTagFilters", () => {
       {
         id: "Color",
         label: "Color",
-        display: "pills",
         items: [
           { id: "Red", label: "Red", count: 1 },
           { id: "Blue", label: "Blue", count: 1 },
@@ -351,13 +341,11 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [{ id: "Acute", label: "Acute", count: 1 }], // Unlisted item appears first
       },
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [
           { id: "Heart", label: "Heart", count: 1 },
           { id: "Brain", label: "Brain", count: 1 },
@@ -403,7 +391,6 @@ describe("getTagFilters", () => {
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [
           { id: "Brain", label: "Brain", count: 2 }, // Appears in 2 items
           { id: "Heart", label: "Heart", count: 2 }, // Appears in 2 items
@@ -412,7 +399,6 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [
           { id: "Acute", label: "Acute", count: 3 }, // Appears in 3 items
           { id: "Chronic", label: "Chronic", count: 1 }, // Appears in 1 item
@@ -477,7 +463,6 @@ describe("getTagFilters", () => {
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [{ id: "Brain", label: "Brain", count: 1 }],
       },
     ])
@@ -518,7 +503,6 @@ describe("getTagFilters", () => {
       {
         id: "Body parts",
         label: "Body parts",
-        display: "pills",
         items: [
           { id: "Heart", label: "Heart", count: 1 },
           { id: "Brain", label: "Brain", count: 1 },
@@ -527,13 +511,11 @@ describe("getTagFilters", () => {
       {
         id: "Condition",
         label: "Condition",
-        display: "pills",
         items: [{ id: "Acute", label: "Acute", count: 1 }],
       },
       {
         id: "Color",
         label: "Color",
-        display: "pills",
         items: [{ id: "Red", label: "Red", count: 1 }],
       },
     ])

--- a/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
@@ -1,6 +1,5 @@
 import type { ProcessedCollectionCardProps } from "~/interfaces"
 import type { CollectionPageSchemaType } from "~/types"
-import { resolveTagCategoryDisplay } from "~/types/constants"
 
 import type { Filter, FilterItem } from "../../../types/Filter"
 
@@ -12,6 +11,10 @@ export const getTagFilters = (
   // associated set of values as well as the selected value.
   // Hence, we store a map here of the category (eg: Body parts)
   // to the number of occurences of each value (eg: { Brain: 3, Leg: 2 })
+  //
+  // NOTE: Tag category `display` (pills vs plaintext) is not attached to
+  // Filter objects. The sidebar always uses checkboxes; `display` is consumed
+  // by card/article tag rendering (PillTags / PlaintextTags) from tagCategories.
   const tagCategoryLabels = new Map<string, Map<string, number>>()
 
   items.forEach(({ tags }) => {
@@ -41,17 +44,12 @@ export const getTagFilters = (
         }),
       )
 
-      const matchedCategory = tagCategories?.find(
-        (tagCategory) => tagCategory.label === category,
-      )
-
       const filters: Filter[] = [
         ...acc,
         {
           items,
           id: category,
           label: category,
-          display: resolveTagCategoryDisplay(matchedCategory?.display),
         },
       ]
 

--- a/packages/components/src/templates/next/types/Filter.ts
+++ b/packages/components/src/templates/next/types/Filter.ts
@@ -1,4 +1,3 @@
-import type { TagCategoryDisplay } from "~/types/constants"
 import { z } from "zod"
 
 export interface FilterItem {
@@ -11,8 +10,6 @@ export interface Filter {
   id: string
   label: string
   items: FilterItem[]
-  // NOTE: only set for tag-category filters; category/year filters omit this.
-  display?: TagCategoryDisplay
 }
 
 interface AppliedFilterItem {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves the Greptile review on #2703 that asked `Filter`/`FilterDrawer` to consume tag category `display`.

**That finding is incorrect.** `display: "pills" | "plaintext"` controls how tags render on collection cards / article headers (`PillTags` / `PlaintextTags`), not how the filter sidebar looks. The sidebar always uses checkboxes. Real consumption lands in stacked #2683 via `getPillAndPlaintextTags` reading `tagCategories` directly.

Attaching `display` to `Filter` in `getTagFilters` was a dead field that made Greptile expect Filter UI branching. This PR removes it so the data model matches the actual consumer.

## Changes

- Remove optional `display` from the `Filter` type
- Stop resolving/attaching `display` in `getTagFilters`
- Drop expected `display` from `getTagFilters` unit assertions (fixture `tagCategories.display` unchanged)

## Test plan

- [x] `getTagFilters` unit tests pass (11/11)
- [ ] Confirm #2683 still owns pills/plaintext card rendering and does not rely on `Filter.display`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ccef608-3e6b-4504-bd2b-31e787771885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ccef608-3e6b-4504-bd2b-31e787771885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes unused display data from collection filters. The main changes are:

- Drops `display` from the `Filter` type.
- Stops attaching tag category `display` in `getTagFilters`.
- Updates `getTagFilters` tests to assert the narrower filter shape.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is small and matches the current filter UI consumers, which only read filter ids, labels, items, and counts.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran unit tests with Vitest in the components package; one test file passed and eleven tests passed; exit code 0.
- Reviewed the ownership evidence for getTagFilters, confirming that the tag category display is not attached to Filter objects, Filter.ts has no display field, and fixtures still include tagCategories.display.

<a href="https://app.greptile.com/trex/runs/14377578/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts | Removes unused tag category display resolution from generated filter data while preserving grouping and ordering behavior. |
| packages/components/src/templates/next/types/Filter.ts | Narrows the `Filter` interface by dropping the unused optional `display` field. |
| packages/components/src/templates/next/layouts/Collection/utils/__tests__/getTagFilters.test.ts | Updates `getTagFilters` expectations to match the narrower `Filter` shape while keeping tag category display fixture data as input. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(components): drop unused display fro..."](https://github.com/opengovsg/isomer/commit/b67831d3932379ce2cd357a35956d4c4940c760a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44109851)</sub>

<!-- /greptile_comment -->