### PR TITLE
feat(ci): add PR diff breakdown (App/Test/Doc/Ignore) to PR description

### DIFF
--- a/.github/scripts/classify-pr-diff.mjs
+++ b/.github/scripts/classify-pr-diff.mjs
@@ -9,6 +9,7 @@
 //   HEAD_SHA   the PR head commit
 
 import { execFileSync } from "node:child_process"
+import { matchesGlob } from "node:path"
 
 const BASE_SHA = requireEnv("BASE_SHA")
 const HEAD_SHA = requireEnv("HEAD_SHA")
@@ -64,46 +65,10 @@ function requireEnv(name) {
   return value
 }
 
-// Minimal glob->RegExp: this repo's bucket globs only ever use `*` and `**`,
-// so a full glob library (brace expansion, extglob, etc.) would be unused
-// surface area — this covers exactly what's needed.
-function globToRegExp(glob) {
-  let pattern = "^"
-  for (let i = 0; i < glob.length; ) {
-    const char = glob[i]
-    if (char === "*" && glob[i + 1] === "*") {
-      pattern += ".*"
-      i += 2
-      if (glob[i] === "/") i += 1
-      continue
-    }
-    if (char === "*") {
-      pattern += "[^/]*"
-      i += 1
-      continue
-    }
-    if ("\\^$.|?+()[]{}".includes(char)) {
-      pattern += `\\${char}`
-      i += 1
-      continue
-    }
-    pattern += char
-    i += 1
-  }
-  return new RegExp(`${pattern}$`)
-}
-
-const matchers = Object.fromEntries(
-  Object.entries(BUCKET_GLOBS).map(([bucket, globs]) => [
-    bucket,
-    globs.map(globToRegExp),
-  ]),
-)
-
 function classify(path) {
   for (const bucket of BUCKET_ORDER) {
     if (bucket === "app") return "app"
-    if (matchers[bucket].some((re) => re.test(path))) return bucket
+    if (BUCKET_GLOBS[bucket].some((glob) => matchesGlob(path, glob))) return bucket
   }
   return "app"
 }

