### PR TITLE
chore(redirects): extract support link as shared constant

### DIFF
--- a/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
@@ -1,6 +1,8 @@
 import { Flex, Stack, Td, Text, Tr } from "@chakra-ui/react"
 import { Link } from "@opengovsg/design-system-react"
 
+import { REDIRECTS_SUPPORT_LINK } from "../constants"
+
 // Shown in place of table rows when a site has no redirects yet. Unlike the
 // generic EmptyTablePlaceholder, this points users to the redirects guide.
 export const RedirectsEmptyPlaceholder = (): JSX.Element => {
@@ -14,11 +16,7 @@ export const RedirectsEmptyPlaceholder = (): JSX.Element => {
             </Text>
             <Text textStyle="body-2" color="base.content.default">
               Unsure how to use redirects?{" "}
-              <Link
-                variant="inline"
-                isExternal
-                href="https://support.isomer.gov.sg"
-              >
+              <Link variant="inline" isExternal href={REDIRECTS_SUPPORT_LINK}>
                 Read our guide
               </Link>
               .

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx
@@ -2,6 +2,8 @@ import { Center, Flex, Icon, Stack, Text } from "@chakra-ui/react"
 import { Link } from "@opengovsg/design-system-react"
 import { BiWrench } from "react-icons/bi"
 
+import { REDIRECTS_SUPPORT_LINK } from "../constants"
+
 export const RedirectsHeader = (): JSX.Element => {
   return (
     <Flex justifyContent="space-between" align="center" w="full">
@@ -22,11 +24,7 @@ export const RedirectsHeader = (): JSX.Element => {
         <Text textStyle="body-2" color="base.content.medium">
           Keep old links working. Redirects send anyone who visits an outdated
           URL to the right place instead. Learn{" "}
-          <Link
-            variant="inline"
-            href="https://support.isomer.gov.sg/en/articles/15897348-redirections"
-            isExternal
-          >
+          <Link variant="inline" href={REDIRECTS_SUPPORT_LINK} isExternal>
             how to use redirects
           </Link>
           .

--- a/apps/studio/src/features/settings/Redirects/constants.ts
+++ b/apps/studio/src/features/settings/Redirects/constants.ts
@@ -1,0 +1,2 @@
+export const REDIRECTS_SUPPORT_LINK =
+  "https://support.isomer.gov.sg/en/articles/15897348-redirections"


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +8 | -10 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |

3 file(s) changed. Buckets derived from [`docs/risk-taxonomy.md`](../blob/main/docs/risk-taxonomy.md) conventions.
<!-- pr-diff-breakdown:end -->

## Problem

The redirects support guide URL was duplicated across two components — `RedirectsHeader` and `RedirectsEmptyPlaceholder` — and the two copies weren't even consistent: the placeholder pointed to the root `https://support.isomer.gov.sg` while the header linked to the specific article.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Extracted the redirects support guide URL into `REDIRECTS_SUPPORT_LINK` in a new `Redirects/constants.ts` file
- Updated `RedirectsHeader` and `RedirectsEmptyPlaceholder` to import and use the constant
- Aligned the placeholder's link to the specific article URL (`/en/articles/15897348-redirections`) rather than the support root

## Before & After Screenshots

No visual change — the same links are rendered, just sourced from a single constant.

## Tests

No production behaviour changed; this is a pure refactor with no logic modifications.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes the redirects support guide link used in the redirects settings UI. The main changes are:

- Added `REDIRECTS_SUPPORT_LINK` in `apps/studio/src/features/settings/Redirects/constants.ts`.
- Updated `RedirectsHeader` to use the shared constant.
- Updated `RedirectsEmptyPlaceholder` to use the same article URL as the header.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge with minimal risk.

The change is a small client-side refactor that consolidates duplicated link text into a feature-local constant and does not alter server behavior or data flow.

No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the pre-change UI state, where the header link pointed to the redirects article and the Read our guide placeholder directed to the support site.
- Captured a before-change poster frame and video to document the UI state prior to updates.
- Observed that after capture, both links render with href set to the specified article, target \_blank, and rel noopener.
- Captured post-change visuals with a poster frame and video to verify the updated links.
- Compared the before- and after-capture states and confirmed there were no visible regressions in rendering.

<a href="https://app.greptile.com/trex/runs/15220225/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx | Replaces the placeholder support-root URL with the shared redirects guide constant; no issues found. |
| apps/studio/src/features/settings/Redirects/components/RedirectsHeader.tsx | Updates the header guide link to use the shared redirects support constant; no issues found. |
| apps/studio/src/features/settings/Redirects/constants.ts | Adds a feature-local redirects support guide URL constant; no issues found. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(redirects): extract support link a..."](https://github.com/opengovsg/isomer/commit/37f1318038e2ce2d86754fe5552b5c0442d17724) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45900170)</sub>

<!-- /greptile_comment -->