### PR TITLE
feat(redirects): add is-advanced-redirects-enabled flag

### DIFF
--- a/apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts
+++ b/apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts
@@ -1,0 +1,5 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+
+export const useIsAdvancedRedirectsEnabled = () =>
+  useFeatureValue<boolean>(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, false)

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -16,6 +16,8 @@ export const IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY =
   "homepage-antiscam-banner-enabled"
 export const EGAZETTE_INFO_FEATURE_KEY = "egazette-info"
 export const IS_REDIRECTIONS_ENABLED_FEATURE_KEY = "is-redirections-enabled"
+export const IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY =
+  "is-advanced-redirects-enabled"
 // When OFF (default): gazette ingestion targets Algolia directly.
 // When ON: gazette ingestion is routed to SearchSG instead.
 export const ENABLE_SEARCHSG_GAZETTE_INGESTION =


### PR DESCRIPTION
## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Prerequisite for wildcard and query-param redirect authoring (stack PR 2/3). Adds the GrowthBook feature flag and hook that gates the advanced redirects UI.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Added `IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY = "is-advanced-redirects-enabled"` constant to `growthbook.ts`
- Added `useIsAdvancedRedirectsEnabled` hook (mirrors the existing `useIsRedirectionsEnabled` pattern)

## Before & After Screenshots

N/A — no UI changes in this PR.

## Tests

No production code changes to verify; no Manual Verification Steps required.

**New dependencies**:

None.

**New dev dependencies**:

None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a GrowthBook flag for advanced redirects. The main changes are:

- New `is-advanced-redirects-enabled` feature key in `apps/studio/src/lib/growthbook.ts`.
- New `useIsAdvancedRedirectsEnabled` hook that reads the flag.
- Default advanced redirects state remains disabled when the flag is unset.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

Small additive feature-flag change that matches the existing redirections flag pattern and does not alter existing behavior.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the advanced\_redirects\_flag\_validation harness and confirmed the test completed with a PASS status and exit code 0, as shown by the run log with the command, cwd, and GrowthBook relationship.
- Generated the harness source file advanced\_redirects\_flag\_validation.mjs to execute the validation during review.
- Attempted a typecheck of the harness using isomer\_studio\_typecheck.log, but the process terminated as SIGTERM after timeout.

<a href="https://app.greptile.com/trex/runs/14781484/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts | Adds a hook that mirrors the existing redirections flag hook and defaults advanced redirects to disabled. |
| apps/studio/src/lib/growthbook.ts | Adds the new GrowthBook feature key constant without modifying existing flag evaluation behavior. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(redirects): add is-advanced-redirec..."](https://github.com/opengovsg/isomer/commit/8c17cfd7c6e680055f4133828ec8cc2202521a7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44961744)</sub>

<!-- /greptile_comment -->