--- a/.github/scripts/classify-pr-diff.mjs
+++ b/.github/scripts/classify-pr-diff.mjs
@@ -129,7 +129,12 @@ function resolveRenamedPath(rawPath) {
 
 const numstat = execFileSync(
   "git",
-  ["diff", "--numstat", BASE_SHA, HEAD_SHA],
+  [
+    "diff",
+    "--numstat",
+    "-M", // detect renames explicitly — don't rely on the runner's diff.renames config
+    `${BASE_SHA}...${HEAD_SHA}`, // three-dot: diff against the merge-base, not base's current tip
+  ],
   { encoding: "utf8" },
 )
   .trim()

--- a/.github/scripts/classify-pr-diff.mjs
+++ b/.github/scripts/classify-pr-diff.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Buckets every file in a PR's diff into App / Test / Doc / Ignore and sums
+// added/deleted lines per bucket. Globs are derived from what this repo
+// actually uses (see docs/risk-taxonomy.md and the vitest/playwright/storybook
+// setups under apps/studio and packages/components) — not generic assumptions.
+//
+// Required env:
+//   BASE_SHA   the PR base commit
+//   HEAD_SHA   the PR head commit
+
+import { execFileSync } from "node:child_process"
+
+const BASE_SHA = requireEnv("BASE_SHA")
+const HEAD_SHA = requireEnv("HEAD_SHA")
+
+// Checked in this order — first match wins. Anything left over falls through
+// to "app" by elimination.
+const BUCKET_GLOBS = {
+  ignore: [
+    "pnpm-lock.yaml",
+    "**/*.lock",
+    "packages/db/src/generated/**",
+    "packages/db/prisma/generated/**",
+    "apps/studio/src/theme/generated/**",
+    "apps/studio/public/assets/css/preview-tw.css",
+    "**/dist/**",
+    "**/.next/**",
+    "**/storybook-static/**",
+    "**/*.tsbuildinfo",
+    "next-env.d.ts",
+  ],
+  doc: [
+    "docs/**",
+    "**/README.md",
+    "**/CONTEXT.md",
+    "**/CLAUDE.md",
+    "**/*.mdx",
+    "**/*.md",
+    ".github/pull_request_template.md",
+  ],
+  test: [
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "apps/studio/tests/e2e/**",
+    "apps/studio/tests/integration/**",
+    "apps/studio/tests/msw/**",
+    "apps/studio/tests/load/**",
+    "tooling/build/scripts/publishing/tests/**",
+    "**/*.stories.tsx",
+    "**/stories/**",
+    "**/*.snap",
+    "**/vitest*.config.*",
+    "**/playwright.config.ts",
+  ],
+}
+
+const BUCKET_ORDER = ["ignore", "doc", "test", "app"]
+const BUCKET_LABELS = {
+  ignore: "🚫 Ignore",
+  doc: "📄 Doc",
+  test: "🧪 Test",
+  app: "⚙️ App",
+}
+
+function requireEnv(name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing required env var: ${name}`)
+  return value
+}
+
+// Minimal glob->RegExp: this repo's bucket globs only ever use `*` and `**`,
+// so a full glob library (brace expansion, extglob, etc.) would be unused
+// surface area — this covers exactly what's needed.
+function globToRegExp(glob) {
+  let pattern = "^"
+  for (let i = 0; i < glob.length; ) {
+    const char = glob[i]
+    if (char === "*" && glob[i + 1] === "*") {
+      pattern += ".*"
+      i += 2
+      if (glob[i] === "/") i += 1
+      continue
+    }
+    if (char === "*") {
+      pattern += "[^/]*"
+      i += 1
+      continue
+    }
+    if ("\\^$.|?+()[]{}".includes(char)) {
+      pattern += `\\${char}`
+      i += 1
+      continue
+    }
+    pattern += char
+    i += 1
+  }
+  return new RegExp(`${pattern}$`)
+}
+
+const matchers = Object.fromEntries(
+  Object.entries(BUCKET_GLOBS).map(([bucket, globs]) => [
+    bucket,
+    globs.map(globToRegExp),
+  ]),
+)
+
+function classify(path) {
+  for (const bucket of BUCKET_ORDER) {
+    if (bucket === "app") return "app"
+    if (matchers[bucket].some((re) => re.test(path))) return bucket
+  }
+  return "app"
+}
+
+// `git diff --numstat` renders renames as either `old => new` or the more
+// compact `prefix{old => new}suffix` for partial-path renames. Classify on
+// the new path in both cases.
+function resolveRenamedPath(rawPath) {
+  const braceMatch = rawPath.match(/^(.*)\{.* => (.*)\}(.*)$/)
+  if (braceMatch) {
+    const [, prefix, newPart, suffix] = braceMatch
+    return `${prefix}${newPart}${suffix}`
+  }
+  const plainMatch = rawPath.match(/^(?:.* => )(.*)$/)
+  if (plainMatch) return plainMatch[1]
+  return rawPath
+}
+
+const numstat = execFileSync(
+  "git",
+  ["diff", "--numstat", BASE_SHA, HEAD_SHA],
+  { encoding: "utf8" },
+)
+  .trim()
+  .split("\n")
+  .filter(Boolean)
+
+const totals = Object.fromEntries(
+  [...BUCKET_ORDER].map((bucket) => [bucket, { add: 0, del: 0, files: 0 }]),
+)
+
+for (const line of numstat) {
+  const [addRaw, delRaw, rawPath] = line.split("\t")
+  // Binary files report "-" for both counts.
+  const add = addRaw === "-" ? 0 : Number(addRaw)
+  const del = delRaw === "-" ? 0 : Number(delRaw)
+  const path = resolveRenamedPath(rawPath)
+  const bucket = classify(path)
+  totals[bucket].add += add
+  totals[bucket].del += del
+  totals[bucket].files += 1
+}
+
+const grandTotal = BUCKET_ORDER.reduce(
+  (sum, bucket) => sum + totals[bucket].files,
+  0,
+)
+
+// Wrapped in a start/end pair (rather than one marker line) so
+// update-pr-description.mjs can find-and-replace this whole block inside a
+// PR description on every push, instead of stacking a copy per push.
+let body = "<!-- pr-diff-breakdown:start -->\n"
+body += "### 📊 PR diff breakdown\n\n"
+body += "| Bucket | Files | +Lines | -Lines |\n"
+body += "|---|---|---|---|\n"
+for (const bucket of BUCKET_ORDER) {
+  const t = totals[bucket]
+  body += `| ${BUCKET_LABELS[bucket]} | ${t.files} | +${t.add} | -${t.del} |\n`
+}
+body += `\n${grandTotal} file(s) changed. Buckets derived from [\`docs/risk-taxonomy.md\`](../blob/main/docs/risk-taxonomy.md) conventions.\n`
+body += "<!-- pr-diff-breakdown:end -->\n"
+
+process.stdout.write(body)

--- a/.github/scripts/classify-pr-diff.mjs
+++ b/.github/scripts/classify-pr-diff.mjs
@@ -16,28 +16,15 @@ const HEAD_SHA = requireEnv("HEAD_SHA")
 // Checked in this order — first match wins. Anything left over falls through
 // to "app" by elimination.
 const BUCKET_GLOBS = {
-  ignore: [
-    "pnpm-lock.yaml",
-    "**/*.lock",
-    "packages/db/src/generated/**",
-    "packages/db/prisma/generated/**",
-    "apps/studio/src/theme/generated/**",
-    "apps/studio/public/assets/css/preview-tw.css",
-    "**/dist/**",
-    "**/.next/**",
-    "**/storybook-static/**",
-    "**/*.tsbuildinfo",
-    "next-env.d.ts",
-  ],
-  doc: [
-    "docs/**",
-    "**/README.md",
-    "**/CONTEXT.md",
-    "**/CLAUDE.md",
-    "**/*.mdx",
-    "**/*.md",
-    ".github/pull_request_template.md",
-  ],
+  // Only paths that can actually appear in a real diff: everything else that
+  // was here previously (dist/, .next/, storybook-static/, *.tsbuildinfo,
+  // next-env.d.ts, preview-tw.css, packages/db/prisma/generated/) is already
+  // gitignored, so it can't show up here short of a force-add — in which
+  // case it's arguably worth surfacing, not hiding. These two generated dirs
+  // are the exception: verified with `git check-ignore` that neither is
+  // actually covered by .gitignore, despite living next to dirs that are.
+  ignore: ["pnpm-lock.yaml", "packages/db/src/generated/**", "apps/studio/src/theme/generated/**"],
+  doc: ["**/*.md", "**/*.mdx"],
   test: [
     "**/__tests__/**",
     "**/*.test.ts",
@@ -47,15 +34,23 @@ const BUCKET_GLOBS = {
     "apps/studio/tests/msw/**",
     "apps/studio/tests/load/**",
     "tooling/build/scripts/publishing/tests/**",
+    "**/*.stories.ts",
     "**/*.stories.tsx",
     "**/stories/**",
     "**/*.snap",
-    "**/vitest*.config.*",
-    "**/playwright.config.ts",
   ],
 }
 
+// Classification priority (ignore > doc > test > app) — NOT the same as the
+// table's row order below. Doc has to be checked before test so e.g. a
+// .mdx file under a stories/ dir counts as Doc, not Test.
 const BUCKET_ORDER = ["ignore", "doc", "test", "app"]
+
+// Table row order — independent of classification priority above, purely
+// for readability (App first, since that's usually what a reviewer cares
+// about most).
+const TABLE_ORDER = ["app", "test", "doc", "ignore"]
+
 const BUCKET_LABELS = {
   ignore: "🚫 Ignore",
   doc: "📄 Doc",
@@ -169,7 +164,7 @@ let body = "<!-- pr-diff-breakdown:start -->\n"
 body += "### 📊 PR diff breakdown\n\n"
 body += "| Bucket | Files | +Lines | -Lines |\n"
 body += "|---|---|---|---|\n"
-for (const bucket of BUCKET_ORDER) {
+for (const bucket of TABLE_ORDER) {
   const t = totals[bucket]
   body += `| ${BUCKET_LABELS[bucket]} | ${t.files} | +${t.add} | -${t.del} |\n`
 }

--- a/.github/scripts/update-pr-description.mjs
+++ b/.github/scripts/update-pr-description.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Prepends the PR diff-breakdown block to a PR's description, replacing any
+// block a previous run already inserted (matched via the
+// <!-- pr-diff-breakdown:start/end --> markers) so re-runs on later pushes
+// update in place instead of stacking a copy per push.
+//
+// Usage: node update-pr-description.mjs <current-body-file> <block-file>
+// Prints the new full PR body to stdout.
+
+import { readFileSync } from "node:fs"
+
+const [, , currentBodyPath, blockPath] = process.argv
+if (!currentBodyPath || !blockPath) {
+  throw new Error(
+    "Usage: update-pr-description.mjs <current-body-file> <block-file>",
+  )
+}
+
+const currentBody = readFileSync(currentBodyPath, "utf8")
+const block = readFileSync(blockPath, "utf8").trim()
+
+const EXISTING_BLOCK_RE =
+  /<!-- pr-diff-breakdown:start -->[\s\S]*?<!-- pr-diff-breakdown:end -->\n?/
+
+const rest = currentBody.replace(EXISTING_BLOCK_RE, "").replace(/^\s+/, "")
+
+process.stdout.write(rest ? `${block}\n\n${rest}` : `${block}\n`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,49 @@ jobs:
           NODE_OPTIONS: -r ${{ env.DD_TRACE_PACKAGE }} --import ${{ env.DD_TRACE_ESM_IMPORT }}
           TZ: Asia/Singapore
 
+  pr-breakdown:
+    name: PR diff breakdown
+    needs: optimize_ci
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && needs.optimize_ci.outputs.skip == 'false'
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Shallow-fetch just the two commits being diffed — `git diff A B` only
+      # needs both commit objects, not shared history, so this is enough even
+      # though the default checkout only has the PR merge ref.
+      - name: Fetch PR base and head commits
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
+          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.head.sha }}
+
+      - name: Classify changed files
+        run: node .github/scripts/classify-pr-diff.mjs > /tmp/pr-breakdown-body.md
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+      - name: Add to step summary
+        run: cat /tmp/pr-breakdown-body.md >> "$GITHUB_STEP_SUMMARY"
+
+      # Same fork-PR restriction as the e2e/bundle-size comments below: this
+      # job can't post to the PR directly, so it hands the body off as an
+      # artifact for post-pr-comment.yml to pick up in the base-repo context.
+      - name: Save PR breakdown metadata
+        run: |
+          mkdir -p /tmp/pr-breakdown-metadata
+          echo "${{ github.event.pull_request.number }}" > /tmp/pr-breakdown-metadata/pr-number.txt
+          cp /tmp/pr-breakdown-body.md /tmp/pr-breakdown-metadata/body.md
+
+      - name: Upload PR breakdown metadata
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pr-breakdown-metadata
+          path: /tmp/pr-breakdown-metadata/
+          retention-days: 1
+
   end-to-end-tests:
     name: End-to-end tests
     needs: optimize_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,10 +344,16 @@ jobs:
       # consuming job derives the PR number itself from the trusted
       # workflow_run event payload instead of trusting a number from this
       # artifact — see post-pr-comment.yml.
+      #
+      # base-ref.txt IS included, but only ever used downstream as a
+      # tie-breaker among candidates already independently constrained by
+      # trusted fields (fork+branch+exact head commit) — never as the
+      # source of truth for which PR to edit. See post-pr-comment.yml.
       - name: Save PR breakdown metadata
         run: |
           mkdir -p /tmp/pr-breakdown-metadata
           cp /tmp/pr-breakdown-body.md /tmp/pr-breakdown-metadata/body.md
+          echo "${{ github.event.pull_request.base.ref }}" > /tmp/pr-breakdown-metadata/base-ref.txt
 
       - name: Upload PR breakdown metadata
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,19 +312,18 @@ jobs:
       # lets classify-pr-diff.mjs's three-dot diff find the real merge-base
       # instead of diffing straight against base's current tip.
       #
-      # Bounded at 500 rather than 0 (full history): this job runs on every
-      # PR push unconditionally (unlike this repo's only other fetch-depth: 0
-      # jobs, Chromatic's, which are gated behind a paths-filter), so an
-      # unbounded clone here would scale with total repo history rather than
-      # with this one PR's size. 500 commits covers roughly 2+ months of
-      # commit history at this repo's current pace — comfortable headroom
-      # for a long-lived or unrebased PR, at negligible extra transfer cost
-      # over a much shallower depth. A PR staler than that fails this one
-      # step visibly (no merge-base found) rather than silently reporting
-      # wrong numbers.
+      # Full history (0) rather than a bounded depth: a bounded fetch trades
+      # a small, currently-negligible cost saving for a real failure mode —
+      # any PR whose merge-base sits further back than the bound hard-fails
+      # this step with "no merge base found," with no continue-on-error, on
+      # every subsequent push to that PR. Full history has no such cliff; at
+      # this repo's current size (~80MB of history) the extra clone cost is
+      # a few seconds at most. This does mean the clone cost grows with the
+      # repo's total lifetime history, not with this one PR's size — worth
+      # revisiting if that ever becomes an actual bottleneck.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 500
+          fetch-depth: 0
 
       - name: Classify changed files
         run: node .github/scripts/classify-pr-diff.mjs > /tmp/pr-breakdown-body.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,16 +312,19 @@ jobs:
       # lets classify-pr-diff.mjs's three-dot diff find the real merge-base
       # instead of diffing straight against base's current tip.
       #
-      # Bounded at 100 rather than 0 (full history): this job runs on every
+      # Bounded at 500 rather than 0 (full history): this job runs on every
       # PR push unconditionally (unlike this repo's only other fetch-depth: 0
       # jobs, Chromatic's, which are gated behind a paths-filter), so an
       # unbounded clone here would scale with total repo history rather than
-      # with this one PR's size. 100 commits covers the vast majority of
-      # real PR ages; a PR staler than that fails this one step visibly
-      # (no merge-base found) rather than silently reporting wrong numbers.
+      # with this one PR's size. 500 commits covers roughly 2+ months of
+      # commit history at this repo's current pace — comfortable headroom
+      # for a long-lived or unrebased PR, at negligible extra transfer cost
+      # over a much shallower depth. A PR staler than that fails this one
+      # step visibly (no merge-base found) rather than silently reporting
+      # wrong numbers.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 100
+          fetch-depth: 500
 
       - name: Classify changed files
         run: node .github/scripts/classify-pr-diff.mjs > /tmp/pr-breakdown-body.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,18 +302,26 @@ jobs:
     permissions:
       contents: read
     steps:
-      # fetch-depth: 0 is required, not just convenient: the default checkout
-      # resolves the PR's synthetic merge ref (refs/pull/N/merge), whose two
-      # parents are the real base and head commits — fork or not, GitHub
-      # materializes that ref server-side, so this is also what makes the
-      # head commit fetchable at all for fork PRs (origin is the base repo;
-      # a fork's head SHA isn't otherwise fetchable from it directly). Full
-      # depth pulls the complete ancestor history of both parents, which is
-      # also what lets classify-pr-diff.mjs's three-dot diff find the real
-      # merge-base instead of diffing straight against base's current tip.
+      # Non-default fetch-depth is required, not just convenient: the default
+      # checkout resolves the PR's synthetic merge ref (refs/pull/N/merge),
+      # whose two parents are the real base and head commits — fork or not,
+      # GitHub materializes that ref server-side, so this is also what makes
+      # the head commit fetchable at all for fork PRs (origin is the base
+      # repo; a fork's head SHA isn't otherwise fetchable from it directly).
+      # Extra depth pulls ancestor history for both parents, which is what
+      # lets classify-pr-diff.mjs's three-dot diff find the real merge-base
+      # instead of diffing straight against base's current tip.
+      #
+      # Bounded at 100 rather than 0 (full history): this job runs on every
+      # PR push unconditionally (unlike this repo's only other fetch-depth: 0
+      # jobs, Chromatic's, which are gated behind a paths-filter), so an
+      # unbounded clone here would scale with total repo history rather than
+      # with this one PR's size. 100 commits covers the vast majority of
+      # real PR ages; a PR staler than that fails this one step visibly
+      # (no merge-base found) rather than silently reporting wrong numbers.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0
+          fetch-depth: 100
 
       - name: Classify changed files
         run: node .github/scripts/classify-pr-diff.mjs > /tmp/pr-breakdown-body.md
@@ -327,10 +335,16 @@ jobs:
       # Same fork-PR restriction as the e2e/bundle-size comments below: this
       # job can't post to the PR directly, so it hands the body off as an
       # artifact for post-pr-comment.yml to pick up in the base-repo context.
+      #
+      # Deliberately NOT including a pr-number.txt here: this step runs with
+      # the PR's own (possibly forked, possibly modified) version of this
+      # workflow file, so anything it writes is attacker-controlled. The
+      # consuming job derives the PR number itself from the trusted
+      # workflow_run event payload instead of trusting a number from this
+      # artifact — see post-pr-comment.yml.
       - name: Save PR breakdown metadata
         run: |
           mkdir -p /tmp/pr-breakdown-metadata
-          echo "${{ github.event.pull_request.number }}" > /tmp/pr-breakdown-metadata/pr-number.txt
           cp /tmp/pr-breakdown-body.md /tmp/pr-breakdown-metadata/body.md
 
       - name: Upload PR breakdown metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,15 +302,18 @@ jobs:
     permissions:
       contents: read
     steps:
+      # fetch-depth: 0 is required, not just convenient: the default checkout
+      # resolves the PR's synthetic merge ref (refs/pull/N/merge), whose two
+      # parents are the real base and head commits — fork or not, GitHub
+      # materializes that ref server-side, so this is also what makes the
+      # head commit fetchable at all for fork PRs (origin is the base repo;
+      # a fork's head SHA isn't otherwise fetchable from it directly). Full
+      # depth pulls the complete ancestor history of both parents, which is
+      # also what lets classify-pr-diff.mjs's three-dot diff find the real
+      # merge-base instead of diffing straight against base's current tip.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      # Shallow-fetch just the two commits being diffed — `git diff A B` only
-      # needs both commit objects, not shared history, so this is enough even
-      # though the default checkout only has the PR merge ref.
-      - name: Fetch PR base and head commits
-        run: |
-          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
-          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.head.sha }}
+        with:
+          fetch-depth: 0
 
       - name: Classify changed files
         run: node .github/scripts/classify-pr-diff.mjs > /tmp/pr-breakdown-body.md

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -20,7 +20,7 @@ on:
     types: [completed]
 
 permissions:
-  actions: read # needed by `gh run download` to access the Actions artifacts API
+  actions: read # needed by actions/download-artifact to access a different run's artifacts
   pull-requests: write
   issues: write # GitHub routes PR comments through the issues API endpoint
 
@@ -38,13 +38,12 @@ jobs:
         # lets subsequent steps gate on `steps.download.outcome` instead of
         # failing the whole job.
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh run download ${{ github.event.workflow_run.id }} \
-            --name e2e-comment-metadata \
-            --dir /tmp/e2e-metadata \
-            --repo ${{ github.repository }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-comment-metadata
+          path: /tmp/e2e-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Read metadata
         if: steps.download.outcome == 'success'
@@ -86,9 +85,9 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     # Job-level permissions: REPLACE the workflow-level block above for this job,
-    # they don't merge — so this has to re-list actions: read (for `gh run
-    # download`) and pull-requests: write (for `gh pr edit`/`gh pr view`) on top
-    # of the contents: read this job newly needs for actions/checkout.
+    # they don't merge — so this has to re-list actions: read (for
+    # actions/download-artifact) and pull-requests: write (for the github-script
+    # steps below) on top of the contents: read this job needs for actions/checkout.
     permissions:
       contents: read
       actions: read
@@ -106,48 +105,54 @@ jobs:
       # rewriting that PR's description instead of its own. head_sha comes
       # from the workflow_run event payload itself, populated by GitHub's own
       # infrastructure, not by anything the PR's workflow run could forge —
-      # and the commits/{sha}/pulls lookup resolves it to a PR correctly even
-      # for fork-originated commits.
+      # and listPullRequestsAssociatedWithCommit resolves it to a PR correctly
+      # even for fork-originated commits.
       - name: Resolve PR number from trusted commit SHA
         id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
-          if [ -z "$number" ]; then
-            echo "No PR associated with ${{ github.event.workflow_run.head_sha }}; skipping." >&2
-            exit 0
-          fi
-          echo "number=$number" >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.payload.workflow_run.head_sha,
+            })
+            if (prs.length === 0) {
+              core.warning(`No PR associated with ${context.payload.workflow_run.head_sha}; skipping.`)
+              return ""
+            }
+            return String(prs[0].number)
 
       - name: Download PR breakdown metadata
         id: download
         # Absent if pr-breakdown was skipped (Graphite optimizer) or wasn't a
         # pull_request run. continue-on-error lets later steps gate on
         # steps.download.outcome instead of failing the whole job.
-        if: steps.pr.outputs.number != ''
+        if: steps.pr.outputs.result != ''
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh run download ${{ github.event.workflow_run.id }} \
-            --name pr-breakdown-metadata \
-            --dir /tmp/pr-breakdown-metadata \
-            --repo ${{ github.repository }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pr-breakdown-metadata
+          path: /tmp/pr-breakdown-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Fetch current PR description
         if: steps.download.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # `.body // ""` coalesces a null description (PRs opened with no body
-          # at all) to an empty string — jq's raw output of null is the
-          # 4-character text "null", which would otherwise get glued into
-          # the description under the breakdown block.
-          gh pr view ${{ steps.pr.outputs.number }} \
-            --repo ${{ github.repository }} \
-            --json body -q '.body // ""' \
-            > /tmp/pr-breakdown-metadata/current-body.md
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs")
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.pr.outputs.result }},
+            })
+            // pr.body is null for a PR opened with no description at all —
+            // writing that straight to a jq-style ".body" would have produced
+            // the literal text "null"; ?? "" avoids that here for free.
+            fs.writeFileSync("/tmp/pr-breakdown-metadata/current-body.md", pr.body ?? "")
 
       - name: Build updated PR description
         if: steps.download.outcome == 'success'
