### PR TITLE
🔖 P2 - fix(studio): hide usage sentence in delete modals when count is zero

### DIFF
--- a/apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx
@@ -30,11 +30,9 @@ interface DeleteFilterModalProps {
   onConfirm: () => void
 }
 
-// Querying usage counts for very large filters is disallowed server-side
-// (see MAX_TAG_OPTION_IDS_FOR_USAGE_COUNT) since the count is not worth the
-// request/SQL cost at that scale. Skip the query entirely and say so, rather
-// than sending a request we know will fail or truncating to a misleading
-// capped number like "999+".
+const DELETE_FILTER_UNDO_TEXT =
+  "To undo this change, you will need to recreate this filter and assign options to each item individually."
+
 function FilterUsageInfobox({
   siteId,
   pageId,
@@ -44,36 +42,18 @@ function FilterUsageInfobox({
   pageId: number
   tagOptionIds: string[]
 }) {
-  if (tagOptionIds.length > MAX_TAG_OPTION_IDS_FOR_USAGE_COUNT) {
-    return (
-      <Text textStyle="body-1" color="base.content.strong">
-        It’s being used on a large number of results. To undo this change, you
-        will need to recreate this filter and assign options to each item
-        individually.
-      </Text>
-    )
-  }
-
   const [{ count }] = trpc.collection.countTagOptionsUsage.useSuspenseQuery({
     siteId,
     pageId,
     tagOptionIds,
   })
 
-  const undoText =
-    "To undo this change, you will need to recreate this filter and assign options to each item individually."
-
-  if (count === 0) {
-    return (
-      <Text textStyle="body-1" color="base.content.strong">
-        {undoText}
-      </Text>
-    )
-  }
-
   return (
     <Text textStyle="body-1" color="base.content.strong">
-      It’s being used on {count === 1 ? "1 item" : `${count} items`}. {undoText}
+      {count > 0
+        ? `It’s being used on ${count === 1 ? "1 item" : `${count} items`}.`
+        : ""}
+      {DELETE_FILTER_UNDO_TEXT}
     </Text>
   )
 }
@@ -103,18 +83,29 @@ export function DeleteFilterModal({
               <ErrorBoundary
                 fallbackRender={() => (
                   <Text textStyle="body-1" color="base.content.strong">
-                    To undo this change, you will need to recreate this filter
-                    and assign options to each item individually.
+                    {DELETE_FILTER_UNDO_TEXT}
                   </Text>
                 )}
               >
-                <Suspense fallback={<Skeleton height="2.5em" width="100%" />}>
-                  <FilterUsageInfobox
-                    siteId={siteId}
-                    pageId={pageId}
-                    tagOptionIds={tagOptionIds}
-                  />
-                </Suspense>
+                {/* Querying usage counts for very large filters is disallowed server-side
+                (see MAX_TAG_OPTION_IDS_FOR_USAGE_COUNT) since the count is not worth the
+                request/SQL cost at that scale. Skip the query entirely and say so, rather
+                than sending a request we know will fail or truncating to a misleading
+                capped number like "999+". */}
+                {tagOptionIds.length > MAX_TAG_OPTION_IDS_FOR_USAGE_COUNT ? (
+                  <Text textStyle="body-1" color="base.content.strong">
+                    It’s being used on a large number of results.{" "}
+                    {DELETE_FILTER_UNDO_TEXT}
+                  </Text>
+                ) : (
+                  <Suspense fallback={<Skeleton height="2.5em" width="100%" />}>
+                    <FilterUsageInfobox
+                      siteId={siteId}
+                      pageId={pageId}
+                      tagOptionIds={tagOptionIds}
+                    />
+                  </Suspense>
+                )}
               </ErrorBoundary>
             </Infobox>
             <HStack align="start">

--- a/apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx
@@ -60,11 +60,20 @@ function FilterUsageInfobox({
     tagOptionIds,
   })
 
+  const undoText =
+    "To undo this change, you will need to recreate this filter and assign options to each item individually."
+
+  if (count === 0) {
+    return (
+      <Text textStyle="body-1" color="base.content.strong">
+        {undoText}
+      </Text>
+    )
+  }
+
   return (
     <Text textStyle="body-1" color="base.content.strong">
-      It’s being used on {count === 1 ? "1 item" : `${count} items`}. To undo
-      this change, you will need to recreate this filter and assign options to
-      each item individually.
+      It’s being used on {count === 1 ? "1 item" : `${count} items`}. {undoText}
     </Text>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -39,7 +39,11 @@ function DeleteOptionWarningBody({
     "To undo this change, you will need to create and re-assign this option to all items."
 
   if (!tagId) {
-    return <Text textStyle="body-2">{undoText}</Text>
+    return (
+      <Text textStyle="body-1" color="base.content.strong">
+        {undoText}
+      </Text>
+    )
   }
 
   const [{ count }] = trpc.collection.countTagOptionsUsage.useSuspenseQuery({
@@ -49,11 +53,15 @@ function DeleteOptionWarningBody({
   })
 
   if (count === 0) {
-    return <Text textStyle="body-2">{undoText}</Text>
+    return (
+      <Text textStyle="body-1" color="base.content.strong">
+        {undoText}
+      </Text>
+    )
   }
 
   return (
-    <Text textStyle="body-2">
+    <Text textStyle="body-1" color="base.content.strong">
       This option is being used in {count} {count === 1 ? "item" : "items"}.{" "}
       {undoText}
     </Text>
@@ -295,7 +303,7 @@ const JsonFormsTagCategoryOptionsArrayLayoutInner = (
           warningBody={
             <ErrorBoundary
               fallbackRender={() => (
-                <Text textStyle="body-2">
+                <Text textStyle="body-1" color="base.content.strong">
                   To undo this change, you will need to create and re-assign
                   this option to all items.
                 </Text>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -26,6 +26,17 @@ import { useDeleteTarget } from "../../hooks/useDeleteTarget"
 import { useLiveLabelIssues } from "../../hooks/useLiveLabelIssues"
 import { createDefaultTagOption } from "./constants"
 
+const DELETE_OPTION_UNDO_TEXT =
+  "To undo this change, you will need to create and re-assign this option to all items."
+
+function DeleteOptionUndoNotice() {
+  return (
+    <Text textStyle="body-1" color="base.content.strong">
+      {DELETE_OPTION_UNDO_TEXT}
+    </Text>
+  )
+}
+
 function DeleteOptionWarningBody({
   siteId,
   pageId,
@@ -33,19 +44,8 @@ function DeleteOptionWarningBody({
 }: {
   siteId: number
   pageId: number
-  tagId?: string
+  tagId: string
 }) {
-  const undoText =
-    "To undo this change, you will need to create and re-assign this option to all items."
-
-  if (!tagId) {
-    return (
-      <Text textStyle="body-1" color="base.content.strong">
-        {undoText}
-      </Text>
-    )
-  }
-
   const [{ count }] = trpc.collection.countTagOptionsUsage.useSuspenseQuery({
     siteId,
     pageId,
@@ -53,17 +53,13 @@ function DeleteOptionWarningBody({
   })
 
   if (count === 0) {
-    return (
-      <Text textStyle="body-1" color="base.content.strong">
-        {undoText}
-      </Text>
-    )
+    return <DeleteOptionUndoNotice />
   }
 
   return (
     <Text textStyle="body-1" color="base.content.strong">
       This option is being used in {count} {count === 1 ? "item" : "items"}.{" "}
-      {undoText}
+      {DELETE_OPTION_UNDO_TEXT}
     </Text>
   )
 }
@@ -91,7 +87,7 @@ const JsonFormsTagCategoryOptionsArrayLayoutInner = (
   const { hasErrorAt } = useBuilderErrors()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const items = get(core?.data, path) as
-    | { label?: string; id?: string }[]
+    | { label?: string; id: string }[]
     | undefined
   // Inline label editing is keyed by array index. editingDraftLabel feeds
   // useLiveLabelIssues so duplicate/blank checks reflect unsaved keystrokes.
@@ -148,13 +144,13 @@ const JsonFormsTagCategoryOptionsArrayLayoutInner = (
     openDeleteModal,
     closeDeleteModal,
     handleConfirmDelete,
-  } = useDeleteTarget<{ label: string; tagId?: string }>({
+  } = useDeleteTarget<{ label: string; tagId: string }>({
     path,
     removeItems,
     isRemoveItemDisabled,
     resolveTarget: (index) => ({
       label: items?.[index]?.label?.trim() ?? "",
-      tagId: items?.[index]?.id,
+      tagId: items?.[index]?.id ?? "", // always set by createDefaultTagOption()
     }),
   })
 
@@ -301,14 +297,7 @@ const JsonFormsTagCategoryOptionsArrayLayoutInner = (
           label={deleteTarget.label}
           noun="filter option"
           warningBody={
-            <ErrorBoundary
-              fallbackRender={() => (
-                <Text textStyle="body-1" color="base.content.strong">
-                  To undo this change, you will need to create and re-assign
-                  this option to all items.
-                </Text>
-              )}
-            >
+            <ErrorBoundary fallbackRender={() => <DeleteOptionUndoNotice />}>
               <Suspense fallback={<Skeleton height="2.5em" width="100%" />}>
                 <DeleteOptionWarningBody
                   siteId={siteId}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -26,25 +26,37 @@ import { useDeleteTarget } from "../../hooks/useDeleteTarget"
 import { useLiveLabelIssues } from "../../hooks/useLiveLabelIssues"
 import { createDefaultTagOption } from "./constants"
 
-function TagOptionUsageCount({
+function DeleteOptionWarningBody({
   siteId,
   pageId,
   tagId,
 }: {
   siteId: number
   pageId: number
-  tagId: string
+  tagId?: string
 }) {
+  const undoText =
+    "To undo this change, you will need to create and re-assign this option to all items."
+
+  if (!tagId) {
+    return <Text textStyle="body-2">{undoText}</Text>
+  }
+
   const [{ count }] = trpc.collection.countTagOptionsUsage.useSuspenseQuery({
     siteId,
     pageId,
     tagOptionIds: [tagId],
   })
 
+  if (count === 0) {
+    return <Text textStyle="body-2">{undoText}</Text>
+  }
+
   return (
-    <>
-      {count} {count === 1 ? "item" : "items"}
-    </>
+    <Text textStyle="body-2">
+      This option is being used in {count} {count === 1 ? "item" : "items"}.{" "}
+      {undoText}
+    </Text>
   )
 }
 
@@ -281,34 +293,22 @@ const JsonFormsTagCategoryOptionsArrayLayoutInner = (
           label={deleteTarget.label}
           noun="filter option"
           warningBody={
-            <Text textStyle="body-2">
-              This option is being used in{" "}
-              <ErrorBoundary fallbackRender={() => <>—</>}>
-                <Suspense
-                  fallback={
-                    <Skeleton
-                      as="span"
-                      display="inline-block"
-                      verticalAlign="middle"
-                      height="1em"
-                      width="2ch"
-                    />
-                  }
-                >
-                  {deleteTarget.tagId ? (
-                    <TagOptionUsageCount
-                      siteId={siteId}
-                      pageId={pageId}
-                      tagId={deleteTarget.tagId}
-                    />
-                  ) : (
-                    <>0 items</>
-                  )}
-                </Suspense>
-              </ErrorBoundary>
-              {". "}To undo this change, you will need to create and re-assign
-              this option to all items.
-            </Text>
+            <ErrorBoundary
+              fallbackRender={() => (
+                <Text textStyle="body-2">
+                  To undo this change, you will need to create and re-assign
+                  this option to all items.
+                </Text>
+              )}
+            >
+              <Suspense fallback={<Skeleton height="2.5em" width="100%" />}>
+                <DeleteOptionWarningBody
+                  siteId={siteId}
+                  pageId={pageId}
+                  tagId={deleteTarget.tagId}
+                />
+              </Suspense>
+            </ErrorBoundary>
           }
           onClose={closeDeleteModal}
           onConfirm={handleConfirmDelete}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -29,14 +29,6 @@ import { createDefaultTagOption } from "./constants"
 const DELETE_OPTION_UNDO_TEXT =
   "To undo this change, you will need to create and re-assign this option to all items."
 
-function DeleteOptionUndoNotice() {
-  return (
-    <Text textStyle="body-1" color="base.content.strong">
-      {DELETE_OPTION_UNDO_TEXT}
-    </Text>
-  )
-}
-
 function DeleteOptionWarningBody({
   siteId,
   pageId,
@@ -52,13 +44,11 @@ function DeleteOptionWarningBody({
     tagOptionIds: [tagId],
   })
 
-  if (count === 0) {
-    return <DeleteOptionUndoNotice />
-  }
-
   return (
     <Text textStyle="body-1" color="base.content.strong">
-      This option is being used in {count} {count === 1 ? "item" : "items"}.{" "}
+      {count > 0
+        ? `This option is being used in ${count === 1 ? "1 item" : `${count} items`}.`
+        : ""}
       {DELETE_OPTION_UNDO_TEXT}
     </Text>
   )
@@ -297,7 +287,13 @@ const JsonFormsTagCategoryOptionsArrayLayoutInner = (
           label={deleteTarget.label}
           noun="filter option"
           warningBody={
-            <ErrorBoundary fallbackRender={() => <DeleteOptionUndoNotice />}>
+            <ErrorBoundary
+              fallbackRender={() => (
+                <Text textStyle="body-1" color="base.content.strong">
+                  {DELETE_OPTION_UNDO_TEXT}
+                </Text>
+              )}
+            >
               <Suspense fallback={<Skeleton height="2.5em" width="100%" />}>
                 <DeleteOptionWarningBody
                   siteId={siteId}

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
@@ -63,6 +63,17 @@ const newCollectionFiltersIsomerAdminParameters = {
   },
 } satisfies Story["parameters"]
 
+const zeroTagOptionsUsageParameters = {
+  growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
+  msw: {
+    handlers: [
+      userHandlers.isIsomerAdmin.admin(),
+      ...COMMON_HANDLERS.slice(0, -1),
+      collectionHandlers.countTagOptionsUsage.zero(),
+    ],
+  },
+} satisfies Story["parameters"]
+
 /** Chromatic delay for play-driven inline edit snapshots. */
 const inlineEditSnapshotParameters = {
   ...newCollectionFiltersIsomerAdminParameters,
@@ -198,6 +209,39 @@ function withinPortals(canvasElement: HTMLElement) {
   return within(canvasElement.ownerDocument.body)
 }
 
+async function playOpenDeleteOptionModal(canvasElement: HTMLElement) {
+  await playOpenManageFilters(canvasElement)
+  await playOpenFirstFilterEditor(canvasElement)
+  await playFillFilterNameAndAddThreeOptions(canvasElement)
+  await renameOptionAtIndex(canvasElement, 0, "Option 1")
+  await clickOptionActionsMenu(canvasElement, 1)
+  const portals = withinPortals(canvasElement)
+  await userEvent.click(await portals.findByText(/^Delete option$/i), {
+    pointerEventsCheck: 0,
+  })
+  await portals.findByRole("dialog", { name: /Delete filter option/i })
+  return portals
+}
+
+async function playOpenDeleteFilterModal(canvasElement: HTMLElement) {
+  await playOpenManageFilters(canvasElement)
+  await playOpenFirstFilterEditor(canvasElement)
+  await playFillFilterNameAndAddThreeOptions(canvasElement)
+  const canvas = within(canvasElement)
+  await userEvent.click(
+    await canvas.findByRole("button", { name: /Return to Filters/i }),
+  )
+  await userEvent.click(
+    await canvas.findByRole("button", { name: /Filter 1 actions/i }),
+  )
+  const portals = withinPortals(canvasElement)
+  await userEvent.click(
+    await portals.findByRole("menuitem", { name: /Delete filter/i }),
+  )
+  await portals.findByText(/You are deleting an entire filter\./i)
+  return portals
+}
+
 export const NonIsomerAdmin: Story = {
   parameters: {
     growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
@@ -269,16 +313,7 @@ export const FiltersOpenOptionRowMenu: Story = {
 export const FiltersDeleteOptionModalDisabledCta: Story = {
   parameters: newCollectionFiltersIsomerAdminParameters,
   play: async ({ canvasElement }) => {
-    await playOpenManageFilters(canvasElement)
-    await playOpenFirstFilterEditor(canvasElement)
-    await playFillFilterNameAndAddThreeOptions(canvasElement)
-    await renameOptionAtIndex(canvasElement, 0, "Option 1")
-    await clickOptionActionsMenu(canvasElement, 1)
-    const portals = withinPortals(canvasElement)
-    await userEvent.click(await portals.findByText(/^Delete option$/i), {
-      pointerEventsCheck: 0,
-    })
-    await portals.findByRole("dialog", { name: /Delete filter option/i })
+    const portals = await playOpenDeleteOptionModal(canvasElement)
     await expect(
       await portals.findByRole("button", { name: /^Delete filter option$/i }),
     ).toBeDisabled()
@@ -302,10 +337,9 @@ export const FiltersDeleteOptionModalEnabledCta: Story = {
 }
 
 export const FiltersDeleteOptionModalZeroUsage: Story = {
-  parameters: newCollectionFiltersIsomerAdminParameters,
-  play: async (context) => {
-    await FiltersDeleteOptionModalDisabledCta.play?.(context)
-    const portals = withinPortals(context.canvasElement)
+  parameters: zeroTagOptionsUsageParameters,
+  play: async ({ canvasElement }) => {
+    const portals = await playOpenDeleteOptionModal(canvasElement)
     await expect(
       portals.queryByText(/This option is being used in/i),
     ).not.toBeInTheDocument()
@@ -353,21 +387,7 @@ export const FiltersOpenFilterRowMenu: Story = {
 export const FiltersDeleteFilterModalDisabledCta: Story = {
   parameters: newCollectionFiltersIsomerAdminParameters,
   play: async ({ canvasElement }) => {
-    await playOpenManageFilters(canvasElement)
-    await playOpenFirstFilterEditor(canvasElement)
-    await playFillFilterNameAndAddThreeOptions(canvasElement)
-    const canvas = within(canvasElement)
-    await userEvent.click(
-      await canvas.findByRole("button", { name: /Return to Filters/i }),
-    )
-    await userEvent.click(
-      await canvas.findByRole("button", { name: /Filter 1 actions/i }),
-    )
-    const portals = withinPortals(canvasElement)
-    await userEvent.click(
-      await portals.findByRole("menuitem", { name: /Delete filter/i }),
-    )
-    await portals.findByText(/You are deleting an entire filter\./i)
+    const portals = await playOpenDeleteFilterModal(canvasElement)
     await portals.findByText(/It’s being used on/i)
     await expect(
       await portals.findByRole("button", { name: /^Delete filter$/i }),
@@ -392,19 +412,9 @@ export const FiltersDeleteFilterModalEnabledCta: Story = {
 }
 
 export const FiltersDeleteFilterModalZeroUsage: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-    msw: {
-      handlers: [
-        userHandlers.isIsomerAdmin.admin(),
-        ...COMMON_HANDLERS.slice(0, -1),
-        collectionHandlers.countTagOptionsUsage.zero(),
-      ],
-    },
-  },
-  play: async (context) => {
-    await FiltersDeleteFilterModalDisabledCta.play?.(context)
-    const portals = withinPortals(context.canvasElement)
+  parameters: zeroTagOptionsUsageParameters,
+  play: async ({ canvasElement }) => {
+    const portals = await playOpenDeleteFilterModal(canvasElement)
     await expect(
       portals.queryByText(/It’s being used on/i),
     ).not.toBeInTheDocument()

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
@@ -301,6 +301,20 @@ export const FiltersDeleteOptionModalEnabledCta: Story = {
   },
 }
 
+export const FiltersDeleteOptionModalZeroUsage: Story = {
+  parameters: newCollectionFiltersIsomerAdminParameters,
+  play: async (context) => {
+    await FiltersDeleteOptionModalDisabledCta.play?.(context)
+    const portals = withinPortals(context.canvasElement)
+    await expect(
+      portals.queryByText(/This option is being used in/i),
+    ).not.toBeInTheDocument()
+    await portals.findByText(
+      /To undo this change, you will need to create and re-assign this option to all items\./i,
+    )
+  },
+}
+
 export const FiltersBackShowsOptionCount: Story = {
   parameters: newCollectionFiltersIsomerAdminParameters,
   play: async ({ canvasElement }) => {
@@ -374,6 +388,29 @@ export const FiltersDeleteFilterModalEnabledCta: Story = {
     await expect(
       await portals.findByRole("button", { name: /^Delete filter$/i }),
     ).not.toBeDisabled()
+  },
+}
+
+export const FiltersDeleteFilterModalZeroUsage: Story = {
+  parameters: {
+    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
+    msw: {
+      handlers: [
+        userHandlers.isIsomerAdmin.admin(),
+        ...COMMON_HANDLERS.slice(0, -1),
+        collectionHandlers.countTagOptionsUsage.zero(),
+      ],
+    },
+  },
+  play: async (context) => {
+    await FiltersDeleteFilterModalDisabledCta.play?.(context)
+    const portals = withinPortals(context.canvasElement)
+    await expect(
+      portals.queryByText(/It’s being used on/i),
+    ).not.toBeInTheDocument()
+    await portals.findByText(
+      /To undo this change, you will need to recreate this filter and assign options to each item individually\./i,
+    )
   },
 }
 

--- a/apps/studio/tests/msw/handlers/collection.ts
+++ b/apps/studio/tests/msw/handlers/collection.ts
@@ -102,5 +102,7 @@ export const collectionHandlers = {
   countTagOptionsUsage: {
     default: () =>
       trpcMsw.collection.countTagOptionsUsage.query(() => ({ count: 3 })),
+    zero: () =>
+      trpcMsw.collection.countTagOptionsUsage.query(() => ({ count: 0 })),
   },
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When deleting a collection filter or filter option, the delete modal infobox shows usage copy like "This option is being used in 0 items" or "It's being used on 0 items". That is misleading — a count of zero means the item is not in use, so the warning sentence should not appear.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- N/A

**Bug Fixes**:

- **Delete filter modal** (`DeleteFilterModal`): when the usage count is 0, the infobox now only shows the undo guidance and omits the "being used on N items" sentence.
- **Delete option modal** (`JsonFormsTagCategoryOptionsControl`): the full warning text is rendered inside a new `DeleteOptionWarningBody` component wrapped in `Suspense` (instead of suspending only the count inline). When there is no `tagId` (unsaved option) or the count is 0, only the undo guidance is shown.

## Before & After Screenshots

**BEFORE**:

Delete modal infobox shows: "This option is being used in 0 items. To undo this change..."

**AFTER**:

Delete modal infobox shows only: "To undo this change, you will need to create and re-assign this option to all items." (when usage count is 0)

## Tests

- Added Storybook play tests: `FiltersDeleteOptionModalZeroUsage` and `FiltersDeleteFilterModalZeroUsage`
- Added MSW handler `countTagOptionsUsage.zero()` for zero-count scenarios
- `pnpm typecheck` passes

**Manual Verification Steps**:

- [ ] Open a collection index page as an Isomer admin and navigate to **Filters** → **Manage filters**
- [ ] Add a new filter with at least one option (unsaved, no tag ID) and open the delete option modal — confirm the infobox does **not** show "being used in 0 items" and only shows the undo guidance
- [ ] Return to the filters list and open the delete filter modal for a filter with no usage — confirm the infobox does **not** show "It's being used on 0 items" and only shows the undo guidance
- [ ] For a filter/option that **is** in use (count > 0), confirm the usage sentence still appears alongside the undo guidance
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c97c3383-788d-48c6-898f-9ec385a42833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c97c3383-788d-48c6-898f-9ec385a42833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates delete modal warning copy for collection filters and options. The main changes are:

- Hides the usage sentence when the usage count is zero.
- Keeps undo guidance visible in zero-count, error, and fallback states.
- Adds Storybook stories and an MSW handler for zero-usage modal scenarios.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge after the warning copy spacing issues are fixed.

The zero-count behavior is implemented and covered. The remaining issues are contained UI copy regressions in the positive-count path. No security concerns were identified.

`apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx`; `apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx`
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to start Storybook for isomer-studio with the command pnpm --filter isomer-studio storybook in the repository, but the process was killed with exit code 137 before Storybook could serve.
- Because the Storybook server never became reachable, Playwright could not navigate to the zero-usage delete option/filter modal stories.

<a href="https://app.greptile.com/trex/runs/15283715/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx | Updates delete-filter warning copy to omit usage text at zero count; non-zero copy currently loses the space before undo text. |
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx | Wraps delete-option usage warning in a Suspense-backed body and hides zero-count usage text; non-zero copy currently loses sentence spacing. |
| apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx | Adds reusable Storybook play helpers and zero-usage stories for delete option/filter modals. |
| apps/studio/tests/msw/handlers/collection.ts | Adds an MSW handler variant returning zero tag-option usage for stories/tests. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant DeleteModal
participant Boundary as Suspense/ErrorBoundary
participant TRPC as countTagOptionsUsage

User->>DeleteModal: Open delete filter or option modal
alt Filter has too many options
    DeleteModal-->>User: Show large-usage warning and undo guidance
else Usage count is queried
    DeleteModal->>Boundary: Render warning body
    Boundary->>TRPC: Query tag option usage count
    TRPC-->>Boundary: Return count
    alt "count > 0"
        Boundary-->>User: Show usage sentence and undo guidance
    else "count = 0"
        Boundary-->>User: Show undo guidance only
    end
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant DeleteModal
participant Boundary as Suspense/ErrorBoundary
participant TRPC as countTagOptionsUsage

User->>DeleteModal: Open delete filter or option modal
alt Filter has too many options
    DeleteModal-->>User: Show large-usage warning and undo guidance
else Usage count is queried
    DeleteModal->>Boundary: Render warning body
    Boundary->>TRPC: Query tag option usage count
    TRPC-->>Boundary: Return count
    alt "count > 0"
        Boundary-->>User: Show usage sentence and undo guidance
    else "count = 0"
        Boundary-->>User: Show undo guidance only
    end
end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(form-builder): enhance filter u..."](https://github.com/opengovsg/isomer/commit/5ec826559d1c8d563e8dd47889e0ba3d2a871c29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45877641)</sub>

<!-- /greptile_comment -->