### PR TITLE
feat(redirect): add bulk-redirect CSV parsing and validation schema

### DIFF
--- a/apps/studio/public/redirects-template.csv
+++ b/apps/studio/public/redirects-template.csv
@@ -1,0 +1,1 @@
+When someone visits,Redirect them to

--- a/apps/studio/src/lib/redirectCsv.test.ts
+++ b/apps/studio/src/lib/redirectCsv.test.ts
@@ -128,6 +128,21 @@ describe("parseRedirectCsv", () => {
     // Assert
     expect(result.fileError).toContain("no redirects")
   })
+
+  it("rejects a file with an unterminated quote as a file error", () => {
+    // Arrange: the unterminated quote on the first row makes papaparse merge the
+    // rest of the file into one field, swallowing the second redirect. That must
+    // be rejected outright rather than validated row-by-row (which would silently
+    // drop /keep -> /somewhere).
+    const csv = `${header}\n/old,"https://example.gov.sg/a\n/keep,/somewhere`
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.rows).toBeUndefined()
+    expect(result.fileError).toContain("quote")
+  })
 })
 
 describe("buildRedirectErrorsCsv", () => {

--- a/apps/studio/src/lib/redirectCsv.test.ts
+++ b/apps/studio/src/lib/redirectCsv.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+import {
+  BULK_REDIRECT_CSV_ERROR_HEADER,
+  BULK_REDIRECT_CSV_HEADERS,
+  BULK_REDIRECT_CSV_NO_ERROR,
+  buildRedirectErrorsCsv,
+  parseRedirectCsv,
+} from "./redirectCsv"
+
+const { source: SOURCE_HEADER, destination: DESTINATION_HEADER } =
+  BULK_REDIRECT_CSV_HEADERS
+
+const header = `${SOURCE_HEADER},${DESTINATION_HEADER}`
+
+describe("parseRedirectCsv", () => {
+  it("parses rows with 1-based line numbers and trims cells", () => {
+    // Arrange
+    const csv = `${header}\n/old , /new\n/blog,https://example.gov.sg`
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.fileError).toBeUndefined()
+    expect(result.rows).toEqual([
+      { rowNumber: 2, source: "/old", destination: "/new", malformed: false },
+      {
+        rowNumber: 3,
+        source: "/blog",
+        destination: "https://example.gov.sg",
+        malformed: false,
+      },
+    ])
+  })
+
+  it("flags a row split by an unquoted comma as malformed", () => {
+    // Arrange: the destination contains an unquoted comma, so it splits into a
+    // stray third field that would otherwise silently truncate the destination.
+    const csv = `${header}\n/old,https://example.gov.sg/a,b`
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.rows?.[0]).toMatchObject({ source: "/old", malformed: true })
+  })
+
+  it("does not flag a well-formed row (or a benign trailing comma) as malformed", () => {
+    // Arrange / Act
+    const result = parseRedirectCsv(`${header}\n/old,/new,`)
+
+    // Assert: the extra column is empty, so the row is not malformed.
+    expect(result.rows?.[0]).toMatchObject({
+      destination: "/new",
+      malformed: false,
+    })
+  })
+
+  it("matches columns by name regardless of order, case, or extra columns", () => {
+    // Arrange: reversed order, different case, and an extra Error column (as a
+    // re-uploaded errors file would have).
+    const csv = [
+      `${BULK_REDIRECT_CSV_ERROR_HEADER},redirect them to,WHEN SOMEONE VISITS`,
+      `No error,/new,/old`,
+    ].join("\n")
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.rows).toEqual([
+      { rowNumber: 2, source: "/old", destination: "/new", malformed: false },
+    ])
+  })
+
+  it("strips a leading BOM before reading the header", () => {
+    // Arrange
+    const csv = `﻿${header}\n/old,/new`
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.rows).toHaveLength(1)
+    expect(result.rows?.[0]).toMatchObject({ source: "/old" })
+  })
+
+  it("flags a missing required column as a file error", () => {
+    // Arrange
+    const csv = `${SOURCE_HEADER},something else\n/old,/new`
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.rows).toBeUndefined()
+    expect(result.fileError).toContain(DESTINATION_HEADER)
+  })
+
+  it("flags an empty file", () => {
+    // Arrange / Act
+    const result = parseRedirectCsv("   \n  ")
+
+    // Assert
+    expect(result.fileError).toContain("empty")
+  })
+
+  it("flags a header-only file as having no redirects", () => {
+    // Arrange / Act
+    const result = parseRedirectCsv(header)
+
+    // Assert
+    expect(result.fileError).toContain("no redirects")
+  })
+})
+
+describe("buildRedirectErrorsCsv", () => {
+  it("lists failed rows first, keeps passing rows marked 'No error', and round-trips", () => {
+    // Arrange
+    const rows = [
+      { source: "/ok", destination: "/fine", error: null },
+      { source: "/bad", destination: "not a url", error: "Enter a valid URL." },
+    ]
+
+    // Act
+    const csv = buildRedirectErrorsCsv(rows)
+    const reparsed = parseRedirectCsv(csv)
+
+    // Assert: failed row is first, and the Error column is ignored on re-parse.
+    const lines = csv.split(/\r?\n/)
+    expect(lines[0]).toContain(BULK_REDIRECT_CSV_ERROR_HEADER)
+    expect(lines[1]).toContain("Enter a valid URL.")
+    expect(csv).toContain(BULK_REDIRECT_CSV_NO_ERROR)
+    expect(reparsed.rows).toEqual([
+      {
+        rowNumber: 2,
+        source: "/bad",
+        destination: "not a url",
+        malformed: false,
+      },
+      { rowNumber: 3, source: "/ok", destination: "/fine", malformed: false },
+    ])
+  })
+})
+
+describe("redirects template file", () => {
+  it("has the exact header the parser expects (guards against drift)", () => {
+    // Arrange
+    const templatePath = fileURLToPath(
+      new URL("../../public/redirects-template.csv", import.meta.url),
+    )
+
+    // Act
+    const contents = readFileSync(templatePath, "utf8")
+    const firstLine = contents.replace(/^﻿/, "").split(/\r?\n/)[0]
+
+    // Assert
+    expect(firstLine).toBe(`${SOURCE_HEADER},${DESTINATION_HEADER}`)
+  })
+})