@@ -159,12 +164,17 @@ jobs:
 
       - name: Update PR description
         if: steps.download.outcome == 'success'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ steps.pr.outputs.number }} \
-            --repo ${{ github.repository }} \
-            --body-file /tmp/pr-breakdown-metadata/new-body.md
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require("fs")
+            const body = fs.readFileSync("/tmp/pr-breakdown-metadata/new-body.md", "utf8")
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.pr.outputs.result }},
+              body,
+            })
 
   post-bundle-size-comment:
     # Mirror of post-e2e-comment above — same fork-PR restriction applies.
@@ -176,13 +186,12 @@ jobs:
         # Absent when components-bundle-size was skipped (no component changes
         # or optimizer short-circuit); gate subsequent steps on outcome.
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh run download ${{ github.event.workflow_run.id }} \
-            --name bundle-size-metadata \
-            --dir /tmp/bundle-size-metadata \
-            --repo ${{ github.repository }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: bundle-size-metadata
+          path: /tmp/bundle-size-metadata
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Post bundle size comment
         if: steps.download.outcome == 'success'

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -85,6 +85,14 @@ jobs:
     # regardless of when CI finishes relative to human activity on the PR.
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
+    # Job-level permissions: REPLACE the workflow-level block above for this job,
+    # they don't merge — so this has to re-list actions: read (for `gh run
+    # download`) and pull-requests: write (for `gh pr edit`/`gh pr view`) on top
+    # of the contents: read this job newly needs for actions/checkout.
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -115,9 +123,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # `.body // ""` coalesces a null description (PRs opened with no body
+          # at all) to an empty string — jq's raw output of null is the
+          # 4-character text "null", which would otherwise get glued into
+          # the description under the breakdown block.
           gh pr view ${{ steps.metadata.outputs.pr-number }} \
             --repo ${{ github.repository }} \
-            --json body -q .body \
+            --json body -q '.body // ""' \
             > /tmp/pr-breakdown-metadata/current-body.md
 
       - name: Build updated PR description

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -78,6 +78,65 @@ jobs:
             Each test has its own directory under the zip; play `video.webm` to watch the run.
             Workflow: [run #${{ github.event.workflow_run.id }}](${{ github.event.workflow_run.html_url }}) — artifact expires in 7 days.
 
+  update-pr-description:
+    # Same fork-PR restriction as post-e2e-comment above, but this job edits
+    # the PR *description* instead of posting a comment, so the breakdown
+    # always renders at the very top of the PR — above every comment,
+    # regardless of when CI finishes relative to human activity on the PR.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github/scripts
+
+      - name: Download PR breakdown metadata
+        id: download
+        # Absent if pr-breakdown was skipped (Graphite optimizer) or wasn't a
+        # pull_request run. continue-on-error lets later steps gate on
+        # steps.download.outcome instead of failing the whole job.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download ${{ github.event.workflow_run.id }} \
+            --name pr-breakdown-metadata \
+            --dir /tmp/pr-breakdown-metadata \
+            --repo ${{ github.repository }}
+
+      - name: Read metadata
+        if: steps.download.outcome == 'success'
+        id: metadata
+        run: |
+          echo "pr-number=$(cat /tmp/pr-breakdown-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
+
+      - name: Fetch current PR description
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr view ${{ steps.metadata.outputs.pr-number }} \
+            --repo ${{ github.repository }} \
+            --json body -q .body \
+            > /tmp/pr-breakdown-metadata/current-body.md
+
+      - name: Build updated PR description
+        if: steps.download.outcome == 'success'
+        run: |
+          node .github/scripts/update-pr-description.mjs \
+            /tmp/pr-breakdown-metadata/current-body.md \
+            /tmp/pr-breakdown-metadata/body.md \
+            > /tmp/pr-breakdown-metadata/new-body.md
+
+      - name: Update PR description
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ steps.metadata.outputs.pr-number }} \
+            --repo ${{ github.repository }} \
+            --body-file /tmp/pr-breakdown-metadata/new-body.md
+
   post-bundle-size-comment:
     # Mirror of post-e2e-comment above — same fork-PR restriction applies.
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -98,11 +98,34 @@ jobs:
         with:
           sparse-checkout: .github/scripts
 
