### PR TITLE
feat(components): add build-utils entrypoint and RSS feed auto-discovery

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,8 +6,8 @@ A government CMS and site builder for Singapore public agencies. Editors create 
 
 ### Collection structure
 
-**Collection Item**: An article (CollectionPage) or link (CollectionLink) that lives inside a collection. Both support tag assignment, including the migrated "Category" tag group (see below).
-_Avoid_: article (when referring to both types), page (ambiguous)
+**Collection Item**: An article (CollectionPage) or link (CollectionLink) that lives inside a collection. A link may target an external URL or an uploaded file — a "file item" is a CollectionLink variant, not a separate resource type. Both support tag assignment, including the migrated "Category" tag group (see below).
+_Avoid_: article (when referring to both types), page (ambiguous), file (as a distinct item type — it is a link variant)
 
 **Collection Index**: The parent page of a collection. Stores the admin-defined taxonomy — Tag Categories — in its blob.
 _Avoid_: collection page, index page (ambiguous across layouts)

--- a/docs/adr/0004-rss-feeds-via-standalone-script-reusing-components.md
+++ b/docs/adr/0004-rss-feeds-via-standalone-script-reusing-components.md
@@ -1,0 +1,17 @@
+# Generate collection RSS feeds from a standalone tooling script that reuses the components package
+
+Collection RSS feeds are produced by a standalone `tsx` script under `tooling/build/scripts/rss/` (mirroring the `publishing/` redirects script) that depends on `@opengovsg/isomer-components` (`workspace:*`) and reuses `getCollectionItems` / `getReferenceLinkHref`, writing one `rss.xml` per Collection Index into `out/` after `build:template`. We chose reuse-via-dependency because the feed's item set and item links must never drift from what the collection page renders, and the only way to guarantee that is to call the same code.
+
+## Considered Options
+
+- **Next route / metadata file (like `app/sitemap.ts` and `app/robots.ts`)** — idiomatic and drift-free by construction, but per-collection feeds collide with the site's `app/[[...permalink]]` catch-all route and hit `output: "export"` route-handler constraints. Rejected: too much routing friction for the shape we need.
+- **Self-contained script that duplicates the collection walk** (the pure `publishing/`-style pattern) — no dependency on the render library, own tests, matches the redirects precedent exactly. Rejected: reimplementing the item filter, sort, and especially `getReferenceLinkHref`'s `[resource:…]` / asset-URL resolution reintroduces drift between the feed and the rendered page, which we explicitly ruled out.
+- **Builder in the package + thin copied script** (put `getRssXml` next to `getSitemapXml`/`getRobotsTxt`, call it from a `generate-sitemap.js`-style script) — drift-free, conceptually consistent. Viable runner-up; rejected only because we preferred the isolated, independently-tested `tsx` package shape of `publishing/`.
+- **Standalone script reusing the package (chosen)** — redirects-style isolated package with its own tests, but reuses `getCollectionItems` via a `workspace:*` dependency instead of copying it.
+
+## Consequences
+
+- **Unusual dependency edge:** a `tooling/build` script now depends on the render component library. Precedent exists (`publishing/` depends on `@isomer/db: workspace:*`), but this is the first tooling dependency on `@opengovsg/isomer-components`.
+- **Barrel-import hazard:** importing from the package root pulls React client components, which can break under `tsx`/Node. The script must deep-import the pure utilities (or the package must expose a Node-safe subpath), verified at build time.
+- **Build sequencing:** the script must run after `pnpm run build:template` (so `out/` exists) and relies on the components workspace package having been built earlier in `publisher.sh`.
+- **Anti-drift is load-bearing:** a test asserts the feed's item set equals `getCollectionItems` output. If that reuse is ever replaced by duplication, this guarantee is lost.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,6 +24,10 @@
     "./templates/next": {
       "import": "./dist/esm/templates/next/index.js",
       "default": "./dist/esm/templates/next/index.js"
+    },
+    "./build-utils": {
+      "import": "./dist/esm/build-utils/index.js",
+      "default": "./dist/esm/build-utils/index.js"
     }
   },
   "publishConfig": {

--- a/packages/components/src/build-utils/__tests__/index.test.ts
+++ b/packages/components/src/build-utils/__tests__/index.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  IsomerCollectionPageSitemap,
+  IsomerSitemap,
+  IsomerSiteProps,
+} from "../index"
+import {
+  getCollectionItems,
+  getReferenceLinkHref,
+  getSitemapAsArray,
+} from "../index"
+
+// This entrypoint exists so build-time scripts (the RSS generator) can reuse the
+// collection utilities without importing the React barrel. If any of these stop
+// being exported, the generator breaks — so assert the surface here.
+describe("build entrypoint", () => {
+  it("re-exports the pure collection build utilities", () => {
+    // Arrange / Act / Assert
+    expect(typeof getCollectionItems).toBe("function")
+    expect(typeof getReferenceLinkHref).toBe("function")
+    expect(typeof getSitemapAsArray).toBe("function")
+  })
+
+  it("re-exports the types those utilities are called with", () => {
+    // Arrange / Act — compile-time only; the assignments fail typecheck if a
+    // type stops being exported.
+    const site: IsomerSiteProps | undefined = undefined
+    const sitemap: IsomerSitemap | undefined = undefined
+    const collection: IsomerCollectionPageSitemap | undefined = undefined
+
+    // Assert
+    expect([site, sitemap, collection]).toEqual([
+      undefined,
+      undefined,
+      undefined,
+    ])
+  })
+})

