### PR TITLE
🎀📊 style(rte-table): add outer primary blue border around cell selection

### DIFF
--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -25,7 +25,10 @@ import { Underline } from "@tiptap/extension-underline"
 import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { textblockTypeInputRule } from "@tiptap/react"
 
-import { getHtmlWithRelativeReferenceLinks } from "../../utils"
+import {
+  createTableSelectionBorderPlugin,
+  getHtmlWithRelativeReferenceLinks,
+} from "../../utils"
 
 export { TableRow } from "@tiptap/extension-table-row"
 
@@ -113,6 +116,9 @@ export const IsomerTable = Table.extend({
         default: "Table caption",
       },
     }
+  },
+  addProseMirrorPlugins() {
+    return [...(this.parent?.() ?? []), createTableSelectionBorderPlugin()]
   },
 })
 

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getSelectedCellBorderClasses.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getSelectedCellBorderClasses.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getSelectedCellBorderClasses,
+  SELECTED_CELL_BORDER_CLASSES,
+} from "../getSelectedCellBorderClasses"
+
+describe("getSelectedCellBorderClasses", () => {
+  const selectionRect = { left: 1, top: 1, right: 3, bottom: 3 }
+
+  it("returns all four sides for a single-cell selection", () => {
+    // Arrange
+    const singleCellSelection = { left: 0, top: 0, right: 1, bottom: 1 }
+    const cellRect = { left: 0, top: 0, right: 1, bottom: 1 }
+
+    // Act
+    const classes = getSelectedCellBorderClasses(singleCellSelection, cellRect)
+
+    // Assert
+    expect(classes).toEqual([
+      SELECTED_CELL_BORDER_CLASSES.top,
+      SELECTED_CELL_BORDER_CLASSES.right,
+      SELECTED_CELL_BORDER_CLASSES.bottom,
+      SELECTED_CELL_BORDER_CLASSES.left,
+    ])
+  })
+
+  it("returns only outer edges for a corner cell in a multi-cell selection", () => {
+    // Arrange
+    const topLeftCell = { left: 1, top: 1, right: 2, bottom: 2 }
+
+    // Act
+    const classes = getSelectedCellBorderClasses(selectionRect, topLeftCell)
+
+    // Assert
+    expect(classes).toEqual([
+      SELECTED_CELL_BORDER_CLASSES.top,
+      SELECTED_CELL_BORDER_CLASSES.left,
+    ])
+  })
+
+  it("returns no edges for an interior cell", () => {
+    // Arrange — 3x3 selection with an interior cell at (2,2)
+    const largeSelection = { left: 0, top: 0, right: 3, bottom: 3 }
+    const interiorCell = { left: 1, top: 1, right: 2, bottom: 2 }
+
+    // Act
+    const classes = getSelectedCellBorderClasses(largeSelection, interiorCell)
+
+    // Assert
+    expect(classes).toEqual([])
+  })
+
+  it("returns the full left edge for a leftmost cell spanning the selection height", () => {
+    // Arrange — row-selection-like leftmost merged/tall cell
+    const rowSelection = { left: 0, top: 1, right: 3, bottom: 2 }
+    const leftmostCell = { left: 0, top: 1, right: 1, bottom: 2 }
+
+    // Act
+    const classes = getSelectedCellBorderClasses(rowSelection, leftmostCell)
+
+    // Assert
+    expect(classes).toEqual([
+      SELECTED_CELL_BORDER_CLASSES.top,
+      SELECTED_CELL_BORDER_CLASSES.bottom,
+      SELECTED_CELL_BORDER_CLASSES.left,
+    ])
+  })
+
+  it("returns top/bottom/right for the rightmost cell in a row selection", () => {
+    // Arrange
+    const rowSelection = { left: 0, top: 1, right: 3, bottom: 2 }
+    const rightmostCell = { left: 2, top: 1, right: 3, bottom: 2 }
+
+    // Act
+    const classes = getSelectedCellBorderClasses(rowSelection, rightmostCell)
+
+    // Assert
+    expect(classes).toEqual([
+      SELECTED_CELL_BORDER_CLASSES.top,
+      SELECTED_CELL_BORDER_CLASSES.right,
+      SELECTED_CELL_BORDER_CLASSES.bottom,
+    ])
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/createTableSelectionBorderPlugin.ts
+++ b/apps/studio/src/features/editing-experience/utils/createTableSelectionBorderPlugin.ts
@@ -1,0 +1,44 @@
+import type { EditorState } from "@tiptap/pm/state"
+import { Plugin, PluginKey } from "@tiptap/pm/state"
+import { CellSelection, selectedRect } from "@tiptap/pm/tables"
+import { Decoration, DecorationSet } from "@tiptap/pm/view"
+
+import { getSelectedCellBorderClasses } from "./getSelectedCellBorderClasses"
+
+export const tableSelectionBorderPluginKey = new PluginKey(
+  "tableSelectionBorder",
+)
+
+/**
+ * Draws a single outer primary border around a CellSelection by tagging only
+ * the selection's perimeter cells with side-specific classes (merged with the
+ * built-in `selectedCell` fill decoration).
+ */
+export const createTableSelectionBorderPlugin = () =>
+  new Plugin({
+    key: tableSelectionBorderPluginKey,
+    props: {
+      decorations(state: EditorState) {
+        if (!(state.selection instanceof CellSelection)) {
+          return DecorationSet.empty
+        }
+
+        const rect = selectedRect(state)
+        const decorations: Decoration[] = []
+
+        state.selection.forEachCell((node, pos) => {
+          const cellRect = rect.map.findCell(pos - rect.tableStart)
+          const classes = getSelectedCellBorderClasses(rect, cellRect)
+          if (classes.length === 0) return
+
+          decorations.push(
+            Decoration.node(pos, pos + node.nodeSize, {
+              class: classes.join(" "),
+            }),
+          )
+        })
+
+        return DecorationSet.create(state.doc, decorations)
+      },
+    },
+  })

--- a/apps/studio/src/features/editing-experience/utils/getSelectedCellBorderClasses.ts
+++ b/apps/studio/src/features/editing-experience/utils/getSelectedCellBorderClasses.ts
@@ -1,0 +1,39 @@
+export type SelectionBorderRect = {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+export const SELECTED_CELL_BORDER_CLASSES = {
+  top: "selectedCell-border-top",
+  right: "selectedCell-border-right",
+  bottom: "selectedCell-border-bottom",
+  left: "selectedCell-border-left",
+} as const
+
+/**
+ * Returns CSS classes for the outer edges of a cell within a rectangular
+ * CellSelection. Internal seams between adjacent selected cells are omitted.
+ */
+export const getSelectedCellBorderClasses = (
+  selectionRect: SelectionBorderRect,
+  cellRect: SelectionBorderRect,
+): string[] => {
+  const classes: string[] = []
+
+  if (cellRect.top === selectionRect.top) {
+    classes.push(SELECTED_CELL_BORDER_CLASSES.top)
+  }
+  if (cellRect.right === selectionRect.right) {
+    classes.push(SELECTED_CELL_BORDER_CLASSES.right)
+  }
+  if (cellRect.bottom === selectionRect.bottom) {
+    classes.push(SELECTED_CELL_BORDER_CLASSES.bottom)
+  }
+  if (cellRect.left === selectionRect.left) {
+    classes.push(SELECTED_CELL_BORDER_CLASSES.left)
+  }
+
+  return classes
+}

--- a/apps/studio/src/features/editing-experience/utils/getSelectedCellBorderClasses.ts
+++ b/apps/studio/src/features/editing-experience/utils/getSelectedCellBorderClasses.ts
@@ -1,4 +1,4 @@
-export type SelectionBorderRect = {
+export interface SelectionBorderRect {
   left: number
   top: number
   right: number

--- a/apps/studio/src/features/editing-experience/utils/index.ts
+++ b/apps/studio/src/features/editing-experience/utils/index.ts
@@ -1,2 +1,4 @@
+export * from "./createTableSelectionBorderPlugin"
 export * from "./getDgsIdFromString"
 export * from "./getHtmlWithRelativeReferenceLinks"
+export * from "./getSelectedCellBorderClasses"

--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -118,6 +118,7 @@ $max-depth: 13;
 
     .selectedCell:after {
       background: rgba(200, 200, 255, 0.2);
+      box-shadow: inset 0 0 0 2px var(--chakra-colors-interaction-main-default);
       content: "";
       left: 0;
       right: 0;

--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -118,7 +118,7 @@ $max-depth: 13;
 
     .selectedCell:after {
       background: rgba(200, 200, 255, 0.2);
-      box-shadow: inset 0 0 0 2px var(--chakra-colors-interaction-main-default);
+      box-shadow: inset 0 0 0 2px #2164da;
       content: "";
       left: 0;
       right: 0;

--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -118,7 +118,9 @@ $max-depth: 13;
 
     .selectedCell:after {
       background: rgba(200, 200, 255, 0.2);
-      box-shadow: inset 0 0 0 2px #2164da;
+      border-color: #2164da;
+      border-style: solid;
+      border-width: 0;
       content: "";
       left: 0;
       right: 0;
@@ -127,6 +129,24 @@ $max-depth: 13;
       pointer-events: none;
       position: absolute;
       z-index: 2;
+    }
+
+    // Side classes come from createTableSelectionBorderPlugin so only the
+    // outer perimeter of a CellSelection is stroked — not internal seams.
+    .selectedCell.selectedCell-border-top:after {
+      border-top-width: 2px;
+    }
+
+    .selectedCell.selectedCell-border-right:after {
+      border-right-width: 2px;
+    }
+
+    .selectedCell.selectedCell-border-bottom:after {
+      border-bottom-width: 2px;
+    }
+
+    .selectedCell.selectedCell-border-left:after {
+      border-left-width: 2px;
     }
 
     td,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Selecting a cell, row, or column in a TipTap table in Studio only showed a light blueish-purple fill. There was no border outlining the active selection, so it was hard to see what was selected.

Closes N/A

## Solution

Keep the existing light `.selectedCell` fill, and draw a 2px primary blue (`#2164da`) stroke around the **outer perimeter** of the `CellSelection` only — not between adjacent selected cells.

Implementation:

1. `getSelectedCellBorderClasses` — pure helper that compares each cell rect to the selection rect and returns only outer-edge side classes (`selectedCell-border-top|right|bottom|left`)
2. `createTableSelectionBorderPlugin` — TipTap ProseMirror decoration plugin (wired on `IsomerTable`) that applies those classes
3. `tiptap.scss` — keeps the fill overlay; enables 2px borders only for the side classes above

Color is hardcoded `#2164da` (same value as `interaction.main.default`), matching the existing convention in `tiptap.scss`.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Table cell / row / column selection now shows a thicker primary blue outline around the whole selection rectangle
- Internal edges between adjacent selected cells are not bordered

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

Selected cells only had a light blueish-purple fill (`rgba(200, 200, 255, 0.2)`), with no selection border.

<img width="608" height="289" alt="Screenshot 2026-07-16 at 5 05 21 AM" src="https://github.com/user-attachments/assets/53c18069-d8f0-409f-a574-3c7d91d0d82d" />

**AFTER**:

Selected cells keep that fill and gain a single 2px `#2164da` outline around the outer edge of the selection (no seams between selected cells).

<img width="613" height="269" alt="Screenshot 2026-07-16 at 5 25 10 AM" src="https://github.com/user-attachments/assets/dd35e496-a1dd-4d26-8028-a845dcf44cf9" />

## Tests

- Unit: `apps/studio/src/features/editing-experience/utils/__tests__/getSelectedCellBorderClasses.test.ts` — covers single-cell, corner, interior, and row-edge cases

**Manual Verification Steps**:

- [ ] Open Studio and edit a page that has a text block with a table
- [ ] Select a single cell — confirm light fill + full 2px primary blue outline on all four sides
- [ ] Drag-select a block of multiple cells — confirm blue border only on the outer perimeter (no borders between selected cells)
- [ ] Select an entire row — confirm continuous blue outline around the row
- [ ] Select an entire column — confirm continuous blue outline around the column
- [ ] Clear the selection — confirm fill and border disappear

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4d11db2-1bd7-44fa-b75c-4a70faf6a8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4d11db2-1bd7-44fa-b75c-4a70faf6a8ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a visible outer border for selected TipTap table cells. The main changes are:

- Adds a helper that computes border-side classes for the outer edges of a cell selection.
- Adds a ProseMirror decoration plugin that applies those classes to selected table cells.
- Wires the plugin into the custom `IsomerTable` extension.
- Updates `tiptap.scss` to render the selected-cell fill with 2px primary-blue perimeter borders.
- Adds unit tests for single-cell, corner, interior, and row-edge selection cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low functional risk.

The change is contained to editor UI decoration and styling. Focused unit tests cover the pure border-class helper. No correctness or security issues were found in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Cleared the initial TipTap table state to baseline with no selected cells, no fill, and no blue outline, as shown in the before-state poster frame and video.
- Validated the after-state visuals show a single selected cell with a full outline and a 2x2 block with a perimeter-only outline, using the repository-backed output and compiled TipTap SCSS.
- Confirmed the run log completed with exit code 0 and reported the computed border widths and classes that indicate no internal blue seams in the 2x2 selection.

<a href="https://app.greptile.com/trex/runs/14610979/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts | Wires the table selection border decoration plugin into the custom TipTap table extension without changing table schema behavior. |
| apps/studio/src/features/editing-experience/utils/createTableSelectionBorderPlugin.ts | Adds a ProseMirror decoration plugin that tags selected table perimeter cells with side-specific classes. |
| apps/studio/src/features/editing-experience/utils/getSelectedCellBorderClasses.ts | Adds a pure helper that maps selected cell rectangles to outer-edge border classes. |
| apps/studio/src/features/editing-experience/utils/__tests__/getSelectedCellBorderClasses.test.ts | Adds unit coverage for single-cell, perimeter, interior, and row-edge border class calculations. |
| apps/studio/src/styles/tiptap.scss | Extends existing TipTap selected-cell styling with side-specific 2px primary-blue borders. |
| apps/studio/src/features/editing-experience/utils/index.ts | Exports the new table selection plugin and border class helper from the feature utility barrel. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant User
  participant Editor as TipTap Editor
  participant Plugin as tableSelectionBorderPlugin
  participant Helper as getSelectedCellBorderClasses
  participant CSS as tiptap.scss

  User->>Editor: Select table cell(s)
  Editor->>Plugin: decorations(state)
  Plugin->>Plugin: selectedRect(state) and forEachCell()
  Plugin->>Helper: Compare cell rect with selection rect
  Helper-->>Plugin: Side-specific border classes
  Plugin-->>Editor: Node decorations for perimeter cells
  Editor->>CSS: Render selectedCell + border classes
  CSS-->>User: Light fill with outer blue perimeter
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant User
  participant Editor as TipTap Editor
  participant Plugin as tableSelectionBorderPlugin
  participant Helper as getSelectedCellBorderClasses
  participant CSS as tiptap.scss

  User->>Editor: Select table cell(s)
  Editor->>Plugin: decorations(state)
  Plugin->>Plugin: selectedRect(state) and forEachCell()
  Plugin->>Helper: Compare cell rect with selection rect
  Helper-->>Plugin: Side-specific border classes
  Plugin-->>Editor: Node decorations for perimeter cells
  Editor->>CSS: Render selectedCell + border classes
  CSS-->>User: Light fill with outer blue perimeter
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(rte-table): use interface for Select..."](https://github.com/opengovsg/isomer/commit/92b0ce6eb04db8ddd8929c78d164558bb361bbb9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44619966)</sub>

<!-- /greptile_comment -->