### PR TITLE
🎀📊 feat(rte-table): promote superscript/subscript onto toolbar when a table is active

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -188,6 +188,26 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
           },
         ],
       },
+      // Table-scoped: promoted onto the main toolbar instead of the overflow
+      // menu while editing inside a table, same as the "Table" group above.
+      {
+        type: "item",
+        icon: MdSuperscript,
+        title: "Superscript",
+        isHidden: () => !editor.isActive("table"),
+        action: () =>
+          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+        isActive: () => editor.isActive("superscript"),
+      },
+      {
+        type: "item",
+        icon: MdSubscript,
+        title: "Subscript",
+        isHidden: () => !editor.isActive("table"),
+        action: () =>
+          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+        isActive: () => editor.isActive("subscript"),
+      },
       // Lesser-used commands are kept inside the overflow items list
       {
         type: "overflow-list",
@@ -196,6 +216,7 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
             type: "item",
             icon: MdSuperscript,
             title: "Superscript",
+            isHidden: () => editor.isActive("table"),
             action: () =>
               editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
             isActive: () => editor.isActive("superscript"),
@@ -204,6 +225,7 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
             type: "item",
             icon: MdSubscript,
             title: "Subscript",
+            isHidden: () => editor.isActive("table"),
             action: () =>
               editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
             isActive: () => editor.isActive("subscript"),
@@ -212,6 +234,7 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
             type: "item",
             icon: MdHorizontalRule,
             title: "Divider",
+            isHidden: () => editor.isActive("table"),
             action: () => editor.chain().focus().setHorizontalRule().run(),
             isActive: () => editor.isActive("divider"),
           },

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
@@ -19,7 +19,11 @@ export interface MenubarOverflowListProps {
 
 export const MenubarOverflowList = ({
   items,
-}: MenubarOverflowListProps): JSX.Element => {
+}: MenubarOverflowListProps): JSX.Element | null => {
+  const visibleItems = items.filter((item) => !item.isHidden?.())
+  if (visibleItems.length === 0) {
+    return null
+  }
   return (
     <Popover placement="bottom">
       {({ isOpen }) => (
@@ -49,7 +53,7 @@ export const MenubarOverflowList = ({
           <PopoverContent w="fit-content">
             <PopoverBody>
               <HStack>
-                {items.map((subItem, index) => (
+                {visibleItems.map((subItem, index) => (
                   <MenuItem
                     key={index}
                     icon={subItem.icon}

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -238,6 +238,26 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
           },
         ],
       },
+      // Table-scoped: promoted onto the main toolbar instead of the overflow
+      // menu while editing inside a table, same as the "Table" group above.
+      {
+        type: "item",
+        icon: MdSuperscript,
+        title: "Superscript",
+        isHidden: () => !editor.isActive("table"),
+        action: () =>
+          editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
+        isActive: () => editor.isActive("superscript"),
+      },
+      {
+        type: "item",
+        icon: MdSubscript,
+        title: "Subscript",
+        isHidden: () => !editor.isActive("table"),
+        action: () =>
+          editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
+        isActive: () => editor.isActive("subscript"),
+      },
       // Lesser-used commands are kept inside the overflow items list
       {
         type: "overflow-list",
@@ -246,6 +266,7 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
             type: "item",
             icon: MdSuperscript,
             title: "Superscript",
+            isHidden: () => editor.isActive("table"),
             action: () =>
               editor.chain().focus().unsetSubscript().toggleSuperscript().run(),
             isActive: () => editor.isActive("superscript"),
@@ -254,6 +275,7 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
             type: "item",
             icon: MdSubscript,
             title: "Subscript",
+            isHidden: () => editor.isActive("table"),
             action: () =>
               editor.chain().focus().unsetSuperscript().toggleSubscript().run(),
             isActive: () => editor.isActive("subscript"),
@@ -262,6 +284,7 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
             type: "item",
             icon: MdHorizontalRule,
             title: "Divider",
+            isHidden: () => editor.isActive("table"),
             action: () => editor.chain().focus().setHorizontalRule().run(),
             isActive: () => editor.isActive("divider"),
           },

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { userEvent, within } from "storybook/test"
+import { expect, userEvent, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -146,5 +146,45 @@ export const LinkModal: Story = {
     await AddTextBlock.play?.(context)
 
     await userEvent.click(canvas.getByRole("button", { name: /link/i }))
+  },
+}
+
+export const ActiveTableToolbar: Story = {
+  play: async (context) => {
+    const { canvasElement } = context
+    const canvas = within(canvasElement)
+    await AddTextBlock.play?.(context)
+
+    // Outside a table: superscript/subscript live only under "More options".
+    // (The page also has an unrelated page-actions "More options" `Menu`
+    // button; the RTE toolbar's overflow list is a `Popover`, so
+    // disambiguate on aria-haspopup.)
+    const overflowTrigger = canvas
+      .getAllByRole("button", { name: /more options/i })
+      .find((button) => button.getAttribute("aria-haspopup") === "dialog")
+    if (!overflowTrigger) throw new Error("Overflow trigger not found")
+    await userEvent.click(overflowTrigger)
+    await canvas.findByRole("button", { name: /^superscript$/i })
+    await expect(
+      canvas.queryAllByRole("button", { name: /^superscript$/i }),
+    ).toHaveLength(1)
+    await userEvent.keyboard("{Escape}")
+
+    await userEvent.click(canvas.getByRole("button", { name: /^table$/i }))
+
+    // Inside a table: promoted directly onto the main toolbar, and no longer
+    // duplicated under "More options" (removed from that list entirely).
+    await canvas.findByRole("button", { name: /^superscript$/i })
+    await canvas.findByRole("button", { name: /^subscript$/i })
+    await expect(
+      canvas.getAllByRole("button", { name: /^superscript$/i }),
+    ).toHaveLength(1)
+
+    // Divider is also table-inapplicable, so "More options" has nothing left
+    // to show and disappears entirely — only the unrelated page-actions menu
+    // button remains.
+    await expect(
+      canvas.getAllByRole("button", { name: /more options/i }),
+    ).toHaveLength(1)
   },
 }


### PR DESCRIPTION
## Problem

Superscript/subscript formatting is buried under the toolbar's overflow "..." menu, even inside a table where it's common (footnote markers, chemical/math notation in cells).

Closes https://linear.app/ogp/issue/ISOM-2353/specs-table-manipulations

## Solution

Promote Superscript/Subscript onto the main toolbar while the cursor is inside a table, and hide them from the overflow list at the same time so they aren't duplicated. Outside a table, they're unchanged — still tucked under the ellipsis.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None — this repositions two existing actions rather than adding new ones.

**Improvements**:

- Superscript/Subscript now render directly on `TextMenuBar` / `AccordionMenuBar`'s main toolbar when `editor.isActive("table")`, instead of only inside the overflow "More options" popover.
- `MenubarOverflowList` now respects each item's `isHidden` (previously ignored, unlike the top-level `Item`/`HorizontalList` components), so items can be conditionally excluded from the overflow list.
- The overflow list's Divider action is also hidden while inside a table (inserting a horizontal rule inside a cell isn't a supported use case).
- The "More options" ("...") trigger itself now disappears entirely once it has no visible items left to show, rather than opening onto an empty popover.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

Superscript/Subscript only reachable via the "..." overflow menu, even inside a table.

<img width="592" height="330" alt="Screenshot 2026-07-16 at 2 04 25 AM" src="https://github.com/user-attachments/assets/04eb2d10-45db-42f3-b850-a1f877f1bc16" />

**AFTER**:

<!-- [insert screenshot here] -->

With the cursor inside a table, Superscript (X²) and Subscript (X₂) appear directly on the main toolbar; the "..." button disappears since nothing remains in the overflow list.

<img width="598" height="347" alt="Screenshot 2026-07-16 at 2 05 25 AM" src="https://github.com/user-attachments/assets/3c292bad-284c-446c-9556-59a627d0d849" />

## Tests

**Manual Verification Steps**:

- [ ] Open a page's rich text block, insert a table, and confirm Superscript (X²) and Subscript (X₂) icons now appear directly on the main toolbar (no need to open "...").
- [ ] With the cursor inside a table, confirm the "..." ("More options") button is gone from the toolbar entirely.
- [ ] Click into a table cell's text, select some text, and confirm Superscript/Subscript toggle correctly via the new toolbar buttons.
- [ ] Move the cursor outside the table (into a normal paragraph) and confirm Superscript/Subscript disappear from the main toolbar and are reachable again via "..." → Superscript/Subscript, and that the "..." button is visible again.
- [ ] Repeat the above inside an Accordion block's rich text editor, since both editors share this change.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the rich-text toolbar behavior for table editing. The main changes are:

- Superscript and subscript move onto the main toolbar while the cursor is inside a table.
- The overflow menu now filters out hidden items and disappears when no visible actions remain.
- The same table toolbar behavior is applied to both text and accordion editors.
- Storybook coverage was added for the active-table toolbar state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are limited to client-side toolbar rendering and Storybook coverage. The updated code follows the existing menu item patterns. No blocking issues were found.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - Started pnpm --filter isomer-studio storybook --host 127.0.0.1 and began polling the internal URL to reach the Storybook server.
- - The webpack build progressed to about 70% before the process was killed, ending the Storybook start attempt.
- - Issued a Playwright Chromium script against the internal URL, but navigation failed with net::ERR\_CONNECTION\_REFUSED because Storybook was not running.
- - Saved blocker artifacts including screenshots, video, and various logs for later inspection.

<a href="https://app.greptile.com/trex/runs/14582029/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx | Adds table-scoped superscript/subscript toolbar items and hides duplicate overflow entries while editing tables. |
| apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx | Filters hidden overflow items and suppresses the overflow trigger when no visible actions remain. |
| apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx | Mirrors the table-scoped superscript/subscript toolbar behavior for the main text editor. |
| apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx | Adds a Storybook interaction story for overflow and promoted toolbar behavior inside tables. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Editor as TipTap editor
participant Toolbar as Text/AccordionMenuBar
participant Overflow as MenubarOverflowList

User->>Editor: Move cursor into/out of table
Toolbar->>Editor: editor.isActive("table")
alt Inside table
    Toolbar-->>User: Show Superscript/Subscript on main toolbar
    Overflow->>Editor: Filter items with isHidden()
    Overflow-->>User: Hide overflow trigger when no items remain
else Outside table
    Toolbar-->>User: Hide promoted Superscript/Subscript buttons
    Overflow->>Editor: Filter items with isHidden()
    Overflow-->>User: Show More options with Superscript/Subscript/Divider
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Editor as TipTap editor
participant Toolbar as Text/AccordionMenuBar
participant Overflow as MenubarOverflowList

User->>Editor: Move cursor into/out of table
Toolbar->>Editor: editor.isActive("table")
alt Inside table
    Toolbar-->>User: Show Superscript/Subscript on main toolbar
    Overflow->>Editor: Filter items with isHidden()
    Overflow-->>User: Hide overflow trigger when no items remain
else Outside table
    Toolbar-->>User: Hide promoted Superscript/Subscript buttons
    Overflow->>Editor: Filter items with isHidden()
    Overflow-->>User: Show More options with Superscript/Subscript/Divider
end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(rte-table): promote superscript/sub..."](https://github.com/opengovsg/isomer/commit/dc8687b473264dd8b2018d3cbd5f11eaa49a6274) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44545500)</sub>

<!-- /greptile_comment -->