### PR TITLE
feat(redirect): add bulk validate/create redirect endpoints

### DIFF
--- a/apps/studio/src/constants/redirect.ts
+++ b/apps/studio/src/constants/redirect.ts
@@ -33,6 +33,14 @@ export const REDIRECT_MESSAGES = {
     "This page or folder you're redirecting to hasn't been published yet.",
 } as const
 
+// Bulk-upload row errors with no single-create equivalent. Kept beside
+// REDIRECT_MESSAGES so all redirect copy lives together; the other bulk row
+// errors reuse REDIRECT_MESSAGES, so the errors file reads like the inline form.
+export const BULK_MALFORMED_ROW_MESSAGE =
+  "This row has extra columns. Put double quotes around any value that contains a comma."
+export const BULK_DUPLICATE_SOURCE_MESSAGE =
+  "This source is listed more than once in your file."
+
 export interface RedirectValidationIssue {
   code: RedirectValidationCode
   message: string

--- a/apps/studio/src/server/modules/database/constants.ts
+++ b/apps/studio/src/server/modules/database/constants.ts
@@ -3,4 +3,6 @@
 export const PG_ERROR_CODES = {
   uniqueViolation: "23505",
   serializationFailure: "40001",
+  // A statement aborted while waiting for a lock (e.g. lock_timeout fired).
+  lockTimeout: "55P03",
 } as const

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -222,6 +222,29 @@ describe("redirect.router bulk upload", async () => {
       expect(errorFor(result, "/n11")).toBeTruthy()
     })
 
+    it("flags only the cycle, not a source that merely points into a loop", async () => {
+      // Arrange: /a is a tail into the /b -> /c -> /d -> /b cycle. Walking from
+      // /a never returns to /a, so /a is a valid redirect and must stay unflagged;
+      // /b, /c, /d are on the cycle and must be flagged. This guards that the
+      // single-pass cycle detection matches the old per-row "returns to start".
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([
+          ["/a", "/b"],
+          ["/b", "/c"],
+          ["/c", "/d"],
+          ["/d", "/b"],
+        ]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/a")).toBeNull()
+      expect(errorFor(result, "/b")).toBeTruthy()
+      expect(errorFor(result, "/c")).toBeTruthy()
+      expect(errorFor(result, "/d")).toBeTruthy()
+      expect(result.errorCount).toBe(3)
+    })
+
     it("flags a row split by an unquoted comma in the destination", async () => {
       // Arrange: an unquoted comma splits the destination into a stray column,
       // which would otherwise silently truncate it and publish a wrong redirect.

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -1,0 +1,367 @@
+import { auth } from "tests/integration/helpers/auth"
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  applyAuthedSession,
+  createMockRequest,
+} from "tests/integration/helpers/iron-session"
+import {
+  setupAdminPermissions,
+  setupPageResource,
+  setupSite,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { BULK_REDIRECT_CSV_HEADERS } from "~/lib/redirectCsv"
+import { createCallerFactory } from "~/server/trpc"
+import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+
+import * as codebuildService from "../../aws/codebuild.service"
+import { db } from "../../database"
+import { redirectRouter } from "../redirect.router"
+
+const createCaller = createCallerFactory(redirectRouter)
+
+// Builds a CSV body with the template's friendly header and the given rows.
+const csvOf = (rows: [source: string, destination: string][]) =>
+  [
+    `${BULK_REDIRECT_CSV_HEADERS.source},${BULK_REDIRECT_CSV_HEADERS.destination}`,
+    ...rows.map(([source, destination]) => `${source},${destination}`),
+  ].join("\n")
+
+describe("redirect.router bulk upload", async () => {
+  let caller: ReturnType<typeof createCaller>
+  let siteId: number
+  let userId: string
+  const session = await applyAuthedSession()
+
+  beforeEach(async () => {
+    await resetTables(
+      "AuditLog",
+      "Redirect",
+      "Blob",
+      "Version",
+      "Resource",
+      "ResourcePermission",
+      "Whitelist",
+      "Site",
+      "User",
+    )
+    const user = await setupUser({
+      userId: session.userId,
+      email: "test@mock.com",
+    })
+    await auth(user)
+    const { site } = await setupSite()
+    siteId = site.id
+    userId = user.id
+    await setupAdminPermissions({ userId: user.id, siteId })
+    caller = createCaller(createMockRequest(session))
+    // Publishing goes through CodeBuild; stub it so tests never hit AWS and can
+    // assert how often a batch republishes.
+    vi.spyOn(codebuildService, "publishSite").mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const seedPublishedPageAtRoot = async (permalink: string) => {
+    await setupPageResource({
+      siteId,
+      resourceType: ResourceType.RootPage,
+      parentId: null,
+    })
+    await setupPageResource({
+      siteId,
+      resourceType: ResourceType.Page,
+      parentId: null,
+      permalink,
+      state: ResourceState.Published,
+      userId,
+    })
+  }
+
+  const errorFor = (
+    result: { rows: { source: string; error: string | null }[] },
+    source: string,
+  ) => result.rows.find((row) => row.source === source)?.error ?? null
+
+  describe("bulkValidate", () => {
+    it("throws 403 without read access to the site", async () => {
+      // Arrange
+      const { site: otherSite } = await setupSite()
+
+      // Act
+      const result = caller.bulkValidate({
+        siteId: otherSite.id,
+        csv: csvOf([["/a", "/b"]]),
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "FORBIDDEN" })
+    })
+
+    it("returns a file-level error for a missing column", async () => {
+      // Arrange / Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: "When someone visits\n/a",
+      })
+
+      // Assert
+      expect(result.fileError).not.toBeNull()
+      expect(result.rows).toEqual([])
+    })
+
+    it("flags a malformed row with the shared schema message", async () => {
+      // Arrange: a source containing a scheme is rejected by the source rules.
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["https://evil.com", "/b"]]),
+      })
+
+      // Assert
+      expect(result.errorCount).toBe(1)
+      expect(errorFor(result, "https://evil.com")).toBeTruthy()
+    })
+
+    it("flags a source listed more than once in the file", async () => {
+      // Arrange / Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([
+          ["/dup", "/one"],
+          ["/dup", "/two"],
+        ]),
+      })
+
+      // Assert: both rows carry the duplicate error.
+      expect(result.errorCount).toBe(2)
+      expect(errorFor(result, "/dup")).toContain("more than once")
+    })
+
+    it("flags a source already redirected on the table", async () => {
+      // Arrange
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/taken", destination: "/elsewhere" })
+        .execute()
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/taken", "/new"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/taken")).toBeTruthy()
+    })
+
+    it("flags a source that shadows a live published page", async () => {
+      // Arrange
+      await seedPublishedPageAtRoot("shadowed")
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/shadowed", "/somewhere"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/shadowed")).toBeTruthy()
+    })
+
+    it("flags a loop formed within the uploaded file", async () => {
+      // Arrange / Act: /a -> /b and /b -> /a in the same upload.
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([
+          ["/a", "/b"],
+          ["/b", "/a"],
+        ]),
+      })
+
+      // Assert: both rows are flagged as loops.
+      expect(result.errorCount).toBe(2)
+      expect(errorFor(result, "/a")).toBeTruthy()
+      expect(errorFor(result, "/b")).toBeTruthy()
+    })
+
+    it("flags a loop formed against an existing table redirect", async () => {
+      // Arrange: table already has /b -> /a; uploading /a -> /b closes the loop.
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/a" })
+        .execute()
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/a", "/b"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/a")).toBeTruthy()
+    })
+
+    it("flags a batch loop longer than 10 hops (any-length cycle)", async () => {
+      // Arrange: a 12-node cycle /n0 -> /n1 -> ... -> /n11 -> /n0, longer than
+      // the former fixed hop cap, so every node must still be flagged.
+      const size = 12
+      const rows = Array.from({ length: size }, (_, i): [string, string] => [
+        `/n${i}`,
+        `/n${(i + 1) % size}`,
+      ])
+
+      // Act
+      const result = await caller.bulkValidate({ siteId, csv: csvOf(rows) })
+
+      // Assert: the whole cycle is rejected, not silently published.
+      expect(result.errorCount).toBe(size)
+      expect(errorFor(result, "/n0")).toBeTruthy()
+      expect(errorFor(result, "/n11")).toBeTruthy()
+    })
+
+    it("flags a row split by an unquoted comma in the destination", async () => {
+      // Arrange: an unquoted comma splits the destination into a stray column,
+      // which would otherwise silently truncate it and publish a wrong redirect.
+      const csv = `${BULK_REDIRECT_CSV_HEADERS.source},${BULK_REDIRECT_CSV_HEADERS.destination}\n/old,https://example.gov.sg/a,b`
+
+      // Act
+      const result = await caller.bulkValidate({ siteId, csv })
+
+      // Assert
+      expect(errorFor(result, "/old")).toContain("extra columns")
+    })
+
+    it("returns a clean result for a fully valid file", async () => {
+      // Arrange / Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([
+          ["/old-one", "/new-one"],
+          ["/old-two", "https://example.gov.sg"],
+        ]),
+      })
+
+      // Assert
+      expect(result.fileError).toBeNull()
+      expect(result.errorCount).toBe(0)
+      expect(result.validCount).toBe(2)
+    })
+  })
+
+  describe("bulkCreate", () => {
+    it("throws 403 without create access to the site", async () => {
+      // Arrange: a viewer-less other site the admin can't create on.
+      const { site: otherSite } = await setupSite()
+
+      // Act
+      const result = caller.bulkCreate({
+        siteId: otherSite.id,
+        csv: csvOf([["/a", "/b"]]),
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "FORBIDDEN" })
+    })
+
+    it("does not publish and returns the validation when a row has an error", async () => {
+      // Arrange
+      const publishSpy = vi.spyOn(codebuildService, "publishSite")
+
+      // Act
+      const result = await caller.bulkCreate({
+        siteId,
+        csv: csvOf([["https://bad-source", "/b"]]),
+      })
+
+      // Assert
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.validation.errorCount).toBe(1)
+      }
+      expect(publishSpy).not.toHaveBeenCalled()
+    })
+
+    it("inserts every row and publishes exactly once on success", async () => {
+      // Arrange
+      const publishSpy = vi.spyOn(codebuildService, "publishSite")
+
+      // Act
+      const result = await caller.bulkCreate({
+        siteId,
+        csv: csvOf([
+          ["/old-one", "/new-one"],
+          ["/old-two", "https://example.gov.sg"],
+        ]),
+      })
+
+      // Assert
+      expect(result).toEqual({ ok: true, publishedCount: 2 })
+      expect(publishSpy).toHaveBeenCalledTimes(1)
+      const live = await db
+        .selectFrom("Redirect")
+        .select(["source", "destination"])
+        .where("siteId", "=", siteId)
+        .where("deletedAt", "is", null)
+        .orderBy("source")
+        .execute()
+      expect(live).toEqual([
+        { source: "/old-one", destination: "/new-one" },
+        { source: "/old-two", destination: "https://example.gov.sg" },
+      ])
+    })
+
+    it("revives a soft-deleted redirect for a source in the batch", async () => {
+      // Arrange: a previously-deleted redirect for /old-one.
+      await db
+        .insertInto("Redirect")
+        .values({
+          siteId,
+          source: "/old-one",
+          destination: "/stale",
+          deletedAt: new Date(),
+        })
+        .execute()
+
+      // Act
+      const result = await caller.bulkCreate({
+        siteId,
+        csv: csvOf([["/old-one", "/fresh"]]),
+      })
+
+      // Assert
+      expect(result).toEqual({ ok: true, publishedCount: 1 })
+      const revived = await db
+        .selectFrom("Redirect")
+        .selectAll()
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/old-one")
+        .executeTakeFirstOrThrow()
+      expect(revived.deletedAt).toBeNull()
+      expect(revived.destination).toBe("/fresh")
+    })
+
+    it("logs one RedirectCreate per row plus one Publish event", async () => {
+      // Arrange / Act
+      await caller.bulkCreate({
+        siteId,
+        csv: csvOf([
+          ["/old-one", "/new-one"],
+          ["/old-two", "/new-two"],
+        ]),
+      })
+
+      // Assert
+      const events = await db
+        .selectFrom("AuditLog")
+        .select("eventType")
+        .where("siteId", "=", siteId)
+        .execute()
+      const created = events.filter((e) => e.eventType === "RedirectCreate")
+      const published = events.filter((e) => e.eventType === "Publish")
+      expect(created).toHaveLength(2)
+      expect(published).toHaveLength(1)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -336,6 +336,27 @@ describe("redirect.router bulk upload", async () => {
       ])
     })
 
