### PR TITLE
fix(publishing): pass S3 sync concurrency to redirect uploads via CLI flag

### DIFF
--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -203,11 +203,12 @@ start_time=$(date +%s)
 echo "Uploading redirect files to S3..."
 (
   cd ../../build/scripts/publishing
-  REDIRECTS_JSON="$REDIRECTS_JSON" \
-    S3_BUCKET_NAME="$S3_BUCKET_NAME" \
-    SITE_NAME="$SITE_NAME" \
-    CODEBUILD_BUILD_NUMBER="$CODEBUILD_BUILD_NUMBER" \
-    pnpm exec tsx uploadRedirects.ts --concurrency "$S3_SYNC_CONCURRENCY"
+  pnpm exec tsx uploadRedirects.ts \
+    --redirects-json "$REDIRECTS_JSON" \
+    --s3-bucket-name "$S3_BUCKET_NAME" \
+    --site-name "$SITE_NAME" \
+    --build-number "$CODEBUILD_BUILD_NUMBER" \
+    --concurrency "$S3_SYNC_CONCURRENCY"
 ) || echo "Warning: some redirects failed to upload, continuing..."
 
 calculate_duration $start_time

--- a/tooling/build/scripts/publisher.sh
+++ b/tooling/build/scripts/publisher.sh
@@ -183,6 +183,7 @@ echo "Number of cores: $NUMBER_OF_CORES"
 S3_SYNC_CONCURRENCY=$((4 * NUMBER_OF_CORES))                                   # 4x is an arbitrary number that should work well for most cases
 S3_SYNC_CONCURRENCY=$((S3_SYNC_CONCURRENCY < 20 ? 10 : S3_SYNC_CONCURRENCY))   # Minimum of 20
 S3_SYNC_CONCURRENCY=$((S3_SYNC_CONCURRENCY > 100 ? 100 : S3_SYNC_CONCURRENCY)) # Maximum of 100 (to prevent AWS from throttling us)
+export S3_SYNC_CONCURRENCY
 echo "S3 sync concurrency: $S3_SYNC_CONCURRENCY"
 aws configure set default.s3.max_concurrent_requests $S3_SYNC_CONCURRENCY
 
@@ -206,8 +207,7 @@ echo "Uploading redirect files to S3..."
     S3_BUCKET_NAME="$S3_BUCKET_NAME" \
     SITE_NAME="$SITE_NAME" \
     CODEBUILD_BUILD_NUMBER="$CODEBUILD_BUILD_NUMBER" \
-    S3_SYNC_CONCURRENCY="$S3_SYNC_CONCURRENCY" \
-    npm run upload-redirects
+    pnpm exec tsx uploadRedirects.ts --concurrency "$S3_SYNC_CONCURRENCY"
 ) || echo "Warning: some redirects failed to upload, continuing..."
 
 calculate_duration $start_time

--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest"
 
 import {
-  flagFromArgv,
   normalizeSource,
+  parseUploadCliArgs,
   resolveConcurrency,
   resolveUploadConfig,
 } from "../uploadRedirects"
@@ -22,27 +22,25 @@ const baseArgs = [
   "100",
 ] as const
 
