### PR TITLE
fix: full-build codegen + skeleton test types for treeshake CI

### DIFF
--- a/packages/components/src/templates/next/render/renderPageContentSkeleton.test.tsx
+++ b/packages/components/src/templates/next/render/renderPageContentSkeleton.test.tsx
@@ -1,6 +1,7 @@
 import type { IsomerComponent, IsomerSiteProps } from "~/types"
 import { describe, expect, it, vi } from "vitest"
 
+import type { RenderComponentProps } from "./types"
 import { renderPageContentSkeleton } from "./renderPageContentSkeleton"
 
 const site = {
@@ -31,7 +32,7 @@ const site = {
 describe("renderPageContentSkeleton", () => {
   it("calls the injected renderComponent for each visible block", () => {
     // Arrange
-    const renderComponent = vi.fn(() => <div />)
+    const renderComponent = vi.fn((_props: RenderComponentProps) => <div />)
     const content = [
       { type: "prose", content: [] },
       { type: "prose", content: [] },
@@ -61,7 +62,7 @@ describe("renderPageContentSkeleton", () => {
 
   it("skips hidden childrenpages blocks", () => {
     // Arrange
-    const renderComponent = vi.fn(() => <div />)
+    const renderComponent = vi.fn((_props: RenderComponentProps) => <div />)
     const content = [
       {
         type: "childrenpages",

--- a/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
+++ b/tooling/build/scripts/publishing/tests/full-build/full-build.test.ts
@@ -15,8 +15,9 @@ const TSX_BIN = join(PACKAGE_DIR, "node_modules", ".bin", "tsx")
 // the template's committed placeholder fixtures are swapped for the real
 // output here and restored afterwards
 const TEMPLATE_DIR = join(PACKAGE_DIR, "..", "..", "..", "template")
-const NEXT_BIN = join(TEMPLATE_DIR, "node_modules", ".bin", "next")
 const OUT_DIR = join(TEMPLATE_DIR, "out")
+const HEAVY_ROUTES_DIR = join(TEMPLATE_DIR, "app", "(heavy)")
+const HEAVY_ROUTES_MANIFEST = join(TEMPLATE_DIR, ".generated-heavy-routes.json")
 const SWAPPED_PATHS = ["schema", "data", "sitemap.json"]
 
 let outputDir: string
@@ -36,6 +37,10 @@ const restoreTemplate = () => {
   }
   rmSync(join(TEMPLATE_DIR, "public", "sitemap.json"), { force: true })
   rmSync(OUT_DIR, { recursive: true, force: true })
+  // build:template codegen — remove so a failed/killed run does not leave
+  // fixture-specific heavy routes in the working tree
+  rmSync(HEAVY_ROUTES_DIR, { recursive: true, force: true })
+  rmSync(HEAVY_ROUTES_MANIFEST, { force: true })
   restored = true
 }
 
@@ -96,7 +101,15 @@ beforeAll(async () => {
     cpSync(indexJsonPath, join(TEMPLATE_DIR, "schema", "not-found.json"))
     rmSync(OUT_DIR, { recursive: true, force: true })
 
-    const buildResult = spawnSync(NEXT_BIN, ["build", "--webpack"], {
+    // Match publisher.sh / build.sh: generate layout routes, then next
+    // build. Collection/search/database landings are excluded from the
+    // catch-all and only emit HTML via codegen'd app/(heavy) pages.
+    //
+    // Spawned (not execFile) so the child can inherit a clean
+    // NODE_OPTIONS — CI injects dd-trace via --require/--import, and
+    // that instrumentation crashes next's build worker under Node 22 +
+    // Next 15.5.
+    const buildResult = spawnSync("pnpm", ["run", "build:template"], {
       cwd: TEMPLATE_DIR,
       encoding: "utf-8",
       timeout: 600_000,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI unblockers for the layout-route treeshake PR (`claude/treeshake-render-dispatch-h1xzju`).

### Full-build test (`news/index.html`)

The publishing full-build Vitest suite called `next build --webpack` directly, skipping `generate:layout-routes`. Collection landings like `/news` only emit HTML via codegen'd `app/(heavy)` pages, so CI failed on `news/index.html`.

- Run `pnpm run build:template` (same as `publisher.sh` / `build.sh`)
- Clean `app/(heavy)` and `.generated-heavy-routes.json` in `restoreTemplate`

### Components typecheck

`renderPageContentSkeleton.test.tsx` used `vi.fn(() => <div />)`, so `mock.calls[n]` was typed as `[]` and `calls[n][0]` failed TS2493 under `tsgo`.

- Annotate the mock with `RenderComponentProps`

## Test plan

- [ ] CI: `tooling/build` publishing full-build tests pass
- [ ] CI: `@opengovsg/isomer-components` typecheck passes
- [ ] Confirm `news/index.html` is present in the built `out/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bfa0a49-b764-41e9-840c-d077e5677acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bfa0a49-b764-41e9-840c-d077e5677acf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates CI coverage for the publishing full-build path and skeleton render test types. The main changes are:

- Runs `build:template` in the full-build test so layout-route codegen is included before `next build`.
- Cleans generated heavy-route files during template restoration.
- Types the `renderComponent` Vitest mock with `RenderComponentProps` so mock call assertions typecheck.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

Changes are limited to tests and align the full-build test with existing publishing scripts. The type annotation change preserves runtime behavior, and no functional or security issues were identified.

No files require special attention.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the related review comment.
- T-Rex validated the publishing CI run by collecting contract-validation artifacts, including typecheck results, test outcomes, build signals, and container-runtime checks.

<a href="https://app.greptile.com/trex/runs/15210327/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/components/src/templates/next/render/renderPageContentSkeleton.test.tsx | Annotates Vitest mock props with `RenderComponentProps` so mock call assertions typecheck without changing runtime behavior. |
| tooling/build/scripts/publishing/tests/full-build/full-build.test.ts | Updates the publishing full-build test to run the template build script including layout-route codegen, and cleans generated heavy-route artifacts during fixture restoration. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Test as full-build.test.ts
participant Publishing as publishing script
participant Template as tooling/template
participant Codegen as generate:layout-routes
participant Next as next build

Test->>Publishing: seed site and run index.ts
Publishing-->>Test: schema/data/sitemap output
Test->>Template: swap fixtures into template
Test->>Template: pnpm run build:template
Template->>Codegen: generate layout route pages
Codegen-->>Template: app/(heavy) pages + manifest
Template->>Next: next build --webpack
Next-->>Template: static out/ HTML
Test->>Template: assert generated pages exist
Test->>Template: restore fixtures and remove generated routes
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Test as full-build.test.ts
participant Publishing as publishing script
participant Template as tooling/template
participant Codegen as generate:layout-routes
participant Next as next build

Test->>Publishing: seed site and run index.ts
Publishing-->>Test: schema/data/sitemap output
Test->>Template: swap fixtures into template
Test->>Template: pnpm run build:template
Template->>Codegen: generate layout route pages
Codegen-->>Template: app/(heavy) pages + manifest
Template->>Next: next build --webpack
Next-->>Template: static out/ HTML
Test->>Template: assert generated pages exist
Test->>Template: restore fixtures and remove generated routes
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Feasible template build does not emit news/index.html**

   - **Bug**
     - After building `@opengovsg/isomer-components` and running the real `isomer-base-template build:template` path, the generated `tooling/template/out` directory did not contain `news/index.html`. The explicit file check exited 1 even though the Next template build itself exited 0.
   - **Cause**
     - The exercised template build generated static params only for `/` and `/about`; the build log route summary did not include `/news`, so no `out/news/index.html` was produced in this path. The Docker-dependent publishing full-build path that may seed/exercise news data was blocked by the sandbox container-runtime limitation, so it could not provide the expected news page either.
   - **Fix**
     - Ensure the publishing/template build path used by CI seeds or code-generates the news route before `next build`, or adjust the test plan if `news/index.html` is only expected from the Docker-backed publishing full-build fixture and not from `isomer-base-template build:template`. Re-run `pnpm --filter publishing test:full-build` in an environment with Docker/Testcontainers to confirm the full fixture behavior.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(components): type renderComponent mo..."](https://github.com/opengovsg/isomer/commit/7e64aa28a74a5765a6c38643987a36627ef7a34e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45877601)</sub>

<!-- /greptile_comment -->