### PR TITLE
chore: add NParks and related sites to audit logs

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -12,6 +12,8 @@ const __dirname = dirname(__filename)
 // Sites requiring audit logs
 const SITES_WITH_AUDIT_LOGS = [
   1, // stb.gov.sg
+  30, // avs.nparks.gov.sg
+  32, // cuge.nparks.gov.sg
   41, // ssg.gov.sg
   46, // sportsingapore.gov.sg
   48, // muis.gov.sg
@@ -20,6 +22,7 @@ const SITES_WITH_AUDIT_LOGS = [
   61, // ipos.gov.sg
   109, // agc.gov.sg
   145, // ite.edu.sg
+  152, // sbg.nparks.gov.sg
   157, // pmo.gov.sg
   166, // mti.gov.sg
   176, // colombo.mfa.gov.sg
@@ -108,22 +111,36 @@ const SITES_WITH_AUDIT_LOGS = [
   259, // washington.mfa.gov.sg
   260, // hanoi.mfa.gov.sg
   261, // hochiminhcity.mfa.gov.sg
-  262, // www.mfa.gov.sg
+  262, // mfa.gov.sg
   263, // nagoya.mfa.gov.sg
   278, // istana.gov.sg
-  284, // www.ptc.gov.sg
-  287, // www.mot.gov.sg
-  289, // www.toteboard.gov.sg
+  283, // biodiversitysg.nparks.gov.sg
+  284, // ptc.gov.sg
+  287, // mot.gov.sg
+  289, // toteboard.gov.sg
   301, // space.gov.sg
+  314, // fotp.nparks.gov.sg
+  315, // gardencityfund.gov.sg
+  316, // gardeningsg.nparks.gov.sg
+  317, // heritagetrees.nparks.gov.sg
+  318, // juronglakegardens.nparks.gov.sg
+  319, // lightsbythelake.nparks.gov.sg
+  320, // naturekakis.nparks.gov.sg
+  321, // pcn.nparks.gov.sg
+  322, // railcorridor.nparks.gov.sg
+  323, // sgf.nparks.gov.sg
+  324, // pulau-ubin.nparks.gov.sg
   334, // seab.gov.sg
-  336, // www.caringcommuters.gov.sg
-  343, // www.motawardsceremony.gov.sg
-  357, // www.ago.gov.sg
+  336, // caringcommuters.gov.sg
+  343, // motawardsceremony.gov.sg
+  357, // ago.gov.sg
   378, // osir.gov.sg
-  397, // www.rp.edu.sg
-  409, // www.hsa.gov.sg
-  484, // www.hpb.gov.sg
-  492, // www.oneservice.gov.sg
+  397, // rp.edu.sg
+  406, // svc.gov.sg
+  409, // hsa.gov.sg
+  484, // hpb.gov.sg
+  492, // oneservice.gov.sg
+  511, // skyrisegreenery.nparks.gov.sg
   512, // cap.gov.sg
 ]
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +28 | -11 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The audit logs script was missing entries for multiple NParks-related sites and other government agencies that require audit logging.

## Solution

Added 17 new site IDs to the `SITES_WITH_AUDIT_LOGS` array in the audit logs script:

**NParks Sites**:
- 314 - Friends of the Parks
- 315 - Garden City Fund
- 316 - Gardening sg
- 317 - Heritage Trees
- 318 - Jurong Lake Gardens
- 319 - Lights by the Lake
- 320 - Nature Kakis
- 321 - Park Connector Network
- 322 - Rail Corridor
- 323 - Singapore Garden Festival
- 324 - Pulau Ubin
- 511 - Sky Rise Greenery

**Other Sites**:
- 30 - AVS (Animal & Veterinary Service)
- 32 - Centre for Urban Greenery and Ecology (CUGE)
- 152 - Singapore Botanic Gardens
- 283 - BiodiversitySG
- 406 - Singapore Veterinary Council

**Breaking Changes**

- [ ] No - this PR is backwards compatible

**Features**:

- Enables audit logging for 17 additional government sites

## Tests

This is a configuration-only change to the audit logs script. No manual verification needed - the sites will now be included in audit log exports when the script runs.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds 17 government site IDs to the audit-log export allowlist and updates several domain comments.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The change only adds unique site IDs to the existing audit-export allowlist and adjusts non-functional comments without altering query or export behavior.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The harness run began with exit code 1 because all 17 IDs were absent, while validating the export-loop contract.
- The harness run later exited with code 0 and listed IDs 30, 32, 152, 283, 314–324, 406, and 511, each with a count of 1.
- Filename patterns useraccess\_site\_monthYear.csv and auditlogs\_site\_monthYear.csv were confirmed, with concrete examples for every new ID.
- The formatter completed with exit code 0, with no production credentials or database connections used, and no changes to the tracked source.
- Artifacts were prepared to support verification, including a JavaScript artifact and multiple log artifacts.

<a href="https://app.greptile.com/trex/runs/15540006/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/prisma/scripts/getAuditLogs.ts | Expands the audit-log site allowlist with unique IDs; no concrete changed-code defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: add NParks and related sites to a..."](https://github.com/opengovsg/isomer/commit/a0307a25789dfd46479524086767bb87db03c5dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46586932)</sub>

<!-- /greptile_comment -->