### PR TITLE
chore: Restrict Datadog RUM to production

### DIFF
--- a/apps/studio/src/pages/_app.tsx
+++ b/apps/studio/src/pages/_app.tsx
@@ -25,31 +25,33 @@ type AppPropsWithAuthAndLayout = AppProps & {
   Component: NextPageWithLayout
 }
 
-datadogRum.init({
-  applicationId: "32c64617-51e3-4a6e-a977-ad113021ffae",
-  clientToken: "pub89baaf356268edcb9ed95847d7c5d679",
-  // `site` refers to the Datadog site parameter of your organization
-  // see https://docs.datadoghq.com/getting_started/site/
-  site: "datadoghq.com",
-  service: "isomer-next",
-  env: env.NEXT_PUBLIC_APP_ENV,
-  version: env.NEXT_PUBLIC_APP_VERSION,
-  sessionSampleRate: 100,
-  sessionReplaySampleRate: 100,
-  trackUserInteractions: true,
-  trackResources: true,
-  trackLongTasks: true,
-  defaultPrivacyLevel: "mask-user-input",
-  // inject tracing information inside headers, to correlate RUM with backend traces
-  allowedTracingUrls: [
-    (url) => {
-      if (!env.NEXT_PUBLIC_APP_URL) {
-        return false
-      }
-      return url.includes(env.NEXT_PUBLIC_APP_URL)
-    },
-  ],
-})
+if (env.NEXT_PUBLIC_APP_ENV === "production") {
+  datadogRum.init({
+    applicationId: "32c64617-51e3-4a6e-a977-ad113021ffae",
+    clientToken: "pub89baaf356268edcb9ed95847d7c5d679",
+    // `site` refers to the Datadog site parameter of your organization
+    // see https://docs.datadoghq.com/getting_started/site/
+    site: "datadoghq.com",
+    service: "isomer-next",
+    env: env.NEXT_PUBLIC_APP_ENV,
+    version: env.NEXT_PUBLIC_APP_VERSION,
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 100,
+    trackUserInteractions: true,
+    trackResources: true,
+    trackLongTasks: true,
+    defaultPrivacyLevel: "mask-user-input",
+    // inject tracing information inside headers, to correlate RUM with backend traces
+    allowedTracingUrls: [
+      (url) => {
+        if (!env.NEXT_PUBLIC_APP_URL) {
+          return false
+        }
+        return url.includes(env.NEXT_PUBLIC_APP_URL)
+      },
+    ],
+  })
+}
 
 // Create a GrowthBook instance
 const gb = new GrowthBook({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Datadog RUM currently initializes in every Studio environment, causing preview and other non-production traffic to be ingested.

## Solution

Initialize Datadog RUM only when `NEXT_PUBLIC_APP_ENV` is `production`.

**Breaking Changes**

- [x] No - this PR is backwards compatible

**Improvements**:

- Prevent non-production Studio environments from sending RUM sessions and session replays.

## Before & After Screenshots

Not applicable; there is no visual change.

## Tests

- `pnpm exec oxfmt --check apps/studio/src/pages/_app.tsx`
- `pnpm --filter isomer-studio exec oxlint --type-aware src/pages/_app.tsx`
- `pnpm --filter isomer-studio typecheck`

**Manual Verification Steps**:

- [ ] Confirm production initializes Datadog RUM.
- [ ] Confirm preview, staging, UAT, VAPT, test, and development do not initialize Datadog RUM.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b13e60da-5f24-43c5-b387-177e05e063a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b13e60da-5f24-43c5-b387-177e05e063a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restricts Datadog RUM initialization in Studio to production only. The main changes are:

- Wraps `datadogRum.init` in a `NEXT_PUBLIC_APP_ENV === "production"` guard.
- Keeps the existing Datadog RUM configuration unchanged for production.
- Skips RUM session and replay collection in preview, staging, UAT, VAPT, test, and development environments.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is narrowly scoped to a single environment guard around existing Datadog RUM initialization, and `production` is an explicit app environment value.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The run finished with exit code 0, and the per-environment rum-gating results show production had 1 datadogRum.init call with env production, while all named non-production environments had 0 calls.
- A generated harness source (rum-gating-harness.cjs) was prepared and used to exercise the changed code path.
- The code formatting check (oxfmt --check) passed with exit code 0, indicating all matched files were correctly formatted.

<a href="https://app.greptile.com/trex/runs/14612906/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/pages/_app.tsx | Wraps Datadog RUM initialization in a production-only `NEXT_PUBLIC_APP_ENV` guard; no correctness issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): restrict Datadog RUM to pro..."](https://github.com/opengovsg/isomer/commit/bb3753601c1419991d2ce0a4b2302059c427c4a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44624112)</sub>

<!-- /greptile_comment -->