### PR TITLE
feat(redirects): author wildcard redirects behind advanced flag

### DIFF
--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -44,15 +44,16 @@ const safeNormalize = (raw: string): string | null => {
 }
 
 // Renders how a wildcard carries the matched remainder onto the destination,
-// e.g. "/old/*" + "/dest" -> "/old/example → /dest/example".
+// e.g. "/old/*" + "/dest" -> "/old/example → /dest/example". The destination is
+// trimmed first so the preview matches the value the schema submits (it trims),
+// rather than reflecting stray leading/trailing whitespace as the user types.
 const buildWildcardPreview = (
   normalizedSource: string,
   destination: string,
 ): string => {
   const prefix = normalizedSource.slice(0, -2) // strip trailing "/*"
-  const base = destination.endsWith("/")
-    ? destination.slice(0, -1)
-    : destination
+  const trimmed = destination.trim()
+  const base = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed
   return `${prefix}/example → ${base}/example`
 }
 

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -47,10 +47,14 @@ const safeNormalize = (raw: string): string | null => {
 // e.g. "/old/*" + "/dest" -> "/old/example → /dest/example". The destination is
 // trimmed first so the preview matches the value the schema submits (it trims),
 // rather than reflecting stray leading/trailing whitespace as the user types.
+// Returns null for a non-wildcard source instead of trusting the caller's
+// `kind === "wildcard"` check, so the "/*" strip below can never run on a
+// source that doesn't have it.
 const buildWildcardPreview = (
   normalizedSource: string,
   destination: string,
-): string => {
+): string | null => {
+  if (!normalizedSource.endsWith("/*")) return null
   const prefix = normalizedSource.slice(0, -2) // strip trailing "/*"
   const trimmed = destination.trim()
   const base = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed
@@ -94,7 +98,8 @@ export const AddRedirectCard = ({
   const [source, destination] = watch(["source", "destination"])
   const isAddDisabled = !source?.trim() || !destination?.trim()
 
-  const normalizedSource = source?.trim() ? safeNormalize(source) : null
+  const trimmedSource = source?.trim()
+  const normalizedSource = trimmedSource ? safeNormalize(trimmedSource) : null
   const kind = normalizedSource ? redirectKind(normalizedSource) : "exact"
 
   // Live preview: /old/* + /dest → /old/example → /dest/example

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Button,
   FormErrorMessage,
+  FormHelperText,
   FormLabel,
   Link,
   useToast,
@@ -27,11 +28,33 @@ import {
 } from "~/constants/toast"
 import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useZodForm } from "~/lib/form"
+import { normalizeRedirectSource, redirectKind } from "~/schemas/redirect"
 
 import { useCreateRedirect } from "../api"
 import { addRedirectSchema, type AddRedirectInput } from "../types"
 import { BulkUploadRedirectsModal } from "./BulkUploadRedirectsModal"
 import { SelectDestinationPageModal } from "./SelectDestinationPageModal"
+
+const safeNormalize = (raw: string): string | null => {
+  try {
+    return normalizeRedirectSource(raw)
+  } catch {
+    return null
+  }
+}
+
+// Renders how a wildcard carries the matched remainder onto the destination,
+// e.g. "/old/*" + "/dest" -> "/old/example → /dest/example".
+const buildWildcardPreview = (
+  normalizedSource: string,
+  destination: string,
+): string => {
+  const prefix = normalizedSource.slice(0, -2) // strip trailing "/*"
+  const base = destination.endsWith("/")
+    ? destination.slice(0, -1)
+    : destination
+  return `${prefix}/example → ${base}/example`
+}
 
 interface AddRedirectCardProps {
   siteId: number
@@ -69,6 +92,18 @@ export const AddRedirectCard = ({
 
   const [source, destination] = watch(["source", "destination"])
   const isAddDisabled = !source?.trim() || !destination?.trim()
+
+  const normalizedSource = source?.trim() ? safeNormalize(source) : null
+  const kind = normalizedSource ? redirectKind(normalizedSource) : "exact"
+
+  // Live preview: /old/* + /dest → /old/example → /dest/example
+  const wildcardPreview =
+    isAdvancedRedirectsEnabled &&
+    kind === "wildcard" &&
+    normalizedSource &&
+    destination
+      ? buildWildcardPreview(normalizedSource, destination)
+      : null
 
   // The "Redirect to a page on your site..." dropdown only surfaces while the
   // destination field is focused (per the design).
@@ -190,13 +225,24 @@ export const AddRedirectCard = ({
               /
             </InputLeftAddon>
             <Input
-              placeholder="redirect-from"
+              placeholder={
+                isAdvancedRedirectsEnabled
+                  ? "redirect-from or path/*"
+                  : "redirect-from"
+              }
               {...register("source", {
                 onChange: clearFieldFeedback("source"),
               })}
             />
           </InputGroup>
           <FormErrorMessage>{errors.source?.message}</FormErrorMessage>
+          {isAdvancedRedirectsEnabled && !errors.source && (
+            <FormHelperText fontSize="xs" color="base.content.medium">
+              {wildcardPreview
+                ? `e.g. ${wildcardPreview}`
+                : "Add /* at the end to redirect a whole section (e.g. /old-news/*)."}
+            </FormHelperText>
+          )}
         </FormControl>
 
         <Box flexShrink={0}>

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -235,6 +235,35 @@ export const AdvancedWildcardPreview: Story = {
   },
 }
 
+// Advanced flag on: a destination pasted with surrounding whitespace still
+// previews the trimmed value the schema submits, not the raw padded input.
+export const AdvancedWildcardPreviewTrimsDestination: Story = {
+  parameters: {
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement.ownerDocument.body)
+    const sourceInput = await screen.findByPlaceholderText(
+      "redirect-from or path/*",
+    )
+    await userEvent.type(sourceInput, "old-news/*")
+    await userEvent.type(
+      screen.getByPlaceholderText("/path-to-page or https://www.google.com"),
+      "  /newsroom  ",
+    )
+    await expect(
+      await screen.findByText(/old-news\/example → \/newsroom\/example/),
+    ).toBeVisible()
+  },
+}
+
 // A redirect that loops back shows the error inline on the destination.
 export const RedirectLoopError: Story = {
   parameters: {

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -207,6 +207,34 @@ export const BulkUploadWithErrors: Story = {
   },
 }
 
+// Advanced flag on: wildcard source typed — shows the live preview help text.
+export const AdvancedWildcardPreview: Story = {
+  parameters: {
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement.ownerDocument.body)
+    const sourceInput = await screen.findByPlaceholderText(
+      "redirect-from or path/*",
+    )
+    await userEvent.type(sourceInput, "old-news/*")
+    await userEvent.type(
+      screen.getByPlaceholderText("/path-to-page or https://www.google.com"),
+      "/newsroom",
+    )
+    await expect(
+      await screen.findByText(/old-news\/example → \/newsroom\/example/),
+    ).toBeVisible()
+  },
+}
+
 // A redirect that loops back shows the error inline on the destination.
 export const RedirectLoopError: Story = {
   parameters: {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +53 | -1 |
| 🧪 Test | 1 | +57 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

Studio users have no way to author wildcard redirects from the UI. This PR adds the authoring affordances behind the `is-advanced-redirects-enabled` GrowthBook flag so the feature can be dark-launched: the flag stays **off** in production until the Lambda@Edge resolver (separate, held infra PR) is deployed.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- **`AddRedirectCard`**: gates the wildcard affordances on `useIsAdvancedRedirectsEnabled()`, alongside the existing bulk-upload card. When the flag is on:
  - The source placeholder becomes `"redirect-from or path/*"` to hint at wildcards.
  - A live helper appears below the source field:
    - **Wildcard** (`/old-news/*` + destination `/newsroom`) → `e.g. /old-news/example → /newsroom/example`.
    - **Otherwise** → `"Add /* at the end to redirect a whole section (e.g. /old-news/*)."`
  - With the flag off, the form behaves exactly as before (no hint, no preview).
- **Storybook** (`Redirects.stories.tsx`): adds `AdvancedWildcardPreview` (types `/old-news/*` + `/newsroom` and asserts the preview text) and `AdvancedWildcardPreviewTrimsDestination` (asserts the preview trims a destination pasted with surrounding whitespace).

> Query-param authoring was removed with the rest of the query support (see #2840) — the form only offers wildcard sources.

**Dark-launch guard**: the flag stays **off** in production until the held infra phase (origin-response Lambda@Edge resolver) ships. With the flag off, the form only hides the wildcard hint/preview — it does not reject a wildcard `source` at the schema or API layer. That's intentional for now: the flag itself is a temporary switch removed once the resolver ships, so it isn't worth hardening server-side enforcement behind it.

## Before & After Screenshots

**BEFORE** (flag off): source input placeholder `"redirect-from"`, no helper text.

**AFTER** (flag on): placeholder `"redirect-from or path/*"`; helper `"Add /* at the end to redirect a whole section (e.g. /old-news/*)."`; with `/old-news/*` + `/newsroom` typed → `e.g. /old-news/example → /newsroom/example`.

## Tests

**Manual Verification Steps**:

- [ ] In Storybook, open `Pages/Site Management/Agency Settings Page/Redirects → AdvancedWildcardPreview`; the play function types `/old-news/*` + `/newsroom` and asserts `old-news/example → /newsroom/example` is visible.
- [ ] With the flag **off**: the source placeholder stays `"redirect-from"` and no helper text appears.
- [ ] With the flag **on**: typing `/news/*` shows the wildcard helper, and adding a destination shows the concrete example.

**New dependencies**:

None.

**New dev dependencies**:

None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds feature-flagged wildcard redirect authoring affordances in Studio. The main changes are:

- Advanced redirect placeholder text and helper copy in `AddRedirectCard`.
- Live wildcard preview for `source` values ending in `/*`.
- Storybook interaction coverage for wildcard preview and destination trimming.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one minor UX issue to consider.

The change is client-side UI and Storybook coverage behind a GrowthBook flag. The remaining issue is non-blocking: invalid wildcard shapes can show a concrete preview before validation rejects them.

**Files Needing Attention:** apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the Storybook test for isomer-studio with pnpm --filter isomer-studio storybook and saved the server logs.
- I opened two Storybook iframe pages in Playwright to exercise the site management agency redirects default and advanced wildcard preview views.
- I verified the wildcard preview by inspecting the after-state image to confirm the expected render.
- I collected and attached multiple artifacts, including logs, videos, and before/after screenshots, to support reviewer inspection.

<a href="https://app.greptile.com/trex/runs/17185724/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx | Adds feature-flagged wildcard placeholder, helper, and preview; one non-blocking UX issue lets schema-invalid wildcard shapes show a concrete preview before submit. |
| apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx | Adds Storybook coverage for advanced wildcard preview and trimmed destinations; no issues found. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant User
participant AddRedirectCard
participant GrowthBook
participant RedirectSchema
participant RedirectAPI

AddRedirectCard->>GrowthBook: useIsAdvancedRedirectsEnabled()
GrowthBook-->>AddRedirectCard: advanced flag state
alt advanced flag enabled
    User->>AddRedirectCard: type wildcard source and destination
    AddRedirectCard->>RedirectSchema: normalizeRedirectSource(source)
    RedirectSchema-->>AddRedirectCard: normalized source
    AddRedirectCard-->>User: show wildcard helper / preview
else advanced flag disabled
    AddRedirectCard-->>User: show exact-source placeholder only
end
User->>AddRedirectCard: submit redirect
AddRedirectCard->>RedirectSchema: validate addRedirectSchema
RedirectSchema-->>AddRedirectCard: normalized form input
AddRedirectCard->>RedirectAPI: createRedirect(siteId, source, destination)
RedirectAPI-->>AddRedirectCard: success or inline error
```
</details>

<sub>Reviews (9): Last reviewed commit: ["fix(redirects): trim source before norma..."](https://github.com/opengovsg/isomer/commit/b74769962793f21d0d8c16c2c94360800da89f5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44964617)</sub>

<!-- /greptile_comment -->