### PR TITLE
🎀📊 feat(rte-table): add duplicate row/column to TableBubbleMenu

### DIFF
--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -318,12 +318,13 @@ describe("TableBubbleMenu", () => {
   })
 
   it("duplicates a body row immediately below with the same cell content", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole } = await renderHarness()
 
     // First body row: cells 3–5 ("Row 1, A/B/C")
     selectCells(editor, 3, 5)
     expect(tableRowCount(editor)).toBe(3)
     expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
 
     const duplicate = await findByText("Duplicate row")
     act(() => {
@@ -334,16 +335,15 @@ describe("TableBubbleMenu", () => {
     expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
     expect(rowTextsAt(editor, 2)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
     expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
-    // Menu stays on the duplicated block
-    expect(await findByText("Duplicate row")).toBeTruthy()
   })
 
   it("duplicates a multi-row selection as a contiguous block", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole } = await renderHarness()
 
     // Both body rows: cells 3–8
     selectCells(editor, 3, 8)
     expect(tableRowCount(editor)).toBe(3)
+    await activateTableBubbleMenu(findByRole)
 
     const duplicate = await findByText("Duplicate row")
     act(() => {
@@ -358,12 +358,13 @@ describe("TableBubbleMenu", () => {
   })
 
   it("duplicates a column immediately to the right with the same cell content", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole } = await renderHarness()
 
     // Column B: header cell 1 + body cells 4 and 7
     selectCells(editor, 1, 7)
     expect(tableColumnCount(editor)).toBe(3)
     expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    await activateTableBubbleMenu(findByRole)
 
     const duplicate = await findByText("Duplicate column")
     act(() => {
@@ -383,15 +384,15 @@ describe("TableBubbleMenu", () => {
       "Row 1, B",
       "Row 1, C",
     ])
-    expect(await findByText("Duplicate column")).toBeTruthy()
   })
 
   it("duplicates a multi-column selection as a contiguous block", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole } = await renderHarness()
 
     // Columns A+B
     selectCells(editor, 0, 7)
     expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    await activateTableBubbleMenu(findByRole)
 
     const duplicate = await findByText("Duplicate column")
     act(() => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -133,6 +133,43 @@ const firstRowTexts = (editor: Editor): string[] => {
   return texts
 }
 
+// Cell text contents for the nth table row (0-indexed), left-to-right.
+const rowTextsAt = (editor: Editor, rowIndex: number): string[] => {
+  const texts: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    const row = node.child(rowIndex)
+    row.forEach((cell) => {
+      texts.push(cell.textContent)
+    })
+    return false
+  })
+  return texts
+}
+
+const tableRowCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.childCount
+    return false
+  })
+  return count
+}
+
+const tableColumnCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.child(0).childCount
+    return false
+  })
+  return count
+}
+
 describe("TableBubbleMenu", () => {
   afterEach(() => {
     cleanup()
@@ -165,6 +202,7 @@ describe("TableBubbleMenu", () => {
 
     expect(queryByText("Header row")).toBeNull()
     expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Duplicate row")).toBeTruthy()
     expect(await findByText("Move up")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
     expect(await findByText("Delete row")).toBeTruthy()
@@ -277,6 +315,97 @@ describe("TableBubbleMenu", () => {
     })
 
     expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
+  })
+
+  it("duplicates a body row immediately below with the same cell content", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // First body row: cells 3–5 ("Row 1, A/B/C")
+    selectCells(editor, 3, 5)
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+
+    const duplicate = await findByText("Duplicate row")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(4)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    // Menu stays on the duplicated block
+    expect(await findByText("Duplicate row")).toBeTruthy()
+  })
+
+  it("duplicates a multi-row selection as a contiguous block", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // Both body rows: cells 3–8
+    selectCells(editor, 3, 8)
+    expect(tableRowCount(editor)).toBe(3)
+
+    const duplicate = await findByText("Duplicate row")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 4)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a column immediately to the right with the same cell content", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // Column B: header cell 1 + body cells 4 and 7
+    selectCells(editor, 1, 7)
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const duplicate = await findByText("Duplicate column")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(4)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column B",
+      "Column C",
+    ])
+    expect(rowTextsAt(editor, 1)).toEqual([
+      "Row 1, A",
+      "Row 1, B",
+      "Row 1, B",
+      "Row 1, C",
+    ])
+    expect(await findByText("Duplicate column")).toBeTruthy()
+  })
+
+  it("duplicates a multi-column selection as a contiguous block", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    // Columns A+B
+    selectCells(editor, 0, 7)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const duplicate = await findByText("Duplicate column")
+    act(() => {
+      duplicate.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(5)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column A",
+      "Column B",
+      "Column C",
+    ])
   })
 
   it("excludes Delete row when the selection includes the header row", async () => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
@@ -26,6 +26,44 @@ const tableInfoAt = (tr: Transaction, tablePos: number): TableInfo | null => {
   }
 }
 
