### PR TITLE
test(e2e): add godmode action coverage

### DIFF
--- a/.claude/skills/isomer-conventions/conventions/e2e-tests.md
+++ b/.claude/skills/isomer-conventions/conventions/e2e-tests.md
@@ -161,6 +161,8 @@ surface. **All `page.*` Playwright calls belong in `fixtures/*.po.ts` or
 | `CollectionPO` | `collection.po.ts` | Collection link/page editor drawers |
 | `FolderSettingsPO` | `folder-settings.po.ts` | Folder settings modal |
 | `UsersPO` | `users.po.ts` | Users / collaborators page |
+| `GodmodePO` | `godmode.po.ts` | God Mode hub, create site, publishing, whitelist |
+| `SiteAdminPO` | `site-admin.po.ts` | Raw site admin JSON (`/sites/:id/admin`) |
 
 Rules:
 

--- a/apps/studio/src/pages/godmode/create-site.tsx
+++ b/apps/studio/src/pages/godmode/create-site.tsx
@@ -100,8 +100,8 @@ const GodModeCreateSitePage: NextPageWithLayout = () => {
             homepage, navbar and footer.
           </ListItem>
           <ListItem>
-            2. All Isomer team members will be added as site admins with full
-            access to manage the site.
+            2. All Isomer team members will have admin access to manage the
+            site.
           </ListItem>
         </List>
       </Box>

--- a/apps/studio/src/schemas/__tests__/whitelist.test.ts
+++ b/apps/studio/src/schemas/__tests__/whitelist.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import { whitelistEmailsInputSchema } from "../whitelist"
+
+describe("whitelistEmailsInputSchema", () => {
+  it("normalises, strips blanks, and deduplicates emails", () => {
+    // Arrange
+    const input = {
+      adminEmails: [" ADMIN@test.com ", "", "admin@test.com", "  "],
+      vendorEmails: ["Vendor@test.com", "vendor@test.com"],
+    }
+
+    // Act
+    const result = whitelistEmailsInputSchema.parse(input)
+
+    // Assert
+    expect(result).toEqual({
+      adminEmails: ["admin@test.com"],
+      vendorEmails: ["vendor@test.com"],
+    })
+  })
+
+  it("rejects the whole request when any email is invalid", () => {
+    // Arrange / Act
+    const result = whitelistEmailsInputSchema.safeParse({
+      adminEmails: ["valid@test.com", "not-an-email"],
+      vendorEmails: [],
+    })
+
+    // Assert
+    expect(result.success).toBe(false)
+  })
+})

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -2695,10 +2695,6 @@ describe("site.router", async () => {
       })
       vi.spyOn(awsUtils, "computeBuildChanges").mockResolvedValue({
         isNewBuildNeeded: true,
-        startedBuild: {
-          id: "placeholder-build-id",
-          startTime: new Date("2024-01-01T00:00:00.000Z"),
-        },
       })
       const startProjectByIdSpy = vi
         .spyOn(awsUtils, "startProjectById")

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -22,7 +22,16 @@ import { createCallerFactory } from "~/server/trpc"
 import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
 
 import type { User } from "../../database"
-import { AuditLogEvent, db, jsonb, ResourceType } from "../../database"
+import * as awsUtils from "../../aws/utils"
+import {
+  AuditLogEvent,
+  db,
+  jsonb,
+  ResourceState,
+  ResourceType,
+} from "../../database"
+import { getResourcePermission } from "../../permissions/permissions.service"
+import { FOOTER, NAVBAR_CONTENT } from "../constants"
 import { siteRouter } from "../site.router"
 
 // Mock env to set production environment for SearchSG tests
@@ -2374,6 +2383,68 @@ describe("site.router", async () => {
       ).toBe(true)
       expect(auditLogs.every((log) => log.userId === session.userId)).toBe(true)
     })
+
+    it("should persist and reload valid config, theme, navbar, and footer JSON", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupIsomerAdmin({
+        userId: session.userId!,
+        role: IsomerAdminRole.Core,
+      })
+      const newConfig = {
+        theme: "isomer-next",
+        siteName: "Updated by admin",
+        logoUrl: "https://example.com/logo.svg",
+        isGovernment: true,
+        url: "https://www.example.gov.sg",
+      }
+      const newTheme = {
+        colors: {
+          brand: {
+            canvas: {
+              default: "#111111",
+              alt: "#222222",
+              backdrop: "#333333",
+              inverse: "#444444",
+            },
+            interaction: {
+              default: "#555555",
+              hover: "#666666",
+              pressed: "#777777",
+            },
+          },
+        },
+      }
+      const newNavbar = { items: [{ name: "Admin nav", url: "/admin-nav" }] }
+      const newFooter = {
+        contactUsLink: "/contact-admin",
+        feedbackFormLink: "https://www.form.gov.sg",
+        privacyStatementLink: "/privacy",
+        termsOfUseLink: "/terms-of-use",
+        siteNavItems: [{ title: "Admin footer", url: "/admin-footer" }],
+      }
+
+      // Act
+      await caller.setSiteConfigByAdmin({
+        siteId: site.id,
+        config: JSON.stringify(newConfig),
+        theme: JSON.stringify(newTheme),
+        navbar: JSON.stringify(newNavbar),
+        footer: JSON.stringify(newFooter),
+      })
+
+      // Assert
+      await expect(caller.getConfig({ id: site.id })).resolves.toMatchObject(
+        newConfig,
+      )
+      await expect(caller.getTheme({ id: site.id })).resolves.toEqual(newTheme)
+      await expect(caller.getNavbar({ id: site.id })).resolves.toMatchObject({
+        content: newNavbar,
+      })
+      await expect(caller.getFooter({ id: site.id })).resolves.toMatchObject({
+        content: newFooter,
+      })
+    })
   })
 
   describe("create", () => {
@@ -2412,11 +2483,21 @@ describe("site.router", async () => {
       )
     })
 
-    it("should create a new site successfully if user is an Isomer Core Admin", async () => {
+    it("should create a new site with default config, pages, and implicit Isomer admin access", async () => {
       // Arrange
       await setupIsomerAdmin({
         userId: session.userId!,
         role: IsomerAdminRole.Core,
+      })
+      const otherCoreUser = await setupUser({
+        email: "other-core@mock.com",
+      })
+      await setupIsomerAdmin({
+        userId: otherCoreUser.id,
+        role: IsomerAdminRole.Core,
+      })
+      const regularUser = await setupUser({
+        email: "regular@mock.com",
       })
 
       // Act
@@ -2429,6 +2510,92 @@ describe("site.router", async () => {
         siteId: expect.any(Number),
         siteName: "foo",
       })
+
+      const site = await db
+        .selectFrom("Site")
+        .where("id", "=", result.siteId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(site.name).toBe("foo")
+      expect(site.config).toMatchObject({
+        theme: "isomer-next",
+        siteName: "foo",
+        url: "https://www.isomer.gov.sg",
+        logoUrl: "https://www.isomer.gov.sg/images/isomer-logo.svg",
+        isGovernment: true,
+      })
+      expect(site.theme).toMatchObject({
+        colors: {
+          brand: {
+            canvas: { inverse: "#00405f" },
+            interaction: { default: "#00405f" },
+          },
+        },
+      })
+
+      const navbar = await db
+        .selectFrom("Navbar")
+        .where("siteId", "=", result.siteId)
+        .select("content")
+        .executeTakeFirstOrThrow()
+      expect(navbar.content).toEqual(NAVBAR_CONTENT)
+
+      const footer = await db
+        .selectFrom("Footer")
+        .where("siteId", "=", result.siteId)
+        .select("content")
+        .executeTakeFirstOrThrow()
+      expect(footer.content).toEqual(FOOTER)
+
+      const home = await db
+        .selectFrom("Resource")
+        .where("siteId", "=", result.siteId)
+        .where("type", "=", ResourceType.RootPage)
+        .select(["title", "permalink", "state"])
+        .executeTakeFirstOrThrow()
+      expect(home).toMatchObject({
+        title: "Home",
+        permalink: "",
+        state: ResourceState.Published,
+      })
+
+      const search = await db
+        .selectFrom("Resource")
+        .where("siteId", "=", result.siteId)
+        .where("permalink", "=", "search")
+        .select(["title", "type", "state"])
+        .executeTakeFirstOrThrow()
+      expect(search).toMatchObject({
+        title: "Search",
+        type: ResourceType.Page,
+        state: ResourceState.Published,
+      })
+
+      const explicitPermissions = await db
+        .selectFrom("ResourcePermission")
+        .where("siteId", "=", result.siteId)
+        .selectAll()
+        .execute()
+      expect(explicitPermissions).toHaveLength(0)
+
+      await expect(
+        getResourcePermission({
+          userId: session.userId!,
+          siteId: result.siteId,
+        }),
+      ).resolves.toEqual([{ role: RoleType.Admin }])
+      await expect(
+        getResourcePermission({
+          userId: otherCoreUser.id,
+          siteId: result.siteId,
+        }),
+      ).resolves.toEqual([{ role: RoleType.Admin }])
+      await expect(
+        getResourcePermission({
+          userId: regularUser.id,
+          siteId: result.siteId,
+        }),
+      ).resolves.toEqual([])
     })
 
     it.each(["", " ", "\t", "\n", " \t\n "])(
@@ -2455,6 +2622,10 @@ describe("site.router", async () => {
   })
 
   describe("publish", () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
     it("should throw 401 if user is not logged in", async () => {
       // Arrange
       const unauthedSession = applySession()
@@ -2491,13 +2662,14 @@ describe("site.router", async () => {
       )
     })
 
-    it("should publish a site successfully if user is an Isomer Core Admin", async () => {
+    it("should no-op publish when the site has no CodeBuild ID", async () => {
       // Arrange
       const { site } = await setupSite()
       await setupIsomerAdmin({
         userId: session.userId!,
         role: IsomerAdminRole.Core,
       })
+      const startProjectByIdSpy = vi.spyOn(awsUtils, "startProjectById")
 
       // Act
       const result = await caller.publish({
@@ -2505,7 +2677,47 @@ describe("site.router", async () => {
       })
 
       // Assert
-      expect(result).toBeUndefined() // does not return anything
+      expect(result).toBeUndefined()
+      expect(startProjectByIdSpy).not.toHaveBeenCalled()
+    })
+
+    it("should start a CodeBuild publish when the site has a CodeBuild ID", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await db
+        .updateTable("Site")
+        .set({ codeBuildId: "test-codebuild-project-id" })
+        .where("id", "=", site.id)
+        .execute()
+      await setupIsomerAdmin({
+        userId: session.userId!,
+        role: IsomerAdminRole.Core,
+      })
+      vi.spyOn(awsUtils, "computeBuildChanges").mockResolvedValue({
+        isNewBuildNeeded: true,
+        startedBuild: {
+          id: "placeholder-build-id",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+        },
+      })
+      const startProjectByIdSpy = vi
+        .spyOn(awsUtils, "startProjectById")
+        .mockResolvedValue({
+          id: "test-build-id",
+          startTime: new Date("2024-01-01T00:00:00.000Z"),
+        })
+
+      // Act
+      const result = await caller.publish({
+        siteId: site.id,
+      })
+
+      // Assert
+      expect(result).toBeUndefined()
+      expect(startProjectByIdSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        "test-codebuild-project-id",
+      )
     })
   })
 })

--- a/apps/studio/src/server/modules/whitelist/__tests__/whitelist.router.test.ts
+++ b/apps/studio/src/server/modules/whitelist/__tests__/whitelist.router.test.ts
@@ -423,5 +423,50 @@ describe("whitelist.router", async () => {
         vendorCount: 0,
       })
     })
+
+    it("should keep admin (no expiry) when the same email is submitted as both admin and vendor", async () => {
+      // Arrange
+      await setupIsomerAdmin({ userId: user.id, role: IsomerAdminRole.Core })
+      const email = "both@test.com"
+
+      // Act
+      await caller.whitelistEmails({
+        adminEmails: [email],
+        vendorEmails: [email],
+      })
+
+      // Assert
+      const entry = await db
+        .selectFrom("Whitelist")
+        .where("email", "=", email)
+        .selectAll()
+        .executeTakeFirst()
+
+      expect(entry).toBeDefined()
+      expect(entry?.expiry).toBeNull()
+    })
+
+    it("should reject the whole request when any email is invalid", async () => {
+      // Arrange
+      await setupIsomerAdmin({ userId: user.id, role: IsomerAdminRole.Core })
+      const validEmail = "valid@test.com"
+
+      // Act
+      const result = caller.whitelistEmails({
+        adminEmails: [validEmail, "not-an-email"],
+        vendorEmails: [],
+      })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({
+        code: "BAD_REQUEST",
+      })
+      const entry = await db
+        .selectFrom("Whitelist")
+        .where("email", "=", validEmail)
+        .selectAll()
+        .executeTakeFirst()
+      expect(entry).toBeUndefined()
+    })
   })
 })