+      # Deliberately does NOT read a PR number out of the artifact below: the
+      # pr-breakdown job that produced it ran with the PR's own (possibly
+      # forked, possibly attacker-modified) version of ci.yml, so anything it
+      # wrote is untrusted — a malicious PR could have pointed pr-number.txt
+      # at an unrelated PR to hijack this job's write-capable token into
+      # rewriting that PR's description instead of its own. head_sha comes
+      # from the workflow_run event payload itself, populated by GitHub's own
+      # infrastructure, not by anything the PR's workflow run could forge —
+      # and the commits/{sha}/pulls lookup resolves it to a PR correctly even
+      # for fork-originated commits.
+      - name: Resolve PR number from trusted commit SHA
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
+          if [ -z "$number" ]; then
+            echo "No PR associated with ${{ github.event.workflow_run.head_sha }}; skipping." >&2
+            exit 0
+          fi
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
       - name: Download PR breakdown metadata
         id: download
         # Absent if pr-breakdown was skipped (Graphite optimizer) or wasn't a
         # pull_request run. continue-on-error lets later steps gate on
         # steps.download.outcome instead of failing the whole job.
+        if: steps.pr.outputs.number != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -111,12 +134,6 @@ jobs:
             --name pr-breakdown-metadata \
             --dir /tmp/pr-breakdown-metadata \
             --repo ${{ github.repository }}
