### PR TITLE
feat(rte-table): add duplicate row/column to TableBubbleMenu

### DIFF
--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -124,6 +124,43 @@ const firstRowTexts = (editor: Editor): string[] => {
   return texts
 }
 
+// Cell text contents for the nth table row (0-indexed), left-to-right.
+const rowTextsAt = (editor: Editor, rowIndex: number): string[] => {
+  const texts: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    const row = node.child(rowIndex)
+    row.forEach((cell) => {
+      texts.push(cell.textContent)
+    })
+    return false
+  })
+  return texts
+}
+
+const tableRowCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.childCount
+    return false
+  })
+  return count
+}
+
+const tableColumnCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.child(0).childCount
+    return false
+  })
+  return count
+}
+
 describe("TableBubbleMenu", () => {
   it("stacks the menu above the selected-cell highlight", async () => {
     const { editor, findByText, container } = await renderHarness()
@@ -149,6 +186,7 @@ describe("TableBubbleMenu", () => {
 
     expect(queryByText("Header row")).toBeNull()
     expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Duplicate row")).toBeTruthy()
     expect(await findByText("Move up")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
     expect(await findByText("Delete row")).toBeTruthy()
@@ -246,6 +284,97 @@ describe("TableBubbleMenu", () => {
     })
 
     expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
+  })
+
+  it("duplicates a body row immediately below with the same cell content", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // First body row: cells 3–5 ("Row 1, A/B/C")
+    selectCells(editor, 3, 5)
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+
+    const duplicate = await findByText("Duplicate row")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(4)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    // Menu stays on the duplicated block
+    expect(await findByText("Duplicate row")).toBeTruthy()
+  })
+
+  it("duplicates a multi-row selection as a contiguous block", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // Both body rows: cells 3–8
+    selectCells(editor, 3, 8)
+    expect(tableRowCount(editor)).toBe(3)
+
+    const duplicate = await findByText("Duplicate row")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 4)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a column immediately to the right with the same cell content", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // Column B: header cell 1 + body cells 4 and 7
+    selectCells(editor, 1, 7)
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const duplicate = await findByText("Duplicate column")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(4)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column B",
+      "Column C",
+    ])
+    expect(rowTextsAt(editor, 1)).toEqual([
+      "Row 1, A",
+      "Row 1, B",
+      "Row 1, B",
+      "Row 1, C",
+    ])
+    expect(await findByText("Duplicate column")).toBeTruthy()
+  })
+
+  it("duplicates a multi-column selection as a contiguous block", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // Columns A+B
+    selectCells(editor, 0, 7)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const duplicate = await findByText("Duplicate column")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(5)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column A",
+      "Column B",
+      "Column C",
+    ])
   })
 
   it("excludes Delete row when the selection includes the header row", async () => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
@@ -1,0 +1,284 @@
+import type { Node } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
+import type { Editor } from "@tiptap/react"
+import {
+  addColSpan,
+  CellSelection,
+  isInTable,
+  selectedRect,
+  TableMap,
+  tableNodeTypes,
+} from "@tiptap/pm/tables"
+
+interface TableInfo {
+  map: TableMap
+  tableStart: number
+  table: Node
+}
+
+const tableInfoAt = (tr: Transaction, tablePos: number): TableInfo | null => {
+  const table = tr.doc.nodeAt(tablePos)
+  if (!table) return null
+  return {
+    table,
+    tableStart: tablePos + 1,
+    map: TableMap.get(table),
+  }
+}
+
+// Insert a copy of `sourceRow` at row index `insertAt`. Cells that span into
+// the insert slot from above expand their rowspan (same as addRow); every other
+// column gets a rowspan-1 clone of the source cell's type and content.
+const insertDuplicateRow = (
+  tr: Transaction,
+  { map, tableStart, table }: TableInfo,
+  sourceRow: number,
+  insertAt: number,
+): Transaction => {
+  let rowPos = tableStart
+  for (let i = 0; i < insertAt; i++) {
+    rowPos += table.child(i).nodeSize
+  }
+
+  const cells: Node[] = []
+  for (let col = 0; col < map.width;) {
+    const insertIndex = insertAt * map.width + col
+
+    // A cell above already covers this slot — grow its rowspan instead of
+    // inserting a parallel cell (mirrors prosemirror-tables' addRow).
+    if (
+      insertAt > 0 &&
+      insertAt < map.height &&
+      map.map[insertIndex] === map.map[insertIndex - map.width]
+    ) {
+      const pos = map.map[insertIndex]
+      if (pos === undefined) {
+        col += 1
+        continue
+      }
+      const node = table.nodeAt(pos)
+      if (!node) {
+        col += 1
+        continue
+      }
+      tr.setNodeMarkup(tableStart + pos, null, {
+        ...node.attrs,
+        rowspan: (node.attrs.rowspan as number) + 1,
+      })
+      col += node.attrs.colspan as number
+      continue
+    }
+
+    const sourceIndex = sourceRow * map.width + col
+    const sourcePos = map.map[sourceIndex]
+    if (sourcePos === undefined) {
+      col += 1
+      continue
+    }
+    const sourceCell = table.nodeAt(sourcePos)
+    if (!sourceCell) {
+      col += 1
+      continue
+    }
+
+    const sourceCellRect = map.findCell(sourcePos)
+    if (sourceCellRect.top !== sourceRow) {
+      // Covered by a rowspan that started above — placeholder empty cell.
+      const placeholder = sourceCell.type.createAndFill({
+        ...sourceCell.attrs,
+        rowspan: 1,
+        colspan: 1,
+        colwidth: null,
+      })
+      if (placeholder) cells.push(placeholder)
+      col += 1
+      continue
+    }
+
+    // Flatten rowspan so the duplicate is a single row; keep colspan/content.
+    cells.push(
+      sourceCell.type.create(
+        { ...sourceCell.attrs, rowspan: 1 },
+        sourceCell.content,
+      ),
+    )
+    col += sourceCell.attrs.colspan as number
+  }
+
+  tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells))
+  return tr
+}
+
+// Clone one column from `sourceCol` into `insertAt`, refreshing the table map
+// after every row mutation so later rows don't resolve stale positions.
+const insertDuplicateColumn = (
+  tr: Transaction,
+  tablePos: number,
+  sourceCol: number,
+  insertAt: number,
+): boolean => {
+  let row = 0
+  for (;;) {
+    const info = tableInfoAt(tr, tablePos)
+    if (!info) return false
+    const { map, tableStart, table } = info
+    if (row >= map.height) return true
+
+    const insertIndex = row * map.width + insertAt
+
+    if (
+      insertAt > 0 &&
+      insertAt < map.width &&
+      map.map[insertIndex - 1] === map.map[insertIndex]
+    ) {
+      const pos = map.map[insertIndex]
+      if (pos === undefined) {
+        row += 1
+        continue
+      }
+      const cell = table.nodeAt(pos)
+      if (!cell) {
+        row += 1
+        continue
+      }
+      tr.setNodeMarkup(
+        tableStart + pos,
+        null,
+        addColSpan(
+          cell.attrs as Parameters<typeof addColSpan>[0],
+          insertAt - map.colCount(pos),
+        ),
+      )
+      row += cell.attrs.rowspan as number
+      continue
+    }
+
+    const sourceIndex = row * map.width + sourceCol
+    const sourcePos = map.map[sourceIndex]
+    if (sourcePos === undefined) {
+      row += 1
+      continue
+    }
+    const sourceCell = table.nodeAt(sourcePos)
+    if (!sourceCell) {
+      row += 1
+      continue
+    }
+
+    const sourceCellRect = map.findCell(sourcePos)
+    const insertPos = map.positionAt(row, insertAt, table)
+    const rowspan = sourceCell.attrs.rowspan as number
+
+    if (sourceCellRect.left !== sourceCol) {
+      const placeholder = sourceCell.type.createAndFill({
+        ...sourceCell.attrs,
+        rowspan: 1,
+        colspan: 1,
+        colwidth: null,
+      })
+      if (placeholder) {
+        tr.insert(tableStart + insertPos, placeholder)
+      }
+      row += 1
+      continue
+    }
+
+    // Flatten colspan for the duplicate column; keep rowspan/content.
+    const colwidth = sourceCell.attrs.colwidth as number[] | null
+    const duplicated = sourceCell.type.create(
+      {
+        ...sourceCell.attrs,
+        colspan: 1,
+        colwidth: colwidth ? [colwidth[0] ?? 0] : null,
+      },
+      sourceCell.content,
+    )
+    tr.insert(tableStart + insertPos, duplicated)
+    row += rowspan
+  }
+}
+
+// Duplicate the selected row block immediately below it, preserving order.
+export const duplicateSelectedRows = (editor: Editor): void => {
+  const { state, view } = editor
+  if (!isInTable(state)) return
+
+  const rect = selectedRect(state)
+  const span = rect.bottom - rect.top
+  if (span <= 0) return
+
+  const tablePos = rect.tableStart - 1
+  let tr = state.tr
+
+  // Insert last→first at the same index so earlier sources land above later
+  // ones and the duplicate block mirrors the original order.
+  for (let sourceRow = rect.bottom - 1; sourceRow >= rect.top; sourceRow--) {
+    const info = tableInfoAt(tr, tablePos)
+    if (!info) return
+    tr = insertDuplicateRow(tr, info, sourceRow, rect.bottom)
+  }
+
+  const info = tableInfoAt(tr, tablePos)
+  if (!info) {
+    view.dispatch(tr)
+    return
+  }
+
+  const newTop = rect.bottom
+  const newBottom = rect.bottom + span
+  const anchor = info.map.positionAt(newTop, 0, info.table)
+  const head = info.map.positionAt(
+    newBottom - 1,
+    info.map.width - 1,
+    info.table,
+  )
+  tr.setSelection(
+    CellSelection.create(
+      tr.doc,
+      info.tableStart + anchor,
+      info.tableStart + head,
+    ),
+  )
+  view.dispatch(tr)
+}
+
+// Duplicate the selected column block immediately to its right, preserving order.
+export const duplicateSelectedColumns = (editor: Editor): void => {
+  const { state, view } = editor
+  if (!isInTable(state)) return
+
+  const rect = selectedRect(state)
+  const span = rect.right - rect.left
+  if (span <= 0) return
+
+  const tablePos = rect.tableStart - 1
+  const tr = state.tr
+
+  // Forward inserts: each copy lands after the original block + prior dups, so
+  // source columns (still left of the insert point) keep stable indices.
+  for (let i = 0; i < span; i++) {
+    if (!insertDuplicateColumn(tr, tablePos, rect.left + i, rect.right + i)) {
+      return
+    }
+  }
+
+  const info = tableInfoAt(tr, tablePos)
+  if (!info) {
+    view.dispatch(tr)
+    return
+  }
+
+  const newLeft = rect.right
+  const newRight = rect.right + span
+  // Bottom-left → top-right matches TipTap's full-column selection orientation.
+  const anchor = info.map.positionAt(info.map.height - 1, newLeft, info.table)
+  const head = info.map.positionAt(0, newRight - 1, info.table)
+  tr.setSelection(
+    CellSelection.create(
+      tr.doc,
+      info.tableStart + anchor,
+      info.tableStart + head,
+    ),
+  )
+  view.dispatch(tr)
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -15,6 +15,7 @@ import { useEditorState } from "@tiptap/react"
 import { BubbleMenu } from "@tiptap/react/menus"
 import { memo, useEffect } from "react"
 import {
+  BiCopy,
   BiDownArrowAlt,
   BiLeftArrowAlt,
   BiRightArrowAlt,
@@ -32,6 +33,10 @@ import {
   IconSplitCell,
 } from "~/components/icons"
 
+import {
+  duplicateSelectedColumns,
+  duplicateSelectedRows,
+} from "./TableBubbleMenu.duplicate"
 import {
   getColumnMovePlan,
   getRowMovePlan,
@@ -296,6 +301,11 @@ const RowSelectionActions = ({
           icon={<IconAddRowBelow boxSize="1rem" />}
           onClick={() => editor.chain().focus().addRowAfter().run()}
         />
+        <ActionButton
+          label="Duplicate row"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedRows(editor)}
+        />
       </ActionGroup>
       {(canMoveUp || canMoveDown) && (
         <>
@@ -373,6 +383,11 @@ const ColumnSelectionActions = ({
           label="Add column right"
           icon={<IconAddColRight boxSize="1rem" />}
           onClick={() => editor.chain().focus().addColumnAfter().run()}
+        />
+        <ActionButton
+          label="Duplicate column"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedColumns(editor)}
         />
       </ActionGroup>
       {(canMoveLeft || canMoveRight) && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Goal
Add Duplicate row / Duplicate column actions to the contextual TableBubbleMenu.

## Approach
One-shot FE change stacked on the existing TableBubbleMenu branch. Implements duplication with ProseMirror table helpers (no new dependency) so multi-row/column selections copy as a contiguous block immediately after the selection.

## What this PR does
- Adds `Duplicate row` and `Duplicate column` actions to the row/column bubble menus (alongside Add)
- Copies cell type + content; flattens rowspan/colspan on the duplicate axis so the table map stays valid
- Reselects the duplicated block so the menu stays available for follow-up actions
- Extends TableBubbleMenu browser tests for single- and multi-axis duplication

## Stack
- Base: `07-15-feat_rte-table_add_contextual_tablebubblemenu_for_table_actions` — TableBubbleMenu foundation
- This PR — duplicate row/column actions

## Verification
- [x] Browser tests pass (`TableBubbleMenu.browser.test.tsx`, 19 tests)
- [x] oxlint (type-aware) / tsc clean for touched files
- [x] oxfmt check clean
- [ ] Chromatic preview (after CI)

## Risk
Low — editor UI affordance only; no schema/API changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-651a6d37-0001-45bf-ae2c-0fd4a141d4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-651a6d37-0001-45bf-ae2c-0fd4a141d4c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