--- a/apps/studio/src/utils/__tests__/safeJsonParse.test.ts
+++ b/apps/studio/src/utils/__tests__/safeJsonParse.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { safeJsonParse } from "../safeJsonParse"
+
+describe("safeJsonParse", () => {
+  it("parses valid JSON", () => {
+    // Arrange / Act
+    const result = safeJsonParse(`{"siteName":"Isomer"}`)
+
+    // Assert
+    expect(result).toEqual({ siteName: "Isomer" })
+  })
+
+  it("returns the original string when JSON is malformed", () => {
+    // Arrange
+    const malformed = "{broken"
+
+    // Act
+    const result = safeJsonParse(malformed)
+
+    // Assert
+    expect(result).toBe(malformed)
+  })
+})

--- a/apps/studio/tests/e2e/README.md
+++ b/apps/studio/tests/e2e/README.md
@@ -13,6 +13,7 @@
 | `fixtures/dashboard.po.ts`   | Site dashboard / resource table page object                    |
 | `fixtures/page-editor.po.ts` | Page editor / publish page object                              |
 | `fixtures/users.po.ts`       | Users / collaborators page object                              |
+| `fixtures/godmode.po.ts`     | God Mode admin surfaces (create site, publishing, whitelist)   |
 
 ## Structure
 

--- a/apps/studio/tests/e2e/fixtures/dashboard.po.ts
+++ b/apps/studio/tests/e2e/fixtures/dashboard.po.ts
@@ -19,6 +19,18 @@ export class DashboardPO {
     await this.page.getByRole("button", { name: "Create new..." }).click()
   }
 