-
-      - name: Read metadata
-        if: steps.download.outcome == 'success'
-        id: metadata
-        run: |
-          echo "pr-number=$(cat /tmp/pr-breakdown-metadata/pr-number.txt)" >> $GITHUB_OUTPUT
 
       - name: Fetch current PR description
         if: steps.download.outcome == 'success'
@@ -127,7 +144,7 @@ jobs:
           # at all) to an empty string — jq's raw output of null is the
           # 4-character text "null", which would otherwise get glued into
           # the description under the breakdown block.
-          gh pr view ${{ steps.metadata.outputs.pr-number }} \
+          gh pr view ${{ steps.pr.outputs.number }} \
             --repo ${{ github.repository }} \
             --json body -q '.body // ""' \
             > /tmp/pr-breakdown-metadata/current-body.md
@@ -145,7 +162,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr edit ${{ steps.metadata.outputs.pr-number }} \
+          gh pr edit ${{ steps.pr.outputs.number }} \
             --repo ${{ github.repository }} \
             --body-file /tmp/pr-breakdown-metadata/new-body.md
 

--- a/.github/workflows/post-pr-comment.yml
+++ b/.github/workflows/post-pr-comment.yml
@@ -97,39 +97,13 @@ jobs:
         with:
           sparse-checkout: .github/scripts
 
