### PR TITLE
test(e2e): extract shared fixtures and migrate existing tests

### DIFF
--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -7,3 +7,32 @@ type: best-practice
 Living reference for `apps/studio/tests/e2e/`. Update this file only when the stack
 introduces a **new reusable pattern** — not when merely adding test cases. See
 `docs/superpowers/plans/2026-07-24-e2e-scale-and-coverage-spec.md`.
+
+## File layout
+
+- `tests/e2e/<module>/<surface>.test.ts` — one file per UI surface
+- `fixtures/` — shared infrastructure (auth, seed, helpers, page objects)
+- Import `test` / `expect` from `@playwright/test` directly (no `fixtures/test.ts` re-export)
+
+## Helpers vs page objects
+
+| Layer | File | Use for |
+|-------|------|---------|
+| **Helpers** | `fixtures/helpers.ts` | Multi-step flows crossing pages or modals (wizard, invite) |
+| **Page objects** | `fixtures/*.po.ts` | Locators + actions on one UI surface (`SitePO`, `DashboardPO`, …) |
+| **DB setup** | `fixtures/reset.ts` | Non-UI reset helpers (site-agnostic; take `siteId` arg) |
+
+## Welcome modal
+
+Call `ensureUserOnboarded(TEST_EMAILS.<role>)` in `beforeEach` so the welcome modal
+does not block tests (singpass global-setup can blank profiles).
+
+## Test pattern
+
+Per UI surface: **one happy-path** + **one permission-gate** where the UI shows a
+signal (hidden button, redirect, disabled control). Do not translate audit-log or
+validation-edge-case scenarios — those stay in integration tests.
+
+## How to detect violations
+
+- Duplicated wizard/invite flows in test files → move to `helpers.ts` or a PO

--- a/apps/studio/tests/e2e/README.md
+++ b/apps/studio/tests/e2e/README.md
@@ -4,7 +4,6 @@
 
 | Module                | Purpose                                                        |
 | --------------------- | -------------------------------------------------------------- |
-| `fixtures/test.ts`    | Re-exports `test` and `expect` — import from here in new tests |
 | `fixtures/user.ts`    | `ensureUserOnboarded(email)` — skip welcome modal              |
 | `fixtures/reset.ts`   | Site-scoped DB reset helpers (`resetSiteAgencySettings`, etc.) |
 | `fixtures/helpers.ts` | Shared UI flows (create page/folder, invite user)              |

--- a/apps/studio/tests/e2e/README.md
+++ b/apps/studio/tests/e2e/README.md
@@ -1,5 +1,17 @@
 # E2E Tests
 
