### PR TITLE
🔖 fix(studio): gate collection Filters on site Admin instead of Isomer Admin

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -13,8 +13,8 @@ import { isEmpty, isEqual } from "lodash-es"
 import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useMe } from "~/features/me/api"
-import { usePermissions } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
@@ -46,8 +46,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { me } = useMe()
-  const ability = usePermissions()
-  const isSiteAdmin = ability.can("create", { parentId: null })
+  const canManageFilters = useCanManageCollectionFilters()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
   const utils = trpc.useUtils()
@@ -75,7 +74,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   })
 
   const schemaFields = useMemo(() => {
-    if (isSiteAdmin) {
+    if (canManageFilters) {
       return drawerStateType === "display"
         ? {
             exclude: ["tagCategories", "tags"],
@@ -87,7 +86,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     return {
       exclude: ["tagCategories", "tags"],
     }
-  }, [drawerStateType, isSiteAdmin])
+  }, [drawerStateType, canManageFilters])
 
   const metadataSchema = getScopedSchema({
     layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -14,6 +14,7 @@ import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useMe } from "~/features/me/api"
+import { usePermissions } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
@@ -45,6 +46,8 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { me } = useMe()
+  const ability = usePermissions()
+  const isSiteAdmin = ability.can("create", { parentId: null })
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
   const utils = trpc.useUtils()
@@ -72,14 +75,19 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   })
 
   const schemaFields = useMemo(() => {
-    return drawerStateType === "display"
-      ? {
-          exclude: ["tagCategories", "tags"],
-        }
-      : {
-          include: ["tagCategories", "tags"],
-        }
-  }, [drawerStateType])
+    if (isSiteAdmin) {
+      return drawerStateType === "display"
+        ? {
+            exclude: ["tagCategories", "tags"],
+          }
+        : {
+            include: ["tagCategories", "tags"],
+          }
+    }
+    return {
+      exclude: ["tagCategories", "tags"],
+    }
+  }, [drawerStateType, isSiteAdmin])
 
   const metadataSchema = getScopedSchema({
     layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -14,12 +14,10 @@ import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useMe } from "~/features/me/api"
-import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
 import { pageSchema } from "../../schema"
 import {
@@ -47,9 +45,6 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { me } = useMe()
-  const { isAdmin: isUserIsomerAdmin } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
-  })
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
   const utils = trpc.useUtils()