--- a/packages/components/src/build-utils/index.ts
+++ b/packages/components/src/build-utils/index.ts
@@ -1,0 +1,20 @@
+// React-free entrypoint for build-time consumers (e.g. the RSS feed generator).
+// Importing the package root (or `./engine`) pulls in React components, which
+// breaks under a plain Node/tsx script. This subpath re-exports only the pure
+// utilities the static-site build needs, via direct module paths so the runtime
+// graph never reaches a React module.
+export {
+  getCollectionItems,
+  type GetCollectionItemsProps,
+} from "~/templates/next/layouts/Collection/utils/getCollectionItems"
+export { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
+export { getSitemapAsArray } from "~/utils/getSitemapAsArray"
+// The types build scripts need alongside the utilities above. Taking them from
+// the package root instead would make `tsc` traverse the React barrel, even
+// though the imports are type-only. `IsomerCollectionPageSitemap` is not
+// exported from the root at all.
+export type {
+  IsomerCollectionPageSitemap,
+  IsomerSitemap,
+} from "~/types/sitemap"
+export type { IsomerSiteProps } from "~/types/site"

--- a/packages/components/src/engine/__tests__/metadata.test.ts
+++ b/packages/components/src/engine/__tests__/metadata.test.ts
@@ -1,0 +1,92 @@
+import type { IsomerPageSchemaType } from "~/types/schema"
+import { describe, expect, it } from "vitest"
+
+import { getMetadata } from "../metadata"
+
+const makeProps = ({
+  layout = "collection",
+  permalink = "/newsroom",
+  title = "Newsroom",
+  url = "https://www.isomer.gov.sg",
+}: {
+  layout?: IsomerPageSchemaType["layout"]
+  permalink?: string
+  title?: string
+  url?: string
+}): IsomerPageSchemaType =>
+  ({
+    layout,
+    site: {
+      siteName: "Test Agency",
+      url,
+      logoUrl: "/images/logo.svg",
+      favicon: "/favicon.ico",
+    },
+    page: {
+      title,
+      permalink,
+      subtitle: "Latest updates",
+      articlePageHeader: { summary: "An article summary" },
+    },
+    content: [],
+  }) as unknown as IsomerPageSchemaType
+
+describe("getMetadata — RSS feed discovery", () => {
+  it("advertises the collection's rss.xml as an application/rss+xml alternate", () => {
+    // Arrange
+    const props = makeProps({ layout: "collection", permalink: "/newsroom" })
+
+    // Act
+    const { alternates } = getMetadata(props)
+
+    // Assert
+    expect(alternates.types).toEqual({
+      "application/rss+xml": [
+        {
+          url: "https://www.isomer.gov.sg/newsroom/rss.xml",
+          title: "Test Agency — Newsroom",
+        },
+      ],
+    })
+  })
+
+  it("does not double the slash when the collection permalink already ends in one", () => {
+    // Arrange
+    const props = makeProps({ layout: "collection", permalink: "/newsroom/" })
+
+    // Act
+    const { alternates } = getMetadata(props)
+
+    // Assert
+    expect(alternates.types?.["application/rss+xml"]).toEqual([
+      {
+        url: "https://www.isomer.gov.sg/newsroom/rss.xml",
+        title: "Test Agency — Newsroom",
+      },
+    ])
+  })
+
+  it("falls back to a relative feed path when the site has no url", () => {
+    // Arrange
+    const props = makeProps({ layout: "collection", url: "" })
+
+    // Act
+    const { alternates } = getMetadata(props)
+
+    // Assert
+    expect(alternates.types?.["application/rss+xml"]).toEqual([
+      { url: "/newsroom/rss.xml", title: "Test Agency — Newsroom" },
+    ])
+  })
+
+  it("emits no feed alternate for non-collection layouts", () => {
+    // Arrange
+    const props = makeProps({ layout: "article" })
+
+    // Act
+    const { alternates } = getMetadata(props)
+
+    // Assert
+    expect(alternates.types).toBeUndefined()
+  })
+})

--- a/packages/components/src/engine/metadata.ts
+++ b/packages/components/src/engine/metadata.ts
@@ -85,6 +85,28 @@ const getCanonicalUrl = (props: IsomerPageSchemaType) => {
   }
 }
 
