### PR TITLE
fix(components): sanitize link hrefs without truncating on unescaped quotes

### DIFF
--- a/packages/components/src/utils/__tests__/getReferenceLinkHref.test.ts
+++ b/packages/components/src/utils/__tests__/getReferenceLinkHref.test.ts
@@ -81,4 +81,16 @@ describe("getReferenceLinkHref", () => {
       "https://assets.example.com/1/dc2b609a-355e-406c-af6c-003683731e7e/RFP%20Template.docx",
     )
   })
+
+  it("should be able to handle unescaped quotes in reference link", () => {
+    const unescapedLink = 'https://example.com/unescaped""quotes'
+
+    const result = getReferenceLinkHref(
+      unescapedLink,
+      EXAMPLE_SITEMAP_ARRAY,
+      "https://assets.example.com",
+    )
+
+    expect(result).toBe(unescapedLink)
+  })
 })

--- a/packages/components/src/utils/getReferenceLinkHref.ts
+++ b/packages/components/src/utils/getReferenceLinkHref.ts
@@ -7,10 +7,18 @@ const getSanitizedLinkHref = (url?: string) => {
     return undefined
   }
 
-  const elem = DOMPurify.sanitize(`<a href="${url}"></a>`, {
-    RETURN_DOM_FRAGMENT: true,
-  })
-  const sanitizedUrl = elem.firstElementChild?.getAttribute("href")
+  // We use DOMPurify to create the document fragment as Node.js has no browser 'document' object.
+  const fragment = DOMPurify.sanitize("<a></a>", { RETURN_DOM_FRAGMENT: true })
+  const anchor = fragment.firstElementChild
+
+  if (!anchor) {
+    return undefined
+  }
+
+  anchor.setAttribute("href", url)
+  DOMPurify.sanitize(anchor, { IN_PLACE: true })
+
+  const sanitizedUrl = anchor.getAttribute("href")
 
   if (sanitizedUrl === null) {
     return undefined


### PR DESCRIPTION
Explainer doc: 
https://app.notion.com/p/opengov/ISOM-2315-Sanitizing-link-hrefs-without-truncating-on-unescaped-quotes-39e77dbba78881489bc3e3a232725630

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Closes [ISOM-2315](https://linear.app/ogp/issue/ISOM-2315/url-containing-unencoded-double-quote-silently-returns-a-truncated)
and #2395

`getSanitizedLinkHref` built the HTML string it sanitized by interpolating the raw, untrusted URL directly into a template literal:

```ts
const elem = DOMPurify.sanitize(`<a href="${url}"></a>`, { RETURN_DOM_FRAGMENT: true })
```

If the URL contained a literal `"` character, it would prematurely close the `href` attribute while the string was still being assembled — before DOMPurify ever parsed it as HTML. In the best case this silently truncated the URL at the quote (the reported bug); in the worst case it lets arbitrary markup get injected into the string DOMPurify parses, relying entirely on DOMPurify's general-purpose HTML sanitization to catch anything dangerous that results, rather than preventing the injection at the source.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- `getSanitizedLinkHref` (`packages/components/src/utils/getReferenceLinkHref.ts`) now builds the anchor element via DOM APIs instead of string concatenation: it creates a bare `<a></a>` fragment through DOMPurify (so we never touch the browser-only global `document`, which doesn't exist during the Node.js static site build), then sets the untrusted URL with `anchor.setAttribute("href", url)`. Since `setAttribute` treats the value as pure data rather than HTML source text, a `"` in the URL can no longer break out of the attribute — the reported truncation bug is fixed, and the underlying HTML-injection risk is closed at the source rather than only being caught downstream by DOMPurify's sanitization pass.

## Before & After Screenshots

**BEFORE**:

N/A — logic-only fix, not a visual change. Before the fix, a link href of `https://example.com/unescaped""quotes` was silently truncated to `https://example.com/unescaped`.

**AFTER**:

N/A — after the fix, the same href is preserved in full as `https://example.com/unescaped""quotes`.

## Tests

<!-- What tests should be run to confirm functionality? -->

Added a unit test in `packages/components/src/utils/__tests__/getReferenceLinkHref.test.ts` covering a URL containing unescaped double quotes, asserting the full URL is returned unmodified.

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] In Studio's page editor, open the link toolbar/modal on some text, pick the "External" link type, and enter a URL containing a literal double quote in the path or query string (e.g. `example.com/page"withquote`). Save and open the page preview — confirm the rendered `<a href>` contains the full URL, not a truncated version.
- [ ] Confirm normal links still work as before: an internal page link (via the "Page" picker), a `mailto:` link, and an asset/file link all resolve to the correct, unmangled href in preview.
- [ ] Publish the page (or check a previously published site with this change deployed) and confirm the same link renders correctly with the full href in the live static HTML.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes quoted URL handling in `getReferenceLinkHref`. The main changes are:

- Builds the sanitized anchor with DOM APIs instead of interpolating the raw URL into HTML.
- Sets the untrusted URL through `setAttribute` before running DOMPurify in place.
- Adds a regression test for links containing unescaped double quotes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is localized to a pure utility, keeps the existing DOMPurify sanitization contract, avoids browser-only globals, and adds focused regression coverage.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that the post-run log shows the Vitest command exited with code 0.
- Verified the Vitest results show 1 test file passed and 6 tests passed, including the named unescaped quotes test.

<a href="https://app.greptile.com/trex/runs/14495472/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/utils/getReferenceLinkHref.ts | Updates link sanitization to construct an anchor as a DOM node, set the untrusted href as attribute data, and sanitize it in place before returning the attribute. |
| packages/components/src/utils/__tests__/getReferenceLinkHref.test.ts | Adds a regression test confirming URLs containing literal double quotes are preserved through reference-link href sanitization. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Caller
participant getReferenceLinkHref
participant DOMPurify
participant Anchor

Caller->>getReferenceLinkHref: referenceLink, sitemapArray, assetsBaseUrl
getReferenceLinkHref->>getReferenceLinkHref: convert asset/reference links
getReferenceLinkHref->>DOMPurify: "sanitize(\"<a></a>\", RETURN_DOM_FRAGMENT)"
DOMPurify-->>getReferenceLinkHref: fragment with anchor
getReferenceLinkHref->>Anchor: setAttribute("href", actualLink)
getReferenceLinkHref->>DOMPurify: sanitize(anchor, IN_PLACE)
getReferenceLinkHref->>Anchor: getAttribute("href")
getReferenceLinkHref-->>Caller: sanitized href or undefined
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Caller
participant getReferenceLinkHref
participant DOMPurify
participant Anchor

Caller->>getReferenceLinkHref: referenceLink, sitemapArray, assetsBaseUrl
getReferenceLinkHref->>getReferenceLinkHref: convert asset/reference links
getReferenceLinkHref->>DOMPurify: "sanitize(\"<a></a>\", RETURN_DOM_FRAGMENT)"
DOMPurify-->>getReferenceLinkHref: fragment with anchor
getReferenceLinkHref->>Anchor: setAttribute("href", actualLink)
getReferenceLinkHref->>DOMPurify: sanitize(anchor, IN_PLACE)
getReferenceLinkHref->>Anchor: getAttribute("href")
getReferenceLinkHref-->>Caller: sanitized href or undefined
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["Avoid constructing dom objects via templ..."](https://github.com/opengovsg/isomer/commit/b49a4d335beaf03ccb4ee90099c1f331be3d1318) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44359229)</sub>

<!-- /greptile_comment -->