### PR TITLE
fix(studio): prevent invalid collection moves

### DIFF
--- a/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceItem.tsx
@@ -2,12 +2,12 @@ import type { ButtonProps } from "@opengovsg/design-system-react"
 import type { ResourceItemContent } from "~/schemas/resource"
 import { Icon, Skeleton, Text, VStack } from "@chakra-ui/react"
 import { dataAttr } from "@chakra-ui/utils"
-import { Button } from "@opengovsg/design-system-react"
+import { Button, TouchableTooltip } from "@opengovsg/design-system-react"
 import { getIcon } from "~/utils/resources"
 
 interface ResourceItemProps {
   item: ResourceItemContent
-  isDisabled?: boolean
+  disabledReason?: string
   isHighlighted?: boolean
   handleOnClick?: () => void
   hasAdditionalLeftPadding?: boolean
@@ -42,12 +42,12 @@ export const ResourceItemSkeleton = () => {
 
 export const ResourceItem = ({
   item,
-  isDisabled,
+  disabledReason,
   isHighlighted = false,
   handleOnClick,
   hasAdditionalLeftPadding = false,
 }: ResourceItemProps) => {
-  return (
+  const resourceItem = (
     <ResourceItemContainer
       data-selected={dataAttr(isHighlighted)}
       _selected={{
@@ -61,7 +61,7 @@ export const ResourceItem = ({
       {...(hasAdditionalLeftPadding && { pl: "2.25rem" })}
       onClick={handleOnClick}
       leftIcon={<Icon as={getIcon(item.type)} />}
-      isDisabled={isDisabled}
+      isDisabled={!!disabledReason}
     >
       <VStack alignItems="flex-start" textAlign="left" gap="0.25rem">
         <Text noOfLines={1} textStyle="caption-1">
@@ -72,5 +72,17 @@ export const ResourceItem = ({
         </Text>
       </VStack>
     </ResourceItemContainer>
+  )
+
+  return disabledReason ? (
+    <TouchableTooltip
+      label={disabledReason}
+      placement="right"
+      wrapperStyles={{ display: "block", width: "100%" }}
+    >
+      {resourceItem}
+    </TouchableTooltip>
+  ) : (
+    resourceItem
   )
 }

--- a/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelector.tsx
@@ -105,7 +105,7 @@ const SuspensableResourceSelector = ({
 
   const {
     isResourceIdHighlighted,
-    isResourceItemDisabled,
+    getResourceItemDisabledReason,
     hasParentInStack,
     handleClickBackButton,
     handleClickResourceItem,
@@ -153,7 +153,7 @@ const SuspensableResourceSelector = ({
         <SuspendableContent
           resourceItemsWithAncestryStack={resourceItemsWithAncestryStack}
           isResourceIdHighlighted={isResourceIdHighlighted}
-          isResourceItemDisabled={isResourceItemDisabled}
+          getResourceItemDisabledReason={getResourceItemDisabledReason}
           hasAdditionalLeftPadding={hasAdditionalLeftPadding}
           handleClickResourceItem={handleClickResourceItem}
           isSearchQueryEmpty={isSearchQueryEmpty}
@@ -166,7 +166,7 @@ const SuspensableResourceSelector = ({
   }, [
     resourceItemsWithAncestryStack,
     isResourceIdHighlighted,
-    isResourceItemDisabled,
+    getResourceItemDisabledReason,
     hasAdditionalLeftPadding,
     handleClickResourceItem,
     isSearchQueryEmpty,

--- a/apps/studio/src/components/ResourceSelector/ResourceSelectorContent.tsx
+++ b/apps/studio/src/components/ResourceSelector/ResourceSelectorContent.tsx
@@ -24,14 +24,14 @@ const NoItemsInFolderResult = () => {
 const ResourceItemsResults = ({
   resourceItemsWithAncestryStack,
   isResourceIdHighlighted,
-  isResourceItemDisabled,
+  getResourceItemDisabledReason,
   hasAdditionalLeftPadding,
   handleClickResourceItem,
 }: Pick<
   SuspendableContentProps,
   | "resourceItemsWithAncestryStack"
   | "isResourceIdHighlighted"
-  | "isResourceItemDisabled"
+  | "getResourceItemDisabledReason"
   | "hasAdditionalLeftPadding"
   | "handleClickResourceItem"
 >) => {
@@ -51,7 +51,7 @@ const ResourceItemsResults = ({
         <ResourceItem
           key={lastChild.id}
           item={lastChild}
-          isDisabled={isResourceItemDisabled(lastChild)}
+          disabledReason={getResourceItemDisabledReason(lastChild)}
           isHighlighted={isResourceIdHighlighted(lastChild.id)}
           handleOnClick={() =>
             handleClickResourceItem(resourceItemWithAncestryStack)
@@ -105,7 +105,9 @@ export const LoadingResourceItemsResults = () => {
 interface SuspendableContentProps {
   resourceItemsWithAncestryStack: ResourceItemContent[][] | undefined
   isResourceIdHighlighted: (resourceId: string) => boolean
-  isResourceItemDisabled: (resourceItem: ResourceItemContent) => boolean
+  getResourceItemDisabledReason: (
+    resourceItem: ResourceItemContent,
+  ) => string | undefined
   hasAdditionalLeftPadding: boolean
   handleClickResourceItem: (
     resourceItemWithAncestryStack: ResourceItemContent[],
@@ -118,7 +120,7 @@ interface SuspendableContentProps {
 export const SuspendableContent = ({
   resourceItemsWithAncestryStack,
   isResourceIdHighlighted,
-  isResourceItemDisabled,
+  getResourceItemDisabledReason,
   hasAdditionalLeftPadding,
   handleClickResourceItem,
   isSearchQueryEmpty,
@@ -145,7 +147,7 @@ export const SuspendableContent = ({
     <ResourceItemsResults
       resourceItemsWithAncestryStack={resourceItemsWithAncestryStack}
       isResourceIdHighlighted={isResourceIdHighlighted}
-      isResourceItemDisabled={isResourceItemDisabled}
+      getResourceItemDisabledReason={getResourceItemDisabledReason}
       hasAdditionalLeftPadding={hasAdditionalLeftPadding}
       handleClickResourceItem={handleClickResourceItem}
     />

--- a/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
+++ b/apps/studio/src/components/ResourceSelector/useResourceSelector.tsx
@@ -53,27 +53,38 @@ export const useResourceSelector = ({
     [nestedChildrenOfExistingResourceResult?.items],
   )
 
-  const isResourceItemDisabled = useCallback(
-    (resourceItem: ResourceItemContent): boolean => {
-      if (!existingResource) return false
+  const getResourceItemDisabledReason = useCallback(
+    (resourceItem: ResourceItemContent): string | undefined => {
+      if (!existingResource) return undefined
 
       // Then we are linking the resource and not moving any resource
       // Thus, no checks are needed because we can link to any resource
-      if (interactionType === "link") return false
+      if (interactionType === "link") return undefined
 
       // A resource should not be able to move to within itself
-      if (existingResource.id === resourceItem.id) return true
+      if (existingResource.id === resourceItem.id) {
+        return "This item cannot be moved into itself."
+      }
+
+      // A resource should not be able to move to its current parent
+      if (existingResource.parentId === resourceItem.id) {
+        return `This item is already in this ${resourceItem.type === ResourceType.Collection ? "collection" : "folder"}.`
+      }
 
       // If a resource is not allowed to have children then it is a page-ish resource
       // Thus, it can move to within any resource and no further checks are needed
-      if (!isAllowedToHaveChildren(existingResource.type)) return false
+      if (!isAllowedToHaveChildren(existingResource.type)) return undefined
 
       // A resource should not be able to move to its nested children
-      return (
+      if (
         nestedChildrenOfExistingResource.some(
           (child) => child.id === resourceItem.id,
-        ) || false
-      )
+        )
+      ) {
+        return "This folder cannot be moved into one of its subfolders."
+      }
+
+      return undefined
     },
     [existingResource, interactionType, nestedChildrenOfExistingResource],
   )
@@ -148,7 +159,7 @@ export const useResourceSelector = ({
 
   return {
     isResourceIdHighlighted,
-    isResourceItemDisabled,
+    getResourceItemDisabledReason,
     hasParentInStack,
     handleClickBackButton,
     handleClickResourceItem,

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -1348,6 +1348,38 @@ describe("resource.router", async () => {
       )
     })
 
+    it("should identify a collection when the destination is the same as the origin", async () => {
+      // Arrange
+      const { collection, site } = await setupCollection({
+        permalink: "collection",
+      })
+      const { page } = await setupCollectionPage({
+        siteId: site.id,
+        parentId: collection.id,
+      })
+      const auditSpy = vitest.spyOn(auditService, "logResourceEvent")
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.move({
+        siteId: site.id,
+        movedResourceId: page.id,
+        destinationResourceId: collection.id,
+      })
+
+      // Assert
+      expect(auditSpy).not.toHaveBeenCalled()
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "You cannot move a resource to the same collection",
+        }),
+      )
+    })
+
     it("should return 403 if destination is a root page but user is not an admin", async () => {
       // Arrange
       const { folder: originFolder, site } = await setupFolder({

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -412,7 +412,7 @@ export const resourceRouter = router({
             if (toMove.parentId === parent.id) {
               throw new TRPCError({
                 code: "BAD_REQUEST",
-                message: "You cannot move a resource to the same folder",
+                message: `You cannot move a resource to the same ${parent.type === ResourceType.Collection ? "collection" : "folder"}`,
               })
             }
 


### PR DESCRIPTION
## Problem

Collection items can select their current collection as a move destination. The move then fails with an inaccurate error referring to the destination as a folder.

Closes #2824

## Solution

Disabled move destinations now include a reason displayed in a right-aligned touchable tooltip. This covers:

- The resource's current folder or collection
- The resource itself
- Descendants of the resource

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

N/A

**Improvements**:

- Explain disabled move destinations using touch-compatible tooltips.

**Bug Fixes**:

- Prevent users from selecting a resource's current parent as its move destination.
- Use collection-specific error copy when moving an item into its current collection.

## Before & After Screenshots

**BEFORE**:

N/A

**AFTER**:

N/A

## Tests

- Focused resource router tests covering same-origin folder and collection moves

**Manual Verification Steps**:

- [ ] Create a collection and add a collection item.
- [ ] Open the item's move modal and search for its current collection.
- [ ] Confirm the current collection is disabled and its tooltip appears on the right with the message: “This item is already in this collection.”
- [ ] Create a second collection and confirm it remains selectable as a valid destination.
- [ ] Create a parent folder containing a child folder.
- [ ] Open the parent folder's move modal and confirm the parent is disabled with the message: “This item cannot be moved into itself.”
- [ ] Search for the child folder and confirm it is disabled with the message: “This folder cannot be moved into one of its subfolders.”

**New scripts**:

N/A

**New dependencies**:

N/A

**New dev dependencies**:

N/A
