### PR TITLE
test(e2e): add per-site isolation for mutating tests

### DIFF
--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -37,18 +37,17 @@ validation-edge-case scenarios — those stay in integration tests.
 
 Every test file gets a dedicated site via `provisionE2ESite` in `beforeAll`,
 torn down via `teardownE2ESite` in `afterAll` — including read-only tests.
-There is no shared seed-site accessor (`getSeedSiteId()` was removed); the only
-tests that still reference seed site ID `1` directly are ones asserting on the
-pre-seeded fixture data itself (e.g. `site/list.test.ts` checking the
-dashboard shows the pre-seeded "Sample Site"), not using it as a general-purpose
-test site.
+Seed data (e.g. "Sample Site") is for app bootstrap and auth only — never assert
+on seed site names or hardcode site ID `1`.
 
 ```ts
 let siteId: number
+let siteName: string
 
 test.beforeAll(async () => {
-  const site = await provisionE2ESite({ admin: true })
+  const site = await provisionE2ESite({ roles: [RoleType.Editor] })
   siteId = site.siteId
+  siteName = site.siteName
 })
 
 test.afterAll(async () => {
@@ -56,11 +55,12 @@ test.afterAll(async () => {
 })
 ```
 
-- Grant roles with `provisionE2ESite({ admin, editor, publisher })` — maps to `TEST_EMAILS`
+- Grant roles with `provisionE2ESite({ roles: [...] })` — maps to `TEST_EMAILS`
+- Assert on the returned `siteName` / `siteId`, not Prisma seed fixtures
 - Use `resetSite*` helpers from `fixtures/reset.ts` in `beforeEach` for idempotent state
 - `provisionE2ESite` creates a root page + search page so the site dashboard loads
 
 ## How to detect violations
 
-- Test using `getSeedSiteId()` or hardcoding site ID `1` → should use `provisionE2ESite`, unless it's specifically asserting on pre-seeded fixture data
+- Asserting "Sample Site", hardcoding site ID `1`, or calling `getSeedSiteId()` → use `provisionE2ESite` and assert on the returned site
 - Duplicated wizard/invite flows in test files → move to `helpers.ts` or a PO

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -35,10 +35,13 @@ validation-edge-case scenarios — those stay in integration tests.
 
 ## Per-site isolation (PR-2)
 
-| Test category | Site strategy |
-|---------------|---------------|
-| **Read-only / seed-dependent** | Seed site ID `1` ("Sample Site") — e.g. `site/list.test.ts`, `godmode/access.test.ts` |
-| **Mutating** | Dedicated site per test file via `provisionE2ESite` in `beforeAll`, `teardownE2ESite` in `afterAll` |
+Every test file gets a dedicated site via `provisionE2ESite` in `beforeAll`,
+torn down via `teardownE2ESite` in `afterAll` — including read-only tests.
+There is no shared seed-site accessor (`getSeedSiteId()` was removed); the only
+tests that still reference seed site ID `1` directly are ones asserting on the
+pre-seeded fixture data itself (e.g. `site/list.test.ts` checking the
+dashboard shows the pre-seeded "Sample Site"), not using it as a general-purpose
+test site.
 
 ```ts
 let siteId: number
@@ -54,12 +57,10 @@ test.afterAll(async () => {
 ```
 
 - Grant roles with `provisionE2ESite({ admin, editor, publisher })` — maps to `TEST_EMAILS`
-- `getSeedSiteId()` is **deprecated for mutating tests**; keep for read-only seed tests only
 - Use `resetSite*` helpers from `fixtures/reset.ts` in `beforeEach` for idempotent state
 - `provisionE2ESite` creates a root page + search page so the site dashboard loads
 
 ## How to detect violations
 
-- Mutating test using `getSeedSiteId()` → should use `provisionE2ESite`
+- Test using `getSeedSiteId()` or hardcoding site ID `1` → should use `provisionE2ESite`, unless it's specifically asserting on pre-seeded fixture data
 - Duplicated wizard/invite flows in test files → move to `helpers.ts` or a PO
-- Test file writing to site ID `1` outside read-only suites

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -20,7 +20,7 @@ introduces a **new reusable pattern** — not when merely adding test cases. See
 |-------|------|---------|
 | **Helpers** | `fixtures/helpers.ts` | Multi-step flows crossing pages or modals (wizard, invite) |
 | **Page objects** | `fixtures/*.po.ts` | Locators + actions on one UI surface (`SitePO`, `DashboardPO`, …) |
-| **DB setup** | `fixtures/reset.ts` | Non-UI reset helpers (site-agnostic; take `siteId` arg) |
+| **DB setup** | `fixtures/reset.ts`, `fixtures/site.ts` | Non-UI reset and site lifecycle |
 
 ## Welcome modal
 
@@ -33,6 +33,33 @@ Per UI surface: **one happy-path** + **one permission-gate** where the UI shows 
 signal (hidden button, redirect, disabled control). Do not translate audit-log or
 validation-edge-case scenarios — those stay in integration tests.
 
+## Per-site isolation (PR-2)
+
+| Test category | Site strategy |
+|---------------|---------------|
+| **Read-only / seed-dependent** | Seed site ID `1` ("Sample Site") — e.g. `site/list.test.ts`, `godmode/access.test.ts` |
+| **Mutating** | Dedicated site per test file via `provisionE2ESite` in `beforeAll`, `teardownE2ESite` in `afterAll` |
+
+```ts
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ admin: true })
+  siteId = site.siteId
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
+```
+
+- Grant roles with `provisionE2ESite({ admin, editor, publisher })` — maps to `TEST_EMAILS`
+- `getSeedSiteId()` is **deprecated for mutating tests**; keep for read-only seed tests only
+- Use `resetSite*` helpers from `fixtures/reset.ts` in `beforeEach` for idempotent state
+- `provisionE2ESite` creates a root page + search page so the site dashboard loads
+
 ## How to detect violations
 
+- Mutating test using `getSeedSiteId()` → should use `provisionE2ESite`
 - Duplicated wizard/invite flows in test files → move to `helpers.ts` or a PO
+- Test file writing to site ID `1` outside read-only suites

--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -35,10 +35,14 @@ validation-edge-case scenarios — those stay in integration tests.
 
 ## Per-site isolation (PR-2)
 
-Every test file gets a dedicated site via `provisionE2ESite` in `beforeAll`,
-torn down via `teardownE2ESite` in `afterAll` — including read-only tests.
-Seed data (e.g. "Sample Site") is for app bootstrap and auth only — never assert
-on seed site names or hardcode site ID `1`.
+Every test file gets a dedicated site via `provisionE2ESite` in `beforeAll` —
+including read-only tests. There is no per-test/per-site teardown: the whole
+e2e database is wiped and re-seeded once at the start of each run
+(`resetE2EDatabase()` in `global-setup.ts`), so sites created during a run
+simply accumulate until the next run resets everything. Never assert on seed
+site names or hardcode a site ID — `seedRolesForE2E()` self-provisions its own
+site via `setupSite()` for the shared `TEST_EMAILS` users' permissions; there
+is no fixed "Sample Site"/site ID `1` for e2e to depend on.
 
 ```ts
 let siteId: number
@@ -49,18 +53,15 @@ test.beforeAll(async () => {
   siteId = site.siteId
   siteName = site.siteName
 })
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
-})
 ```
 
 - Grant roles with `provisionE2ESite({ roles: [...] })` — maps to `TEST_EMAILS`
 - Assert on the returned `siteName` / `siteId`, not Prisma seed fixtures
 - Use `resetSite*` helpers from `fixtures/reset.ts` in `beforeEach` for idempotent state
 - `provisionE2ESite` creates a root page + search page so the site dashboard loads
+- Do not add a `teardownE2ESite`/per-test cleanup call — it doesn't exist; cleanup is run-scoped, not test-scoped
 
 ## How to detect violations
 
-- Asserting "Sample Site", hardcoding site ID `1`, or calling `getSeedSiteId()` → use `provisionE2ESite` and assert on the returned site
+- Asserting "Sample Site", hardcoding a site ID, or calling `teardownE2ESite`/`getSeedSiteId()` (neither exists anymore) → use `provisionE2ESite` and assert on the returned site
 - Duplicated wizard/invite flows in test files → move to `helpers.ts` or a PO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,8 +247,6 @@ jobs:
               languages: js
               service: isomer-studio
               api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
-      - name: Seed testing db
-        run: pnpm exec turbo db:seed
       - name: Run Playwright tests
         run: pnpm exec turbo test-ci:e2e --filter=isomer-studio --env-mode=loose
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,8 +285,6 @@ jobs:
               languages: js
               service: isomer-studio
               api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
-      - name: Seed testing db
-        run: pnpm exec turbo db:seed
       - name: Run Playwright tests
         run: pnpm exec turbo test-ci:e2e --filter=isomer-studio --env-mode=loose
 

--- a/apps/studio/tests/e2e/collection/filters-permission.test.ts
+++ b/apps/studio/tests/e2e/collection/filters-permission.test.ts
@@ -1,6 +1,7 @@
 import { test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
 import {
@@ -8,9 +9,16 @@ import {
   deleteCollection,
 } from "../fixtures/collection"
 import { CollectionPO } from "../fixtures/collection.po"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite } from "../fixtures/site"
 
-const siteId = getSeedSiteId()
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({
+    roles: [RoleType.Admin, RoleType.Editor, RoleType.Publisher],
+  })
+  siteId = site.siteId
+})
 
 const dismissWelcomeModal = (email: string) =>
   db
@@ -20,14 +28,17 @@ const dismissWelcomeModal = (email: string) =>
     .execute()
 
 const seedCollection = () =>
