### PR TITLE
chore(ci): parallelize independent CI prep steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
-      - name: Lint
-        run: pnpm run lint && pnpm run lint:ws
-
-      - name: Lint Dockerfile
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
-        with:
-          dockerfile: "./apps/studio/Dockerfile"
-          failure-threshold: "error"
+      - parallel:
+          - name: Lint
+            run: pnpm run lint && pnpm run lint:ws
+          - name: Lint Dockerfile
+            uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
+            with:
+              dockerfile: "./apps/studio/Dockerfile"
+              failure-threshold: "error"
 
   format:
     runs-on: ubuntu-latest
@@ -86,18 +86,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Install Playwright (Chromium)
-        # Required by the vitest "browser" project (Vitest Browser Mode).
-        run: pnpm --filter isomer-studio exec playwright install chromium
-      - name: Install dependencies
-        # Not using test:unit dependency in Turbo because Datadog Test Visibility requires only the test suite to be run
-        run: pnpm exec turbo run generate --filter=isomer-studio
-      - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
-        with:
-          languages: js
-          service: isomer-studio
-          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
+      - parallel:
+          - name: Install Playwright (Chromium)
+            # Required by the vitest "browser" project (Vitest Browser Mode).
+            run: pnpm --filter isomer-studio exec playwright install chromium
+          - name: Install dependencies
+            # Not using test:unit dependency in Turbo because Datadog Test Visibility requires only the test suite to be run
+            run: pnpm exec turbo run generate --filter=isomer-studio
+          - name: Configure Datadog Test Visibility
+            uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+            with:
+              languages: js
+              service: isomer-studio
+              api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Studio
         # Loose env mode required for env vars to be passed to the run
         run: pnpm exec turbo test-ci:unit --filter=isomer-studio --env-mode=loose -- --shard=${{ matrix.shard }}/${{ matrix.total_shards }}
@@ -116,15 +117,16 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Install Playwright (Chromium)
-        # Required by the vitest "browser" project (Vitest Browser Mode).
-        run: pnpm --filter @opengovsg/isomer-components exec playwright install chromium
-      - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
-        with:
-          languages: js
-          service: isomer-studio
-          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
+      - parallel:
+          - name: Install Playwright (Chromium)
+            # Required by the vitest "browser" project (Vitest Browser Mode).
+            run: pnpm --filter @opengovsg/isomer-components exec playwright install chromium
+          - name: Configure Datadog Test Visibility
+            uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+            with:
+              languages: js
+              service: isomer-studio
+              api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test Components
         run: pnpm exec turbo test-ci:unit --filter=@opengovsg/isomer-components --env-mode=loose
         env:
@@ -163,14 +165,15 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Start test containers
-        run: pnpm exec turbo run setup:test --filter=@isomer/pgboss
-      - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
-        with:
-          languages: js
-          service: isomer-pgboss
-          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
+      - parallel:
+          - name: Start test containers
+            run: pnpm exec turbo run setup:test --filter=@isomer/pgboss
+          - name: Configure Datadog Test Visibility
+            uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+            with:
+              languages: js
+              service: isomer-pgboss
+              api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Test pgboss
         run: pnpm exec turbo test-ci:unit --filter=@isomer/pgboss --env-mode=loose
         env:
@@ -217,8 +220,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Setup
         uses: ./.github/actions/setup
-      - name: Install Playwright (Chromium)
-        run: pnpm --filter isomer-studio exec playwright install chromium
       - name: Load .env file
         uses: opengovsg/dotenv@eff1dce037c4c0143cc4180a810511024c2560c0 # v2
         with:
@@ -232,17 +233,20 @@ jobs:
           key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-nextjs-
-      - name: Build Studio app
-        # Loose env mode required for env vars to be passed to the run
-        run: pnpm exec turbo build --filter=isomer-studio --env-mode=loose
-      - name: Start test containers
-        run: pnpm run setup:test
-      - name: Configure Datadog Test Visibility
-        uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
-        with:
-          languages: js
-          service: isomer-studio
-          api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
+      - parallel:
+          - name: Install Playwright (Chromium)
+            run: pnpm --filter isomer-studio exec playwright install chromium
+          - name: Build Studio app
+            # Loose env mode required for env vars to be passed to the run
+            run: pnpm exec turbo build --filter=isomer-studio --env-mode=loose
+          - name: Start test containers
+            run: pnpm run setup:test
+          - name: Configure Datadog Test Visibility
+            uses: datadog/test-visibility-github-action@4e7afb05b464fd349275e41e65a7f4de83e7f46b # v2.10.0
+            with:
+              languages: js
+              service: isomer-studio
+              api_key: ${{ secrets.DD_API_KEY_GITHUB_ACTIONS }}
       - name: Seed testing db
         run: pnpm exec turbo db:seed
       - name: Run Playwright tests


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +54 | -50 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Several CI jobs run independent setup steps sequentially (Playwright browser install, Docker startup, code generation, Datadog tracer setup, Dockerfile linting, etc.). That adds avoidable wall-clock time on every push and PR, especially in slower jobs like end-to-end tests.

## Solution

Use GitHub Actions [`parallel`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel) step groups to run independent prep work concurrently within a single job, then continue with dependent steps after the implicit wait.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- **`lint`**: Run Oxlint and Hadolint Dockerfile checks in parallel after setup.
- **`test-studio`**: Run Playwright Chromium install, `turbo generate`, and Datadog Test Visibility setup in parallel before unit tests.
- **`test-components`**: Run Playwright Chromium install and Datadog setup in parallel before unit tests.
- **`test-pgboss`**: Run test container startup and Datadog setup in parallel before unit tests.
- **`end-to-end-tests`**: Run Playwright install, Studio build, test container startup, and Datadog setup in parallel after `.env` load and Next.js cache restore; keep `db:seed` and Playwright test execution sequential afterward.

**Bug Fixes**:

- N/A

## Before & After

Measured on the `end-to-end-tests` job from a representative CI run on this branch vs. `main`.

| Metric | Before | After | Saved | Improvement |
|---|---|---|---|---|
| Parallel prep block (Playwright install + build + containers + Datadog) | ~2m 16s (136s) | ~1m 53s (113s) | ~23s | **~17%** |
| Total `end-to-end-tests` job duration | ~5m 00s (300s) | ~4m 40s (280s) | ~20s | **~7%** |

The parallel block improvement (~17%) reflects wall-clock overlap of four previously sequential steps. Total job savings (~7%) is smaller because seed, Playwright test execution, teardown, and artifact upload still run sequentially after the parallel group.

## Tests

- [x] Push this branch and confirm all affected CI jobs pass (`lint`, `test-studio`, `test-components`, `test-pgboss`, `end-to-end-tests`).
- [x] Compare job durations against a recent `main` run to confirm prep steps overlap as expected in the Actions UI.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Made with [Cursor](https://cursor.com)