@@ -77,19 +72,14 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   })
 
   const schemaFields = useMemo(() => {
-    if (isUserIsomerAdmin) {
-      return drawerStateType === "display"
-        ? {
-            exclude: ["tagCategories", "tags"],
-          }
-        : {
-            include: ["tagCategories", "tags"],
-          }
-    }
-    return {
-      exclude: ["tagCategories", "tags"],
-    }
-  }, [drawerStateType, isUserIsomerAdmin])
+    return drawerStateType === "display"
+      ? {
+          exclude: ["tagCategories", "tags"],
+        }
+      : {
+          include: ["tagCategories", "tags"],
+        }
+  }, [drawerStateType])
 
   const metadataSchema = getScopedSchema({
     layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -33,7 +33,7 @@ import { DEFAULT_BLOCKS } from "~/components/PageEditor/constants"
 import { BlockEditingPlaceholder } from "~/components/Svg"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
-import { Can } from "~/features/permissions"
+import { CanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -126,7 +126,7 @@ const FixedBlock = () => {
           description="Customise the Collection’s Summary, Layout, Sorting logic, and Thumbnail."
           icon={BiCog}
         />
-        <Can do="create" on={{ parentId: null }}>
+        <CanManageCollectionFilters>
           <BaseBlock
             variant="vertical"
             onClick={() => {
@@ -137,7 +137,7 @@ const FixedBlock = () => {
             description="Define and manage filters for this Collection."
             icon={BiSlider}
           />
-        </Can>
+        </CanManageCollectionFilters>{" "}
       </>
     )
   }

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -33,6 +33,7 @@ import { DEFAULT_BLOCKS } from "~/components/PageEditor/constants"
 import { BlockEditingPlaceholder } from "~/components/Svg"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { Can } from "~/features/permissions"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -125,16 +126,18 @@ const FixedBlock = () => {
           description="Customise the Collection’s Summary, Layout, Sorting logic, and Thumbnail."
           icon={BiCog}
         />
-        <BaseBlock
-          variant="vertical"
-          onClick={() => {
-            setCurrActiveIdx(0)
-            setDrawerState({ state: "collectionEditor", type: "filter" })
-          }}
-          label="Filters"
-          description="Define and manage filters for this Collection."
-          icon={BiSlider}
-        />
+        <Can do="create" on={{ parentId: null }}>
+          <BaseBlock
+            variant="vertical"
+            onClick={() => {
+              setCurrActiveIdx(0)
+              setDrawerState({ state: "collectionEditor", type: "filter" })
+            }}
+            label="Filters"
+            description="Define and manage filters for this Collection."
+            icon={BiSlider}
+          />
+        </Can>
       </>
     )
   }

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -82,10 +82,6 @@ const FIXED_BLOCK_CONTENT: Record<string, FixedBlockContent> = {
 }
 
 const FixedBlock = () => {
-  const { isAdmin: isUserIsomerAdmin } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
-  })
-
   const { setCurrActiveIdx, setDrawerState, previewPageState } =
     useEditorDrawerContext()
   const pageLayout = previewPageState.layout
@@ -129,18 +125,16 @@ const FixedBlock = () => {
           description="Customise the Collection’s Summary, Layout, Sorting logic, and Thumbnail."
           icon={BiCog}
         />
-        {isUserIsomerAdmin && (
-          <BaseBlock
-            variant="vertical"
-            onClick={() => {
-              setCurrActiveIdx(0)
-              setDrawerState({ state: "collectionEditor", type: "filter" })
-            }}
-            label="Filters"
-            description="Define and manage filters for this Collection."
-            icon={BiSlider}
-          />
-        )}
+        <BaseBlock
+          variant="vertical"
+          onClick={() => {
+            setCurrActiveIdx(0)
+            setDrawerState({ state: "collectionEditor", type: "filter" })
+          }}
+          label="Filters"
+          description="Define and manage filters for this Collection."
+          icon={BiSlider}
+        />
       </>
     )
   }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -9,6 +9,7 @@ import { Suspense, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { pageSchema } from "~/features/editing-experience/schema"
+import { usePermissions } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 
@@ -318,4 +319,14 @@ export const jsonFormsTagCategoryOptionsControlTester: RankedTester = rankWith(
   schemaMatches((schema) => schema.format === "tag-category-options"),
 )
 
-export default JsonFormsTagCategoryOptionsArrayLayout
+const JsonFormsTagCategoryOptionsControl = (props: ArrayLayoutProps) => {
+  // Site Admin only — same gate as root create (navbar/footer settings).
+  const ability = usePermissions()
+  if (!ability.can("create", { parentId: null })) {
+    return null
+  }
+
+  return <JsonFormsTagCategoryOptionsArrayLayout {...props} />
+}
+
+export default JsonFormsTagCategoryOptionsControl

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -8,8 +8,8 @@ import { get } from "lodash-es"
 import { Suspense, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
+import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { pageSchema } from "~/features/editing-experience/schema"
-import { usePermissions } from "~/features/permissions"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
 
@@ -320,9 +320,8 @@ export const jsonFormsTagCategoryOptionsControlTester: RankedTester = rankWith(
 )
 
 const JsonFormsTagCategoryOptionsControl = (props: ArrayLayoutProps) => {
-  // Site Admin only — same gate as root create (navbar/footer settings).
-  const ability = usePermissions()
-  if (!ability.can("create", { parentId: null })) {
+  const canManageFilters = useCanManageCollectionFilters()
+  if (!canManageFilters) {
     return null
   }
 

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -9,10 +9,8 @@ import { Suspense, useState } from "react"
 import { ErrorBoundary } from "react-error-boundary"
 import { JSON_FORMS_RANKING } from "~/constants/formBuilder"
 import { pageSchema } from "~/features/editing-experience/schema"
-import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { trpc } from "~/utils/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
 
 import { AddItemButton } from "../../components/AddItemButton"
 import { DeleteConfirmModal } from "../../components/DeleteConfirmModal"
@@ -320,17 +318,4 @@ export const jsonFormsTagCategoryOptionsControlTester: RankedTester = rankWith(
   schemaMatches((schema) => schema.format === "tag-category-options"),
 )
 
-const JsonFormsTagCategoryOptionsControl = (props: ArrayLayoutProps) => {
-  // Tag category options are admin-only until the feature ships broadly.
-  const { isAdmin: isUserIsomerAdmin } = useIsUserIsomerAdmin({
-    roles: [IsomerAdminRole.Core, IsomerAdminRole.Migrator],
-  })
-
-  if (!isUserIsomerAdmin) {
-    return null
-  }
-
-  return <JsonFormsTagCategoryOptionsArrayLayout {...props} />
-}
-
-export default JsonFormsTagCategoryOptionsControl
+export default JsonFormsTagCategoryOptionsArrayLayout

--- a/apps/studio/src/features/editing-experience/hooks/canManageCollectionFilters.tsx
+++ b/apps/studio/src/features/editing-experience/hooks/canManageCollectionFilters.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from "react"
+import type { ResourceAbility } from "~/server/modules/permissions/permissions.type"
+import { usePermissions } from "~/features/permissions"
+
+/**
+ * Single source of truth for who can manage Collection Filters / tag categories.
+ *
+ * Today that is site Admins (CASL: create at site root). Change only here if
+ * the required permission should differ from other site-admin settings.
+ */
+export const canManageCollectionFilters = (ability: ResourceAbility): boolean =>
+  ability.can("create", { parentId: null })
+
+export const useCanManageCollectionFilters = (): boolean =>
+  canManageCollectionFilters(usePermissions())
+
+export const CanManageCollectionFilters = ({
+  children,
+}: PropsWithChildren): JSX.Element | null => {
+  const canManage = useCanManageCollectionFilters()
+  if (!canManage) {
+    return null
+  }
+  return <>{children}</>
+}

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -1,10 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { userEvent, within } from "storybook/test"
+import { expect, userEvent, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
-import { userHandlers } from "tests/msw/handlers/user"
 import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
@@ -110,7 +109,7 @@ export const WithBanner: Story = {
   },
 }
 
-export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
+export const NewCollectionIndexEditingExperienceAsAdmin: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   },
@@ -121,17 +120,20 @@ export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
   },
 }
 
-export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
+export const NewCollectionIndexEditingExperienceAsEditor: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
-      handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
+      handlers: [resourceHandlers.getRolesFor.editor(), ...COMMON_HANDLERS],
     },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
-    await canvas.findByRole("button", { name: /Filters/i })
+    await canvas.findByRole("button", { name: /Collection display/i })
+    expect(
+      canvas.queryByRole("button", { name: /Filters/i }),
+    ).not.toBeInTheDocument()
   },
 }
 

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -131,7 +131,7 @@ export const NewCollectionIndexEditingExperienceAsEditor: Story = {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
     await canvas.findByRole("button", { name: /Collection display/i })
-    expect(
+    await expect(
       canvas.queryByRole("button", { name: /Filters/i }),
     ).not.toBeInTheDocument()
   },

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -117,10 +117,10 @@ export const NewCollectionIndexEditingExperienceNonIsomerAdmin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
+    await canvas.findByRole("button", { name: /Filters/i })
   },
 }
 