+## Fixtures
+
+| Module                | Purpose                                                        |
+| --------------------- | -------------------------------------------------------------- |
+| `fixtures/test.ts`    | Re-exports `test` and `expect` — import from here in new tests |
+| `fixtures/user.ts`    | `ensureUserOnboarded(email)` — skip welcome modal              |
+| `fixtures/reset.ts`   | Site-scoped DB reset helpers (`resetSiteAgencySettings`, etc.) |
+| `fixtures/helpers.ts` | Shared UI flows (create page/folder, invite user)              |
+| `fixtures/auth.ts`    | Role storage-state paths and `TEST_EMAILS`                     |
+| `fixtures/seed.ts`    | Idempotent E2E role seeding                                    |
+| `fixtures/site.po.ts` | Site settings page object                                      |
+
 ## Structure
 
 - `fixtures/` — reusable test infrastructure (login flow, page objects, role storage state).

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -1,0 +1,63 @@
+import { expect, type Page } from "@playwright/test"
+import { type RoleType } from "~prisma/generated/generatedEnums"
+
+export const createPageViaWizard = async (
+  page: Page,
+  {
+    startUrl,
+    title,
+    siteId,
+  }: { startUrl: string; title: string; siteId: number },
+) => {
+  await page.goto(startUrl)
+
+  await page.getByRole("button", { name: "Create new..." }).click()
+  await page.getByRole("menuitem", { name: "Page" }).click()
+
+  await page.getByRole("button", { name: "Next: Page title and URL" }).click()
+
+  await page.getByLabel("Page title").fill(title)
+  await page.getByRole("button", { name: "Start editing" }).click()
+
+  await page.waitForURL(new RegExp(`/sites/${siteId}/pages/\\d+$`))
+}
+
+export const createFolderViaWizard = async (
+  page: Page,
+  { siteId, title }: { siteId: number; title: string },
+) => {
+  await page.goto(`/sites/${siteId}`)
+
+  await page.getByRole("button", { name: "Create new..." }).click()
+  await page.getByRole("menuitem", { name: "Folder" }).click()
+
+  await page.getByLabel("Folder name").fill(title)
+  await page.getByRole("button", { name: "Create Folder" }).click()
+
+  await expect(page.getByText("Folder created!")).toBeVisible()
+}
+
+export const openInviteModal = async (page: Page, siteId: number) => {
+  await page.goto(`/sites/${siteId}/users`)
+  await page.getByRole("button", { name: "Add new user" }).click()
+}
+
+export const inviteCollaborator = async (
+  page: Page,
+  {
+    email,
+    role,
+    siteId,
+  }: { email: string; role: keyof typeof RoleType; siteId: number },
+) => {
+  await openInviteModal(page, siteId)
+  await page.getByLabel("Email address").fill(email)
+  await page.getByRole("button", { name: new RegExp(`^${role}`) }).click()
+
+  const sendBtn = page.getByRole("button", { name: "Send invite" })
+  await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
+  await sendBtn.click()
+  await expect(page.getByText(/Sent invite to/)).toBeVisible({
+    timeout: 10_000,
+  })
+}

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -44,11 +44,7 @@ export const openInviteModal = async (page: Page, siteId: number) => {
 
 export const inviteCollaborator = async (
   page: Page,
-  {
-    email,
-    role,
-    siteId,
-  }: { email: string; role: RoleType; siteId: number },
+  { email, role, siteId }: { email: string; role: RoleType; siteId: number },
 ) => {
   await openInviteModal(page, siteId)
   await page.getByLabel("Email address").fill(email)

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -48,7 +48,7 @@ export const inviteCollaborator = async (
     email,
     role,
     siteId,
-  }: { email: string; role: keyof typeof RoleType; siteId: number },
+  }: { email: string; role: RoleType; siteId: number },
 ) => {
   await openInviteModal(page, siteId)
   await page.getByLabel("Email address").fill(email)

--- a/apps/studio/tests/e2e/fixtures/reset.ts
+++ b/apps/studio/tests/e2e/fixtures/reset.ts
@@ -1,0 +1,29 @@
+import { sql } from "kysely"
+import { db } from "~/server/modules/database"
+
+export { ensureUserOnboarded } from "./user"
+
+const DEFAULT_AGENCY_SITE_NAME = "Isomer"
+
+/** Reset site name and config.siteName for agency settings tests. */
+export const resetSiteAgencySettings = (siteId: number) =>
+  db
+    .updateTable("Site")
+    .set({
+      name: DEFAULT_AGENCY_SITE_NAME,
+      config: sql`jsonb_set(config, '{siteName}', '"Isomer"')`,
+    })
+    .where("id", "=", siteId)
+    .execute()
+
+/** Remove notification config so the banner toggle starts off. */
+export const resetSiteNotification = (siteId: number) =>
+  db
+    .updateTable("Site")
+    .set({ config: sql`config - 'notification'` })
+    .where("id", "=", siteId)
+    .execute()
+
+/** Reset theme column to seed default (null) for colours settings tests. */
+export const resetSiteTheme = (siteId: number) =>
+  db.updateTable("Site").set({ theme: null }).where("id", "=", siteId).execute()

--- a/apps/studio/tests/e2e/fixtures/reset.ts
+++ b/apps/studio/tests/e2e/fixtures/reset.ts
@@ -1,20 +1,33 @@
+import type { IsomerSiteConfigProps } from "@opengovsg/isomer-components"
 import { sql } from "kysely"
-import { db } from "~/server/modules/database"
+import { db, jsonb } from "~/server/modules/database"
 
 export { ensureUserOnboarded } from "./user"
 
 const DEFAULT_AGENCY_SITE_NAME = "Isomer"
 
 /** Reset site name and config.siteName for agency settings tests. */
-export const resetSiteAgencySettings = (siteId: number) =>
-  db
+export const resetSiteAgencySettings = async (
+  siteId: number,
+  siteName: string = DEFAULT_AGENCY_SITE_NAME,
+) => {
+  const site = await db
+    .selectFrom("Site")
+    .where("id", "=", siteId)
+    .select("config")
+    .executeTakeFirstOrThrow()
+
+  const config = site.config as IsomerSiteConfigProps
+
+  await db
     .updateTable("Site")
     .set({
-      name: DEFAULT_AGENCY_SITE_NAME,
-      config: sql`jsonb_set(config, '{siteName}', '"Isomer"')`,
+      name: siteName,
+      config: jsonb({ ...config, siteName }),
     })
     .where("id", "=", siteId)
     .execute()
+}
 
 /** Remove notification config so the banner toggle starts off. */
 export const resetSiteNotification = (siteId: number) =>
@@ -24,6 +37,30 @@ export const resetSiteNotification = (siteId: number) =>
     .where("id", "=", siteId)
     .execute()
 
-/** Reset theme column to seed default (null) for colours settings tests. */
+// Mirrors createSite() defaults in server/modules/site/site.service.ts so the
+// colours form validates and setTheme can update an existing theme row.
+const DEFAULT_SITE_THEME = {
+  colors: {
+    brand: {
+      canvas: {
+        alt: "#bfcfd7",
+        default: "#e6ecef",
+        inverse: "#00405f",
+        backdrop: "#80a0af",
+      },
+      interaction: {
+        hover: "#002e44",
+        default: "#00405f",
+        pressed: "#00283b",
+      },
+    },
+  },
+}
+
+/** Reset theme column to the provisioned-site default for colours settings tests. */
 export const resetSiteTheme = (siteId: number) =>
-  db.updateTable("Site").set({ theme: null }).where("id", "=", siteId).execute()
+  db
+    .updateTable("Site")
+    .set({ theme: jsonb(DEFAULT_SITE_THEME) })
+    .where("id", "=", siteId)
+    .execute()

--- a/apps/studio/tests/e2e/fixtures/test.ts
+++ b/apps/studio/tests/e2e/fixtures/test.ts
@@ -1,1 +1,0 @@
-export { expect, test } from "@playwright/test"

--- a/apps/studio/tests/e2e/fixtures/test.ts
+++ b/apps/studio/tests/e2e/fixtures/test.ts
@@ -1,0 +1,1 @@
+export { expect, test } from "@playwright/test"

--- a/apps/studio/tests/e2e/fixtures/user.ts
+++ b/apps/studio/tests/e2e/fixtures/user.ts
@@ -1,0 +1,12 @@
+import { db } from "~/server/modules/database"
+
+const E2E_USER_NAME = "test-e2e"
+const E2E_USER_PHONE = "82345678"
+
+/** Skip the welcome modal by ensuring name + phone are set on the user. */
+export const ensureUserOnboarded = (email: string) =>
+  db
+    .updateTable("User")
+    .set({ name: E2E_USER_NAME, phone: E2E_USER_PHONE })
+    .where("email", "=", email)
+    .execute()

--- a/apps/studio/tests/e2e/page/create-page.test.ts
+++ b/apps/studio/tests/e2e/page/create-page.test.ts
@@ -1,47 +1,15 @@
-import { expect, test, type Page } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
 import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
-import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
+import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
+import { createPageViaWizard } from "../fixtures/helpers"
 import { getSeedSiteId } from "../fixtures/seed"
+import { expect, test } from "../fixtures/test"
+import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Page ${crypto.randomUUID().slice(0, 8)}`
 
-// The welcome modal blocks the dashboard until the user has a name + phone, so
-// set them before the create flow is reachable.
-const dismissWelcomeModal = (email: string) =>
-  db
-    .updateTable("User")
-    .set({ name: "test-e2e", phone: "82345678" })
-    .where("email", "=", email)
-    .execute()
-
-// Drives the full menu → modal → form wizard and waits for the post-create
-// redirect. `startUrl` is the dashboard the flow begins on — the site root or a
-// folder page; the wizard, labels and redirect are identical for both.
-const createPageViaWizard = async (
-  page: Page,
-  { startUrl, title }: { startUrl: string; title: string },
-) => {
-  await page.goto(startUrl)
-
-  await page.getByRole("button", { name: "Create new..." }).click()
-  await page.getByRole("menuitem", { name: "Page" }).click()
-
-  // Layout screen: keep the default layout and proceed.
-  await page.getByRole("button", { name: "Next: Page title and URL" }).click()
-
-  // Details screen: title auto-fills the URL.
-  await page.getByLabel("Page title").fill(title)
-  await page.getByRole("button", { name: "Start editing" }).click()
-
-  // Router pushes to /sites/{siteId}/pages/{pageId}.
-  await page.waitForURL(new RegExp(`/sites/${getSeedSiteId()}/pages/\\d+$`))
-}
-
-// A folder isn't part of the seed, so create one per-test to nest pages under.
-// Returns the folder id (BigInt columns are serialized as strings).
 const createSeedFolder = () =>
   db
     .insertInto("Resource")
@@ -58,8 +26,6 @@ const createSeedFolder = () =>
     .returning("id")
     .executeTakeFirstOrThrow()
 
-// Deleting the folder cascades to its child pages (Resource.parent is
-// onDelete: Cascade), so this also clears anything the wizard created under it.
 const deleteFolder = (folderId: string) =>
   db.deleteFrom("Resource").where("id", "=", folderId).execute()
 
@@ -67,14 +33,10 @@ test.describe("admin", () => {
   test.use({ storageState: storageStateFor("admin") })
 
   test.beforeEach(async () => {
-    await dismissWelcomeModal(TEST_EMAILS.admin)
+    await ensureUserOnboarded(TEST_EMAILS.admin)
   })
 
   test.afterEach(async () => {
-    // Remove any pages whose title starts with "E2E Test Page" so subsequent
-    // runs don't accumulate state. permalink uniqueness is enforced per-site,
-    // and the create flow auto-derives permalink from title — using a unique
-    // title per run side-steps conflicts, but we still clean up afterwards.
     await db
       .deleteFrom("Resource")
       .where("siteId", "=", getSeedSiteId())
@@ -83,16 +45,17 @@ test.describe("admin", () => {
   })
 
   test("admin can create a new page via the wizard", async ({ page }) => {
+    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
-      startUrl: `/sites/${getSeedSiteId()}`,
+      startUrl: `/sites/${siteId}`,
       title,
+      siteId,
     })
 
-    // Verify in DB the page was created at the root with Draft state.
     const created = await db
       .selectFrom("Resource")
-      .where("siteId", "=", getSeedSiteId())
+      .where("siteId", "=", siteId)
       .where("title", "=", title)
       .select(["id", "state", "type", "parentId"])
       .executeTakeFirst()
@@ -107,15 +70,11 @@ test.describe("publisher", () => {
   test.use({ storageState: storageStateFor("publisher") })
 
   test.beforeEach(async () => {
-    await dismissWelcomeModal(TEST_EMAILS.publisher)
+    await ensureUserOnboarded(TEST_EMAILS.publisher)
   })
 
   test("publisher does not see the Create new button", async ({ page }) => {
     await page.goto(`/sites/${getSeedSiteId()}`)
-    // Site content table is visible (page rendered) but the create menu is
-    // gated by `<Can do="create" on={{ parentId: null }}>` and absent for
-    // publishers — base permissions grant them read/update at the root, not
-    // create.
     await expect(
       page.getByRole("button", { name: "Create new..." }),
     ).not.toBeVisible()
@@ -126,30 +85,24 @@ test.describe("editor", () => {
   test.use({ storageState: storageStateFor("editor") })
 
   test.beforeEach(async () => {
-    await dismissWelcomeModal(TEST_EMAILS.editor)
+    await ensureUserOnboarded(TEST_EMAILS.editor)
   })
 
   test("editor does not see the Create new button", async ({ page }) => {
     await page.goto(`/sites/${getSeedSiteId()}`)
-    // Editors, like publishers, only get read/update at the root, so the
-    // `<Can do="create" on={{ parentId: null }}>`-gated menu is absent.
     await expect(
       page.getByRole("button", { name: "Create new..." }),
     ).not.toBeVisible()
   })
 })
 
-// The permission model inside a folder differs from the root: base permissions
-// grant create on resources with a non-null parent to every role, and the
-// folder page does not gate the "Create new..." menu behind `<Can>`. So a
-// publisher — who cannot create at the root — can create pages inside a folder.
 test.describe("admin — create page in a subfolder", () => {
   test.use({ storageState: storageStateFor("admin") })
 
   let folderId: string
 
   test.beforeEach(async () => {
-    await dismissWelcomeModal(TEST_EMAILS.admin)
+    await ensureUserOnboarded(TEST_EMAILS.admin)
     folderId = (await createSeedFolder()).id
   })
 
@@ -158,15 +111,17 @@ test.describe("admin — create page in a subfolder", () => {
   })
 
   test("admin can create a new page inside a folder", async ({ page }) => {
+    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
-      startUrl: `/sites/${getSeedSiteId()}/folders/${folderId}`,
+      startUrl: `/sites/${siteId}/folders/${folderId}`,
       title,
+      siteId,
     })
 
     const created = await db
       .selectFrom("Resource")
-      .where("siteId", "=", getSeedSiteId())
+      .where("siteId", "=", siteId)
       .where("title", "=", title)
       .select(["id", "state", "parentId"])
       .executeTakeFirst()
@@ -182,7 +137,7 @@ test.describe("publisher — create page in a subfolder", () => {
   let folderId: string
 
   test.beforeEach(async () => {
-    await dismissWelcomeModal(TEST_EMAILS.publisher)
+    await ensureUserOnboarded(TEST_EMAILS.publisher)
     folderId = (await createSeedFolder()).id
   })
 
@@ -191,15 +146,17 @@ test.describe("publisher — create page in a subfolder", () => {
   })
 
   test("publisher can create a new page inside a folder", async ({ page }) => {
+    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
-      startUrl: `/sites/${getSeedSiteId()}/folders/${folderId}`,
+      startUrl: `/sites/${siteId}/folders/${folderId}`,
       title,
+      siteId,
     })
 
     const created = await db
       .selectFrom("Resource")
-      .where("siteId", "=", getSeedSiteId())
+      .where("siteId", "=", siteId)
       .where("title", "=", title)
       .select(["id", "state", "parentId"])
       .executeTakeFirst()
@@ -215,7 +172,7 @@ test.describe("editor — create page in a subfolder", () => {
   let folderId: string
 
   test.beforeEach(async () => {
-    await dismissWelcomeModal(TEST_EMAILS.editor)
+    await ensureUserOnboarded(TEST_EMAILS.editor)
     folderId = (await createSeedFolder()).id
   })
 
@@ -224,15 +181,17 @@ test.describe("editor — create page in a subfolder", () => {
   })
 
   test("editor can create a new page inside a folder", async ({ page }) => {
+    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
-      startUrl: `/sites/${getSeedSiteId()}/folders/${folderId}`,
+      startUrl: `/sites/${siteId}/folders/${folderId}`,
       title,
+      siteId,
     })
 
     const created = await db
       .selectFrom("Resource")
-      .where("siteId", "=", getSeedSiteId())
+      .where("siteId", "=", siteId)
       .where("title", "=", title)
       .select(["id", "state", "parentId"])
       .executeTakeFirst()

--- a/apps/studio/tests/e2e/page/create-page.test.ts
+++ b/apps/studio/tests/e2e/page/create-page.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
 import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
@@ -5,7 +6,6 @@ import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createPageViaWizard } from "../fixtures/helpers"
 import { getSeedSiteId } from "../fixtures/seed"
-import { expect, test } from "../fixtures/test"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Page ${crypto.randomUUID().slice(0, 8)}`

--- a/apps/studio/tests/e2e/resource/create-folder.test.ts
+++ b/apps/studio/tests/e2e/resource/create-folder.test.ts
@@ -1,26 +1,21 @@
-import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
 
-import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
+import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
+import { createFolderViaWizard } from "../fixtures/helpers"
 import { getSeedSiteId } from "../fixtures/seed"
+import { expect, test } from "../fixtures/test"
+import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Folder ${crypto.randomUUID().slice(0, 8)}`
 
 test.use({ storageState: storageStateFor("admin") })
 
 test.beforeEach(async () => {
-  // Welcome-modal workaround (see settings tests for rationale).
-  await db
-    .updateTable("User")
-    .set({ name: "test-e2e", phone: "82345678" })
-    .where("email", "=", TEST_EMAILS.admin)
-    .execute()
+  await ensureUserOnboarded(TEST_EMAILS.admin)
 })
 
 test.afterEach(async () => {
-  // Clean up any folders created during the test. permalink uniqueness is
-  // enforced per-site, so re-runs collide unless we delete.
   await db
     .deleteFrom("Resource")
     .where("siteId", "=", getSeedSiteId())
@@ -31,23 +26,13 @@ test.afterEach(async () => {
 test("admin can create a folder via the Create new wizard", async ({
   page,
 }) => {
+  const siteId = getSeedSiteId()
   const title = UNIQUE_TITLE()
-  await page.goto(`/sites/${getSeedSiteId()}`)
+  await createFolderViaWizard(page, { siteId, title })
 
-  await page.getByRole("button", { name: "Create new..." }).click()
-  await page.getByRole("menuitem", { name: "Folder" }).click()
-
-  await page.getByLabel("Folder name").fill(title)
-  await page.getByRole("button", { name: "Create Folder" }).click()
-
-  // Unlike create-page, the folder mutation does not navigate — it closes
-  // the modal and shows a success toast. Wait for the toast as the signal.
-  await expect(page.getByText("Folder created!")).toBeVisible()
-
-  // Verify in DB: folder Resource row exists with type Folder.
   const created = await db
     .selectFrom("Resource")
-    .where("siteId", "=", getSeedSiteId())
+    .where("siteId", "=", siteId)
     .where("title", "=", title)
     .select(["id", "type"])
     .executeTakeFirst()

--- a/apps/studio/tests/e2e/resource/create-folder.test.ts
+++ b/apps/studio/tests/e2e/resource/create-folder.test.ts
@@ -1,10 +1,10 @@
+import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createFolderViaWizard } from "../fixtures/helpers"
 import { getSeedSiteId } from "../fixtures/seed"
-import { expect, test } from "../fixtures/test"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Folder ${crypto.randomUUID().slice(0, 8)}`

--- a/apps/studio/tests/e2e/site/settings-agency.test.ts
+++ b/apps/studio/tests/e2e/site/settings-agency.test.ts
@@ -1,33 +1,15 @@
-import { expect, test } from "@playwright/test"
-import { sql } from "kysely"
-import { db } from "~/server/modules/database"
-
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
+import { resetSiteAgencySettings } from "../fixtures/reset"
 import { getSeedSiteId } from "../fixtures/seed"
 import { SitePO } from "../fixtures/site.po"
+import { expect, test } from "../fixtures/test"
+import { ensureUserOnboarded } from "../fixtures/user"
 
 test.use({ storageState: storageStateFor("admin") })
 
 test.beforeEach(async () => {
-  // Ensure the admin user has name + phone set so the "Welcome" onboarding
-  // dialog does not appear and obstruct the form. Other suites (e.g.
-  // singpass.test.ts) blank out user profiles in the shared test DB, so
-  // re-populate it here to keep this test independent of run order.
-  await db
-    .updateTable("User")
-    .set({ name: "test-e2e", phone: "82345678" })
-    .where("email", "=", TEST_EMAILS.admin)
-    .execute()
-
-  // Reset both the name column and config.siteName so the test is idempotent.
-  await db
-    .updateTable("Site")
-    .set({
-      name: "Isomer",
-      config: sql`jsonb_set(config, '{siteName}', '"Isomer"')`,
-    })
-    .where("id", "=", getSeedSiteId())
-    .execute()
+  await ensureUserOnboarded(TEST_EMAILS.admin)
+  await resetSiteAgencySettings(getSeedSiteId())
 })
 
 test("admin can update site name on the agency settings page", async ({
@@ -44,7 +26,6 @@ test("admin can update site name on the agency settings page", async ({
   await site.publishButton().click()
   await site.expectChangesPublishedToast()
 
-  // Hard-assert persistence: reload and verify the value sticks.
   await page.reload()
   await expect(page.getByLabel("Site name")).toHaveValue("Isomer (renamed)")
 })
@@ -53,12 +34,7 @@ test.describe("publisher", () => {
   test.use({ storageState: storageStateFor("publisher") })
 
   test.beforeEach(async () => {
-    // Same welcome-modal workaround as the admin test block.
-    await db
-      .updateTable("User")
-      .set({ name: "test-e2e", phone: "82345678" })
-      .where("email", "=", TEST_EMAILS.publisher)
-      .execute()
+    await ensureUserOnboarded(TEST_EMAILS.publisher)
   })
 
   test("publisher does not see the Publish button on agency settings", async ({
@@ -67,9 +43,7 @@ test.describe("publisher", () => {
     await page.goto(`/sites/${getSeedSiteId()}/settings/agency`)
     await page.waitForURL(/\/settings\/agency$/)
 
-    // Form input is visible (settings page rendered)…
     await expect(page.getByLabel("Site name")).toBeVisible()
-    // …but the Publish button (gated by `<Can do="create">`) is not.
     await expect(
       page.getByRole("button", { name: "Publish" }),
     ).not.toBeVisible()

--- a/apps/studio/tests/e2e/site/settings-agency.test.ts
+++ b/apps/studio/tests/e2e/site/settings-agency.test.ts
@@ -1,8 +1,9 @@
+import { expect, test } from "@playwright/test"
+
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteAgencySettings } from "../fixtures/reset"
 import { getSeedSiteId } from "../fixtures/seed"
 import { SitePO } from "../fixtures/site.po"
-import { expect, test } from "../fixtures/test"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 test.use({ storageState: storageStateFor("admin") })

--- a/apps/studio/tests/e2e/site/settings-notification.test.ts
+++ b/apps/studio/tests/e2e/site/settings-notification.test.ts
@@ -1,29 +1,15 @@
-import { expect, test } from "@playwright/test"
-import { sql } from "kysely"
-import { db } from "~/server/modules/database"
-
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
+import { resetSiteNotification } from "../fixtures/reset"
 import { getSeedSiteId } from "../fixtures/seed"
 import { SitePO } from "../fixtures/site.po"
+import { expect, test } from "../fixtures/test"
+import { ensureUserOnboarded } from "../fixtures/user"
 
 test.use({ storageState: storageStateFor("admin") })
 
 test.beforeEach(async () => {
-  // Ensure the admin user has name + phone set so the "Welcome" onboarding
-  // dialog does not appear and obstruct the form.
-  await db
-    .updateTable("User")
-    .set({ name: "test-e2e", phone: "82345678" })
-    .where("email", "=", TEST_EMAILS.admin)
-    .execute()
-
-  // Reset the notification on the seed site so the test starts from a clean
-  // state (toggle off). The `-` operator removes a key from a JSONB column.
-  await db
-    .updateTable("Site")
-    .set({ config: sql`config - 'notification'` })
-    .where("id", "=", getSeedSiteId())
-    .execute()
+  await ensureUserOnboarded(TEST_EMAILS.admin)
+  await resetSiteNotification(getSeedSiteId())
 })
 
 test("admin can save a notification title", async ({ page }) => {
@@ -31,15 +17,10 @@ test("admin can save a notification title", async ({ page }) => {
   await page.goto(`/sites/${getSeedSiteId()}/settings/notification`)
   await page.waitForURL(/\/settings\/notification$/)
 
-  // The notification object is optional. FormBuilder renders optional objects
-  // with a Switch (Chakra UI). The Switch renders a <label> wrapping a hidden
-  // <input type="checkbox">. The label intercepts pointer events, so we click
-  // the label (.chakra-switch) rather than the underlying input.
   const toggleLabel = page.locator(".chakra-switch")
   await expect(toggleLabel).toBeVisible()
   await toggleLabel.click()
 
-  // After toggling on, the "Notification title" input should appear.
   const titleField = page.getByLabel("Notification title")
   await expect(titleField).toBeVisible({ timeout: 5000 })
   await titleField.fill("e2e test notification")
@@ -47,10 +28,8 @@ test("admin can save a notification title", async ({ page }) => {
   await site.publishButton().click()
   await site.expectChangesPublishedToast()
 
-  // Stretch: reload and confirm persistence.
   await page.reload()
   await page.waitForURL(/\/settings\/notification$/)
-  // After reload, the toggle should still be checked (notification persisted).
   const reloadedCheckbox = page.getByRole("checkbox")
   await expect(reloadedCheckbox).toBeChecked()
   await expect(page.getByLabel("Notification title")).toHaveValue(

--- a/apps/studio/tests/e2e/site/settings-notification.test.ts
+++ b/apps/studio/tests/e2e/site/settings-notification.test.ts
@@ -1,8 +1,9 @@
+import { expect, test } from "@playwright/test"
+
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteNotification } from "../fixtures/reset"
 import { getSeedSiteId } from "../fixtures/seed"
 import { SitePO } from "../fixtures/site.po"
-import { expect, test } from "../fixtures/test"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 test.use({ storageState: storageStateFor("admin") })

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -1,10 +1,10 @@
+import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { inviteCollaborator, openInviteModal } from "../fixtures/helpers"
 import { getSeedSiteId } from "../fixtures/seed"
-import { expect, test } from "../fixtures/test"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_INVITEE = () =>

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -1,23 +1,18 @@
-import { expect, test, type Page } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
-import { type RoleType } from "~prisma/generated/generatedEnums"
 
-import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
+import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
+import { inviteCollaborator, openInviteModal } from "../fixtures/helpers"
 import { getSeedSiteId } from "../fixtures/seed"
+import { expect, test } from "../fixtures/test"
+import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_INVITEE = () =>
   `e2e-invitee-${crypto.randomUUID().slice(0, 8)}@open.gov.sg`
 
-// Non-gov.sg domain — i.e. a "vendor" collaborator. Vendors can only be
-// added if their email is whitelisted (any whitelist entry, temporary or
-// permanent, is sufficient for any role including Admin).
 const UNIQUE_VENDOR = () =>
   `e2e-vendor-${crypto.randomUUID().slice(0, 8)}@vendor.example.com`
 
-// Whitelist a vendor email so the whitelist gate isn't the blocker. A future
-// expiry marks it as a (temporary) vendor entry rather than a permanent one;
-// isEmailWhitelisted treats both as equally valid.
 const whitelistVendor = async (email: string) => {
   const expiry = new Date()
   expiry.setDate(expiry.getDate() + 90)
@@ -32,33 +27,6 @@ const whitelistVendor = async (email: string) => {
     .execute()
 }
 
-const openInviteModal = async (page: Page) => {
-  await page.goto(`/sites/${getSeedSiteId()}/users`)
-  await page.getByRole("button", { name: "Add new user" }).click()
-}
-
-// Drives the modal happy path: fill email, pick role, wait for the whitelist
-// check to enable Send, then submit.
-const inviteCollaborator = async (
-  page: Page,
-  { email, role }: { email: string; role: keyof typeof RoleType },
-) => {
-  await openInviteModal(page)
-  await page.getByLabel("Email address").fill(email)
-  // RoleBoxes are clickable cards; their accessible name is "<Role> role".
-  await page.getByRole("button", { name: new RegExp(`^${role}`) }).click()
-
-  const sendBtn = page.getByRole("button", { name: "Send invite" })
-  // The form debounces email + runs a whitelist check before enabling Send.
-  await expect(sendBtn).toBeEnabled({ timeout: 10_000 })
-  await sendBtn.click()
-  await expect(page.getByText(/Sent invite to/)).toBeVisible({
-    timeout: 10_000,
-  })
-}
-
-// Polls the DB for the active permission role granted to an invitee on the
-// seed site.
 const expectGrantedRole = (email: string) =>
   expect.poll(
     async () => {
@@ -78,16 +46,9 @@ const expectGrantedRole = (email: string) =>
 test.use({ storageState: storageStateFor("admin") })
 
 test.beforeEach(async () => {
-  // Welcome-modal workaround (see settings tests for rationale).
-  await db
-    .updateTable("User")
-    .set({ name: "test-e2e", phone: "82345678" })
-    .where("email", "=", TEST_EMAILS.admin)
-    .execute()
+  await ensureUserOnboarded(TEST_EMAILS.admin)
 })
 
-// Hard-delete e2e users matching `emailPattern` + their permissions so re-runs
-// are clean. ResourcePermission has FK to User so delete permissions first.
 const deleteUsersByEmail = async (emailPattern: string) => {
   const users = await db
     .selectFrom("User")
@@ -102,9 +63,7 @@ const deleteUsersByEmail = async (emailPattern: string) => {
 
 test.afterEach(async () => {
   await deleteUsersByEmail("e2e-invitee-%@open.gov.sg")
-  // Cleanup for vendor users created by the positive vendor-invite test.
   await deleteUsersByEmail("e2e-vendor-%@vendor.example.com")
-  // Remove any vendor whitelist entries created by these tests.
   await db
     .deleteFrom("Whitelist")
     .where("email", "like", "e2e-vendor-%@vendor.example.com")
@@ -112,45 +71,60 @@ test.afterEach(async () => {
 })
 
 test("admin can invite a new collaborator as Editor", async ({ page }) => {
+  const siteId = getSeedSiteId()
   const inviteeEmail = UNIQUE_INVITEE()
-  await inviteCollaborator(page, { email: inviteeEmail, role: "Editor" })
+  await inviteCollaborator(page, {
+    email: inviteeEmail,
+    role: "Editor",
+    siteId,
+  })
   await expectGrantedRole(inviteeEmail).toBe("Editor")
 })
 
 test("admin can invite a new collaborator as Publisher", async ({ page }) => {
+  const siteId = getSeedSiteId()
   const inviteeEmail = UNIQUE_INVITEE()
-  await inviteCollaborator(page, { email: inviteeEmail, role: "Publisher" })
+  await inviteCollaborator(page, {
+    email: inviteeEmail,
+    role: "Publisher",
+    siteId,
+  })
   await expectGrantedRole(inviteeEmail).toBe("Publisher")
 })
 
 test("admin can invite a new collaborator as Admin", async ({ page }) => {
-  // A gov.sg invitee is whitelisted by the `.gov.sg` suffix and eligible for
-  // the Admin role.
+  const siteId = getSeedSiteId()
   const inviteeEmail = UNIQUE_INVITEE()
-  await inviteCollaborator(page, { email: inviteeEmail, role: "Admin" })
+  await inviteCollaborator(page, {
+    email: inviteeEmail,
+    role: "Admin",
+    siteId,
+  })
   await expectGrantedRole(inviteeEmail).toBe("Admin")
 })
 
 test("admin can invite a whitelisted vendor collaborator as Admin", async ({
   page,
 }) => {
+  const siteId = getSeedSiteId()
   const vendorEmail = UNIQUE_VENDOR()
-  // A temporary (vendor) whitelist grant is now sufficient for Admin, same
-  // as a permanent one.
   await whitelistVendor(vendorEmail)
-  await inviteCollaborator(page, { email: vendorEmail, role: "Admin" })
+  await inviteCollaborator(page, {
+    email: vendorEmail,
+    role: "Admin",
+    siteId,
+  })
   await expectGrantedRole(vendorEmail).toBe("Admin")
 })
 
 test("admin cannot invite a non-whitelisted vendor collaborator", async ({
   page,
 }) => {
+  const siteId = getSeedSiteId()
   const vendorEmail = UNIQUE_VENDOR()
-  await openInviteModal(page)
+  await openInviteModal(page, siteId)
   await page.getByLabel("Email address").fill(vendorEmail)
 
-  // Default role is Editor, so the Admin restriction isn't in play — the sole
-  // blocker is the missing whitelist entry.
   await expect(
     page.getByText("There are non-gov.sg domains that need to be whitelisted"),
   ).toBeVisible({ timeout: 10_000 })
@@ -160,13 +134,10 @@ test("admin cannot invite a non-whitelisted vendor collaborator", async ({
 test("admin cannot invite a non-whitelisted vendor collaborator, even as Admin", async ({
   page,
 }) => {
+  const siteId = getSeedSiteId()
   const vendorEmail = UNIQUE_VENDOR()
-  await openInviteModal(page)
+  await openInviteModal(page, siteId)
 
-  // Selecting Admin has no whitelist-specific effect of its own -- there's no
-  // distinction between Admin and any other role. The role box is never
-  // disabled; the block comes purely from the general "needs whitelisting"
-  // gate that applies to every role.
   await page.getByRole("button", { name: /^Admin/ }).click()
   await page.getByLabel("Email address").fill(vendorEmail)
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 0 | +0 | -0 |
| 🧪 Test | 8 | +212 | -205 |
| 📄 Doc | 2 | +40 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

E2E tests duplicate welcome-modal workarounds, DB reset logic, and UI flow helpers across multiple test files. This makes the suite harder to extend and is the first blocker in the E2E scale-up spec (PR-1).

Part of stacked E2E work: #2933 → **this PR** → per-site isolation (next).

## Solution

Extract shared E2E infrastructure into `apps/studio/tests/e2e/fixtures/` and migrate existing tests to use it.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Add `fixtures/test.ts` — re-export `test` / `expect` for new tests
- Add `fixtures/user.ts` — `ensureUserOnboarded(email)` to skip welcome modal
- Add `fixtures/reset.ts` — `resetSiteAgencySettings`, `resetSiteNotification`, `resetSiteTheme`
- Add `fixtures/helpers.ts` — `createPageViaWizard`, `createFolderViaWizard`, `openInviteModal`, `inviteCollaborator`
- Migrate `create-page`, `create-folder`, `invite-user`, and settings tests to shared fixtures
- Document fixtures in `tests/e2e/README.md`

**Bug Fixes**:

- None

## Before & After Screenshots

**BEFORE**:

N/A — test infrastructure refactor

**AFTER**:

N/A — test infrastructure refactor

## Tests

- [ ] `cd apps/studio && pnpm dev:e2e` — all active E2E tests pass
- [ ] No duplicated `dismissWelcomeModal` / inline welcome-modal `beforeEach` in migrated test files

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR extracts duplicated E2E setup, reset, and UI-flow logic into shared fixtures and migrates the existing tests to use them.
- Adds reusable onboarding, site-reset, page/folder creation, and collaborator-invite helpers.
- Migrates page, folder, settings, and user-invite tests to the shared fixtures.
- Documents the fixture layout and E2E conventions.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/tests/e2e/fixtures/helpers.ts | Adds shared Playwright flows and fixes the previously reported type-check failure by using the imported `RoleType` union directly. |
| apps/studio/tests/e2e/fixtures/reset.ts | Centralizes site-scoped agency, notification, and theme reset operations for E2E tests. |
| apps/studio/tests/e2e/fixtures/user.ts | Centralizes the database setup used to prevent the welcome modal from blocking E2E tests. |
| apps/studio/tests/e2e/page/create-page.test.ts | Migrates page-creation tests to shared onboarding and wizard helpers while preserving their assertions and cleanup. |
| apps/studio/tests/e2e/resource/create-folder.test.ts | Migrates folder creation to the shared onboarding and wizard helpers. |
| apps/studio/tests/e2e/site/settings-agency.test.ts | Replaces inline user and agency-setting setup with shared fixtures. |
| apps/studio/tests/e2e/site/settings-notification.test.ts | Replaces inline onboarding and notification reset logic with shared fixtures. |
| apps/studio/tests/e2e/user/invite-user.test.ts | Migrates invitation flows and modal navigation to the shared helper API. |

</details>

<sub>Reviews (4): Last reviewed commit: ["style(e2e): fix oxfmt formatting in help..."](https://github.com/opengovsg/isomer/commit/3bf36bc31ea0e02dc21f482b781f0094d3859ccc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54270138)</sub>

<!-- /greptile_comment -->