### PR TITLE
fix(template): disable next/link prefetch to stop RSC segment 404s

### DIFF
--- a/tooling/template/app/providers.tsx
+++ b/tooling/template/app/providers.tsx
@@ -1,9 +1,17 @@
 "use client"
 
-import type { PropsWithChildren } from "react"
+import type { ComponentProps, PropsWithChildren } from "react"
 import { LinkComponentProvider } from "@opengovsg/isomer-components"
 import Link from "next/link"
 
+// Next 16 segment-prefetch requests __next.*.txt RSC files our static export never emits,
+// so every prefetch 404s. Disabling prefetch stops those requests at the source.
+const NoPrefetchLink = (props: ComponentProps<typeof Link>) => (
+  <Link {...props} prefetch={false} />
+)
+
 export const IsomerProviders = ({ children }: PropsWithChildren) => (
-  <LinkComponentProvider value={Link}>{children}</LinkComponentProvider>
+  <LinkComponentProvider value={NoPrefetchLink}>
+    {children}
+  </LinkComponentProvider>
 )


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +10 | -2 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Next.js 16's segment-cache prefetch makes the client request per-segment RSC files at paths like `/__next._tree.txt?_rsc=…`, `/__next.$oc$permalink.__PAGE__.txt?_rsc=…` on every `next/link` prefetch and navigation. Our static export never emits those files — the `.segments` generation is patched out (`patches/next@*.patch`) to avoid `ENAMETOOLONG` build failures on long slugs — so every one of those requests 404s.

The result is ~103M 404s over 2 weeks across published sites (plus the associated `404.html` egress), and page preloading is effectively broken. The bug is a known upstream regression ([vercel/next.js#85374](https://github.com/vercel/next.js/issues/85374), absent in Next 15).

Closes ISOM-2381

## Solution

Wrap the injected `next/link` in the template's `LinkComponentProvider` with `prefetch={false}`, stopping the segment-prefetch requests at the source. Client-side navigation still works because the router falls back to the old-format `index.txt` RSC payload that our export still generates.

This is a **temporary mitigation**; re-enabling prefetch once upstream is fixed (and removing the `.segments` patch) is tracked in **ISOM-2386**.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Disable `next/link` prefetch in the published-site template so the client no longer requests `__next*.txt` / `_rsc` segment files that 404. Eliminates the ~103M 404s / 2 weeks and the associated `404.html` egress.

**Improvements**:

- Restores working client-side navigation via the old-format `index.txt` payload. No preloading regression in practice, since segment prefetch was 100% failing (404) before this change.

**Scope note**: the change lives in `tooling/template/app/providers.tsx`, which is consumed only by the published-site build (`tooling/template/app/layout.tsx`). Studio preview uses its own separate `LinkComponentProvider` (`FakeLink`) and is unaffected.

## Before & After

No visual change — this is a network-behaviour fix. Observed on a local static-export build, navigating between pages with DevTools → Network open:

**BEFORE** (navigating to a page):

```
GET /__next._head.txt?_rsc=…                    → 404
GET /__next._index.txt?_rsc=…                   → 404
GET /__next.$oc$permalink.txt?_rsc=…            → 404
GET /__next.$oc$permalink.__PAGE__.txt?_rsc=…   → 404
```

**AFTER** (navigating to a real page, e.g. `/about/`):

```
GET /about/index.txt?_rsc=…                     → 200   (page transitions client-side)
```

No `__next*.txt` requests are made; no 404s.

## Tests

**Manual Verification Steps**:

- [ ] Build and publish a test site on this template change (or point a preview build at this branch).
- [ ] Open the published site and open browser DevTools → Network; filter by `_rsc` (or `.txt`).
- [ ] Click an internal navigation link to another page on the site.
- [ ] Confirm **no** requests to `/__next*.txt?_rsc=…` appear (these returned 404 before this change).
- [ ] Confirm the destination page loads via client-side navigation, with at most a `…/index.txt?_rsc=…` request returning **200**.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Disables speculative Next.js link prefetching for published static sites while preserving navigation-time RSC loading.
- Adds a typed `NoPrefetchLink` wrapper that forces `prefetch={false}`.
- Supplies the wrapper through the published template’s `LinkComponentProvider`.
- Leaves Studio preview link handling unchanged.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the mitigation scoped to published-site links and navigation-time static RSC payloads remaining available.

The wrapper preserves all existing link props, overrides only prefetch behavior, satisfies the provider’s component contract, and does not affect the separate Studio preview provider.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated that after-build navigation now hits only the /about/index.txt?\_rsc=... request and returns HTTP 200, with earlier /\_\_next\*.txt?\_rsc 404s eliminated.
- Verified that the after build bypassed the Turbo cache and the generated layout bundle includes prefetch:!1.
- Viewed videos and screenshots showing the real generated Isomer home page and the completed About Us destination, not mocked content.
- Compared baseline and changed renderings using the home page and About Us images to confirm the visual changes.
- Inspected navigation and resource logs and the related bundle assets to corroborate the navigation and layout changes.

<a href="https://app.greptile.com/trex/runs/15968290/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/template/app/providers.tsx | Correctly replaces the published-site link provider with a type-compatible wrapper that disables unavailable segment prefetches without removing navigation-time RSC payload support. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(template): disable next/link prefetc..."](https://github.com/opengovsg/isomer/commit/ea687680cd9379d35c8fc198d02849a0caba740f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47463214)</sub>

<!-- /greptile_comment -->