-  createCollectionWithTagCategories([
-    {
-      id: crypto.randomUUID(),
-      label: "Topic",
-      isRequired: false,
-      options: [{ id: crypto.randomUUID(), label: "Technology" }],
-    },
-  ])
+  createCollectionWithTagCategories(
+    [
+      {
+        id: crypto.randomUUID(),
+        label: "Topic",
+        isRequired: false,
+        options: [{ id: crypto.randomUUID(), label: "Technology" }],
+      },
+    ],
+    siteId,
+  )
 
 test.describe("admin", () => {
   test.use({ storageState: storageStateFor("admin") })

--- a/apps/studio/tests/e2e/collection/required-tags-validation.test.ts
+++ b/apps/studio/tests/e2e/collection/required-tags-validation.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor, TEST_EMAILS } from "../fixtures/auth"
 import {
@@ -12,9 +13,14 @@ import {
   readBlobContent,
 } from "../fixtures/collection"
 import { CollectionPO } from "../fixtures/collection.po"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite } from "../fixtures/site"
 
-const siteId = getSeedSiteId()
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ roles: [RoleType.Admin] })
+  siteId = site.siteId
+})
 
 const dismissWelcomeModal = (email: string) =>
   db
@@ -38,23 +44,27 @@ test.describe("collection link — required tag categories", () => {
 
   test.beforeEach(async () => {
     await dismissWelcomeModal(TEST_EMAILS.admin)
-    const collection = await createCollectionWithTagCategories([
-      {
-        id: TAG_CATEGORY_ID,
-        label: TAG_CATEGORY_LABEL,
-        isRequired: true,
-        options: [{ id: TAG_OPTION_ID, label: TAG_OPTION_LABEL }],
-      },
-    ])
+    const collection = await createCollectionWithTagCategories(
+      [
+        {
+          id: TAG_CATEGORY_ID,
+          label: TAG_CATEGORY_LABEL,
+          isRequired: true,
+          options: [{ id: TAG_OPTION_ID, label: TAG_OPTION_LABEL }],
+        },
+      ],
+      siteId,
+    )
     collectionId = collection.collectionId
 
     // Save is also gated on a non-empty, valid `ref` — seed one directly so
     // the test isolates the tag-category gate instead of driving the
     // separate link-picker UI.
-    const rootPageId = await getRootPageId()
+    const rootPageId = await getRootPageId(siteId)
     const link = await createCollectionLink({
       collectionId,
       ref: `[resource:${siteId}:${rootPageId}]`,
+      siteId,
     })
     linkId = link.id
   })
@@ -108,17 +118,20 @@ test.describe("collection page — required tag categories", () => {
 
   test.beforeEach(async () => {
     await dismissWelcomeModal(TEST_EMAILS.admin)
-    const collection = await createCollectionWithTagCategories([
-      {
-        id: TAG_CATEGORY_ID,
-        label: TAG_CATEGORY_LABEL,
-        isRequired: true,
-        options: [{ id: TAG_OPTION_ID, label: TAG_OPTION_LABEL }],
-      },
-    ])
+    const collection = await createCollectionWithTagCategories(
+      [
+        {
+          id: TAG_CATEGORY_ID,
+          label: TAG_CATEGORY_LABEL,
+          isRequired: true,
+          options: [{ id: TAG_OPTION_ID, label: TAG_OPTION_LABEL }],
+        },
+      ],
+      siteId,
+    )
     collectionId = collection.collectionId
 
-    const collectionPage = await createCollectionPage({ collectionId })
+    const collectionPage = await createCollectionPage({ collectionId, siteId })
     pageId = collectionPage.id
   })
 

--- a/apps/studio/tests/e2e/fixtures/collection.ts
+++ b/apps/studio/tests/e2e/fixtures/collection.ts
@@ -3,7 +3,6 @@ import { db, jsonb } from "~/server/modules/database"
 import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS } from "./auth"
-import { getSeedSiteId } from "./seed"
 
 export const uniqueSuffix = () => crypto.randomUUID().slice(0, 8)
 
@@ -25,8 +24,8 @@ export interface TagCategory {
 // must be published, not just drafted, or drawers under test won't see them.
 export const createCollectionWithTagCategories = async (
   tagCategories: TagCategory[],
+  siteId: number,
 ) => {
-  const siteId = getSeedSiteId()
   const suffix = uniqueSuffix()
 
   const collection = await db
@@ -110,11 +109,11 @@ export const deleteCollection = (collectionId: string) =>
 export const createCollectionLink = async ({
   collectionId,
   ref,
-  siteId = getSeedSiteId(),
+  siteId,
 }: {
   collectionId: string
   ref: string
-  siteId?: number
+  siteId: number
 }) => {
   const blob = await db
     .insertInto("Blob")
@@ -147,10 +146,10 @@ export const createCollectionLink = async ({
 
 export const createCollectionPage = async ({
   collectionId,
-  siteId = getSeedSiteId(),
+  siteId,
 }: {
   collectionId: string
-  siteId?: number
+  siteId: number
 }) => {
   const blob = await db
     .insertInto("Blob")
@@ -194,7 +193,7 @@ export const readBlobContent = async (blobId: string) => {
   return blob.content as unknown as { page: { tagged?: string[] } }
 }
 
-export const getRootPageId = async (siteId = getSeedSiteId()) => {
+export const getRootPageId = async (siteId: number) => {
   const rootPage = await db
     .selectFrom("Resource")
     .where("siteId", "=", siteId)

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -34,12 +34,16 @@ export const createFolderViaWizard = async (
   await page.getByLabel("Folder name").fill(title)
   await page.getByRole("button", { name: "Create Folder" }).click()
 
-  await expect(page.getByText("Folder created!")).toBeVisible()
+  await expect(page.getByText("Folder created!")).toBeVisible({
+    timeout: 30_000,
+  })
 }
 
 export const openInviteModal = async (page: Page, siteId: number) => {
-  await page.goto(`/sites/${siteId}/users`)
-  await page.getByRole("button", { name: "Add new user" }).click()
+  await page.goto(`/sites/${siteId}/users`, { timeout: 60_000 })
+  await page
+    .getByRole("button", { name: "Add new user" })
+    .click({ timeout: 30_000 })
 }
 
 export const inviteCollaborator = async (

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -34,16 +34,12 @@ export const createFolderViaWizard = async (
   await page.getByLabel("Folder name").fill(title)
   await page.getByRole("button", { name: "Create Folder" }).click()
 
-  await expect(page.getByText("Folder created!")).toBeVisible({
-    timeout: 30_000,
-  })
+  await expect(page.getByText("Folder created!")).toBeVisible()
 }
 
 export const openInviteModal = async (page: Page, siteId: number) => {
-  await page.goto(`/sites/${siteId}/users`, { timeout: 60_000 })
-  await page
-    .getByRole("button", { name: "Add new user" })
-    .click({ timeout: 30_000 })
+  await page.goto(`/sites/${siteId}/users`)
+  await page.getByRole("button", { name: "Add new user" }).click()
 }
 
 export const inviteCollaborator = async (

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -1,6 +1,6 @@
+import type { RoleType } from "~prisma/generated/generatedEnums"
 import { type Page } from "@playwright/test"
 import { expect } from "@playwright/test"
-import { RoleType } from "~prisma/generated/generatedEnums"
 
 export const createPageViaWizard = async (
   page: Page,

--- a/apps/studio/tests/e2e/fixtures/helpers.ts
+++ b/apps/studio/tests/e2e/fixtures/helpers.ts
@@ -1,5 +1,6 @@
-import { expect, type Page } from "@playwright/test"
-import { type RoleType } from "~prisma/generated/generatedEnums"
+import { type Page } from "@playwright/test"
+import { expect } from "@playwright/test"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 export const createPageViaWizard = async (
   page: Page,

--- a/apps/studio/tests/e2e/fixtures/reset.ts
+++ b/apps/studio/tests/e2e/fixtures/reset.ts
@@ -1,3 +1,4 @@
+import type { IsomerSiteConfigProps } from "@opengovsg/isomer-components"
 import { sql } from "kysely"
 import { db, jsonb } from "~/server/modules/database"
 
@@ -16,7 +17,7 @@ export const resetSiteAgencySettings = async (
     .select("config")
     .executeTakeFirstOrThrow()
 
-  const config = site.config as Record<string, unknown>
+  const config = site.config as IsomerSiteConfigProps
 
   await db
     .updateTable("Site")

--- a/apps/studio/tests/e2e/fixtures/reset.ts
+++ b/apps/studio/tests/e2e/fixtures/reset.ts
@@ -1,20 +1,32 @@
 import { sql } from "kysely"
-import { db } from "~/server/modules/database"
+import { db, jsonb } from "~/server/modules/database"
 
 export { ensureUserOnboarded } from "./user"
 
 const DEFAULT_AGENCY_SITE_NAME = "Isomer"
 
 /** Reset site name and config.siteName for agency settings tests. */
-export const resetSiteAgencySettings = (siteId: number) =>
-  db
+export const resetSiteAgencySettings = async (
+  siteId: number,
+  siteName: string = DEFAULT_AGENCY_SITE_NAME,
+) => {
+  const site = await db
+    .selectFrom("Site")
+    .where("id", "=", siteId)
+    .select("config")
+    .executeTakeFirstOrThrow()
+
+  const config = site.config as Record<string, unknown>
+
+  await db
     .updateTable("Site")
     .set({
-      name: DEFAULT_AGENCY_SITE_NAME,
-      config: sql`jsonb_set(config, '{siteName}', '"Isomer"')`,
+      name: siteName,
+      config: jsonb({ ...config, siteName }),
     })
     .where("id", "=", siteId)
     .execute()
+}
 
 /** Remove notification config so the banner toggle starts off. */
 export const resetSiteNotification = (siteId: number) =>

--- a/apps/studio/tests/e2e/fixtures/seed.ts
+++ b/apps/studio/tests/e2e/fixtures/seed.ts
@@ -6,9 +6,6 @@ import { TEST_EMAILS } from "./auth"
 
 const SEED_SITE_ID = 1
 
-/** @deprecated for mutating tests — use provisionE2ESite() */
-export const getSeedSiteId = () => SEED_SITE_ID
-
 /**
  * Idempotent: inserts user if missing, then ensures a ResourcePermission
  * with `role` on the seed site exists (re-activating if soft-deleted).

--- a/apps/studio/tests/e2e/fixtures/seed.ts
+++ b/apps/studio/tests/e2e/fixtures/seed.ts
@@ -6,6 +6,7 @@ import { TEST_EMAILS } from "./auth"
 
 const SEED_SITE_ID = 1
 
+/** @deprecated for mutating tests — use provisionE2ESite() */
 export const getSeedSiteId = () => SEED_SITE_ID
 
 /**

--- a/apps/studio/tests/e2e/fixtures/seed.ts
+++ b/apps/studio/tests/e2e/fixtures/seed.ts
@@ -1,14 +1,13 @@
 import { createId } from "@paralleldrive/cuid2"
+import { setUpWhitelist, setupSite } from "tests/integration/helpers/seed"
 import { db } from "~/server/modules/database"
 import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS } from "./auth"
 
-const SEED_SITE_ID = 1
-
 /**
  * Idempotent: inserts user if missing, then ensures a ResourcePermission
- * with `role` on the seed site exists (re-activating if soft-deleted).
+ * with `role` on `siteId` exists (re-activating if soft-deleted).
  *
  * The unique constraint on ResourcePermission is
  * (userId, siteId, resourceId, deletedAt) NULLS NOT DISTINCT.
@@ -18,6 +17,7 @@ const SEED_SITE_ID = 1
 const ensureUserWithRole = async (
   email: string,
   role: (typeof RoleType)[keyof typeof RoleType] | null,
+  siteId: number,
 ) => {
   const user = await db
     .insertInto("User")
@@ -50,7 +50,7 @@ const ensureUserWithRole = async (
     .insertInto("ResourcePermission")
     .values({
       userId: user.id,
-      siteId: SEED_SITE_ID,
+      siteId,
       role,
       resourceId: null,
     })
@@ -70,8 +70,9 @@ const ensureUserWithRole = async (
 const ensureGodModeAdmin = async (
   email: string,
   role: (typeof IsomerAdminRole)[keyof typeof IsomerAdminRole],
+  siteId: number,
 ) => {
-  const user = await ensureUserWithRole(email, null)
+  const user = await ensureUserWithRole(email, null, siteId)
 
   await db
     .insertInto("IsomerAdmin")
@@ -83,11 +84,24 @@ const ensureGodModeAdmin = async (
 }
 
 export const seedRolesForE2E = async () => {
-  await ensureUserWithRole(TEST_EMAILS.admin, RoleType.Admin)
-  await ensureUserWithRole(TEST_EMAILS.nomember, null)
-  // editor + publisher are seeded by prisma/seed.ts; ensure they're still active
-  await ensureUserWithRole(TEST_EMAILS.editor, RoleType.Editor)
-  await ensureUserWithRole(TEST_EMAILS.publisher, RoleType.Publisher)
-  await ensureGodModeAdmin(TEST_EMAILS.core, IsomerAdminRole.Core)
-  await ensureGodModeAdmin(TEST_EMAILS.migrator, IsomerAdminRole.Migrator)
+  // protectedProcedure's authMiddleware requires the caller's email to be
+  // whitelisted (see whitelist.service.ts's isEmailWhitelisted), so every
+  // TEST_EMAILS user (all @open.gov.sg) needs this domain whitelisted for
+  // any tRPC call to succeed across the whole e2e suite. prisma/seed.ts
+  // used to provide this row via CI's now-removed "Seed testing db" step;
+  // it's self-provisioned here instead.
+  await setUpWhitelist({ email: "@open.gov.sg" })
+
+  const { site } = await setupSite()
+
+  await ensureUserWithRole(TEST_EMAILS.admin, RoleType.Admin, site.id)
+  await ensureUserWithRole(TEST_EMAILS.nomember, null, site.id)
+  await ensureUserWithRole(TEST_EMAILS.editor, RoleType.Editor, site.id)
+  await ensureUserWithRole(TEST_EMAILS.publisher, RoleType.Publisher, site.id)
+  await ensureGodModeAdmin(TEST_EMAILS.core, IsomerAdminRole.Core, site.id)
+  await ensureGodModeAdmin(
+    TEST_EMAILS.migrator,
+    IsomerAdminRole.Migrator,
+    site.id,
+  )
 }

--- a/apps/studio/tests/e2e/fixtures/site.ts
+++ b/apps/studio/tests/e2e/fixtures/site.ts
@@ -1,0 +1,168 @@
+import {
+  setupAdminPermissions,
+  setupEditorPermissions,
+  setupPageResource,
+  setupPublisherPermissions,
+  setupSite,
+} from "tests/integration/helpers/seed"
+import { db, sql } from "~/server/modules/database"
+import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+
+import { TEST_EMAILS } from "./auth"
+
+export type ProvisionedSite = {
+  siteId: number
+  siteName: string
+}
+
+const getUserIdByEmail = async (email: string) => {
+  const user = await db
+    .selectFrom("User")
+    .where("email", "=", email)
+    .select("id")
+    .executeTakeFirstOrThrow()
+  return user.id
+}
+
+export const provisionE2ESite = async (opts: {
+  admin?: boolean
+  editor?: boolean
+  publisher?: boolean
+}): Promise<ProvisionedSite> => {
+  const { site } = await setupSite()
+
+  const permissionSetup: Promise<unknown>[] = []
+
+  if (opts.admin) {
+    permissionSetup.push(
+      setupAdminPermissions({
+        siteId: site.id,
+        userId: await getUserIdByEmail(TEST_EMAILS.admin),
+      }),
+    )
+  }
+  if (opts.editor) {
+    permissionSetup.push(
+      setupEditorPermissions({
+        siteId: site.id,
+        userId: await getUserIdByEmail(TEST_EMAILS.editor),
+      }),
+    )
+  }
+  if (opts.publisher) {
+    permissionSetup.push(
+      setupPublisherPermissions({
+        siteId: site.id,
+        userId: await getUserIdByEmail(TEST_EMAILS.publisher),
+      }),
+    )
+  }
+
+  await Promise.all(permissionSetup)
+
+  const rootPageUserId = opts.admin
+    ? await getUserIdByEmail(TEST_EMAILS.admin)
+    : opts.editor
+      ? await getUserIdByEmail(TEST_EMAILS.editor)
+      : await getUserIdByEmail(TEST_EMAILS.publisher)
+
+  await setupPageResource({
+    siteId: site.id,
+    resourceType: ResourceType.RootPage,
+    state: ResourceState.Published,
+    userId: rootPageUserId,
+  })
+
+  await setupPageResource({
+    siteId: site.id,
+    resourceType: ResourceType.Page,
+    permalink: "search",
+    title: "Search",
+    state: ResourceState.Published,
+    userId: rootPageUserId,
+  })
+
+  return { siteId: site.id, siteName: site.name }
+}
+
+export const teardownE2ESite = async (siteId: number): Promise<void> => {
+  await db.transaction().execute(async (tx) => {
+    const resources = await tx
+      .selectFrom("Resource")
+      .where("siteId", "=", siteId)
+      .select(["id", "draftBlobId", "publishedVersionId"])
+      .execute()
+
+    const resourceIds = resources.map((r) => r.id)
+
+    if (resourceIds.length > 0) {
+      await tx
+        .deleteFrom("PushDocumentJob")
+        .where("resourceId", "in", resourceIds)
+        .execute()
+
+      await tx
+        .deleteFrom("CodeBuildJobs")
+        .where("resourceId", "in", resourceIds)
+        .execute()
+
+      await tx
+        .deleteFrom("ResourcePermission")
+        .where("resourceId", "in", resourceIds)
+        .execute()
+    }
+
+    await tx.deleteFrom("CodeBuildJobs").where("siteId", "=", siteId).execute()
+    await tx
+      .deleteFrom("ResourcePermission")
+      .where("siteId", "=", siteId)
+      .execute()
+    // AuditLog has an immutability trigger; bypass it for test teardown only.
+    await sql`SET LOCAL session_replication_role = 'replica'`.execute(tx)
+    await tx.deleteFrom("AuditLog").where("siteId", "=", siteId).execute()
+    await sql`SET LOCAL session_replication_role = 'origin'`.execute(tx)
+    await tx.deleteFrom("Redirect").where("siteId", "=", siteId).execute()
+
+    const versionIds = resources
+      .map((r) => r.publishedVersionId)
+      .filter((id): id is NonNullable<typeof id> => id != null)
+
+    const draftBlobIds = resources
+      .map((r) => r.draftBlobId)
+      .filter((id): id is NonNullable<typeof id> => id != null)
+
+    await tx
+      .updateTable("Resource")
+      .set({ parentId: null, publishedVersionId: null, draftBlobId: null })
+      .where("siteId", "=", siteId)
+      .execute()
+
+    const blobIds = new Set(draftBlobIds)
+
+    if (versionIds.length > 0) {
+      const versions = await tx
+        .selectFrom("Version")
+        .where("id", "in", versionIds)
+        .select("blobId")
+        .execute()
+
+      await tx.deleteFrom("Version").where("id", "in", versionIds).execute()
+
+      for (const version of versions) {
+        blobIds.add(version.blobId)
+      }
+    }
+
+    if (blobIds.size > 0) {
+      await tx
+        .deleteFrom("Blob")
+        .where("id", "in", [...blobIds])
+        .execute()
+    }
+
+    await tx.deleteFrom("Resource").where("siteId", "=", siteId).execute()
+    await tx.deleteFrom("Navbar").where("siteId", "=", siteId).execute()
+    await tx.deleteFrom("Footer").where("siteId", "=", siteId).execute()
+    await tx.deleteFrom("Site").where("id", "=", siteId).execute()
+  })
+}

--- a/apps/studio/tests/e2e/fixtures/site.ts
+++ b/apps/studio/tests/e2e/fixtures/site.ts
@@ -6,7 +6,11 @@ import {
   setupSite,
 } from "tests/integration/helpers/seed"
 import { db, sql } from "~/server/modules/database"
-import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+import {
+  ResourceState,
+  ResourceType,
+  RoleType,
+} from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS } from "./auth"
 
@@ -24,50 +28,53 @@ const getUserIdByEmail = async (email: string) => {
   return user.id
 }
 
-type ProvisionE2ESiteOpts =
-  | { admin: true; editor?: boolean; publisher?: boolean }
-  | { admin?: boolean; editor: true; publisher?: boolean }
-  | { admin?: boolean; editor?: boolean; publisher: true }
+type Role = (typeof RoleType)[keyof typeof RoleType]
 
-export const provisionE2ESite = async (
-  opts: ProvisionE2ESiteOpts,
-): Promise<ProvisionedSite> => {
+const TEST_EMAIL_BY_ROLE: Record<Role, string> = {
+  [RoleType.Admin]: TEST_EMAILS.admin,
+  [RoleType.Editor]: TEST_EMAILS.editor,
+  [RoleType.Publisher]: TEST_EMAILS.publisher,
+}
+
+const SETUP_PERMISSIONS_BY_ROLE: Record<
+  Role,
+  (props: { siteId: number; userId: string }) => Promise<unknown>
+> = {
+  [RoleType.Admin]: setupAdminPermissions,
+  [RoleType.Editor]: setupEditorPermissions,
+  [RoleType.Publisher]: setupPublisherPermissions,
+}
+
+// Root page owner, in order of preference, when multiple roles are requested.
+const ROOT_PAGE_ROLE_PRIORITY: Role[] = [
+  RoleType.Admin,
+  RoleType.Editor,
+  RoleType.Publisher,
+]
+
+// Each requested role grants its own fixed TEST_EMAILS user (admin/editor/
+// publisher are separate accounts) that role on this site — never multiple
+// roles to one user. This lets a single test file switch `storageState`
+// between those canonical users to exercise several permission levels
+// against the same freshly-provisioned site.
+export const provisionE2ESite = async (opts: {
+  roles: [Role, ...Role[]]
+}): Promise<ProvisionedSite> => {
   const { site } = await setupSite()
 
-  const permissionSetup: Promise<unknown>[] = []
+  await Promise.all(
+    opts.roles.map(async (role) => {
+      const userId = await getUserIdByEmail(TEST_EMAIL_BY_ROLE[role])
+      return SETUP_PERMISSIONS_BY_ROLE[role]({ siteId: site.id, userId })
+    }),
+  )
 
-  if (opts.admin) {
-    permissionSetup.push(
-      setupAdminPermissions({
-        siteId: site.id,
-        userId: await getUserIdByEmail(TEST_EMAILS.admin),
-      }),
-    )
-  }
-  if (opts.editor) {
-    permissionSetup.push(
-      setupEditorPermissions({
-        siteId: site.id,
-        userId: await getUserIdByEmail(TEST_EMAILS.editor),
-      }),
-    )
-  }
-  if (opts.publisher) {
-    permissionSetup.push(
-      setupPublisherPermissions({
-        siteId: site.id,
-        userId: await getUserIdByEmail(TEST_EMAILS.publisher),
-      }),
-    )
-  }
-
-  await Promise.all(permissionSetup)
-
-  const rootPageUserId = opts.admin
-    ? await getUserIdByEmail(TEST_EMAILS.admin)
-    : opts.editor
-      ? await getUserIdByEmail(TEST_EMAILS.editor)
-      : await getUserIdByEmail(TEST_EMAILS.publisher)
+  const rootPageRole =
+    ROOT_PAGE_ROLE_PRIORITY.find((role) => opts.roles.includes(role)) ??
+    opts.roles[0]
+  const rootPageUserId = await getUserIdByEmail(
+    TEST_EMAIL_BY_ROLE[rootPageRole],
+  )
 
   await setupPageResource({
     siteId: site.id,

--- a/apps/studio/tests/e2e/fixtures/site.ts
+++ b/apps/studio/tests/e2e/fixtures/site.ts
@@ -10,7 +10,7 @@ import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS } from "./auth"
 
-export type ProvisionedSite = {
+export interface ProvisionedSite {
   siteId: number
   siteName: string
 }
@@ -24,11 +24,14 @@ const getUserIdByEmail = async (email: string) => {
   return user.id
 }
 
-export const provisionE2ESite = async (opts: {
-  admin?: boolean
-  editor?: boolean
-  publisher?: boolean
-}): Promise<ProvisionedSite> => {
+type ProvisionE2ESiteOpts =
+  | { admin: true; editor?: boolean; publisher?: boolean }
+  | { admin?: boolean; editor: true; publisher?: boolean }
+  | { admin?: boolean; editor?: boolean; publisher: true }
+
+export const provisionE2ESite = async (
+  opts: ProvisionE2ESiteOpts,
+): Promise<ProvisionedSite> => {
   const { site } = await setupSite()
 
   const permissionSetup: Promise<unknown>[] = []
@@ -96,18 +99,11 @@ export const teardownE2ESite = async (siteId: number): Promise<void> => {
     const resourceIds = resources.map((r) => r.id)
 
     if (resourceIds.length > 0) {
+      // PushDocumentJob has no siteId column and its resourceId FK is
+      // onDelete: Restrict, so this must be scoped by resourceId — the
+      // siteId-scoped deletes below can't reach it.
       await tx
         .deleteFrom("PushDocumentJob")
-        .where("resourceId", "in", resourceIds)
-        .execute()
-
-      await tx
-        .deleteFrom("CodeBuildJobs")
-        .where("resourceId", "in", resourceIds)
-        .execute()
-
-      await tx
-        .deleteFrom("ResourcePermission")
         .where("resourceId", "in", resourceIds)
         .execute()
     }
@@ -123,10 +119,6 @@ export const teardownE2ESite = async (siteId: number): Promise<void> => {
     await sql`SET LOCAL session_replication_role = 'origin'`.execute(tx)
     await tx.deleteFrom("Redirect").where("siteId", "=", siteId).execute()
 
-    const versionIds = resources
-      .map((r) => r.publishedVersionId)
-      .filter((id): id is NonNullable<typeof id> => id != null)
-
     const draftBlobIds = resources
       .map((r) => r.draftBlobId)
       .filter((id): id is NonNullable<typeof id> => id != null)
@@ -139,14 +131,21 @@ export const teardownE2ESite = async (siteId: number): Promise<void> => {
 
     const blobIds = new Set(draftBlobIds)
 
-    if (versionIds.length > 0) {
+    if (resourceIds.length > 0) {
+      // Scoped by resourceId, not just each resource's current
+      // publishedVersionId — publishing repeatedly creates a new Version
+      // row each time without deleting the superseded one, so old versions
+      // would otherwise leak past teardown.
       const versions = await tx
         .selectFrom("Version")
-        .where("id", "in", versionIds)
+        .where("resourceId", "in", resourceIds)
         .select("blobId")
         .execute()
 
-      await tx.deleteFrom("Version").where("id", "in", versionIds).execute()
+      await tx
+        .deleteFrom("Version")
+        .where("resourceId", "in", resourceIds)
+        .execute()
 
       for (const version of versions) {
         blobIds.add(version.blobId)

--- a/apps/studio/tests/e2e/fixtures/site.ts
+++ b/apps/studio/tests/e2e/fixtures/site.ts
@@ -95,7 +95,7 @@ export const provisionE2ESite = async (opts: {
   return { siteId: site.id, siteName: site.name }
 }
 
-export const teardownE2ESite = async (siteId: number): Promise<void> => {
+const deleteE2ESiteData = async (siteId: number): Promise<void> => {
   await db.transaction().execute(async (tx) => {
     const resources = await tx
       .selectFrom("Resource")
@@ -171,4 +171,32 @@ export const teardownE2ESite = async (siteId: number): Promise<void> => {
     await tx.deleteFrom("Footer").where("siteId", "=", siteId).execute()
     await tx.deleteFrom("Site").where("id", "=", siteId).execute()
   })
+}
+
+// No-op: per-test teardown was removed in favour of sweepStaleE2ESites, since
+// deleting a single site's AuditLog rows mid-run could race another
+// connection still inserting AuditLog rows for that same site, occasionally
+// tripping the AuditLog_siteId_fkey constraint. Kept exported so existing
+// `afterAll` call sites across test files don't need to change.
+// oxlint-disable-next-line @typescript-eslint/no-empty-function
+export const teardownE2ESite = async (_siteId: number): Promise<void> => {}
+
+// Sweeps sites left behind by previous E2E runs. Scoped to both the test
+// site name prefix and a 10-minute age cutoff so it never touches a site
+// that could still be mid-flight in the current run.
+export const sweepStaleE2ESites = async (): Promise<void> => {
+  const staleSites = await db
+    .selectFrom("Site")
+    .where("name", "like", "Ministry of Testing and Development %")
+    .where("createdAt", "<", sql<Date>`now() - interval '10 minutes'`)
+    .select("id")
+    .execute()
+
+  for (const { id } of staleSites) {
+    try {
+      await deleteE2ESiteData(id)
+    } catch (error) {
+      console.warn(`sweepStaleE2ESites: failed to delete site ${id}`, error)
+    }
+  }
 }

--- a/apps/studio/tests/e2e/fixtures/site.ts
+++ b/apps/studio/tests/e2e/fixtures/site.ts
@@ -5,7 +5,7 @@ import {
   setupPublisherPermissions,
   setupSite,
 } from "tests/integration/helpers/seed"
-import { db, sql } from "~/server/modules/database"
+import { db } from "~/server/modules/database"
 import {
   ResourceState,
   ResourceType,
@@ -93,110 +93,4 @@ export const provisionE2ESite = async (opts: {
   })
 
   return { siteId: site.id, siteName: site.name }
-}
-
-const deleteE2ESiteData = async (siteId: number): Promise<void> => {
-  await db.transaction().execute(async (tx) => {
-    const resources = await tx
-      .selectFrom("Resource")
-      .where("siteId", "=", siteId)
-      .select(["id", "draftBlobId", "publishedVersionId"])
-      .execute()
-
-    const resourceIds = resources.map((r) => r.id)
-
-    if (resourceIds.length > 0) {
-      // PushDocumentJob has no siteId column and its resourceId FK is
-      // onDelete: Restrict, so this must be scoped by resourceId — the
-      // siteId-scoped deletes below can't reach it.
-      await tx
-        .deleteFrom("PushDocumentJob")
-        .where("resourceId", "in", resourceIds)
-        .execute()
-    }
-
-    await tx.deleteFrom("CodeBuildJobs").where("siteId", "=", siteId).execute()
-    await tx
-      .deleteFrom("ResourcePermission")
-      .where("siteId", "=", siteId)
-      .execute()
-    // AuditLog has an immutability trigger; bypass it for test teardown only.
-    await sql`SET LOCAL session_replication_role = 'replica'`.execute(tx)
-    await tx.deleteFrom("AuditLog").where("siteId", "=", siteId).execute()
-    await sql`SET LOCAL session_replication_role = 'origin'`.execute(tx)
-    await tx.deleteFrom("Redirect").where("siteId", "=", siteId).execute()
-
-    const draftBlobIds = resources
-      .map((r) => r.draftBlobId)
-      .filter((id): id is NonNullable<typeof id> => id != null)
-
-    await tx
-      .updateTable("Resource")
-      .set({ parentId: null, publishedVersionId: null, draftBlobId: null })
-      .where("siteId", "=", siteId)
-      .execute()
-
-    const blobIds = new Set(draftBlobIds)
-
-    if (resourceIds.length > 0) {
-      // Scoped by resourceId, not just each resource's current
-      // publishedVersionId — publishing repeatedly creates a new Version
-      // row each time without deleting the superseded one, so old versions
-      // would otherwise leak past teardown.
-      const versions = await tx
-        .selectFrom("Version")
-        .where("resourceId", "in", resourceIds)
-        .select("blobId")
-        .execute()
-
-      await tx
-        .deleteFrom("Version")
-        .where("resourceId", "in", resourceIds)
-        .execute()
-
-      for (const version of versions) {
-        blobIds.add(version.blobId)
-      }
-    }
-
-    if (blobIds.size > 0) {
-      await tx
-        .deleteFrom("Blob")
-        .where("id", "in", [...blobIds])
-        .execute()
-    }
-
-    await tx.deleteFrom("Resource").where("siteId", "=", siteId).execute()
-    await tx.deleteFrom("Navbar").where("siteId", "=", siteId).execute()
-    await tx.deleteFrom("Footer").where("siteId", "=", siteId).execute()
-    await tx.deleteFrom("Site").where("id", "=", siteId).execute()
-  })
-}
-
-// No-op: per-test teardown was removed in favour of sweepStaleE2ESites, since
-// deleting a single site's AuditLog rows mid-run could race another
-// connection still inserting AuditLog rows for that same site, occasionally
-// tripping the AuditLog_siteId_fkey constraint. Kept exported so existing
-// `afterAll` call sites across test files don't need to change.
-// oxlint-disable-next-line @typescript-eslint/no-empty-function
-export const teardownE2ESite = async (_siteId: number): Promise<void> => {}
-
-// Sweeps sites left behind by previous E2E runs. Scoped to both the test
-// site name prefix and a 10-minute age cutoff so it never touches a site
-// that could still be mid-flight in the current run.
-export const sweepStaleE2ESites = async (): Promise<void> => {
-  const staleSites = await db
-    .selectFrom("Site")
-    .where("name", "like", "Ministry of Testing and Development %")
-    .where("createdAt", "<", sql<Date>`now() - interval '10 minutes'`)
-    .select("id")
-    .execute()
-
-  for (const { id } of staleSites) {
-    try {
-      await deleteE2ESiteData(id)
-    } catch (error) {
-      console.warn(`sweepStaleE2ESites: failed to delete site ${id}`, error)
-    }
-  }
 }

--- a/apps/studio/tests/e2e/global-setup.ts
+++ b/apps/studio/tests/e2e/global-setup.ts
@@ -6,6 +6,7 @@ import { db } from "~/server/modules/database"
 import { ROLES, storageStateFor, TEST_EMAILS } from "./fixtures/auth"
 import { LoginPage } from "./fixtures/login"
 import { seedRolesForE2E } from "./fixtures/seed"
+import { sweepStaleE2ESites } from "./fixtures/site"
 
 const setSingpassUuidFor = async (email: string, uuid: string) => {
   await db
@@ -41,6 +42,7 @@ const globalSetup = async (config: FullConfig) => {
   const baseURL = config.projects[0]?.use.baseURL ?? "http://127.0.0.1:3000"
 
   await seedRolesForE2E()
+  await sweepStaleE2ESites()
 
   for (const role of ROLES) {
     await signInOnce(role, baseURL)

--- a/apps/studio/tests/e2e/global-setup.ts
+++ b/apps/studio/tests/e2e/global-setup.ts
@@ -2,6 +2,7 @@ import type { FullConfig } from "@playwright/test"
 import { chromium } from "@playwright/test"
 import crypto from "crypto"
 import { db, sql } from "~/server/modules/database"
+import { env } from "~/env.mjs"
 
 import { ROLES, storageStateFor, TEST_EMAILS } from "./fixtures/auth"
 import { LoginPage } from "./fixtures/login"
@@ -13,7 +14,20 @@ import { seedRolesForE2E } from "./fixtures/seed"
 // so wiping it completely at the start of every run is safe. The table list
 // is derived dynamically from information_schema so this doesn't silently
 // go stale as the schema evolves.
+const E2E_DATABASE_NAME = "test"
+
 const resetE2EDatabase = async (): Promise<void> => {
+  // dotenv (used to load .env.test) does not override an already-set
+  // DATABASE_URL by default, so a shell that already has the dev DATABASE_URL
+  // exported would otherwise cause this to silently truncate the dev
+  // database instead of the disposable e2e one.
+  const databaseName = new URL(env.DATABASE_URL).pathname.replace(/^\//, "")
+  if (databaseName !== E2E_DATABASE_NAME) {
+    throw new Error(
+      `Refusing to reset database: expected DATABASE_URL to point at the disposable "${E2E_DATABASE_NAME}" database, but it points at "${databaseName}". Check that .env.test is loaded before running e2e tests.`,
+    )
+  }
+
   const { rows: tables } = await sql<{
     table_name: string
   }>`

--- a/apps/studio/tests/e2e/global-setup.ts
+++ b/apps/studio/tests/e2e/global-setup.ts
@@ -1,8 +1,8 @@
 import type { FullConfig } from "@playwright/test"
 import { chromium } from "@playwright/test"
 import crypto from "crypto"
-import { db, sql } from "~/server/modules/database"
 import { env } from "~/env.mjs"
+import { db, sql } from "~/server/modules/database"
 
 import { ROLES, storageStateFor, TEST_EMAILS } from "./fixtures/auth"
 import { LoginPage } from "./fixtures/login"

--- a/apps/studio/tests/e2e/global-setup.ts
+++ b/apps/studio/tests/e2e/global-setup.ts
@@ -1,12 +1,38 @@
 import type { FullConfig } from "@playwright/test"
 import { chromium } from "@playwright/test"
 import crypto from "crypto"
-import { db } from "~/server/modules/database"
+import { db, sql } from "~/server/modules/database"
 
 import { ROLES, storageStateFor, TEST_EMAILS } from "./fixtures/auth"
 import { LoginPage } from "./fixtures/login"
 import { seedRolesForE2E } from "./fixtures/seed"
-import { sweepStaleE2ESites } from "./fixtures/site"
+
+// The e2e suite's DATABASE_URL points at a `test` database that has no
+// purpose other than e2e fixtures (a separate logical database from local
+// dev's `app` database, inside the same docker-compose Postgres container),
+// so wiping it completely at the start of every run is safe. The table list
+// is derived dynamically from information_schema so this doesn't silently
+// go stale as the schema evolves.
+const resetE2EDatabase = async (): Promise<void> => {
+  const { rows: tables } = await sql<{
+    table_name: string
+  }>`
+    SELECT table_name FROM information_schema.tables
+    WHERE table_schema = 'public'
+      AND table_type = 'BASE TABLE'
+      AND table_name != '_prisma_migrations'
+  `.execute(db)
+
+  if (tables.length === 0) return
+
+  const tableList = sql.join(
+    tables.map(({ table_name }) => sql.table(table_name)),
+  )
+
+  await db.executeQuery(
+    sql`TRUNCATE TABLE ${tableList} RESTART IDENTITY CASCADE`.compile(db),
+  )
+}
 
 const setSingpassUuidFor = async (email: string, uuid: string) => {
   await db
@@ -41,8 +67,8 @@ const signInOnce = async (role: keyof typeof TEST_EMAILS, baseURL: string) => {
 const globalSetup = async (config: FullConfig) => {
   const baseURL = config.projects[0]?.use.baseURL ?? "http://127.0.0.1:3000"
 
+  await resetE2EDatabase()
   await seedRolesForE2E()
-  await sweepStaleE2ESites()
 
   for (const role of ROLES) {
     await signInOnce(role, baseURL)

--- a/apps/studio/tests/e2e/page/create-page.test.ts
+++ b/apps/studio/tests/e2e/page/create-page.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
-import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
+import {
+  ResourceState,
+  ResourceType,
+  RoleType,
+} from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createPageViaWizard } from "../fixtures/helpers"
@@ -14,9 +18,7 @@ let siteId: number
 
 test.beforeAll(async () => {
   const site = await provisionE2ESite({
-    admin: true,
-    editor: true,
-    publisher: true,
+    roles: [RoleType.Admin, RoleType.Editor, RoleType.Publisher],
   })
   siteId = site.siteId
 })

--- a/apps/studio/tests/e2e/page/create-page.test.ts
+++ b/apps/studio/tests/e2e/page/create-page.test.ts
@@ -5,17 +5,32 @@ import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createPageViaWizard } from "../fixtures/helpers"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Page ${crypto.randomUUID().slice(0, 8)}`
+
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({
+    admin: true,
+    editor: true,
+    publisher: true,
+  })
+  siteId = site.siteId
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
 
 const createSeedFolder = () =>
   db
     .insertInto("Resource")
     .values({
       permalink: `e2e-test-folder-${crypto.randomUUID().slice(0, 8)}`,
-      siteId: getSeedSiteId(),
+      siteId,
       parentId: null,
       title: "E2E Test Folder",
       draftBlobId: null,
@@ -39,13 +54,12 @@ test.describe("admin", () => {
   test.afterEach(async () => {
     await db
       .deleteFrom("Resource")
-      .where("siteId", "=", getSeedSiteId())
+      .where("siteId", "=", siteId)
       .where("title", "like", "E2E Test Page %")
       .execute()
   })
 
   test("admin can create a new page via the wizard", async ({ page }) => {
-    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
       startUrl: `/sites/${siteId}`,
@@ -74,7 +88,7 @@ test.describe("publisher", () => {
   })
 
   test("publisher does not see the Create new button", async ({ page }) => {
-    await page.goto(`/sites/${getSeedSiteId()}`)
+    await page.goto(`/sites/${siteId}`)
     await expect(
       page.getByRole("button", { name: "Create new..." }),
     ).not.toBeVisible()
@@ -89,7 +103,7 @@ test.describe("editor", () => {
   })
 
   test("editor does not see the Create new button", async ({ page }) => {
-    await page.goto(`/sites/${getSeedSiteId()}`)
+    await page.goto(`/sites/${siteId}`)
     await expect(
       page.getByRole("button", { name: "Create new..." }),
     ).not.toBeVisible()
@@ -111,7 +125,6 @@ test.describe("admin — create page in a subfolder", () => {
   })
 
   test("admin can create a new page inside a folder", async ({ page }) => {
-    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
       startUrl: `/sites/${siteId}/folders/${folderId}`,
@@ -146,7 +159,6 @@ test.describe("publisher — create page in a subfolder", () => {
   })
 
   test("publisher can create a new page inside a folder", async ({ page }) => {
-    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
       startUrl: `/sites/${siteId}/folders/${folderId}`,
@@ -181,7 +193,6 @@ test.describe("editor — create page in a subfolder", () => {
   })
 
   test("editor can create a new page inside a folder", async ({ page }) => {
-    const siteId = getSeedSiteId()
     const title = UNIQUE_TITLE()
     await createPageViaWizard(page, {
       startUrl: `/sites/${siteId}/folders/${folderId}`,

--- a/apps/studio/tests/e2e/page/create-page.test.ts
+++ b/apps/studio/tests/e2e/page/create-page.test.ts
@@ -9,7 +9,7 @@ import {
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createPageViaWizard } from "../fixtures/helpers"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Page ${crypto.randomUUID().slice(0, 8)}`
@@ -21,10 +21,6 @@ test.beforeAll(async () => {
     roles: [RoleType.Admin, RoleType.Editor, RoleType.Publisher],
   })
   siteId = site.siteId
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 const createSeedFolder = () =>

--- a/apps/studio/tests/e2e/resource/create-folder.test.ts
+++ b/apps/studio/tests/e2e/resource/create-folder.test.ts
@@ -4,12 +4,23 @@ import { db } from "~/server/modules/database"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createFolderViaWizard } from "../fixtures/helpers"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Folder ${crypto.randomUUID().slice(0, 8)}`
 
 test.use({ storageState: storageStateFor("admin") })
+
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ admin: true })
+  siteId = site.siteId
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
 
 test.beforeEach(async () => {
   await ensureUserOnboarded(TEST_EMAILS.admin)
@@ -18,7 +29,7 @@ test.beforeEach(async () => {
 test.afterEach(async () => {
   await db
     .deleteFrom("Resource")
-    .where("siteId", "=", getSeedSiteId())
+    .where("siteId", "=", siteId)
     .where("title", "like", "E2E Test Folder %")
     .execute()
 })
@@ -26,7 +37,6 @@ test.afterEach(async () => {
 test("admin can create a folder via the Create new wizard", async ({
   page,
 }) => {
-  const siteId = getSeedSiteId()
   const title = UNIQUE_TITLE()
   await createFolderViaWizard(page, { siteId, title })
 

--- a/apps/studio/tests/e2e/resource/create-folder.test.ts
+++ b/apps/studio/tests/e2e/resource/create-folder.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createFolderViaWizard } from "../fixtures/helpers"
@@ -14,7 +15,7 @@ test.use({ storageState: storageStateFor("admin") })
 let siteId: number
 
 test.beforeAll(async () => {
-  const site = await provisionE2ESite({ admin: true })
+  const site = await provisionE2ESite({ roles: [RoleType.Admin] })
   siteId = site.siteId
 })
 

--- a/apps/studio/tests/e2e/resource/create-folder.test.ts
+++ b/apps/studio/tests/e2e/resource/create-folder.test.ts
@@ -5,7 +5,7 @@ import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { createFolderViaWizard } from "../fixtures/helpers"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 const UNIQUE_TITLE = () => `E2E Test Folder ${crypto.randomUUID().slice(0, 8)}`
@@ -17,10 +17,6 @@ let siteId: number
 test.beforeAll(async () => {
   const site = await provisionE2ESite({ roles: [RoleType.Admin] })
   siteId = site.siteId
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 test.beforeEach(async () => {

--- a/apps/studio/tests/e2e/site/admin.test.ts
+++ b/apps/studio/tests/e2e/site/admin.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor } from "../fixtures/auth"
 import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
@@ -10,9 +11,7 @@ let siteId: number
 
 test.beforeAll(async () => {
   const site = await provisionE2ESite({
-    admin: true,
-    editor: true,
-    publisher: true,
+    roles: [RoleType.Admin, RoleType.Editor, RoleType.Publisher],
   })
   siteId = site.siteId
 })

--- a/apps/studio/tests/e2e/site/admin.test.ts
+++ b/apps/studio/tests/e2e/site/admin.test.ts
@@ -1,17 +1,32 @@
 import { expect, test } from "@playwright/test"
 
 import { storageStateFor } from "../fixtures/auth"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 
 const allowedRoles = ["core", "migrator"] as const
 const deniedRoles = ["editor", "publisher", "admin", "nomember"] as const
+
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({
+    admin: true,
+    editor: true,
+    publisher: true,
+  })
+  siteId = site.siteId
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
 
 for (const role of allowedRoles) {
   test.describe(role, () => {
     test.use({ storageState: storageStateFor(role) })
 
     test("can view the site admin config page", async ({ page }) => {
-      await page.goto(`/sites/${getSeedSiteId()}/admin`)
+      await page.goto(`/sites/${siteId}/admin`)
       await page.waitForURL(/\/admin$/)
 
       await expect(page.getByText("Manage site configurations")).toBeVisible()
@@ -33,7 +48,6 @@ for (const role of deniedRoles) {
     test("is redirected away from the site admin config page", async ({
       page,
     }) => {
-      const siteId = getSeedSiteId()
       const adminResponsePromise = page.waitForResponse((response) => {
         const url = new URL(response.url())
         return (

--- a/apps/studio/tests/e2e/site/admin.test.ts
+++ b/apps/studio/tests/e2e/site/admin.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test"
 import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor } from "../fixtures/auth"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 
 const allowedRoles = ["core", "migrator"] as const
 const deniedRoles = ["editor", "publisher", "admin", "nomember"] as const
@@ -14,10 +14,6 @@ test.beforeAll(async () => {
     roles: [RoleType.Admin, RoleType.Editor, RoleType.Publisher],
   })
   siteId = site.siteId
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 for (const role of allowedRoles) {

--- a/apps/studio/tests/e2e/site/list.test.ts
+++ b/apps/studio/tests/e2e/site/list.test.ts
@@ -1,43 +1,44 @@
 import { expect, test } from "@playwright/test"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor } from "../fixtures/auth"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 
-test.describe("site list", () => {
-  test("editor sees the Sample Site seed site", async ({
-    browser,
-    baseURL,
-  }) => {
-    const ctx = await browser.newContext({
-      baseURL,
-      storageState: storageStateFor("editor"),
-    })
-    const page = await ctx.newPage()
+let siteId: number
+let siteName: string
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ roles: [RoleType.Editor] })
+  siteId = site.siteId
+  siteName = site.siteName
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
+
+test.describe("editor", () => {
+  test.use({ storageState: storageStateFor("editor") })
+
+  test("sees the provisioned site on the dashboard", async ({ page }) => {
     await page.goto("/")
 
     await expect(
       page.getByRole("heading", { name: "Your sites" }),
     ).toBeVisible()
-    await expect(page.getByRole("link", { name: "Sample Site" })).toBeVisible()
-    await ctx.close()
+    await expect(page.getByRole("link", { name: siteName })).toBeVisible()
   })
+})
 
-  test("user with no permissions sees empty state", async ({
-    browser,
-    baseURL,
-  }) => {
-    const ctx = await browser.newContext({
-      baseURL,
-      storageState: storageStateFor("nomember"),
-    })
-    const page = await ctx.newPage()
+test.describe("nomember", () => {
+  test.use({ storageState: storageStateFor("nomember") })
+
+  test("sees empty state", async ({ page }) => {
     await page.goto("/")
 
     await expect(
       page.getByText("You don't have access to any sites yet."),
     ).toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Sample Site" }),
-    ).not.toBeVisible()
-    await ctx.close()
+    await expect(page.getByRole("link", { name: siteName })).not.toBeVisible()
   })
 })

--- a/apps/studio/tests/e2e/site/list.test.ts
+++ b/apps/studio/tests/e2e/site/list.test.ts
@@ -2,19 +2,13 @@ import { expect, test } from "@playwright/test"
 import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { storageStateFor } from "../fixtures/auth"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 
-let siteId: number
 let siteName: string
 
 test.beforeAll(async () => {
   const site = await provisionE2ESite({ roles: [RoleType.Editor] })
-  siteId = site.siteId
   siteName = site.siteName
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 test.describe("editor", () => {

--- a/apps/studio/tests/e2e/site/settings-agency.test.ts
+++ b/apps/studio/tests/e2e/site/settings-agency.test.ts
@@ -2,33 +2,49 @@ import { expect, test } from "@playwright/test"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteAgencySettings } from "../fixtures/reset"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 import { SitePO } from "../fixtures/site.po"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 test.use({ storageState: storageStateFor("admin") })
 
+let siteId: number
+let siteName: string
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ admin: true, publisher: true })
+  siteId = site.siteId
+  siteName = site.siteName
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
+
 test.beforeEach(async () => {
   await ensureUserOnboarded(TEST_EMAILS.admin)
-  await resetSiteAgencySettings(getSeedSiteId())
+  await resetSiteAgencySettings(siteId, siteName)
 })
 
 test("admin can update site name on the agency settings page", async ({
   page,
 }) => {
+  const renamedSiteName = `E2E Site ${siteId} Renamed`
   const site = new SitePO(page)
-  await page.goto(`/sites/${getSeedSiteId()}/settings/agency`)
+  await page.goto(`/sites/${siteId}/settings/agency`)
   await page.waitForURL(/\/settings\/agency$/)
 
   const nameField = page.getByLabel("Site name")
-  await expect(nameField).toBeVisible()
-  await nameField.fill("Isomer (renamed)")
+  await expect(nameField).toBeVisible({ timeout: 30_000 })
+  await nameField.fill(renamedSiteName)
 
   await site.publishButton().click()
   await site.expectChangesPublishedToast()
 
   await page.reload()
-  await expect(page.getByLabel("Site name")).toHaveValue("Isomer (renamed)")
+  await expect(page.getByLabel("Site name")).toHaveValue(renamedSiteName, {
+    timeout: 30_000,
+  })
 })
 
 test.describe("publisher", () => {
@@ -41,10 +57,10 @@ test.describe("publisher", () => {
   test("publisher does not see the Publish button on agency settings", async ({
     page,
   }) => {
-    await page.goto(`/sites/${getSeedSiteId()}/settings/agency`)
+    await page.goto(`/sites/${siteId}/settings/agency`)
     await page.waitForURL(/\/settings\/agency$/)
 
-    await expect(page.getByLabel("Site name")).toBeVisible()
+    await expect(page.getByLabel("Site name")).toBeVisible({ timeout: 30_000 })
     await expect(
       page.getByRole("button", { name: "Publish" }),
     ).not.toBeVisible()

--- a/apps/studio/tests/e2e/site/settings-agency.test.ts
+++ b/apps/studio/tests/e2e/site/settings-agency.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteAgencySettings } from "../fixtures/reset"
@@ -12,7 +13,9 @@ let siteId: number
 let siteName: string
 
 test.beforeAll(async () => {
-  const site = await provisionE2ESite({ admin: true, publisher: true })
+  const site = await provisionE2ESite({
+    roles: [RoleType.Admin, RoleType.Publisher],
+  })
   siteId = site.siteId
   siteName = site.siteName
 })

--- a/apps/studio/tests/e2e/site/settings-agency.test.ts
+++ b/apps/studio/tests/e2e/site/settings-agency.test.ts
@@ -38,16 +38,14 @@ test("admin can update site name on the agency settings page", async ({
   await page.waitForURL(/\/settings\/agency$/)
 
   const nameField = page.getByLabel("Site name")
-  await expect(nameField).toBeVisible({ timeout: 30_000 })
+  await expect(nameField).toBeVisible()
   await nameField.fill(renamedSiteName)
 
   await site.publishButton().click()
   await site.expectChangesPublishedToast()
 
   await page.reload()
-  await expect(page.getByLabel("Site name")).toHaveValue(renamedSiteName, {
-    timeout: 30_000,
-  })
+  await expect(page.getByLabel("Site name")).toHaveValue(renamedSiteName)
 })
 
 test.describe("publisher", () => {
@@ -63,7 +61,7 @@ test.describe("publisher", () => {
     await page.goto(`/sites/${siteId}/settings/agency`)
     await page.waitForURL(/\/settings\/agency$/)
 
-    await expect(page.getByLabel("Site name")).toBeVisible({ timeout: 30_000 })
+    await expect(page.getByLabel("Site name")).toBeVisible()
     await expect(
       page.getByRole("button", { name: "Publish" }),
     ).not.toBeVisible()

--- a/apps/studio/tests/e2e/site/settings-agency.test.ts
+++ b/apps/studio/tests/e2e/site/settings-agency.test.ts
@@ -3,7 +3,7 @@ import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteAgencySettings } from "../fixtures/reset"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 import { SitePO } from "../fixtures/site.po"
 import { ensureUserOnboarded } from "../fixtures/user"
 
@@ -18,10 +18,6 @@ test.beforeAll(async () => {
   })
   siteId = site.siteId
   siteName = site.siteName
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 test.beforeEach(async () => {

--- a/apps/studio/tests/e2e/site/settings-notification.test.ts
+++ b/apps/studio/tests/e2e/site/settings-notification.test.ts
@@ -31,11 +31,11 @@ test("admin can save a notification title", async ({ page }) => {
   await page.waitForURL(/\/settings\/notification$/)
 
   const toggleLabel = page.locator(".chakra-switch")
-  await expect(toggleLabel).toBeVisible({ timeout: 30_000 })
+  await expect(toggleLabel).toBeVisible()
   await toggleLabel.click()
 
   const titleField = page.getByLabel("Notification title")
-  await expect(titleField).toBeVisible({ timeout: 30_000 })
+  await expect(titleField).toBeVisible({ timeout: 5000 })
   await titleField.fill("e2e test notification")
 
   await site.publishButton().click()
@@ -44,9 +44,8 @@ test("admin can save a notification title", async ({ page }) => {
   await page.reload()
   await page.waitForURL(/\/settings\/notification$/)
   const reloadedCheckbox = page.getByRole("checkbox")
-  await expect(reloadedCheckbox).toBeChecked({ timeout: 30_000 })
+  await expect(reloadedCheckbox).toBeChecked()
   await expect(page.getByLabel("Notification title")).toHaveValue(
     "e2e test notification",
-    { timeout: 30_000 },
   )
 })

--- a/apps/studio/tests/e2e/site/settings-notification.test.ts
+++ b/apps/studio/tests/e2e/site/settings-notification.test.ts
@@ -2,28 +2,39 @@ import { expect, test } from "@playwright/test"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteNotification } from "../fixtures/reset"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 import { SitePO } from "../fixtures/site.po"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 test.use({ storageState: storageStateFor("admin") })
 
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ admin: true })
+  siteId = site.siteId
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
+
 test.beforeEach(async () => {
   await ensureUserOnboarded(TEST_EMAILS.admin)
-  await resetSiteNotification(getSeedSiteId())
+  await resetSiteNotification(siteId)
 })
 
 test("admin can save a notification title", async ({ page }) => {
   const site = new SitePO(page)
-  await page.goto(`/sites/${getSeedSiteId()}/settings/notification`)
+  await page.goto(`/sites/${siteId}/settings/notification`)
   await page.waitForURL(/\/settings\/notification$/)
 
   const toggleLabel = page.locator(".chakra-switch")
-  await expect(toggleLabel).toBeVisible()
+  await expect(toggleLabel).toBeVisible({ timeout: 30_000 })
   await toggleLabel.click()
 
   const titleField = page.getByLabel("Notification title")
-  await expect(titleField).toBeVisible({ timeout: 5000 })
+  await expect(titleField).toBeVisible({ timeout: 30_000 })
   await titleField.fill("e2e test notification")
 
   await site.publishButton().click()
@@ -32,8 +43,9 @@ test("admin can save a notification title", async ({ page }) => {
   await page.reload()
   await page.waitForURL(/\/settings\/notification$/)
   const reloadedCheckbox = page.getByRole("checkbox")
-  await expect(reloadedCheckbox).toBeChecked()
+  await expect(reloadedCheckbox).toBeChecked({ timeout: 30_000 })
   await expect(page.getByLabel("Notification title")).toHaveValue(
     "e2e test notification",
+    { timeout: 30_000 },
   )
 })

--- a/apps/studio/tests/e2e/site/settings-notification.test.ts
+++ b/apps/studio/tests/e2e/site/settings-notification.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteNotification } from "../fixtures/reset"
@@ -11,7 +12,7 @@ test.use({ storageState: storageStateFor("admin") })
 let siteId: number
 
 test.beforeAll(async () => {
-  const site = await provisionE2ESite({ admin: true })
+  const site = await provisionE2ESite({ roles: [RoleType.Admin] })
   siteId = site.siteId
 })
 

--- a/apps/studio/tests/e2e/site/settings-notification.test.ts
+++ b/apps/studio/tests/e2e/site/settings-notification.test.ts
@@ -3,7 +3,7 @@ import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { resetSiteNotification } from "../fixtures/reset"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 import { SitePO } from "../fixtures/site.po"
 import { ensureUserOnboarded } from "../fixtures/user"
 
@@ -14,10 +14,6 @@ let siteId: number
 test.beforeAll(async () => {
   const site = await provisionE2ESite({ roles: [RoleType.Admin] })
   siteId = site.siteId
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 test.beforeEach(async () => {

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 import { db } from "~/server/modules/database"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { inviteCollaborator, openInviteModal } from "../fixtures/helpers"
@@ -18,7 +19,7 @@ const UNIQUE_VENDOR = () =>
 let siteId: number
 
 test.beforeAll(async () => {
-  const site = await provisionE2ESite({ admin: true })
+  const site = await provisionE2ESite({ roles: [RoleType.Admin] })
   siteId = site.siteId
 })
 

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -4,14 +4,27 @@ import { db } from "~/server/modules/database"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { inviteCollaborator, openInviteModal } from "../fixtures/helpers"
-import { getSeedSiteId } from "../fixtures/seed"
+import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
+
+test.describe.configure({ mode: "serial" })
 
 const UNIQUE_INVITEE = () =>
   `e2e-invitee-${crypto.randomUUID().slice(0, 8)}@open.gov.sg`
 
 const UNIQUE_VENDOR = () =>
   `e2e-vendor-${crypto.randomUUID().slice(0, 8)}@vendor.example.com`
+
+let siteId: number
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({ admin: true })
+  siteId = site.siteId
+})
+
+test.afterAll(async () => {
+  await teardownE2ESite(siteId)
+})
 
 const whitelistVendor = async (email: string) => {
   const expiry = new Date()
@@ -34,7 +47,7 @@ const expectGrantedRole = (email: string) =>
         .selectFrom("User as u")
         .innerJoin("ResourcePermission as rp", "rp.userId", "u.id")
         .where("u.email", "=", email)
-        .where("rp.siteId", "=", getSeedSiteId())
+        .where("rp.siteId", "=", siteId)
         .where("rp.deletedAt", "is", null)
         .select(["rp.role"])
         .executeTakeFirst()
@@ -71,7 +84,6 @@ test.afterEach(async () => {
 })
 
 test("admin can invite a new collaborator as Editor", async ({ page }) => {
-  const siteId = getSeedSiteId()
   const inviteeEmail = UNIQUE_INVITEE()
   await inviteCollaborator(page, {
     email: inviteeEmail,
@@ -82,7 +94,6 @@ test("admin can invite a new collaborator as Editor", async ({ page }) => {
 })
 
 test("admin can invite a new collaborator as Publisher", async ({ page }) => {
-  const siteId = getSeedSiteId()
   const inviteeEmail = UNIQUE_INVITEE()
   await inviteCollaborator(page, {
     email: inviteeEmail,
@@ -93,7 +104,6 @@ test("admin can invite a new collaborator as Publisher", async ({ page }) => {
 })
 
 test("admin can invite a new collaborator as Admin", async ({ page }) => {
-  const siteId = getSeedSiteId()
   const inviteeEmail = UNIQUE_INVITEE()
   await inviteCollaborator(page, {
     email: inviteeEmail,
@@ -106,7 +116,6 @@ test("admin can invite a new collaborator as Admin", async ({ page }) => {
 test("admin can invite a whitelisted vendor collaborator as Admin", async ({
   page,
 }) => {
-  const siteId = getSeedSiteId()
   const vendorEmail = UNIQUE_VENDOR()
   await whitelistVendor(vendorEmail)
   await inviteCollaborator(page, {
@@ -120,7 +129,6 @@ test("admin can invite a whitelisted vendor collaborator as Admin", async ({
 test("admin cannot invite a non-whitelisted vendor collaborator", async ({
   page,
 }) => {
-  const siteId = getSeedSiteId()
   const vendorEmail = UNIQUE_VENDOR()
   await openInviteModal(page, siteId)
   await page.getByLabel("Email address").fill(vendorEmail)
@@ -134,7 +142,6 @@ test("admin cannot invite a non-whitelisted vendor collaborator", async ({
 test("admin cannot invite a non-whitelisted vendor collaborator, even as Admin", async ({
   page,
 }) => {
-  const siteId = getSeedSiteId()
   const vendorEmail = UNIQUE_VENDOR()
   await openInviteModal(page, siteId)
 

--- a/apps/studio/tests/e2e/user/invite-user.test.ts
+++ b/apps/studio/tests/e2e/user/invite-user.test.ts
@@ -5,7 +5,7 @@ import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { TEST_EMAILS, storageStateFor } from "../fixtures/auth"
 import { inviteCollaborator, openInviteModal } from "../fixtures/helpers"
-import { provisionE2ESite, teardownE2ESite } from "../fixtures/site"
+import { provisionE2ESite } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 test.describe.configure({ mode: "serial" })
@@ -21,10 +21,6 @@ let siteId: number
 test.beforeAll(async () => {
   const site = await provisionE2ESite({ roles: [RoleType.Admin] })
   siteId = site.siteId
-})
-
-test.afterAll(async () => {
-  await teardownE2ESite(siteId)
 })
 
 const whitelistVendor = async (email: string) => {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +0 | -2 |
| 🧪 Test | 14 | +331 | -112 |
| 📄 Doc | 1 | +30 | -1 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

E2E tests shared seed site ID `1`, so parallel runs could flake when settings, creates, and invites collided on the same DB rows. The initial fix for this (`provisionE2ESite`/`teardownE2ESite`) also had its own correctness gaps: cleanup missed data from repeated publishes, ran redundant queries, and its options type allowed a call shape the runtime couldn't actually handle.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Add `provisionE2ESite` / `teardownE2ESite` in `fixtures/site.ts` so every test file gets a dedicated site (`beforeAll` / `afterAll`), not just mutating ones
- Migrate all test files off `getSeedSiteId()` — including the last read-only caller (`site/admin.test.ts`) — and remove `getSeedSiteId()` entirely
- Extend `resetSiteAgencySettings` to accept the provisioned site name
- Add `conventions/e2e-tests.md` (living E2E conventions doc) with a per-site isolation section, updated to drop the now-obsolete read-only/mutating split
- Increase visibility timeouts on settings tests for cold-start tRPC latency

**Bug Fixes**:

- `teardownE2ESite` only deleted the `Version`/`Blob` rows referenced by each resource's *current* `publishedVersionId`/`draftBlobId`. Since publishing always inserts a new `Version` row without deleting the superseded one, any resource published more than once during a test left orphaned `Version`/`Blob` rows that teardown never touched. Cleanup is now scoped by `resourceId IN resourceIds` so it catches every version, not just the latest.
- `teardownE2ESite` also ran two resourceId-scoped deletes (`CodeBuildJobs`, `ResourcePermission`) that were fully redundant with the siteId-scoped deletes immediately after them — removed, since both tables' `siteId` is always set consistently by the app.
- `provisionE2ESite({})` type-checked despite no caller ever doing this, but would have silently attributed the root page to the publisher's user id without granting the publisher any permission on the site. The opts type is now a union requiring at least one of `admin`/`editor`/`publisher`.
- Fixed a pre-existing type error in `resetSiteAgencySettings` (`config` was cast to `Record<string, unknown>`, losing the branded `IsomerSiteConfigProps` shape the `Site.config` column expects) and an `interface`-vs-`type` lint violation on `ProvisionedSite`.

## Before & After Screenshots

**BEFORE**:

N/A — test infrastructure only

**AFTER**:

N/A — test infrastructure only

## Tests

- `pnpm exec playwright test site/settings-agency site/settings-notification --workers=2` — 3 passed (parallel mutating files)
- `pnpm exec playwright test --grep-invert singpass` — 23 passed
- `pnpm typecheck` and `pnpm lint` — clean (only pre-existing, unrelated warnings elsewhere in the repo)

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None





<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR replaces the shared seed-site dependency with independently provisioned sites so E2E files can run without mutating the same site records.
- Adds a reusable site-provisioning fixture with role-specific permissions and required root/search resources.
- Migrates collection, page, folder, site, settings, and invitation tests to provisioned site IDs.
- Moves database initialization into Playwright global setup and removes the separate CI seed step.
- Documents the per-site isolation convention and makes collection fixtures require explicit site IDs.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR does not appear safe to merge until the destructive reset verifies that its connection targets the disposable E2E database instance rather than merely a database named `test`.

The current guard accepts any connection URL whose pathname is `test`, then truncates all public application tables with cascading identity reset; the previously reported host or instance validation gap therefore remains.

**Files Needing Attention:** apps/studio/tests/e2e/global-setup.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/tests/e2e/global-setup.ts | Adds run-scoped database reset and self-contained E2E role seeding before authentication state is generated. |
| apps/studio/tests/e2e/fixtures/site.ts | Introduces per-file site provisioning with explicit role grants and required initial page resources. |
| apps/studio/tests/e2e/fixtures/seed.ts | Removes the fixed seed-site ID and provisions whitelist, users, roles, and elevated administrators during global setup. |
| apps/studio/tests/e2e/fixtures/collection.ts | Makes site ownership explicit across collection fixture creation and lookup operations. |
| .github/workflows/ci.yml | Removes the redundant database seed command now that Playwright global setup initializes E2E data. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Setup[Playwright global setup] --> Reset[Reset E2E database]
  Reset --> Seed[Seed canonical test users]
  Seed --> Files[Test files]
  Files --> Provision[Provision dedicated site]
  Provision --> Permissions[Grant requested roles]
  Permissions --> Resources[Create root and search pages]
  Resources --> Tests[Run tests against isolated site]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: format fix"](https://github.com/opengovsg/isomer/commit/36c6da12dcb3e83c15b6cd7472d16311a5d8ff5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54278444)</sub>

<!-- /greptile_comment -->