-// "Filters" block is currently only accessible by Isomer Admin
 export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
@@ -131,6 +131,7 @@ export const NewCollectionIndexEditingExperienceIsomerAdmin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
+    await canvas.findByRole("button", { name: /Filters/i })
   },
 }
 
@@ -144,13 +145,9 @@ export const NewCollectionIndexEditingExperienceForDisplay: Story = {
   },
 }
 
-// Currently only accessible by Isomer Admin
 export const NewCollectionIndexEditingExperienceForFilters: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-    msw: {
-      handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
-    },
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
@@ -56,11 +56,8 @@ const meta: Meta<typeof EditPage> = {
 export default meta
 type Story = StoryObj<typeof EditPage>
 
-const newCollectionFiltersIsomerAdminParameters = {
+const newCollectionFiltersParameters = {
   growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  msw: {
-    handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
-  },
 } satisfies Story["parameters"]
 
 const zeroTagOptionsUsageParameters = {
@@ -76,7 +73,7 @@ const zeroTagOptionsUsageParameters = {
 
 /** Chromatic delay for play-driven inline edit snapshots. */
 const inlineEditSnapshotParameters = {
-  ...newCollectionFiltersIsomerAdminParameters,
+  ...newCollectionFiltersParameters,
   chromatic: { delay: 300 },
 } satisfies Story["parameters"]
 
@@ -249,10 +246,10 @@ export const NonIsomerAdmin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
+    await expect(canvas.getByRole("button", { name: /Filters/i })).toBeVisible()
   },
 }
 
-// "Filters" block is currently only accessible by Isomer Admin
 export const IsomerAdmin: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
@@ -263,6 +260,7 @@ export const IsomerAdmin: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
+    await expect(canvas.getByRole("button", { name: /Filters/i })).toBeVisible()
   },
 }
 
