### PR TITLE
fix(rte-table): stop TableCaption jumping on focus/blur

### DIFF
--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
@@ -36,9 +36,7 @@ const CounterText = ({ length }: { length: number }) => {
     <Text
       as="span"
       fontSize="xs"
-      color={
-        isAtLimit ? "utility.feedback.critical" : "base.content.medium"
-      }
+      color={isAtLimit ? "utility.feedback.critical" : "base.content.medium"}
       fontWeight={isAtLimit ? "semibold" : "normal"}
     >
       {length}/{CAPTION_MAX_LENGTH} characters
@@ -179,6 +177,12 @@ interface TableCaptionSlotProps extends SingleTableCaptionProps {
  * `IsomerTable` extension/CSS, so this stays scoped to this component and
  * doesn't affect tables anywhere else. The margin is restored on cleanup.
  *
+ * Caption `top` is the table's margin-edge (border-box top minus the margin
+ * currently on the table), not `borderBoxTop - newMargin`. That keeps the
+ * input line stable when the caption box grows/shrinks — e.g. when the
+ * character counter mounts on focus — instead of jumping the whole caption
+ * up and later dropping it into the table on blur.
+ *
  * Measurement happens in `useLayoutEffect`, not inline during render — doing
  * it in a plain `useMemo`/render body can capture an all-zero rect if the
  * browser hasn't flushed layout yet, and (since deps may not change again)
@@ -214,12 +218,18 @@ const TableCaptionSlot = ({
       // Caption box is always mounted (just hidden until positioned), so it
       // already has a real height on the first measurement.
       const captionHeight = captionRef.current?.offsetHeight ?? 0
+      // Peel off the margin we last wrote so the caption anchors to the
+      // margin-edge origin. Using the *new* reserved height here instead
+      // would jump the input up when the focus counter appears, and drop it
+      // into the table when the counter disappears.
+      const currentMarginTop = Number.parseFloat(tableDom.style.marginTop) || 0
       const { rect: next, marginTop } = computeCaptionLayout({
         tableRect: tableDom.getBoundingClientRect(),
         containerRect: container.getBoundingClientRect(),
         scrollTop: container.scrollTop,
         scrollLeft: container.scrollLeft,
         captionHeight,
+        currentMarginTop,
         gapPx: CAPTION_TABLE_GAP_PX,
       })
       tableDom.style.marginTop = `${marginTop}px`
@@ -294,8 +304,7 @@ const TableCaptionReady = ({
       tables: getTableInstances(currentEditor),
       doc: currentEditor.state.doc,
     }),
-    equalityFn: (previous, next) =>
-      next !== null && previous.doc === next.doc,
+    equalityFn: (previous, next) => next !== null && previous.doc === next.doc,
   })
 
   return (

--- a/apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts
@@ -35,21 +35,27 @@ describe("resolveCaptionOnBlur", () => {
 })
 
 describe("computeCaptionLayout", () => {
-  it("places the caption above the table, accounting container offset, scroll, height, and gap", () => {
+  it("places the caption at the margin edge in steady state", () => {
+    // Arrange: table already has the reserved margin matching caption + gap
+    const captionHeight = 24
+    const gapPx = 8
+    const currentMarginTop = captionHeight + gapPx
+
+    // Act
     const { rect, marginTop } = computeCaptionLayout({
       tableRect: { top: 200, left: 50, width: 400 },
       containerRect: { top: 100, left: 10 },
       scrollTop: 20,
       scrollLeft: 5,
-      captionHeight: 24,
-      gapPx: 8,
+      captionHeight,
+      currentMarginTop,
+      gapPx,
     })
 
-    // marginTop reserves caption height + gap on the table DOM node
-    expect(marginTop).toBe(24 + 8)
-    // top = (table.top - container.top) + scrollTop - marginTop
-    expect(rect.top).toBe(200 - 100 + 20 - 32)
-    // left = (table.left - container.left) + scrollLeft
+    // Assert
+    expect(marginTop).toBe(captionHeight + gapPx)
+    // top = (table.top - container.top) + scrollTop - currentMarginTop
+    expect(rect.top).toBe(200 - 100 + 20 - currentMarginTop)
     expect(rect.left).toBe(50 - 10 + 5)
     expect(rect.width).toBe(400)
   })
@@ -61,16 +67,95 @@ describe("computeCaptionLayout", () => {
       scrollTop: 0,
       scrollLeft: 0,
       captionHeight: 10,
+      currentMarginTop: 0,
     })
     expect(marginTop).toBe(10 + CAPTION_TABLE_GAP_PX)
+  })
+
+  it("keeps caption top stable when height grows (focus counter)", () => {
+    // Arrange: steady-state caption, then counter appears (height 24 → 44)
+    const gapPx = 8
+    const tableBorderTop = 200
+    const containerTop = 100
+    const scrollTop = 0
+    const unfocusedHeight = 24
+    const focusedHeight = 44
+    const currentMarginTop = unfocusedHeight + gapPx
+
+    const before = computeCaptionLayout({
+      tableRect: { top: tableBorderTop, left: 0, width: 400 },
+      containerRect: { top: containerTop, left: 0 },
+      scrollTop,
+      scrollLeft: 0,
+      captionHeight: unfocusedHeight,
+      currentMarginTop,
+      gapPx,
+    })
+
+    // Act: same table border-box (margin not yet updated), taller caption
+    const after = computeCaptionLayout({
+      tableRect: { top: tableBorderTop, left: 0, width: 400 },
+      containerRect: { top: containerTop, left: 0 },
+      scrollTop,
+      scrollLeft: 0,
+      captionHeight: focusedHeight,
+      currentMarginTop,
+      gapPx,
+    })
+
+    // Assert: input line must not jump up; only reserved margin grows
+    expect(after.rect.top).toBe(before.rect.top)
+    expect(after.marginTop).toBe(focusedHeight + gapPx)
+    expect(after.marginTop - before.marginTop).toBe(
+      focusedHeight - unfocusedHeight,
+    )
+  })
+
+  it("keeps caption top stable when height shrinks (blur counter)", () => {
+    // Arrange: focused caption with counter, then counter disappears (44 → 24)
+    const gapPx = 8
+    const tableBorderTop = 200
+    const containerTop = 100
+    const scrollTop = 0
+    const focusedHeight = 44
+    const unfocusedHeight = 24
+    const currentMarginTop = focusedHeight + gapPx
+
+    const before = computeCaptionLayout({
+      tableRect: { top: tableBorderTop, left: 0, width: 400 },
+      containerRect: { top: containerTop, left: 0 },
+      scrollTop,
+      scrollLeft: 0,
+      captionHeight: focusedHeight,
+      currentMarginTop,
+      gapPx,
+    })
+
+    // Act: same table border-box (margin not yet updated), shorter caption
+    const after = computeCaptionLayout({
+      tableRect: { top: tableBorderTop, left: 0, width: 400 },
+      containerRect: { top: containerTop, left: 0 },
+      scrollTop,
+      scrollLeft: 0,
+      captionHeight: unfocusedHeight,
+      currentMarginTop,
+      gapPx,
+    })
+
+    // Assert: caption must not drop into the table; top stays on margin edge
+    expect(after.rect.top).toBe(before.rect.top)
+    expect(after.marginTop).toBe(unfocusedHeight + gapPx)
+    // After applying the new (smaller) margin, table moves up by the delta;
+    // caption bottom + gap should still equal the new table border top.
+    const captionBottom = after.rect.top + unfocusedHeight
+    const newTableBorderTop = after.rect.top + after.marginTop // margin-edge + new margin
+    expect(newTableBorderTop - captionBottom).toBe(gapPx)
   })
 })
 
 describe("captionRectsEqual", () => {
   it("returns false when previous is null", () => {
-    expect(
-      captionRectsEqual(null, { top: 0, left: 0, width: 100 }),
-    ).toBe(false)
+    expect(captionRectsEqual(null, { top: 0, left: 0, width: 100 })).toBe(false)
   })
 
   it("returns true only when all fields match", () => {

--- a/apps/studio/src/features/editing-experience/components/TableCaption/utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/utils.ts
@@ -21,6 +21,14 @@ export interface ComputeCaptionLayoutParams {
   scrollTop: number
   scrollLeft: number
   captionHeight: number
+  /**
+   * The table's currently applied top margin in px. `tableRect.top` is the
+   * border-box top (so it already reflects this margin); subtracting it
+   * recovers the margin-edge origin. Pass the margin that is on the table
+   * *right now* — not the margin about to be written — otherwise the caption
+   * jumps whenever its height changes (e.g. the focus character counter).
+   */
+  currentMarginTop: number
   gapPx?: number
 }
 
@@ -108,6 +116,15 @@ export const resolveCaptionOnBlur = (
  *
  * Coordinates are container-relative, including scroll offsets, so the
  * caption stays aligned as the editor scrolls.
+ *
+ * The caption's `top` is the table's margin-edge (border-box top minus the
+ * margin currently applied). Anchoring there — instead of at
+ * `borderBoxTop - newMarginTop` — keeps the input line stable when the
+ * caption box grows or shrinks: extra height expands downward into the
+ * reserved margin, and the table's margin is resized to match. Using the
+ * new reserved height as the offset was the source of the "jumps up on
+ * focus / overlaps the table on blur" bug when the character counter
+ * toggled.
  */
 export const computeCaptionLayout = ({
   tableRect,
@@ -115,13 +132,16 @@ export const computeCaptionLayout = ({
   scrollTop,
   scrollLeft,
   captionHeight,
+  currentMarginTop,
   gapPx = CAPTION_TABLE_GAP_PX,
 }: ComputeCaptionLayoutParams): CaptionLayout => {
   const marginTop = captionHeight + gapPx
+  const marginEdgeTop =
+    tableRect.top - containerRect.top + scrollTop - currentMarginTop
   return {
     marginTop,
     rect: {
-      top: tableRect.top - containerRect.top + scrollTop - marginTop,
+      top: marginEdgeTop,
       left: tableRect.left - containerRect.left + scrollLeft,
       width: tableRect.width,
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the table caption “jumping” when focusing/blurring the inline caption input.

**Regression:** Introduced in `d28e33832` (extract `computeCaptionLayout`). Pre-extract measure order was:

1. set `marginTop` to the new caption height
2. *then* `getBoundingClientRect()` (rect already reflected the new margin)
3. `top = tableBorderTop − newHeight`

That worked. The extract reordered to measure → compute → apply, but still subtracted `newHeight` from a rect that still had the *old* margin — so when the focus counter mounted/unmounted, the input jumped up on focus and dropped into the table on blur.

**Fix:** Anchor to the table’s current margin-edge (`tableBorderTop − currentMarginTop`). Same geometric result as the pre-extract “set margin first” path, while keeping the pure measure-then-apply order. Height changes expand/shrink downward into the reserved margin; the input line stays put.

## Test plan

- [x] Unit tests for steady state + focus grow + blur shrink (`utils.test.ts`)
- [ ] Manually: click caption → input should not jump up; counter appears below
- [ ] Manually: blur/Enter → caption should not drop into the table
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4655168-5b8b-41a6-9b43-0150d4253e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4655168-5b8b-41a6-9b43-0150d4253e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the inline table caption position when the caption height changes. The main changes are:

- Pass the table's current top margin into the caption layout calculation.
- Anchor the caption to the table margin edge instead of the new reserved height.
- Add unit tests for steady state, focus growth, and blur shrink behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

No blocking issues found in the changed code.

No files need attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Studio startup log shows the startup command, working directory, exit code 1, and a Prisma datasource blocker preventing Studio from starting in this environment.
- The TableCaption utilities log confirms a fallback command was used and all 11 utility tests passed with exit code 0.
- The environment did not reach a product UI change scenario because the Studio editor could not execute the altered UI behavior in this environment.

<a href="https://app.greptile.com/trex/runs/14466658/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx | Reads the table's current inline margin before computing the caption layout. |
| apps/studio/src/features/editing-experience/components/TableCaption/utils.ts | Updates the caption geometry helper to use the current margin edge as the top anchor. |
| apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts | Adds focused layout tests for stable caption positioning across height changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rte-table): stop TableCaption jumpin..."](https://github.com/opengovsg/isomer/commit/0d66063455123e055bdea16e29528ad8bebe0c2f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44299355)</sub>

<!-- /greptile_comment -->