### PR TITLE
fix: skip implicit publish for unpublished pages on settings update

### DIFF
--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -2794,8 +2794,9 @@ describe("page.router", async () => {
         ...expectedSettings,
       })
 
-      // Assert
-      await assertAuditLogRows(2)
+      // Assert — only a ResourceUpdate entry; an unpublished page has no live
+      // presence, so no implicit publish happens.
+      await assertAuditLogRows(1)
       const actualResource = await db
         .selectFrom("Resource")
         .where("id", "=", page.id)
@@ -2809,7 +2810,62 @@ describe("page.router", async () => {
         .executeTakeFirstOrThrow()
       expect(result).toMatchObject(actualResource)
       expect(result).toMatchObject(expectedSettings)
-      await assertAuditLogRows(2)
+    })
+
+    it("should not log a Publish event when updating settings of an unpublished page", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({ resourceType: "Page" })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.updateSettings({
+        siteId: site.id,
+        pageId: Number(page.id),
+        type: "Page",
+        title: "New Title",
+        permalink: "new-permalink",
+      })
+
+      // Assert
+      const publishLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Publish)
+        .selectAll()
+        .execute()
+      expect(publishLogs).toHaveLength(0)
+    })
+
+    it("should log a Publish event when updating settings of a published page", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.updateSettings({
+        siteId: site.id,
+        pageId: Number(page.id),
+        type: "Page",
+        title: "New Title",
+        permalink: "new-permalink",
+      })
+
+      // Assert
+      const publishLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Publish)
+        .selectAll()
+        .execute()
+      expect(publishLogs).toHaveLength(1)
     })
 
     it("should update root page settings successfully", async () => {

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -903,8 +903,12 @@ export const pageRouter = router({
             }
 
             // We do an implicit publish so that we can make the changes to the
-            // page settings immediately visible on the end site
-            await publishResource(ctx.user.id, updatedResource, ctx.logger)
+            // page settings immediately visible on the end site. A page that
+            // has never been published has no live presence, so skip the site
+            // rebuild and Publish audit entry for it.
+            if (updatedResource.publishedVersionId !== null) {
+              await publishResource(ctx.user.id, updatedResource, ctx.logger)
+            }
 
             return pick(updatedResource, [
               "id",


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +6 | -2 |
| 🧪 Test | 1 | +59 | -3 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Updating the settings (title/permalink) of a page always triggered an **implicit publish**, regardless of whether the page had ever been published. For a page that is still a draft — one with no live presence on the end site — this had two undesirable effects:

- It kicked off a full site rebuild for a page that does not exist publicly.
- It wrote a spurious `Publish` audit-log entry, making it look like a draft page had been published to the live site.

## Solution

`updateSettings` now guards the implicit publish behind a check on `updatedResource.publishedVersionId`. The implicit publish (site rebuild + `Publish` audit entry) only runs when the page has previously been published (i.e. it has a live version). Draft pages simply record the `ResourceUpdate` and skip the publish path entirely.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Avoids unnecessary site rebuilds when editing the settings of a page that has never been published.

**Bug Fixes**:

- No longer emits a `Publish` audit-log event when updating the settings of an unpublished (draft) page. A `Publish` event is still logged when the page is already live.

## Tests

Run the page router unit tests:

```bash
cd apps/studio && pnpm test:unit -- src/server/modules/page/__tests__/page.router.test.ts
```

New/updated coverage in `page.router.test.ts`:

- Updating settings of an unpublished page logs a single `ResourceUpdate` entry and no `Publish` event.
- Updating settings of a published page still logs a `Publish` event.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents page settings updates from implicitly publishing pages that have never been published.
- Guards the publish call using the updated resource’s `publishedVersionId`.
- Preserves implicit publishing for pages with an existing live version.
- Updates unit tests to verify audit-log behavior for published and unpublished pages.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the new guard matching the resource publication model and retaining the existing behavior for live pages.

A live resource is represented by a non-null published version, so the guard skips only the inappropriate rebuild and Publish audit path for never-published drafts while preserving settings persistence and ResourceUpdate auditing.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reviewed the general-contract-validation-proof showing the page-router test run log with the exact command, working directory, exit code, test selection output, and Testcontainers stack trace, and identified the blocker as Could not find a working container runtime strategy during GenericContainer.start in tests/common.ts.

<a href="https://app.greptile.com/trex/runs/15686705/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/server/modules/page/page.router.ts | Adds a publication-state guard so settings updates only trigger a rebuild and Publish audit event for resources with a live version. |
| apps/studio/src/server/modules/page/__tests__/page.router.test.ts | Updates audit-row expectations and covers Publish event behavior for published and unpublished pages. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: do not publish if page is still d..."](https://github.com/opengovsg/isomer/commit/549d1fcd64f8d5eff6691c905464ecc07e5cb170) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46881023)</sub>

<!-- /greptile_comment -->