### PR TITLE
fix(godmode): scope publish button loading state per site

### DIFF
--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -36,24 +36,21 @@ const GodModePublishingPage: NextPageWithLayout = () => {
   const { data: sites = [] } = trpc.site.listAllSites.useQuery()
 
   const { mutate: publishOneSite } = trpc.site.publish.useMutation({
-    onSuccess: (_, { siteId }) => {
+    onSettled: (_, __, { siteId }) => {
       setPublishingSiteIds((prev) => {
         const next = new Set(prev)
         next.delete(siteId)
         return next
       })
+    },
+    onSuccess: () => {
       toast({
         title: "Site published successfully",
         status: "success",
         ...BRIEF_TOAST_SETTINGS,
       })
     },
-    onError: (error, { siteId }) => {
-      setPublishingSiteIds((prev) => {
-        const next = new Set(prev)
-        next.delete(siteId)
-        return next
-      })
+    onError: (error) => {
       toast({
         title: "Failed to publish site",
         description: error.message,
@@ -123,6 +120,7 @@ const GodModePublishingPage: NextPageWithLayout = () => {
                         publishOneSite({ siteId: site.id })
                       }}
                       isLoading={publishingSiteIds.has(site.id)}
+                      isDisabled={publishingSiteIds.has(site.id)}
                     >
                       Publish
                     </Button>

--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -16,6 +16,7 @@ import {
 } from "@chakra-ui/react"
 import { useToast } from "@opengovsg/design-system-react"
 import NextLink from "next/link"
+import { useState } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { requireGodModeAdmin } from "~/features/godmode/serverSideProps"
 import { type NextPageWithLayout } from "~/lib/types"
@@ -28,29 +29,39 @@ export const getServerSideProps: GetServerSideProps = (context) =>
 
 const GodModePublishingPage: NextPageWithLayout = () => {
   const toast = useToast()
+  const [publishingSiteIds, setPublishingSiteIds] = useState<Set<number>>(
+    new Set(),
+  )
 
   const { data: sites = [] } = trpc.site.listAllSites.useQuery()
 
-  const { mutate: publishOneSite, isPending: isPublishingOneSite } =
-    trpc.site.publish.useMutation({
-      onSuccess: () => {
-        toast({
-          title: "Site published successfully",
-          status: "success",
-          ...BRIEF_TOAST_SETTINGS,
-        })
-      },
-      onError: (error) => {
-        toast({
-          title: "Failed to publish site",
-          description: error.message,
-          status: "error",
-          ...BRIEF_TOAST_SETTINGS,
-        })
-      },
-    })
-
-  const isLoading = isPublishingOneSite
+  const { mutate: publishOneSite } = trpc.site.publish.useMutation({
+    onSuccess: (_, { siteId }) => {
+      setPublishingSiteIds((prev) => {
+        const next = new Set(prev)
+        next.delete(siteId)
+        return next
+      })
+      toast({
+        title: "Site published successfully",
+        status: "success",
+        ...BRIEF_TOAST_SETTINGS,
+      })
+    },
+    onError: (error, { siteId }) => {
+      setPublishingSiteIds((prev) => {
+        const next = new Set(prev)
+        next.delete(siteId)
+        return next
+      })
+      toast({
+        title: "Failed to publish site",
+        description: error.message,
+        status: "error",
+        ...BRIEF_TOAST_SETTINGS,
+      })
+    },
+  })
 
   return (
     <Flex flexDir="column" py="2rem" maxW="57rem" mx="auto" width="100%">
@@ -105,8 +116,13 @@ const GodModePublishingPage: NextPageWithLayout = () => {
                     <Button
                       size="xs"
                       colorScheme="blue"
-                      onClick={() => publishOneSite({ siteId: site.id })}
-                      isLoading={isLoading}
+                      onClick={() => {
+                        setPublishingSiteIds((prev) =>
+                          new Set(prev).add(site.id),
+                        )
+                        publishOneSite({ siteId: site.id })
+                      }}
+                      isLoading={publishingSiteIds.has(site.id)}
                     >
                       Publish
                     </Button>


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

When clicking the **Publish** button on the godmode publishing page, every other Publish button in the table also entered the loading state. This happened because the loading state was derived from a single `useMutation` hook's `isPending`, which is shared across all rows.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Replaced the single `isPending` boolean (from `useMutation`) with a `Set<number>` state (`publishingSiteIds`) that tracks the IDs of all sites whose publish request is currently in flight.
- On click, the site's ID is added to the set before the mutation fires.
- In `onSuccess` and `onError` callbacks (which receive the original input variables), the site's ID is removed from the set.
- Each button now reads `publishingSiteIds.has(site.id)` for its `isLoading` prop, so only the button for the in-flight site shows a spinner — even when multiple publishes are triggered simultaneously.

## Before & After Screenshots

**BEFORE**:

<!-- Clicking any Publish button caused every Publish button in the table to show a loading spinner -->

**AFTER**:

<!-- Only the Publish button for the site being published shows a loading spinner -->

## Tests

**Manual Verification Steps**:

- [ ] Navigate to `/godmode/publishing` as a Core IsomerAdmin.
- [ ] Click the **Publish** button for any site — confirm only that row's button enters the loading state.
- [ ] While the first publish is in flight, click a second site's **Publish** button — confirm both buttons show loading independently and each clears on completion.
- [ ] Trigger a publish that errors (e.g. use a site with an invalid CodeBuild ID if available) — confirm the error toast appears and only that button exits the loading state.

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR scopes the God Mode publish loading state to each site row. The main changes are:

- Adds local `publishingSiteIds` state to track in-flight publish requests by site ID.
- Clears each site ID from the loading set when its publish mutation settles.
- Uses the row’s site ID to drive `isLoading` and disable only that row’s Publish button.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is limited to one client-side page and preserves the existing publish mutation, success toast, and error toast behavior.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A generated focused component harness was prepared for the attempted manual verification.
- The Vitest run log was captured to show the Chromium browser execution and the failure before test import or render.
- It was noted that the sandbox run did not reach completion, limiting verification of the changed code path.

<a href="https://app.greptile.com/trex/runs/14509261/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/pages/godmode/publishing.tsx | Updates the God Mode publishing page to track publish-button loading state per site using local Set state; no issues found. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Admin as Godmode admin
participant Page as Publishing page
participant State as publishingSiteIds Set
participant API as trpc.site.publish

Admin->>Page: Click Publish for siteId
Page->>State: Add siteId
Page->>API: "mutate({ siteId })"
Page-->>Admin: Only matching row shows loading
API-->>Page: onSuccess or onError
Page->>State: Remove settled siteId
Page-->>Admin: Matching row clears loading
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Admin as Godmode admin
participant Page as Publishing page
participant State as publishingSiteIds Set
participant API as trpc.site.publish

Admin->>Page: Click Publish for siteId
Page->>State: Add siteId
Page->>API: "mutate({ siteId })"
Page-->>Admin: Only matching row shows loading
API-->>Page: onSuccess or onError
Page->>State: Remove settled siteId
Page-->>Admin: Matching row clears loading
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(godmode): use onSettled for cleanup,..."](https://github.com/opengovsg/isomer/commit/fdcf06ab5432be18bf0484c16b224f08e144d470) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44387175)</sub>

<!-- /greptile_comment -->