### PR TITLE
Allow Admin role for whitelisted non-gov.sg email domains

### DIFF
--- a/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx
@@ -32,7 +32,7 @@ import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { addUserModalAtom, DEFAULT_ADD_USER_MODAL_STATE } from "../../atoms"
 import { SingpassConditionalTooltip } from "../SingpassConditionalTooltip"
-import { AddAdminWarning, NonGovEmailCannotBeAdmin } from "./Banners"
+import { AddAdminWarning, EmailNotWhitelistedForAdmin } from "./Banners"
 import { ISOMER_GUIDE_URL, ROLE_CONFIGS } from "./constants"
 import { RoleBox } from "./RoleBox"
 
@@ -112,6 +112,18 @@ export const AddUserModal = () => {
     },
   )
 
+  const { data: isWhitelistedAdmin, refetch: checkWhitelistAdmin } =
+    trpc.whitelist.isEmailWhitelistedAdmin.useQuery(
+      { siteId, email: (debouncedEmail || "").trim() },
+      {
+        enabled: false,
+      },
+    )
+
+  // Non-gov.sg emails can still be assigned the Admin role if their domain
+  // has been granted a permanent (non-expiring) whitelist entry.
+  const isAdminRoleDisabled = isNonGovEmailInput && !isWhitelistedAdmin
+
   useEffect(() => {
     // Run after the whitelist check is successful
     if (!isSuccess) {
@@ -142,11 +154,13 @@ export const AddUserModal = () => {
     if (!debouncedEmail || errors.email) return
 
     void checkWhitelist()
+    void checkWhitelistAdmin()
   }, [
     debouncedEmail,
     isNonGovEmailInput,
     errors.email,
     checkWhitelist,
+    checkWhitelistAdmin,
     setAddUserModalState,
   ])
 
@@ -209,7 +223,7 @@ export const AddUserModal = () => {
               <FormControl
                 isRequired
                 isInvalid={
-                  watch("role") === RoleType.Admin && isNonGovEmailInput
+                  watch("role") === RoleType.Admin && isAdminRoleDisabled
                 }
               >
                 <FormLabel
@@ -235,16 +249,18 @@ export const AddUserModal = () => {
                       isSelected={watch("role") === role}
                       onClick={() => setValue("role", role)}
                       permissionLabels={permissionLabels}
-                      isDisabled={role === RoleType.Admin && isNonGovEmailInput}
+                      isDisabled={
+                        role === RoleType.Admin && isAdminRoleDisabled
+                      }
                     />
                   ))}
                 </HStack>
               </FormControl>
-              {watch("role") === RoleType.Admin && !isNonGovEmailInput && (
+              {watch("role") === RoleType.Admin && !isAdminRoleDisabled && (
                 <AddAdminWarning />
               )}
-              {watch("role") === RoleType.Admin && isNonGovEmailInput && (
-                <NonGovEmailCannotBeAdmin />
+              {watch("role") === RoleType.Admin && isAdminRoleDisabled && (
+                <EmailNotWhitelistedForAdmin />
               )}
             </VStack>
           </VStack>
@@ -267,7 +283,7 @@ export const AddUserModal = () => {
                 email === "" ||
                 additionalEmailError ||
                 email !== debouncedEmail || // check if email has changed
-                (watch("role") === RoleType.Admin && isNonGovEmailInput) ||
+                (watch("role") === RoleType.Admin && isAdminRoleDisabled) ||
                 !isSingpassEnabled
               }
             >

--- a/apps/studio/src/features/users/components/UserPermissionModal/Banners/EmailNotWhitelistedForAdmin.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/Banners/EmailNotWhitelistedForAdmin.tsx
@@ -1,6 +1,6 @@
 import { Infobox } from "@opengovsg/design-system-react"
 
-export const NonGovEmailCannotBeAdmin = () => (
+export const EmailNotWhitelistedForAdmin = () => (
   <Infobox
     textStyle="body-2"
     size="sm"
@@ -10,6 +10,7 @@ export const NonGovEmailCannotBeAdmin = () => (
     w="100%"
     border="none"
   >
-    Non-gov.sg emails cannot be added as admin. Select another role.
+    Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added
+    as admin. Select another role.
   </Infobox>
 )

--- a/apps/studio/src/features/users/components/UserPermissionModal/Banners/index.ts
+++ b/apps/studio/src/features/users/components/UserPermissionModal/Banners/index.ts
@@ -1,2 +1,2 @@
 export * from "./AddAdminWarning"
-export * from "./NonGovEmailCannotBeAdmin"
+export * from "./EmailNotWhitelistedForAdmin"

--- a/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
+++ b/apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx
@@ -30,7 +30,7 @@ import {
   updateUserModalAtom,
 } from "../../atoms"
 import { SingpassConditionalTooltip } from "../SingpassConditionalTooltip"
-import { AddAdminWarning, NonGovEmailCannotBeAdmin } from "./Banners"
+import { AddAdminWarning, EmailNotWhitelistedForAdmin } from "./Banners"
 import { ISOMER_GUIDE_URL, ROLE_CONFIGS } from "./constants"
 import { RoleBox } from "./RoleBox"
 
@@ -95,6 +95,16 @@ export const EditUserModal = () => {
 
   const isNonGovEmailInput = useMemo(() => !isGovEmail(email), [email])
 
+  const { data: isWhitelistedAdmin } =
+    trpc.whitelist.isEmailWhitelistedAdmin.useQuery(
+      { siteId, email },
+      { enabled: !!siteId && isNonGovEmailInput },
+    )
+
+  // Non-gov.sg emails can still be assigned the Admin role if their domain
+  // has been granted a permanent (non-expiring) whitelist entry.
+  const isAdminRoleDisabled = isNonGovEmailInput && !isWhitelistedAdmin
+
   return (
     <Modal isOpen={!!siteId && !!userId} onClose={onClose}>
       <ModalOverlay />
@@ -133,16 +143,18 @@ export const EditUserModal = () => {
                       isSelected={selectedRole === role}
                       onClick={() => setValue("role", role)}
                       permissionLabels={permissionLabels}
-                      isDisabled={role === RoleType.Admin && isNonGovEmailInput}
+                      isDisabled={
+                        role === RoleType.Admin && isAdminRoleDisabled
+                      }
                     />
                   ))}
                 </HStack>
               </FormControl>
-              {selectedRole === RoleType.Admin && !isNonGovEmailInput && (
+              {selectedRole === RoleType.Admin && !isAdminRoleDisabled && (
                 <AddAdminWarning />
               )}
-              {selectedRole === RoleType.Admin && isNonGovEmailInput && (
-                <NonGovEmailCannotBeAdmin />
+              {selectedRole === RoleType.Admin && isAdminRoleDisabled && (
+                <EmailNotWhitelistedForAdmin />
               )}
             </VStack>
           </VStack>

--- a/apps/studio/src/schemas/whitelist.ts
+++ b/apps/studio/src/schemas/whitelist.ts
@@ -7,6 +7,10 @@ export const isEmailWhitelistedInputSchema = z.object({
 
 export const isEmailWhitelistedOutputSchema = z.boolean()
 
+export const isEmailWhitelistedAdminInputSchema = isEmailWhitelistedInputSchema
+
+export const isEmailWhitelistedAdminOutputSchema = z.boolean()
+
 // Helper schema to normalize and deduplicate email array
 // Trims, lowercases, filters empty strings, and removes duplicates
 const emailArraySchema = z

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -259,11 +259,10 @@ describe("user.router", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
-    it("should throw 403 if assigning a whitelisted non-gov.sg email with admin role", async () => {
+    it("should throw 403 if assigning a non-whitelisted non-gov.sg email with admin role", async () => {
       // Arrange
       const nonGovSgEmail = "test@coolvendor.com"
       await setupAdminPermissions({ userId: session.userId, siteId })
-      await setUpWhitelist({ email: nonGovSgEmail })
 
       // Act
       const result = caller.create({
@@ -283,6 +282,22 @@ describe("user.router", () => {
       // Assert DB - audit logs
       const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLogs).toHaveLength(0)
+    })
+
+    it("should create a whitelisted non-gov.sg email with admin role", async () => {
+      // Arrange
+      const nonGovSgEmail = "test@coolvendor.com"
+      await setupAdminPermissions({ userId: session.userId, siteId })
+      await setUpWhitelist({ email: nonGovSgEmail })
+
+      // Act
+      const result = await caller.create({
+        siteId,
+        users: [{ email: nonGovSgEmail, role: RoleType.Admin }],
+      })
+
+      // Assert
+      expect(result).toEqual(expect.anything())
     })
 
     it("should create a whitelisted non-gov.sg email with non-admin role", async () => {
@@ -1542,12 +1557,12 @@ describe("user.router", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
-    it("should throw 403 if assigning a non-gov.sg email with admin role", async () => {
+    it("should throw 403 if assigning a non-whitelisted non-gov.sg email with admin role", async () => {
       // Arrange
       await setupAdminPermissions({ userId: session.userId, siteId })
 
       const userToUpdate = await setupUser({
-        email: "test@coolvendor.com",
+        email: "test-not-whitelisted@coolvendor.com",
         isDeleted: false,
       })
       await setupEditorPermissions({ userId: userToUpdate.id, siteId })
@@ -1571,6 +1586,34 @@ describe("user.router", () => {
       // Assert DB - audit logs
       const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLogs).toHaveLength(0)
+    })
+
+    it("should update a whitelisted non-gov.sg email to admin role successfully", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const userToUpdate = await setupUser({
+        email: "test@coolvendor.com",
+        isDeleted: false,
+      })
+      await setupEditorPermissions({ userId: userToUpdate.id, siteId })
+      await setUpWhitelist({ email: userToUpdate.email })
+
+      // Act
+      const result = await caller.update({
+        siteId,
+        userId: userToUpdate.id,
+        role: RoleType.Admin,
+      })
+
+      // Assert
+      expect(result).toEqual(
+        expect.objectContaining({
+          siteId,
+          userId: userToUpdate.id,
+          role: RoleType.Admin,
+        }),
+      )
     })
 
     it("should update a non-gov.sg email with non-admin role successfully", async () => {

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -275,7 +275,7 @@ describe("user.router", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
         }),
       )
 
@@ -303,7 +303,7 @@ describe("user.router", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
         }),
       )
 
@@ -1607,7 +1607,7 @@ describe("user.router", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
         }),
       )
 
@@ -1672,7 +1672,7 @@ describe("user.router", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
         }),
       )
 

--- a/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.router.test.ts
@@ -284,6 +284,34 @@ describe("user.router", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
+    it("should throw 403 if assigning a temporarily (vendor) whitelisted non-gov.sg email with admin role", async () => {
+      // Arrange
+      const nonGovSgEmail = "test-vendor-whitelisted@coolvendor.com"
+      const oneYearFromNow = new Date()
+      oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1)
+      await setupAdminPermissions({ userId: session.userId, siteId })
+      await setUpWhitelist({ email: nonGovSgEmail, expiry: oneYearFromNow })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        users: [{ email: nonGovSgEmail, role: RoleType.Admin }],
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Non-gov.sg emails cannot be added as admin. Select another role.",
+        }),
+      )
+
+      // Assert DB - audit logs
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(0)
+    })
+
     it("should create a whitelisted non-gov.sg email with admin role", async () => {
       // Arrange
       const nonGovSgEmail = "test@coolvendor.com"
@@ -1614,6 +1642,43 @@ describe("user.router", () => {
           role: RoleType.Admin,
         }),
       )
+    })
+
+    it("should throw 403 if updating a temporarily (vendor) whitelisted non-gov.sg email to admin role", async () => {
+      // Arrange
+      await setupAdminPermissions({ userId: session.userId, siteId })
+
+      const userToUpdate = await setupUser({
+        email: "test-vendor-whitelisted@coolvendor.com",
+        isDeleted: false,
+      })
+      await setupEditorPermissions({ userId: userToUpdate.id, siteId })
+      const oneYearFromNow = new Date()
+      oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1)
+      await setUpWhitelist({
+        email: userToUpdate.email,
+        expiry: oneYearFromNow,
+      })
+
+      // Act
+      const result = caller.update({
+        siteId,
+        userId: userToUpdate.id,
+        role: RoleType.Admin,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Non-gov.sg emails cannot be added as admin. Select another role.",
+        }),
+      )
+
+      // Assert DB - audit logs
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(0)
     })
 
     it("should update a non-gov.sg email with non-admin role successfully", async () => {

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -283,7 +283,7 @@ describe("user.service", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
         }),
       )
 
@@ -315,7 +315,7 @@ describe("user.service", () => {
         new TRPCError({
           code: "FORBIDDEN",
           message:
-            "Non-gov.sg emails cannot be added as admin. Select another role.",
+            "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
         }),
       )
 

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -292,6 +292,38 @@ describe("user.service", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
+    it("should throw 403 if assigning a temporarily (vendor) whitelisted non-gov.sg email with admin role", async () => {
+      // Arrange
+      const nonGovSgEmail = "test-vendor-whitelisted@coolvendor.com"
+      const oneYearFromNow = new Date()
+      oneYearFromNow.setFullYear(oneYearFromNow.getFullYear() + 1)
+      await setUpWhitelist({ email: nonGovSgEmail, expiry: oneYearFromNow })
+
+      // Act
+      const result = db.transaction().execute((tx) => {
+        return createUserWithPermission({
+          byUserId: creatorUserId,
+          email: nonGovSgEmail,
+          role: RoleType.Admin,
+          siteId,
+          tx,
+        })
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "Non-gov.sg emails cannot be added as admin. Select another role.",
+        }),
+      )
+
+      // Assert DB - audit logs
+      const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLogs).toHaveLength(0)
+    })
+
     it("should create a whitelisted non-gov.sg email with admin role", async () => {
       // Arrange
       const nonGovSgEmail = "test@coolvendor.com"

--- a/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
+++ b/apps/studio/src/server/modules/user/__tests__/user.service.test.ts
@@ -263,10 +263,9 @@ describe("user.service", () => {
       expect(auditLogs).toHaveLength(0)
     })
 
-    it("should throw 403 if assigning a non-gov.sg email with admin role", async () => {
+    it("should throw 403 if assigning a non-whitelisted non-gov.sg email with admin role", async () => {
       // Arrange
       const nonGovSgEmail = "test@coolvendor.com"
-      await setUpWhitelist({ email: nonGovSgEmail })
 
       // Act
       const result = db.transaction().execute((tx) => {
@@ -291,6 +290,26 @@ describe("user.service", () => {
       // Assert DB - audit logs
       const auditLogs = await db.selectFrom("AuditLog").selectAll().execute()
       expect(auditLogs).toHaveLength(0)
+    })
+
+    it("should create a whitelisted non-gov.sg email with admin role", async () => {
+      // Arrange
+      const nonGovSgEmail = "test@coolvendor.com"
+      await setUpWhitelist({ email: nonGovSgEmail })
+
+      // Act
+      const result = await db.transaction().execute((tx) => {
+        return createUserWithPermission({
+          byUserId: creatorUserId,
+          email: nonGovSgEmail,
+          role: RoleType.Admin,
+          siteId,
+          tx,
+        })
+      })
+
+      // Assert
+      expect(result).toEqual(expect.anything())
     })
 
     it("should create a non-gov.sg email with non-admin role", async () => {

--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -34,7 +34,6 @@ import {
   validatePermissionsForManagingUsers,
 } from "../permissions/permissions.service"
 import { getSiteNameAndCodeBuildId } from "../site/site.service"
-import { isEmailWhitelisted } from "../whitelist/whitelist.service"
 import {
   createUserWithPermission,
   deleteUserPermission,
@@ -307,8 +306,7 @@ export const userRouter = router({
         })
       }
 
-      const isWhitelisted = await isEmailWhitelisted(user.email)
-      validateEmailRoleCombination({ email: user.email, role, isWhitelisted })
+      await validateEmailRoleCombination({ email: user.email, role })
 
       const updatedUserPermission = await updateUserSitewidePermission({
         byUserId: ctx.user.id,

--- a/apps/studio/src/server/modules/user/user.router.ts
+++ b/apps/studio/src/server/modules/user/user.router.ts
@@ -34,6 +34,7 @@ import {
   validatePermissionsForManagingUsers,
 } from "../permissions/permissions.service"
 import { getSiteNameAndCodeBuildId } from "../site/site.service"
+import { isEmailWhitelisted } from "../whitelist/whitelist.service"
 import {
   createUserWithPermission,
   deleteUserPermission,
@@ -306,7 +307,8 @@ export const userRouter = router({
         })
       }
 
-      validateEmailRoleCombination({ email: user.email, role })
+      const isWhitelisted = await isEmailWhitelisted(user.email)
+      validateEmailRoleCombination({ email: user.email, role, isWhitelisted })
 
       const updatedUserPermission = await updateUserSitewidePermission({
         byUserId: ctx.user.id,

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -9,7 +9,10 @@ import { AuditLogEvent } from "~prisma/generated/generatedEnums"
 import type { DB, Transaction } from "../database"
 import { logPermissionEvent, logUserEvent } from "../audit/audit.service"
 import { db, RoleType } from "../database"
-import { isEmailWhitelisted } from "../whitelist/whitelist.service"
+import {
+  isEmailWhitelisted,
+  isEmailWhitelistedAdmin,
+} from "../whitelist/whitelist.service"
 
 export const isUserDeleted = async (email: string) => {
   const lowercaseEmail = email.toLowerCase()
@@ -23,16 +26,18 @@ export const isUserDeleted = async (email: string) => {
   return user?.deletedAt ? true : false
 }
 
-export const validateEmailRoleCombination = ({
+export const validateEmailRoleCombination = async ({
   email,
   role,
-  isWhitelisted,
 }: {
   email: string
   role: ResourcePermission["role"]
-  isWhitelisted: boolean
 }) => {
-  if (role === RoleType.Admin && !isGovEmail(email) && !isWhitelisted) {
+  if (
+    role === RoleType.Admin &&
+    !isGovEmail(email) &&
+    !(await isEmailWhitelistedAdmin(email))
+  ) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message:
@@ -67,9 +72,9 @@ export const createUserWithPermission = async ({
     })
   }
 
-  const isWhitelisted = await isEmailWhitelisted(email)
-  validateEmailRoleCombination({ email, role, isWhitelisted })
+  await validateEmailRoleCombination({ email, role })
 
+  const isWhitelisted = await isEmailWhitelisted(email)
   if (!isWhitelisted) {
     throw new TRPCError({
       code: "FORBIDDEN",

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -41,7 +41,7 @@ export const validateEmailRoleCombination = async ({
     throw new TRPCError({
       code: "FORBIDDEN",
       message:
-        "Non-gov.sg emails cannot be added as admin. Select another role.",
+        "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
     })
   }
 }

--- a/apps/studio/src/server/modules/user/user.service.ts
+++ b/apps/studio/src/server/modules/user/user.service.ts
@@ -26,11 +26,13 @@ export const isUserDeleted = async (email: string) => {
 export const validateEmailRoleCombination = ({
   email,
   role,
+  isWhitelisted,
 }: {
   email: string
   role: ResourcePermission["role"]
+  isWhitelisted: boolean
 }) => {
-  if (!isGovEmail(email) && role === RoleType.Admin) {
+  if (role === RoleType.Admin && !isGovEmail(email) && !isWhitelisted) {
     throw new TRPCError({
       code: "FORBIDDEN",
       message:
@@ -65,9 +67,9 @@ export const createUserWithPermission = async ({
     })
   }
 
-  validateEmailRoleCombination({ email, role })
-
   const isWhitelisted = await isEmailWhitelisted(email)
+  validateEmailRoleCombination({ email, role, isWhitelisted })
+
   if (!isWhitelisted) {
     throw new TRPCError({
       code: "FORBIDDEN",

--- a/apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts
+++ b/apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts
@@ -1,7 +1,10 @@
 import { resetTables } from "tests/integration/helpers/db"
 import { setUpWhitelist } from "tests/integration/helpers/seed"
 
-import { isEmailWhitelisted } from "../whitelist.service"
+import {
+  isEmailWhitelisted,
+  isEmailWhitelistedAdmin,
+} from "../whitelist.service"
 
 describe("whitelist.service", () => {
   beforeAll(async () => {
@@ -32,6 +35,10 @@ describe("whitelist.service", () => {
     await setUpWhitelist({
       email: "expired@whitelisted.com.sg",
       expiry: oneYearAgo,
+    })
+    await setUpWhitelist({
+      email: "temp-exact@vendor.com.sg",
+      expiry: oneYearFromNow,
     })
   })
 
@@ -121,5 +128,84 @@ describe("whitelist.service", () => {
 
     // Assert
     expect(result).toBe(true)
+  })
+
+  describe("isEmailWhitelistedAdmin", () => {
+    it("should return true if the exact email address is permanently whitelisted", async () => {
+      // Arrange
+      const email = "whitelisted@example.com"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    it("should return false if the exact email address is only temporarily (vendor) whitelisted", async () => {
+      // Arrange
+      const email = "vendor-whitelisted@example.com"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(false)
+    })
+
+    it("should return false if the email is not whitelisted at all", async () => {
+      // Arrange
+      const email = "vendor-expired@example.com"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(false)
+    })
+
+    it("should return true if the exact email domain is permanently whitelisted", async () => {
+      // Arrange
+      const email = "user@vendor.com.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    it("should return false if the exact email domain is only temporarily (vendor) whitelisted", async () => {
+      // Arrange
+      const email = "user@whitelisted.com.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(false)
+    })
+
+    it("should return true if the suffix of the email domain is permanently whitelisted", async () => {
+      // Arrange
+      const email = "user@agency.gov.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
+
+    it("should return true if the exact email is only temporarily whitelisted but the domain is permanently whitelisted", async () => {
+      // Arrange
+      const email = "temp-exact@vendor.com.sg"
+
+      // Act
+      const result = await isEmailWhitelistedAdmin(email)
+
+      // Assert
+      expect(result).toBe(true)
+    })
   })
 })

--- a/apps/studio/src/server/modules/whitelist/whitelist.router.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.router.ts
@@ -1,4 +1,6 @@
 import {
+  isEmailWhitelistedAdminInputSchema,
+  isEmailWhitelistedAdminOutputSchema,
   isEmailWhitelistedInputSchema,
   isEmailWhitelistedOutputSchema,
   whitelistEmailsInputSchema,
@@ -10,7 +12,11 @@ import {
   validatePermissionsForManagingUsers,
   validateUserIsIsomerAdmin,
 } from "../permissions/permissions.service"
-import { isEmailWhitelisted, whitelistEmails } from "./whitelist.service"
+import {
+  isEmailWhitelisted,
+  isEmailWhitelistedAdmin,
+  whitelistEmails,
+} from "./whitelist.service"
 
 export const whitelistRouter = router({
   isEmailWhitelisted: protectedProcedure
@@ -27,6 +33,21 @@ export const whitelistRouter = router({
       })
 
       return await isEmailWhitelisted(email)
+    }),
+  isEmailWhitelistedAdmin: protectedProcedure
+    .input(isEmailWhitelistedAdminInputSchema)
+    .output(isEmailWhitelistedAdminOutputSchema)
+    .query(async ({ ctx, input: { siteId, email } }) => {
+      // Validate permissions as this endpoint is used for user management
+      // and allows checking if emails are whitelisted. This ensures proper
+      // access control even though the operation itself is read-only.
+      await validatePermissionsForManagingUsers({
+        siteId,
+        userId: ctx.user.id,
+        action: "manage",
+      })
+
+      return await isEmailWhitelistedAdmin(email)
     }),
   whitelistEmails: protectedProcedure
     .input(whitelistEmailsInputSchema)

--- a/apps/studio/src/server/modules/whitelist/whitelist.service.ts
+++ b/apps/studio/src/server/modules/whitelist/whitelist.service.ts
@@ -1,8 +1,13 @@
+import type { Expression, ExpressionBuilder, SqlBool } from "kysely"
 import { TRPCError } from "@trpc/server"
 import { isValidEmail } from "~/utils/email"
 
 import type { DB, Transaction } from "../database"
 import { db } from "../database"
+
+type WhitelistExpiryFilter = (
+  eb: ExpressionBuilder<DB, "Whitelist">,
+) => Expression<SqlBool>
 
 const normalise = (email: string) => {
   return email.toLowerCase().trim()
@@ -85,7 +90,16 @@ export const whitelistEmails = async ({
   })
 }
 
-export const isEmailWhitelisted = async (email: string) => {
+// Walks the exact email -> domain -> domain suffix chain and returns the
+// first Whitelist row matching `matchExpiry` at each step. The expiry
+// condition must be applied per-step (not just on the final result): a
+// closer match (e.g. an expired/temporary exact email) can shadow a further,
+// still-valid match (e.g. a permanent domain grant) further down the chain,
+// so we can't just fetch "the" match once and inspect its expiry after.
+const findWhitelistMatch = async (
+  email: string,
+  matchExpiry: WhitelistExpiryFilter,
+) => {
   const lowercaseEmail = email.toLowerCase()
 
   // Extra guard even if Zod validation has already checked
@@ -100,14 +114,12 @@ export const isEmailWhitelisted = async (email: string) => {
   const exactMatch = await db
     .selectFrom("Whitelist")
     .where("email", "=", lowercaseEmail)
-    .where(({ eb }) =>
-      eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
-    )
-    .select(["id"])
+    .where(matchExpiry)
+    .select(["id", "expiry"])
     .executeTakeFirst()
 
   if (exactMatch) {
-    return true
+    return exactMatch
   }
 
   // Step 2: Check if the exact email domain is whitelisted
@@ -123,14 +135,12 @@ export const isEmailWhitelisted = async (email: string) => {
   const domainMatch = await db
     .selectFrom("Whitelist")
     .where("email", "=", emailDomain)
-    .where(({ eb }) =>
-      eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
-    )
-    .select(["id"])
+    .where(matchExpiry)
+    .select(["id", "expiry"])
     .executeTakeFirst()
 
   if (domainMatch) {
-    return true
+    return domainMatch
   }
 
   // Step 3: Check if the suffix of the email domain is whitelisted
@@ -142,16 +152,34 @@ export const isEmailWhitelisted = async (email: string) => {
     const suffixMatch = await db
       .selectFrom("Whitelist")
       .where("email", "=", suffix)
-      .where(({ eb }) =>
-        eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
-      )
-      .select(["id"])
+      .where(matchExpiry)
+      .select(["id", "expiry"])
       .executeTakeFirst()
 
     if (suffixMatch) {
-      return true
+      return suffixMatch
     }
   }
 
-  return false
+  return undefined
+}
+
+export const isEmailWhitelisted = async (email: string) => {
+  const match = await findWhitelistMatch(email, ({ eb }) =>
+    eb.or([eb("expiry", "is", null), eb("expiry", ">", new Date())]),
+  )
+
+  return !!match
+}
+
+// Whitelist entries with a NULL expiry are permanent grants (added via the
+// "admin" textarea in godmode/whitelist), as opposed to temporary vendor
+// grants which carry a 90-day expiry. Only permanent entries should count
+// towards site Admin-role eligibility.
+export const isEmailWhitelistedAdmin = async (email: string) => {
+  const match = await findWhitelistMatch(email, ({ eb }) =>
+    eb("expiry", "is", null),
+  )
+
+  return !!match
 }

--- a/apps/studio/src/stories/Page/AddUserModal.stories.tsx
+++ b/apps/studio/src/stories/Page/AddUserModal.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { expect, userEvent, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
@@ -96,7 +96,23 @@ export const AdminWarningBanner: Story = {
   },
 }
 
-export const NonGovEmailCannotBeAdmin: Story = {
+// A wholly non-whitelisted non-gov.sg domain also cannot be Admin, but that
+// scenario is already covered from the general-whitelist-gate angle by
+// EmailIsNotWhitelisted below. The interesting/representative case for the
+// Admin-specific gate is a *vendor* (temporarily whitelisted) email: it's
+// allowed to be added at all (isEmailWhitelisted: true, no domain error),
+// but still isn't Admin-eligible since it isn't a *permanent* grant
+// (isEmailWhitelistedAdmin: false).
+export const VendorEmailCannotBeAdmin: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...COMMON_HANDLERS,
+        whitelistHandlers.isEmailWhitelisted.true(),
+        whitelistHandlers.isEmailWhitelistedAdmin.false(),
+      ],
+    },
+  },
   play: async (context) => {
     const { canvasElement } = context
     await Default.play?.(context)
@@ -111,13 +127,63 @@ export const NonGovEmailCannotBeAdmin: Story = {
       ),
     )[0]
     if (emailInput) {
-      await userEvent.type(emailInput, "this_is_a_non_gov_email@non-gov.sg")
+      await userEvent.type(emailInput, "someone@vendor-agency.com")
     }
 
-    const nonGovEmailCannotBeAdminText = await screen.findByText(
-      "Non-gov.sg emails cannot be added as admin. Select another role.",
+    const emailNotWhitelistedForAdminText = await screen.findByText(
+      "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin. Select another role.",
     )
-    await expect(nonGovEmailCannotBeAdminText).toBeVisible()
+    await expect(emailNotWhitelistedForAdminText).toBeVisible()
+
+    const sendInviteButton = await screen.findByText("Send invite")
+    await waitFor(() => expect(sendInviteButton).toBeDisabled())
+  },
+}
+
+// Regression test for the fix allowing Admin for non-gov.sg emails whose
+// domain has a permanent whitelist grant. The email is typed first and the
+// whitelist checks are awaited *before* selecting Admin, so the assertion
+// actually exercises the whitelisted-domain path rather than the "no email
+// entered yet" default state.
+export const NonGovEmailWhitelistedForAdmin: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...COMMON_HANDLERS,
+        whitelistHandlers.isEmailWhitelisted.true(),
+        whitelistHandlers.isEmailWhitelistedAdmin.true(),
+      ],
+    },
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    await Default.play?.(context)
+
+    const screen = within(canvasElement.ownerDocument.body)
+
+    const emailInput = Array.from(
+      canvasElement.ownerDocument.querySelectorAll(
+        'input[name="email"][required]',
+      ),
+    )[0]
+    if (emailInput) {
+      await userEvent.type(emailInput, "someone@whitelisted-non-gov-domain.com")
+    }
+
+    const AdminRoleButton = await screen.findByRole("button", {
+      name: "Admin role",
+    })
+    await waitFor(() => expect(AdminRoleButton).not.toBeDisabled())
+
+    await userEvent.click(AdminRoleButton)
+
+    const adminWarningText = await screen.findByText(
+      "You are adding a new admin to the website. An admin can make any change to the site content, settings, and users.",
+    )
+    await expect(adminWarningText).toBeVisible()
+
+    const sendInviteButton = await screen.findByText("Send invite")
+    await waitFor(() => expect(sendInviteButton).not.toBeDisabled())
   },
 }
 
@@ -127,6 +193,7 @@ export const EmailIsNotWhitelisted: Story = {
       handlers: [
         ...COMMON_HANDLERS,
         whitelistHandlers.isEmailWhitelisted.false(),
+        whitelistHandlers.isEmailWhitelistedAdmin.false(),
       ],
     },
   },

--- a/apps/studio/src/stories/Page/EditUserModal.stories.tsx
+++ b/apps/studio/src/stories/Page/EditUserModal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { expect, userEvent, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { userHandlers } from "tests/msw/handlers/user"
+import { whitelistHandlers } from "tests/msw/handlers/whitelist"
 import UsersPage from "~/pages/sites/[siteId]/users"
 import { createSingpassEnabledGbParameters } from "~/stories/utils/growthbook"
 
@@ -99,7 +100,20 @@ export const ToastAfterEditingUser: Story = {
   },
 }
 
-export const NonGovEmailCannotBeAdmin: Story = {
+// "Editor User" (editor@example.com) is a non-gov.sg email that is not
+// permanently whitelisted for Admin — this represents either a wholly
+// non-whitelisted domain, or a vendor (temporarily whitelisted) one; from
+// this modal's perspective they're indistinguishable, since Admin
+// eligibility here depends only on isEmailWhitelistedAdmin.
+export const VendorEmailCannotBeAdmin: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...ADMIN_HANDLERS,
+        whitelistHandlers.isEmailWhitelistedAdmin.false(),
+      ],
+    },
+  },
   play: async (context) => {
     const { canvasElement } = context
     const rootScreen = within(canvasElement.ownerDocument.body)
@@ -112,5 +126,54 @@ export const NonGovEmailCannotBeAdmin: Story = {
 
     const editUserButton = await rootScreen.findByText("Edit user")
     await userEvent.click(editUserButton, { pointerEventsCheck: 0 })
+
+    // The Admin box starts (and stays) disabled here: the email is fixed as
+    // soon as the modal opens, so unlike AddUserModal there's no "type the
+    // email after selecting Admin" window — a click on a disabled button
+    // never fires onClick, so selectedRole can never become Admin and the
+    // "cannot be admin" banner can never render. The observable regression
+    // check is therefore that the box stays disabled, not a banner click-through.
+    const AdminRoleButton = await rootScreen.findByRole("button", {
+      name: "Admin role",
+    })
+    await waitFor(() => expect(AdminRoleButton).toBeDisabled())
+  },
+}
+
+// Regression test for the fix allowing Admin for non-gov.sg emails whose
+// domain has a permanent whitelist grant.
+export const NonGovEmailWhitelistedForAdmin: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        ...ADMIN_HANDLERS,
+        whitelistHandlers.isEmailWhitelistedAdmin.true(),
+      ],
+    },
+  },
+  play: async (context) => {
+    const { canvasElement } = context
+    const rootScreen = within(canvasElement.ownerDocument.body)
+    const screen = within(canvasElement)
+
+    const actionMenu = await screen.findByRole("button", {
+      name: "Options for Editor User",
+    })
+    await userEvent.click(actionMenu)
+
+    const editUserButton = await rootScreen.findByText("Edit user")
+    await userEvent.click(editUserButton, { pointerEventsCheck: 0 })
+
+    const AdminRoleButton = await rootScreen.findByRole("button", {
+      name: "Admin role",
+    })
+    await waitFor(() => expect(AdminRoleButton).not.toBeDisabled())
+
+    await userEvent.click(AdminRoleButton)
+
+    const adminWarningText = await rootScreen.findByText(
+      "You are adding a new admin to the website. An admin can make any change to the site content, settings, and users.",
+    )
+    await expect(adminWarningText).toBeVisible()
   },
 }

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -146,7 +146,9 @@ test("admin cannot invite a vendor collaborator as Admin", async ({ page }) => {
   // shows, and Send stays blocked.
   await expect(page.getByRole("button", { name: /^Admin/ })).toBeDisabled()
   await expect(
-    page.getByText("Non-gov.sg emails cannot be added as admin"),
+    page.getByText(
+      "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin",
+    ),
   ).toBeVisible()
   await expect(page.getByRole("button", { name: "Send invite" })).toBeDisabled()
 })

--- a/apps/studio/tests/msw/handlers/whitelist.ts
+++ b/apps/studio/tests/msw/handlers/whitelist.ts
@@ -11,4 +11,14 @@ export const whitelistHandlers = {
         return false
       }),
   },
+  isEmailWhitelistedAdmin: {
+    true: () =>
+      trpcMsw.whitelist.isEmailWhitelistedAdmin.query(() => {
+        return true
+      }),
+    false: () =>
+      trpcMsw.whitelist.isEmailWhitelistedAdmin.query(() => {
+        return false
+      }),
+  },
 }


### PR DESCRIPTION
📄 **[Full explainer with diagrams & quiz](https://app.notion.com/p/39f77dbba78881b3a22aff80346a39e3)**

## Problem

The `Admin` role — which can manage other users' permissions — was hard-restricted to `.gov.sg` emails, regardless of whitelist status. A vendor/partner domain that had been explicitly, *permanently* whitelisted by an Isomer Core Admin (already trusted enough to log in and use the product at all) could still never be made an `Admin` on a site.

Closes ISOM-2314

## Solution

Admin eligibility now comes from either of two sources: a `.gov.sg` email, or a **permanent** whitelist grant (`Whitelist.expiry IS NULL`). A temporary "vendor" grant (has an `expiry` date, e.g. the 90-day window used for vendor onboarding) is deliberately **not** sufficient — it clears the general login/whitelist gate but not the stricter Admin gate.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Permanently-whitelisted non-`.gov.sg` emails can now be assigned the `Admin` role, on both the create/invite and update flows.
- Add/Edit User modals now query a new `whitelist.isEmailWhitelistedAdmin` endpoint and reflect real Admin eligibility in the UI (Admin box enabled/disabled, correct banner, Send-invite button state), instead of the old naive "non-gov.sg ⇒ always disabled" check.

**Improvements**:

- Deduplicated the whitelist exact/domain/suffix matching logic: both `isEmailWhitelisted` and the new `isEmailWhitelistedAdmin` now share a single parameterized `findWhitelistMatch` helper instead of two independently-maintained copies of the same three-step lookup.
- `validateEmailRoleCombination` is now self-contained — it computes Admin eligibility itself (async) instead of requiring every caller to pre-compute and pass in a boolean.
- Renamed the "cannot be admin" banner (`NonGovEmailCannotBeAdmin` → `EmailNotWhitelistedForAdmin`) and its copy, and the backend's matching `FORBIDDEN` error message, from "Non-gov.sg emails cannot be added as admin" to "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin" — the old copy became inaccurate once whitelisted non-gov emails could qualify.

**Bug Fixes**:

- N/A

## Tests

Added/updated coverage across the stack:
- `apps/studio/src/server/modules/whitelist/__tests__/whitelist.service.test.ts` — full matrix for `isEmailWhitelistedAdmin` (permanent vs. temporary, exact/domain/suffix), including a shadowing case where a temporarily-whitelisted exact email must not block a permanently-whitelisted domain match further down the lookup chain.
- `apps/studio/src/server/modules/user/__tests__/{user.service,user.router}.test.ts` — both create and update flows assert a temporarily (vendor) whitelisted non-gov email is still rejected for Admin, alongside the permanent-grant success case.
- `apps/studio/src/stories/Page/{AddUserModal,EditUserModal}.stories.tsx` — new `VendorEmailCannotBeAdmin` / `NonGovEmailWhitelistedForAdmin` stories with MSW mocks for the new endpoint, asserting the Admin box state, banner, and (for Add) the Send-invite button state.
- `apps/studio/tests/e2e/user/invite-user.test.ts` (pre-existing suite) — updated its string assertion for the banner rename; already covers a gov.sg Admin invite (succeeds), a whitelisted-vendor-as-Admin attempt (still rejected), and a non-whitelisted-at-all invite (blocked by the separate general whitelist gate).

Full unit suite passes (1551 passed, 41 skipped).

**Manual Verification Steps**:

- [ ] Whitelist a non-gov.sg domain **permanently** (no expiry) via the godmode whitelist "no expiry" textarea, then invite an email on that domain as `Admin` from a site's Manage Users page — confirm the Admin box is selectable and the invite succeeds.
- [ ] Whitelist a non-gov.sg domain **temporarily** (vendor, 90-day expiry) via the godmode whitelist "Vendors" textarea, then attempt to invite an email on that domain as `Admin` — confirm the Admin box is disabled, the "Non-whitelisted or vendor (temporarily whitelisted) emails cannot be added as admin" banner shows, and Send invite stays disabled.
- [ ] Attempt to invite a non-gov.sg, non-whitelisted-at-all email — confirm it's still blocked (by the separate "needs whitelisting" error), regardless of role.
- [ ] Confirm `.gov.sg` emails can still be assigned `Admin` regardless of whitelist status (no regression).
- [ ] Repeat the permanent-vs-vendor checks above using **Edit user** (role dropdown on an existing user) instead of Add user, to confirm the same gating applies there.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates user role checks so non-`gov.sg` emails can become `Admin` only with a permanent whitelist grant. The main changes are:

- Adds a permanent-only Admin whitelist lookup in the whitelist service and router.
- Applies the Admin whitelist check in both invite and role-update flows.
- Updates Add/Edit User modals to enable or disable the Admin role based on Admin whitelist status.
- Adds router, service, Storybook, MSW, and E2E coverage for non-whitelisted, temporary vendor, and permanent-whitelisted cases.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with low-to-medium risk from user-management policy changes.

No blocking issues were found. The changed server paths are covered by service and router tests, and the UI behavior is covered through Storybook, MSW, and E2E updates.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex analyzed the Storybook runs for the user-permission-modal and confirmed a sequence of issues: the first dev attempt stayed in webpack compilation and did not serve HTTP, the static build failed due to a missing @opengovsg/isomer-components, a subsequent build after adding the dependency progressed but was killed with exit code 137, and a second dev attempt after dependencies again stalled in webpack compilation and did not serve HTTP within the poll window.
- T-Rex inspected the admin whitelist API tests and observed the pre-run Testcontainers setup failed, the isolated role-validation test completed with 1 passed, and harness scaffolding files were generated for the tests.

<a href="https://app.greptile.com/trex/runs/15044818/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/user/user.service.ts | Makes Admin role validation async and backs non-gov Admin eligibility with the permanent whitelist check. |
| apps/studio/src/server/modules/whitelist/whitelist.service.ts | Refactors whitelist lookup into a shared matcher and adds permanent-only Admin eligibility. |
| apps/studio/src/server/modules/whitelist/whitelist.router.ts | Exposes a permission-checked tRPC query for Admin whitelist eligibility. |
| apps/studio/src/features/users/components/UserPermissionModal/AddUserModal.tsx | Adds an Admin-specific whitelist query to enable permanent-whitelisted non-gov emails while keeping non-admin whitelist validation unchanged. |
| apps/studio/src/features/users/components/UserPermissionModal/EditUserModal.tsx | Adds Admin whitelist status lookup so role editing allows permanent-whitelisted non-gov emails. |
| apps/studio/src/server/modules/user/__tests__/user.router.test.ts | Covers create and update router behavior for non-whitelisted, temporary vendor, and permanent-whitelisted Admin assignments. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant UI as Add/Edit User Modal
participant WR as whitelistRouter
participant WS as whitelist.service
participant UR as userRouter/user.service
participant DB as Whitelist DB

UI->>WR: isEmailWhitelistedAdmin(siteId, email)
WR->>WR: validatePermissionsForManagingUsers(manage)
WR->>WS: isEmailWhitelistedAdmin(email)
WS->>DB: check exact email/domain/suffix with expiry IS NULL
DB-->>WS: permanent match or none
WS-->>WR: boolean
WR-->>UI: Admin role enabled/disabled
UI->>UR: create/update user with Admin role
UR->>WS: validateEmailRoleCombination(email, Admin)
WS->>DB: permanent whitelist lookup for non-gov email
UR-->>UI: success or FORBIDDEN
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant UI as Add/Edit User Modal
participant WR as whitelistRouter
participant WS as whitelist.service
participant UR as userRouter/user.service
participant DB as Whitelist DB

UI->>WR: isEmailWhitelistedAdmin(siteId, email)
WR->>WR: validatePermissionsForManagingUsers(manage)
WR->>WS: isEmailWhitelistedAdmin(email)
WS->>DB: check exact email/domain/suffix with expiry IS NULL
DB-->>WS: permanent match or none
WS-->>WR: boolean
WR-->>UI: Admin role enabled/disabled
UI->>UR: create/update user with Admin role
UR->>WS: validateEmailRoleCombination(email, Admin)
WS->>DB: permanent whitelist lookup for non-gov email
UR-->>UI: success or FORBIDDEN
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(users): sync backend FORBIDDEN messa..."](https://github.com/opengovsg/isomer/commit/2439dc00f0c41d4b95e3973c567a11efc9752e0e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44736050)</sub>

<!-- /greptile_comment -->