### PR TITLE
feat(redirects): accept wildcard sources and emit build manifest

### DIFF
--- a/apps/studio/src/schemas/__tests__/redirect.test.ts
+++ b/apps/studio/src/schemas/__tests__/redirect.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_BULK_REDIRECT_CSV_BYTES,
   MAX_REDIRECT_DESTINATION_LENGTH,
   MAX_REDIRECT_SOURCE_LENGTH,
+  redirectKind,
 } from "../redirect"
 
 const VALID_REDIRECT = {
@@ -232,11 +233,11 @@ describe("createRedirectSchema", () => {
       expect(result.source).toBe("/old-page")
     })
 
-    it("should reject sources containing a wildcard with the unsupported-wildcard message", () => {
+    it("should reject mid-string and double wildcards", () => {
       // Arrange
-      const wildcardSources = ["/promo/*", "/promo/**", "/pro*mo"]
+      const invalidWildcardSources = ["/promo/**", "/pro*mo"]
 
-      wildcardSources.forEach((source) => {
+      invalidWildcardSources.forEach((source) => {
         // Act
         const result = createRedirectSchema.safeParse({
           ...VALID_REDIRECT,
@@ -247,10 +248,63 @@ describe("createRedirectSchema", () => {
         expect(result.success).toBe(false)
         if (!result.success) {
           expect(result.error.issues.map((issue) => issue.message)).toContain(
-            "Wildcards aren't supported yet — enter the full path",
+            "Use a wildcard only as a trailing /* on a path, e.g. /news/*",
           )
         }
       })
+    })
+  })
+
+  describe("wildcard sources", () => {
+    const parseSource = (source: string) =>
+      createRedirectSchema.safeParse({ siteId: 1, source, destination: "/x" })
+
+    it("accepts a single trailing /*", () => {
+      const r = parseSource("/news/*")
+      expect(r.success).toBe(true)
+      if (r.success) expect(r.data.source).toBe("/news/*")
+    })
+
+    it("lowercases the path but keeps the /*", () => {
+      const r = parseSource("/News/Press/*")
+      expect(r.success && r.data.source).toBe("/news/press/*")
+    })
+
+    it("rejects a mid-string *", () => {
+      expect(parseSource("/news/*/2020").success).toBe(false)
+    })
+
+    it("rejects root-equivalent wildcards that would match the whole site", () => {
+      // "/*", "//*" (collapses to root) and "/./*" (dot segment) all reduce to a
+      // root wildcard and must be rejected — see the segment-based shape check.
+      const rootWildcards = ["/*", "//*", "/./*"]
+      rootWildcards.forEach((source) => {
+        expect(parseSource(source).success).toBe(false)
+      })
+    })
+
+    it("rejects a wildcard whose prefix contains a '..' segment", () => {
+      expect(parseSource("/news/../*").success).toBe(false)
+    })
+  })
+
+  describe("query sources are not supported", () => {
+    const parseSource = (source: string) =>
+      createRedirectSchema.safeParse({ siteId: 1, source, destination: "/x" })
+
+    it("rejects a source containing a query string", () => {
+      // "?" is outside the source character whitelist, so a query-based source
+      // (including one appended to a reserved prefix like "/_next?x=1") is
+      // rejected before any other check.
+      expect(parseSource("/gallery.html?id=123").success).toBe(false)
+      expect(parseSource("/_next?bypass=1").success).toBe(false)
+    })
+  })
+
+  describe("redirectKind", () => {
+    it("classifies by the stored source string", () => {
+      expect(redirectKind("/news/*")).toBe("wildcard")
+      expect(redirectKind("/faq")).toBe("exact")
     })
   })
 

--- a/apps/studio/src/schemas/redirect.ts
+++ b/apps/studio/src/schemas/redirect.ts
@@ -33,8 +33,10 @@ export const MAX_REDIRECT_REFERENCES = 100
 export const MAX_REDIRECT_PAGE_SIZE = 100
 
 // Whitelist of characters allowed in a source path: RFC 3986 `pchar` plus "/"
-// and "%". Whitelisting keeps anything that could corrupt the published rules
-// (spaces, control chars, "?", "#", "\\", non-ASCII) out up front.
+// and "%". The "*" (part of pchar) is permitted so a trailing "/*" wildcard can
+// pass; the wildcard-shape refine below constrains where it may appear.
+// Whitelisting keeps spaces, control chars, "?", "#", "\\", and non-ASCII out up
+// front — a query string is not a supported redirect source.
 const SOURCE_ALLOWED_CHARS_REGEX = /^[A-Za-z0-9\-._~!$&'()*+,;=:@%/]+$/
 
 // ASCII control characters (0x00-0x1f, 0x7f). A destination is persisted verbatim
@@ -67,6 +69,14 @@ export const isValidExternalDestination = (value: string) => {
   }
 }
 
+export type RedirectKind = "exact" | "wildcard"
+
+// Classifies a stored (already-normalised) source by its shape. The build and
+// the edge resolver both branch on this. A trailing "/*" is a wildcard;
+// everything else is an exact path.
+export const redirectKind = (source: string): RedirectKind =>
+  source.endsWith("/*") ? "wildcard" : "exact"
+
 // Strips slashes from both ends of a path so "/foo/", "foo" and "foo//"
 // all normalise to the same inner segments before validation.
 const trimSlashes = (value: string) => value.replace(/^\/+|\/+$/g, "")
@@ -78,10 +88,17 @@ export const normalizeRedirectPath = (value: string) =>
   `/${trimSlashes(value).replace(/\/{2,}/g, "/")}`
 
 // Sources are additionally lowercased — page permalinks are lowercase-only, so
-// a source must lowercase to compare against (and not shadow) a real page.
-// Exported so the server's source/loop guards compare in the same form.
-export const normalizeRedirectSource = (value: string) =>
-  normalizeRedirectPath(value).toLowerCase()
+// a source must lowercase to compare against (and not shadow) a real page. A
+// trailing "/*" wildcard is normalised on its path part and re-appended, so
+// "/News/Press/*" -> "/news/press/*". Exported so the server's source/loop
+// guards and the build's manifest key compare the same way.
+export const normalizeRedirectSource = (value: string): string => {
+  const isWildcard = value.endsWith("/*")
+  const path = normalizeRedirectPath(
+    isWildcard ? value.slice(0, -2) : value,
+  ).toLowerCase()
+  return isWildcard ? `${path}/*` : path
+}
 
 // True when the (normalised) source falls under a reserved prefix — the prefix
 // itself or anything nested beneath it.
@@ -101,12 +118,23 @@ const sourceSchema = z
     message:
       "Source can only contain letters, numbers, and URL path characters",
   })
-  // Wildcard redirects aren't supported yet. A "*" would be stored as a literal
-  // path character that can never match an incoming request, so reject it with a
-  // clear message instead of silently creating a dead redirect.
-  .refine((value) => !value.includes("*"), {
-    message: "Wildcards aren't supported yet — enter the full path",
-  })
+  // A "*" is only allowed as a single trailing "/*" wildcard (the sole form the
+  // prefix-walk resolver supports). Reject a mid-string or repeated "*", and any
+  // root-equivalent prefix ("/*", "//*", "/./*") that would redirect the whole
+  // site. The prefix is checked on segments — not a raw length — so that
+  // collapsing "//" or a "." segment can't smuggle a root wildcard through.
+  .refine(
+    (value) => {
+      if (!value.includes("*")) return true
+      if (!value.endsWith("/*")) return false
+      const prefix = value.slice(0, -2)
+      if (prefix.includes("*")) return false
+      return trimSlashes(prefix)
+        .split("/")
+        .some((segment) => segment !== "" && segment !== ".")
+    },
+    { message: "Use a wildcard only as a trailing /* on a path, e.g. /news/*" },
+  )
   // The source is a path on this site, never a full URL — a scheme like
   // "https://" can never match an incoming request path, so reject it instead
   // of silently mangling it into a slashed source.

--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -6,6 +6,7 @@ import {
 } from "tests/integration/helpers/iron-session"
 import {
   setupAdminPermissions,
+  setupFolder,
   setupPageResource,
   setupSite,
   setupUser,
@@ -169,6 +170,59 @@ describe("redirect.router bulk upload", async () => {
 
       // Assert
       expect(errorFor(result, "/shadowed")).toBeTruthy()
+    })
+
+    it("flags a wildcard source whose prefix is itself a live published page", async () => {
+      // Arrange
+      await seedPublishedPageAtRoot("news")
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/news/*", "/somewhere"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/news/*")).toBeTruthy()
+    })
+
+    it("flags a wildcard source whose prefix has a live page nested under it", async () => {
+      // Arrange — "/news/story" published means "news" is a live folder, so
+      // "/news/*" would shadow it at the edge.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({ siteId, permalink: "news" })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        permalink: "story",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/news/*", "/somewhere"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/news/*")).toBeTruthy()
+    })
+
+    it("does not flag a wildcard source when nothing lives under its prefix", async () => {
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/anything/*", "/somewhere"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/anything/*")).toBeNull()
     })
 
     it("flags a loop formed within the uploaded file", async () => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -2002,4 +2002,47 @@ describe("redirect.router", async () => {
       expect(count).toBe(0)
     })
   })
+
+  describe("create — wildcard sources", () => {
+    it("stores a wildcard whose internal destination becomes a page reference", async () => {
+      // Arrange
+      const { page } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "new-section",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      await caller.create({
+        siteId,
+        source: "/old-section/*",
+        destination: "/new-section",
+      })
+
+      // Assert — the destination resolves to a [resource:…] reference so it
+      // follows the page if its permalink changes; the "/*" stays in the source.
+      const row = await db
+        .selectFrom("Redirect")
+        .select(["source", "destination"])
+        .where("siteId", "=", siteId)
+        .where("source", "=", "/old-section/*")
+        .executeTakeFirstOrThrow()
+      expect(row.source).toBe("/old-section/*")
+      expect(row.destination).toBe(`[resource:${siteId}:${page.id}]`)
+    })
+
+    it("does not block a wildcard source as if it shadowed a published page", async () => {
+      // Arrange — there is no published page at "/anything/*" (the literal path
+      // with "/*" can never match any real resource), so the create must succeed.
+      await expect(
+        caller.create({
+          siteId,
+          source: "/anything/*",
+          destination: "/home",
+        }),
+      ).resolves.toBeDefined()
+    })
+  })
 })

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -2033,9 +2033,9 @@ describe("redirect.router", async () => {
       expect(row.destination).toBe(`[resource:${siteId}:${page.id}]`)
     })
 
-    it("does not block a wildcard source as if it shadowed a published page", async () => {
-      // Arrange — there is no published page at "/anything/*" (the literal path
-      // with "/*" can never match any real resource), so the create must succeed.
+    it("does not block a wildcard source when nothing lives under its prefix", async () => {
+      // Arrange — no resource sits at "/anything" at all, so nothing can be
+      // published under it either; the create must succeed.
       await expect(
         caller.create({
           siteId,
@@ -2043,6 +2043,56 @@ describe("redirect.router", async () => {
           destination: "/home",
         }),
       ).resolves.toBeDefined()
+    })
+
+    it("blocks a wildcard source when a published page already exists under its prefix", async () => {
+      // Arrange — "/news/story" is published, so "/news" is a live folder.
+      // "/news/*" would shadow it: the edge resolver's prefix walk would
+      // intercept "/news/story" and redirect it away instead of serving it.
+      const { folder } = await setupFolder({ siteId, permalink: "news" })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        permalink: "story",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        source: "/news/*",
+        destination: "/home",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+      })
+    })
+
+    it("blocks a wildcard source when the prefix itself is a published page", async () => {
+      // Arrange
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        permalink: "news",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+
+      // Act
+      const result = caller.create({
+        siteId,
+        source: "/news/*",
+        destination: "/home",
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({
+        code: "PRECONDITION_FAILED",
+      })
     })
   })
 })

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -32,6 +32,7 @@ import {
   isValidExternalDestination,
   normalizeRedirectPath,
   normalizeRedirectSource,
+  redirectKind,
   redirectRowSchema,
 } from "~/schemas/redirect"
 import { getReferenceLink } from "~/utils/link"
@@ -369,6 +370,93 @@ const getChainedRedirect = async (
   return { redirect, normalizedDestination, target, isLoop }
 }
 
+// True when a live (published) page already sits at `source` — the exact path
+// for an exact source, or anywhere at or beneath the prefix for a wildcard
+// source. A wildcard like "/news/*" must block on a live page at "/news"
+// itself OR nested under it (e.g. "/news/story"): the edge resolver's
+// prefix-walk would intercept every one of those paths and redirect them away
+// instead of serving them. Resolves a folder/collection to its index page (via
+// getResourceByFullPermalink), so a live container itself also counts.
+const hasLivePageAtSource = async (
+  siteId: number,
+  source: string,
+): Promise<boolean> => {
+  if (redirectKind(source) !== "wildcard") {
+    const pageAtSource = await getResourceByFullPermalink({
+      siteId,
+      fullPermalink: source,
+    })
+    return !!pageAtSource && pageAtSource.publishedVersionId !== null
+  }
+
+  const prefix = source.slice(0, -2) // strip trailing "/*"
+  const segments = prefix.split("/").filter(Boolean)
+  // The root wildcard ("/*") is already rejected by the schema, so this can't
+  // be empty in practice — guarded anyway since an empty prefix has no single
+  // resource to resolve below.
+  if (segments.length === 0) {
+    return false
+  }
+
+  // Walk the exact segment chain to the resource sitting AT the prefix (not
+  // resolved to an index page — its subtree is walked next), mirroring
+  // getResourceByFullPermalink's own segment walk.
+  const candidates = await db
+    .selectFrom("Resource")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.permalink", "in", segments)
+    .where("Resource.type", "not in", [
+      ResourceType.IndexPage,
+      ResourceType.FolderMeta,
+      ResourceType.CollectionMeta,
+    ])
+    .select(["id", "permalink", "parentId"])
+    .execute()
+  let parentId: string | null = null
+  let current: (typeof candidates)[number] | undefined
+  for (const segment of segments) {
+    current = candidates.find(
+      (candidate) =>
+        candidate.permalink === segment && candidate.parentId === parentId,
+    )
+    if (!current) {
+      // Nothing lives at the prefix, so nothing can be published under it.
+      return false
+    }
+    parentId = String(current.id)
+  }
+  if (!current) {
+    return false
+  }
+
+  // The prefix resource itself or anything nested beneath it being published
+  // is enough to shadow — walk its subtree for the first published hit rather
+  // than materialising every descendant.
+  const published = await db
+    .withRecursive("subtree", (eb) =>
+      eb
+        .selectFrom("Resource")
+        .where("Resource.siteId", "=", siteId)
+        .where("Resource.id", "=", current.id)
+        .select("Resource.id")
+        // `union` (not `unionAll`) dedupes rows so a malformed parent chain
+        // with a cycle can't drive the recursion forever.
+        .union((fb) =>
+          fb
+            .selectFrom("Resource")
+            .innerJoin("subtree", "subtree.id", "Resource.parentId")
+            .where("Resource.siteId", "=", siteId)
+            .select("Resource.id"),
+        ),
+    )
+    .selectFrom("subtree")
+    .innerJoin("Resource", "Resource.id", "subtree.id")
+    .where("Resource.publishedVersionId", "is not", null)
+    .select("Resource.id")
+    .executeTakeFirst()
+  return published !== undefined
+}
+
 // Preflight for redirect.create: returns blocking errors without mutating.
 // Advisory only — create re-enforces every error. Destination-liveness is no
 // longer warned here; the table flags not-yet-published destinations instead.
@@ -389,16 +477,9 @@ export const validateRedirect = async ({
     })
   }
 
-  // A redirect whose source is a published page's live URL would shadow that
-  // page, so block it. Resolves a folder/collection to its index page, so a
-  // live container is caught too. Only published resources block — an
-  // unpublished page isn't live yet, and publishing it later is guarded on the
-  // page side.
-  const pageAtSource = await getResourceByFullPermalink({
-    siteId,
-    fullPermalink: source,
-  })
-  if (pageAtSource && pageAtSource.publishedVersionId !== null) {
+  // A redirect whose source would shadow a published page — either the exact
+  // page or, for a wildcard, anything at/under its prefix — is blocked.
+  if (await hasLivePageAtSource(siteId, source)) {
     errors.push({
       code: RedirectValidationCode.SourceIsExistingPage,
       message: REDIRECT_MESSAGES.sourceIsExistingPage,
@@ -518,15 +599,12 @@ export const createRedirect = async ({
       }
 
       // Re-enforce the source-vs-published-page guard (a published page or live
-      // folder/collection at this URL would be shadowed). A page publish doesn't
-      // take the redirect lock, so this plain read can still race one going live
-      // — accepted, since a redirect shadowing a page is recoverable by deleting
+      // folder/collection at this URL — or, for a wildcard, anywhere at/under
+      // its prefix — would be shadowed). A page publish doesn't take the
+      // redirect lock, so this plain read can still race one going live —
+      // accepted, since a redirect shadowing a page is recoverable by deleting
       // it. PRECONDITION_FAILED keeps it distinct from the already-exists CONFLICT.
-      const pageAtSource = await getResourceByFullPermalink({
-        siteId,
-        fullPermalink: source,
-      })
-      if (pageAtSource && pageAtSource.publishedVersionId !== null) {
+      if (await hasLivePageAtSource(siteId, source)) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
           message: REDIRECT_MESSAGES.sourceIsExistingPage,
@@ -909,7 +987,11 @@ const runBulkValidation = async (
     }
   }
 
-  // 4) Source shadows a live published page or container.
+  // 4) Source shadows a live published page or container — an exact source
+  // checks the literal path, a wildcard checks anywhere at/under its prefix
+  // (the same distinction hasLivePageAtSource makes for a single create).
+  // Batched across the whole file (one lookup for every exact source, one for
+  // every wildcard prefix's subtree) rather than a query per row.
   const sourcesToCheck = [
     ...new Set(
       rows.flatMap((row) =>
@@ -919,11 +1001,20 @@ const runBulkValidation = async (
       ),
     ),
   ]
-  if (sourcesToCheck.length > 0) {
-    const idByPermalink = await getResourceIdsByPermalinks(
-      siteId,
-      sourcesToCheck,
-    )
+  const exactSources: string[] = []
+  const wildcardPrefixBySource = new Map<string, string>()
+  for (const source of sourcesToCheck) {
+    if (redirectKind(source) === "wildcard") {
+      wildcardPrefixBySource.set(source, source.slice(0, -2))
+    } else {
+      exactSources.push(source)
+    }
+  }
+
+  const shadowedSources = new Set<string>()
+
+  if (exactSources.length > 0) {
+    const idByPermalink = await getResourceIdsByPermalinks(siteId, exactSources)
     const resourceIds = [...idByPermalink.values()].filter(
       (id): id is number => id !== null,
     )
@@ -931,14 +1022,75 @@ const runBulkValidation = async (
       siteId,
       resourceIds,
     )
-    for (const row of rows) {
-      if (row.error !== null || row.normalizedSource === null) {
-        continue
-      }
-      const resourceId = idByPermalink.get(row.normalizedSource) ?? null
+    for (const source of exactSources) {
+      const resourceId = idByPermalink.get(source) ?? null
       if (resourceId !== null && publishedState.get(resourceId)) {
-        row.error = REDIRECT_MESSAGES.sourceIsExistingPage
+        shadowedSources.add(source)
       }
+    }
+  }
+
+  const wildcardPrefixes = [...new Set(wildcardPrefixBySource.values())]
+  if (wildcardPrefixes.length > 0) {
+    // Resolve every wildcard's prefix to the (raw, non-index-page-substituted)
+    // resource sitting at that path, same as getResourceIdsByPermalinks
+    // resolves any other permalink — reused rather than re-walking segments.
+    const rootIdByPrefix = await getResourceIdsByPermalinks(
+      siteId,
+      wildcardPrefixes,
+    )
+    const rootIds = [...new Set(rootIdByPrefix.values())]
+      .filter((id): id is number => id !== null)
+      .map(String)
+    if (rootIds.length > 0) {
+      // One recursive walk covering every wildcard root at once, carrying each
+      // row's root id through the recursion so a published hit anywhere in a
+      // root's subtree (including the root itself) can be attributed back to
+      // it — the multi-root analogue of hasLivePageAtSource's single-prefix
+      // walk.
+      const shadowedRoots = await db
+        .withRecursive("subtree", (eb) =>
+          eb
+            .selectFrom("Resource")
+            .where("Resource.siteId", "=", siteId)
+            .where("Resource.id", "in", rootIds)
+            .select(["Resource.id as rootId", "Resource.id"])
+            .union((fb) =>
+              fb
+                .selectFrom("Resource")
+                .innerJoin("subtree", "subtree.id", "Resource.parentId")
+                .where("Resource.siteId", "=", siteId)
+                .select(["subtree.rootId", "Resource.id"]),
+            ),
+        )
+        .selectFrom("subtree")
+        .innerJoin("Resource", "Resource.id", "subtree.id")
+        .where("Resource.publishedVersionId", "is not", null)
+        .select("subtree.rootId")
+        .distinct()
+        .execute()
+      const shadowedRootIds = new Set(
+        shadowedRoots.map((row) => String(row.rootId)),
+      )
+      for (const [source, prefix] of wildcardPrefixBySource) {
+        const rootId = rootIdByPrefix.get(prefix)
+        if (
+          rootId !== null &&
+          rootId !== undefined &&
+          shadowedRootIds.has(String(rootId))
+        ) {
+          shadowedSources.add(source)
+        }
+      }
+    }
+  }
+
+  for (const row of rows) {
+    if (row.error !== null || row.normalizedSource === null) {
+      continue
+    }
+    if (shadowedSources.has(row.normalizedSource)) {
+      row.error = REDIRECT_MESSAGES.sourceIsExistingPage
     }
   }
 

--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   buildManifest,
@@ -166,5 +166,21 @@ describe("buildManifest", () => {
 
   it("returns an empty redirects map for an empty input", () => {
     expect(buildManifest([])).toEqual({ version: 1, redirects: {} })
+  })
+
+  describe("duplicate sources", () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it("keeps the first destination and warns instead of silently overwriting", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+      const result = buildManifest([
+        { source: "/news/*", destination: "/newsroom" },
+        { source: "/news/*", destination: "/second-wins-if-not-guarded" },
+      ])
+      expect(result.redirects["/news/*"]).toBe("/newsroom")
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("/news/*"))
+    })
   })
 })

--- a/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
+++ b/tooling/build/scripts/publishing/tests/uploadRedirects.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildManifest,
   normalizeSource,
   parseUploadCliArgs,
+  partitionRedirects,
   resolveConcurrency,
   resolveUploadConfig,
 } from "../uploadRedirects"
@@ -114,5 +116,55 @@ describe("normalizeSource", () => {
   it("rejects malformed percent-encoding", () => {
     // Arrange / Act / Assert — a lone "%" is not a valid escape sequence
     expect(normalizeSource("/foo%bar")).toBeNull()
+  })
+})
+
+describe("partitionRedirects", () => {
+  it("splits exact from wildcard by source shape", () => {
+    const { exact, manifestEntries } = partitionRedirects([
+      { source: "/faq", destination: "/faqs" },
+      { source: "/news/*", destination: "/newsroom" },
+      { source: "/promotions/*", destination: "https://x.gov.sg/g" },
+    ])
+    expect(exact.map((r) => r.source)).toEqual(["/faq"])
+    expect(manifestEntries.map((r) => r.source)).toEqual([
+      "/news/*",
+      "/promotions/*",
+    ])
+  })
+
+  it("returns empty arrays when all rows are exact", () => {
+    const { exact, manifestEntries } = partitionRedirects([
+      { source: "/a", destination: "/b" },
+    ])
+    expect(exact).toHaveLength(1)
+    expect(manifestEntries).toHaveLength(0)
+  })
+
+  it("returns empty arrays when input is empty", () => {
+    const { exact, manifestEntries } = partitionRedirects([])
+    expect(exact).toHaveLength(0)
+    expect(manifestEntries).toHaveLength(0)
+  })
+})
+
+describe("buildManifest", () => {
+  it("produces a versioned flat map keyed by source", () => {
+    expect(
+      buildManifest([
+        { source: "/news/*", destination: "/newsroom" },
+        { source: "/promotions/*", destination: "https://x.gov.sg/g" },
+      ]),
+    ).toEqual({
+      version: 1,
+      redirects: {
+        "/news/*": "/newsroom",
+        "/promotions/*": "https://x.gov.sg/g",
+      },
+    })
+  })
+
+  it("returns an empty redirects map for an empty input", () => {
+    expect(buildManifest([])).toEqual({ version: 1, redirects: {} })
   })
 })

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -129,7 +129,18 @@ export function buildManifest(entries: Redirect[]): {
   redirects: Record<string, string>
 } {
   const redirects: Record<string, string> = {}
-  for (const { source, destination } of entries) redirects[source] = destination
+  for (const { source, destination } of entries) {
+    // Keep the first destination and warn on a repeat, mirroring the exact-path
+    // dedup above — silently overwriting would let a later row change a wildcard's
+    // target with no signal in the build log.
+    if (Object.prototype.hasOwnProperty.call(redirects, source)) {
+      console.warn(
+        `Skipping duplicate wildcard source in manifest: ${source} (keeping first destination "${redirects[source]}")`,
+      )
+      continue
+    }
+    redirects[source] = destination
+  }
   return { version: MANIFEST_VERSION, redirects }
 }
 

--- a/tooling/build/scripts/publishing/uploadRedirects.ts
+++ b/tooling/build/scripts/publishing/uploadRedirects.ts
@@ -99,6 +99,57 @@ export function normalizeSource(source: string): string | null {
   return trimmed
 }
 
+export const MANIFEST_KEY_SUFFIX = "_redirects/manifest.json"
+
+// A stored source is a wildcard ("…/*") — those go in the manifest for the edge
+// resolver to prefix-match. Everything else is an exact redirect and stays a
+// 0-byte S3 object served directly by CloudFront.
+const isManifestKind = (source: string): boolean => source.endsWith("/*")
+
+export function partitionRedirects(rows: Redirect[]): {
+  exact: Redirect[]
+  manifestEntries: Redirect[]
+} {
+  const exact: Redirect[] = []
+  const manifestEntries: Redirect[] = []
+  for (const r of rows) {
+    ;(isManifestKind(r.source) ? manifestEntries : exact).push(r)
+  }
+  return { exact, manifestEntries }
+}
+
+// `version` is the manifest schema version: the edge resolver reads it to know
+// how to interpret the file, so an incompatible future format can bump it and
+// let the resolver branch on / reject an unexpected version rather than
+// mis-parsing. Bump it only on a breaking shape change.
+export const MANIFEST_VERSION = 1
+
+export function buildManifest(entries: Redirect[]): {
+  version: number
+  redirects: Record<string, string>
+} {
+  const redirects: Record<string, string> = {}
+  for (const { source, destination } of entries) redirects[source] = destination
+  return { version: MANIFEST_VERSION, redirects }
+}
+
+async function uploadManifest(
+  client: S3Client,
+  config: UploadConfig,
+  entries: Redirect[],
+): Promise<void> {
+  const body = JSON.stringify(buildManifest(entries))
+  await client.send(
+    new PutObjectCommand({
+      Bucket: config.s3BucketName,
+      Key: `${config.siteName}/${config.buildNumber}/latest/${MANIFEST_KEY_SUFFIX}`,
+      Body: body,
+      ContentType: "application/json",
+      CacheControl: "max-age=600",
+    }),
+  )
+}
+
 async function uploadOne(
   client: S3Client,
   config: UploadConfig,
@@ -170,9 +221,15 @@ async function main(): Promise<void> {
     `Loaded ${raw.length} redirect row(s) from ${config.redirectsJson}`,
   )
 
+  // Partition BEFORE per-kind normalisation: wildcard sources must not go
+  // through normalizeSource (it strips the leading slash and would mangle the
+  // "/*"). Their stored sources are already canonical (written by the schema).
+  const { exact: rawExact, manifestEntries } = partitionRedirects(raw)
+
+  // Exact: normalise the S3 key (decode %-encoding, strip slashes, safety checks).
   const seen = new Set<string>()
-  const valid: Redirect[] = []
-  for (const r of raw) {
+  const validExact: Redirect[] = []
+  for (const r of rawExact) {
     const source = normalizeSource(r.source)
     if (!source) {
       console.warn(
@@ -190,29 +247,42 @@ async function main(): Promise<void> {
       )
     }
     seen.add(source)
-    valid.push({ source, destination: r.destination })
-  }
-
-  if (valid.length === 0) {
-    console.log("No valid redirects to upload.")
-    return
+    validExact.push({ source, destination: r.destination })
   }
 
   // Region/credentials come from the environment (CodeBuild IAM role +
   // AWS_REGION), same as `aws s3 cp` previously.
   const client = new S3Client({})
+  let totalFailed = 0
 
-  console.log(
-    `Uploading ${valid.length} redirect(s) with concurrency ${config.concurrency}...`,
-  )
-  const { failed } = await runWithConcurrency(
-    client,
-    config,
-    valid,
-    config.concurrency,
-  )
-  console.log(`Uploaded ${valid.length - failed}/${valid.length} redirects.`)
-  if (failed > 0) process.exit(1)
+  if (validExact.length > 0) {
+    console.log(
+      `Uploading ${validExact.length} exact redirect(s) with concurrency ${config.concurrency}...`,
+    )
+    const { failed } = await runWithConcurrency(
+      client,
+      config,
+      validExact,
+      config.concurrency,
+    )
+    console.log(
+      `Uploaded ${validExact.length - failed}/${validExact.length} exact redirects.`,
+    )
+    totalFailed += failed
+  }
+
+  // Wildcard sources go to a single manifest the edge resolver reads.
+  if (manifestEntries.length > 0) {
+    await uploadManifest(client, config, manifestEntries)
+    console.log(`Uploaded manifest with ${manifestEntries.length} rule(s).`)
+  }
+
+  if (validExact.length === 0 && manifestEntries.length === 0) {
+    console.log("No valid redirects to upload.")
+    return
+  }
+
+  if (totalFailed > 0) process.exit(1)
 }
 
 // Run only when executed directly (`tsx uploadRedirects.ts`), not when the file


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +322 | -61 |
| 🧪 Test | 4 | +274 | -5 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Studio rejects a trailing `/*` as a redirect source, so wildcard redirects (`/prefix/*`, which redirect a whole subtree) can't be authored. This PR adds the schema acceptance, build-time manifest generation, and service-layer coverage — everything needed before the UI (#2841) and the Lambda@Edge resolver (held, separate infra PR).

> Note: query-param sources (`/path?a=1`) were considered but **dropped** — they can't be resolved correctly behind CloudFront's path-only cache key, so redirect resolution stays path/wildcard-based.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- **Schema (`apps/studio/src/schemas/redirect.ts`)**: `sourceSchema` now accepts a single **trailing `/*`** wildcard. The shape check runs on normalised path segments, so it rejects a bare/root wildcard (`/*`, `//*`, `/./*`), a mid-string `*`, and multiple `*`. New exports: `redirectKind` (classifies a stored source as `"exact" | "wildcard"`) and the `RedirectKind` type.
- **Build (`tooling/build/scripts/publishing/uploadRedirects.ts`)**: `partitionRedirects()` splits the loaded `redirects.json` by source shape. Exact sources continue to upload as 0-byte S3 objects (unchanged). Wildcard sources are collected into a single versioned `_redirects/manifest.json` (`{ version: 1, redirects: { [source]: destination } }`) at `…/<SITE>/<BUILD>/latest/_redirects/manifest.json`, merged into the CLI (`parseArgs`/`config`) upload path. New exports: `partitionRedirects`, `buildManifest`, `MANIFEST_KEY_SUFFIX`, `MANIFEST_VERSION`.

**Improvements**:

- `normalizeRedirectSource` preserves a trailing `/*` on the normalised path, so the stored key is byte-identical to what the edge resolver computes from an incoming request.

## Before & After Screenshots

N/A — no UI changes in this PR.

## Tests

**Manual Verification Steps**:

- [ ] Confirm the schema **accepts** `/news/*` and lowercases the path (`/News/*` → `/news/*`).
- [ ] Confirm the schema **rejects** a mid-string wildcard (`/a/*/b`) and every root-equivalent wildcard (`/*`, `//*`, `/./*`).
- [ ] Confirm a query-string source (e.g. `/gallery.html?a=1`) is **rejected** (query sources are not supported).
- [ ] (Unit — covered) `pnpm --filter isomer-studio test:unit -- src/schemas/__tests__/redirect.test.ts` passes.
- [ ] (Unit — covered) `cd tooling/build/scripts/publishing && pnpm test` passes (partition + manifest).

**New dependencies**:

None.

**New dev dependencies**:

None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds wildcard redirect support and publishes wildcard rules through a build manifest. The main changes are:

- Accepts a single trailing `/*` in redirect source schemas.
- Normalizes wildcard sources while preserving the trailing wildcard marker.
- Adds redirect service checks for wildcard sources that would shadow live pages.
- Emits wildcard redirects into a versioned `_redirects/manifest.json` during publishing.
- Adds tests for schema validation, service behavior, bulk validation, and manifest generation.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR has one contained issue in bulk wildcard redirect creation.

Schema handling, create validation, bulk preview validation, and manifest publishing are covered. The bulk-create transaction recheck does not mirror wildcard subtree shadowing, so a publish race can persist incorrect redirect state.

**Files Needing Attention:** apps/studio/src/server/modules/redirect/redirect.service.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Node harness that mirrors the bulk transaction recheck and published a /news/story descendant; the harness showed the wildcard-aware subtree detects the live descendant while the literal /news/\* recheck maps to null, and the command exited with code 1 after indicating the redirect insertion would be permitted despite the live descendant.
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<a href="https://app.greptile.com/trex/runs/16702256/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/schemas/__tests__/redirect.test.ts | Adds schema tests for accepted trailing wildcard sources, rejected invalid wildcard/query forms, and redirectKind classification. |
| apps/studio/src/schemas/redirect.ts | Extends redirect source validation and normalization to support trailing `/*` wildcards while keeping reserved, query, and source-shape guards. |
| apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts | Adds bulk validation coverage for wildcard sources that would shadow live pages at or beneath their prefix. |
| apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts | Adds create-route coverage for storing wildcard redirects and blocking wildcards over existing published content. |
| apps/studio/src/server/modules/redirect/redirect.service.ts | Adds wildcard live-page shadow checks for validation, create, and bulk preview, but the bulk-create transaction recheck still misses wildcard descendant shadowing. |
| tooling/build/scripts/publishing/tests/uploadRedirects.test.ts | Adds partition and manifest tests, including duplicate wildcard source handling. |
| tooling/build/scripts/publishing/uploadRedirects.ts | Partitions exact redirects from wildcard redirects and uploads a versioned wildcard manifest alongside existing exact S3 redirect objects. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Editor
participant Studio as Studio redirect service
participant DB as Postgres Redirect/Resource
participant Publisher as Build uploadRedirects
participant S3 as S3 latest prefix
participant Edge as Lambda@Edge resolver

Editor->>Studio: "Create or bulk upload /prefix/* redirect"
Studio->>Studio: Validate source schema and classify wildcard
Studio->>DB: Check live pages at/under wildcard prefix
Studio->>DB: Store redirect source and destination
Studio->>Publisher: Publish site redirects.json
Publisher->>Publisher: Partition exact vs wildcard redirects
Publisher->>S3: Upload exact redirect objects
Publisher->>S3: Upload _redirects/manifest.json
Edge->>S3: Read wildcard manifest for prefix resolution
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `apps/studio/src/server/modules/redirect/redirect.service.ts`, line 1514-1521 ([link](https://github.com/opengovsg/isomer/blob/bb6e80e5ab8a13eb7a1a7a68802ddcd28e5e313b/apps/studio/src/server/modules/redirect/redirect.service.ts#L1514-L1521)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Check wildcard shadows**
   `assertPermalinkNotShadowed` only looks for a redirect whose `source` exactly equals `newFullPermalink`. With this PR, a live redirect like `/news/*` also shadows a page published or moved to `/news/story`, but this query returns no row. The page can go live behind an existing wildcard redirect and remain unreachable on the published site.

   **Context Used:** apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/redirect/redirect.service.ts
   Line: 1514-1521
   
   Comment:
   **Check wildcard shadows**
   `assertPermalinkNotShadowed` only looks for a redirect whose `source` exactly equals `newFullPermalink`. With this PR, a live redirect like `/news/*` also shadows a page published or moved to `/news/story`, but this query returns no row. The page can go live behind an existing wildcard redirect and remain unreachable on the published site.
   
   **Context Used:** apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201514-1521%0A%0AComment%3A%0A**Check%20wildcard%20shadows**%0A%60assertPermalinkNotShadowed%60%20only%20looks%20for%20a%20redirect%20whose%20%60source%60%20exactly%20equals%20%60newFullPermalink%60.%20With%20this%20PR%2C%20a%20live%20redirect%20like%20%60%2Fnews%2F*%60%20also%20shadows%20a%20page%20published%20or%20moved%20to%20%60%2Fnews%2Fstory%60%2C%20but%20this%20query%20returns%20no%20row.%20The%20page%20can%20go%20live%20behind%20an%20existing%20wildcard%20redirect%20and%20remain%20unreachable%20on%20the%20published%20site.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201514-1521%0A%0AComment%3A%0A**Check%20wildcard%20shadows**%0A%60assertPermalinkNotShadowed%60%20only%20looks%20for%20a%20redirect%20whose%20%60source%60%20exactly%20equals%20%60newFullPermalink%60.%20With%20this%20PR%2C%20a%20live%20redirect%20like%20%60%2Fnews%2F*%60%20also%20shadows%20a%20page%20published%20or%20moved%20to%20%60%2Fnews%2Fstory%60%2C%20but%20this%20query%20returns%20no%20row.%20The%20page%20can%20go%20live%20behind%20an%20existing%20wildcard%20redirect%20and%20remain%20unreachable%20on%20the%20published%20site.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fwildcard-redirects-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fwildcard-redirects-2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201514-1521%0A%0AComment%3A%0A**Check%20wildcard%20shadows**%0A%60assertPermalinkNotShadowed%60%20only%20looks%20for%20a%20redirect%20whose%20%60source%60%20exactly%20equals%20%60newFullPermalink%60.%20With%20this%20PR%2C%20a%20live%20redirect%20like%20%60%2Fnews%2F*%60%20also%20shadows%20a%20page%20published%20or%20moved%20to%20%60%2Fnews%2Fstory%60%2C%20but%20this%20query%20returns%20no%20row.%20The%20page%20can%20go%20live%20behind%20an%20existing%20wildcard%20redirect%20and%20remain%20unreachable%20on%20the%20published%20site.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>

2. `apps/studio/src/server/modules/redirect/redirect.service.ts`, line 1276-1292 ([link](https://github.com/opengovsg/isomer/blob/bb6e80e5ab8a13eb7a1a7a68802ddcd28e5e313b/apps/studio/src/server/modules/redirect/redirect.service.ts#L1276-L1292)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Recheck wildcard races**
   `bulkCreateRedirects` revalidates wildcard rows before insert, but this race recheck passes the literal `/news/*` source into `getResourceIdsByPermalinks`. That cannot resolve the `/news` prefix or its subtree, so if `/news/story` is published after validation and before this transaction, the bulk insert still commits a wildcard redirect that shadows the live page.

   **Context Used:** apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/redirect/redirect.service.ts
   Line: 1276-1292
   
   Comment:
   **Recheck wildcard races**
   `bulkCreateRedirects` revalidates wildcard rows before insert, but this race recheck passes the literal `/news/*` source into `getResourceIdsByPermalinks`. That cannot resolve the `/news` prefix or its subtree, so if `/news/story` is published after validation and before this transaction, the bulk insert still commits a wildcard redirect that shadows the live page.
   
   **Context Used:** apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201276-1292%0A%0AComment%3A%0A**Recheck%20wildcard%20races**%0A%60bulkCreateRedirects%60%20revalidates%20wildcard%20rows%20before%20insert%2C%20but%20this%20race%20recheck%20passes%20the%20literal%20%60%2Fnews%2F*%60%20source%20into%20%60getResourceIdsByPermalinks%60.%20That%20cannot%20resolve%20the%20%60%2Fnews%60%20prefix%20or%20its%20subtree%2C%20so%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20the%20bulk%20insert%20still%20commits%20a%20wildcard%20redirect%20that%20shadows%20the%20live%20page.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201276-1292%0A%0AComment%3A%0A**Recheck%20wildcard%20races**%0A%60bulkCreateRedirects%60%20revalidates%20wildcard%20rows%20before%20insert%2C%20but%20this%20race%20recheck%20passes%20the%20literal%20%60%2Fnews%2F*%60%20source%20into%20%60getResourceIdsByPermalinks%60.%20That%20cannot%20resolve%20the%20%60%2Fnews%60%20prefix%20or%20its%20subtree%2C%20so%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20the%20bulk%20insert%20still%20commits%20a%20wildcard%20redirect%20that%20shadows%20the%20live%20page.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fwildcard-redirects-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fwildcard-redirects-2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201276-1292%0A%0AComment%3A%0A**Recheck%20wildcard%20races**%0A%60bulkCreateRedirects%60%20revalidates%20wildcard%20rows%20before%20insert%2C%20but%20this%20race%20recheck%20passes%20the%20literal%20%60%2Fnews%2F*%60%20source%20into%20%60getResourceIdsByPermalinks%60.%20That%20cannot%20resolve%20the%20%60%2Fnews%60%20prefix%20or%20its%20subtree%2C%20so%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20the%20bulk%20insert%20still%20commits%20a%20wildcard%20redirect%20that%20shadows%20the%20live%20page.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>

3. `apps/studio/src/server/modules/redirect/redirect.service.ts`, line 1277-1288 ([link](https://github.com/opengovsg/isomer/blob/b38360c3070add38a01d266946ee2a3ca70c31cc/apps/studio/src/server/modules/redirect/redirect.service.ts#L1277-L1288)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Recheck wildcard shadowing**
   The transactional bulk-create recheck still treats every source as an exact permalink, so a race can publish a wildcard over a newly published descendant. `runBulkValidation` now walks wildcard subtrees, but here `getResourceIdsByPermalinks(siteId, sources)` looks up the literal `/news/*`; if `/news/story` is published after validation and before this transaction, `shadowsLivePage` stays false and the batch commits a redirect that shadows the live page. Reuse the wildcard subtree check here before inserting.

   **Context Used:** apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))
   
   <details><summary><strong>Artifacts</strong></summary><br />
   
   **[Repro: focused wildcard transaction recheck harness](https://app.greptile.com/trex/artifacts/59276f72-7149-4f7c-8b72-4fc3a8c1a67f)**
   
   - Evidence file captured while the check ran.
   
   **[Repro: harness output showing literal wildcard lookup misses live descendant](https://app.greptile.com/trex/artifacts/e6666642-c7c8-4d79-8795-57f0d1124119)**
   
   - The full command output behind this check.
   
   <a href="https://app.greptile.com/trex/runs/16702256/artifacts?artifact=59276f72-7149-4f7c-8b72-4fc3a8c1a67f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/redirect/redirect.service.ts
   Line: 1277-1288
   
   Comment:
   **Recheck wildcard shadowing**
   The transactional bulk-create recheck still treats every source as an exact permalink, so a race can publish a wildcard over a newly published descendant. `runBulkValidation` now walks wildcard subtrees, but here `getResourceIdsByPermalinks(siteId, sources)` looks up the literal `/news/*`; if `/news/story` is published after validation and before this transaction, `shadowsLivePage` stays false and the batch commits a redirect that shadows the live page. Reuse the wildcard subtree check here before inserting.
   
   **Context Used:** apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201277-1288%0A%0AComment%3A%0A**Recheck%20wildcard%20shadowing**%0AThe%20transactional%20bulk-create%20recheck%20still%20treats%20every%20source%20as%20an%20exact%20permalink%2C%20so%20a%20race%20can%20publish%20a%20wildcard%20over%20a%20newly%20published%20descendant.%20%60runBulkValidation%60%20now%20walks%20wildcard%20subtrees%2C%20but%20here%20%60getResourceIdsByPermalinks%28siteId%2C%20sources%29%60%20looks%20up%20the%20literal%20%60%2Fnews%2F*%60%3B%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20%60shadowsLivePage%60%20stays%20false%20and%20the%20batch%20commits%20a%20redirect%20that%20shadows%20the%20live%20page.%20Reuse%20the%20wildcard%20subtree%20check%20here%20before%20inserting.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201277-1288%0A%0AComment%3A%0A**Recheck%20wildcard%20shadowing**%0AThe%20transactional%20bulk-create%20recheck%20still%20treats%20every%20source%20as%20an%20exact%20permalink%2C%20so%20a%20race%20can%20publish%20a%20wildcard%20over%20a%20newly%20published%20descendant.%20%60runBulkValidation%60%20now%20walks%20wildcard%20subtrees%2C%20but%20here%20%60getResourceIdsByPermalinks%28siteId%2C%20sources%29%60%20looks%20up%20the%20literal%20%60%2Fnews%2F*%60%3B%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20%60shadowsLivePage%60%20stays%20false%20and%20the%20batch%20commits%20a%20redirect%20that%20shadows%20the%20live%20page.%20Reuse%20the%20wildcard%20subtree%20check%20here%20before%20inserting.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fwildcard-redirects-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fwildcard-redirects-2%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%0ALine%3A%201277-1288%0A%0AComment%3A%0A**Recheck%20wildcard%20shadowing**%0AThe%20transactional%20bulk-create%20recheck%20still%20treats%20every%20source%20as%20an%20exact%20permalink%2C%20so%20a%20race%20can%20publish%20a%20wildcard%20over%20a%20newly%20published%20descendant.%20%60runBulkValidation%60%20now%20walks%20wildcard%20subtrees%2C%20but%20here%20%60getResourceIdsByPermalinks%28siteId%2C%20sources%29%60%20looks%20up%20the%20literal%20%60%2Fnews%2F*%60%3B%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20%60shadowsLivePage%60%20stays%20false%20and%20the%20batch%20commits%20a%20redirect%20that%20shadows%20the%20live%20page.%20Reuse%20the%20wildcard%20subtree%20check%20here%20before%20inserting.%0A%0A**Context%20Used%3A**%20apps%2Fstudio%2Fsrc%2Fserver%2FCLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Fopengovsg%2Fgithub%2Fopengovsg%2Fisomer%2F-%2Fcustom-context%3Fmemory%3D3a90a680-2aa0-4412-a830-5cb1e15f4dad%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%3A1277-1288%0A**Recheck%20wildcard%20shadowing**%0AThe%20transactional%20bulk-create%20recheck%20still%20treats%20every%20source%20as%20an%20exact%20permalink%2C%20so%20a%20race%20can%20publish%20a%20wildcard%20over%20a%20newly%20published%20descendant.%20%60runBulkValidation%60%20now%20walks%20wildcard%20subtrees%2C%20but%20here%20%60getResourceIdsByPermalinks%28siteId%2C%20sources%29%60%20looks%20up%20the%20literal%20%60%2Fnews%2F*%60%3B%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20%60shadowsLivePage%60%20stays%20false%20and%20the%20batch%20commits%20a%20redirect%20that%20shadows%20the%20live%20page.%20Reuse%20the%20wildcard%20subtree%20check%20here%20before%20inserting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%3A1277-1288%0A**Recheck%20wildcard%20shadowing**%0AThe%20transactional%20bulk-create%20recheck%20still%20treats%20every%20source%20as%20an%20exact%20permalink%2C%20so%20a%20race%20can%20publish%20a%20wildcard%20over%20a%20newly%20published%20descendant.%20%60runBulkValidation%60%20now%20walks%20wildcard%20subtrees%2C%20but%20here%20%60getResourceIdsByPermalinks%28siteId%2C%20sources%29%60%20looks%20up%20the%20literal%20%60%2Fnews%2F*%60%3B%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20%60shadowsLivePage%60%20stays%20false%20and%20the%20batch%20commits%20a%20redirect%20that%20shadows%20the%20live%20page.%20Reuse%20the%20wildcard%20subtree%20check%20here%20before%20inserting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2840&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fwildcard-redirects-2%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fwildcard-redirects-2%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fredirect%2Fredirect.service.ts%3A1277-1288%0A**Recheck%20wildcard%20shadowing**%0AThe%20transactional%20bulk-create%20recheck%20still%20treats%20every%20source%20as%20an%20exact%20permalink%2C%20so%20a%20race%20can%20publish%20a%20wildcard%20over%20a%20newly%20published%20descendant.%20%60runBulkValidation%60%20now%20walks%20wildcard%20subtrees%2C%20but%20here%20%60getResourceIdsByPermalinks%28siteId%2C%20sources%29%60%20looks%20up%20the%20literal%20%60%2Fnews%2F*%60%3B%20if%20%60%2Fnews%2Fstory%60%20is%20published%20after%20validation%20and%20before%20this%20transaction%2C%20%60shadowsLivePage%60%20stays%20false%20and%20the%20batch%20commits%20a%20redirect%20that%20shadows%20the%20live%20page.%20Reuse%20the%20wildcard%20subtree%20check%20here%20before%20inserting.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/server/modules/redirect/redirect.service.ts:1277-1288
**Recheck wildcard shadowing**
The transactional bulk-create recheck still treats every source as an exact permalink, so a race can publish a wildcard over a newly published descendant. `runBulkValidation` now walks wildcard subtrees, but here `getResourceIdsByPermalinks(siteId, sources)` looks up the literal `/news/*`; if `/news/story` is published after validation and before this transaction, `shadowsLivePage` stays false and the batch commits a redirect that shadows the live page. Reuse the wildcard subtree check here before inserting.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["fix(redirects): block a wildcard source ..."](https://github.com/opengovsg/isomer/commit/b38360c3070add38a01d266946ee2a3ca70c31cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44963150)</sub>

**Context used:**

- Context used - apps/studio/src/server/CLAUDE.md ([source](https://app.greptile.com/opengovsg/github/opengovsg/isomer/-/custom-context?memory=3a90a680-2aa0-4412-a830-5cb1e15f4dad))

<!-- /greptile_comment -->