+    it("publishes when the batch chains onto an existing redirect without looping", async () => {
+      // Arrange: an existing /b -> /c; the batch adds /a -> /b, forming the chain
+      // /a -> /b -> /c with no loop. The in-transaction loop recheck must not
+      // spuriously abort on a legitimate chain spanning existing and batch rows.
+      const publishSpy = vi.spyOn(codebuildService, "publishSite")
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/c" })
+        .execute()
+
+      // Act
+      const result = await caller.bulkCreate({
+        siteId,
+        csv: csvOf([["/a", "/b"]]),
+      })
+
+      // Assert
+      expect(result).toEqual({ ok: true, publishedCount: 1 })
+      expect(publishSpy).toHaveBeenCalledTimes(1)
+    })
+
     it("revives a soft-deleted redirect for a source in the batch", async () => {
       // Arrange: a previously-deleted redirect for /old-one.
       await db

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -204,6 +204,26 @@ describe("redirect.router bulk upload", async () => {
       expect(errorFor(result, "/a")).toBeTruthy()
     })
 
+    it("flags a loop even when the destination carries a query string", async () => {
+      // Arrange: table has /b -> /a. Uploading /a -> /b?ref=x still closes the
+      // loop — a request to /b?ref=x hits the /b source rule (the query is
+      // ignored in matching), so the destination must resolve to /b for the
+      // loop check, not to a distinct "/b?ref=x" node.
+      await db
+        .insertInto("Redirect")
+        .values({ siteId, source: "/b", destination: "/a" })
+        .execute()
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/a", "/b?ref=x"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/a")).toContain("never-ending loop")
+    })
+
     it("flags a batch loop longer than 10 hops (any-length cycle)", async () => {
       // Arrange: a 12-node cycle /n0 -> /n1 -> ... -> /n11 -> /n0, longer than
       // the former fixed hop cap, so every node must still be flagged.

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -16,6 +16,7 @@ import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
 import * as codebuildService from "../../aws/codebuild.service"
 import { db } from "../../database"
+import * as resourceService from "../../resource/resource.service"
 import { redirectRouter } from "../redirect.router"
 
 const createCaller = createCallerFactory(redirectRouter)
@@ -362,6 +363,43 @@ describe("redirect.router bulk upload", async () => {
       const published = events.filter((e) => e.eventType === "Publish")
       expect(created).toHaveLength(2)
       expect(published).toHaveLength(1)
+    })
+
+    it("does not publish a redirect shadowing a page that goes live mid-publish", async () => {
+      // Arrange: a published page really exists at /shadowed, but the initial
+      // validation is made to miss it — the first permalink lookup (validation's
+      // shadow check) returns nothing, simulating a page that only goes live
+      // after validation but before the insert. The in-transaction recheck and
+      // the re-validation then see the real page.
+      const publishSpy = vi.spyOn(codebuildService, "publishSite")
+      await seedPublishedPageAtRoot("shadowed")
+      vi.spyOn(
+        resourceService,
+        "getResourceIdsByPermalinks",
+      ).mockImplementationOnce(() =>
+        Promise.resolve(new Map<string, number | null>()),
+      )
+
+      // Act
+      const result = await caller.bulkCreate({
+        siteId,
+        csv: csvOf([["/shadowed", "/somewhere"]]),
+      })
+
+      // Assert: the batch aborts instead of committing a shadowing redirect, and
+      // the offending row comes back flagged so the modal can show it.
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(errorFor(result.validation, "/shadowed")).toBeTruthy()
+      }
+      expect(publishSpy).not.toHaveBeenCalled()
+      const live = await db
+        .selectFrom("Redirect")
+        .select("source")
+        .where("siteId", "=", siteId)
+        .where("deletedAt", "is", null)
+        .execute()
+      expect(live).toHaveLength(0)
     })
   })
 })

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -245,6 +245,33 @@ describe("redirect.router bulk upload", async () => {
       expect(result.errorCount).toBe(3)
     })
 