-      # Deliberately does NOT read a PR number out of the artifact below: the
-      # pr-breakdown job that produced it ran with the PR's own (possibly
-      # forked, possibly attacker-modified) version of ci.yml, so anything it
-      # wrote is untrusted — a malicious PR could have pointed pr-number.txt
-      # at an unrelated PR to hijack this job's write-capable token into
-      # rewriting that PR's description instead of its own. head_sha comes
-      # from the workflow_run event payload itself, populated by GitHub's own
-      # infrastructure, not by anything the PR's workflow run could forge —
-      # and listPullRequestsAssociatedWithCommit resolves it to a PR correctly
-      # even for fork-originated commits.
-      - name: Resolve PR number from trusted commit SHA
-        id: pr
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          result-encoding: string
-          script: |
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: context.payload.workflow_run.head_sha,
-            })
-            if (prs.length === 0) {
-              core.warning(`No PR associated with ${context.payload.workflow_run.head_sha}; skipping.`)
-              return ""
-            }
-            return String(prs[0].number)
-
+      # Download happens before PR resolution now: the resolution step below
+      # wants base-ref.txt from this artifact as an optional tie-breaker.
       - name: Download PR breakdown metadata
         id: download
         # Absent if pr-breakdown was skipped (Graphite optimizer) or wasn't a
         # pull_request run. continue-on-error lets later steps gate on
         # steps.download.outcome instead of failing the whole job.