-describe("flagFromArgv", () => {
-  it("reads a named flag from argv", () => {
-    expect(flagFromArgv("--concurrency", [...baseArgs])).toBe("100")
+describe("parseUploadCliArgs", () => {
+  it("parses publisher flags from argv", () => {
+    expect(parseUploadCliArgs([...baseArgs])).toEqual({
+      "redirects-json": "/tmp/redirects.json",
+      "s3-bucket-name": "my-bucket",
+      "site-name": "my-site",
+      "build-number": "42",
+      concurrency: "100",
+    })
   })
 
-  it("returns undefined when the flag is absent", () => {
-    expect(
-      flagFromArgv("--concurrency", ["node", "uploadRedirects.ts"]),
-    ).toBeUndefined()
+  it("returns empty values when flags are absent", () => {
+    expect(parseUploadCliArgs(["node", "uploadRedirects.ts"])).toEqual({})
   })
 })
 
 describe("resolveConcurrency", () => {
   it("uses S3_SYNC_CONCURRENCY when it is a positive integer", () => {
     expect(resolveConcurrency("47")).toBe(47)
-  })
-
-  it("prefers --concurrency when argv supplies it", () => {
-    expect(
-      resolveConcurrency(flagFromArgv("--concurrency", [...baseArgs])),
-    ).toBe(100)
   })
 
   it("falls back to 20 when unset or invalid", () => {

--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -1,10 +1,44 @@
 import { describe, expect, it } from "vitest"
 
-import { normalizeSource, resolveConcurrency } from "../uploadRedirects"
+import {
+  concurrencyFromArgv,
+  normalizeSource,
+  resolveConcurrency,
+} from "../uploadRedirects"
+
+describe("concurrencyFromArgv", () => {
+  it("reads --concurrency from argv", () => {
+    expect(
+      concurrencyFromArgv([
+        "node",
+        "uploadRedirects.ts",
+        "--concurrency",
+        "100",
+      ]),
+    ).toBe("100")
+  })
+
+  it("returns undefined when the flag is absent", () => {
+    expect(concurrencyFromArgv(["node", "uploadRedirects.ts"])).toBeUndefined()
+  })
+})
 
 describe("resolveConcurrency", () => {
   it("uses S3_SYNC_CONCURRENCY when it is a positive integer", () => {
     expect(resolveConcurrency("47")).toBe(47)
+  })
+
+  it("prefers --concurrency over S3_SYNC_CONCURRENCY when argv supplies it", () => {
+    expect(
+      resolveConcurrency(
+        concurrencyFromArgv([
+          "node",
+          "uploadRedirects.ts",
+          "--concurrency",
+          "100",
+        ]),
+      ),
+    ).toBe(100)
   })
 
   it("falls back to 20 when unset or invalid", () => {

--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -1,25 +1,36 @@
 import { describe, expect, it } from "vitest"
 
 import {
-  concurrencyFromArgv,
+  flagFromArgv,
   normalizeSource,
   resolveConcurrency,
+  resolveUploadConfig,
 } from "../uploadRedirects"
 
-describe("concurrencyFromArgv", () => {
-  it("reads --concurrency from argv", () => {
-    expect(
-      concurrencyFromArgv([
-        "node",
-        "uploadRedirects.ts",
-        "--concurrency",
-        "100",
-      ]),
-    ).toBe("100")
+const baseArgs = [
+  "node",
+  "uploadRedirects.ts",
+  "--redirects-json",
+  "/tmp/redirects.json",
+  "--s3-bucket-name",
+  "my-bucket",
+  "--site-name",
+  "my-site",
+  "--build-number",
+  "42",
+  "--concurrency",
+  "100",
+] as const
+
+describe("flagFromArgv", () => {
+  it("reads a named flag from argv", () => {
+    expect(flagFromArgv("--concurrency", [...baseArgs])).toBe("100")
   })
 
   it("returns undefined when the flag is absent", () => {
-    expect(concurrencyFromArgv(["node", "uploadRedirects.ts"])).toBeUndefined()
+    expect(
+      flagFromArgv("--concurrency", ["node", "uploadRedirects.ts"]),
+    ).toBeUndefined()
   })
 })
 
@@ -28,16 +39,9 @@ describe("resolveConcurrency", () => {
     expect(resolveConcurrency("47")).toBe(47)
   })
 
-  it("prefers --concurrency over S3_SYNC_CONCURRENCY when argv supplies it", () => {
+  it("prefers --concurrency when argv supplies it", () => {
     expect(
-      resolveConcurrency(
-        concurrencyFromArgv([
-          "node",
-          "uploadRedirects.ts",
-          "--concurrency",
-          "100",
-        ]),
-      ),
+      resolveConcurrency(flagFromArgv("--concurrency", [...baseArgs])),
     ).toBe(100)
   })
 
@@ -47,6 +51,22 @@ describe("resolveConcurrency", () => {
     expect(resolveConcurrency("0")).toBe(20)
     expect(resolveConcurrency("-1")).toBe(20)
     expect(resolveConcurrency("nope")).toBe(20)
+  })
+})
+
+describe("resolveUploadConfig", () => {
+  it("reads all publisher inputs from argv", () => {
+    expect(resolveUploadConfig([...baseArgs])).toEqual({
+      redirectsJson: "/tmp/redirects.json",
+      s3BucketName: "my-bucket",
+      siteName: "my-site",
+      buildNumber: "42",
+      concurrency: 100,
+    })
+  })
+
+  it("returns null when required inputs are missing", () => {
+    expect(resolveUploadConfig(["node", "uploadRedirects.ts"])).toBeNull()
   })
 })
 

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -1,9 +1,18 @@
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3"
 import * as fs from "fs"
+import { parseArgs } from "node:util"
 import { argv } from "process"
 import { pathToFileURL } from "url"
 
 const DEFAULT_CONCURRENCY = 20
+
+const uploadCliOptions = {
+  "redirects-json": { type: "string" },
+  "s3-bucket-name": { type: "string" },
+  "site-name": { type: "string" },
+  "build-number": { type: "string" },
+  concurrency: { type: "string" },
+} as const
 
 interface Redirect {
   source: string
@@ -18,19 +27,17 @@ export interface UploadConfig {
   concurrency: number
 }
 
-/** Read a `--flag value` pair from argv; used by publisher.sh for explicit inputs. */
-export function flagFromArgv(
-  flag: string,
-  args: readonly string[] = argv,
-): string | undefined {
-  const i = args.indexOf(flag)
-  return i >= 0 ? args[i + 1] : undefined
+export function parseUploadCliArgs(args: readonly string[] = argv) {
+  return parseArgs({
+    args: args.slice(2),
+    options: uploadCliOptions,
+    strict: false,
+  }).values
 }
 
-/** Prefer --concurrency / S3_SYNC_CONCURRENCY from publisher.sh; fall back if unset/invalid. */
+/** Prefer CLI / S3_SYNC_CONCURRENCY from publisher.sh; fall back if unset/invalid. */
 export function resolveConcurrency(
-  raw: string | undefined = flagFromArgv("--concurrency") ??
-    process.env.S3_SYNC_CONCURRENCY,
+  raw: string | undefined = process.env.S3_SYNC_CONCURRENCY,
 ): number {
   const parsed = raw === undefined ? NaN : Number.parseInt(raw, 10)
   if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_CONCURRENCY
@@ -41,13 +48,13 @@ export function resolveConcurrency(
 export function resolveUploadConfig(
   args: readonly string[] = argv,
 ): UploadConfig | null {
-  const redirectsJson =
-    flagFromArgv("--redirects-json", args) ?? process.env.REDIRECTS_JSON
-  const s3BucketName =
-    flagFromArgv("--s3-bucket-name", args) ?? process.env.S3_BUCKET_NAME
-  const siteName = flagFromArgv("--site-name", args) ?? process.env.SITE_NAME
+  const values = parseUploadCliArgs(args)
+
+  const redirectsJson = values["redirects-json"] ?? process.env.REDIRECTS_JSON
+  const s3BucketName = values["s3-bucket-name"] ?? process.env.S3_BUCKET_NAME
+  const siteName = values["site-name"] ?? process.env.SITE_NAME
   const buildNumber =
-    flagFromArgv("--build-number", args) ?? process.env.CODEBUILD_BUILD_NUMBER
+    values["build-number"] ?? process.env.CODEBUILD_BUILD_NUMBER
 
   if (!redirectsJson || !s3BucketName || !siteName || !buildNumber) {
     return null
@@ -59,7 +66,7 @@ export function resolveUploadConfig(
     siteName,
     buildNumber,
     concurrency: resolveConcurrency(
-      flagFromArgv("--concurrency", args) ?? process.env.S3_SYNC_CONCURRENCY,
+      values.concurrency ?? process.env.S3_SYNC_CONCURRENCY,
     ),
   }
 }

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -3,10 +3,6 @@ import * as fs from "fs"
 import { argv } from "process"
 import { pathToFileURL } from "url"
 
-const REDIRECTS_JSON = process.env.REDIRECTS_JSON
-const S3_BUCKET = process.env.S3_BUCKET_NAME
-const SITE_NAME = process.env.SITE_NAME
-const BUILD_NUMBER = process.env.CODEBUILD_BUILD_NUMBER
 const DEFAULT_CONCURRENCY = 20
 
 interface Redirect {
@@ -14,22 +10,58 @@ interface Redirect {
   destination: string
 }
 
-/** CLI flag from publisher.sh; takes precedence over env when set. */
-export function concurrencyFromArgv(
+export interface UploadConfig {
+  redirectsJson: string
+  s3BucketName: string
+  siteName: string
+  buildNumber: string
+  concurrency: number
+}
+
+/** Read a `--flag value` pair from argv; used by publisher.sh for explicit inputs. */
+export function flagFromArgv(
+  flag: string,
   args: readonly string[] = argv,
 ): string | undefined {
-  const i = args.indexOf("--concurrency")
+  const i = args.indexOf(flag)
   return i >= 0 ? args[i + 1] : undefined
 }
 
 /** Prefer --concurrency / S3_SYNC_CONCURRENCY from publisher.sh; fall back if unset/invalid. */
 export function resolveConcurrency(
-  raw: string | undefined = concurrencyFromArgv() ??
+  raw: string | undefined = flagFromArgv("--concurrency") ??
     process.env.S3_SYNC_CONCURRENCY,
 ): number {
   const parsed = raw === undefined ? NaN : Number.parseInt(raw, 10)
   if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_CONCURRENCY
   return parsed
+}
+
+/** CLI flags from publisher.sh take precedence; env vars remain for local runs. */
+export function resolveUploadConfig(
+  args: readonly string[] = argv,
+): UploadConfig | null {
+  const redirectsJson =
+    flagFromArgv("--redirects-json", args) ?? process.env.REDIRECTS_JSON
+  const s3BucketName =
+    flagFromArgv("--s3-bucket-name", args) ?? process.env.S3_BUCKET_NAME
+  const siteName = flagFromArgv("--site-name", args) ?? process.env.SITE_NAME
+  const buildNumber =
+    flagFromArgv("--build-number", args) ?? process.env.CODEBUILD_BUILD_NUMBER
+
+  if (!redirectsJson || !s3BucketName || !siteName || !buildNumber) {
+    return null
+  }
+
+  return {
+    redirectsJson,
+    s3BucketName,
+    siteName,
+    buildNumber,
+    concurrency: resolveConcurrency(
+      flagFromArgv("--concurrency", args) ?? process.env.S3_SYNC_CONCURRENCY,
+    ),
+  }
 }
 
 // Returns the normalised S3 key segment, or null if the source is unsafe/empty.
@@ -62,6 +94,7 @@ export function normalizeSource(source: string): string | null {
 
 async function uploadOne(
   client: S3Client,
+  config: UploadConfig,
   source: string,
   destination: string,
 ): Promise<void> {
@@ -74,8 +107,8 @@ async function uploadOne(
 
   await client.send(
     new PutObjectCommand({
-      Bucket: S3_BUCKET,
-      Key: `${SITE_NAME}/${BUILD_NUMBER}/latest/${key}`,
+      Bucket: config.s3BucketName,
+      Key: `${config.siteName}/${config.buildNumber}/latest/${key}`,
       // Empty Buffer (not "") so the SDK knows Content-Length upfront and
       // does not warn about a stream of unknown length.
       Body: Buffer.alloc(0),
@@ -91,6 +124,7 @@ async function uploadOne(
 // Worker-pool: each worker pulls from the shared queue until it is empty.
 async function runWithConcurrency(
   client: S3Client,
+  config: UploadConfig,
   items: Redirect[],
   limit: number,
 ): Promise<{ failed: number }> {
@@ -101,7 +135,7 @@ async function runWithConcurrency(
       const r = queue.shift()
       if (!r) break
       try {
-        await uploadOne(client, r.source, r.destination)
+        await uploadOne(client, config, r.source, r.destination)
       } catch (err) {
         console.error("Redirect upload failed:", err)
         failed++
@@ -115,14 +149,19 @@ async function runWithConcurrency(
 }
 
 async function main(): Promise<void> {
-  if (!REDIRECTS_JSON || !S3_BUCKET || !SITE_NAME || !BUILD_NUMBER) {
+  const config = resolveUploadConfig()
+  if (!config) {
     throw new Error(
-      "Missing required env vars: REDIRECTS_JSON, S3_BUCKET_NAME, SITE_NAME, CODEBUILD_BUILD_NUMBER",
+      "Missing required inputs: --redirects-json, --s3-bucket-name, --site-name, --build-number (or the matching env vars)",
     )
   }
 
-  const raw: Redirect[] = JSON.parse(fs.readFileSync(REDIRECTS_JSON, "utf-8"))
-  console.log(`Loaded ${raw.length} redirect row(s) from ${REDIRECTS_JSON}`)
+  const raw: Redirect[] = JSON.parse(
+    fs.readFileSync(config.redirectsJson, "utf-8"),
+  )
+  console.log(
+    `Loaded ${raw.length} redirect row(s) from ${config.redirectsJson}`,
+  )
 
   const seen = new Set<string>()
   const valid: Redirect[] = []
@@ -155,12 +194,16 @@ async function main(): Promise<void> {
   // Region/credentials come from the environment (CodeBuild IAM role +
   // AWS_REGION), same as `aws s3 cp` previously.
   const client = new S3Client({})
-  const concurrency = resolveConcurrency()
 
   console.log(
-    `Uploading ${valid.length} redirect(s) with concurrency ${concurrency}...`,
+    `Uploading ${valid.length} redirect(s) with concurrency ${config.concurrency}...`,
   )
-  const { failed } = await runWithConcurrency(client, valid, concurrency)
+  const { failed } = await runWithConcurrency(
+    client,
+    config,
+    valid,
+    config.concurrency,
+  )
   console.log(`Uploaded ${valid.length - failed}/${valid.length} redirects.`)
   if (failed > 0) process.exit(1)
 }

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -14,9 +14,18 @@ interface Redirect {
   destination: string
 }
 
-/** Prefer S3_SYNC_CONCURRENCY from publisher.sh; fall back if unset/invalid. */
+/** CLI flag from publisher.sh; takes precedence over env when set. */
+export function concurrencyFromArgv(
+  args: readonly string[] = argv,
+): string | undefined {
+  const i = args.indexOf("--concurrency")
+  return i >= 0 ? args[i + 1] : undefined
+}
+
+/** Prefer --concurrency / S3_SYNC_CONCURRENCY from publisher.sh; fall back if unset/invalid. */
 export function resolveConcurrency(
-  raw: string | undefined = process.env.S3_SYNC_CONCURRENCY,
+  raw: string | undefined = concurrencyFromArgv() ??
+    process.env.S3_SYNC_CONCURRENCY,
 ): number {
   const parsed = raw === undefined ? NaN : Number.parseInt(raw, 10)
   if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_CONCURRENCY


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`publisher.sh` computes `S3_SYNC_CONCURRENCY` (up to 100) for `aws s3 sync`, but `uploadRedirects.ts` was logging and using the default of 20 during redirect uploads.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Export `S3_SYNC_CONCURRENCY` from `publisher.sh` after it is computed.
- Invoke redirect uploads via `pnpm exec tsx uploadRedirects.ts` with explicit CLI flags instead of relying on `npm run` / env var forwarding.

**Improvements**:

- All publisher inputs are passed consistently as CLI flags:
  - `--redirects-json`
  - `--s3-bucket-name`
  - `--site-name`
  - `--build-number`
  - `--concurrency`
- CLI parsing uses Node's built-in `util.parseArgs` with a single options schema.
- Env vars remain as fallbacks for local runs (`pnpm run upload-redirects`).

## Tests

- Unit tests for `parseUploadCliArgs`, `resolveUploadConfig`, and concurrency resolution in `tests/uploadRedirects.test.ts`.
- Verified locally: full CLI invocation logs `concurrency 100`.

**Manual Verification Steps**:

- [ ] Run a publish build on a machine with enough cores for `S3_SYNC_CONCURRENCY` > 20 and confirm the redirect upload log matches the earlier `S3 sync concurrency:` line.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7372e68-5227-47d3-93e8-95b180fb6324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7372e68-5227-47d3-93e8-95b180fb6324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR forwards the publisher-computed S3 concurrency into redirect uploads. The main changes are:

- Exports `S3_SYNC_CONCURRENCY` after it is computed in `publisher.sh`.
- Invokes `uploadRedirects.ts` with explicit CLI flags for all publisher inputs.
- Adds `parseArgs`-based CLI parsing with environment-variable fallbacks for local runs.
- Adds unit tests for CLI parsing, upload config resolution, and concurrency handling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are narrowly scoped to forwarding existing publisher values into the redirect upload script. Environment-variable fallbacks are preserved for local usage. Targeted tests cover the new parsing and config behavior. No functional or security issues were identified in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the uploadRedirects CLI with concurrency 100, uploaded 1 redirect, and observed an exit code 1 after the concurrency log due to the AWS endpoint being pointed at a refused local endpoint.
- Executed the uploadRedirects Vitest suite, which reported 1 test file and 13 tests passing, validating parse and resolve concurrency behavior.
- Reviewed the publisher.sh concurrency handling by examining lines 179–211, confirming the computed S3\_SYNC\_CONCURRENCY value and that it is passed to uploadRedirects.ts as --concurrency.

<a href="https://app.greptile.com/trex/runs/14662880/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publisher.sh | Exports computed `S3_SYNC_CONCURRENCY` and invokes redirect uploads with explicit CLI flags so the computed concurrency is forwarded. |
| tooling/build/scripts/publishing/uploadRedirects.ts | Adds `parseArgs`-based CLI parsing, centralized upload config resolution, and threads config/concurrency through redirect uploads without identified issues. |
| tooling/build/scripts/publishing/tests/uploadRedirects.test.ts | Adds unit coverage for CLI argument parsing and upload config resolution, including required-input handling. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Publisher as publisher.sh
participant Upload as uploadRedirects.ts
participant S3 as AWS S3

Publisher->>Publisher: Compute S3_SYNC_CONCURRENCY
Publisher->>Upload: pnpm exec tsx uploadRedirects.ts --redirects-json --s3-bucket-name --site-name --build-number --concurrency
Upload->>Upload: parseUploadCliArgs()
Upload->>Upload: resolveUploadConfig() with env fallbacks
Upload->>Upload: Read and normalize redirects JSON
Upload->>S3: PutObject redirect files with config.concurrency worker pool
Upload-->>Publisher: exit 0 or non-zero on failed uploads
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Publisher as publisher.sh
participant Upload as uploadRedirects.ts
participant S3 as AWS S3

Publisher->>Publisher: Compute S3_SYNC_CONCURRENCY
Publisher->>Upload: pnpm exec tsx uploadRedirects.ts --redirects-json --s3-bucket-name --site-name --build-number --concurrency
Upload->>Upload: parseUploadCliArgs()
Upload->>Upload: resolveUploadConfig() with env fallbacks
Upload->>Upload: Read and normalize redirects JSON
Upload->>S3: PutObject redirect files with config.concurrency worker pool
Upload-->>Publisher: exit 0 or non-zero on failed uploads
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(publishing): parse redirect upl..."](https://github.com/opengovsg/isomer/commit/1e1355816f0e16c696d0cdd6695fef979eeb939a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44724866)</sub>

<!-- /greptile_comment -->