### PR TITLE
chore(redirect): remove is-redirections-enabled feature flag

### DIFF
--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -157,10 +157,8 @@ export const AddRedirectCard = ({
             color="base.content.default"
             flexShrink={0}
           />
-          <Flex wrap="wrap" columnGap="0.25rem" rowGap="0.25rem">
-            <Text textStyle="subhead-2" color="base.content.default">
-              Have more than 10 redirects to add? You can
-            </Text>
+          <Text textStyle="subhead-2" color="base.content.default">
+            Have more than 10 redirects to add? You can{" "}
             <Link
               as="button"
               type="button"
@@ -171,10 +169,8 @@ export const AddRedirectCard = ({
             >
               bulk upload with a .csv instead
             </Link>
-            <Text textStyle="subhead-2" color="base.content.default">
-              .
-            </Text>
-          </Flex>
+            .
+          </Text>
         </Flex>
       )}
 

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -169,8 +169,11 @@ export const AddRedirectCard = ({
               color="interaction.links.default"
               onClick={onBulkUploadOpen}
             >
-              bulk upload with a .csv instead.
+              bulk upload with a .csv instead
             </Link>
+            <Text textStyle="subhead-2" color="base.content.default">
+              .
+            </Text>
           </Flex>
         </Flex>
       )}

--- a/apps/studio/src/features/settings/SettingsSidenav/SettingsSidenav.tsx
+++ b/apps/studio/src/features/settings/SettingsSidenav/SettingsSidenav.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/router"
 import { BiDirections, BiPaint, BiWrench } from "react-icons/bi"
 import { CmsCollapsibleSidenav } from "~/components/CmsSidebar/CmsCollapsibleSidenav"
 import { siteSchema } from "~/features/editing-experience/schema"
-import { useIsRedirectionsEnabled } from "~/hooks/useIsRedirectionsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 
 import { HeaderRow } from "./components"
@@ -29,8 +28,6 @@ interface SideNavItem {
 export const SettingsSidenav = ({ onSidenavClose }: SettingsSidenavProps) => {
   const { siteId } = useQueryParse(siteSchema)
   const router = useRouter()
-  const isRedirectionsEnabled = useIsRedirectionsEnabled()
-
   const SIDENAV_ITEMS: SideNavItem[] = [
     {
       header: { label: "General", icon: BiWrench },
@@ -44,14 +41,10 @@ export const SettingsSidenav = ({ onSidenavClose }: SettingsSidenavProps) => {
           label: "Integrations",
           href: `/sites/${siteId}/settings/integrations`,
         },
-        ...(isRedirectionsEnabled
-          ? [
-              {
-                label: "Redirects",
-                href: `/sites/${siteId}/settings/redirects`,
-              },
-            ]
-          : []),
+        {
+          label: "Redirects",
+          href: `/sites/${siteId}/settings/redirects`,
+        },
       ],
     },
     {

--- a/apps/studio/src/hooks/useIsRedirectionsEnabled.ts
+++ b/apps/studio/src/hooks/useIsRedirectionsEnabled.ts
@@ -1,5 +1,0 @@
-import { useFeatureValue } from "@growthbook/growthbook-react"
-import { IS_REDIRECTIONS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
-
-export const useIsRedirectionsEnabled = () =>
-  useFeatureValue<boolean>(IS_REDIRECTIONS_ENABLED_FEATURE_KEY, false)

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -15,9 +15,6 @@ export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 export const IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY =
   "homepage-antiscam-banner-enabled"
 export const EGAZETTE_INFO_FEATURE_KEY = "egazette-info"
-export const IS_REDIRECTIONS_ENABLED_FEATURE_KEY = "is-redirections-enabled"
-// Gates the "advanced redirects" surface (bulk CSV upload) separately from the
-// base redirects feature, which is already fully enabled pending flag removal.
 export const IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY =
   "is-advanced-redirects-enabled"
 // When OFF (default): gazette ingestion targets Algolia directly.

--- a/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx
@@ -1,28 +1,13 @@
 import type { NextPageWithLayout } from "~/lib/types"
-import { useGrowthBook } from "@growthbook/growthbook-react"
-import { useRouter } from "next/router"
-import { useEffect } from "react"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
 import { siteSchema } from "~/features/editing-experience/schema"
 import { RedirectsSettings } from "~/features/settings/Redirects"
-import { useIsRedirectionsEnabled } from "~/hooks/useIsRedirectionsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { SiteSettingsLayout } from "~/templates/layouts/SiteSettingsLayout"
 import { ResourceType } from "~prisma/generated/generatedEnums"
 
 const RedirectsSettingsPage: NextPageWithLayout = () => {
   const { siteId } = useQueryParse(siteSchema)
-  const router = useRouter()
-  const gb = useGrowthBook()
-  const isRedirectionsEnabled = useIsRedirectionsEnabled()
-
-  useEffect(() => {
-    if (gb?.ready && !isRedirectionsEnabled) {
-      void router.replace(`/sites/${siteId}/settings/agency`)
-    }
-  }, [gb?.ready, isRedirectionsEnabled, router, siteId])
-
-  if (!gb?.ready || !isRedirectionsEnabled) return null
 
   return <RedirectsSettings siteId={Number(siteId)} />
 }

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -5,10 +5,7 @@ import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import RedirectsSettingsPage from "~/pages/sites/[siteId]/settings/redirects"
 import { ADMIN_HANDLERS } from "~/stories/handlers"
-import {
-  createAdvancedRedirectsEnabledGbParameters,
-  createRedirectionsEnabledGbParameters,
-} from "~/stories/utils/growthbook"
+import { createAdvancedRedirectsEnabledGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   ...ADMIN_HANDLERS,
@@ -48,7 +45,6 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   parameters: {
-    growthbook: [createRedirectionsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -61,7 +57,6 @@ export const Default: Story = {
 
 export const Empty: Story = {
   parameters: {
-    growthbook: [createRedirectionsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.empty(),
@@ -91,7 +86,6 @@ const submitNewRedirect = async (canvasElement: HTMLElement) => {
 // Creating over an existing live redirect shows the error inline on the source.
 export const AlreadyExistsError: Story = {
   parameters: {
-    growthbook: [createRedirectionsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -145,10 +139,7 @@ const openModalAndUpload = async (canvasElement: HTMLElement) => {
 // Clicking the inline bulk-upload CTA opens the modal at its initial upload state.
 export const BulkUploadModal: Story = {
   parameters: {
-    growthbook: [
-      createRedirectionsEnabledGbParameters(true),
-      createAdvancedRedirectsEnabledGbParameters(true),
-    ],
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -172,10 +163,7 @@ export const BulkUploadModal: Story = {
 // A fully valid file lands on the ready-to-publish screen.
 export const BulkUploadReadyToPublish: Story = {
   parameters: {
-    growthbook: [
-      createRedirectionsEnabledGbParameters(true),
-      createAdvancedRedirectsEnabledGbParameters(true),
-    ],
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -200,10 +188,7 @@ export const BulkUploadReadyToPublish: Story = {
 // A file with a bad row lands on the errors screen with the download affordance.
 export const BulkUploadWithErrors: Story = {
   parameters: {
-    growthbook: [
-      createRedirectionsEnabledGbParameters(true),
-      createAdvancedRedirectsEnabledGbParameters(true),
-    ],
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -225,7 +210,6 @@ export const BulkUploadWithErrors: Story = {
 // A redirect that loops back shows the error inline on the destination.
 export const RedirectLoopError: Story = {
   parameters: {
-    growthbook: [createRedirectionsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -7,7 +7,6 @@ import {
   EGAZETTE_INFO_FEATURE_KEY,
   IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY,
   IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
-  IS_REDIRECTIONS_ENABLED_FEATURE_KEY,
   IS_SINGPASS_ENABLED_FEATURE_KEY,
 } from "~/lib/growthbook"
 
@@ -44,10 +43,6 @@ export const createCategoryIdDropdownGbParameters = (siteId: string) => {
 
 export const createSingpassEnabledGbParameters = (isEnabled: boolean) => {
   return [IS_SINGPASS_ENABLED_FEATURE_KEY, isEnabled]
-}
-
-export const createRedirectionsEnabledGbParameters = (isEnabled: boolean) => {
-  return [IS_REDIRECTIONS_ENABLED_FEATURE_KEY, isEnabled]
 }
 
 export const createAdvancedRedirectsEnabledGbParameters = (


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 5 | +9 | -40 |
| 🧪 Test | 2 | +4 | -25 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Redirects have been fully rolled out to all sites. The `is-redirections-enabled` GrowthBook flag is no longer needed and can be cleaned up.

Also fixes a minor UI issue where the trailing period in the bulk-upload CTA was included inside the hyperlink, making it look underlined/clickable.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- Removed the `is-redirections-enabled` GrowthBook feature flag entirely. The Redirects sidenav item and settings page are now unconditionally rendered for all sites.
- Deleted the `useIsRedirectionsEnabled` hook and the `IS_REDIRECTIONS_ENABLED_FEATURE_KEY` constant.
- Simplified the redirects settings page — removed the `gb.ready` guard and the redirect-to-agency fallback that ran when the flag was off.
- Cleaned up Storybook stories and the `createRedirectionsEnabledGbParameters` helper, which are no longer needed.

**Bug Fixes**:

- Moved the trailing `.` outside the bulk-upload CTA `<Link>` so the period is not underlined as part of the link text.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**Manual Verification Steps**:

- [ ] Navigate to any site's settings page. Confirm "Redirects" appears in the left-hand sidenav under "General" without needing any GrowthBook flag enabled.
- [ ] Click "Redirects" and confirm the redirects settings page loads correctly.
- [ ] On the redirects settings page, confirm the bulk-upload CTA reads "bulk upload with a .csv instead." where only "bulk upload with a .csv instead" is underlined (the period is not part of the link).

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the obsolete redirects rollout flag.
- Makes the Redirects navigation item and settings page unconditionally available.
- Deletes the retired GrowthBook hook, key, and Storybook parameter helper.
- Keeps the bulk-upload CTA’s trailing period outside the hyperlink while preserving inline punctuation layout.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex captured a baseline Storybook run in redirects-settings-01-before.log to establish the pre-change environment.
- T-Rex captured a post-change Storybook run in redirects-settings-02-after.log to compare against the baseline.
- T-Rex reviewed the execution log to confirm the commands, working directory, termination status, and memory state, noting available memory around 43 MiB with no swap.

<a href="https://app.greptile.com/trex/runs/15546533/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx | Places the CTA sentence, link, and unlinked trailing period in one text container. |
| apps/studio/src/features/settings/SettingsSidenav/SettingsSidenav.tsx | Makes the Redirects navigation item unconditional. |
| apps/studio/src/pages/sites/[siteId]/settings/redirects.tsx | Removes GrowthBook readiness and rollout checks from the redirects settings page. |
| apps/studio/src/lib/growthbook.ts | Removes the retired redirects feature key while retaining the separate advanced-redirects flag. |
| apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx | Removes obsolete redirects rollout parameters from the affected stories. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(redirect): keep bulk-upload CTA sent..."](https://github.com/opengovsg/isomer/commit/292a87e80687d3990e1942a6ce62bf6ca0b94eef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46570926)</sub>

<!-- /greptile_comment -->