+// Advertise the collection's RSS feed for auto-discovery by browsers and feed
+// readers. The feed itself is written to `<permalink>/rss.xml` by the build.
+const getFeedAlternates = (props: IsomerPageSchemaType) => {
+  if (props.layout !== ISOMER_PAGE_LAYOUTS.Collection) {
+    return undefined
+  }
+
+  const permalinkWithTrailingSlash = props.page.permalink.endsWith("/")
+    ? props.page.permalink
+    : `${props.page.permalink}/`
+  const feedPath = `${permalinkWithTrailingSlash}rss.xml`
+  const feedUrl = props.site.url
+    ? new URL(feedPath, props.site.url).toString()
+    : feedPath
+
+  return {
+    "application/rss+xml": [
+      { url: feedUrl, title: `${props.site.siteName} — ${props.page.title}` },
+    ],
+  }
+}
+
 export const getMetadata = (props: IsomerPageSchemaType) => {
   const faviconUrl = `${props.site.assetsBaseUrl ?? ""}${props.site.favicon || "/favicon.ico"}`
   const canonicalUrl = getCanonicalUrl(props)
@@ -129,6 +151,7 @@ export const getMetadata = (props: IsomerPageSchemaType) => {
     },
     alternates: {
       canonical: canonicalUrl,
+      types: getFeedAlternates(props),
     },
   }
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +47 | -0 |
| 🧪 Test | 2 | +131 | -0 |
| 📄 Doc | 2 | +19 | -2 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Isomer collections (newsrooms, publications, press releases, etc.) have no machine-readable feed. Visitors cannot subscribe to a collection in a feed reader, and downstream systems cannot syndicate collection content.

This is the first PR of a two-PR stack. It prepares the `@opengovsg/isomer-components` package so the build tooling can generate feeds without pulling the React barrel, and it adds feed auto-discovery to collection pages. The feed files themselves are produced in the stacked PR (#2809).

Closes: N/A (no linked ticket)

## Solution

Design and trade-offs are recorded in `docs/adr/0004-rss-feeds-via-standalone-script-reusing-components.md`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Additive only: a new package subpath export and one optional metadata field. Existing consumers are unaffected.

**Features**:

- Add `@opengovsg/isomer-components/build-utils` — a React-free entrypoint that re-exports `getCollectionItems`, `getReferenceLinkHref`, and `getSitemapAsArray`, plus the types they are called with (`IsomerSiteProps`, `IsomerSitemap`, `IsomerCollectionPageSitemap`). Taking those types from the package root instead would make `tsc` traverse the React barrel even though the imports are type-only, and `IsomerCollectionPageSitemap` is not exported from the root at all. This lets the RSS build script (#2809) reuse the exact collection logic used to render collection pages, so the feed can never drift from the page, without importing the React component barrel.
- `getMetadata` now advertises a collection's RSS feed via `<link rel="alternate" type="application/rss+xml">` in the page `<head>` on collection layouts only, enabling browsers and feed readers to auto-discover the feed.

**Improvements**:

- ADR 0004 records why feeds are generated by a standalone tooling script that reuses the components package rather than a Next route or a duplicated walk.
- `CONTEXT.md` glossary clarifies that a "file" item is a `CollectionLink` variant, not a separate resource type.

## Tests

Unit tests cover the new `build-utils` entrypoint surface (both the functions and the type re-exports) and the `getMetadata` RSS alternate (present on collections with the correct absolute URL and title; absent on non-collection layouts; correct handling of trailing-slash permalinks and missing `site.url`).

**Manual Verification Steps**:

- [ ] After deploy, open a published collection page and view page source; confirm a `<link rel="alternate" type="application/rss+xml" href="…/<collection>/rss.xml" title="<Site name> — <Collection title>">` is present in `<head>`.
- [ ] Open a non-collection page (article or content page) and confirm no `application/rss+xml` alternate link is present.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

