### PR TITLE
feat: add item sorting for folders and root

### DIFF
--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -1,6 +1,5 @@
 import type { ResourceOrderByOption } from "~/schemas/resource"
 import { HStack, Text } from "@chakra-ui/react"
-import { Menu } from "@opengovsg/design-system-react"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
   createColumnHelper,
@@ -17,7 +16,7 @@ import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { CollectionTableData } from "./types"
-import { RESOURCE_TABLE_SORT_OPTIONS } from "../ResourceTable/constants"
+import { ResourceSortMenu } from "../ResourceTable/ResourceSortMenu"
 import { TitleCell } from "../ResourceTable/TitleCell"
 import { CollectionTableMenu } from "./CollectionTableMenu"
 
@@ -128,46 +127,13 @@ export const CollectionTable = ({
           {totalRowCount} {totalRowCount === 1 ? "item" : "items"}
         </Text>
 
-        <HStack>
-          <Text textStyle="caption-1" color="base.content.default">
-            Sort by:
-          </Text>
-          <Menu size="sm" variant="clear">
-            {({ isOpen }) => (
-              <>
-                <Menu.Button
-                  variant="clear"
-                  size="sm"
-                  p="0"
-                  minH="auto"
-                  colorScheme="sub"
-                  fontSize="0.75rem"
-                  isOpen={isOpen}
-                >
-                  {RESOURCE_TABLE_SORT_OPTIONS[sortOption]}
-                </Menu.Button>
-                <Menu.List pt="0.75rem" pb="0.5rem">
-                  {Object.entries(RESOURCE_TABLE_SORT_OPTIONS).map(
-                    ([option, label]) => (
-                      <Menu.Item
-                        key={option}
-                        onClick={() => {
-                          setSortOption(option as ResourceOrderByOption)
-                          onPaginationChange((old) => ({
-                            ...old,
-                            pageIndex: 0,
-                          }))
-                        }}
-                      >
-                        {label}
-                      </Menu.Item>
-                    ),
-                  )}
-                </Menu.List>
-              </>
-            )}
-          </Menu>
-        </HStack>
+        <ResourceSortMenu
+          value={sortOption}
+          onChange={(option) => {
+            setSortOption(option)
+            onPaginationChange((old) => ({ ...old, pageIndex: 0 }))
+          }}
+        />
       </HStack>
 
       <Datatable

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -1,3 +1,4 @@
+import type { ResourceOrderByOption } from "~/schemas/resource"
 import { HStack, Text } from "@chakra-ui/react"
 import { Menu } from "@opengovsg/design-system-react"
 import { keepPreviousData } from "@tanstack/react-query"
@@ -15,7 +16,7 @@ import { useTablePagination } from "~/hooks/useTablePagination"
 import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
-import type { CollectionTableData, CollectionTableSortOptions } from "./types"
+import type { CollectionTableData } from "./types"
 import { RESOURCE_TABLE_SORT_OPTIONS } from "../ResourceTable/constants"
 import { TitleCell } from "../ResourceTable/TitleCell"
 import { CollectionTableMenu } from "./CollectionTableMenu"
@@ -67,7 +68,7 @@ export const CollectionTable = ({
   resourceId,
 }: CollectionTableProps): JSX.Element => {
   const [sortOption, setSortOption] =
-    useState<CollectionTableSortOptions>("updated-desc")
+    useState<ResourceOrderByOption>("updated-desc")
 
   const columns = useMemo(
     () => getColumns({ siteId, resourceId }),
@@ -151,7 +152,7 @@ export const CollectionTable = ({
                       <Menu.Item
                         key={option}
                         onClick={() => {
-                          setSortOption(option as CollectionTableSortOptions)
+                          setSortOption(option as ResourceOrderByOption)
                           onPaginationChange((old) => ({
                             ...old,
                             pageIndex: 0,

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -16,9 +16,9 @@ import { trpc } from "~/utils/trpc"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 import type { CollectionTableData, CollectionTableSortOptions } from "./types"
+import { RESOURCE_TABLE_SORT_OPTIONS } from "../ResourceTable/constants"
 import { TitleCell } from "../ResourceTable/TitleCell"
 import { CollectionTableMenu } from "./CollectionTableMenu"
-import { COLLECTION_TABLE_SORT_OPTIONS } from "./constants"
 
 const columnsHelper = createColumnHelper<CollectionTableData>()
 
@@ -143,10 +143,10 @@ export const CollectionTable = ({
                   fontSize="0.75rem"
                   isOpen={isOpen}
                 >
-                  {COLLECTION_TABLE_SORT_OPTIONS[sortOption]}
+                  {RESOURCE_TABLE_SORT_OPTIONS[sortOption]}
                 </Menu.Button>
                 <Menu.List pt="0.75rem" pb="0.5rem">
-                  {Object.entries(COLLECTION_TABLE_SORT_OPTIONS).map(
+                  {Object.entries(RESOURCE_TABLE_SORT_OPTIONS).map(
                     ([option, label]) => (
                       <Menu.Item
                         key={option}

--- a/apps/studio/src/features/dashboard/components/CollectionTable/constants.ts
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/constants.ts
@@ -1,9 +1,0 @@
-import type { CollectionTableSortOptions } from "./types"
-
-export const COLLECTION_TABLE_SORT_OPTIONS: Record<
-  CollectionTableSortOptions,
-  string
-> = {
-  "updated-desc": "Recently edited",
-  "title-asc": "Alphabetical",
-}

--- a/apps/studio/src/features/dashboard/components/CollectionTable/types.ts
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/types.ts
@@ -1,7 +1,7 @@
-import type { readCollectionOrderByOptions } from "~/schemas/collection"
 import type { RouterOutput } from "~/utils/trpc"
+
+import type { ResourceSortOption } from "../ResourceTable/types"
 
 export type CollectionTableData = RouterOutput["collection"]["list"][number]
 
-export type CollectionTableSortOptions =
-  (typeof readCollectionOrderByOptions)[number]
+export type CollectionTableSortOptions = ResourceSortOption

--- a/apps/studio/src/features/dashboard/components/CollectionTable/types.ts
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/types.ts
@@ -1,7 +1,3 @@
 import type { RouterOutput } from "~/utils/trpc"
 
-import type { ResourceSortOption } from "../ResourceTable/types"
-
 export type CollectionTableData = RouterOutput["collection"]["list"][number]
-
-export type CollectionTableSortOptions = ResourceSortOption

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceSortMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceSortMenu.tsx
@@ -1,0 +1,50 @@
+import type { ResourceOrderByOption } from "~/schemas/resource"
+import { HStack, Text } from "@chakra-ui/react"
+import { Menu } from "@opengovsg/design-system-react"
+
+import { RESOURCE_TABLE_SORT_OPTIONS } from "./constants"
+
+interface ResourceSortMenuProps {
+  value: ResourceOrderByOption
+  onChange: (option: ResourceOrderByOption) => void
+}
+
+export const ResourceSortMenu = ({
+  value,
+  onChange,
+}: ResourceSortMenuProps): JSX.Element => (
+  <HStack>
+    <Text textStyle="caption-1" color="base.content.default">
+      Sort by:
+    </Text>
+    <Menu size="sm" variant="clear">
+      {({ isOpen }) => (
+        <>
+          <Menu.Button
+            variant="clear"
+            size="sm"
+            p="0"
+            minH="auto"
+            colorScheme="sub"
+            fontSize="0.75rem"
+            isOpen={isOpen}
+          >
+            {RESOURCE_TABLE_SORT_OPTIONS[value]}
+          </Menu.Button>
+          <Menu.List pt="0.75rem" pb="0.5rem">
+            {Object.entries(RESOURCE_TABLE_SORT_OPTIONS).map(
+              ([option, label]) => (
+                <Menu.Item
+                  key={option}
+                  onClick={() => onChange(option as ResourceOrderByOption)}
+                >
+                  {label}
+                </Menu.Item>
+              ),
+            )}
+          </Menu.List>
+        </>
+      )}
+    </Menu>
+  </HStack>
+)

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -1,4 +1,5 @@
-import type { RouterOutput } from "~/utils/trpc"
+import { HStack, Text } from "@chakra-ui/react"
+import { Menu } from "@opengovsg/design-system-react"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
   createColumnHelper,
@@ -6,17 +7,17 @@ import {
   getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table"
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { TableHeader } from "~/components/Datatable"
 import { Datatable } from "~/components/Datatable/Datatable"
 import { EmptyTablePlaceholder } from "~/components/Datatable/EmptyTablePlaceholder"
 import { useTablePagination } from "~/hooks/useTablePagination"
 import { trpc } from "~/utils/trpc"
 
+import type { ResourceSortOption, ResourceTableData } from "./types"
+import { RESOURCE_TABLE_SORT_OPTIONS } from "./constants"
 import { ResourceTableMenu } from "./ResourceTableMenu"
 import { TitleCell } from "./TitleCell"
-
-type ResourceTableData = RouterOutput["resource"]["listWithoutRoot"][number]
 
 const columnsHelper = createColumnHelper<ResourceTableData>()
 
@@ -61,6 +62,9 @@ export const ResourceTable = ({
   siteId,
   resourceId,
 }: ResourceTableProps): JSX.Element => {
+  const [sortOption, setSortOption] =
+    useState<ResourceSortOption>("updated-desc")
+
   const columns = useMemo(
     () => getColumns({ siteId, resourceId }),
     [siteId, resourceId],
@@ -84,6 +88,7 @@ export const ResourceTable = ({
       {
         siteId,
         resourceId,
+        orderBy: sortOption,
         limit,
         offset: skip,
       },
@@ -108,22 +113,76 @@ export const ResourceTable = ({
   })
 
   return (
-    <Datatable
-      pagination
-      emptyPlaceholder={
-        <EmptyTablePlaceholder
-          entityName="page"
-          groupLabel="folder"
-          hasSearchTerm={false}
-        />
-      }
-      isFetching={isFetching || isCountLoading}
-      instance={tableInstance}
-      sx={{
-        tableLayout: "auto",
-        overflowX: "auto",
-      }}
-      totalRowCount={totalCount}
-    />
+    <>
+      <HStack
+        px="0.75rem"
+        mb="-0.25rem"
+        w="full"
+        justifyContent="space-between"
+      >
+        <Text textStyle="caption-1" color="base.content.default">
+          {totalCount} {totalCount === 1 ? "item" : "items"}
+        </Text>
+
+        <HStack>
+          <Text textStyle="caption-1" color="base.content.default">
+            Sort by:
+          </Text>
+          <Menu size="sm" variant="clear">
+            {({ isOpen }) => (
+              <>
+                <Menu.Button
+                  variant="clear"
+                  size="sm"
+                  p="0"
+                  minH="auto"
+                  colorScheme="sub"
+                  fontSize="0.75rem"
+                  isOpen={isOpen}
+                >
+                  {RESOURCE_TABLE_SORT_OPTIONS[sortOption]}
+                </Menu.Button>
+                <Menu.List pt="0.75rem" pb="0.5rem">
+                  {Object.entries(RESOURCE_TABLE_SORT_OPTIONS).map(
+                    ([option, label]) => (
+                      <Menu.Item
+                        key={option}
+                        onClick={() => {
+                          setSortOption(option as ResourceSortOption)
+                          onPaginationChange((old) => ({
+                            ...old,
+                            pageIndex: 0,
+                          }))
+                        }}
+                      >
+                        {label}
+                      </Menu.Item>
+                    ),
+                  )}
+                </Menu.List>
+              </>
+            )}
+          </Menu>
+        </HStack>
+      </HStack>
+
+      <Datatable
+        pagination
+        emptyPlaceholder={
+          <EmptyTablePlaceholder
+            entityName="page"
+            groupLabel="folder"
+            hasSearchTerm={false}
+          />
+        }
+        isFetching={isFetching || isCountLoading}
+        instance={tableInstance}
+        sx={{
+          tableLayout: "auto",
+          overflowX: "auto",
+        }}
+        totalRowCount={totalCount}
+      />
+    </>
   )
 }

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -1,6 +1,5 @@
 import type { ResourceOrderByOption } from "~/schemas/resource"
 import { HStack, Text } from "@chakra-ui/react"
-import { Menu } from "@opengovsg/design-system-react"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
   createColumnHelper,
@@ -16,7 +15,7 @@ import { useTablePagination } from "~/hooks/useTablePagination"
 import { trpc } from "~/utils/trpc"
 
 import type { ResourceTableData } from "./types"
-import { RESOURCE_TABLE_SORT_OPTIONS } from "./constants"
+import { ResourceSortMenu } from "./ResourceSortMenu"
 import { ResourceTableMenu } from "./ResourceTableMenu"
 import { TitleCell } from "./TitleCell"
 
@@ -113,9 +112,6 @@ export const ResourceTable = ({
     pageCount,
   })
 
-  // TODO: this sort header + Datatable wiring is now a near-exact duplicate
-  // of CollectionTable.tsx - consider extracting a shared component (raised
-  // as non-blocking in PR #2811 review: github.com/opengovsg/isomer/pull/2811)
   return (
     <>
       <HStack
@@ -128,46 +124,13 @@ export const ResourceTable = ({
           {totalCount} {totalCount === 1 ? "item" : "items"}
         </Text>
 
-        <HStack>
-          <Text textStyle="caption-1" color="base.content.default">
-            Sort by:
-          </Text>
-          <Menu size="sm" variant="clear">
-            {({ isOpen }) => (
-              <>
-                <Menu.Button
-                  variant="clear"
-                  size="sm"
-                  p="0"
-                  minH="auto"
-                  colorScheme="sub"
-                  fontSize="0.75rem"
-                  isOpen={isOpen}
-                >
-                  {RESOURCE_TABLE_SORT_OPTIONS[sortOption]}
-                </Menu.Button>
-                <Menu.List pt="0.75rem" pb="0.5rem">
-                  {Object.entries(RESOURCE_TABLE_SORT_OPTIONS).map(
-                    ([option, label]) => (
-                      <Menu.Item
-                        key={option}
-                        onClick={() => {
-                          setSortOption(option as ResourceOrderByOption)
-                          onPaginationChange((old) => ({
-                            ...old,
-                            pageIndex: 0,
-                          }))
-                        }}
-                      >
-                        {label}
-                      </Menu.Item>
-                    ),
-                  )}
-                </Menu.List>
-              </>
-            )}
-          </Menu>
-        </HStack>
+        <ResourceSortMenu
+          value={sortOption}
+          onChange={(option) => {
+            setSortOption(option)
+            onPaginationChange((old) => ({ ...old, pageIndex: 0 }))
+          }}
+        />
       </HStack>
 
       <Datatable

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -1,3 +1,4 @@
+import type { ResourceOrderByOption } from "~/schemas/resource"
 import { HStack, Text } from "@chakra-ui/react"
 import { Menu } from "@opengovsg/design-system-react"
 import { keepPreviousData } from "@tanstack/react-query"
@@ -14,7 +15,7 @@ import { EmptyTablePlaceholder } from "~/components/Datatable/EmptyTablePlacehol
 import { useTablePagination } from "~/hooks/useTablePagination"
 import { trpc } from "~/utils/trpc"
 
-import type { ResourceSortOption, ResourceTableData } from "./types"
+import type { ResourceTableData } from "./types"
 import { RESOURCE_TABLE_SORT_OPTIONS } from "./constants"
 import { ResourceTableMenu } from "./ResourceTableMenu"
 import { TitleCell } from "./TitleCell"
@@ -63,7 +64,7 @@ export const ResourceTable = ({
   resourceId,
 }: ResourceTableProps): JSX.Element => {
   const [sortOption, setSortOption] =
-    useState<ResourceSortOption>("updated-desc")
+    useState<ResourceOrderByOption>("updated-desc")
 
   const columns = useMemo(
     () => getColumns({ siteId, resourceId }),
@@ -112,6 +113,9 @@ export const ResourceTable = ({
     pageCount,
   })
 
+  // TODO: this sort header + Datatable wiring is now a near-exact duplicate
+  // of CollectionTable.tsx - consider extracting a shared component (raised
+  // as non-blocking in PR #2811 review: github.com/opengovsg/isomer/pull/2811)
   return (
     <>
       <HStack
@@ -148,7 +152,7 @@ export const ResourceTable = ({
                       <Menu.Item
                         key={option}
                         onClick={() => {
-                          setSortOption(option as ResourceSortOption)
+                          setSortOption(option as ResourceOrderByOption)
                           onPaginationChange((old) => ({
                             ...old,
                             pageIndex: 0,

--- a/apps/studio/src/features/dashboard/components/ResourceTable/constants.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/constants.ts
@@ -1,0 +1,6 @@
+import type { ResourceSortOption } from "./types"
+
+export const RESOURCE_TABLE_SORT_OPTIONS: Record<ResourceSortOption, string> = {
+  "updated-desc": "Recently edited",
+  "title-asc": "Alphabetical",
+}

--- a/apps/studio/src/features/dashboard/components/ResourceTable/constants.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/constants.ts
@@ -1,6 +1,9 @@
-import type { ResourceSortOption } from "./types"
+import type { ResourceOrderByOption } from "~/schemas/resource"
 
-export const RESOURCE_TABLE_SORT_OPTIONS: Record<ResourceSortOption, string> = {
+export const RESOURCE_TABLE_SORT_OPTIONS: Record<
+  ResourceOrderByOption,
+  string
+> = {
   "updated-desc": "Recently edited",
   "title-asc": "Alphabetical",
 }

--- a/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
@@ -1,7 +1,4 @@
-import type { resourceOrderByOptions } from "~/schemas/resource"
 import type { RouterOutput } from "~/utils/trpc"
 
 export type ResourceTableData =
   RouterOutput["resource"]["listWithoutRoot"][number]
-
-export type ResourceSortOption = (typeof resourceOrderByOptions)[number]

--- a/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/types.ts
@@ -1,4 +1,7 @@
+import type { resourceOrderByOptions } from "~/schemas/resource"
 import type { RouterOutput } from "~/utils/trpc"
 
 export type ResourceTableData =
   RouterOutput["resource"]["listWithoutRoot"][number]
+
+export type ResourceSortOption = (typeof resourceOrderByOptions)[number]

--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -6,6 +6,7 @@ import { z } from "zod"
 import { generateBasePermalinkSchema } from "./common"
 import { MAX_FOLDER_PERMALINK_LENGTH, MAX_FOLDER_TITLE_LENGTH } from "./folder"
 import { offsetPaginationSchema } from "./pagination"
+import { resourceOrderByOptions } from "./resource"
 
 export type CollectionLinkProps = Static<typeof LinkRefPageSchema>
 
@@ -106,19 +107,11 @@ export const getCollectionsSchema = z.object({
   hasChildren: z.boolean().optional().default(false),
 })
 
-export const readCollectionOrderByOptions = [
-  "updated-desc",
-  "title-asc",
-] as const
-
 export const readCollectionSchema = z
   .object({
     siteId: z.number().min(1),
     resourceId: z.number().min(1),
-    orderBy: z
-      .enum(readCollectionOrderByOptions)
-      .optional()
-      .default("updated-desc"),
+    orderBy: z.enum(resourceOrderByOptions).optional().default("updated-desc"),
   })
   .merge(offsetPaginationSchema)
 

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -62,10 +62,13 @@ export const getParentSchema = z.object({
   resourceId: bigIntSchema,
 })
 
+export const resourceOrderByOptions = ["updated-desc", "title-asc"] as const
+
 export const listResourceSchema = z
   .object({
     siteId: z.number(),
     resourceId: z.number().optional(),
+    orderBy: z.enum(resourceOrderByOptions).optional().default("updated-desc"),
   })
   .merge(offsetPaginationSchema)
 

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -64,6 +64,8 @@ export const getParentSchema = z.object({
 
 export const resourceOrderByOptions = ["updated-desc", "title-asc"] as const
 
+export type ResourceOrderByOption = (typeof resourceOrderByOptions)[number]
+
 export const listResourceSchema = z
   .object({
     siteId: z.number(),

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -796,6 +796,48 @@ describe("collection.router", async () => {
       expect(titles).toEqual(["Alpha", "Bravo", "Charlie"])
     })
 
+    it("should sort case-insensitively when orderBy is title-asc", async () => {
+      // Arrange: titles chosen so a case-sensitive (byte-order) sort would
+      // put "Banana" before "apple" - a naive `title asc` would return
+      // ["Banana", "apple", "cherry"], which isn't what a user means by
+      // "Alphabetical".
+      const { collection, site } = await setupCollection()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "cherry",
+        permalink: "cherry",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "apple",
+        permalink: "apple",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Banana",
+        permalink: "banana",
+      })
+
+      // Act
+      const result = await caller.list({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+        orderBy: "title-asc",
+      })
+
+      // Assert
+      const titles = result.map((r) => r.title)
+      expect(titles).toEqual(["apple", "Banana", "cherry"])
+    })
+
     it("should sort by updatedAt descending when orderBy is updated-desc", async () => {
       // Arrange
       const { collection, site } = await setupCollection()

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -28,6 +28,7 @@ import {
 import { PG_ERROR_CODES } from "../database/constants"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import {
+  applyResourceOrderBy,
   defaultResourceSelect,
   getBlobOfResource,
   getSiteResourceById,
@@ -297,18 +298,9 @@ export const collectionRouter = router({
             ResourceType.CollectionLink,
           ])
 
-        switch (orderBy) {
-          case "title-asc":
-            query = query.orderBy("Resource.title", "asc")
-            break
-          case "updated-desc":
-          default:
-            query = query.orderBy("Resource.updatedAt", "desc")
-            break
-        }
+        query = applyResourceOrderBy(query, orderBy)
 
         return await query
-          .orderBy("Resource.id", "asc") // to ensure deterministic ordering
           .limit(limit)
           .offset(offset)
           .select(defaultResourceSelect)

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -2634,6 +2634,46 @@ describe("resource.router", async () => {
       expect(allIds).toEqual(expectedIds)
     })
 
+    it("should sort case-insensitively when orderBy is title-asc", async () => {
+      // Arrange: titles chosen so a case-sensitive (byte-order) sort would
+      // put "Banana" before "apple" - a naive `title asc` would return
+      // ["Banana", "apple", "cherry"], which isn't what a user means by
+      // "Alphabetical".
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        title: "cherry",
+        permalink: "cherry",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        title: "apple",
+        permalink: "apple",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        title: "Banana",
+        permalink: "banana",
+      })
+
+      // Act
+      const result = await caller.listWithoutRoot({
+        siteId: site.id,
+        orderBy: "title-asc",
+      })
+
+      // Assert
+      expect(result.map((r) => r.title)).toEqual(["apple", "Banana", "cherry"])
+    })
+
     it("should throw 403 if user does not have read access to site", async () => {
       // Arrange
       const { site } = await setupSite()

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -2325,11 +2325,13 @@ describe("resource.router", async () => {
     ] as const
 
     const testListComparable = (
-      a: { updatedAt: Date; title: string },
-      b: { updatedAt: Date; title: string },
+      a: { updatedAt: Date; id: string },
+      b: { updatedAt: Date; id: string },
     ) => {
       if (b.updatedAt.valueOf() === a.updatedAt.valueOf()) {
-        return a.title.localeCompare(b.title)
+        // Tie-broken by id, matching applyResourceOrderBy - title isn't
+        // unique, so it can't guarantee deterministic pagination.
+        return Number(a.id) - Number(b.id)
       }
       return b.updatedAt.valueOf() - a.updatedAt.valueOf()
     }
@@ -2564,6 +2566,72 @@ describe("resource.router", async () => {
         .sort(testListComparable)
         .slice(0, 10)
       expect(expected).toMatchObject(result)
+    })
+
+    it("should return deterministic paginated results when items share the same updatedAt and title", async () => {
+      // Arrange: Create 4 pages with identical title and updatedAt to trigger
+      // non-deterministic ordering without a tie-breaker. Regression test for
+      // the same pagination bug fixed for collection.list (see #1824).
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      const sharedTitle = "Identical title"
+      const permalinks = ["page-1", "page-2", "page-3", "page-4"]
+      const pages = await Promise.all(
+        permalinks.map((permalink) =>
+          setupPageResource({
+            siteId: site.id,
+            resourceType: "Page",
+            title: sharedTitle,
+            permalink,
+          }),
+        ),
+      )
+
+      const sharedUpdatedAt = new Date("2024-01-01T00:00:00.000Z")
+      await db
+        .updateTable("Resource")
+        .set({ updatedAt: sharedUpdatedAt })
+        .where(
+          "id",
+          "in",
+          pages.map(({ page }) => page.id),
+        )
+        .execute()
+
+      // Act
+      const page1First = await caller.listWithoutRoot({
+        siteId: site.id,
+        limit: 2,
+        offset: 0,
+      })
+      const page1Second = await caller.listWithoutRoot({
+        siteId: site.id,
+        limit: 2,
+        offset: 0,
+      })
+      const page2Result = await caller.listWithoutRoot({
+        siteId: site.id,
+        limit: 2,
+        offset: 2,
+      })
+
+      // Assert: repeated calls to the same page return identical results
+      expect(page1First.map((r) => r.id)).toEqual(page1Second.map((r) => r.id))
+
+      // Assert: no duplicate IDs across pages
+      const page1Ids = new Set(page1First.map((r) => r.id))
+      const page2Ids = new Set(page2Result.map((r) => r.id))
+      const overlap = [...page1Ids].filter((id) => page2Ids.has(id))
+      expect(overlap).toHaveLength(0)
+
+      // Assert: all 4 items are returned across pages (none skipped)
+      const allIds = new Set([...page1Ids, ...page2Ids])
+      const expectedIds = new Set(pages.map(({ page }) => page.id))
+      expect(allIds).toEqual(expectedIds)
     })
 
     it("should throw 403 if user does not have read access to site", async () => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -44,6 +44,7 @@ import {
 } from "../redirect/redirect.service"
 import { validateUserPermissionsForSite } from "../site/site.service"
 import {
+  applyResourceOrderBy,
   defaultResourceSelect,
   getBatchAncestryWithSelfQuery,
   getResourceFullPermalink,
@@ -629,47 +630,52 @@ export const resourceRouter = router({
 
   listWithoutRoot: protectedProcedure
     .input(listResourceSchema)
-    .query(async ({ ctx, input: { siteId, resourceId, offset, limit } }) => {
-      await bulkValidateUserPermissionsForResources({
-        action: "read",
-        resourceIds: [resourceId ? String(resourceId) : null],
-        userId: ctx.user.id,
-        siteId: Number(siteId),
-      })
+    .query(
+      async ({
+        ctx,
+        input: { siteId, resourceId, offset, limit, orderBy },
+      }) => {
+        await bulkValidateUserPermissionsForResources({
+          action: "read",
+          resourceIds: [resourceId ? String(resourceId) : null],
+          userId: ctx.user.id,
+          siteId: Number(siteId),
+        })
 
-      let query = db
-        .selectFrom("Resource")
-        .where("Resource.siteId", "=", siteId)
-        .where("Resource.type", "!=", ResourceType.RootPage)
-        .where("Resource.type", "!=", ResourceType.IndexPage)
-        .where("Resource.type", "!=", ResourceType.FolderMeta)
-        .where("Resource.type", "!=", ResourceType.CollectionMeta)
-        .orderBy("Resource.updatedAt", "desc")
-        .orderBy("Resource.title", "asc")
-        .offset(offset)
-        .limit(limit)
+        let query = db
+          .selectFrom("Resource")
+          .where("Resource.siteId", "=", siteId)
+          .where("Resource.type", "!=", ResourceType.RootPage)
+          .where("Resource.type", "!=", ResourceType.IndexPage)
+          .where("Resource.type", "!=", ResourceType.FolderMeta)
+          .where("Resource.type", "!=", ResourceType.CollectionMeta)
 
-      if (resourceId) {
-        query = query.where("Resource.parentId", "=", String(resourceId))
-      } else {
-        query = query.where("Resource.parentId", "is", null)
-      }
+        if (resourceId) {
+          query = query.where("Resource.parentId", "=", String(resourceId))
+        } else {
+          query = query.where("Resource.parentId", "is", null)
+        }
 
-      // TODO: Add pagination support
-      return query
-        .select([
-          "Resource.id",
-          "Resource.permalink",
-          "Resource.title",
-          "Resource.publishedVersionId",
-          "Resource.draftBlobId",
-          "Resource.type",
-          "Resource.parentId",
-          "Resource.updatedAt",
-          "Resource.scheduledAt",
-        ])
-        .execute()
-    }),
+        query = applyResourceOrderBy(query, orderBy)
+
+        // TODO: Add pagination support
+        return query
+          .offset(offset)
+          .limit(limit)
+          .select([
+            "Resource.id",
+            "Resource.permalink",
+            "Resource.title",
+            "Resource.publishedVersionId",
+            "Resource.draftBlobId",
+            "Resource.type",
+            "Resource.parentId",
+            "Resource.updatedAt",
+            "Resource.scheduledAt",
+          ])
+          .execute()
+      },
+    ),
 
   delete: protectedProcedure
     .input(deleteResourceSchema)

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1,8 +1,8 @@
 import type { SelectExpression, SelectQueryBuilder } from "kysely"
 import type { UnwrapTagged } from "type-fest"
 import type {
-  resourceOrderByOptions,
   ResourceItemContent,
+  ResourceOrderByOption,
 } from "~/schemas/resource"
 import {
   createChildrenPagesComparator,
@@ -63,14 +63,14 @@ export const defaultResourceSelect = [
   "Resource.scheduledBy",
 ] satisfies SelectExpression<DB, "Resource">[]
 
-export type ResourceOrderByOption = (typeof resourceOrderByOptions)[number]
-
 // Shared by any query listing rows from the `Resource` table (e.g. folder/root
 // listings, collection item listings) so they sort identically and paginate
 // deterministically. `id` is used as the final tie-breaker (rather than
 // `title`, which isn't unique) to avoid non-deterministic ordering across
 // pages when rows share the same `updatedAt`/`title` - see #1824 for the bug
-// this pattern was introduced to fix.
+// this pattern was introduced to fix. Sorting by `lower(title)` (rather than
+// `title`) makes "Alphabetical" case-insensitive - plain `title asc` sorts by
+// byte value under most collations, so e.g. "Zebra" would sort before "apple".
 export const applyResourceOrderBy = <O>(
   query: SelectQueryBuilder<DB, "Resource", O>,
   orderBy: ResourceOrderByOption,
@@ -78,7 +78,7 @@ export const applyResourceOrderBy = <O>(
   switch (orderBy) {
     case "title-asc":
       return query
-        .orderBy("Resource.title", "asc")
+        .orderBy(sql`lower("Resource"."title")`, "asc")
         .orderBy("Resource.id", "asc")
     case "updated-desc":
     default:

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -65,12 +65,7 @@ export const defaultResourceSelect = [
 
 // Shared by any query listing rows from the `Resource` table (e.g. folder/root
 // listings, collection item listings) so they sort identically and paginate
-// deterministically. `id` is used as the final tie-breaker (rather than
-// `title`, which isn't unique) to avoid non-deterministic ordering across
-// pages when rows share the same `updatedAt`/`title` - see #1824 for the bug
-// this pattern was introduced to fix. Sorting by `lower(title)` (rather than
-// `title`) makes "Alphabetical" case-insensitive - plain `title asc` sorts by
-// byte value under most collations, so e.g. "Zebra" would sort before "apple".
+// deterministically. `id` is used as the final tie-breaker
 export const applyResourceOrderBy = <O>(
   query: SelectQueryBuilder<DB, "Resource", O>,
   orderBy: ResourceOrderByOption,

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1,6 +1,9 @@
-import type { SelectExpression } from "kysely"
+import type { SelectExpression, SelectQueryBuilder } from "kysely"
 import type { UnwrapTagged } from "type-fest"
-import type { ResourceItemContent } from "~/schemas/resource"
+import type {
+  resourceOrderByOptions,
+  ResourceItemContent,
+} from "~/schemas/resource"
 import {
   createChildrenPagesComparator,
   type IsomerSitemap,
@@ -59,6 +62,31 @@ export const defaultResourceSelect = [
   "Resource.scheduledAt",
   "Resource.scheduledBy",
 ] satisfies SelectExpression<DB, "Resource">[]
+
+export type ResourceOrderByOption = (typeof resourceOrderByOptions)[number]
+
+// Shared by any query listing rows from the `Resource` table (e.g. folder/root
+// listings, collection item listings) so they sort identically and paginate
+// deterministically. `id` is used as the final tie-breaker (rather than
+// `title`, which isn't unique) to avoid non-deterministic ordering across
+// pages when rows share the same `updatedAt`/`title` - see #1824 for the bug
+// this pattern was introduced to fix.
+export const applyResourceOrderBy = <O>(
+  query: SelectQueryBuilder<DB, "Resource", O>,
+  orderBy: ResourceOrderByOption,
+): SelectQueryBuilder<DB, "Resource", O> => {
+  switch (orderBy) {
+    case "title-asc":
+      return query
+        .orderBy("Resource.title", "asc")
+        .orderBy("Resource.id", "asc")
+    case "updated-desc":
+    default:
+      return query
+        .orderBy("Resource.updatedAt", "desc")
+        .orderBy("Resource.id", "asc")
+  }
+}
 
 const defaultResourceWithBlobSelect = [
   ...defaultResourceSelect,


### PR DESCRIPTION
📄 **[Full explainer with diagrams & quiz](https://app.notion.com/p/39e77dbba78881cfa88bccb838e57a43)**

## Problem

Studio's dashboard listing for Collections already has a "Sort by: Recently edited / Alphabetical" dropdown, but the equivalent listing for Folders and the site Root has no way to sort at all — it's always hardcoded to "recently edited first".

Closes [ISOM-2310](https://linear.app/ogp/issue/ISOM-2310/add-item-sorting-for-folders-and-root)

## Solution

Root and Folder already share the exact same `ResourceTable` component and `resource.listWithoutRoot` query (the only difference is whether a `resourceId` is passed), so this is a single fix that covers both.

- Added an `orderBy` input (`"updated-desc" | "title-asc"`) to `listResourceSchema`, mirroring the option set Collections already use.
- Extracted a shared `applyResourceOrderBy` helper in `resource.service.ts`, used by both `resource.listWithoutRoot` and `collection.list`, so the two endpoints sort identically instead of each having their own copy of the same switch statement.
- Added the same "Sort by:" dropdown UI to `ResourceTable.tsx` that `CollectionTable.tsx` already has, including resetting to page 1 when the sort option changes (since pagination is offset-based and a new sort order invalidates the previous page's row identity).
- Deduplicated the sort option labels/type: `ResourceTable/constants.ts` and `types.ts` are now the single source of truth, and `CollectionTable` imports from there instead of keeping its own copy.

**Bug fix included in this PR**: while unifying the ordering logic, found that `listWithoutRoot`'s tie-breaker (for rows with identical `updatedAt`) was `title asc`, which isn't unique — two folders can share a title — and could return duplicate/missing rows across pages. `collection.list` already had this fixed via an `id asc` tie-breaker (`id` is a primary key, guaranteed unique) after hitting this exact bug in production previously. `listWithoutRoot` never got that same fix; it now uses the same `id asc` tie-breaker via the shared helper. A regression test was added mirroring the one Collections already have for this.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Sort dropdown ("Recently edited" / "Alphabetical") on the Folder and Root item listings in Studio's dashboard.

**Improvements**:

- Shared `applyResourceOrderBy` helper deduplicates sort logic between `resource.router.ts` and `collection.router.ts`.
- Shared `orderBy` option list/labels/type between Collection and Folder/Root schemas and UI, removing duplicate constant definitions.

**Bug Fixes**:

- `resource.listWithoutRoot` now uses a unique (`id asc`) pagination tie-breaker instead of `title asc`, preventing duplicate/missing rows across pages when items share the same `updatedAt` and `title`.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

Added a regression test in `resource.router.test.ts` that forces four pages to share an identical `title` and `updatedAt`, then asserts paginated results are stable across repeated calls and that no row is duplicated or skipped. Updated the existing `testListComparable` test helper to match the new `id`-based tie-break (this surfaced that the test environment does produce real `updatedAt` ties, confirming the bug was live). Full unit suite passes (1536 passed, 41 skipped, 0 failures); `tsc --noEmit` and `pnpm lint` are clean.

**Manual Verification Steps**:

- [ ] Open a site in Studio, navigate to the site's Home/Root listing, confirm a "Sort by:" dropdown with "Recently edited" and "Alphabetical" options appears above the item table
- [ ] Select "Alphabetical" and confirm items reorder A→Z by title, and pagination resets to page 1
- [ ] Navigate into a Folder with several child pages/folders, confirm the same dropdown appears and behaves the same way
- [ ] Confirm the Collection listing's existing sort dropdown still works unchanged (no regression from the shared helper refactor)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds sorting support for folder, root, and collection resource listings. The main changes are:

- Shared `orderBy` schema options for resource and collection list queries.
- A reusable `ResourceSortMenu` used by both folder/root and collection tables.
- Server-side ordering through `applyResourceOrderBy`, with case-insensitive title sorting and `id` tie-breaks.
- Pagination reset when the selected sort option changes.
- Tests for deterministic pagination and alphabetical sorting.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with normal human review for a medium-risk server and UI change.

No blocking issues were found. The updated code keeps permission checks in place, validates the new input through shared schemas, and adds deterministic database ordering with tests.

No files require special attention beyond the changed resource listing path.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the requested contract-validation verification and confirmed that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/dashboard/components/ResourceTable/ResourceSortMenu.tsx | Adds a shared sort dropdown for `updated-desc` and `title-asc` options. |
| apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx | Adds sort state, passes `orderBy` to the list query, and resets pagination on sort changes. |
| apps/studio/src/schemas/resource.ts | Adds validated resource list `orderBy` input and exports the shared order-by type. |
| apps/studio/src/schemas/collection.ts | Reuses the shared resource order-by options for collection list input validation. |
| apps/studio/src/server/modules/resource/resource.service.ts | Adds `applyResourceOrderBy` with case-insensitive title ordering and deterministic `id` tie-breaks. |
| apps/studio/src/server/modules/resource/resource.router.ts | Applies shared ordering to folder and root resource listings before pagination. |
| apps/studio/src/server/modules/collection/collection.router.ts | Delegates collection list ordering to the shared resource ordering helper. |
| apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts | Adds tests for deterministic paginated results and case-insensitive title sorting. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant ResourceTable
  participant ResourceSortMenu
  participant TRPC as tRPC resource.listWithoutRoot / collection.list
  participant Service as applyResourceOrderBy
  participant DB as Resource table

  User->>ResourceSortMenu: Select sort option
  ResourceSortMenu->>ResourceTable: onChange(orderBy)
  ResourceTable->>ResourceTable: setSortOption + reset pageIndex to 0
  ResourceTable->>TRPC: Query with siteId, resourceId, orderBy, limit, offset
  TRPC->>TRPC: Validate schema + permissions
  TRPC->>Service: applyResourceOrderBy(query, orderBy)
  Service->>DB: ORDER BY lower(title)/updatedAt, id tie-breaker
  DB-->>ResourceTable: Sorted paginated resources
  ResourceTable-->>User: Render updated listing
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant ResourceTable
  participant ResourceSortMenu
  participant TRPC as tRPC resource.listWithoutRoot / collection.list
  participant Service as applyResourceOrderBy
  participant DB as Resource table

  User->>ResourceSortMenu: Select sort option
  ResourceSortMenu->>ResourceTable: onChange(orderBy)
  ResourceTable->>ResourceTable: setSortOption + reset pageIndex to 0
  ResourceTable->>TRPC: Query with siteId, resourceId, orderBy, limit, offset
  TRPC->>TRPC: Validate schema + permissions
  TRPC->>Service: applyResourceOrderBy(query, orderBy)
  Service->>DB: ORDER BY lower(title)/updatedAt, id tie-breaker
  DB-->>ResourceTable: Sorted paginated resources
  ResourceTable-->>User: Render updated listing
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: extract shared ResourceSortMen..."](https://github.com/opengovsg/isomer/commit/141cffe47dd2210f2138b21060ebb7fd9014aa14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44435760)</sub>

<!-- /greptile_comment -->