+    it("resolves a [resource:...] destination when checking for loops", async () => {
+      // Arrange: a page at /b, referenced by a batch row /a -> [resource:site:b].
+      // With a batch /b -> /a, the reference resolves to /b, closing the loop
+      // /a -> /b -> /a. The reference must be resolved when building the loop
+      // graph — a path-only check would miss it and report the file clean.
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: null,
+        permalink: "b",
+      })
+      const reference = `[resource:${siteId}:${page.id}]`
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([
+          ["/a", reference],
+          ["/b", "/a"],
+        ]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/a")).toBeTruthy()
+      expect(errorFor(result, "/b")).toBeTruthy()
+    })
+
     it("flags a row split by an unquoted comma in the destination", async () => {
       // Arrange: an unquoted comma splits the destination into a stray column,
       // which would otherwise silently truncate it and publish a wrong redirect.

--- a/apps/studio/src/server/modules/redirect/redirect.router.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.router.ts
@@ -1,4 +1,5 @@
 import {
+  bulkRedirectsCsvSchema,
   countRedirectsByDestinationSchema,
   countRedirectsSchema,
   createRedirectSchema,
@@ -11,6 +12,8 @@ import { protectedProcedure, router } from "~/server/trpc"
 
 import { validateUserPermissionsForSite } from "../site/site.service"
 import {
+  bulkCreateRedirects,
+  bulkValidateRedirects,
   countRedirects,
   countRedirectsPointingToResource,
   createRedirect,
@@ -103,6 +106,42 @@ export const redirectRouter = router({
       })
 
       return countRedirectsPointingToResource(input)
+    }),
+
+  // Validates a whole uploaded CSV without writing anything, so the bulk-upload
+  // modal can show row errors or a ready-to-publish preview. A mutation (not a
+  // query) purely so the CSV rides in the POST body — a query serialises its
+  // input into the request URL, which the server/proxy rejects once the file
+  // nears the size cap (a connection reset). Still read-only and gated on "read"
+  // like the single-redirect `validate` preflight above.
+  bulkValidate: protectedProcedure
+    .input(bulkRedirectsCsvSchema)
+    .mutation(async ({ ctx, input }) => {
+      await validateUserPermissionsForSite({
+        siteId: input.siteId,
+        userId: ctx.user.id,
+        action: "read",
+      })
+
+      return bulkValidateRedirects(input)
+    }),
+
+  // Commits a validated batch: re-validates server-side, inserts every row in
+  // one transaction, and publishes once. Site-admin only like `create`.
+  bulkCreate: protectedProcedure
+    .input(bulkRedirectsCsvSchema)
+    .mutation(async ({ ctx, input }) => {
+      await validateUserPermissionsForSite({
+        siteId: input.siteId,
+        userId: ctx.user.id,
+        action: "create",
+      })
+
+      return bulkCreateRedirects({
+        ...input,
+        byUserId: ctx.user.id,
+        logger: ctx.logger,
+      })
     }),
 
   // create/delete publish immediately (no separate publish step). Site-wide

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -20,7 +20,13 @@ import {
 } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import { sql } from "kysely"
-import { REDIRECT_MESSAGES, RedirectValidationCode } from "~/constants/redirect"
+import { chunk } from "lodash-es"
+import {
+  BULK_DUPLICATE_SOURCE_MESSAGE,
+  BULK_MALFORMED_ROW_MESSAGE,
+  REDIRECT_MESSAGES,
+  RedirectValidationCode,
+} from "~/constants/redirect"
 import { parseRedirectCsv } from "~/lib/redirectCsv"
 import {
   isValidExternalDestination,
@@ -596,22 +602,12 @@ const BULK_REDIRECT_INSERT_CHUNK_SIZE = 500
 // automatically when the transaction ends.
 const REDIRECT_WRITE_LOCK_NAMESPACE = 0x5244 // "RD"
 
-// Shown when a row is split by an unquoted comma into extra columns.
-const BULK_MALFORMED_ROW_MESSAGE =
-  "This row has extra columns. Put double quotes around any value that contains a comma."
-
 // Thrown inside the bulk insert when a source stopped being publishable between
 // validation and the insert — either it gained a live redirect (the upsert
 // skipped it, a shortfall) or a page was published at it (the in-txn recheck).
 // bulkCreate catches it to re-validate and return fresh row verdicts rather than
 // surface a generic failure.
 class BulkRedirectRaceError extends Error {}
-
-// Cross-file duplicate copy. The other row errors reuse the shared Studio
-// messages (REDIRECT_MESSAGES) so the errors file reads the same as the inline
-// form errors, per the design.
-const BULK_DUPLICATE_SOURCE_MESSAGE =
-  "This source is listed more than once in your file."
 
 // One row after evaluation: the values as the editor typed them (for the errors
 // file + preview), the normalized values (for the DB checks + insert), and the
@@ -693,6 +689,10 @@ const resolveDestinationsForStorage = async (
   destinations: string[],
 ): Promise<Map<string, string>> => {
   const result = new Map<string, string>()
+  // First pass resolves everything storable as-is (query/fragment paths,
+  // external URLs, existing references) and sets those directly, collecting the
+  // internal paths that still need a resource lookup. parseDestination returns
+  // value === destination for an internal path, so the path doubles as the key.
   const internalPaths: string[] = []
   for (const destination of new Set(destinations)) {
     const parsed = parseDestination(destination)
@@ -707,18 +707,18 @@ const resolveDestinationsForStorage = async (
     internalPaths.push(parsed.value)
   }
 
+  // Second pass resolves only those internal paths: each becomes a [resource:...]
+  // reference when a resource lives at that permalink, or stays literal when none
+  // does (a typo or an as-yet-uncreated page — it just won't follow moves).
   const idByPath = internalPaths.length
     ? await getResourceIdsByPermalinks(siteId, internalPaths)
     : new Map<string, number | null>()
-  for (const destination of new Set(destinations)) {
-    if (result.has(destination)) {
-      continue
-    }
-    const resourceId = idByPath.get(destination) ?? null
+  for (const path of internalPaths) {
+    const resourceId = idByPath.get(path) ?? null
     result.set(
-      destination,
+      path,
       resourceId === null
-        ? destination
+        ? path
         : getReferenceLink({
             siteId: String(siteId),
             resourceId: String(resourceId),
@@ -738,8 +738,7 @@ const resolveDestinationsForStorage = async (
 // leading INTO a cycle is (correctly) not included.
 const findCycleNodes = (edges: Map<string, string | null>): Set<string> => {
   const cycleNodes = new Set<string>()
-  // 0 = on the path currently being walked, 1 = fully explored.
-  const state = new Map<string, 0 | 1>()
+  const state = new Map<string, "walking" | "explored">()
   for (const start of edges.keys()) {
     if (state.has(start)) {
       continue
@@ -749,19 +748,26 @@ const findCycleNodes = (edges: Map<string, string | null>): Set<string> => {
     const path: string[] = []
     let current: string | null = start
     while (current !== null && !state.has(current)) {
-      state.set(current, 0)
+      state.set(current, "walking")
       path.push(current)
       current = edges.get(current) ?? null
     }
-    // Stopping on a node still marked "on the current path" closed a cycle; every
-    // node from it to the end of the path lies on that cycle.
-    if (current !== null && state.get(current) === 0) {
+    // The walk stops in one of three ways, and only the last is a cycle:
+    //   - current === null       → the chain terminates; no cycle.
+    //   - state is "explored"    → it merged into an already-resolved chain
+    //                              (e.g. a tail leading into someone else's
+    //                              path); no new cycle on this walk.
+    //   - state is "walking"     → we looped back onto the current path; every
+    //                              node from there to the end lies on the cycle.
+    // (So we can't assert current === null for the no-cycle case — the explored
+    // exit is equally valid.)
+    if (current !== null && state.get(current) === "walking") {
       for (const node of path.slice(path.indexOf(current))) {
         cycleNodes.add(node)
       }
     }
     for (const node of path) {
-      state.set(node, 1)
+      state.set(node, "explored")
     }
   }
   return cycleNodes
@@ -1076,18 +1082,13 @@ export const bulkCreateRedirects = async ({
       }
 
       const insertedRows: typeof existingRows = []
-      for (
-        let i = 0;
-        i < valuesToInsert.length;
-        i += BULK_REDIRECT_INSERT_CHUNK_SIZE
-      ) {
-        const chunk = valuesToInsert.slice(
-          i,
-          i + BULK_REDIRECT_INSERT_CHUNK_SIZE,
-        )
+      for (const batch of chunk(
+        valuesToInsert,
+        BULK_REDIRECT_INSERT_CHUNK_SIZE,
+      )) {
         const inserted = await tx
           .insertInto("Redirect")
-          .values(chunk)
+          .values(batch)
           .onConflict((oc) =>
             oc
               .columns(["siteId", "source"])
@@ -1160,15 +1161,8 @@ export const bulkCreateRedirects = async ({
         userId: byUser.id,
         metadata: {},
       }))
-      for (
-        let i = 0;
-        i < auditValues.length;
-        i += BULK_REDIRECT_INSERT_CHUNK_SIZE
-      ) {
-        await tx
-          .insertInto("AuditLog")
-          .values(auditValues.slice(i, i + BULK_REDIRECT_INSERT_CHUNK_SIZE))
-          .execute()
+      for (const batch of chunk(auditValues, BULK_REDIRECT_INSERT_CHUNK_SIZE)) {
+        await tx.insertInto("AuditLog").values(batch).execute()
       }
 
       // The whole batch republishes once, audited as a single Publish event.
@@ -1194,7 +1188,18 @@ export const bulkCreateRedirects = async ({
       // shows the offending row(s) rather than a generic failure — this keeps
       // the ok:false contract.
       const { fileError, rows } = await runBulkValidation(siteId, csv)
-      return { ok: false, validation: toValidationResult(fileError, rows) }
+      const validation = toValidationResult(fileError, rows)
+      // The race may have cleared by the time we re-validate (e.g. the
+      // conflicting redirect was deleted). With nothing left to flag, ok:false
+      // would strand the modal on an errors screen listing no rows, so surface a
+      // transient conflict instead — the client prompts a retry, which succeeds.
+      if (validation.fileError === null && validation.errorCount === 0) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "The site changed while publishing. Please try again.",
+        })
+      }
+      return { ok: false, validation }
     }
     throw error
   }

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -3,6 +3,7 @@ import type {
   RedirectValidationResult,
 } from "~/constants/redirect"
 import type {
+  BulkRedirectsCsvInput,
   CountRedirectsByDestinationInput,
   CountRedirectsInput,
   CreateRedirectInput,
@@ -20,10 +21,12 @@ import {
 import { TRPCError } from "@trpc/server"
 import { sql } from "kysely"
 import { REDIRECT_MESSAGES, RedirectValidationCode } from "~/constants/redirect"
+import { parseRedirectCsv } from "~/lib/redirectCsv"
 import {
   isValidExternalDestination,
   normalizeRedirectPath,
   normalizeRedirectSource,
+  redirectRowSchema,
 } from "~/schemas/redirect"
 import { getReferenceLink } from "~/utils/link"
 import { ResourceType } from "~prisma/generated/generatedEnums"
@@ -566,6 +569,510 @@ export const createRedirect = async ({
   await publishSite(logger, { siteId })
 
   return created
+}
+
+// ---------------------------------------------------------------------------
+// Bulk upload (CSV)
+// ---------------------------------------------------------------------------
+
+// Rows are inserted in chunks so a large upload doesn't build one enormous
+// INSERT (mirrors the migration script's chunking).
+const BULK_REDIRECT_INSERT_CHUNK_SIZE = 500
+
+// Shown when a row is split by an unquoted comma into extra columns.
+const BULK_MALFORMED_ROW_MESSAGE =
+  "This row has extra columns. Put double quotes around any value that contains a comma."
+
+// Thrown inside the bulk insert when a source went live between validation and
+// the insert (the upsert skipped it). bulkCreate catches it to re-validate and
+// return fresh row verdicts rather than surface a generic failure.
+class BulkRedirectRaceError extends Error {}
+
+// Cross-file duplicate copy. The other row errors reuse the shared Studio
+// messages (REDIRECT_MESSAGES) so the errors file reads the same as the inline
+// form errors, per the design.
+const BULK_DUPLICATE_SOURCE_MESSAGE =
+  "This source is listed more than once in your file."
+
+// One row after evaluation: the values as the editor typed them (for the errors
+// file + preview), the normalized values (for the DB checks + insert), and the
+// single chosen error (null when the row passed).
+interface EvaluatedRedirectRow {
+  rowNumber: number
+  source: string
+  destination: string
+  normalizedSource: string | null
+  normalizedDestination: string | null
+  error: string | null
+}
+
+// Public per-row verdict returned to the client (drops the internal normalized
+// values). Ordered as parsed; the client sorts errors first for the errors file.
+export interface BulkRedirectRowResult {
+  rowNumber: number
+  source: string
+  destination: string
+  error: string | null
+}
+
+export interface BulkRedirectValidationResult {
+  // A file-level problem (empty / missing column / unreadable / too big) that
+  // stops evaluation before any row is checked; null when the file parsed.
+  fileError: string | null
+  rows: BulkRedirectRowResult[]
+  validCount: number
+  errorCount: number
+}
+
+// Resolves stored redirect destinations to the source-comparable path they
+// point at (for loop detection): an internal path normalized as a source, a
+// [resource:...] reference resolved to the page's current permalink, everything
+// else (external URL, missing/cross-site reference) to null (never chains).
+// References are resolved in one batch rather than a query each.
+const resolveStoredDestinationsToSources = async (
+  siteId: number,
+  storedDestinations: string[],
+): Promise<Map<string, string | null>> => {
+  const result = new Map<string, string | null>()
+  const referenceIdByDestination = new Map<string, number>()
+  for (const destination of new Set(storedDestinations)) {
+    if (destination.startsWith("/")) {
+      result.set(destination, normalizeRedirectSource(destination))
+      continue
+    }
+    const match = REFERENCE_DESTINATION_REGEX.exec(destination)
+    if (match && Number(match[1]) === siteId) {
+      referenceIdByDestination.set(destination, Number(match[2]))
+      continue
+    }
+    result.set(destination, null)
+  }
+
+  const referenceIds = [...referenceIdByDestination.values()]
+  const permalinks = referenceIds.length
+    ? await getResourceFullPermalinks(siteId, referenceIds)
+    : new Map<number, string>()
+  for (const [destination, resourceId] of referenceIdByDestination) {
+    const permalink = permalinks.get(resourceId)
+    result.set(
+      destination,
+      permalink ? normalizeRedirectSource(permalink) : null,
+    )
+  }
+  return result
+}
+
+// Batched form of resolveDestinationForStorage: an internal path that maps to a
+// resource becomes a [resource:...] reference; a query/fragment path or a path
+// with no matching resource stays literal; references and external URLs are
+// stored verbatim. Resolves every internal path in one query rather than one per
+// row, at the cost of matching getResourceIdsByPermalinks' structural resolution
+// (the container id itself, not via its index page — the canonical id the build
+// remaps to anyway).
+const resolveDestinationsForStorage = async (
+  siteId: number,
+  destinations: string[],
+): Promise<Map<string, string>> => {
+  const result = new Map<string, string>()
+  const internalPaths: string[] = []
+  for (const destination of new Set(destinations)) {
+    const parsed = parseDestination(destination)
+    if (
+      parsed.type !== "internalPath" ||
+      parsed.value.includes("?") ||
+      parsed.value.includes("#")
+    ) {
+      result.set(destination, destination)
+      continue
+    }
+    internalPaths.push(parsed.value)
+  }
+
+  const idByPath = internalPaths.length
+    ? await getResourceIdsByPermalinks(siteId, internalPaths)
+    : new Map<string, number | null>()
+  for (const destination of new Set(destinations)) {
+    if (result.has(destination)) {
+      continue
+    }
+    const resourceId = idByPath.get(destination) ?? null
+    result.set(
+      destination,
+      resourceId === null
+        ? destination
+        : getReferenceLink({
+            siteId: String(siteId),
+            resourceId: String(resourceId),
+          }),
+    )
+  }
+  return result
+}
+
+// Walks the redirect chain from `start`, following each source to the source it
+// redirects to, and reports whether it returns to `start` — a loop. The chain is
+// followed to its end or until it repeats a node (tracked in `visited`), so a
+// batch cycle of ANY length is caught; `visited` also stops an unrelated
+// downstream cycle (one that never passes through `start`) from spinning forever.
+const formsLoop = (
+  edges: Map<string, string | null>,
+  start: string,
+): boolean => {
+  const visited = new Set<string>()
+  let current = edges.get(start) ?? null
+  while (current !== null) {
+    if (current === start) {
+      return true
+    }
+    if (visited.has(current)) {
+      return false
+    }
+    visited.add(current)
+    current = edges.get(current) ?? null
+  }
+  return false
+}
+
+// Evaluates every CSV row against the same rules as a single create, plus the
+// two cross-file checks the design calls for (duplicate source in the file, loop
+// formed within the batch). Each row keeps at most one error, chosen in
+// precedence order: format → duplicate-in-file → already-on-table → shadows a
+// page → loop. Returns the internal rows (with normalized values) so the caller
+// can both build the public verdict and insert the surviving rows.
+const runBulkValidation = async (
+  siteId: number,
+  csv: string,
+): Promise<{ fileError: string | null; rows: EvaluatedRedirectRow[] }> => {
+  const parsed = parseRedirectCsv(csv)
+  if (parsed.fileError !== undefined) {
+    return { fileError: parsed.fileError, rows: [] }
+  }
+
+  // 1) Per-row format validation via the shared row schema (same rules, and the
+  // same messages, as the inline add form). A row split by an unquoted comma is
+  // rejected first — its parsed destination is truncated, so it can't be trusted.
+  const rows: EvaluatedRedirectRow[] = parsed.rows.map(
+    ({ rowNumber, source, destination, malformed }) => {
+      const base = { rowNumber, source, destination }
+      if (malformed) {
+        return {
+          ...base,
+          normalizedSource: null,
+          normalizedDestination: null,
+          error: BULK_MALFORMED_ROW_MESSAGE,
+        }
+      }
+      const result = redirectRowSchema.safeParse({ source, destination })
+      if (!result.success) {
+        return {
+          ...base,
+          normalizedSource: null,
+          normalizedDestination: null,
+          error:
+            result.error.issues[0]?.message ?? "This redirect isn't valid.",
+        }
+      }
+      return {
+        ...base,
+        normalizedSource: result.data.source,
+        normalizedDestination: result.data.destination,
+        error: null,
+      }
+    },
+  )
+
+  // 2) Duplicate source within the uploaded file.
+  const sourceCounts = new Map<string, number>()
+  for (const row of rows) {
+    if (row.error === null && row.normalizedSource !== null) {
+      sourceCounts.set(
+        row.normalizedSource,
+        (sourceCounts.get(row.normalizedSource) ?? 0) + 1,
+      )
+    }
+  }
+  for (const row of rows) {
+    if (
+      row.error === null &&
+      row.normalizedSource !== null &&
+      (sourceCounts.get(row.normalizedSource) ?? 0) > 1
+    ) {
+      row.error = BULK_DUPLICATE_SOURCE_MESSAGE
+    }
+  }
+
+  // Load every live redirect once; reused for the on-table check and the loop
+  // graph so the whole batch is validated against the DB in memory.
+  const liveRedirects = await db
+    .selectFrom("Redirect")
+    .select(["source", "destination"])
+    .where("siteId", "=", siteId)
+    .where("deletedAt", "is", null)
+    .execute()
+
+  // 3) Source already redirected on the table.
+  const liveSources = new Set(liveRedirects.map((redirect) => redirect.source))
+  for (const row of rows) {
+    if (
+      row.error === null &&
+      row.normalizedSource !== null &&
+      liveSources.has(row.normalizedSource)
+    ) {
+      row.error = REDIRECT_MESSAGES.alreadyExists
+    }
+  }
+
+  // 4) Source shadows a live published page or container.
+  const sourcesToCheck = [
+    ...new Set(
+      rows.flatMap((row) =>
+        row.error === null && row.normalizedSource !== null
+          ? [row.normalizedSource]
+          : [],
+      ),
+    ),
+  ]
+  if (sourcesToCheck.length > 0) {
+    const idByPermalink = await getResourceIdsByPermalinks(
+      siteId,
+      sourcesToCheck,
+    )
+    const resourceIds = [...idByPermalink.values()].filter(
+      (id): id is number => id !== null,
+    )
+    const publishedState = await getPublishedStateByResourceIds(
+      siteId,
+      resourceIds,
+    )
+    for (const row of rows) {
+      if (row.error !== null || row.normalizedSource === null) {
+        continue
+      }
+      const resourceId = idByPermalink.get(row.normalizedSource) ?? null
+      if (resourceId !== null && publishedState.get(resourceId)) {
+        row.error = REDIRECT_MESSAGES.sourceIsExistingPage
+      }
+    }
+  }
+
+  // 5) Loops in the combined graph. Only rows that survived the checks above
+  // (and so would actually be created) contribute an edge, alongside every
+  // existing live redirect.
+  const resolvedExisting = await resolveStoredDestinationsToSources(
+    siteId,
+    liveRedirects.map((redirect) => redirect.destination),
+  )
+  const edges = new Map<string, string | null>()
+  for (const redirect of liveRedirects) {
+    edges.set(
+      redirect.source,
+      resolvedExisting.get(redirect.destination) ?? null,
+    )
+  }
+  for (const row of rows) {
+    if (row.error !== null || row.normalizedSource === null) {
+      continue
+    }
+    const destination = row.normalizedDestination
+    const nextSource =
+      destination !== null && destination.startsWith("/")
+        ? normalizeRedirectSource(destination)
+        : null
+    // A surviving row has a unique source and never collides with an existing
+    // redirect's source (both were flagged above), so this never clobbers an
+    // existing edge.
+    edges.set(row.normalizedSource, nextSource)
+  }
+  for (const row of rows) {
+    if (row.error !== null || row.normalizedSource === null) {
+      continue
+    }
+    if (formsLoop(edges, row.normalizedSource)) {
+      row.error = REDIRECT_MESSAGES.loop
+    }
+  }
+
+  return { fileError: null, rows }
+}
+
+const toValidationResult = (
+  fileError: string | null,
+  rows: EvaluatedRedirectRow[],
+): BulkRedirectValidationResult => {
+  const publicRows: BulkRedirectRowResult[] = rows.map(
+    ({ rowNumber, source, destination, error }) => ({
+      rowNumber,
+      source,
+      destination,
+      error,
+    }),
+  )
+  return {
+    fileError,
+    rows: publicRows,
+    validCount: publicRows.filter((row) => row.error === null).length,
+    errorCount: publicRows.filter((row) => row.error !== null).length,
+  }
+}
+
+// Validates an uploaded CSV without writing anything. Powers the modal's
+// "Process redirects" step: drives the errors screen or the ready-to-publish
+// preview.
+export const bulkValidateRedirects = async ({
+  siteId,
+  csv,
+}: BulkRedirectsCsvInput): Promise<BulkRedirectValidationResult> => {
+  const { fileError, rows } = await runBulkValidation(siteId, csv)
+  return toValidationResult(fileError, rows)
+}
+
+// Result of committing a bulk upload: a published count on success, or the fresh
+// validation to re-render the errors screen when re-validation now fails (a race
+// since the preview) — never a partial publish.
+export type BulkCreateRedirectsResult =
+  | { ok: true; publishedCount: number }
+  | { ok: false; validation: BulkRedirectValidationResult }
+
+// Publishes a whole validated batch: re-validates server-side (trust boundary +
+// race guard), inserts every row in one transaction (chunked, reviving any
+// soft-deleted row like a single create), audits one RedirectCreate per row plus
+// one Publish, then rebuilds the site once.
+export const bulkCreateRedirects = async ({
+  siteId,
+  csv,
+  byUserId,
+  logger,
+}: BulkRedirectsCsvInput & {
+  byUserId: string
+  logger: Logger<string>
+}): Promise<BulkCreateRedirectsResult> => {
+  const byUser = await getByUser(byUserId)
+
+  const { fileError, rows } = await runBulkValidation(siteId, csv)
+  if (fileError !== null || rows.some((row) => row.error !== null)) {
+    return { ok: false, validation: toValidationResult(fileError, rows) }
+  }
+
+  // Every surviving row has normalized values (error === null implies both were
+  // set). The guard narrows the types without an assertion; it never drops a row
+  // here since we returned early above on any error.
+  const validRows = rows.flatMap((row) =>
+    row.normalizedSource !== null && row.normalizedDestination !== null
+      ? [
+          {
+            source: row.normalizedSource,
+            destination: row.normalizedDestination,
+          },
+        ]
+      : [],
+  )
+  const storedByDestination = await resolveDestinationsForStorage(
+    siteId,
+    validRows.map((row) => row.destination),
+  )
+  const valuesToInsert = validRows.map((row) => ({
+    siteId,
+    source: row.source,
+    destination: storedByDestination.get(row.destination) ?? row.destination,
+  }))
+  const sources = valuesToInsert.map((value) => value.source)
+
+  try {
+    const created = await db.transaction().execute(async (tx) => {
+      // Re-read every existing row (live or soft-deleted) for these sources
+      // first, so each audit entry's `before` is the real committed row.
+      const existingRows = sources.length
+        ? await tx
+            .selectFrom("Redirect")
+            .selectAll()
+            .where("siteId", "=", siteId)
+            .where("source", "in", sources)
+            .execute()
+        : []
+      const existingBySource = new Map(
+        existingRows.map((row) => [row.source, row]),
+      )
+
+      const insertedRows: typeof existingRows = []
+      for (
+        let i = 0;
+        i < valuesToInsert.length;
+        i += BULK_REDIRECT_INSERT_CHUNK_SIZE
+      ) {
+        const chunk = valuesToInsert.slice(
+          i,
+          i + BULK_REDIRECT_INSERT_CHUNK_SIZE,
+        )
+        const inserted = await tx
+          .insertInto("Redirect")
+          .values(chunk)
+          .onConflict((oc) =>
+            oc
+              .columns(["siteId", "source"])
+              .doUpdateSet((eb) => ({
+                destination: eb.ref("excluded.destination"),
+                deletedAt: null,
+                // Revived rows republish now, so refresh createdAt (the publish
+                // time shown to users).
+                createdAt: dbNow,
+              }))
+              // Only soft-deleted rows may be revived; a live one must not be
+              // silently overwritten.
+              .where("Redirect.deletedAt", "is not", null),
+          )
+          .returningAll()
+          .execute()
+        insertedRows.push(...inserted)
+      }
+
+      // One returned row per input is expected (new rows insert, soft-deleted rows
+      // revive). A shortfall means a source went live between validation and the
+      // insert (the upsert skipped it) — abort the txn so a partial batch never
+      // publishes; bulkCreate catches this and re-validates for fresh row errors.
+      if (insertedRows.length !== valuesToInsert.length) {
+        throw new BulkRedirectRaceError()
+      }
+
+      // One RedirectCreate per redirect, pairing each committed row with its real
+      // before-row (matching how the delete cascade audits per row).
+      for (const row of insertedRows) {
+        await logRedirectEvent(tx, {
+          siteId,
+          by: byUser,
+          eventType: AuditLogEvent.RedirectCreate,
+          delta: {
+            before: existingBySource.get(row.source) ?? null,
+            after: row,
+          },
+        })
+      }
+
+      // The whole batch republishes once, audited as a single Publish event.
+      await logPublishEvent(tx, {
+        siteId,
+        by: byUser,
+        delta: { before: null, after: null },
+        eventType: AuditLogEvent.Publish,
+        metadata: { redirects: { created: insertedRows } },
+      })
+
+      return insertedRows
+    })
+
+    // Publish once after commit (see createRedirect's two-step publish).
+    await publishSite(logger, { siteId })
+
+    return { ok: true, publishedCount: created.length }
+  } catch (error) {
+    if (error instanceof BulkRedirectRaceError) {
+      // A source went live between validation and the insert. Re-validate
+      // against the now-current table so the modal shows the offending row(s)
+      // rather than a generic failure — this keeps the ok:false contract.
+      const { fileError, rows } = await runBulkValidation(siteId, csv)
+      return { ok: false, validation: toValidationResult(fileError, rows) }
+    }
+    throw error
+  }
 }
 
 // Redirects driven by a permalink change (move / rename). Both run inside the

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -874,31 +874,43 @@ const runBulkValidation = async (
 
   // 5) Loops in the combined graph. Only rows that survived the checks above
   // (and so would actually be created) contribute an edge, alongside every
-  // existing live redirect.
-  const resolvedExisting = await resolveStoredDestinationsToSources(
+  // existing live redirect. Batch destinations are resolved to their target
+  // source the same way as stored ones — a `[resource:...]` reference must
+  // contribute the right edge. A path-only check would drop a reference to a
+  // null edge, letting a reference-formed loop slip past validation while the
+  // in-transaction recheck (which resolves references) catches it, so the two
+  // must agree.
+  const resolvedDestinations = await resolveStoredDestinationsToSources(
     siteId,
-    liveRedirects.map((redirect) => redirect.destination),
+    [
+      ...liveRedirects.map((redirect) => redirect.destination),
+      ...rows.flatMap((row) =>
+        row.error === null && row.normalizedDestination !== null
+          ? [row.normalizedDestination]
+          : [],
+      ),
+    ],
   )
   const edges = new Map<string, string | null>()
   for (const redirect of liveRedirects) {
     edges.set(
       redirect.source,
-      resolvedExisting.get(redirect.destination) ?? null,
+      resolvedDestinations.get(redirect.destination) ?? null,
     )
   }
   for (const row of rows) {
     if (row.error !== null || row.normalizedSource === null) {
       continue
     }
-    const destination = row.normalizedDestination
-    const nextSource =
-      destination !== null && destination.startsWith("/")
-        ? normalizeRedirectSource(destination)
-        : null
     // A surviving row has a unique source and never collides with an existing
     // redirect's source (both were flagged above), so this never clobbers an
     // existing edge.
-    edges.set(row.normalizedSource, nextSource)
+    edges.set(
+      row.normalizedSource,
+      row.normalizedDestination !== null
+        ? (resolvedDestinations.get(row.normalizedDestination) ?? null)
+        : null,
+    )
   }
   const cycleNodes = findCycleNodes(edges)
   for (const row of rows) {

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -186,6 +186,12 @@ const getPublishedStateByResourceIds = async (
   return result
 }
 
+// Strips a "?query"/"#fragment" off a path, leaving the bare path before the
+// first "?" or "#". A redirect source is always a clean path, so a destination
+// like "/b?x" has to compare as "/b" — both when resolving it for display and
+// when matching it against sources for loop detection.
+const stripQueryFragment = (value: string) => value.split(/[?#]/)[0] ?? value
+
 // Resolves stored internal destinations (both [resource:...] references and
 // literal "/paths") for the table. For references it returns the destination
 // page's current permalink for display (null if the page is gone). `warn` is
@@ -199,10 +205,6 @@ export const resolveRedirectReferences = async ({
 }: ResolveRedirectReferencesInput): Promise<
   { reference: string; permalink: string | null; warn: boolean }[]
 > => {
-  // A literal path may carry a "?query"/"#fragment" that isn't part of the
-  // resource path — resolve against the bare path.
-  const stripQueryFragment = (value: string) => value.split(/[?#]/)[0] ?? value
-
   // Classify each destination synchronously. References are anchored AND must
   // belong to this site; a cross-site reference can't resolve here. Literal
   // paths carry their bare path so they can be resolved together in one batch
@@ -497,10 +499,10 @@ export const createRedirect = async ({
         })
       }
 
-      // Re-enforce the no-loop rule server-side; the preflight is advisory. Unlike
-      // the recreate check (constraint-backed), this is a plain read, so two admins
-      // racing the mirror pair (/a->/b and /b->/a) could each pass and persist a
-      // loop — accepted, since the result is recoverable by deleting either side.
+      // Re-enforce the no-loop rule server-side; the preflight is advisory. The
+      // per-site advisory lock above serialises redirect writes, so a concurrent
+      // create can't slip the other half of a mirror pair (/a->/b and /b->/a)
+      // past this read — the later writer waits, then sees the committed row.
       const chained = await getChainedRedirect(tx, {
         siteId,
         source,
@@ -516,9 +518,10 @@ export const createRedirect = async ({
       }
 
       // Re-enforce the source-vs-published-page guard (a published page or live
-      // folder/collection at this URL would be shadowed). Also a plain read, so
-      // same accepted race as above. PRECONDITION_FAILED keeps it distinct from
-      // the already-exists CONFLICT.
+      // folder/collection at this URL would be shadowed). A page publish doesn't
+      // take the redirect lock, so this plain read can still race one going live
+      // — accepted, since a redirect shadowing a page is recoverable by deleting
+      // it. PRECONDITION_FAILED keeps it distinct from the already-exists CONFLICT.
       const pageAtSource = await getResourceByFullPermalink({
         siteId,
         fullPermalink: source,
@@ -690,7 +693,13 @@ const resolveStoredDestinationsToSources = async (
   const referenceIdByDestination = new Map<string, number>()
   for (const destination of new Set(storedDestinations)) {
     if (destination.startsWith("/")) {
-      result.set(destination, normalizeRedirectSource(destination))
+      // Compare against sources by the bare path: a source can't carry "?"/"#",
+      // so "/b?x" must resolve to the "/b" node or a /a->/b?x, /b->/a loop is
+      // missed (a request to /b?x still matches the /b source rule).
+      result.set(
+        destination,
+        normalizeRedirectSource(stripQueryFragment(destination)),
+      )
       continue
     }
     const match = REFERENCE_DESTINATION_REGEX.exec(destination)
@@ -1086,15 +1095,21 @@ export const bulkCreateRedirects = async ({
       )
 
       // Re-read every existing row (live or soft-deleted) for these sources
-      // first, so each audit entry's `before` is the real committed row.
-      const existingRows = sources.length
-        ? await tx
-            .selectFrom("Redirect")
-            .selectAll()
-            .where("siteId", "=", siteId)
-            .where("source", "in", sources)
-            .execute()
-        : []
+      // first, so each audit entry's `before` is the real committed row. Chunked
+      // so a large batch's WHERE source IN (...) can't exceed Postgres' 65535
+      // bind-parameter cap.
+      const existingRows = (
+        await Promise.all(
+          chunk(sources, BULK_REDIRECT_INSERT_CHUNK_SIZE).map((batch) =>
+            tx
+              .selectFrom("Redirect")
+              .selectAll()
+              .where("siteId", "=", siteId)
+              .where("source", "in", batch)
+              .execute(),
+          ),
+        )
+      ).flat()
       const existingBySource = new Map(
         existingRows.map((row) => [row.source, row]),
       )
@@ -1209,12 +1224,15 @@ export const bulkCreateRedirects = async ({
       }
 
       // The whole batch republishes once, audited as a single Publish event.
+      // Store only the count here — the per-row detail lives in the RedirectCreate
+      // entries above, so embedding every inserted row would just bloat this one
+      // AuditLog row (thousands of rows on a large upload).
       await logPublishEvent(tx, {
         siteId,
         by: byUser,
         delta: { before: null, after: null },
         eventType: AuditLogEvent.Publish,
-        metadata: { redirects: { created: insertedRows } },
+        metadata: { redirects: { createdCount: insertedRows.length } },
       })
 
       return insertedRows

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -1076,6 +1076,36 @@ export const bulkCreateRedirects = async ({
         throw new BulkRedirectRaceError()
       }
 
+      // Re-check for loops against the just-inserted batch plus any redirect
+      // created concurrently. Validation ruled out loops as of its read, but a
+      // redirect completing one (e.g. /b -> /a landing after a batch /a -> /b was
+      // validated) could have been created since — the shortfall and
+      // published-page rechecks don't catch that. Read the table via tx (so it
+      // sees this batch and any committed concurrent redirect), rebuild the
+      // combined graph, and abort if a batch source now lies on a cycle (mirrors
+      // createRedirect's in-transaction loop guard).
+      const liveAfterInsert = await tx
+        .selectFrom("Redirect")
+        .select(["source", "destination"])
+        .where("siteId", "=", siteId)
+        .where("deletedAt", "is", null)
+        .execute()
+      const resolvedAfter = await resolveStoredDestinationsToSources(
+        siteId,
+        liveAfterInsert.map((redirect) => redirect.destination),
+      )
+      const graphAfter = new Map<string, string | null>()
+      for (const redirect of liveAfterInsert) {
+        graphAfter.set(
+          redirect.source,
+          resolvedAfter.get(redirect.destination) ?? null,
+        )
+      }
+      const cycleNodes = findCycleNodes(graphAfter)
+      if (sources.some((source) => cycleNodes.has(source))) {
+        throw new BulkRedirectRaceError()
+      }
+
       // One RedirectCreate per redirect, pairing each committed row with its real
       // before-row (matching how the delete cascade audits per row).
       for (const row of insertedRows) {

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -576,8 +576,16 @@ export const createRedirect = async ({
 // ---------------------------------------------------------------------------
 
 // Rows are inserted in chunks so a large upload doesn't build one enormous
-// INSERT (mirrors the migration script's chunking).
+// INSERT (mirrors the migration script's chunking). Postgres also caps a
+// statement at 65535 bind parameters, so the chunk keeps every batched insert
+// (redirects and their audit rows) well under that.
 const BULK_REDIRECT_INSERT_CHUNK_SIZE = 500
+
+// Arbitrary namespace for the per-site advisory lock that serialises bulk
+// redirect writes (there is no other advisory-lock user, but the two-key form
+// keeps this from ever colliding with a future one). pg_advisory_xact_lock
+// releases automatically when the transaction ends.
+const REDIRECT_WRITE_LOCK_NAMESPACE = 0x5244 // "RD"
 
 // Shown when a row is split by an unquoted comma into extra columns.
 const BULK_MALFORMED_ROW_MESSAGE =
@@ -1009,6 +1017,16 @@ export const bulkCreateRedirects = async ({
 
   try {
     const created = await db.transaction().execute(async (tx) => {
+      // Serialise redirect writes for this site: two concurrent bulk creates
+      // could otherwise each miss the other's uncommitted rows in the rechecks
+      // below (READ COMMITTED doesn't see them) and both publish — e.g. one
+      // inserting /a -> /b while the other inserts /b -> /a, forming a loop. The
+      // xact lock makes the later transaction wait, so its recheck sees the
+      // committed rows and aborts. Released automatically at commit/rollback.
+      await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
+        tx,
+      )
+
       // Re-read every existing row (live or soft-deleted) for these sources
       // first, so each audit entry's `before` is the real committed row.
       const existingRows = sources.length
@@ -1119,17 +1137,29 @@ export const bulkCreateRedirects = async ({
       }
 
       // One RedirectCreate per redirect, pairing each committed row with its real
-      // before-row (matching how the delete cascade audits per row).
-      for (const row of insertedRows) {
-        await logRedirectEvent(tx, {
-          siteId,
-          by: byUser,
-          eventType: AuditLogEvent.RedirectCreate,
-          delta: {
-            before: existingBySource.get(row.source) ?? null,
-            after: row,
-          },
-        })
+      // before-row. Inserted in the same chunks as the redirects rather than one
+      // round-trip per row (via logRedirectEvent) — a large upload would
+      // otherwise run thousands of sequential inserts inside the transaction,
+      // holding locks and a connection far longer than needed.
+      const auditValues = insertedRows.map((row) => ({
+        siteId,
+        eventType: AuditLogEvent.RedirectCreate,
+        delta: {
+          before: existingBySource.get(row.source) ?? null,
+          after: row,
+        },
+        userId: byUser.id,
+        metadata: {},
+      }))
+      for (
+        let i = 0;
+        i < auditValues.length;
+        i += BULK_REDIRECT_INSERT_CHUNK_SIZE
+      ) {
+        await tx
+          .insertInto("AuditLog")
+          .values(auditValues.slice(i, i + BULK_REDIRECT_INSERT_CHUNK_SIZE))
+          .execute()
       }
 
       // The whole batch republishes once, audited as a single Publish event.

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -459,6 +459,14 @@ export const createRedirect = async ({
   const byUser = await getByUser(byUserId)
 
   const created = await db.transaction().execute(async (tx) => {
+    // Serialise redirect writes for this site (the same lock bulkCreateRedirects
+    // takes), so a single create and a concurrent bulk create can't each miss
+    // the other's uncommitted row in the loop/shadow guards below and both
+    // publish a loop. Released automatically at commit/rollback.
+    await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
+      tx,
+    )
+
     // Reject creating over a live redirect. A soft-deleted row for the same
     // source still holds the (siteId, source) unique constraint and is revived
     // by the upsert below.
@@ -581,10 +589,11 @@ export const createRedirect = async ({
 // (redirects and their audit rows) well under that.
 const BULK_REDIRECT_INSERT_CHUNK_SIZE = 500
 
-// Arbitrary namespace for the per-site advisory lock that serialises bulk
-// redirect writes (there is no other advisory-lock user, but the two-key form
-// keeps this from ever colliding with a future one). pg_advisory_xact_lock
-// releases automatically when the transaction ends.
+// Arbitrary namespace for the per-site advisory lock that serialises redirect
+// writes (single create + bulk create) so their loop/shadow rechecks can't race
+// each other. There is no other advisory-lock user, but the two-key form keeps
+// this from ever colliding with a future one; pg_advisory_xact_lock releases
+// automatically when the transaction ends.
 const REDIRECT_WRITE_LOCK_NAMESPACE = 0x5244 // "RD"
 
 // Shown when a row is split by an unquoted comma into extra columns.

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -583,9 +583,11 @@ const BULK_REDIRECT_INSERT_CHUNK_SIZE = 500
 const BULK_MALFORMED_ROW_MESSAGE =
   "This row has extra columns. Put double quotes around any value that contains a comma."
 
-// Thrown inside the bulk insert when a source went live between validation and
-// the insert (the upsert skipped it). bulkCreate catches it to re-validate and
-// return fresh row verdicts rather than surface a generic failure.
+// Thrown inside the bulk insert when a source stopped being publishable between
+// validation and the insert — either it gained a live redirect (the upsert
+// skipped it, a shortfall) or a page was published at it (the in-txn recheck).
+// bulkCreate catches it to re-validate and return fresh row verdicts rather than
+// surface a generic failure.
 class BulkRedirectRaceError extends Error {}
 
 // Cross-file duplicate copy. The other row errors reuse the shared Studio
@@ -993,6 +995,31 @@ export const bulkCreateRedirects = async ({
         existingRows.map((row) => [row.source, row]),
       )
 
+      // Re-enforce the source-vs-published-page guard here, close to the insert.
+      // A page could have gone live at one of these sources since validation, and
+      // the upsert only guards against a concurrent live redirect (the shortfall
+      // check below) — so a redirect shadowing the now-live page would otherwise
+      // publish. Mirrors createRedirect's in-transaction recheck. On a hit, abort
+      // so the catch re-validates and returns fresh per-row errors (keeping the
+      // ok:false contract) rather than committing a shadowing redirect.
+      if (sources.length > 0) {
+        const idByPermalink = await getResourceIdsByPermalinks(siteId, sources)
+        const pageResourceIds = [...idByPermalink.values()].filter(
+          (id): id is number => id !== null,
+        )
+        const publishedState = await getPublishedStateByResourceIds(
+          siteId,
+          pageResourceIds,
+        )
+        const shadowsLivePage = sources.some((source) => {
+          const resourceId = idByPermalink.get(source) ?? null
+          return resourceId !== null && publishedState.get(resourceId) === true
+        })
+        if (shadowsLivePage) {
+          throw new BulkRedirectRaceError()
+        }
+      }
+
       const insertedRows: typeof existingRows = []
       for (
         let i = 0;
@@ -1065,9 +1092,10 @@ export const bulkCreateRedirects = async ({
     return { ok: true, publishedCount: created.length }
   } catch (error) {
     if (error instanceof BulkRedirectRaceError) {
-      // A source went live between validation and the insert. Re-validate
-      // against the now-current table so the modal shows the offending row(s)
-      // rather than a generic failure — this keeps the ok:false contract.
+      // A source gained a live redirect or a published page between validation
+      // and the insert. Re-validate against the now-current table so the modal
+      // shows the offending row(s) rather than a generic failure — this keeps
+      // the ok:false contract.
       const { fileError, rows } = await runBulkValidation(siteId, csv)
       return { ok: false, validation: toValidationResult(fileError, rows) }
     }

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -20,7 +20,7 @@ import {
 } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import { sql } from "kysely"
-import { chunk } from "lodash-es"
+import { chunk, get } from "lodash-es"
 import {
   BULK_DUPLICATE_SOURCE_MESSAGE,
   BULK_MALFORMED_ROW_MESSAGE,
@@ -43,6 +43,7 @@ import type { SafeKysely, Transaction } from "../database"
 import { logPublishEvent, logRedirectEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { AuditLogEvent, db } from "../database"
+import { PG_ERROR_CODES } from "../database/constants"
 import {
   getDescendantResourceIds,
   getResourceByFullPermalink,
@@ -464,118 +465,126 @@ export const createRedirect = async ({
 }) => {
   const byUser = await getByUser(byUserId)
 
-  const created = await db.transaction().execute(async (tx) => {
-    // Serialise redirect writes for this site (the same lock bulkCreateRedirects
-    // takes), so a single create and a concurrent bulk create can't each miss
-    // the other's uncommitted row in the loop/shadow guards below and both
-    // publish a loop. Released automatically at commit/rollback.
-    await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
-      tx,
-    )
-
-    // Reject creating over a live redirect. A soft-deleted row for the same
-    // source still holds the (siteId, source) unique constraint and is revived
-    // by the upsert below.
-    const existing = await tx
-      .selectFrom("Redirect")
-      .selectAll()
-      .where("siteId", "=", siteId)
-      .where("source", "=", source)
-      .executeTakeFirst()
-    if (existing && existing.deletedAt === null) {
-      throw new TRPCError({
-        code: "CONFLICT",
-        message: `A redirect already exists for ${source}`,
-      })
-    }
-
-    // Re-enforce the no-loop rule server-side; the preflight is advisory. Unlike
-    // the recreate check (constraint-backed), this is a plain read, so two admins
-    // racing the mirror pair (/a->/b and /b->/a) could each pass and persist a
-    // loop — accepted, since the result is recoverable by deleting either side.
-    const chained = await getChainedRedirect(tx, {
-      siteId,
-      source,
-      destination,
-    })
-    if (chained?.isLoop) {
-      // UNPROCESSABLE_CONTENT is reserved for the loop guard — the form maps it
-      // to the loop message on the destination field; don't reuse it elsewhere.
-      throw new TRPCError({
-        code: "UNPROCESSABLE_CONTENT",
-        message: REDIRECT_MESSAGES.loop,
-      })
-    }
-
-    // Re-enforce the source-vs-published-page guard (a published page or live
-    // folder/collection at this URL would be shadowed). Also a plain read, so
-    // same accepted race as above. PRECONDITION_FAILED keeps it distinct from
-    // the already-exists CONFLICT.
-    const pageAtSource = await getResourceByFullPermalink({
-      siteId,
-      fullPermalink: source,
-    })
-    if (pageAtSource && pageAtSource.publishedVersionId !== null) {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: REDIRECT_MESSAGES.sourceIsExistingPage,
-      })
-    }
-
-    // Resolve an internal-path destination to a [resource:...] reference (so it
-    // follows page renames); a path with no live page yet is kept literal (the
-    // preflight already warned). Never blocks the create.
-    const storedDestination = await resolveDestinationForStorage(
-      siteId,
-      destination,
-    )
-
-    const created = await tx
-      .insertInto("Redirect")
-      .values({ siteId, source, destination: storedDestination })
-      .onConflict((oc) =>
-        oc
-          .columns(["siteId", "source"])
-          .doUpdateSet({
-            destination: storedDestination,
-            deletedAt: null,
-            // Revived rows republish now, so refresh createdAt (the publish
-            // time shown to users).
-            createdAt: dbNow,
-          })
-          // Only soft-deleted rows may be revived; a concurrent live create
-          // must surface as a conflict, not silently overwrite.
-          .where("Redirect.deletedAt", "is not", null),
+  const created = await db
+    .transaction()
+    .execute(async (tx) => {
+      // Bound the wait for the lock so a stalled holder can't block this write
+      // indefinitely; the wait aborts as a retryable CONFLICT (see the .catch).
+      await sql`SET LOCAL lock_timeout = ${sql.lit(REDIRECT_LOCK_TIMEOUT_MS)}`.execute(
+        tx,
       )
-      .returningAll()
-      // A null row means the upsert skipped a live redirect — a conflict.
-      .executeTakeFirstOrThrow(
-        () =>
-          new TRPCError({
-            code: "CONFLICT",
-            message: `A redirect already exists for ${source}`,
-          }),
+      // Serialise redirect writes for this site (the same lock bulkCreateRedirects
+      // takes), so a single create and a concurrent bulk create can't each miss
+      // the other's uncommitted row in the loop/shadow guards below and both
+      // publish a loop. Released automatically at commit/rollback.
+      await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
+        tx,
       )
 
-    // delta holds the real before/after rows committed.
-    await logRedirectEvent(tx, {
-      siteId,
-      by: byUser,
-      eventType: AuditLogEvent.RedirectCreate,
-      delta: { before: existing ?? null, after: created },
-    })
+      // Reject creating over a live redirect. A soft-deleted row for the same
+      // source still holds the (siteId, source) unique constraint and is revived
+      // by the upsert below.
+      const existing = await tx
+        .selectFrom("Redirect")
+        .selectAll()
+        .where("siteId", "=", siteId)
+        .where("source", "=", source)
+        .executeTakeFirst()
+      if (existing && existing.deletedAt === null) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `A redirect already exists for ${source}`,
+        })
+      }
 
-    // Every mutation republishes the site; audited as a separate Publish event.
-    await logPublishEvent(tx, {
-      siteId,
-      by: byUser,
-      delta: { before: null, after: null },
-      eventType: AuditLogEvent.Publish,
-      metadata: { redirects: { created: [created] } },
-    })
+      // Re-enforce the no-loop rule server-side; the preflight is advisory. Unlike
+      // the recreate check (constraint-backed), this is a plain read, so two admins
+      // racing the mirror pair (/a->/b and /b->/a) could each pass and persist a
+      // loop — accepted, since the result is recoverable by deleting either side.
+      const chained = await getChainedRedirect(tx, {
+        siteId,
+        source,
+        destination,
+      })
+      if (chained?.isLoop) {
+        // UNPROCESSABLE_CONTENT is reserved for the loop guard — the form maps it
+        // to the loop message on the destination field; don't reuse it elsewhere.
+        throw new TRPCError({
+          code: "UNPROCESSABLE_CONTENT",
+          message: REDIRECT_MESSAGES.loop,
+        })
+      }
 
-    return created
-  })
+      // Re-enforce the source-vs-published-page guard (a published page or live
+      // folder/collection at this URL would be shadowed). Also a plain read, so
+      // same accepted race as above. PRECONDITION_FAILED keeps it distinct from
+      // the already-exists CONFLICT.
+      const pageAtSource = await getResourceByFullPermalink({
+        siteId,
+        fullPermalink: source,
+      })
+      if (pageAtSource && pageAtSource.publishedVersionId !== null) {
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: REDIRECT_MESSAGES.sourceIsExistingPage,
+        })
+      }
+
+      // Resolve an internal-path destination to a [resource:...] reference (so it
+      // follows page renames); a path with no live page yet is kept literal (the
+      // preflight already warned). Never blocks the create.
+      const storedDestination = await resolveDestinationForStorage(
+        siteId,
+        destination,
+      )
+
+      const created = await tx
+        .insertInto("Redirect")
+        .values({ siteId, source, destination: storedDestination })
+        .onConflict((oc) =>
+          oc
+            .columns(["siteId", "source"])
+            .doUpdateSet({
+              destination: storedDestination,
+              deletedAt: null,
+              // Revived rows republish now, so refresh createdAt (the publish
+              // time shown to users).
+              createdAt: dbNow,
+            })
+            // Only soft-deleted rows may be revived; a concurrent live create
+            // must surface as a conflict, not silently overwrite.
+            .where("Redirect.deletedAt", "is not", null),
+        )
+        .returningAll()
+        // A null row means the upsert skipped a live redirect — a conflict.
+        .executeTakeFirstOrThrow(
+          () =>
+            new TRPCError({
+              code: "CONFLICT",
+              message: `A redirect already exists for ${source}`,
+            }),
+        )
+
+      // delta holds the real before/after rows committed.
+      await logRedirectEvent(tx, {
+        siteId,
+        by: byUser,
+        eventType: AuditLogEvent.RedirectCreate,
+        delta: { before: existing ?? null, after: created },
+      })
+
+      // Every mutation republishes the site; audited as a separate Publish event.
+      await logPublishEvent(tx, {
+        siteId,
+        by: byUser,
+        delta: { before: null, after: null },
+        eventType: AuditLogEvent.Publish,
+        metadata: { redirects: { created: [created] } },
+      })
+
+      return created
+    })
+    .catch(rethrowLockTimeoutAsConflict)
 
   // Publish after the transaction commits so the external CodeBuild call is off
   // the row locks and a failed publish can't roll back a saved redirect
@@ -601,6 +610,35 @@ const BULK_REDIRECT_INSERT_CHUNK_SIZE = 500
 // this from ever colliding with a future one; pg_advisory_xact_lock releases
 // automatically when the transaction ends.
 const REDIRECT_WRITE_LOCK_NAMESPACE = 0x5244 // "RD"
+
+// Cap how long a redirect write waits for the per-site advisory lock. A writer
+// that waits longer aborts (Postgres 55P03) rather than blocking indefinitely on
+// a stalled holder and tying up a pooled connection. 15s is well above the
+// lock's normal hold time — it only covers the in-transaction DB work, since
+// publishSite runs after commit.
+const REDIRECT_LOCK_TIMEOUT_MS = 15_000
+
+// Shown when a write aborts on that timeout: another redirect write for the same
+// site is in flight, so the caller just retries.
+const REDIRECT_WRITE_BUSY_MESSAGE =
+  "Another change to this site's redirects is in progress. Please try again."
+
+// True when a query aborted waiting for a lock — here, the advisory lock's
+// lock_timeout firing.
+const isLockTimeoutError = (error: unknown): boolean =>
+  get(error, "code") === PG_ERROR_CODES.lockTimeout
+
+// Rethrow a lock-timeout wait as a retryable CONFLICT; pass everything else
+// through unchanged (so the transaction's own TRPCErrors keep their codes).
+const rethrowLockTimeoutAsConflict = (error: unknown): never => {
+  if (isLockTimeoutError(error)) {
+    throw new TRPCError({
+      code: "CONFLICT",
+      message: REDIRECT_WRITE_BUSY_MESSAGE,
+    })
+  }
+  throw error
+}
 
 // Thrown inside the bulk insert when a source stopped being publishable between
 // validation and the insert — either it gained a live redirect (the upsert
@@ -1032,6 +1070,11 @@ export const bulkCreateRedirects = async ({
 
   try {
     const created = await db.transaction().execute(async (tx) => {
+      // Bound the wait for the lock so a stalled holder can't block this write
+      // indefinitely; the wait aborts as a retryable CONFLICT (see the catch).
+      await sql`SET LOCAL lock_timeout = ${sql.lit(REDIRECT_LOCK_TIMEOUT_MS)}`.execute(
+        tx,
+      )
       // Serialise redirect writes for this site: two concurrent bulk creates
       // could otherwise each miss the other's uncommitted rows in the rechecks
       // below (READ COMMITTED doesn't see them) and both publish — e.g. one
@@ -1182,6 +1225,14 @@ export const bulkCreateRedirects = async ({
 
     return { ok: true, publishedCount: created.length }
   } catch (error) {
+    // A writer that waited past the lock_timeout for the per-site advisory lock
+    // aborts here; surface it as a retryable conflict rather than a 500.
+    if (isLockTimeoutError(error)) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: REDIRECT_WRITE_BUSY_MESSAGE,
+      })
+    }
     if (error instanceof BulkRedirectRaceError) {
       // A source gained a live redirect or a published page between validation
       // and the insert. Re-validate against the now-current table so the modal

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -711,28 +711,43 @@ const resolveDestinationsForStorage = async (
   return result
 }
 
-// Walks the redirect chain from `start`, following each source to the source it
-// redirects to, and reports whether it returns to `start` — a loop. The chain is
-// followed to its end or until it repeats a node (tracked in `visited`), so a
-// batch cycle of ANY length is caught; `visited` also stops an unrelated
-// downstream cycle (one that never passes through `start`) from spinning forever.
-const formsLoop = (
-  edges: Map<string, string | null>,
-  start: string,
-): boolean => {
-  const visited = new Set<string>()
-  let current = edges.get(start) ?? null
-  while (current !== null) {
-    if (current === start) {
-      return true
+// Finds every node that lies on a cycle in the functional redirect graph `edges`
+// (each source maps to at most one next source). One traversal over the whole
+// graph — O(total edges) — instead of re-walking the chain from each row, which
+// is O(N^2) and lets a long uploaded chain (up to ~100k rows within the 1MB cap)
+// block the single-threaded event loop. A node is on a cycle iff following its
+// chain returns to it, so membership in the returned set is exactly the old
+// per-row "chain from `start` returns to `start`" check — a source on the tail
+// leading INTO a cycle is (correctly) not included.
+const findCycleNodes = (edges: Map<string, string | null>): Set<string> => {
+  const cycleNodes = new Set<string>()
+  // 0 = on the path currently being walked, 1 = fully explored.
+  const state = new Map<string, 0 | 1>()
+  for (const start of edges.keys()) {
+    if (state.has(start)) {
+      continue
     }
-    if (visited.has(current)) {
-      return false
+    // Walk forward, recording the path, until the chain ends (null), reaches an
+    // already-explored node, or revisits a node still on the current path.
+    const path: string[] = []
+    let current: string | null = start
+    while (current !== null && !state.has(current)) {
+      state.set(current, 0)
+      path.push(current)
+      current = edges.get(current) ?? null
     }
-    visited.add(current)
-    current = edges.get(current) ?? null
+    // Stopping on a node still marked "on the current path" closed a cycle; every
+    // node from it to the end of the path lies on that cycle.
+    if (current !== null && state.get(current) === 0) {
+      for (const node of path.slice(path.indexOf(current))) {
+        cycleNodes.add(node)
+      }
+    }
+    for (const node of path) {
+      state.set(node, 1)
+    }
   }
-  return false
+  return cycleNodes
 }
 
 // Evaluates every CSV row against the same rules as a single create, plus the
@@ -885,11 +900,12 @@ const runBulkValidation = async (
     // existing edge.
     edges.set(row.normalizedSource, nextSource)
   }
+  const cycleNodes = findCycleNodes(edges)
   for (const row of rows) {
     if (row.error !== null || row.normalizedSource === null) {
       continue
     }
-    if (formsLoop(edges, row.normalizedSource)) {
+    if (cycleNodes.has(row.normalizedSource)) {
       row.error = REDIRECT_MESSAGES.loop
     }
   }

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -9,6 +9,7 @@ import {
   type IsomerSitemap,
 } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
+import chunk from "lodash-es/chunk"
 import get from "lodash-es/get"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
 import {
@@ -1084,9 +1085,14 @@ export const getResourceIdsByPermalinks = async (
   )
   const allSegments = [...new Set([...segmentsByPath.values()].flat())]
 
-  // One query for every candidate segment across all paths, plus the root page
-  // only when a bare "/" path is present — two round-trips regardless of N.
-  const [root, candidates] = await Promise.all([
+  // Chunk the candidate lookup so a large bulk upload (many distinct segments)
+  // can't push the IN (...) past Postgres' 65535 bind-parameter cap and fail the
+  // whole query. Well under the cap; candidates from every chunk are merged.
+  const SEGMENT_LOOKUP_CHUNK_SIZE = 20_000
+
+  // One query per candidate-segment chunk across all paths, plus the root page
+  // only when a bare "/" path is present.
+  const [root, candidateChunks] = await Promise.all([
     needsRoot
       ? db
           .selectFrom("Resource")
@@ -1096,15 +1102,18 @@ export const getResourceIdsByPermalinks = async (
           .select("Resource.id")
           .executeTakeFirst()
       : Promise.resolve(undefined),
-    allSegments.length > 0
-      ? db
+    Promise.all(
+      chunk(allSegments, SEGMENT_LOOKUP_CHUNK_SIZE).map((segments) =>
+        db
           .selectFrom("Resource")
           .where("Resource.siteId", "=", siteId)
-          .where("Resource.permalink", "in", allSegments)
+          .where("Resource.permalink", "in", segments)
           .select(["Resource.id", "Resource.permalink", "Resource.parentId"])
-          .execute()
-      : Promise.resolve([]),
+          .execute(),
+      ),
+    ),
   ])
+  const candidates = candidateChunks.flat()
 
   // Index candidates by (parentId, permalink) so each segment step is an O(1)
   // lookup. A linear `candidates.find` per segment is O(segments * candidates),

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1106,6 +1106,21 @@ export const getResourceIdsByPermalinks = async (
       : Promise.resolve([]),
   ])
 
+  // Index candidates by (parentId, permalink) so each segment step is an O(1)
+  // lookup. A linear `candidates.find` per segment is O(segments * candidates),
+  // which a large bulk upload against a resource-heavy site pushes into hundreds
+  // of millions of comparisons — enough to block the event loop. The " "
+  // separator is safe: a parentId is only digits, so the concatenation is
+  // injective (the first space always delimits parentId from permalink).
+  const idByParentAndPermalink = new Map<string, string>()
+  for (const candidate of candidates) {
+    const key = `${candidate.parentId ?? ""} ${candidate.permalink}`
+    // Keep the first match, mirroring the previous `Array.find` semantics.
+    if (!idByParentAndPermalink.has(key)) {
+      idByParentAndPermalink.set(key, String(candidate.id))
+    }
+  }
+
   for (const [path, segments] of segmentsByPath) {
     if (segments.length === 0) {
       result.set(path, root ? Number(root.id) : null)
@@ -1117,16 +1132,13 @@ export const getResourceIdsByPermalinks = async (
     let leafId: number | null = null
     let resolved = true
     for (const segment of segments) {
-      const match = candidates.find(
-        (candidate) =>
-          candidate.permalink === segment && candidate.parentId === parentId,
-      )
-      if (!match) {
+      const matchId = idByParentAndPermalink.get(`${parentId ?? ""} ${segment}`)
+      if (matchId === undefined) {
         resolved = false
         break
       }
-      leafId = Number(match.id)
-      parentId = String(match.id)
+      leafId = Number(matchId)
+      parentId = matchId
     }
     result.set(path, resolved ? leafId : null)
   }

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1109,12 +1109,12 @@ export const getResourceIdsByPermalinks = async (
   // Index candidates by (parentId, permalink) so each segment step is an O(1)
   // lookup. A linear `candidates.find` per segment is O(segments * candidates),
   // which a large bulk upload against a resource-heavy site pushes into hundreds
-  // of millions of comparisons — enough to block the event loop. The " "
+  // of millions of comparisons — enough to block the event loop. The "/"
   // separator is safe: a parentId is only digits, so the concatenation is
-  // injective (the first space always delimits parentId from permalink).
+  // injective — the first "/" always delimits parentId from permalink.
   const idByParentAndPermalink = new Map<string, string>()
   for (const candidate of candidates) {
-    const key = `${candidate.parentId ?? ""} ${candidate.permalink}`
+    const key = `${candidate.parentId ?? ""}/${candidate.permalink}`
     // Keep the first match, mirroring the previous `Array.find` semantics.
     if (!idByParentAndPermalink.has(key)) {
       idByParentAndPermalink.set(key, String(candidate.id))
@@ -1132,7 +1132,7 @@ export const getResourceIdsByPermalinks = async (
     let leafId: number | null = null
     let resolved = true
     for (const segment of segments) {
-      const matchId = idByParentAndPermalink.get(`${parentId ?? ""} ${segment}`)
+      const matchId = idByParentAndPermalink.get(`${parentId ?? ""}/${segment}`)
       if (matchId === undefined) {
         resolved = false
         break


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 5 | +889 | -113 |
| 🧪 Test | 1 | +496 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

> **📚 Part of a 3-PR stack** — bulk upload redirects, split from the original #2778. Review and merge bottom-up:
> 1. #2805 — CSV parsing + validation schema
> 2. **#2806 — bulk validate/create endpoints ← _this PR_**
> 3. #2778 — modal UI + feature flag

## Problem

Bulk-uploading redirects must be validated **authoritatively on the server** (the trust boundary — the browser check is only for fast feedback) and, only if every row is clean, created as one all-or-nothing batch that publishes the site exactly once. A partially-applied batch, or one that silently skips bad rows, would leave the site's redirects in a confusing state.

This layer adds the two tRPC endpoints on top of the parsing/validation foundation in #2805. There is **no UI yet** — the modal that calls these lands in #2778.

## Solution

Adds `redirect.bulkValidate` and `redirect.bulkCreate`, both sent over POST (the CSV body is too large for a GET query string).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- **`redirect.bulkValidate`** (read-gated): re-parses the CSV server-side and returns a file-level error plus per-row verdicts, covering:
  - format rules (shared `redirectRowSchema` from #2805) and malformed/stray-column rows;
  - a source listed more than once **within the file**;
  - a source already redirected on the live table;
  - a source that **shadows a live published page/folder**;
  - **loops of any length** across the combined graph of the uploaded batch + the live redirects table.
- **`redirect.bulkCreate`** (create / site-admin gated): revalidates server-side, resolves internal destinations to `[resource:…]` references, then in a single transaction batch-upserts every row (reviving soft-deleted rows for reused sources), writes one `RedirectCreate` audit per row plus a single `Publish`, and rebuilds the site **once**. All-or-nothing: any error blocks the whole batch. If a concurrent change invalidates the batch between validate and insert, it returns fresh row verdicts instead of publishing.

**Improvements**:

- Loop detection follows each chain to its end or to a repeated node (visited-set), rather than capping at a fixed number of hops — so a long batch loop is caught rather than silently published.

**Bug Fixes**:

- None (new endpoints).

## Before & After Screenshots

N/A — backend endpoints, no UI in this layer. The rendered flow lives in #2778.

## Tests

Integration tests (`__tests__/bulkRedirects.router.test.ts`) run against a real Postgres:

- `bulkValidate`: 403 without read access, missing header column, malformed row, duplicate-within-file, source already on the table, shadowing a published page, loop within the file, loop against the live table, a >10-hop (any-length) cycle, and a fully-valid file.
- `bulkCreate`: 403 without create access, error → no publish, happy-path insert + exactly one publish, soft-deleted revive, and one `RedirectCreate` per row plus one `Publish`.

**Manual Verification Steps**:

These endpoints are only reachable through the modal in #2778 (behind the `is-advanced-redirects-enabled` flag). Once the stack is deployed, verify this layer's behaviour via that flow:

- [ ] Upload a CSV whose rows form a loop (e.g. `/a → /b` and `/b → /a`) and confirm **both** rows are rejected and nothing is published.
- [ ] Upload a CSV with a source that already exists in the redirects table, and one that matches a live published page's URL — confirm both are flagged.
- [ ] Upload a valid CSV, publish, and confirm every row appears in the redirects table and the site republishes **once** (check the audit log shows one `RedirectCreate` per row and a single `Publish`).
- [ ] Re-upload a CSV reusing a source that was previously deleted, and confirm the redirect is revived with the new destination rather than erroring.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds two tRPC endpoints — `redirect.bulkValidate` and `redirect.bulkCreate` — that let editors upload a CSV of redirects and publish them as a single all-or-nothing batch. It addresses multiple race conditions raised in previous review rounds: the per-site `pg_advisory_xact_lock` serialises all redirect writes; an in-transaction shadow check catches pages published between validation and insert; and the combined-graph loop check runs post-insert inside the transaction so a concurrently committed redirect cannot close a loop.

- **`bulkValidate`** parses the CSV server-side, then checks format, in-file duplicate sources, already-live redirects, published-page shadows, and loops (including `[resource:...]` reference destinations) in a single read pass.
- **`bulkCreate`** re-validates, resolves destinations to `[resource:...]` references, acquires the per-site advisory lock, upserts rows (reviving soft-deleted ones), re-enforces the shadow and loop guards inside the transaction, writes one `RedirectCreate` audit per row and a single `Publish`, then rebuilds the site once.
- **`resource.service.ts`** receives a performance fix: `getResourceIdsByPermalinks` now builds a `Map<string,string>` index for O(1) segment lookup and chunks the `WHERE permalink IN (...)` query to stay under Postgres' 65 535 bind-parameter cap.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The batch write path is all-or-nothing, correctly serialised with a per-site advisory lock, and all previously raised race windows (page shadow, loop after concurrent insert, shortfall on conflicting live redirect) are re-checked inside the transaction.

Every race condition surfaced in the previous review rounds has been addressed: the per-site advisory lock is acquired by both createRedirect and bulkCreateRedirects; the in-transaction shadow guard catches pages published between validation and insert; the combined-graph loop check runs after the insert so a concurrently committed redirect that would close a cycle is detected before commit. The resource.service.ts optimisation is correct and preserves the original find semantics. Integration tests cover the major failure modes including the page-shadow race. No functional regressions were found.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/redirect/redirect.service.ts | Core bulk logic: adds runBulkValidation, bulkValidateRedirects, and bulkCreateRedirects with per-site advisory lock, in-transaction shadow/loop rechecks, chunked upsert, and audit logging. Also adds the lock to createRedirect. All previously flagged race conditions are addressed. |
| apps/studio/src/server/modules/redirect/redirect.router.ts | Adds bulkValidate (read-gated, POST mutation) and bulkCreate (create-gated, POST mutation) endpoints; permission checks and input schemas look correct. |
| apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts | Integration tests cover 403 guards, file errors, per-row validation (malformed, duplicate, on-table, shadow, loops of all lengths, reference destinations), happy-path insert + single publish, soft-delete revive, audit log counts, and the page-shadow race condition. |
| apps/studio/src/server/modules/resource/resource.service.ts | getResourceIdsByPermalinks optimised: candidate lookup chunked to avoid the 65 535 bind-parameter cap, and Array.find replaced with a Map index for O(1) per-segment lookups. Map key construction is injective for numeric parentIds. |
| apps/studio/src/lib/redirectCsv.ts | New isomorphic CSV parser: BOM stripping, blank-line-aware row numbering, header matching by name, malformed-row detection, and errors-file builder. Correctly handles re-uploaded error files with an extra Error column. |
| apps/studio/src/schemas/redirect.ts | Adds bulkRedirectsCsvSchema with a dual code-unit / UTF-8-byte cap and redirectRowSchema (shared by form and CSV), plus normalizeDestinationScheme and refineSourceDestinationDiffer helpers. |
| apps/studio/src/lib/redirectCsv.test.ts | Unit tests for parseRedirectCsv and buildRedirectErrorsCsv: covers BOM, header variants, blank lines, malformed rows, empty file, template round-trip. |
| apps/studio/src/server/modules/database/constants.ts | Adds lockTimeout (55P03) to the PG_ERROR_CODES map for the advisory-lock timeout handling. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Router
    participant Service
    participant DB

    Note over Client,DB: bulkValidate (read-only)
    Client->>Router: "bulkValidate({ siteId, csv })"
    Router->>Service: runBulkValidation(siteId, csv)
    Service->>Service: parseRedirectCsv → per-row Zod validation
    Service->>DB: SELECT live redirects (source check)
    Service->>DB: getResourceIdsByPermalinks (shadow check)
    Service->>DB: resolveStoredDestinationsToSources (loop graph)
    Service->>Service: findCycleNodes → flag loop rows
    Service-->>Client: BulkRedirectValidationResult

    Note over Client,DB: bulkCreate (write, all-or-nothing)
    Client->>Router: "bulkCreate({ siteId, csv })"
    Router->>Service: bulkCreateRedirects(siteId, csv, userId)
    Service->>Service: runBulkValidation (pre-flight)
    alt any error
        Service-->>Client: ok false + validation
    end
    Service->>DB: resolveDestinationsForStorage (batch)
    Service->>DB: BEGIN TRANSACTION
    Service->>DB: "SET LOCAL lock_timeout = 15s"
    Service->>DB: pg_advisory_xact_lock(RD, siteId)
    Service->>DB: SELECT existing rows (audit before-state)
    Service->>DB: shadow recheck (getResourceIdsByPermalinks)
    alt shadow race
        Service->>DB: ROLLBACK
        Service-->>Client: ok false + fresh validation
    end
    Service->>DB: INSERT ON CONFLICT upsert (chunked)
    alt shortfall race
        Service->>DB: ROLLBACK
        Service-->>Client: ok false + fresh validation
    end
    Service->>DB: SELECT liveAfterInsert via tx
    Service->>Service: findCycleNodes (loop recheck)
    alt loop race
        Service->>DB: ROLLBACK
        Service-->>Client: ok false + fresh validation
    end
    Service->>DB: INSERT AuditLog RedirectCreate x N
    Service->>DB: INSERT AuditLog Publish x 1
    Service->>DB: COMMIT (releases advisory lock)
    Service->>DB: publishSite (CodeBuild, outside txn)
    Service-->>Client: ok true + publishedCount
```
</details>

<sub>Reviews (10): Last reviewed commit: ["fix(redirect): address review — chunk IN..."](https://github.com/opengovsg/isomer/commit/a0eb60d144d2b8d64a652a785b454c2b2b41fa59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44385295)</sub>

<!-- /greptile_comment -->