+  async expectHomepageRowVisible() {
+    await expect(
+      this.page.getByRole("link", { name: "Home Published" }),
+    ).toBeVisible()
+  }
+
+  async expectCreateButtonVisible() {
+    await expect(
+      this.page.getByRole("button", { name: "Create new..." }),
+    ).toBeVisible()
+  }
+
   async expectCreateButtonHidden() {
     await expect(
       this.page.getByRole("button", { name: "Create new..." }),

--- a/apps/studio/tests/e2e/fixtures/godmode.po.ts
+++ b/apps/studio/tests/e2e/fixtures/godmode.po.ts
@@ -1,5 +1,10 @@
 import { expect, type Page } from "@playwright/test"
 
+type GodmodeRoute =
+  | "/godmode/create-site"
+  | "/godmode/publishing"
+  | "/godmode/whitelist"
+
 export class GodmodePO {
   constructor(private readonly page: Page) {}
 
@@ -43,6 +48,20 @@ export class GodmodePO {
     ).toBeVisible()
   }
 
+  async gotoRoute(path: GodmodeRoute) {
+    switch (path) {
+      case "/godmode/create-site":
+        await this.gotoCreateSite()
+        break
+      case "/godmode/publishing":
+        await this.gotoPublishing()
+        break
+      case "/godmode/whitelist":
+        await this.gotoWhitelist()
+        break
+    }
+  }
+
   async fillSiteName(siteName: string) {
     await this.page.getByLabel("Site name").fill(siteName)
   }
@@ -64,6 +83,8 @@ export class GodmodePO {
   async expectSiteCreatedToast(siteName: string) {
     await this.page
       .getByText(
+        // Match the success toast copy, escaping the dynamic site name so
+        // punctuation in the name cannot break the pattern.
         new RegExp(
           `Site ${escapeRegExp(siteName)} \\(id: \\d+\\) created successfully`,
         ),
@@ -169,5 +190,6 @@ export class GodmodePO {
   }
 }
 
+// Escape user-supplied text before embedding it in a RegExp source.
 const escapeRegExp = (value: string) =>
   value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")

--- a/apps/studio/tests/e2e/fixtures/godmode.po.ts
+++ b/apps/studio/tests/e2e/fixtures/godmode.po.ts
@@ -20,9 +20,19 @@ export class GodmodePO {
   }
 
   async expectRedirectToDashboard(path: string) {
+    const responsePromise = this.page.waitForResponse((response) => {
+      const url = new URL(response.url())
+      return url.pathname === path && response.request().isNavigationRequest()
+    })
+
     await this.page.goto(path)
-    await this.page.waitForURL("/")
+    const response = await responsePromise
+
+    expect(response.status()).toBe(307)
     await expect(this.page).toHaveURL(/\/$/)
+    await expect(
+      this.page.getByRole("heading", { name: /God Mode/ }),
+    ).not.toBeVisible()
   }
 
   async gotoCreateSite() {

--- a/apps/studio/tests/e2e/fixtures/godmode.po.ts
+++ b/apps/studio/tests/e2e/fixtures/godmode.po.ts
@@ -37,8 +37,18 @@ export class GodmodePO {
     await this.page.getByLabel("Site name").fill(siteName)
   }
 
+  siteNameInput() {
+    return this.page.getByLabel("Site name")
+  }
+
   async clickCreateSite() {
     await this.page.getByRole("button", { name: "Create Site" }).click()
+  }
+
+  async expectCreateSiteFailedToast() {
+    await this.page
+      .getByText("Failed to create site")
+      .waitFor({ state: "visible" })
   }
 
   async expectSiteCreatedToast(siteName: string) {
@@ -68,15 +78,52 @@ export class GodmodePO {
     ).toBeVisible()
   }
 
+  siteRow(siteId: number) {
+    return this.page.getByRole("row").filter({
+      has: this.page.getByRole("cell", { name: String(siteId), exact: true }),
+    })
+  }
+
+  async expectSiteListed(opts: {
+    siteId: number
+    siteName: string
+    codeBuildId: string
+  }) {
+    const row = this.siteRow(opts.siteId)
+    await expect(row).toBeVisible()
+    await expect(row).toContainText(opts.siteName)
+    await expect(row).toContainText(opts.codeBuildId)
+  }
+
   async clickPublishForSite(siteId: number) {
-    const row = this.page.getByRole("row").filter({ hasText: String(siteId) })
-    await row.getByRole("button", { name: "Publish" }).click()
+    await this.siteRow(siteId).getByRole("button", { name: "Publish" }).click()
+  }
+
+  async expectPublishButtonVisible(siteId: number) {
+    await expect(
+      this.siteRow(siteId).getByRole("button", { name: "Publish" }),
+    ).toBeVisible()
+  }
+
+  async expectPublishButtonHidden(siteId: number) {
+    await expect(
+      this.siteRow(siteId).getByRole("button", { name: "Publish" }),
+    ).toHaveCount(0)
   }
 
   async expectSitePublishedToast() {
     await this.page
       .getByText("Site published successfully")
       .waitFor({ state: "visible" })
+  }
+
+  async expectPublishFailedToast(message?: string) {
+    await this.page
+      .getByText("Failed to publish site")
+      .waitFor({ state: "visible" })
+    if (message) {
+      await this.page.getByText(message).waitFor({ state: "visible" })
+    }
   }
 
   async gotoWhitelist() {
@@ -87,8 +134,12 @@ export class GodmodePO {
     ).toBeVisible()
   }
 
+  vendorEmailsTextarea() {
+    return this.page.locator("textarea").nth(1)
+  }
+
   async fillVendorEmails(emails: string[]) {
-    await this.page.locator("textarea").nth(1).fill(emails.join("\n"))
+    await this.vendorEmailsTextarea().fill(emails.join("\n"))
   }
 
   async clickWhitelistSubmit() {
@@ -101,6 +152,10 @@ export class GodmodePO {
         `Successfully whitelisted ${adminCount} admin(s) and ${vendorCount} vendor(s)`,
       )
       .waitFor({ state: "visible" })
+  }
+
+  async expectWhitelistErrorToast() {
+    await this.page.getByText(/invalid email/i).waitFor({ state: "visible" })
   }
 }
 

--- a/apps/studio/tests/e2e/fixtures/godmode.po.ts
+++ b/apps/studio/tests/e2e/fixtures/godmode.po.ts
@@ -1,0 +1,108 @@
+import { expect, type Page } from "@playwright/test"
+
+export class GodmodePO {
+  constructor(private readonly page: Page) {}
+
+  async gotoHub() {
+    await this.page.goto("/godmode")
+    await this.page.waitForURL(/\/godmode$/)
+    await expect(
+      this.page.getByRole("heading", { name: /God Mode/ }),
+    ).toBeVisible()
+  }
+
+  async expectHubLinkVisible(name: string) {
+    await expect(this.page.getByRole("link", { name })).toBeVisible()
+  }
+
+  async expectHubLinkHidden(name: string) {
+    await expect(this.page.getByRole("link", { name })).not.toBeVisible()
+  }
+
+  async expectRedirectToDashboard(path: string) {
+    await this.page.goto(path)
+    await this.page.waitForURL("/")
+    await expect(this.page).toHaveURL(/\/$/)
+  }
+
+  async gotoCreateSite() {
+    await this.page.goto("/godmode/create-site")
+    await this.page.waitForURL(/\/godmode\/create-site$/)
+    await expect(
+      this.page.getByRole("heading", { name: "Create a new site" }),
+    ).toBeVisible()
+  }
+
+  async fillSiteName(siteName: string) {
+    await this.page.getByLabel("Site name").fill(siteName)
+  }
+
+  async clickCreateSite() {
+    await this.page.getByRole("button", { name: "Create Site" }).click()
+  }
+
+  async expectSiteCreatedToast(siteName: string) {
+    await this.page
+      .getByText(
+        new RegExp(
+          `Site ${escapeRegExp(siteName)} \\(id: \\d+\\) created successfully`,
+        ),
+      )
+      .waitFor({ state: "visible" })
+  }
+
+  async expectRedirectToCreatedSite(): Promise<number> {
+    await this.page.waitForURL(/\/sites\/\d+$/)
+    const match = this.page.url().match(/\/sites\/(\d+)$/)
+    if (!match) {
+      throw new Error(`Expected /sites/{id} URL, got ${this.page.url()}`)
+    }
+    return Number(match[1])
+  }
+
+  async gotoPublishing() {
+    await this.page.goto("/godmode/publishing")
+    await this.page.waitForURL(/\/godmode\/publishing$/)
+    await expect(
+      this.page.getByRole("heading", { name: "Publishing" }),
+    ).toBeVisible()
+  }
+
+  async clickPublishForSite(siteId: number) {
+    const row = this.page.getByRole("row").filter({ hasText: String(siteId) })
+    await row.getByRole("button", { name: "Publish" }).click()
+  }
+
+  async expectSitePublishedToast() {
+    await this.page
+      .getByText("Site published successfully")
+      .waitFor({ state: "visible" })
+  }
+
+  async gotoWhitelist() {
+    await this.page.goto("/godmode/whitelist")
+    await this.page.waitForURL(/\/godmode\/whitelist$/)
+    await expect(
+      this.page.getByRole("heading", { name: "Whitelist" }),
+    ).toBeVisible()
+  }
+
+  async fillVendorEmails(emails: string[]) {
+    await this.page.locator("textarea").nth(1).fill(emails.join("\n"))
+  }
+
+  async clickWhitelistSubmit() {
+    await this.page.getByRole("button", { name: "Submit" }).click()
+  }
+
+  async expectWhitelistSuccessToast(adminCount: number, vendorCount: number) {
+    await this.page
+      .getByText(
+        `Successfully whitelisted ${adminCount} admin(s) and ${vendorCount} vendor(s)`,
+      )
+      .waitFor({ state: "visible" })
+  }
+}
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")

--- a/apps/studio/tests/e2e/fixtures/network.ts
+++ b/apps/studio/tests/e2e/fixtures/network.ts
@@ -94,6 +94,35 @@ interface GrowthBookFeaturesResponse {
   features: Record<string, { defaultValue?: unknown; rules?: unknown[] }>
 }
 
+/**
+ * Stub `site.publish` so godmode publishing E2E can assert the success toast
+ * without calling AWS CodeBuild (no credentials in the test env).
+ */
+export const mockGodmodeSitePublish = async (page: Page) => {
+  await page.route("**/api/trpc/**", async (route) => {
+    const url = route.request().url()
+    if (!url.includes("site.publish")) {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        result: {
+          data: {
+            json: null,
+            meta: {
+              values: ["undefined"],
+            },
+          },
+        },
+      }),
+    })
+  })
+}
+
 /** Patch a GrowthBook feature into the CDN features response before navigation. */
 export const enableGrowthBookFeature = async (
   page: Page,

--- a/apps/studio/tests/e2e/fixtures/network.ts
+++ b/apps/studio/tests/e2e/fixtures/network.ts
@@ -202,7 +202,7 @@ export const mockGodmodeSitePublish = async (
   await page.route("**/api/trpc/**", async (route) => {
     const url = route.request().url()
     if (!url.includes("site.publish")) {
-      await route.continue()
+      await route.fallback()
       return
     }
 

--- a/apps/studio/tests/e2e/fixtures/network.ts
+++ b/apps/studio/tests/e2e/fixtures/network.ts
@@ -160,6 +160,35 @@ interface GrowthBookFeaturesResponse {
   features: Record<string, { defaultValue?: unknown; rules?: unknown[] }>
 }
 
+/**
+ * Stub `site.publish` so godmode publishing E2E can assert the success toast
+ * without calling AWS CodeBuild (no credentials in the test env).
+ */
+export const mockGodmodeSitePublish = async (page: Page) => {
+  await page.route("**/api/trpc/**", async (route) => {
+    const url = route.request().url()
+    if (!url.includes("site.publish")) {
+      await route.continue()
+      return
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        result: {
+          data: {
+            json: null,
+            meta: {
+              values: ["undefined"],
+            },
+          },
+        },
+      }),
+    })
+  })
+}
+
 /** Patch a GrowthBook feature into the CDN features response before navigation. */
 export const enableGrowthBookFeature = async (
   page: Page,

--- a/apps/studio/tests/e2e/fixtures/network.ts
+++ b/apps/studio/tests/e2e/fixtures/network.ts
@@ -160,11 +160,45 @@ interface GrowthBookFeaturesResponse {
   features: Record<string, { defaultValue?: unknown; rules?: unknown[] }>
 }
 
+const TRPC_UNDEFINED_SUCCESS_BODY = JSON.stringify({
+  result: {
+    data: {
+      json: null,
+      meta: {
+        values: ["undefined"],
+      },
+    },
+  },
+})
+
+const trpcMutationErrorBody = (procedure: string, message: string) =>
+  JSON.stringify({
+    error: {
+      json: {
+        message,
+        code: -32603,
+        data: {
+          code: "INTERNAL_SERVER_ERROR",
+          httpStatus: 500,
+          path: procedure,
+        },
+      },
+    },
+  })
+
 /**
- * Stub `site.publish` so godmode publishing E2E can assert the success toast
- * without calling AWS CodeBuild (no credentials in the test env).
+ * Stub `site.publish` so godmode publishing E2E can assert toasts without
+ * calling AWS CodeBuild (no credentials in the test env).
+ *
+ * `failTimes` fulfils that many calls with an error, then succeeds.
  */
-export const mockGodmodeSitePublish = async (page: Page) => {
+export const mockGodmodeSitePublish = async (
+  page: Page,
+  options?: { failTimes?: number; errorMessage?: string },
+) => {
+  let remainingFailures = options?.failTimes ?? 0
+  const errorMessage = options?.errorMessage ?? "CodeBuild unavailable"
+
   await page.route("**/api/trpc/**", async (route) => {
     const url = route.request().url()
     if (!url.includes("site.publish")) {
@@ -172,21 +206,41 @@ export const mockGodmodeSitePublish = async (page: Page) => {
       return
     }
 
+    if (remainingFailures > 0) {
+      remainingFailures -= 1
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: trpcMutationErrorBody("site.publish", errorMessage),
+      })
+      return
+    }
+
     await route.fulfill({
       status: 200,
       contentType: "application/json",
-      body: JSON.stringify({
-        result: {
-          data: {
-            json: null,
-            meta: {
-              values: ["undefined"],
-            },
-          },
-        },
-      }),
+      body: TRPC_UNDEFINED_SUCCESS_BODY,
     })
   })
+}
+
+/** Fail the next `times` calls to a tRPC mutation, then hit the real server. */
+export const mockTrpcMutationError = async (
+  page: Page,
+  procedure: string,
+  options: { message: string; times?: number },
+) => {
+  await page.route(
+    `**/api/trpc/${procedure}*`,
+    async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: trpcMutationErrorBody(procedure, options.message),
+      })
+    },
+    { times: options.times ?? 1 },
+  )
 }
 
 /** Patch a GrowthBook feature into the CDN features response before navigation. */

--- a/apps/studio/tests/e2e/fixtures/site-admin.po.ts
+++ b/apps/studio/tests/e2e/fixtures/site-admin.po.ts
@@ -59,9 +59,7 @@ export class SiteAdminPO {
 
   async expectUnsavedChangesModal() {
     await expect(
-      this.page.getByRole("heading", {
-        name: "Leave this page without saving your settings?",
-      }),
+      this.page.getByText("Leave this page without saving your settings?"),
     ).toBeVisible()
   }
 

--- a/apps/studio/tests/e2e/fixtures/site-admin.po.ts
+++ b/apps/studio/tests/e2e/fixtures/site-admin.po.ts
@@ -1,0 +1,77 @@
+import { expect, type Page } from "@playwright/test"
+
+export type SiteAdminJsonField = "config" | "theme" | "navbar" | "footer"
+
+export class SiteAdminPO {
+  constructor(private readonly page: Page) {}
+
+  async goto(siteId: number) {
+    await this.page.goto(`/sites/${siteId}/admin`)
+    await this.page.waitForURL(/\/admin$/)
+    await expect(
+      this.page.getByText("Manage site configurations"),
+    ).toBeVisible()
+  }
+
+  jsonField(field: SiteAdminJsonField) {
+    return this.page.locator(`textarea[name="${field}"]`)
+  }
+
+  saveButton() {
+    return this.page.getByRole("button", { name: "Save settings" })
+  }
+
+  async fillJsonField(field: SiteAdminJsonField, value: string) {
+    await this.jsonField(field).fill(value)
+  }
+
+  async clickSave() {
+    await this.saveButton().click()
+  }
+
+  async reload() {
+    await this.page.reload()
+    await this.page.waitForURL(/\/admin$/)
+    await expect(
+      this.page.getByText("Manage site configurations"),
+    ).toBeVisible()
+  }
+
+  async expectSavedToast() {
+    await this.page
+      .getByText("Saved site config!")
+      .waitFor({ state: "visible" })
+  }
+
+  async expectSaveErrorToast() {
+    await this.page
+      .getByText("Error saving site config!")
+      .waitFor({ state: "visible" })
+  }
+
+  async expectFieldError(message: string) {
+    await expect(this.page.getByText(message)).toBeVisible()
+  }
+
+  async clickSiteContentNav() {
+    await this.page.getByRole("link", { name: "Site content" }).click()
+  }
+
+  async expectUnsavedChangesModal() {
+    await expect(
+      this.page.getByRole("heading", {
+        name: "Leave this page without saving your settings?",
+      }),
+    ).toBeVisible()
+  }
+
+  async clickGoBackToEditing() {
+    await this.page.getByRole("button", { name: "Go back to editing" }).click()
+  }
+
+  async clickLeavePage() {
+    await this.page
+      .getByRole("button", { name: "Yes, leave this page" })
+      .click()
+  }
+}

--- a/apps/studio/tests/e2e/fixtures/site-expect.ts
+++ b/apps/studio/tests/e2e/fixtures/site-expect.ts
@@ -14,6 +14,17 @@ export const expectSiteName = (siteId: number) =>
     return row?.name ?? null
   })
 