@@ -280,16 +278,15 @@ export const CollectionDisplay: Story = {
   },
 }
 
-// Currently only accessible by Isomer Admin
 export const ManageFilters: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)
   },
 }
 
 export const FiltersAddThreeOptions: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)
     await playOpenFirstFilterEditor(canvasElement)
@@ -298,7 +295,7 @@ export const FiltersAddThreeOptions: Story = {
 }
 
 export const FiltersOpenOptionRowMenu: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)
     await playOpenFirstFilterEditor(canvasElement)
@@ -311,7 +308,7 @@ export const FiltersOpenOptionRowMenu: Story = {
 }
 
 export const FiltersDeleteOptionModalDisabledCta: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     const portals = await playOpenDeleteOptionModal(canvasElement)
     await expect(
@@ -321,7 +318,7 @@ export const FiltersDeleteOptionModalDisabledCta: Story = {
 }
 
 export const FiltersDeleteOptionModalEnabledCta: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async (context) => {
     await FiltersDeleteOptionModalDisabledCta.play?.(context)
     const portals = withinPortals(context.canvasElement)
@@ -350,7 +347,7 @@ export const FiltersDeleteOptionModalZeroUsage: Story = {
 }
 
 export const FiltersBackShowsOptionCount: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)
     await playOpenFirstFilterEditor(canvasElement)
@@ -365,7 +362,7 @@ export const FiltersBackShowsOptionCount: Story = {
 }
 
 export const FiltersOpenFilterRowMenu: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)
     await playOpenFirstFilterEditor(canvasElement)
@@ -385,7 +382,7 @@ export const FiltersOpenFilterRowMenu: Story = {
 }
 
 export const FiltersDeleteFilterModalDisabledCta: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async ({ canvasElement }) => {
     const portals = await playOpenDeleteFilterModal(canvasElement)
     await portals.findByText(/It’s being used on/i)
@@ -396,7 +393,7 @@ export const FiltersDeleteFilterModalDisabledCta: Story = {
 }
 
 export const FiltersDeleteFilterModalEnabledCta: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
+  parameters: newCollectionFiltersParameters,
   play: async (context) => {
     await FiltersDeleteFilterModalDisabledCta.play?.(context)
     const portals = withinPortals(context.canvasElement)
@@ -430,7 +427,6 @@ export const FiltersDeleteFilterModalManyOptions: Story = {
     msw: {
       handlers: [
         pageHandlers.readPageAndBlob.collectionWithManyFilterOptions(),
-        userHandlers.isIsomerAdmin.admin(),
         ...COMMON_HANDLERS,
       ],
     },
@@ -484,9 +480,6 @@ export const CollectionDisplaySaveToast: Story = {
 export const ManageFiltersSaveToast: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-    msw: {
-      handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
-    },
   },
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
@@ -5,7 +5,6 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
-import { userHandlers } from "tests/msw/handlers/user"
 import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 
@@ -64,7 +63,6 @@ const zeroTagOptionsUsageParameters = {
   growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   msw: {
     handlers: [
-      userHandlers.isIsomerAdmin.admin(),
       ...COMMON_HANDLERS.slice(0, -1),
       collectionHandlers.countTagOptionsUsage.zero(),
     ],
@@ -239,27 +237,16 @@ async function playOpenDeleteFilterModal(canvasElement: HTMLElement) {
   return portals
 }
 
-export const NonIsomerAdmin: Story = {
+export const ManageCollection: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
-    await expect(canvas.getByRole("button", { name: /Filters/i })).toBeVisible()
-  },
-}
-
-export const IsomerAdmin: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-    msw: {
-      handlers: [userHandlers.isIsomerAdmin.admin(), ...COMMON_HANDLERS],
-    },
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement)
-    await canvas.findByText(/Manage Collection/i)
+    await expect(
+      canvas.getByRole("button", { name: /Collection display/i }),
+    ).toBeVisible()
     await expect(canvas.getByRole("button", { name: /Filters/i })).toBeVisible()
   },
 }

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
@@ -251,6 +251,26 @@ export const ManageCollection: Story = {
   },
 }
 