+// Look up the cell node at a TableMap index, returning both the node and its
+// position so callers don't repeat the "undefined map slot" / "missing node"
+// guard at every call site.
+const resolveCell = (
+  table: Node,
+  map: TableMap,
+  index: number,
+): { pos: number; node: Node } | null => {
+  const pos = map.map[index]
+  if (pos === undefined) return null
+  const node = table.nodeAt(pos)
+  if (!node) return null
+  return { pos, node }
+}
+
+// Dispatch `tr` after reselecting the block described by `corners`, resolved
+// against the table's post-mutation TableInfo. Shared by
+// duplicateSelectedRows/Columns, which differ only in which corners to select.
+const selectBlockAndDispatch = (
+  editor: Editor,
+  tr: Transaction,
+  tablePos: number,
+  corners: (info: TableInfo) => { anchor: number; head: number },
+): void => {
+  const info = tableInfoAt(tr, tablePos)
+  if (info) {
+    const { anchor, head } = corners(info)
+    tr.setSelection(
+      CellSelection.create(
+        tr.doc,
+        info.tableStart + anchor,
+        info.tableStart + head,
+      ),
+    )
+  }
+  editor.view.dispatch(tr)
+}
+
 // Insert a copy of `sourceRow` at row index `insertAt`. Cells that span into
 // the insert slot from above expand their rowspan (same as addRow); every other
 // column gets a rowspan-1 clone of the source cell's type and content.