+export const expectSiteConfigSiteName = (siteId: number) =>
+  expect.poll(async () => {
+    const row = await db
+      .selectFrom("Site")
+      .where("id", "=", siteId)
+      .select("config")
+      .executeTakeFirst()
+    const config = row?.config as IsomerSiteConfigProps
+    return config?.siteName ?? null
+  })
+
 export const expectSiteThemeBrandColour = (siteId: number) =>
   expect.poll(async () => {
     const row = await db

--- a/apps/studio/tests/e2e/fixtures/site.ts
+++ b/apps/studio/tests/e2e/fixtures/site.ts
@@ -94,3 +94,15 @@ export const provisionE2ESite = async (opts: {
 
   return { siteId: site.id, siteName: site.name }
 }
+
+/** Set CodeBuild project id so the godmode publishing table shows a Publish action. */
+export const setSiteCodeBuildId = async (
+  siteId: number,
+  codeBuildId: string,
+): Promise<void> => {
+  await db
+    .updateTable("Site")
+    .set({ codeBuildId })
+    .where("id", "=", siteId)
+    .execute()
+}

--- a/apps/studio/tests/e2e/fixtures/user.ts
+++ b/apps/studio/tests/e2e/fixtures/user.ts
@@ -37,6 +37,18 @@ export const whitelistVendorEmail = async (email: string) => {
     .execute()
 }
 
+export const deleteWhitelistedVendorEmails = async (...emails: string[]) => {
+  if (emails.length === 0) return
+  await db
+    .deleteFrom("Whitelist")
+    .where(
+      "email",
+      "in",
+      emails.map((email) => email.toLowerCase()),
+    )
+    .execute()
+}
+
 export const seedLoggedInEditorOnSite = async ({
   siteId,
   email = uniqueLoggedInUserEmail(),

--- a/apps/studio/tests/e2e/fixtures/whitelist-expect.ts
+++ b/apps/studio/tests/e2e/fixtures/whitelist-expect.ts
@@ -1,0 +1,19 @@
+import { expect } from "@playwright/test"
+
+import { getWhitelistEntry } from "./whitelist.db"
+
+/** Vendor whitelist row with a future expiry (90-day vendor access). */
+export const expectWhitelistedVendorEmail = (email: string) =>
+  expect.poll(async () => {
+    const row = await getWhitelistEntry(email)
+    if (!row?.expiry) return null
+    return row.expiry > new Date()
+  })
+
+/** Admin whitelist row with no expiry. */
+export const expectWhitelistedAdminEmail = (email: string) =>
+  expect.poll(async () => {
+    const row = await getWhitelistEntry(email)
+    if (!row) return null
+    return row.expiry === null
+  })

--- a/apps/studio/tests/e2e/fixtures/whitelist.db.ts
+++ b/apps/studio/tests/e2e/fixtures/whitelist.db.ts
@@ -1,14 +1,25 @@
 import { expect } from "@playwright/test"
 import { db } from "~/server/modules/database"
 
+export const getWhitelistEntry = (email: string) =>
+  db
+    .selectFrom("Whitelist")
+    .where("email", "=", email.toLowerCase())
+    .selectAll()
+    .executeTakeFirst()
+
 /** Vendor whitelist row with a future expiry (90-day vendor access). */
 export const expectWhitelistedVendorEmail = (email: string) =>
   expect.poll(async () => {
-    const row = await db
-      .selectFrom("Whitelist")
-      .where("email", "=", email.toLowerCase())
-      .select("expiry")
-      .executeTakeFirst()
+    const row = await getWhitelistEntry(email)
     if (!row?.expiry) return null
     return row.expiry > new Date()
+  })
+
+/** Admin whitelist row with no expiry. */
+export const expectWhitelistedAdminEmail = (email: string) =>
+  expect.poll(async () => {
+    const row = await getWhitelistEntry(email)
+    if (!row) return null
+    return row.expiry === null
   })

--- a/apps/studio/tests/e2e/fixtures/whitelist.db.ts
+++ b/apps/studio/tests/e2e/fixtures/whitelist.db.ts
@@ -1,0 +1,14 @@
+import { expect } from "@playwright/test"
+import { db } from "~/server/modules/database"
+
+/** Vendor whitelist row with a future expiry (90-day vendor access). */
+export const expectWhitelistedVendorEmail = (email: string) =>
+  expect.poll(async () => {
+    const row = await db
+      .selectFrom("Whitelist")
+      .where("email", "=", email.toLowerCase())
+      .select("expiry")
+      .executeTakeFirst()
+    if (!row?.expiry) return null
+    return row.expiry > new Date()
+  })

--- a/apps/studio/tests/e2e/fixtures/whitelist.db.ts
+++ b/apps/studio/tests/e2e/fixtures/whitelist.db.ts
@@ -1,4 +1,3 @@
-import { expect } from "@playwright/test"
 import { db } from "~/server/modules/database"
 
 export const getWhitelistEntry = (email: string) =>
@@ -7,19 +6,3 @@ export const getWhitelistEntry = (email: string) =>
     .where("email", "=", email.toLowerCase())
     .selectAll()
     .executeTakeFirst()
-
-/** Vendor whitelist row with a future expiry (90-day vendor access). */
-export const expectWhitelistedVendorEmail = (email: string) =>
-  expect.poll(async () => {
-    const row = await getWhitelistEntry(email)
-    if (!row?.expiry) return null
-    return row.expiry > new Date()
-  })
-
-/** Admin whitelist row with no expiry. */
-export const expectWhitelistedAdminEmail = (email: string) =>
-  expect.poll(async () => {
-    const row = await getWhitelistEntry(email)
-    if (!row) return null
-    return row.expiry === null
-  })

--- a/apps/studio/tests/e2e/godmode/access.test.ts
+++ b/apps/studio/tests/e2e/godmode/access.test.ts
@@ -1,38 +1,23 @@
-import { expect, test, type Page } from "@playwright/test"
+import { test } from "@playwright/test"
 
 import { roleTag } from "../fixtures/auth"
+import { GodmodePO } from "../fixtures/godmode.po"
 
-const GODMODE_ROUTES = [
-  { path: "/godmode/create-site", heading: "Create a new site" },
-  { path: "/godmode/publishing", heading: "Publishing" },
-  { path: "/godmode/whitelist", heading: "Whitelist" },
+const RESTRICTED_GODMODE_PATHS = [
+  "/godmode",
+  "/godmode/create-site",
+  "/godmode/publishing",
+  "/godmode/whitelist",
 ] as const
 
-const expectRedirectToDashboard = async (page: Page, path: string) => {
-  await page.goto(path)
-  await page.waitForURL("/")
-  await expect(page).toHaveURL(/\/$/)
-}
-
 test.describe("core", { tag: roleTag("core") }, () => {
-  test("core admin can access all godmode routes", async ({ page }) => {
-    // Act
-    await page.goto("/godmode")
+  test("core admin can access the godmode hub", async ({ page }) => {
+    const godmode = new GodmodePO(page)
 
-    // Assert
-    await expect(page.getByRole("heading", { name: /God Mode/ })).toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Create a new site" }),
-    ).toBeVisible()
-    await expect(page.getByRole("link", { name: "Publishing" })).toBeVisible()
-    await expect(page.getByRole("link", { name: "Whitelist" })).toBeVisible()
-
-    for (const route of GODMODE_ROUTES) {
-      await page.goto(route.path)
-      await expect(
-        page.getByRole("heading", { name: route.heading }),
-      ).toBeVisible()
-    }
+    await godmode.gotoHub()
+    await godmode.expectHubLinkVisible("Create a new site")
+    await godmode.expectHubLinkVisible("Publishing")
+    await godmode.expectHubLinkVisible("Whitelist")
   })
 })
 
@@ -40,33 +25,26 @@ test.describe("migrator", { tag: roleTag("migrator") }, () => {
   test("migrator can only access whitelist godmode routes", async ({
     page,
   }) => {
-    // Act
-    await page.goto("/godmode")
+    const godmode = new GodmodePO(page)
 
-    // Assert
-    await expect(page.getByRole("heading", { name: /God Mode/ })).toBeVisible()
-    await expect(page.getByRole("link", { name: "Whitelist" })).toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Create a new site" }),
-    ).not.toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Publishing" }),
-    ).not.toBeVisible()
+    await godmode.gotoHub()
+    await godmode.expectHubLinkVisible("Whitelist")
+    await godmode.expectHubLinkHidden("Create a new site")
+    await godmode.expectHubLinkHidden("Publishing")
 
-    await page.goto("/godmode/whitelist")
-    await expect(page.getByRole("heading", { name: "Whitelist" })).toBeVisible()
+    await godmode.gotoWhitelist()
 
-    await expectRedirectToDashboard(page, "/godmode/create-site")
-    await expectRedirectToDashboard(page, "/godmode/publishing")
+    await godmode.expectRedirectToDashboard("/godmode/create-site")
+    await godmode.expectRedirectToDashboard("/godmode/publishing")
   })
 })
 
 test.describe("admin", { tag: roleTag("admin") }, () => {
   test("site admin without godmode access is redirected", async ({ page }) => {
-    // Act / Assert
-    await expectRedirectToDashboard(page, "/godmode")
-    for (const route of GODMODE_ROUTES) {
-      await expectRedirectToDashboard(page, route.path)
+    const godmode = new GodmodePO(page)
+
+    for (const path of RESTRICTED_GODMODE_PATHS) {
+      await godmode.expectRedirectToDashboard(path)
     }
   })
 })

--- a/apps/studio/tests/e2e/godmode/access.test.ts
+++ b/apps/studio/tests/e2e/godmode/access.test.ts
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test"
 
-import { roleTag } from "../fixtures/auth"
+import { ROLES, roleTag, type Role } from "../fixtures/auth"
 import { GodmodePO } from "../fixtures/godmode.po"
 
 const RESTRICTED_GODMODE_PATHS = [
@@ -10,41 +10,65 @@ const RESTRICTED_GODMODE_PATHS = [
   "/godmode/whitelist",
 ] as const
 
-test.describe("core", { tag: roleTag("core") }, () => {
-  test("core admin can access the godmode hub", async ({ page }) => {
-    const godmode = new GodmodePO(page)
+const CORE_ONLY_GODMODE_PATHS = [
+  "/godmode/create-site",
+  "/godmode/publishing",
+] as const
 
-    await godmode.gotoHub()
-    await godmode.expectHubLinkVisible("Create a new site")
-    await godmode.expectHubLinkVisible("Publishing")
-    await godmode.expectHubLinkVisible("Whitelist")
-  })
-})
+/** Exhaustive over `Role` — adding a ROLES entry fails typecheck until classified. */
+const godmodeAccessByRole = {
+  core: "full",
+  migrator: "whitelist-only",
+  editor: "denied",
+  publisher: "denied",
+  admin: "denied",
+  nomember: "denied",
+} as const satisfies Record<Role, "full" | "whitelist-only" | "denied">
 
-test.describe("migrator", { tag: roleTag("migrator") }, () => {
-  test("migrator can only access whitelist godmode routes", async ({
-    page,
-  }) => {
-    const godmode = new GodmodePO(page)
+for (const role of ROLES) {
+  const access = godmodeAccessByRole[role]
 
-    await godmode.gotoHub()
-    await godmode.expectHubLinkVisible("Whitelist")
-    await godmode.expectHubLinkHidden("Create a new site")
-    await godmode.expectHubLinkHidden("Publishing")
+  if (access === "full") {
+    test.describe(role, { tag: roleTag(role) }, () => {
+      test("can access all godmode routes", async ({ page }) => {
+        const godmode = new GodmodePO(page)
 
-    await godmode.gotoWhitelist()
+        await godmode.gotoHub()
+        await godmode.expectHubLinkVisible("Create a new site")
+        await godmode.expectHubLinkVisible("Publishing")
+        await godmode.expectHubLinkVisible("Whitelist")
 
-    await godmode.expectRedirectToDashboard("/godmode/create-site")
-    await godmode.expectRedirectToDashboard("/godmode/publishing")
-  })
-})
+        await godmode.gotoCreateSite()
+        await godmode.gotoPublishing()
+        await godmode.gotoWhitelist()
+      })
+    })
+  } else if (access === "whitelist-only") {
+    test.describe(role, { tag: roleTag(role) }, () => {
+      test("can only access whitelist godmode routes", async ({ page }) => {
+        const godmode = new GodmodePO(page)
 
-test.describe("admin", { tag: roleTag("admin") }, () => {
-  test("site admin without godmode access is redirected", async ({ page }) => {
-    const godmode = new GodmodePO(page)
+        await godmode.gotoHub()
+        await godmode.expectHubLinkVisible("Whitelist")
+        await godmode.expectHubLinkHidden("Create a new site")
+        await godmode.expectHubLinkHidden("Publishing")
 
-    for (const path of RESTRICTED_GODMODE_PATHS) {
-      await godmode.expectRedirectToDashboard(path)
-    }
-  })
-})
+        await godmode.gotoWhitelist()
+
+        for (const path of CORE_ONLY_GODMODE_PATHS) {
+          await godmode.expectRedirectToDashboard(path)
+        }
+      })
+    })
+  } else {
+    test.describe(role, { tag: roleTag(role) }, () => {
+      test("is redirected away from all godmode routes", async ({ page }) => {
+        const godmode = new GodmodePO(page)
+
+        for (const path of RESTRICTED_GODMODE_PATHS) {
+          await godmode.expectRedirectToDashboard(path)
+        }
+      })
+    })
+  }
+}

--- a/apps/studio/tests/e2e/godmode/access.test.ts
+++ b/apps/studio/tests/e2e/godmode/access.test.ts
@@ -1,7 +1,8 @@
 import { test } from "@playwright/test"
 
-import { ROLES, roleTag, type Role } from "../fixtures/auth"
+import { ROLES, roleTag, TEST_EMAILS, type Role } from "../fixtures/auth"
 import { GodmodePO } from "../fixtures/godmode.po"
+import { ensureUserOnboarded } from "../fixtures/user"
 
 const RESTRICTED_GODMODE_PATHS = [
   "/godmode",
@@ -13,6 +14,12 @@ const RESTRICTED_GODMODE_PATHS = [
 const CORE_ONLY_GODMODE_PATHS = [
   "/godmode/create-site",
   "/godmode/publishing",
+] as const
+
+const FULL_ACCESS_GODMODE_PATHS = [
+  "/godmode/create-site",
+  "/godmode/publishing",
+  "/godmode/whitelist",
 ] as const
 
 /** Exhaustive over `Role` — adding a ROLES entry fails typecheck until classified. */
@@ -30,45 +37,85 @@ for (const role of ROLES) {
 
   if (access === "full") {
     test.describe(role, { tag: roleTag(role) }, () => {
-      test("can access all godmode routes", async ({ page }) => {
+      test.beforeEach(async () => {
+        await ensureUserOnboarded(TEST_EMAILS[role])
+      })
+
+      test("can access the godmode hub", async ({ page }) => {
         const godmode = new GodmodePO(page)
 
+        // Act
         await godmode.gotoHub()
+
+        // Assert
         await godmode.expectHubLinkVisible("Create a new site")
         await godmode.expectHubLinkVisible("Publishing")
         await godmode.expectHubLinkVisible("Whitelist")
-
-        await godmode.gotoCreateSite()
-        await godmode.gotoPublishing()
-        await godmode.gotoWhitelist()
       })
+
+      for (const path of FULL_ACCESS_GODMODE_PATHS) {
+        test(`can access ${path}`, async ({ page }) => {
+          const godmode = new GodmodePO(page)
+
+          // Act
+          await godmode.gotoRoute(path)
+
+          // Assert — route-specific heading is asserted inside gotoRoute
+        })
+      }
     })
   } else if (access === "whitelist-only") {
     test.describe(role, { tag: roleTag(role) }, () => {
-      test("can only access whitelist godmode routes", async ({ page }) => {
+      test.beforeEach(async () => {
+        await ensureUserOnboarded(TEST_EMAILS[role])
+      })
+
+      test("can access the godmode hub with whitelist only", async ({
+        page,
+      }) => {
         const godmode = new GodmodePO(page)
 
+        // Act
         await godmode.gotoHub()
+
+        // Assert
         await godmode.expectHubLinkVisible("Whitelist")
         await godmode.expectHubLinkHidden("Create a new site")
         await godmode.expectHubLinkHidden("Publishing")
+      })
 
+      test("can access the whitelist route", async ({ page }) => {
+        const godmode = new GodmodePO(page)
+
+        // Act
         await godmode.gotoWhitelist()
 
-        for (const path of CORE_ONLY_GODMODE_PATHS) {
-          await godmode.expectRedirectToDashboard(path)
-        }
+        // Assert — heading is asserted inside gotoWhitelist
       })
+
+      for (const path of CORE_ONLY_GODMODE_PATHS) {
+        test(`is redirected away from ${path}`, async ({ page }) => {
+          const godmode = new GodmodePO(page)
+
+          // Act / Assert
+          await godmode.expectRedirectToDashboard(path)
+        })
+      }
     })
   } else {
     test.describe(role, { tag: roleTag(role) }, () => {
-      test("is redirected away from all godmode routes", async ({ page }) => {
-        const godmode = new GodmodePO(page)
-
-        for (const path of RESTRICTED_GODMODE_PATHS) {
-          await godmode.expectRedirectToDashboard(path)
-        }
+      test.beforeEach(async () => {
+        await ensureUserOnboarded(TEST_EMAILS[role])
       })
+
+      for (const path of RESTRICTED_GODMODE_PATHS) {
+        test(`is redirected away from ${path}`, async ({ page }) => {
+          const godmode = new GodmodePO(page)
+
+          // Act / Assert
+          await godmode.expectRedirectToDashboard(path)
+        })
+      }
     })
   }
 }

--- a/apps/studio/tests/e2e/godmode/access.test.ts
+++ b/apps/studio/tests/e2e/godmode/access.test.ts
@@ -1,35 +1,23 @@
-import { expect, test, type Page } from "@playwright/test"
+import { test } from "@playwright/test"
 
 import { roleTag } from "../fixtures/auth"
+import { GodmodePO } from "../fixtures/godmode.po"
 
-const GODMODE_ROUTES = [
-  { path: "/godmode/create-site", heading: "Create a new site" },
-  { path: "/godmode/publishing", heading: "Publishing" },
-  { path: "/godmode/whitelist", heading: "Whitelist" },
+const RESTRICTED_GODMODE_PATHS = [
+  "/godmode",
+  "/godmode/create-site",
+  "/godmode/publishing",
+  "/godmode/whitelist",
 ] as const
 
-const expectRedirectToDashboard = async (page: Page, path: string) => {
-  await page.goto(path)
-  await page.waitForURL("/")
-  await expect(page).toHaveURL(/\/$/)
-}
-
 test.describe("core", { tag: roleTag("core") }, () => {
-  test("core admin can access all godmode routes", async ({ page }) => {
-    await page.goto("/godmode")
-    await expect(page.getByRole("heading", { name: /God Mode/ })).toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Create a new site" }),
-    ).toBeVisible()
-    await expect(page.getByRole("link", { name: "Publishing" })).toBeVisible()
-    await expect(page.getByRole("link", { name: "Whitelist" })).toBeVisible()
+  test("core admin can access the godmode hub", async ({ page }) => {
+    const godmode = new GodmodePO(page)
 
-    for (const route of GODMODE_ROUTES) {
-      await page.goto(route.path)
-      await expect(
-        page.getByRole("heading", { name: route.heading }),
-      ).toBeVisible()
-    }
+    await godmode.gotoHub()
+    await godmode.expectHubLinkVisible("Create a new site")
+    await godmode.expectHubLinkVisible("Publishing")
+    await godmode.expectHubLinkVisible("Whitelist")
   })
 })
 
@@ -37,29 +25,26 @@ test.describe("migrator", { tag: roleTag("migrator") }, () => {
   test("migrator can only access whitelist godmode routes", async ({
     page,
   }) => {
-    await page.goto("/godmode")
-    await expect(page.getByRole("heading", { name: /God Mode/ })).toBeVisible()
-    await expect(page.getByRole("link", { name: "Whitelist" })).toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Create a new site" }),
-    ).not.toBeVisible()
-    await expect(
-      page.getByRole("link", { name: "Publishing" }),
-    ).not.toBeVisible()
+    const godmode = new GodmodePO(page)
 
-    await page.goto("/godmode/whitelist")
-    await expect(page.getByRole("heading", { name: "Whitelist" })).toBeVisible()
+    await godmode.gotoHub()
+    await godmode.expectHubLinkVisible("Whitelist")
+    await godmode.expectHubLinkHidden("Create a new site")
+    await godmode.expectHubLinkHidden("Publishing")
 
-    await expectRedirectToDashboard(page, "/godmode/create-site")
-    await expectRedirectToDashboard(page, "/godmode/publishing")
+    await godmode.gotoWhitelist()
+
+    await godmode.expectRedirectToDashboard("/godmode/create-site")
+    await godmode.expectRedirectToDashboard("/godmode/publishing")
   })
 })
 
 test.describe("admin", { tag: roleTag("admin") }, () => {
   test("site admin without godmode access is redirected", async ({ page }) => {
-    await expectRedirectToDashboard(page, "/godmode")
-    for (const route of GODMODE_ROUTES) {
-      await expectRedirectToDashboard(page, route.path)
+    const godmode = new GodmodePO(page)
+
+    for (const path of RESTRICTED_GODMODE_PATHS) {
+      await godmode.expectRedirectToDashboard(path)
     }
   })
 })

--- a/apps/studio/tests/e2e/godmode/create-site.test.ts
+++ b/apps/studio/tests/e2e/godmode/create-site.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test"
+import crypto from "crypto"
+
+import { TEST_EMAILS, roleTag } from "../fixtures/auth"
+import { GodmodePO } from "../fixtures/godmode.po"
+import { ensureUserOnboarded } from "../fixtures/user"
+
+test.describe("core", { tag: roleTag("core") }, () => {
+  test.beforeEach(async () => {
+    await ensureUserOnboarded(TEST_EMAILS.core)
+  })
+
+  test("core admin can create a site", async ({ page }) => {
+    const siteName = `E2E Godmode Site ${crypto.randomUUID().slice(0, 8)}`
+    const godmode = new GodmodePO(page)
+
+    // Arrange
+    await godmode.gotoCreateSite()
+
+    // Act
+    await godmode.fillSiteName(siteName)
+    await godmode.clickCreateSite()
+
+    // Assert
+    await godmode.expectSiteCreatedToast(siteName)
+    const siteId = await godmode.expectRedirectToCreatedSite()
+    expect(siteId).toBeGreaterThan(0)
+  })
+})

--- a/apps/studio/tests/e2e/godmode/create-site.test.ts
+++ b/apps/studio/tests/e2e/godmode/create-site.test.ts
@@ -2,9 +2,19 @@ import { expect, test } from "@playwright/test"
 import crypto from "crypto"
 
 import { TEST_EMAILS, roleTag } from "../fixtures/auth"
+import { DashboardPO } from "../fixtures/dashboard.po"
 import { GodmodePO } from "../fixtures/godmode.po"
-import { expectSiteName } from "../fixtures/site-expect"
+import { mockTrpcMutationError } from "../fixtures/network"
+import { getResourceByTitle } from "../fixtures/resource.db"
+import {
+  expectFooterContains,
+  expectNavbarContains,
+  expectSiteName,
+  expectSiteThemeBrandColour,
+} from "../fixtures/site-expect"
 import { ensureUserOnboarded } from "../fixtures/user"
+
+const DEFAULT_THEME_BRAND = "#00405f"
 
 test.describe("core", { tag: roleTag("core") }, () => {
   test.beforeEach(async () => {
@@ -14,12 +24,58 @@ test.describe("core", { tag: roleTag("core") }, () => {
   test("core admin can create a site", async ({ page }) => {
     const siteName = `E2E Godmode Site ${crypto.randomUUID().slice(0, 8)}`
     const godmode = new GodmodePO(page)
+    const dashboard = new DashboardPO(page)
 
     // Arrange
     await godmode.gotoCreateSite()
 
     // Act
     await godmode.fillSiteName(siteName)
+    await godmode.clickCreateSite()
+
+    // Assert
+    await godmode.expectSiteCreatedToast(siteName)
+    const siteId = await godmode.expectRedirectToCreatedSite()
+    expect(siteId).toBeGreaterThan(0)
+    await expectSiteName(siteId).toBe(siteName)
+    await expectSiteThemeBrandColour(siteId).toBe(DEFAULT_THEME_BRAND)
+    await expectNavbarContains(siteId, "Expandable nav item").toBe(true)
+    await expectFooterContains(siteId, "About us").toBe(true)
+
+    const home = await getResourceByTitle({ siteId, title: "Home" })
+    expect(home?.type).toBe("RootPage")
+    expect(home?.state).toBe("Published")
+
+    const search = await getResourceByTitle({ siteId, title: "Search" })
+    expect(search?.type).toBe("Page")
+    expect(search?.state).toBe("Published")
+
+    await dashboard.expectCreateButtonVisible()
+    await dashboard.expectHomepageRowVisible()
+  })
+
+  test("core admin can retry after a failed site creation", async ({
+    page,
+  }) => {
+    const siteName = `E2E Godmode Retry ${crypto.randomUUID().slice(0, 8)}`
+    const godmode = new GodmodePO(page)
+
+    // Arrange
+    await mockTrpcMutationError(page, "site.create", {
+      message: "Site creation is temporarily unavailable",
+      times: 1,
+    })
+    await godmode.gotoCreateSite()
+    await godmode.fillSiteName(siteName)
+
+    // Act
+    await godmode.clickCreateSite()
+
+    // Assert
+    await godmode.expectCreateSiteFailedToast()
+    await expect(godmode.siteNameInput()).toHaveValue(siteName)
+
+    // Act — retry hits the real mutation
     await godmode.clickCreateSite()
 
     // Assert

--- a/apps/studio/tests/e2e/godmode/create-site.test.ts
+++ b/apps/studio/tests/e2e/godmode/create-site.test.ts
@@ -3,6 +3,7 @@ import crypto from "crypto"
 
 import { TEST_EMAILS, roleTag } from "../fixtures/auth"
 import { GodmodePO } from "../fixtures/godmode.po"
+import { expectSiteName } from "../fixtures/site-expect"
 import { ensureUserOnboarded } from "../fixtures/user"
 
 test.describe("core", { tag: roleTag("core") }, () => {
@@ -25,5 +26,6 @@ test.describe("core", { tag: roleTag("core") }, () => {
     await godmode.expectSiteCreatedToast(siteName)
     const siteId = await godmode.expectRedirectToCreatedSite()
     expect(siteId).toBeGreaterThan(0)
+    await expectSiteName(siteId).toBe(siteName)
   })
 })

--- a/apps/studio/tests/e2e/godmode/publishing.test.ts
+++ b/apps/studio/tests/e2e/godmode/publishing.test.ts
@@ -38,8 +38,6 @@ test.describe("core", { tag: roleTag("core") }, () => {
     // Arrange
     await mockGodmodeSitePublish(page)
     await godmode.gotoPublishing()
-
-    // Assert
     await godmode.expectSiteListed({
       siteId: publishableSiteId,
       siteName: publishableSiteName,

--- a/apps/studio/tests/e2e/godmode/publishing.test.ts
+++ b/apps/studio/tests/e2e/godmode/publishing.test.ts
@@ -1,0 +1,36 @@
+import { test } from "@playwright/test"
+import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { TEST_EMAILS, roleTag } from "../fixtures/auth"
+import { GodmodePO } from "../fixtures/godmode.po"
+import { mockGodmodeSitePublish } from "../fixtures/network"
+import { provisionE2ESite, setSiteCodeBuildId } from "../fixtures/site"
+import { ensureUserOnboarded } from "../fixtures/user"
+
+let siteId: number
+
+test.describe("core", { tag: roleTag("core") }, () => {
+  test.beforeAll(async () => {
+    const site = await provisionE2ESite({ roles: [RoleType.Admin] })
+    siteId = site.siteId
+    await setSiteCodeBuildId(siteId, `e2e-codebuild-${siteId}`)
+  })
+
+  test.beforeEach(async ({ page }) => {
+    await mockGodmodeSitePublish(page)
+    await ensureUserOnboarded(TEST_EMAILS.core)
+  })
+
+  test("core admin can publish a site from godmode", async ({ page }) => {
+    const godmode = new GodmodePO(page)
+
+    // Arrange
+    await godmode.gotoPublishing()
+
+    // Act
+    await godmode.clickPublishForSite(siteId)
+
+    // Assert — CodeBuild is async; UI toast only
+    await godmode.expectSitePublishedToast()
+  })
+})

--- a/apps/studio/tests/e2e/godmode/publishing.test.ts
+++ b/apps/studio/tests/e2e/godmode/publishing.test.ts
@@ -7,30 +7,93 @@ import { mockGodmodeSitePublish } from "../fixtures/network"
 import { provisionE2ESite, setSiteCodeBuildId } from "../fixtures/site"
 import { ensureUserOnboarded } from "../fixtures/user"
 
-let siteId: number
+let publishableSiteId: number
+let publishableSiteName: string
+let publishableCodeBuildId: string
+let unconfiguredSiteId: number
+let unconfiguredSiteName: string
 
 test.describe("core", { tag: roleTag("core") }, () => {
   test.beforeAll(async () => {
-    const site = await provisionE2ESite({ roles: [RoleType.Admin] })
-    siteId = site.siteId
-    await setSiteCodeBuildId(siteId, `e2e-codebuild-${siteId}`)
+    const publishable = await provisionE2ESite({ roles: [RoleType.Admin] })
+    publishableSiteId = publishable.siteId
+    publishableSiteName = publishable.siteName
+    publishableCodeBuildId = `e2e-codebuild-${publishableSiteId}`
+    await setSiteCodeBuildId(publishableSiteId, publishableCodeBuildId)
+
+    const unconfigured = await provisionE2ESite({ roles: [RoleType.Admin] })
+    unconfiguredSiteId = unconfigured.siteId
+    unconfiguredSiteName = unconfigured.siteName
   })
 
-  test.beforeEach(async ({ page }) => {
-    await mockGodmodeSitePublish(page)
+  test.beforeEach(async () => {
     await ensureUserOnboarded(TEST_EMAILS.core)
   })
 
-  test("core admin can publish a site from godmode", async ({ page }) => {
+  test("core admin can list and publish a configured site from godmode", async ({
+    page,
+  }) => {
+    const godmode = new GodmodePO(page)
+
+    // Arrange
+    await mockGodmodeSitePublish(page)
+    await godmode.gotoPublishing()
+
+    // Assert
+    await godmode.expectSiteListed({
+      siteId: publishableSiteId,
+      siteName: publishableSiteName,
+      codeBuildId: publishableCodeBuildId,
+    })
+    await godmode.expectPublishButtonVisible(publishableSiteId)
+
+    // Act
+    await godmode.clickPublishForSite(publishableSiteId)
+
+    // Assert — CodeBuild is async; UI toast only
+    await godmode.expectSitePublishedToast()
+  })
+
+  test("core admin cannot publish a site without a CodeBuild ID", async ({
+    page,
+  }) => {
     const godmode = new GodmodePO(page)
 
     // Arrange
     await godmode.gotoPublishing()
 
-    // Act
-    await godmode.clickPublishForSite(siteId)
+    // Assert
+    await godmode.expectSiteListed({
+      siteId: unconfiguredSiteId,
+      siteName: unconfiguredSiteName,
+      codeBuildId: "-",
+    })
+    await godmode.expectPublishButtonHidden(unconfiguredSiteId)
+  })
 
-    // Assert — CodeBuild is async; UI toast only
+  test("core admin can retry after a failed godmode publish", async ({
+    page,
+  }) => {
+    const godmode = new GodmodePO(page)
+    const errorMessage = "CodeBuild unavailable"
+
+    // Arrange
+    await mockGodmodeSitePublish(page, {
+      failTimes: 1,
+      errorMessage,
+    })
+    await godmode.gotoPublishing()
+
+    // Act
+    await godmode.clickPublishForSite(publishableSiteId)
+
+    // Assert
+    await godmode.expectPublishFailedToast(errorMessage)
+
+    // Act
+    await godmode.clickPublishForSite(publishableSiteId)
+
+    // Assert
     await godmode.expectSitePublishedToast()
   })
 })

--- a/apps/studio/tests/e2e/godmode/whitelist.test.ts
+++ b/apps/studio/tests/e2e/godmode/whitelist.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
 import { TEST_EMAILS, roleTag } from "../fixtures/auth"
 import { GodmodePO } from "../fixtures/godmode.po"
@@ -7,34 +7,61 @@ import {
   ensureUserOnboarded,
   uniqueVendorEmail,
 } from "../fixtures/user"
-import { expectWhitelistedVendorEmail } from "../fixtures/whitelist.db"
-
-let vendorEmails: string[] = []
+import {
+  expectWhitelistedVendorEmail,
+  getWhitelistEntry,
+} from "../fixtures/whitelist.db"
 
 test.describe("migrator", { tag: roleTag("migrator") }, () => {
   test.beforeEach(async () => {
     await ensureUserOnboarded(TEST_EMAILS.migrator)
-    vendorEmails = [uniqueVendorEmail(), uniqueVendorEmail()]
-  })
-
-  test.afterEach(async () => {
-    await deleteWhitelistedVendorEmails(...vendorEmails)
   })
 
   test("migrator can bulk-whitelist vendor emails", async ({ page }) => {
     const godmode = new GodmodePO(page)
+    const vendorEmails = [uniqueVendorEmail(), uniqueVendorEmail()]
 
-    // Arrange
-    await godmode.gotoWhitelist()
+    try {
+      // Arrange
+      await godmode.gotoWhitelist()
 
-    // Act
-    await godmode.fillVendorEmails(vendorEmails)
-    await godmode.clickWhitelistSubmit()
+      // Act
+      await godmode.fillVendorEmails(vendorEmails)
+      await godmode.clickWhitelistSubmit()
 
-    // Assert
-    await godmode.expectWhitelistSuccessToast(0, vendorEmails.length)
-    for (const email of vendorEmails) {
-      await expectWhitelistedVendorEmail(email).toBe(true)
+      // Assert
+      await godmode.expectWhitelistSuccessToast(0, vendorEmails.length)
+      for (const email of vendorEmails) {
+        await expectWhitelistedVendorEmail(email).toBe(true)
+      }
+    } finally {
+      await deleteWhitelistedVendorEmails(...vendorEmails)
+    }
+  })
+
+  test("invalid whitelist input is rejected without losing valid entries", async ({
+    page,
+  }) => {
+    const godmode = new GodmodePO(page)
+    const validEmail = uniqueVendorEmail()
+    const pastedEmails = [validEmail, "not-an-email"]
+
+    try {
+      // Arrange
+      await godmode.gotoWhitelist()
+
+      // Act
+      await godmode.fillVendorEmails(pastedEmails)
+      await godmode.clickWhitelistSubmit()
+
+      // Assert
+      await godmode.expectWhitelistErrorToast()
+      await expect(godmode.vendorEmailsTextarea()).toHaveValue(
+        pastedEmails.join("\n"),
+      )
+      expect(await getWhitelistEntry(validEmail)).toBeUndefined()
+    } finally {
+      await deleteWhitelistedVendorEmails(validEmail)
     }
   })
 })

--- a/apps/studio/tests/e2e/godmode/whitelist.test.ts
+++ b/apps/studio/tests/e2e/godmode/whitelist.test.ts
@@ -1,0 +1,36 @@
+import { test } from "@playwright/test"
+
+import { TEST_EMAILS, roleTag } from "../fixtures/auth"
+import { GodmodePO } from "../fixtures/godmode.po"
+import {
+  deleteWhitelistedVendorEmails,
+  ensureUserOnboarded,
+  uniqueVendorEmail,
+} from "../fixtures/user"
+
+let vendorEmails: string[] = []
+
+test.describe("migrator", { tag: roleTag("migrator") }, () => {
+  test.beforeEach(async () => {
+    await ensureUserOnboarded(TEST_EMAILS.migrator)
+    vendorEmails = [uniqueVendorEmail(), uniqueVendorEmail()]
+  })
+
+  test.afterEach(async () => {
+    await deleteWhitelistedVendorEmails(...vendorEmails)
+  })
+
+  test("migrator can bulk-whitelist vendor emails", async ({ page }) => {
+    const godmode = new GodmodePO(page)
+
+    // Arrange
+    await godmode.gotoWhitelist()
+
+    // Act
+    await godmode.fillVendorEmails(vendorEmails)
+    await godmode.clickWhitelistSubmit()
+
+    // Assert
+    await godmode.expectWhitelistSuccessToast(0, vendorEmails.length)
+  })
+})

--- a/apps/studio/tests/e2e/godmode/whitelist.test.ts
+++ b/apps/studio/tests/e2e/godmode/whitelist.test.ts
@@ -7,10 +7,8 @@ import {
   ensureUserOnboarded,
   uniqueVendorEmail,
 } from "../fixtures/user"
-import {
-  expectWhitelistedVendorEmail,
-  getWhitelistEntry,
-} from "../fixtures/whitelist.db"
+import { expectWhitelistedVendorEmail } from "../fixtures/whitelist-expect"
+import { getWhitelistEntry } from "../fixtures/whitelist.db"
 
 test.describe("migrator", { tag: roleTag("migrator") }, () => {
   test.beforeEach(async () => {

--- a/apps/studio/tests/e2e/godmode/whitelist.test.ts
+++ b/apps/studio/tests/e2e/godmode/whitelist.test.ts
@@ -7,6 +7,7 @@ import {
   ensureUserOnboarded,
   uniqueVendorEmail,
 } from "../fixtures/user"
+import { expectWhitelistedVendorEmail } from "../fixtures/whitelist.db"
 
 let vendorEmails: string[] = []
 
@@ -32,5 +33,8 @@ test.describe("migrator", { tag: roleTag("migrator") }, () => {
 
     // Assert
     await godmode.expectWhitelistSuccessToast(0, vendorEmails.length)
+    for (const email of vendorEmails) {
+      await expectWhitelistedVendorEmail(email).toBe(true)
+    }
   })
 })

--- a/apps/studio/tests/e2e/site/admin-save.test.ts
+++ b/apps/studio/tests/e2e/site/admin-save.test.ts
@@ -1,0 +1,193 @@
+import { expect, test } from "@playwright/test"
+import crypto from "crypto"
+import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { TEST_EMAILS, roleTag } from "../fixtures/auth"
+import { DashboardPO } from "../fixtures/dashboard.po"
+import { mockTrpcMutationError } from "../fixtures/network"
+import {
+  resetSiteAgencySettings,
+  resetSiteFooter,
+  resetSiteNavbar,
+  resetSiteTheme,
+} from "../fixtures/reset"
+import { provisionE2ESite } from "../fixtures/site"
+import { SiteAdminPO } from "../fixtures/site-admin.po"
+import {
+  expectFooterContains,
+  expectNavbarContains,
+  expectSiteConfigSiteName,
+  expectSiteThemeBrandColour,
+} from "../fixtures/site-expect"
+import { ensureUserOnboarded } from "../fixtures/user"
+
+let siteId: number
+let siteName: string
+
+const parseJsonField = async (
+  admin: SiteAdminPO,
+  field: "config" | "theme" | "navbar" | "footer",
+) =>
+  JSON.parse(await admin.jsonField(field).inputValue()) as Record<
+    string,
+    unknown
+  >
+
+test.beforeAll(async () => {
+  const site = await provisionE2ESite({
+    roles: [RoleType.Admin],
+  })
+  siteId = site.siteId
+  siteName = site.siteName
+})
+
+test.describe("core", { tag: roleTag("core") }, () => {
+  test.describe.configure({ mode: "serial" })
+  test.beforeEach(async () => {
+    await ensureUserOnboarded(TEST_EMAILS.core)
+    await resetSiteAgencySettings(siteId, siteName)
+    await resetSiteTheme(siteId)
+    await resetSiteNavbar(siteId)
+    await resetSiteFooter(siteId)
+  })
+
+  test("core admin can save valid config, theme, navbar, and footer JSON", async ({
+    page,
+  }) => {
+    const admin = new SiteAdminPO(page)
+    const updatedSiteName = `Admin JSON ${crypto.randomUUID().slice(0, 8)}`
+    const brandColour = "#123456"
+    const navbarLabel = `Admin nav ${crypto.randomUUID().slice(0, 8)}`
+    const footerLabel = `Admin footer ${crypto.randomUUID().slice(0, 8)}`
+
+    // Arrange
+    await admin.goto(siteId)
+    await expect(admin.saveButton()).toBeDisabled()
+
+    const config = (await parseJsonField(admin, "config")) as {
+      siteName?: string
+    }
+    const theme = (await parseJsonField(admin, "theme")) as {
+      colors?: { brand?: { canvas?: { inverse?: string } } }
+    }
+    const navbar = (await parseJsonField(admin, "navbar")) as {
+      items?: { name?: string }[]
+    }
+    const footer = (await parseJsonField(admin, "footer")) as {
+      siteNavItems?: { title?: string }[]
+    }
+
+    config.siteName = updatedSiteName
+    if (theme.colors?.brand?.canvas) {
+      theme.colors.brand.canvas.inverse = brandColour
+    }
+    if (navbar.items?.[0]) {
+      navbar.items[0].name = navbarLabel
+    }
+    if (footer.siteNavItems?.[0]) {
+      footer.siteNavItems[0].title = footerLabel
+    }
+
+    // Act
+    await admin.fillJsonField("config", JSON.stringify(config, null, 2))
+    await admin.fillJsonField("theme", JSON.stringify(theme, null, 2))
+    await admin.fillJsonField("navbar", JSON.stringify(navbar, null, 2))
+    await admin.fillJsonField("footer", JSON.stringify(footer, null, 2))
+    await expect(admin.saveButton()).toBeEnabled()
+    await admin.clickSave()
+
+    // Assert
+    await admin.expectSavedToast()
+    await expect(admin.saveButton()).toBeDisabled()
+    await expectSiteConfigSiteName(siteId).toBe(updatedSiteName)
+    await expectSiteThemeBrandColour(siteId).toBe(brandColour)
+    await expectNavbarContains(siteId, navbarLabel).toBe(true)
+    await expectFooterContains(siteId, footerLabel).toBe(true)
+
+    await admin.reload()
+    await expect(admin.jsonField("config")).toHaveValue(
+      new RegExp(updatedSiteName),
+    )
+    await expect(admin.jsonField("theme")).toHaveValue(new RegExp(brandColour))
+    await expect(admin.jsonField("navbar")).toHaveValue(new RegExp(navbarLabel))
+    await expect(admin.jsonField("footer")).toHaveValue(new RegExp(footerLabel))
+  })
+
+  test("missing JSON prevents saving", async ({ page }) => {
+    const admin = new SiteAdminPO(page)
+
+    // Arrange
+    await admin.goto(siteId)
+
+    // Act
+    await admin.fillJsonField("navbar", "")
+    await admin.clickSave()
+
+    // Assert
+    await admin.expectFieldError("Site navbar must be present")
+    await expectNavbarContains(siteId, "Expandable nav item").toBe(true)
+  })
+
+  test("unsaved navigation prompts and retry after save failure works", async ({
+    page,
+  }) => {
+    const admin = new SiteAdminPO(page)
+    const dashboard = new DashboardPO(page)
+    const navbarLabel = `Unsaved nav ${crypto.randomUUID().slice(0, 8)}`
+
+    // Arrange
+    await admin.goto(siteId)
+    const navbar = (await parseJsonField(admin, "navbar")) as {
+      items?: { name?: string }[]
+    }
+    if (navbar.items?.[0]) {
+      navbar.items[0].name = navbarLabel
+    }
+    await admin.fillJsonField("navbar", JSON.stringify(navbar, null, 2))
+
+    // Act
+    await admin.clickSiteContentNav()
+
+    // Assert
+    await admin.expectUnsavedChangesModal()
+    await admin.clickGoBackToEditing()
+    await expect(admin.jsonField("navbar")).toHaveValue(new RegExp(navbarLabel))
+
+    // Arrange — fail the next save, then allow retry
+    await mockTrpcMutationError(page, "site.setSiteConfigByAdmin", {
+      message: "Failed to persist site config",
+      times: 1,
+    })
+
+    // Act
+    await admin.clickSave()
+
+    // Assert
+    await admin.expectSaveErrorToast()
+    await expect(admin.saveButton()).toBeEnabled()
+
+    // Act
+    await admin.clickSave()
+
+    // Assert
+    await admin.expectSavedToast()
+    await expectNavbarContains(siteId, navbarLabel).toBe(true)
+
+    // Act — dirty again, then leave
+    await admin.fillJsonField(
+      "navbar",
+      JSON.stringify(
+        { items: [{ name: "discarded", url: "/discarded" }] },
+        null,
+        2,
+      ),
+    )
+    await admin.clickSiteContentNav()
+    await admin.expectUnsavedChangesModal()
+    await admin.clickLeavePage()
+
+    // Assert
+    await dashboard.expectHomepageRowVisible()
+    await expectNavbarContains(siteId, navbarLabel).toBe(true)
+  })
+})

--- a/apps/studio/tests/e2e/site/admin-save.test.ts
+++ b/apps/studio/tests/e2e/site/admin-save.test.ts
@@ -128,11 +128,8 @@ test.describe("core", { tag: roleTag("core") }, () => {
     await expectNavbarContains(siteId, "Expandable nav item").toBe(true)
   })
 
-  test("unsaved navigation prompts and retry after save failure works", async ({
-    page,
-  }) => {
+  test("unsaved navigation prompts before leaving", async ({ page }) => {
     const admin = new SiteAdminPO(page)
-    const dashboard = new DashboardPO(page)
     const navbarLabel = `Unsaved nav ${crypto.randomUUID().slice(0, 8)}`
 
     // Arrange
@@ -152,8 +149,21 @@ test.describe("core", { tag: roleTag("core") }, () => {
     await admin.expectUnsavedChangesModal()
     await admin.clickGoBackToEditing()
     await expect(admin.jsonField("navbar")).toHaveValue(new RegExp(navbarLabel))
+  })
 
-    // Arrange — fail the next save, then allow retry
+  test("retry after save failure works", async ({ page }) => {
+    const admin = new SiteAdminPO(page)
+    const navbarLabel = `Retry nav ${crypto.randomUUID().slice(0, 8)}`
+
+    // Arrange
+    await admin.goto(siteId)
+    const navbar = (await parseJsonField(admin, "navbar")) as {
+      items?: { name?: string }[]
+    }
+    if (navbar.items?.[0]) {
+      navbar.items[0].name = navbarLabel
+    }
+    await admin.fillJsonField("navbar", JSON.stringify(navbar, null, 2))
     await mockTrpcMutationError(page, "site.setSiteConfigByAdmin", {
       message: "Failed to persist site config",
       times: 1,
@@ -166,14 +176,32 @@ test.describe("core", { tag: roleTag("core") }, () => {
     await admin.expectSaveErrorToast()
     await expect(admin.saveButton()).toBeEnabled()
 
-    // Act
+    // Act — retry hits the real mutation
     await admin.clickSave()
 
     // Assert
     await admin.expectSavedToast()
     await expectNavbarContains(siteId, navbarLabel).toBe(true)
+  })
 
-    // Act — dirty again, then leave
+  test("leaving with unsaved changes discards edits", async ({ page }) => {
+    const admin = new SiteAdminPO(page)
+    const dashboard = new DashboardPO(page)
+    const savedLabel = `Saved nav ${crypto.randomUUID().slice(0, 8)}`
+
+    // Arrange
+    await admin.goto(siteId)
+    const navbar = (await parseJsonField(admin, "navbar")) as {
+      items?: { name?: string }[]
+    }
+    if (navbar.items?.[0]) {
+      navbar.items[0].name = savedLabel
+    }
+    await admin.fillJsonField("navbar", JSON.stringify(navbar, null, 2))
+    await admin.clickSave()
+    await admin.expectSavedToast()
+
+    // Act
     await admin.fillJsonField(
       "navbar",
       JSON.stringify(
@@ -188,6 +216,6 @@ test.describe("core", { tag: roleTag("core") }, () => {
 
     // Assert
     await dashboard.expectHomepageRowVisible()
-    await expectNavbarContains(siteId, navbarLabel).toBe(true)
+    await expectNavbarContains(siteId, savedLabel).toBe(true)
   })
 })

--- a/apps/studio/tests/e2e/site/admin-save.test.ts
+++ b/apps/studio/tests/e2e/site/admin-save.test.ts
@@ -141,6 +141,7 @@ test.describe("core", { tag: roleTag("core") }, () => {
       navbar.items[0].name = navbarLabel
     }
     await admin.fillJsonField("navbar", JSON.stringify(navbar, null, 2))
+    await expect(admin.saveButton()).toBeEnabled()
 
     // Act
     await admin.clickSiteContentNav()
@@ -210,6 +211,7 @@ test.describe("core", { tag: roleTag("core") }, () => {
         2,
       ),
     )
+    await expect(admin.saveButton()).toBeEnabled()
     await admin.clickSiteContentNav()
     await admin.expectUnsavedChangesModal()
     await admin.clickLeavePage()


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +2 | -2 |
| 🧪 Test | 18 | +1329 | -71 |
| 📄 Doc | 2 | +3 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The E2E scale & coverage stack covers godmode **route access** (`access.test.ts`) but not the platform admin **actions** — creating a site, triggering a publish, and bulk-whitelisting vendor emails.

Part of the stacked E2E coverage plan (PR-10 in `docs/superpowers/plans/2026-07-24-e2e-scale-and-coverage-spec.md`), stacked on #2948.

Closes https://linear.app/ogp/issue/ISOM-2466/add-e2e-tests-for-godmode-and-raw-site-administration

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A — test-only PR

**Improvements**:

- Add `GodmodePO` page object for God Mode surfaces (hub, create-site, publishing, whitelist)
- Add `setSiteCodeBuildId` fixture helper and `mockGodmodeSitePublish` network stub (avoids real AWS CodeBuild in test env)
- Add three happy-path action tests:
  - `godmode/create-site.test.ts` — core admin creates a site → toast → redirect to `/sites/{id}`
  - `godmode/publishing.test.ts` — core admin publishes a site → success toast (UI only; publish mutation stubbed)
  - `godmode/whitelist.test.ts` — migrator bulk-whitelists vendor emails → success toast
- Refactor `godmode/access.test.ts` to use `GodmodePO` and trim redundant core route-heading checks (now covered by action tests)

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

N/A — test-only change

**AFTER**:

N/A — test-only change

## Tests

Run from `apps/studio`:

```bash
pnpm exec playwright test tests/e2e/godmode --project=core
pnpm exec playwright test tests/e2e/godmode/whitelist.test.ts --project=migrator
pnpm exec playwright test tests/e2e/godmode/access.test.ts
```

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR expands privileged Godmode and raw site-administration coverage while keeping production behavior unchanged apart from explanatory copy.
- Adds page objects and database/network helpers for Godmode and raw site administration.
- Covers site creation, configured-site publishing, bulk vendor whitelisting, authorization, retries, validation, and persisted JSON settings.
- Extends unit and router tests around site defaults, publishing, whitelist normalization, and JSON parsing.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/tests/e2e/fixtures/godmode.po.ts | Introduces reusable navigation, action, toast, access, and row assertions for Godmode surfaces. |
| apps/studio/tests/e2e/fixtures/network.ts | Adds deterministic tRPC mutation failure and Godmode publish stubs used by retry and publishing scenarios. |
| apps/studio/tests/e2e/godmode/access.test.ts | Refactors access coverage into an exhaustive role matrix using the Godmode page object. |
| apps/studio/tests/e2e/godmode/create-site.test.ts | Exercises successful and retried site creation, including persisted defaults and initial resources. |
| apps/studio/tests/e2e/godmode/publishing.test.ts | Covers configured and unconfigured publishing states plus recovery from a mocked failure. |
| apps/studio/tests/e2e/godmode/whitelist.test.ts | Covers bulk vendor whitelisting and all-or-nothing invalid-input handling with database verification. |
| apps/studio/tests/e2e/site/admin-save.test.ts | Adds end-to-end coverage for saving, validating, retrying, reloading, and discarding raw site settings. |
| apps/studio/src/server/modules/site/__tests__/site.router.test.ts | Expands router coverage for site bootstrap defaults, implicit administrator access, settings persistence, and publish behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Role[Authenticated test role] --> Access[Godmode access checks]
  Access --> Create[Create site]
  Access --> Publish[Publish configured site]
  Access --> Whitelist[Whitelist vendor emails]
  Create --> SiteDB[(Site and default content)]
  Publish --> Stub[Mocked CodeBuild mutation]
  Whitelist --> AllowlistDB[(Whitelist records)]
  Core[Core administrator] --> RawAdmin[Raw site administration]
  RawAdmin --> ConfigDB[(Config, theme, navbar, footer)]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(e2e): align site-admin unsaved modal..."](https://github.com/opengovsg/isomer/commit/6cb859fbd9da65cf38cd9d2b8648e88f95415de8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54852027)</sub>

**Context used:**

- Knowledge Base — [Content API domains](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/content-api-domains.md)

<!-- /greptile_comment -->