+/** Editors can open Collection display but cannot manage Filters. */
+export const ManageCollectionAsEditor: Story = {
+  parameters: {
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
+    msw: {
+      handlers: [resourceHandlers.getRolesFor.editor(), ...COMMON_HANDLERS],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText(/Manage Collection/i)
+    await expect(
+      canvas.getByRole("button", { name: /Collection display/i }),
+    ).toBeVisible()
+    await expect(
+      canvas.queryByRole("button", { name: /Filters/i }),
+    ).not.toBeInTheDocument()
+  },
+}
+
 export const CollectionDisplay: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],

--- a/apps/studio/tests/e2e/collection/filters-permission.test.ts
+++ b/apps/studio/tests/e2e/collection/filters-permission.test.ts
@@ -55,6 +55,39 @@ test.describe("admin", () => {
   })
 })
 
+// Core/Migrator are seeded with IsomerAdmin only — no site ResourcePermission
+// (see ensureGodModeAdmin in fixtures/seed.ts). They still get implicit site
+// Admin via getResourcePermission, so Filters must remain available.
+for (const role of ["core", "migrator"] as const) {
+  test.describe(`isomer admin (${role}) without site permission`, () => {
+    test.use({ storageState: storageStateFor(role) })
+
+    let collectionId: string
+    let indexPageId: string
+
+    test.beforeEach(async () => {
+      await dismissWelcomeModal(TEST_EMAILS[role])
+      ;({ collectionId, indexPageId } = await seedCollection())
+    })
+
+    test.afterEach(async () => {
+      await deleteCollection(collectionId)
+    })
+
+    test("can see and open Filters on the collection index", async ({
+      page,
+    }) => {
+      const collection = new CollectionPO(page)
+      await page.goto(`/sites/${siteId}/pages/${indexPageId}`)
+
+      await collection.expectManageCollectionVisible()
+      await collection.expectFiltersVisible()
+      await collection.openFilters()
+      await collection.expectManageFiltersDrawerOpen()
+    })
+  })
+}
+
 for (const role of ["editor", "publisher"] as const) {
   test.describe(role, () => {
     test.use({ storageState: storageStateFor(role) })

--- a/apps/studio/tests/e2e/collection/filters-permission.test.ts
+++ b/apps/studio/tests/e2e/collection/filters-permission.test.ts
@@ -1,0 +1,83 @@
+import { test } from "@playwright/test"
+import crypto from "crypto"
+import { db } from "~/server/modules/database"
+
+import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
+import {
+  createCollectionWithTagCategories,
+  deleteCollection,
+} from "../fixtures/collection"
+import { CollectionPO } from "../fixtures/collection.po"
+import { getSeedSiteId } from "../fixtures/seed"
+
+const siteId = getSeedSiteId()
+
+const dismissWelcomeModal = (email: string) =>
+  db
+    .updateTable("User")
+    .set({ name: "test-e2e", phone: "82345678" })
+    .where("email", "=", email)
+    .execute()
+
+const seedCollection = () =>
+  createCollectionWithTagCategories([
+    {
+      id: crypto.randomUUID(),
+      label: "Topic",
+      isRequired: false,
+      options: [{ id: crypto.randomUUID(), label: "Technology" }],
+    },
+  ])
+
+test.describe("admin", () => {
+  test.use({ storageState: storageStateFor("admin") })
+
+  let collectionId: string
+  let indexPageId: string
+
+  test.beforeEach(async () => {
+    await dismissWelcomeModal(TEST_EMAILS.admin)
+    ;({ collectionId, indexPageId } = await seedCollection())
+  })
+
+  test.afterEach(async () => {
+    await deleteCollection(collectionId)
+  })
+
+  test("can see and open Filters on the collection index", async ({ page }) => {
+    const collection = new CollectionPO(page)
+    await page.goto(`/sites/${siteId}/pages/${indexPageId}`)
+
+    await collection.expectManageCollectionVisible()
+    await collection.expectFiltersVisible()
+    await collection.openFilters()
+    await collection.expectManageFiltersDrawerOpen()
+  })
+})
+
+for (const role of ["editor", "publisher"] as const) {
+  test.describe(role, () => {
+    test.use({ storageState: storageStateFor(role) })
+
+    let collectionId: string
+    let indexPageId: string
+
+    test.beforeEach(async () => {
+      await dismissWelcomeModal(TEST_EMAILS[role])
+      ;({ collectionId, indexPageId } = await seedCollection())
+    })
+
+    test.afterEach(async () => {
+      await deleteCollection(collectionId)
+    })
+
+    test("cannot see Filters on the collection index", async ({ page }) => {
+      const collection = new CollectionPO(page)
+      await page.goto(`/sites/${siteId}/pages/${indexPageId}`)
+
+      await collection.expectManageCollectionVisible()
+      await collection.expectCollectionDisplayVisible()
+      await collection.expectFiltersHidden()
+    })
+  })
+}

--- a/apps/studio/tests/e2e/fixtures/collection.po.ts
+++ b/apps/studio/tests/e2e/fixtures/collection.po.ts
@@ -34,4 +34,35 @@ export class CollectionPO {
       this.page.getByText("At least one option must be selected"),
     ).toBeVisible()
   }
+
+  /** New collection editing experience root section (feature flag on). */
+  async expectManageCollectionVisible() {
+    await expect(this.page.getByText("Manage Collection")).toBeVisible()
+  }
+
+  async expectCollectionDisplayVisible() {
+    await expect(
+      this.page.getByRole("button", { name: /Collection display/i }),
+    ).toBeVisible()
+  }
+
+  async expectFiltersVisible() {
+    await expect(
+      this.page.getByRole("button", { name: /Filters/i }),
+    ).toBeVisible()
+  }
+
+  async expectFiltersHidden() {
+    await expect(
+      this.page.getByRole("button", { name: /Filters/i }),
+    ).not.toBeVisible()
+  }
+
+  async openFilters() {
+    await this.page.getByRole("button", { name: /Filters/i }).click()
+  }
+
+  async expectManageFiltersDrawerOpen() {
+    await expect(this.page.getByText("Manage filters")).toBeVisible()
+  }
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +35 | -21 |
| 🧪 Test | 4 | +181 | -35 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Collection Filters / tag category management was gated to **Isomer Admins** (Core/Migrator). Site Admins could not manage Filters even with the feature flag on, and the gate did not match how other site-admin settings work.

## Solution

Gate Filters on **site Admin** permission, and centralise that check in one place specific to Filters:

`apps/studio/src/features/editing-experience/hooks/canManageCollectionFilters.tsx`

- `canManageCollectionFilters(ability)` — pure check (today: CASL `create` at site root)
- `useCanManageCollectionFilters()` — hook for imperative gates
- `CanManageCollectionFilters` — component wrapper for JSX

| Role | Collection display | Filters |
|------|-------------------|---------|
| Site Admin | Yes | Yes |
| Editor / Publisher | Yes | No |

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Filters UI uses Filters-specific permission helpers instead of Isomer Admin or inline CASL checks
- Storybook covers Admin vs Editor (`ManageCollection`, `ManageCollectionAsEditor`)
- E2E: `tests/e2e/collection/filters-permission.test.ts` asserts Admin can open Filters; Editor/Publisher cannot see it

**Not changed**:

- Feature flag `is-new-collection-tags-management-enabled` still gates the new collection editing experience
- Raw JSON editor remains Isomer Admin–only
- Save still uses normal page write permissions (UI gate only, same as before)

## Tests

**Manual Verification Steps**:

- [ ] Feature flag on + **site Admin**: Collection → Manage Collection → Filters is visible and editable
- [ ] Feature flag on + **site Editor**: Collection display visible; Filters not shown
- [ ] Feature flag on + **site Publisher**: Filters not shown
- [ ] As site Admin, create/edit/delete tag categories and options, then save
- [ ] Feature flag off: legacy Collection settings UI still shows
- [ ] Isomer Admin still sees Raw JSON editor
- [ ] Storybook: `ManageCollection`, `ManageCollectionAsEditor`, `ManageFilters` pass
- [ ] E2E: `pnpm exec playwright test tests/e2e/collection/filters-permission.test.ts`

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb4ee3ae-6caf-4162-bc70-f1468b957cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb4ee3ae-6caf-4162-bc70-f1468b957cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR moves the Collection Filters / tag-category management gate from Isomer Admin (Core/Migrator roles) to site Admin, consolidating the permission check into a single new module (`canManageCollectionFilters.tsx`) that exports a pure function, a hook, and a JSX wrapper component.

- The CASL check `ability.can(\"create\", { parentId: null })` correctly resolves to `true` only for the Admin role, matching the `permissions.util.ts` definitions for Editor, Publisher, and Admin.
- Three call sites (`CollectionEditorStateDrawer`, `RootStateDrawer`, `JsonFormsTagCategoryOptionsControl`) are updated to use the new helpers; Storybook stories and an E2E permission test round out the coverage.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change narrows a single UI gate from a global Isomer Admin check to a site Admin check, with no server-side permission changes.

The CASL check maps cleanly to Admin-only per permissions.util.ts, the three changed call sites are all UI-only guards, and the new permission logic is covered by Storybook stories and an E2E test for all four roles. The only finding is an inconsequential trailing whitespace node in JSX.

No files require special attention beyond the cosmetic whitespace nit in RootStateDrawer.tsx.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/hooks/canManageCollectionFilters.tsx | New centralised permission abstraction: pure function, hook, and JSX wrapper that all delegate to ability.can("create", { parentId: null }), which correctly resolves to true for Admin role only based on permissions.util.ts. |
| apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx | Swaps useIsUserIsomerAdmin (Core/Migrator only) for useCanManageCollectionFilters (site Admin) to gate the tag categories schema fields; logic is otherwise unchanged. |
| apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx | Replaces inline Isomer-admin guard with <CanManageCollectionFilters> wrapper; leaves a stray {" "} text node after the closing tag of the wrapper. |
| apps/studio/tests/e2e/collection/filters-permission.test.ts | New E2E test covering admin, Isomer Admin (Core/Migrator), editor, and publisher roles; correctly tests the Filters button visibility and the Manage Filters drawer. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Collection Index page] --> B{Feature flag\nis-new-collection-tags-management-enabled?}
    B -- off --> C[Legacy Collection settings UI]
    B -- on --> D[New Manage Collection UI]
    D --> E[Collection display block - visible to all]
    D --> F{canManageCollectionFilters\nability.can create parentId=null}
    F -- Admin role --> G[Filters block visible\nManageFilters drawer accessible\ntagCategories schema fields included]
    F -- Editor / Publisher role --> H[Filters block hidden\ntagCategories always excluded]
    G --> I[Isomer Admin also sees\nRaw JSON editor - unchanged]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(studio): assert Isomer Admins can o..."](https://github.com/opengovsg/isomer/commit/23c46871012d399d36972a59ff54757e9133f618) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46023891)</sub>

<!-- /greptile_comment -->