### PR TITLE
fix(dashboard): hide publish warning and fix button label for draft pages

### DIFF
--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -131,13 +131,14 @@ const PageSettingsModalContent = ({
   )
 
   const originalPermalink = permalinkTree[permalinkTree.length - 1] ?? ""
+  const isPagePublished = publishedVersionId !== null
   // Offer the redirect only when a published Page/CollectionPage URL actually
   // changes — an unpublished page has no live URL to preserve, so the server
   // skips redirect creation for it anyway.
   const showRedirectOption =
     (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
     permalink !== originalPermalink &&
-    publishedVersionId !== null
+    isPagePublished
   const oldFullPermalink = `${permalinksToRender.parentPermalinks}${originalPermalink}`
 
   const utils = trpc.useUtils()
@@ -295,10 +296,12 @@ const PageSettingsModalContent = ({
             </FormControl>
           )}
 
-          <Infobox variant="warning" size="sm">
-            {`Changes to your title${type === ResourceType.CollectionLink ? "" : " and URL"} will get published immediately. If you
+          {isPagePublished && (
+            <Infobox variant="warning" size="sm">
+              {`Changes to your title${type === ResourceType.CollectionLink ? "" : " and URL"} will get published immediately. If you
             don't want to publish ${type === ResourceType.CollectionLink ? "it" : "them"}, make this change later.`}
-          </Infobox>
+            </Infobox>
+          )}
         </VStack>
       </ModalBody>
 
@@ -307,7 +310,7 @@ const PageSettingsModalContent = ({
           Close
         </Button>
         <Button onClick={onSubmit} isLoading={isPending}>
-          Publish immediately
+          {isPagePublished ? "Publish immediately" : "Save"}
         </Button>
       </ModalFooter>
     </ModalContent>

--- a/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/PageSettingsModal.tsx
@@ -153,11 +153,18 @@ const PageSettingsModalContent = ({
         await utils.folder.invalidate()
         await utils.collection.invalidate()
 
-        toast({
-          title: "Saved and published settings",
-          description: "Check your site in 5-10 minutes to view it live.",
-          status: "success",
-        })
+        toast(
+          isPagePublished
+            ? {
+                title: "Saved and published settings",
+                description: "Check your site in 5-10 minutes to view it live.",
+                status: "success",
+              }
+            : {
+                title: "Saved settings",
+                status: "success",
+              },
+        )
       },
       onError: (error) => {
         toast({

--- a/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
+++ b/apps/studio/src/stories/components/PageSettingsModal.stories.tsx
@@ -120,5 +120,9 @@ export const UnpublishedPageHidesRedirectOption: Story = {
     await userEvent.type(urlInput, "renamed-page")
     // The "Redirect page automatically" option must not appear.
     await expect(body.queryByText("Redirect page automatically")).toBeNull()
+    // The publish warning must not appear for a page that hasn't been published.
+    await expect(body.queryByText(/will get published immediately/)).toBeNull()
+    // The confirm button should say "Save", not "Publish immediately".
+    await body.findByRole("button", { name: "Save" })
   },
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +20 | -10 |
| 🧪 Test | 1 | +4 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

The page settings modal showed a "Changes to your title and URL will get published immediately" warning and a "Publish immediately" button label unconditionally — even when the page had never been published. This was inaccurate and potentially confusing for editors working on draft pages.

Fixes ISOM-2377.

## Solution

<!-- How did you solve the problem? -->

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Introduced a named constant `isPagePublished` (`publishedVersionId !== null`) to make the intent explicit and reusable across the component.
- Gated the "will get published immediately" warning `Infobox` behind `isPagePublished`, so it only appears when the page already has a published version.
- Changed the confirm button label to "Publish immediately" for published pages and "Save" for draft pages, accurately reflecting what the action will do.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Open the page settings modal for a page that **has never been published** (draft). Confirm that the yellow warning about publishing immediately is **not shown**, and the confirm button reads **"Save"**.
- [ ] Open the page settings modal for a page that **has been published** at least once. Confirm that the yellow warning about publishing immediately **is shown**, and the confirm button reads **"Publish immediately"**.
- [ ] On a published page, change the URL and confirm the redirect checkbox still appears as before.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the page settings modal for draft and published pages. The main changes are:

- Hides the immediate-publish warning when a page has never been published.
- Uses `Save` for draft pages and `Publish immediately` for published pages.
- Shows draft-specific success toast copy after saving settings.
- Extends the Storybook interaction to cover the unpublished-page modal state.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The changes are contained to reversible Studio UI behavior and Storybook coverage. No server contracts, persistence, auth, or publish pipeline behavior are changed. No functional or security issues were found in the changed paths.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The Storybook server run for the page-settings story started, showed compilation progress, and was killed with Exit status 137 before reaching readiness.
- A Playwright validation script was generated to assert warning visibility, button labels, and redirect checkbox behavior against the Storybook stories.
- No screenshots or videos were produced because Storybook never reached readiness, so no capture artifacts were created.

<a href="https://app.greptile.com/trex/runs/15412420/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/dashboard/components/PageSettingsModal.tsx | Adds an `isPagePublished` guard so draft pages no longer show immediate-publish copy, use a draft-appropriate success toast, or offer redirect creation for unpublished URLs. |
| apps/studio/src/stories/components/PageSettingsModal.stories.tsx | Extends the unpublished-page Storybook interaction to assert the redirect option and publish warning are hidden and the confirm button reads `Save`. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Editor
participant Modal as PageSettingsModal
participant PageAPI as trpc.page.readPage
participant Mutation as trpc.page.updateSettings

Editor->>Modal: Open page settings
Modal->>PageAPI: Load title + publishedVersionId
PageAPI-->>Modal: Return page metadata
alt publishedVersionId is not null
    Modal-->>Editor: Show publish warning and "Publish immediately"
    Editor->>Modal: Save settings
    Modal->>Mutation: updateSettings
    Mutation-->>Modal: Success
    Modal-->>Editor: "Saved and published settings" toast
else publishedVersionId is null
    Modal-->>Editor: Hide publish warning and show "Save"
    Editor->>Modal: Save draft settings
    Modal->>Mutation: updateSettings
    Mutation-->>Modal: Success
    Modal-->>Editor: "Saved settings" toast
end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(dashboard): assert publish warning ..."](https://github.com/opengovsg/isomer/commit/bacd3c955129b53e3778bab2b0cfa5d9f98bc651) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45856752)</sub>

<!-- /greptile_comment -->