--- a/apps/studio/src/lib/redirectCsv.test.ts
+++ b/apps/studio/src/lib/redirectCsv.test.ts
@@ -35,6 +35,20 @@ describe("parseRedirectCsv", () => {
     ])
   })
 
+  it("keeps physical line numbers when the file has blank lines", () => {
+    // Arrange: a blank line sits between the header and the row. Skipping blanks
+    // before numbering would report the row as line 2, but its true line is 3.
+    const csv = `${header}\n\n/old,/new`
+
+    // Act
+    const result = parseRedirectCsv(csv)
+
+    // Assert
+    expect(result.rows).toEqual([
+      { rowNumber: 3, source: "/old", destination: "/new", malformed: false },
+    ])
+  })
+
   it("flags a row split by an unquoted comma as malformed", () => {
     // Arrange: the destination contains an unquoted comma, so it splits into a
     // stray third field that would otherwise silently truncate the destination.
@@ -77,7 +91,7 @@ describe("parseRedirectCsv", () => {
 
   it("strips a leading BOM before reading the header", () => {
     // Arrange
-    const csv = `﻿${header}\n/old,/new`
+    const csv = `\uFEFF${header}\n/old,/new`
 
     // Act
     const result = parseRedirectCsv(csv)
@@ -154,7 +168,7 @@ describe("redirects template file", () => {
 
     // Act
     const contents = readFileSync(templatePath, "utf8")
-    const firstLine = contents.replace(/^﻿/, "").split(/\r?\n/)[0]
+    const firstLine = contents.replace(/^\uFEFF/, "").split(/\r?\n/)[0]
 
     // Assert
     expect(firstLine).toBe(`${SOURCE_HEADER},${DESTINATION_HEADER}`)

--- a/apps/studio/src/lib/redirectCsv.ts
+++ b/apps/studio/src/lib/redirectCsv.ts
@@ -23,8 +23,10 @@ export const BULK_REDIRECT_CSV_ERROR_HEADER = "Error"
 export const BULK_REDIRECT_CSV_NO_ERROR = "No error"
 
 export interface ParsedRedirectRow {
-  // 1-based line number in the uploaded file (the header is line 1), so a
-  // per-row error can point the editor at the offending line.
+  // 1-based physical line number in the uploaded file, so a per-row error can
+  // point the editor at the offending line. Blank lines are counted, so this
+  // stays the true file line even when leading blanks push the header past
+  // line 1.
   rowNumber: number
   source: string
   destination: string

--- a/apps/studio/src/lib/redirectCsv.ts
+++ b/apps/studio/src/lib/redirectCsv.ts
@@ -1,0 +1,149 @@
+// Shared CSV parsing + errors-file generation for the bulk-upload-redirects
+// feature. Isomorphic (papaparse runs in both the browser and Node): the client
+// parses a picked file for instant file-level errors and the preview, and the
+// server re-parses the same raw text authoritatively before validating. Keeping
+// the parse in one place means both sides agree on columns, row numbers, and
+// what counts as a malformed file.
+import Papa from "papaparse"
+
+// The template's column headers, shown to editors as the Add-redirect form
+// labels. The downloadable template and the errors file share these exact
+// strings so a corrected errors file re-uploads without renaming anything.
+export const BULK_REDIRECT_CSV_HEADERS = {
+  source: "When someone visits",
+  destination: "Redirect them to",
+} as const
+
+// Appended to the errors file only. Not one of the required columns, so it is
+// ignored when a corrected errors file is re-uploaded.
+export const BULK_REDIRECT_CSV_ERROR_HEADER = "Error"
+
+// Written in the Error column for rows that passed validation, so the errors
+// file lists every row (failed ones first) rather than only the failures.
+export const BULK_REDIRECT_CSV_NO_ERROR = "No error"
+
+export interface ParsedRedirectRow {
+  // 1-based line number in the uploaded file (the header is line 1), so a
+  // per-row error can point the editor at the offending line.
+  rowNumber: number
+  source: string
+  destination: string
+  // True when the row has stray extra columns — almost always an unquoted comma
+  // inside a value — so the source/destination read from the fixed columns can't
+  // be trusted. Surfaced as a row error rather than silently truncating a value.
+  malformed: boolean
+}
+
+// A file-level problem detected before any row is validated — the design's
+// upload-stage errors: an empty file, a missing required column, or no data
+// rows. `fileError` is user-facing copy. Per-row problems (including a malformed
+// row) are surfaced as row errors during validation, not here.
+export type ParseRedirectCsvResult =
+  | { fileError: string; rows?: undefined }
+  | { fileError?: undefined; rows: ParsedRedirectRow[] }
+
+// Case- and whitespace-insensitive header comparison, so "when someone visits",
+// " When Someone Visits " and the canonical label all match the same column.
+const normalizeHeader = (value: string) => value.trim().toLowerCase()
+
+// Parses raw CSV text into redirect rows, or returns a single file-level error.
+// Columns are matched by header name (not position), so extra columns — e.g.
+// the Error column on a re-uploaded errors file — are ignored, and the two
+// required columns may appear in any order.
+export const parseRedirectCsv = (csv: string): ParseRedirectCsvResult => {
+  // Strip a leading UTF-8 BOM (spreadsheet exports add one) so it doesn't become
+  // part of the first header cell.
+  const cleaned = csv.replace(/^﻿/, "")
+  // Catch an empty (or whitespace-only) file up front — papaparse reports it as
+  // a parse error rather than empty data, and we want the clearer "empty" copy.
+  if (cleaned.trim().length === 0) {
+    return {
+      fileError: "This file is empty. Add your redirects and try again.",
+    }
+  }
+
+  const { data } = Papa.parse<string[]>(cleaned, {
+    skipEmptyLines: "greedy",
+  })
+  // papaparse is lenient and still returns rows for messy input, so we don't
+  // treat a parse `errors` list as fatal for the whole file — a genuinely
+  // unreadable file falls through to the header check and is flagged as a
+  // missing column. Field-count problems are handled per row (see `malformed`).
+  if (data.length === 0) {
+    return {
+      fileError: "This file is empty. Add your redirects and try again.",
+    }
+  }
+
+  const header = data[0] ?? []
+  const sourceIndex = header.findIndex(
+    (cell) =>
+      normalizeHeader(cell) ===
+      normalizeHeader(BULK_REDIRECT_CSV_HEADERS.source),
+  )
+  const destinationIndex = header.findIndex(
+    (cell) =>
+      normalizeHeader(cell) ===
+      normalizeHeader(BULK_REDIRECT_CSV_HEADERS.destination),
+  )
+  if (sourceIndex === -1 || destinationIndex === -1) {
+    return {
+      fileError: `Your file is missing the "${BULK_REDIRECT_CSV_HEADERS.source}" or "${BULK_REDIRECT_CSV_HEADERS.destination}" column. Use the redirects template.`,
+    }
+  }
+
+  const dataRows = data.slice(1)
+  if (dataRows.length === 0) {
+    return {
+      fileError:
+        "This file has no redirects. Add at least one row and try again.",
+    }
+  }
+
+  const expectedColumns = header.length
+  const rows = dataRows.map((row, index) => ({
+    // +2: skip the header (line 1) and shift from 0-based to 1-based.
+    rowNumber: index + 2,
+    source: (row[sourceIndex] ?? "").trim(),
+    destination: (row[destinationIndex] ?? "").trim(),
+    // Non-empty columns beyond the header mean a value contained an unquoted
+    // comma and got split into stray fields — papaparse keeps the pieces
+    // silently, so the destination read from its column would be truncated.
+    malformed:
+      row.length > expectedColumns &&
+      row.slice(expectedColumns).some((cell) => cell.trim() !== ""),
+  }))
+  return { rows }
+}
+
+// A validated row for the errors file: the values as the editor typed them plus
+// the plain-language explanation (null when the row passed).
+export interface RedirectRowWithError {
+  source: string
+  destination: string
+  error: string | null
+}
+
+// Builds the downloadable errors file: every row, failed ones first, with an
+// added Error column. Passing rows are kept (marked "No error") so the editor
+// fixes the flagged rows in place and re-uploads the same file.
+export const buildRedirectErrorsCsv = (
+  rows: RedirectRowWithError[],
+): string => {
+  const failedFirst = [
+    ...rows.filter((row) => row.error !== null),
+    ...rows.filter((row) => row.error === null),
+  ]
+  return Papa.unparse({
+    fields: [
+      BULK_REDIRECT_CSV_HEADERS.source,
+      BULK_REDIRECT_CSV_HEADERS.destination,
+      BULK_REDIRECT_CSV_ERROR_HEADER,
+    ],
+    data: failedFirst.map((row) => [
+      row.source,
+      row.destination,
+      row.error ?? BULK_REDIRECT_CSV_NO_ERROR,
+    ]),
+  })
+}

--- a/apps/studio/src/lib/redirectCsv.ts
+++ b/apps/studio/src/lib/redirectCsv.ts
@@ -52,8 +52,9 @@ const normalizeHeader = (value: string) => value.trim().toLowerCase()
 // required columns may appear in any order.
 export const parseRedirectCsv = (csv: string): ParseRedirectCsvResult => {
   // Strip a leading UTF-8 BOM (spreadsheet exports add one) so it doesn't become
-  // part of the first header cell.
-  const cleaned = csv.replace(/^﻿/, "")
+  // part of the first header cell. `\uFEFF` rather than a literal BOM so the
+  // intent is visible and editors/formatters can't silently drop it.
+  const cleaned = csv.replace(/^\uFEFF/, "")
   // Catch an empty (or whitespace-only) file up front — papaparse reports it as
   // a parse error rather than empty data, and we want the clearer "empty" copy.
   if (cleaned.trim().length === 0) {
@@ -62,20 +63,28 @@ export const parseRedirectCsv = (csv: string): ParseRedirectCsvResult => {
     }
   }
 
+  // Keep blank lines (no "greedy" skip) so every row keeps its physical file
+  // line for `rowNumber`; blank rows are dropped below, after numbering. (A
+  // quoted field spanning newlines is still one row, so "line" means CSV record.)
   const { data } = Papa.parse<string[]>(cleaned, {
-    skipEmptyLines: "greedy",
+    skipEmptyLines: false,
   })
-  // papaparse is lenient and still returns rows for messy input, so we don't
-  // treat a parse `errors` list as fatal for the whole file — a genuinely
-  // unreadable file falls through to the header check and is flagged as a
-  // missing column. Field-count problems are handled per row (see `malformed`).
-  if (data.length === 0) {
+  // A blank line: no cells, or only empty/whitespace cells. papaparse is lenient
+  // and still returns rows for messy input, so a genuinely unreadable file falls
+  // through to the header check and is flagged as a missing column. Field-count
+  // problems are handled per row (see `malformed`).
+  const isBlankRow = (row: string[]) => row.every((cell) => cell.trim() === "")
+
+  // The header is the first non-blank line (tolerating leading blank lines some
+  // spreadsheet exports add). Its position anchors the physical line numbers.
+  const headerIndex = data.findIndex((row) => !isBlankRow(row))
+  if (headerIndex === -1) {
     return {
       fileError: "This file is empty. Add your redirects and try again.",
     }
   }
 
-  const header = data[0] ?? []
+  const header = data[headerIndex] ?? []
   const sourceIndex = header.findIndex(
     (cell) =>
       normalizeHeader(cell) ===
@@ -92,27 +101,30 @@ export const parseRedirectCsv = (csv: string): ParseRedirectCsvResult => {
     }
   }
 
-  const dataRows = data.slice(1)
-  if (dataRows.length === 0) {
+  const expectedColumns = header.length
+  const rows = data
+    // Number every line (1-based) BEFORE dropping blanks, so a blank line still
+    // advances the count and rowNumber stays the true line in the uploaded file.
+    .map((row, index) => ({ row, rowNumber: index + 1 }))
+    .slice(headerIndex + 1)
+    .filter(({ row }) => !isBlankRow(row))
+    .map(({ row, rowNumber }) => ({
+      rowNumber,
+      source: (row[sourceIndex] ?? "").trim(),
+      destination: (row[destinationIndex] ?? "").trim(),
+      // Non-empty columns beyond the header mean a value contained an unquoted
+      // comma and got split into stray fields — papaparse keeps the pieces
+      // silently, so the destination read from its column would be truncated.
+      malformed:
+        row.length > expectedColumns &&
+        row.slice(expectedColumns).some((cell) => cell.trim() !== ""),
+    }))
+  if (rows.length === 0) {
     return {
       fileError:
         "This file has no redirects. Add at least one row and try again.",
     }
   }
-
-  const expectedColumns = header.length
-  const rows = dataRows.map((row, index) => ({
-    // +2: skip the header (line 1) and shift from 0-based to 1-based.
-    rowNumber: index + 2,
-    source: (row[sourceIndex] ?? "").trim(),
-    destination: (row[destinationIndex] ?? "").trim(),
-    // Non-empty columns beyond the header mean a value contained an unquoted
-    // comma and got split into stray fields — papaparse keeps the pieces
-    // silently, so the destination read from its column would be truncated.
-    malformed:
-      row.length > expectedColumns &&
-      row.slice(expectedColumns).some((cell) => cell.trim() !== ""),
-  }))
   return { rows }
 }
 

--- a/apps/studio/src/lib/redirectCsv.ts
+++ b/apps/studio/src/lib/redirectCsv.ts
@@ -66,13 +66,23 @@ export const parseRedirectCsv = (csv: string): ParseRedirectCsvResult => {
   // Keep blank lines (no "greedy" skip) so every row keeps its physical file
   // line for `rowNumber`; blank rows are dropped below, after numbering. (A
   // quoted field spanning newlines is still one row, so "line" means CSV record.)
-  const { data } = Papa.parse<string[]>(cleaned, {
+  const { data, errors } = Papa.parse<string[]>(cleaned, {
     skipEmptyLines: false,
   })
+  // A stray or unterminated quote makes papaparse merge fields and swallow the
+  // following rows (it still returns partial `data`), so those redirects would
+  // silently vanish from the batch. Reject the whole file. Field-count mismatches
+  // are deliberately NOT treated as fatal here — an unquoted comma is a per-row
+  // problem surfaced via `malformed`, not a broken file.
+  if (errors.some((error) => error.type === "Quotes")) {
+    return {
+      fileError:
+        "We couldn't read this file. Check that every quote (\") is matched, then try again.",
+    }
+  }
   // A blank line: no cells, or only empty/whitespace cells. papaparse is lenient
   // and still returns rows for messy input, so a genuinely unreadable file falls
-  // through to the header check and is flagged as a missing column. Field-count
-  // problems are handled per row (see `malformed`).
+  // through to the header check and is flagged as a missing column.
   const isBlankRow = (row: string[]) => row.every((cell) => cell.trim() === "")
 
   // The header is the first non-blank line (tolerating leading blank lines some

--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  bulkRedirectsCsvSchema,
   createRedirectSchema,
+  MAX_BULK_REDIRECT_CSV_BYTES,
   MAX_REDIRECT_DESTINATION_LENGTH,
   MAX_REDIRECT_SOURCE_LENGTH,
 } from "../redirect"
@@ -570,5 +572,35 @@ describe("createRedirectSchema", () => {
       // Assert
       expect(result.success).toBe(true)
     })
+  })
+})
+
+describe("bulkRedirectsCsvSchema", () => {
+  it("accepts a small valid CSV", () => {
+    // Arrange / Act
+    const result = bulkRedirectsCsvSchema.safeParse({
+      siteId: 1,
+      csv: "When someone visits,Redirect them to\n/old,/new",
+    })
+
+    // Assert
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a CSV over the byte limit even when under the UTF-16 length limit", () => {
+    // Arrange: "字" is one UTF-16 code unit but three UTF-8 bytes, so this string
+    // stays under the code-unit ceiling while its byte size exceeds the cap — the
+    // limit must be enforced in bytes, not code units.
+    const csv = "字".repeat(400_000)
+    expect(csv.length).toBeLessThanOrEqual(MAX_BULK_REDIRECT_CSV_BYTES)
+    expect(new TextEncoder().encode(csv).length).toBeGreaterThan(
+      MAX_BULK_REDIRECT_CSV_BYTES,
+    )
+
+    // Act
+    const result = bulkRedirectsCsvSchema.safeParse({ siteId: 1, csv })
+
+    // Assert
+    expect(result.success).toBe(false)
   })
 })

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -241,16 +241,26 @@ export type RedirectRowInput = z.infer<typeof redirectRowSchema>
 // Caps the raw CSV text a bulk upload may send. Redirect rows are short ASCII,
 // so ~1MB already covers thousands of them; the client enforces the same limit
 // on the picked file's byte size, and this is the matching server-side trust
-// boundary. Counted in UTF-16 code units, close enough to bytes for the ASCII
-// the source whitelist enforces.
+// boundary.
 export const MAX_BULK_REDIRECT_CSV_BYTES = 1_000_000
+
+// `string().max()` counts UTF-16 code units, which undercounts multi-byte
+// characters — a code-unit cap would let a non-ASCII file exceed the byte budget
+// (and diverge from the client's byte-size check). Measure the encoded UTF-8
+// bytes so the limit matches its name and the client.
+const utf8ByteLength = (value: string) => new TextEncoder().encode(value).length
 
 export const bulkRedirectsCsvSchema = z.object({
   siteId: z.number().min(1),
   csv: z
     .string()
     .min(1, { message: "Upload a .csv file to continue" })
-    .max(MAX_BULK_REDIRECT_CSV_BYTES, { message: "File is too big" }),
+    // Cheap code-unit ceiling first (code units <= bytes), so the byte check
+    // below never has to encode a pathologically large string.
+    .max(MAX_BULK_REDIRECT_CSV_BYTES, { message: "File is too big" })
+    .refine((csv) => utf8ByteLength(csv) <= MAX_BULK_REDIRECT_CSV_BYTES, {
+      message: "File is too big",
+    }),
 })
 export type BulkRedirectsCsvInput = z.infer<typeof bulkRedirectsCsvSchema>
 

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -203,6 +203,57 @@ export const createRedirectSchema = createRedirectObjectSchema.superRefine(
 )
 export type CreateRedirectInput = z.infer<typeof createRedirectSchema>
 
+// Convenience applied just before the destination rules so users don't have to
+// type the scheme the published site serves over:
+//   - an "http://" destination is upgraded to "https://"
+//   - a leading "www." host gets "https://" prefixed
+// A "www." prefix unambiguously signals an external host (an internal path
+// starts with "/"), so it's safe to infer. A schemeless host WITHOUT "www."
+// ("google.com") is left untouched — it's ambiguous against an internal path
+// ("test.zip" vs "/test.zip") — and fails validation as an invalid URL. Shared
+// by the add-redirect form and the bulk-upload row schema below.
+export const normalizeDestinationScheme = (value: string): string => {
+  if (value.startsWith("http://")) {
+    return `https://${value.slice("http://".length)}`
+  }
+  if (value.startsWith("www.")) {
+    return `https://${value}`
+  }
+  return value
+}
+
+// One redirect as entered in the add form or a bulk-upload CSV row: every rule
+// the create schema applies except siteId (the server supplies it), with the
+// destination first passed through the scheme fix-up. Shared so a typed-in
+// redirect and a CSV row are validated by exactly the same rules.
+export const redirectRowSchema = z
+  .object({
+    source: createRedirectObjectSchema.shape.source,
+    destination: z
+      .string()
+      .trim()
+      .transform(normalizeDestinationScheme)
+      .pipe(createRedirectObjectSchema.shape.destination),
+  })
+  .superRefine(refineSourceDestinationDiffer)
+export type RedirectRowInput = z.infer<typeof redirectRowSchema>
+
+// Caps the raw CSV text a bulk upload may send. Redirect rows are short ASCII,
+// so ~1MB already covers thousands of them; the client enforces the same limit
+// on the picked file's byte size, and this is the matching server-side trust
+// boundary. Counted in UTF-16 code units, close enough to bytes for the ASCII
+// the source whitelist enforces.
+export const MAX_BULK_REDIRECT_CSV_BYTES = 1_000_000
+
+export const bulkRedirectsCsvSchema = z.object({
+  siteId: z.number().min(1),
+  csv: z
+    .string()
+    .min(1, { message: "Upload a .csv file to continue" })
+    .max(MAX_BULK_REDIRECT_CSV_BYTES, { message: "File is too big" }),
+})
+export type BulkRedirectsCsvInput = z.infer<typeof bulkRedirectsCsvSchema>
+
 export const deleteRedirectSchema = z.object({
   siteId: z.number().min(1),
   // Redirect.id is a bigint in the DB, surfaced as a string by kysely — reject


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +235 | -0 |
| 🧪 Test | 2 | +223 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

> **📚 Part of a 3-PR stack** — bulk upload redirects, split from the original #2778. Review and merge bottom-up:
> 1. **#2805 — CSV parsing + validation schema ← _this PR_**
> 2. #2806 — bulk validate/create endpoints
> 3. #2778 — modal UI + feature flag

## Problem

Bulk-uploading redirects needs to turn a friendly-header CSV into redirect rows and validate each row by the **same rules as the existing single-add form** — and it needs to do this in two places: in the browser (for instant feedback) and on the server (the authoritative trust boundary).

This is the foundational layer of the stack: the shared, isomorphic parsing + validation building blocks, with **no server or UI wiring yet**. Nothing here is user-reachable on its own; it is consumed by #2806 (endpoints) and #2778 (modal).

## Solution

Adds a shared CSV parser and extracts the redirect-row validation so both the client and server use identical logic.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- `lib/redirectCsv` (isomorphic — runs in browser and Node):
  - `parseRedirectCsv` — matches the friendly template header (`When someone visits` / `Redirect them to`), handles a UTF-8 BOM, reports file-level errors (a missing required column, an empty file, unterminated quotes; extra columns are ignored so a re-uploaded errors file still parses), and flags **malformed rows** where an unquoted comma splits a row into stray non-empty columns (so a destination can't be silently truncated).
  - `buildRedirectErrorsCsv` — emits a downloadable errors file in the same column shape as the template, so a corrected file re-uploads directly.
  - Shared header/message constants used by both sides.
- `schemas/redirect`:
  - `redirectRowSchema` + `normalizeDestinationScheme` — a single source/destination row's rules, **shared with the single-add form**.
  - `bulkRedirectsCsvSchema` and `MAX_BULK_REDIRECT_CSV_BYTES` (1 MB upload cap).
- `public/redirects-template.csv` — static, header-only template offered for download in the modal.

**Improvements**:

- Extracts `redirectRowSchema` so the add form and a bulk CSV row validate by identical rules, instead of duplicating the logic.

**Bug Fixes**:

- None.

## Before & After Screenshots

N/A — no user-facing UI in this layer. The rendered flow lives in #2778.

## Tests

Unit test `lib/redirectCsv.test.ts` covers header matching, BOM handling, file-level errors, the malformed/stray-column case, the errors-file round-trip, and a template-drift guard (fails if the static template header stops matching the parser).

**Manual Verification Steps**:

This layer has no independently reachable surface — its behaviour is exercised end-to-end through the modal in #2778 (see that PR's steps). The parsing/validation rules themselves are covered by the unit test above:

- [ ] `cd apps/studio && pnpm test:unit -- src/lib/redirectCsv.test.ts` passes.

**New scripts**:

- None.

**New dependencies**:

- None (`papaparse`, used by the parser, was already a dependency).

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds the shared foundation for bulk redirect CSV uploads. The main changes are:

- Shared CSV parsing for the redirect upload template.
- Error CSV generation that can be re-uploaded after fixes.
- Shared redirect-row validation for bulk rows and the existing add form rules.
- A byte-based 1 MB CSV upload schema.
- A header-only static CSV template and unit coverage for parser/schema behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low risk.

No blocking issues were found. The changes are additive shared parsing and schema utilities with focused tests for the key parser and byte-limit behavior.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- An explicit unit test attempt was executed to reproduce the runtime blocker, and the explicit attempt artifact captured the requested command, the working directory, and the container runtime blocker.
- Harness artifacts show the generated fallback test file and the fallback Vitest configuration, confirming that the fallback path is wired and ready for validation.
- The final run of the fallback path completed with all 5 tests passing and exit code 0, as documented in the final log.

<a href="https://app.greptile.com/trex/runs/15510051/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/public/redirects-template.csv | Adds the header-only bulk redirects template matching the parser constants. |
| apps/studio/src/lib/redirectCsv.test.ts | Adds coverage for CSV parsing, malformed rows, file-level errors, error CSV round-tripping, and template/header drift. |
| apps/studio/src/lib/redirectCsv.ts | Adds shared bulk redirect CSV parsing and error CSV generation with header matching, BOM handling, parser quote-error rejection, blank-line-aware numbering, and malformed-row detection. |
| apps/studio/src/schemas/__tests__/redirect.test.ts | Adds tests for the bulk redirect CSV upload schema, including UTF-8 byte-size enforcement. |
| apps/studio/src/schemas/redirect.ts | Adds shared redirect row validation, destination scheme normalization, and a 1 MB byte-based bulk CSV input schema. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Upload as Future bulk upload caller
participant Parser as parseRedirectCsv
participant RowSchema as redirectRowSchema
participant CsvSchema as bulkRedirectsCsvSchema
participant Errors as buildRedirectErrorsCsv

Upload->>CsvSchema: validate siteId + raw CSV byte limit
Upload->>Parser: parse raw CSV text
Parser-->>Upload: fileError or parsed rows with line numbers
Upload->>RowSchema: validate each parsed source/destination
RowSchema-->>Upload: normalized row or validation error
Upload->>Errors: build downloadable error CSV when rows fail
Errors-->>Upload: template-compatible CSV with Error column
```
</details>

<sub>Reviews (8): Last reviewed commit: ["docs(redirect): clarify rowNumber is the..."](https://github.com/opengovsg/isomer/commit/a2e6610fd6e029e58072358dc34045e9c814c557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44385288)</sub>

<!-- /greptile_comment -->