### PR TITLE
fix: apply oxfmt 0.58.0 formatting

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -41,17 +41,18 @@ tRPC context (`src/server/context.ts`) includes: `session`, Prisma client, Kysel
 **Schema**: `prisma/schema.prisma` (PostgreSQL via Neon)
 
 Core models:
-| Model | Purpose |
-|-------|---------|
-| `Resource` | All site content — pages, folders, collections. Hierarchical via `parentId`. |
-| `Blob` | JSON content storage (draft blobs) |
-| `Version` | Published snapshots of a resource (immutable) |
-| `Site` | Website config and theme (stored as JSON) |
-| `User` | Accounts — soft-deleted via `deletedAt` |
-| `ResourcePermission` | CASL-based RBAC: Admin / Editor / Publisher roles |
-| `IsomerAdmin` | Platform-level admins with expiry |
-| `AuditLog` | Append-only audit trail with before/after deltas |
-| `CodeBuildJobs` | Build/deploy job tracking |
+
+| Model                | Purpose                                                                      |
+| -------------------- | ---------------------------------------------------------------------------- |
+| `Resource`           | All site content — pages, folders, collections. Hierarchical via `parentId`. |
+| `Blob`               | JSON content storage (draft blobs)                                           |
+| `Version`            | Published snapshots of a resource (immutable)                                |
+| `Site`               | Website config and theme (stored as JSON)                                    |
+| `User`               | Accounts — soft-deleted via `deletedAt`                                      |
+| `ResourcePermission` | CASL-based RBAC: Admin / Editor / Publisher roles                            |
+| `IsomerAdmin`        | Platform-level admins with expiry                                            |
+| `AuditLog`           | Append-only audit trail with before/after deltas                             |
+| `CodeBuildJobs`      | Build/deploy job tracking                                                    |
 
 **Draft-publish model**: A `Resource` has a draft `Blob` for in-progress edits. Publishing creates a new `Version` pointing to a frozen `Blob`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Runs `pnpm format:fix` against the oxfmt 0.58.0 bump
- Reformats the Core models markdown table in `apps/studio/README.md` so format CI passes

## Test plan
- [x] `pnpm format` passes locally
- [ ] Confirm format check CI is green on this branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39b21575-475c-4066-aa50-b04518fdf7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39b21575-475c-4066-aa50-b04518fdf7e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR reformats the Studio README for `oxfmt` compatibility. The main changes are:

- Normalized spacing in the Core models Markdown table.
- Added the blank line before the table expected by the formatter.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to Markdown formatting in `apps/studio/README.md` and does not affect code, configuration, runtime behavior, security, or data models.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the general contract validation proof to verify code formatting; the PNPM format log shows isomer-studio:format: All matched files use the correct format, and the run completed with 12 successful tasks out of 12 in 29.168 seconds with exit code 0.

<a href="https://app.greptile.com/trex/runs/14412586/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/README.md | Markdown-only formatting update to the Core models table; no runtime or documentation-content issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: apply oxfmt 0.58.0 formatting to st..."](https://github.com/opengovsg/isomer/commit/0f34d7dd7e3f3476087cb37ebc78e535e74add80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44183054)</sub>

<!-- /greptile_comment -->