-        if: steps.pr.outputs.result != ''
         continue-on-error: true
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -138,8 +112,67 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Fetch current PR description
+      # Does NOT trust pr-number.txt (there isn't one) or base-ref.txt as the
+      # source of truth for which PR to edit: everything this job's own
+      # (possibly forked, possibly attacker-modified) ci.yml run wrote is
+      # untrusted. head_sha/head_repository/head_branch instead come from the
+      # workflow_run event payload itself, populated by GitHub's own
+      # infrastructure — a fork can't forge these by editing its workflow.
+      #
+      # Filtering on open PRs from that exact fork+branch, then verifying the
+      # exact head commit, can still legitimately return more than one match
+      # (e.g. Graphite stacked PRs briefly sharing a head commit, or the same
+      # branch opened against two different base branches). base-ref.txt is
+      # used ONLY to break that tie: it can never redirect to an unrelated
+      # PR, because the candidate set is already constrained to PRs from this
+      # exact fork+branch+commit — something only this run's own author could
+      # have produced. If it doesn't resolve to exactly one PR, skip rather
+      # than guess.
+      - name: Resolve PR from trusted workflow_run head ref
+        id: pr
         if: steps.download.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          result-encoding: string
+          script: |
+            const fs = require("fs")
+            const headSha = context.payload.workflow_run.head_sha
+            const headRepo = context.payload.workflow_run.head_repository
+            const headBranch = context.payload.workflow_run.head_branch
+            if (!headSha || !headRepo?.owner?.login || !headBranch) {
+              core.warning("Missing workflow_run head metadata; skipping.")
+              return ""
+            }
+            const headRef = `${headRepo.owner.login}:${headBranch}`
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: "open",
+              head: headRef,
+            })
+            let matches = pulls.filter((p) => p.head.sha === headSha)
+            if (matches.length > 1) {
+              let claimedBase = ""
+              try {
+                claimedBase = fs
+                  .readFileSync("/tmp/pr-breakdown-metadata/base-ref.txt", "utf8")
+                  .trim()
+              } catch {}
+              if (claimedBase) {
+                const narrowed = matches.filter((p) => p.base.ref === claimedBase)
+                if (narrowed.length === 1) matches = narrowed
+              }
+            }
+            if (matches.length !== 1) {
+              core.warning(
+                `Expected exactly 1 open PR for ${headRef}@${headSha}, found ${matches.length}; skipping.`,
+              )
+              return ""
+            }
+            return String(matches[0].number)
+
+      - name: Fetch current PR description
+        if: steps.pr.outputs.result != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -155,7 +188,7 @@ jobs:
             fs.writeFileSync("/tmp/pr-breakdown-metadata/current-body.md", pr.body ?? "")
 
       - name: Build updated PR description