@@ -51,35 +89,26 @@ const insertDuplicateRow = (
       insertAt < map.height &&
       map.map[insertIndex] === map.map[insertIndex - map.width]
     ) {
-      const pos = map.map[insertIndex]
-      if (pos === undefined) {
+      const resolved = resolveCell(table, map, insertIndex)
+      if (!resolved) {
         col += 1
         continue
       }
-      const node = table.nodeAt(pos)
-      if (!node) {
-        col += 1
-        continue
-      }
-      tr.setNodeMarkup(tableStart + pos, null, {
-        ...node.attrs,
-        rowspan: (node.attrs.rowspan as number) + 1,
+      tr.setNodeMarkup(tableStart + resolved.pos, null, {
+        ...resolved.node.attrs,
+        rowspan: (resolved.node.attrs.rowspan as number) + 1,
       })
-      col += node.attrs.colspan as number
+      col += resolved.node.attrs.colspan as number
       continue
     }
 
     const sourceIndex = sourceRow * map.width + col
-    const sourcePos = map.map[sourceIndex]
-    if (sourcePos === undefined) {
+    const resolvedSource = resolveCell(table, map, sourceIndex)
+    if (!resolvedSource) {
       col += 1
       continue
     }
-    const sourceCell = table.nodeAt(sourcePos)
-    if (!sourceCell) {
-      col += 1
-      continue
-    }
+    const { node: sourceCell, pos: sourcePos } = resolvedSource
 
     const sourceCellRect = map.findCell(sourcePos)
     if (sourceCellRect.top !== sourceRow) {
@@ -131,39 +160,30 @@ const insertDuplicateColumn = (
       insertAt < map.width &&
       map.map[insertIndex - 1] === map.map[insertIndex]
     ) {
-      const pos = map.map[insertIndex]
-      if (pos === undefined) {
-        row += 1
-        continue
-      }
-      const cell = table.nodeAt(pos)
-      if (!cell) {
+      const resolved = resolveCell(table, map, insertIndex)
+      if (!resolved) {
         row += 1
         continue
       }
       tr.setNodeMarkup(
-        tableStart + pos,
+        tableStart + resolved.pos,
         null,
         addColSpan(
-          cell.attrs as Parameters<typeof addColSpan>[0],
-          insertAt - map.colCount(pos),
+          resolved.node.attrs as Parameters<typeof addColSpan>[0],
+          insertAt - map.colCount(resolved.pos),
         ),
       )
-      row += cell.attrs.rowspan as number
+      row += resolved.node.attrs.rowspan as number
       continue
     }
 
     const sourceIndex = row * map.width + sourceCol
-    const sourcePos = map.map[sourceIndex]
-    if (sourcePos === undefined) {
+    const resolvedSource = resolveCell(table, map, sourceIndex)
+    if (!resolvedSource) {
       row += 1
       continue
     }
-    const sourceCell = table.nodeAt(sourcePos)
-    if (!sourceCell) {
-      row += 1
-      continue
-    }
+    const { node: sourceCell, pos: sourcePos } = resolvedSource
 
     const sourceCellRect = map.findCell(sourcePos)
     const insertPos = map.positionAt(row, insertAt, table)
@@ -200,7 +220,7 @@ const insertDuplicateColumn = (
 
 // Duplicate the selected row block immediately below it, preserving order.
 export const duplicateSelectedRows = (editor: Editor): void => {
-  const { state, view } = editor
+  const { state } = editor
   if (!isInTable(state)) return
 
   const rect = selectedRect(state)
@@ -218,33 +238,19 @@ export const duplicateSelectedRows = (editor: Editor): void => {
     tr = insertDuplicateRow(tr, info, sourceRow, rect.bottom)
   }
 
-  const info = tableInfoAt(tr, tablePos)
-  if (!info) {
-    view.dispatch(tr)
-    return
-  }
-
-  const newTop = rect.bottom
-  const newBottom = rect.bottom + span
-  const anchor = info.map.positionAt(newTop, 0, info.table)
-  const head = info.map.positionAt(
-    newBottom - 1,
-    info.map.width - 1,
-    info.table,
-  )
-  tr.setSelection(
-    CellSelection.create(
-      tr.doc,
-      info.tableStart + anchor,
-      info.tableStart + head,
+  selectBlockAndDispatch(editor, tr, tablePos, (info) => ({
+    anchor: info.map.positionAt(rect.bottom, 0, info.table),
+    head: info.map.positionAt(
+      rect.bottom + span - 1,
+      info.map.width - 1,
+      info.table,
     ),
-  )
-  view.dispatch(tr)
+  }))
 }
 
 // Duplicate the selected column block immediately to its right, preserving order.
 export const duplicateSelectedColumns = (editor: Editor): void => {
-  const { state, view } = editor
+  const { state } = editor
   if (!isInTable(state)) return
 
   const rect = selectedRect(state)
@@ -262,23 +268,9 @@ export const duplicateSelectedColumns = (editor: Editor): void => {
     }
   }
 
-  const info = tableInfoAt(tr, tablePos)
-  if (!info) {
-    view.dispatch(tr)
-    return
-  }
-
-  const newLeft = rect.right
-  const newRight = rect.right + span
   // Bottom-left → top-right matches TipTap's full-column selection orientation.
-  const anchor = info.map.positionAt(info.map.height - 1, newLeft, info.table)
-  const head = info.map.positionAt(0, newRight - 1, info.table)
-  tr.setSelection(
-    CellSelection.create(
-      tr.doc,
-      info.tableStart + anchor,
-      info.tableStart + head,
-    ),
-  )
-  view.dispatch(tr)
+  selectBlockAndDispatch(editor, tr, tablePos, (info) => ({
+    anchor: info.map.positionAt(info.map.height - 1, rect.right, info.table),
+    head: info.map.positionAt(0, rect.right + span - 1, info.table),
+  }))
 }

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
@@ -1,0 +1,284 @@
+import type { Node } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
+import type { Editor } from "@tiptap/react"
+import {
+  addColSpan,
+  CellSelection,
+  isInTable,
+  selectedRect,
+  TableMap,
+  tableNodeTypes,
+} from "@tiptap/pm/tables"
+
+interface TableInfo {
+  map: TableMap
+  tableStart: number
+  table: Node
+}
+
+const tableInfoAt = (tr: Transaction, tablePos: number): TableInfo | null => {
+  const table = tr.doc.nodeAt(tablePos)
+  if (!table) return null
+  return {
+    table,
+    tableStart: tablePos + 1,
+    map: TableMap.get(table),
+  }
+}
+
+// Insert a copy of `sourceRow` at row index `insertAt`. Cells that span into
+// the insert slot from above expand their rowspan (same as addRow); every other
+// column gets a rowspan-1 clone of the source cell's type and content.
+const insertDuplicateRow = (
+  tr: Transaction,
+  { map, tableStart, table }: TableInfo,
+  sourceRow: number,
+  insertAt: number,
+): Transaction => {
+  let rowPos = tableStart
+  for (let i = 0; i < insertAt; i++) {
+    rowPos += table.child(i).nodeSize
+  }
+
+  const cells: Node[] = []
+  for (let col = 0; col < map.width;) {
+    const insertIndex = insertAt * map.width + col
+
+    // A cell above already covers this slot — grow its rowspan instead of
+    // inserting a parallel cell (mirrors prosemirror-tables' addRow).
+    if (
+      insertAt > 0 &&
+      insertAt < map.height &&
+      map.map[insertIndex] === map.map[insertIndex - map.width]
+    ) {
+      const pos = map.map[insertIndex]
+      if (pos === undefined) {
+        col += 1
+        continue
+      }
+      const node = table.nodeAt(pos)
+      if (!node) {
+        col += 1
+        continue
+      }
+      tr.setNodeMarkup(tableStart + pos, null, {
+        ...node.attrs,
+        rowspan: (node.attrs.rowspan as number) + 1,
+      })
+      col += node.attrs.colspan as number
+      continue
+    }
+
+    const sourceIndex = sourceRow * map.width + col
+    const sourcePos = map.map[sourceIndex]
+    if (sourcePos === undefined) {
+      col += 1
+      continue
+    }
+    const sourceCell = table.nodeAt(sourcePos)
+    if (!sourceCell) {
+      col += 1
+      continue
+    }
+
+    const sourceCellRect = map.findCell(sourcePos)
+    if (sourceCellRect.top !== sourceRow) {
+      // Covered by a rowspan that started above — placeholder empty cell.
+      const placeholder = sourceCell.type.createAndFill({
+        ...sourceCell.attrs,
+        rowspan: 1,
+        colspan: 1,
+        colwidth: null,
+      })
+      if (placeholder) cells.push(placeholder)
+      col += 1
+      continue
+    }
+
+    // Flatten rowspan so the duplicate is a single row; keep colspan/content.
+    cells.push(
+      sourceCell.type.create(
+        { ...sourceCell.attrs, rowspan: 1 },
+        sourceCell.content,
+      ),
+    )
+    col += sourceCell.attrs.colspan as number
+  }
+
+  tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells))
+  return tr
+}
+
+// Clone one column from `sourceCol` into `insertAt`, refreshing the table map
+// after every row mutation so later rows don't resolve stale positions.
+const insertDuplicateColumn = (
+  tr: Transaction,
+  tablePos: number,
+  sourceCol: number,
+  insertAt: number,
+): boolean => {
+  let row = 0
+  for (;;) {
+    const info = tableInfoAt(tr, tablePos)
+    if (!info) return false
+    const { map, tableStart, table } = info
+    if (row >= map.height) return true
+
+    const insertIndex = row * map.width + insertAt
+
+    if (
+      insertAt > 0 &&
+      insertAt < map.width &&
+      map.map[insertIndex - 1] === map.map[insertIndex]
+    ) {
+      const pos = map.map[insertIndex]
+      if (pos === undefined) {
+        row += 1
+        continue
+      }
+      const cell = table.nodeAt(pos)
+      if (!cell) {
+        row += 1
+        continue
+      }
+      tr.setNodeMarkup(
+        tableStart + pos,
+        null,
+        addColSpan(
+          cell.attrs as Parameters<typeof addColSpan>[0],
+          insertAt - map.colCount(pos),
+        ),
+      )
+      row += cell.attrs.rowspan as number
+      continue
+    }
+
+    const sourceIndex = row * map.width + sourceCol
+    const sourcePos = map.map[sourceIndex]
+    if (sourcePos === undefined) {
+      row += 1
+      continue
+    }
+    const sourceCell = table.nodeAt(sourcePos)
+    if (!sourceCell) {
+      row += 1
+      continue
+    }
+
+    const sourceCellRect = map.findCell(sourcePos)
+    const insertPos = map.positionAt(row, insertAt, table)
+    const rowspan = sourceCell.attrs.rowspan as number
+
+    if (sourceCellRect.left !== sourceCol) {
+      const placeholder = sourceCell.type.createAndFill({
+        ...sourceCell.attrs,
+        rowspan: 1,
+        colspan: 1,
+        colwidth: null,
+      })
+      if (placeholder) {
+        tr.insert(tableStart + insertPos, placeholder)
+      }
+      row += 1
+      continue
+    }
+
+    // Flatten colspan for the duplicate column; keep rowspan/content.
+    const colwidth = sourceCell.attrs.colwidth as number[] | null
+    const duplicated = sourceCell.type.create(
+      {
+        ...sourceCell.attrs,
+        colspan: 1,
+        colwidth: colwidth ? [colwidth[0] ?? 0] : null,
+      },
+      sourceCell.content,
+    )
+    tr.insert(tableStart + insertPos, duplicated)
+    row += rowspan
+  }
+}
+
+// Duplicate the selected row block immediately below it, preserving order.
+export const duplicateSelectedRows = (editor: Editor): void => {
+  const { state, view } = editor
+  if (!isInTable(state)) return
+
+  const rect = selectedRect(state)
+  const span = rect.bottom - rect.top
+  if (span <= 0) return
+
+  const tablePos = rect.tableStart - 1
+  let tr = state.tr
+
+  // Insert last→first at the same index so earlier sources land above later
+  // ones and the duplicate block mirrors the original order.
+  for (let sourceRow = rect.bottom - 1; sourceRow >= rect.top; sourceRow--) {
+    const info = tableInfoAt(tr, tablePos)
+    if (!info) return
+    tr = insertDuplicateRow(tr, info, sourceRow, rect.bottom)
+  }
+
+  const info = tableInfoAt(tr, tablePos)
+  if (!info) {
+    view.dispatch(tr)
+    return
+  }
+
+  const newTop = rect.bottom
+  const newBottom = rect.bottom + span
+  const anchor = info.map.positionAt(newTop, 0, info.table)
+  const head = info.map.positionAt(
+    newBottom - 1,
+    info.map.width - 1,
+    info.table,
+  )
+  tr.setSelection(
+    CellSelection.create(
+      tr.doc,
+      info.tableStart + anchor,
+      info.tableStart + head,
+    ),
+  )
+  view.dispatch(tr)
+}
+
+// Duplicate the selected column block immediately to its right, preserving order.
+export const duplicateSelectedColumns = (editor: Editor): void => {
+  const { state, view } = editor
+  if (!isInTable(state)) return
+
+  const rect = selectedRect(state)
+  const span = rect.right - rect.left
+  if (span <= 0) return
+
+  const tablePos = rect.tableStart - 1
+  const tr = state.tr
+
+  // Forward inserts: each copy lands after the original block + prior dups, so
+  // source columns (still left of the insert point) keep stable indices.
+  for (let i = 0; i < span; i++) {
+    if (!insertDuplicateColumn(tr, tablePos, rect.left + i, rect.right + i)) {
+      return
+    }
+  }
+
+  const info = tableInfoAt(tr, tablePos)
+  if (!info) {
+    view.dispatch(tr)
+    return
+  }
+
+  const newLeft = rect.right
+  const newRight = rect.right + span
+  // Bottom-left → top-right matches TipTap's full-column selection orientation.
+  const anchor = info.map.positionAt(info.map.height - 1, newLeft, info.table)
+  const head = info.map.positionAt(0, newRight - 1, info.table)
+  tr.setSelection(
+    CellSelection.create(
+      tr.doc,
+      info.tableStart + anchor,
+      info.tableStart + head,
+    ),
+  )
+  view.dispatch(tr)
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -15,6 +15,7 @@ import { useEditorState } from "@tiptap/react"
 import { BubbleMenu } from "@tiptap/react/menus"
 import { memo, useCallback, useEffect, useState } from "react"
 import {
+  BiCopy,
   BiDownArrowAlt,
   BiLeftArrowAlt,
   BiPencil,
@@ -33,6 +34,10 @@ import {
   IconSplitCell,
 } from "~/components/icons"
 
+import {
+  duplicateSelectedColumns,
+  duplicateSelectedRows,
+} from "./TableBubbleMenu.duplicate"
 import {
   getColumnMovePlan,
   getRowMovePlan,
@@ -302,6 +307,11 @@ const RowSelectionActions = ({
           icon={<IconAddRowBelow boxSize="1rem" />}
           onClick={() => editor.chain().focus().addRowAfter().run()}
         />
+        <ActionButton
+          label="Duplicate row"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedRows(editor)}
+        />
         {canMoveUp && (
           <ActionButton
             label="Move up"
@@ -364,6 +374,11 @@ const ColumnSelectionActions = ({
           label="Add column right"
           icon={<IconAddColRight boxSize="1rem" />}
           onClick={() => editor.chain().focus().addColumnAfter().run()}
+        />
+        <ActionButton
+          label="Duplicate column"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedColumns(editor)}
         />
         {canMoveLeft && (
           <ActionButton


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +291 | -0 |
| 🧪 Test | 1 | +130 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Duplicating a row or column currently requires manually adding a new one and recreating its contents by hand — there's no way to just copy an existing row/column.

Closes https://linear.app/ogp/issue/ISOM-2371/p2-rte-add-duplicate-rowcolumn-to-table-bubble-menu

## Solution

Adds "Duplicate row" and "Duplicate column" actions to `TableBubbleMenu`, stacked on top of #2794. Copies the selected block (including multi-row/column selections) and inserts the copy immediately after the selection.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- New "Duplicate row" action on the row-selection bubble menu, and "Duplicate column" on the column-selection bubble menu (`TableBubbleMenu.duplicate.ts`). Both support multi-row/multi-column selections, duplicating the whole selected block in one action.

**Improvements**:

- None.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

Row/column selection bubble menu only offers add/move/delete — no way to duplicate.

**AFTER**:

<!-- [insert screenshot here] -->

Row/column selection bubble menu now also shows a "Duplicate" action next to add-row/add-column.

https://github.com/user-attachments/assets/ec2f599f-7146-4cf4-bd5e-ca9e1ed1edc0

## Tests

**Manual Verification Steps**:

- [ ] Open a page's rich text block, insert a table, select a single row, and confirm a "Duplicate row" action appears in the bubble menu; click it and confirm a copy of the row is inserted immediately below.
- [ ] Select multiple contiguous rows and confirm duplicating copies the whole selected block in order, inserted right after the selection.
- [ ] Repeat both checks for column selection ("Duplicate column").
- [ ] Repeat inside an Accordion block's rich text editor, since both editors share this change.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
