### PR TITLE
fix(stories): actually insert a table in ActiveTableToolbar story

### DIFF
--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -170,7 +170,13 @@ export const ActiveTableToolbar: Story = {
     ).toHaveLength(1)
     await userEvent.keyboard("{Escape}")
 
+    // Clicking "Table" only opens the size-picker popover — a cell still
+    // needs to be picked to actually insert a table and put the cursor
+    // inside it (see TableSizePicker.tsx).
     await userEvent.click(canvas.getByRole("button", { name: /^table$/i }))
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /^1 by 1 table$/i }),
+    )
 
     // Inside a table: promoted directly onto the main toolbar, and no longer
     // duplicated under "More options" (removed from that list entirely).


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 0 | +0 | -0 |
| 🧪 Test | 1 | +6 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The `ActiveTableToolbar` Storybook interaction test (added in #2817) was flaky in Chromatic, failing intermittently in one of two ways:

- `Unable to find role="button" and name /^superscript$/i`
- `expect(...getAllByRole("button", { name: /more options/i })).toHaveLength(1)` — got 2 instead

## Solution

Clicking the "Table" toolbar button only opens the size-picker popover (`TableSizePicker.tsx`) — it does not insert a table. Inserting a table requires an additional click on one of the grid cells. The story never performed that second click, so the editor never actually entered table mode.

This explains both flakes as two faces of the same root cause:

- When the earlier `{Escape}` cleanly closed the "More options" overflow popover, there was no superscript button left anywhere in the DOM once "in table" assertions ran, so `findByRole` timed out.
- When that popover's close was still settling, its (outside-table) superscript button happened to still be in the DOM, letting the earlier `findByRole`/`getAllByRole` checks pass by coincidence — but since no table was ever inserted, the overflow trigger never unmounted, so the final "More options" count came back as 2 instead of 1.

Fixed by clicking the "1 by 1 table" grid cell after opening the size picker, so a table is actually inserted before the "inside a table" toolbar assertions run.

Verified against a live Storybook instance: reverting the fix reliably reproduces both reported failure modes; with the fix, the story consistently passes (exactly 1 superscript button, 1 subscript button, 1 "More options" button, and a "Delete table" button confirming the table was really inserted).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Fixed a flaky Storybook interaction test (`ActiveTableToolbar`) that never actually inserted a table before asserting on in-table toolbar behavior.

## Before & After Screenshots

Not applicable — this is a test-only change with no UI impact.

## Tests

- `pnpm --filter studio storybook` → run the `Pages/Edit Page/Content Page` → `Active Table Toolbar` story and confirm the interaction test passes consistently.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a flaky Storybook interaction test in `ActiveTableToolbar` by adding the missing step to actually insert a table — clicking the "1 by 1 table" grid cell after the `TableSizePicker` popover opens — so that subsequent in-table toolbar assertions run against a real table editor state.

- **Root cause fixed**: clicking the "Table" toolbar button only opened the size-picker popover; without a follow-up click on a grid cell no table was ever inserted, leaving the editor in an ambiguous state that caused intermittent assertion failures.
- **Consistency gap (no change here)**: the nearby `AddTable` story still stops at opening the size-picker without selecting a cell, so it also never inserts a table — but that story makes no assertions about being inside a table, so it is not broken by the same root cause.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Test-only change; no production code is modified and the fix directly addresses the described flakiness root cause.

The single added interaction step correctly inserts a table before in-table assertions run. The `findByRole` (async) variant is the right choice here since the grid cell appears after the popover animates open. No production paths are affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx | Adds the missing `findByRole("button", { name: /^1 by 1 table$/i })` click so a table is actually inserted before in-table toolbar assertions run; fixes intermittent test failures with no logic change to production code. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Test as Interaction Test
    participant TB as RTE Toolbar
    participant SP as TableSizePicker
    participant Editor as ProseMirror Editor

    Note over Test,Editor: Before fix (flaky)
    Test->>TB: click "Table" button
    TB->>SP: open size-picker popover
    Note right of SP: No table inserted yet
    Test->>Editor: assert in-table toolbar state ❌

    Note over Test,Editor: After fix (stable)
    Test->>TB: click "Table" button
    TB->>SP: open size-picker popover
    Test->>SP: click "1 by 1 table" cell
    SP->>Editor: insert 1×1 table, move cursor inside
    Test->>Editor: assert in-table toolbar state ✅
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; of https://github.co..."](https://github.com/opengovsg/isomer/commit/a07a0c22c3d9786c2d45c8a31e907f997ddaf73c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46539749)</sub>

<!-- /greptile_comment -->