-        if: steps.download.outcome == 'success'
+        if: steps.pr.outputs.result != ''
         run: |
           node .github/scripts/update-pr-description.mjs \
             /tmp/pr-breakdown-metadata/current-body.md \
@@ -163,7 +196,7 @@ jobs:
             > /tmp/pr-breakdown-metadata/new-body.md
 
       - name: Update PR description
-        if: steps.download.outcome == 'success'
+        if: steps.pr.outputs.result != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
## Problem

A PR's raw +N/-M line count doesn't tell you what changed. 500 lines could be app logic, tests, docs, or a lockfile bump. We had no automated breakdown of that.

## Solution

Adds a `pr-breakdown` job that buckets each changed file as App, Test, Doc, or Ignore, sums added/deleted lines per bucket, and writes the result to the top of the PR description. It stays in sync on every push.

Globs come from this repo's real layout: vitest colocated `__tests__`, Playwright `apps/studio/tests/e2e/**`, integration/msw/load dirs, Storybook `.stories.tsx`, plus `docs/**`, package READMEs, `CLAUDE.md`, and `CONTEXT.md`. See `docs/risk-taxonomy.md`.

Same two-workflow relay as the e2e video-link and bundle-size comments. `ci.yml`'s `pr-breakdown` job runs in the untrusted `pull_request` context and uploads the classified result as an artifact. `post-pr-comment.yml`'s `update-pr-description` job picks it up in the trusted `workflow_run` context, where `pull-requests: write` actually works, and merges it into the PR description between `<!-- pr-diff-breakdown:start/end -->` markers so it sits above the human-written description.

No new dependencies. Classification uses Node's built-in `path.matchesGlob`.

## Tests

Ran `classify-pr-diff.mjs` and `update-pr-description.mjs` against historical commits `ef641e6d4`, `45fc2cb6b`, and `5cad70ce7`:

- Colocated test file → Test, lockfile → Ignore, README → Doc, everything else → App
- Merging the description twice in a row is byte-identical, so later pushes replace the block instead of stacking copies

### Manual checks

- [ ] `pr-breakdown` job appears and succeeds on this PR
- [ ] PR description gets a PR diff breakdown table at the top after CI
- [ ] Push another commit and confirm the table updates in place

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds an automated PR diff breakdown to the CI flow. The main changes are:

- A new script classifies changed files into App, Test, Doc, and Ignore buckets.
- A new CI job generates the breakdown table and uploads it as workflow metadata.
- A `workflow_run` job resolves the matching PR and updates the PR description in place.
- A small merge script replaces the existing marker block so repeated runs do not duplicate the table.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

No blocking correctness or security issues were identified in the changed files. The workflow keeps the pull request job read-only and resolves the target pull request from trusted workflow metadata before writing.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/scripts/classify-pr-diff.mjs | Adds a Node script that classifies `git diff --numstat` output into app/test/doc/ignore buckets and renders the PR description block. |
| .github/scripts/update-pr-description.mjs | Adds an idempotent marker-based merge script that prepends or replaces the generated diff-breakdown block in the PR body. |
| .github/workflows/ci.yml | Adds a read-only `pr-breakdown` pull-request job that checks out full history, generates the breakdown, and uploads metadata for the follow-up workflow. |
| .github/workflows/post-pr-comment.yml | Adds a privileged `workflow_run` job that resolves the PR from trusted run metadata, downloads the breakdown artifact, and updates the PR description. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant PR as Pull request
participant CI as CI pr-breakdown job
participant Artifact as Actions artifact
participant Post as post-pr-comment workflow_run job
participant GH as GitHub Pulls API

PR->>CI: pull_request run starts
CI->>CI: git diff --numstat BASE...HEAD
CI->>CI: classify files into App/Test/Doc/Ignore
CI->>Artifact: upload pr-breakdown-metadata
CI-->>Post: workflow_run completed
Post->>Artifact: download pr-breakdown-metadata
Post->>GH: list open PRs by trusted head repo/branch
GH-->>Post: candidate PRs
Post->>Post: verify exact head SHA and optional base ref
Post->>GH: fetch current PR body
Post->>Post: replace or prepend marker block
Post->>GH: update PR description
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant PR as Pull request
participant CI as CI pr-breakdown job
participant Artifact as Actions artifact
participant Post as post-pr-comment workflow_run job
participant GH as GitHub Pulls API

PR->>CI: pull_request run starts
CI->>CI: git diff --numstat BASE...HEAD
CI->>CI: classify files into App/Test/Doc/Ignore
CI->>Artifact: upload pr-breakdown-metadata
CI-->>Post: workflow_run completed
Post->>Artifact: download pr-breakdown-metadata
Post->>GH: list open PRs by trusted head repo/branch
GH-->>Post: candidate PRs
Post->>Post: verify exact head SHA and optional base ref
Post->>GH: fetch current PR body
Post->>Post: replace or prepend marker block
Post->>GH: update PR description
```

</a>
</details>

<sub>Reviews (8): Last reviewed commit: ["refactor(ci): replace custom glob-to-Reg..."](https://github.com/opengovsg/isomer/commit/11cbf0025e9a7b616ee772f04be15eaec4b029b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45544559)</sub>

<!-- /greptile_comment -->