### PR TITLE
feat(redirects): create wildcard redirects when moving or renaming folders

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -245,16 +245,25 @@ const SuspendableModalContent = ({
             </FormControl>
             {isAdvancedRedirectsEnabled && permalink !== originalPermalink && (
               <FormControl>
-                <Checkbox
-                  alignItems="flex-start"
-                  size="sm"
-                  {...register("shouldCreateRedirect")}
-                >
-                  <Text textStyle="body-2" color="base.content.strong">
-                    Redirect visitors from everything under the old URL to the
-                    new location.
-                  </Text>
-                </Checkbox>
+                <Controller
+                  control={control}
+                  name="shouldCreateRedirect"
+                  render={({ field: { value, onChange, ref, ...field } }) => (
+                    <Checkbox
+                      alignItems="flex-start"
+                      size="sm"
+                      isChecked={!!value}
+                      onChange={(e) => onChange(e.target.checked)}
+                      ref={ref}
+                      {...field}
+                    >
+                      <Text textStyle="body-2" color="base.content.strong">
+                        Redirect visitors from everything under the old URL to
+                        the new location.
+                      </Text>
+                    </Checkbox>
+                  )}
+                />
               </FormControl>
             )}
           </VStack>

--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -17,6 +17,7 @@ import {
 } from "@chakra-ui/react"
 import {
   Button,
+  Checkbox,
   FormErrorMessage,
   FormHelperText,
   FormLabel,
@@ -28,6 +29,7 @@ import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { generateResourceUrl } from "~/features/editing-experience/components/utils"
+import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useZodForm } from "~/lib/form"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
@@ -106,11 +108,13 @@ const SuspendableModalContent = ({
       siteId,
       resourceId: Number(folderId),
     })
+  const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
   const { register, handleSubmit, watch, control, formState } = useZodForm({
     mode: "onChange",
     defaultValues: {
       title: originalTitle,
       permalink: originalPermalink,
+      shouldCreateRedirect: true,
     },
     schema: baseEditFolderSchema.omit({ siteId: true, resourceId: true }),
   })
@@ -239,6 +243,20 @@ const SuspendableModalContent = ({
                 characters left
               </FormHelperText>
             </FormControl>
+            {isAdvancedRedirectsEnabled && permalink !== originalPermalink && (
+              <FormControl>
+                <Checkbox
+                  alignItems="flex-start"
+                  size="sm"
+                  {...register("shouldCreateRedirect")}
+                >
+                  <Text textStyle="body-2" color="base.content.strong">
+                    Redirect visitors from everything under the old URL to the
+                    new location.
+                  </Text>
+                </Checkbox>
+              </FormControl>
+            )}
           </VStack>
         </ModalBody>
         <ModalFooter>

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -19,6 +19,7 @@ import { ResourceSelector } from "~/components/ResourceSelector/ResourceSelector
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { usePermissions } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
+import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
 import { normalizeRedirectPath } from "~/schemas/redirect"
@@ -128,11 +129,20 @@ const MoveResourceContent = withSuspense(
       { enabled: !!curResourceId },
     )
 
+    const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
+
     // Only published Page/CollectionPage have a live URL worth preserving — the
     // server skips redirect creation for unpublished pages, so don't offer it.
-    const isRedirectableType =
+    const isPageRedirectable =
       (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
       publishedVersionId !== null
+    // A Folder/Collection preserves its subtree with one wildcard redirect. It
+    // has no publishedVersionId of its own, so the server decides (on published
+    // descendants); here we only gate on the advanced-redirects flag.
+    const isFolderRedirect =
+      (type === ResourceType.Folder || type === ResourceType.Collection) &&
+      isAdvancedRedirectsEnabled
+    const isRedirectableType = isPageRedirectable || isFolderRedirect
     const oldFullPermalink = normalizeRedirectPath(movedFullPermalink)
     const newFullPermalink = normalizeRedirectPath(
       `${curResourceId && destination ? destination.fullPermalink : ""}/${movedSlug}`,
@@ -178,7 +188,9 @@ const MoveResourceContent = withSuspense(
                   p="1rem"
                 >
                   <Text textStyle="body-2" color="base.content.strong">
-                    The page URL will change to {newFullPermalink}.
+                    {isFolderRedirect
+                      ? `The URL will change to ${newFullPermalink}, and every page under it will move too.`
+                      : `The page URL will change to ${newFullPermalink}.`}
                   </Text>
                 </Box>
                 {showRedirectOption && (
@@ -204,8 +216,9 @@ const MoveResourceContent = withSuspense(
                       }
                     >
                       <Text textStyle="body-2" color="base.content.strong">
-                        Check this box to automatically redirect visitors from{" "}
-                        {oldFullPermalink} to this new URL.
+                        {isFolderRedirect
+                          ? `Check this box to redirect visitors from everything under ${oldFullPermalink}/ to the new location.`
+                          : `Check this box to automatically redirect visitors from ${oldFullPermalink} to this new URL.`}
                       </Text>
                     </Checkbox>
                   </>

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -47,6 +47,10 @@ export const baseEditFolderSchema = baseFolderSchema.extend({
     .max(MAX_FOLDER_TITLE_LENGTH, {
       message: `Folder title should be shorter than ${MAX_FOLDER_TITLE_LENGTH} characters.`,
     }),
+  // When the permalink changes, preserve the old URLs of everything under this
+  // folder with a wildcard redirect. Defaults true (matches the move flow); the
+  // UI only surfaces the choice behind the advanced-redirects flag.
+  shouldCreateRedirect: z.boolean().optional().default(true),
 })
 
 export const editFolderSchema = baseEditFolderSchema.superRefine(

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -565,7 +565,11 @@ describe("folder.router", async () => {
         userId: session.userId,
         siteId: site.id,
       })
-      await db.updateTable("Resource").set({ parentId: page.id }).execute()
+      await db
+        .updateTable("Resource")
+        .set({ parentId: page.id })
+        .where("id", "=", folder.id)
+        .execute()
       const permalink = "tempora-link"
 
       // Act

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -918,6 +918,48 @@ describe("folder.router", async () => {
           .execute()
         expect(redirects).toHaveLength(0)
       })
+
+      it("allows moving a folder back to its old path, reclaiming its own wildcard", async () => {
+        // Arrange — first move /old-folder -> /new-folder creates the wildcard
+        // /old-folder/* -> folder.
+        enableAdvancedRedirects()
+        const { site, folder } = await setupFolderWithPublishedChild()
+        await caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+        })
+        const folderRef = getReferenceLink({
+          siteId: String(site.id),
+          resourceId: folder.id,
+        })
+
+        // Act — roll back /new-folder -> /old-folder. The folder's own
+        // /old-folder/* wildcard from the first move must be reclaimed, not
+        // treated as a descendant shadow that blocks the move.
+        const result = caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "old folder",
+          permalink: "old-folder",
+        })
+
+        // Assert — the rollback succeeds and the folder is back at /old-folder.
+        await expect(result).resolves.toMatchObject({ permalink: "old-folder" })
+
+        // The old-folder wildcard is reclaimed (no live redirect at /old-folder/*),
+        // and a fresh /new-folder/* wildcard preserves the vacated path.
+        const live = await db
+          .selectFrom("Redirect")
+          .select(["source", "destination"])
+          .where("siteId", "=", site.id)
+          .where("deletedAt", "is", null)
+          .execute()
+        expect(live).toEqual([
+          { source: "/new-folder/*", destination: folderRef },
+        ])
+      })
     })
   })
 

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -1,6 +1,8 @@
 import { TRPCError } from "@trpc/server"
 import { auth } from "tests/integration/helpers/auth"
 import { resetTables } from "tests/integration/helpers/db"
+import { mockFeatureFlags } from "tests/integration/helpers/growthbook/mockFeatureFlags"
+import { mockGrowthBook } from "tests/integration/helpers/growthbook/mockInstance"
 import {
   applyAuthedSession,
   applySession,
@@ -14,7 +16,9 @@ import {
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
+import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { createCallerFactory } from "~/server/trpc"
+import { getReferenceLink } from "~/utils/link"
 
 import { AuditLogEvent, db, ResourceState, ResourceType } from "../../database"
 import { folderRouter } from "../folder.router"
@@ -735,6 +739,185 @@ describe("folder.router", async () => {
       expect(auditLogs).toBeDefined()
       expect(auditLogs?.userId).toEqual(session.userId)
       expect(auditLogs?.eventType).toEqual(AuditLogEvent.ResourceUpdate)
+    })
+
+    describe("redirects on rename", () => {
+      const enableAdvancedRedirects = () => {
+        mockGrowthBook.setForcedFeatures(
+          new Map([
+            ...mockFeatureFlags,
+            [IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, true],
+          ]),
+        )
+      }
+
+      afterEach(() => {
+        // Restore the baseline forced features so the flag doesn't leak.
+        mockGrowthBook.setForcedFeatures(mockFeatureFlags)
+      })
+
+      // Sets up a root folder with one published child page, plus admin
+      // permissions on the site. Returns the ids needed to rename it.
+      const setupFolderWithPublishedChild = async ({
+        folderPermalink = "old-folder",
+        childPermalink = "child",
+      }: { folderPermalink?: string; childPermalink?: string } = {}) => {
+        const { site, folder } = await setupFolder({
+          permalink: folderPermalink,
+        })
+        const { page: child } = await setupPageResource({
+          siteId: site.id,
+          parentId: folder.id,
+          resourceType: ResourceType.Page,
+          permalink: childPermalink,
+          state: ResourceState.Published,
+          userId: session.userId,
+        })
+        await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+        return { site, folder, child }
+      }
+
+      it("blocks the rename when a published descendant would land under an existing redirect", async () => {
+        // Arrange — a published child sits at /old-folder/child. Renaming the
+        // folder to /new-folder would move it to /new-folder/child, where an
+        // existing exact redirect (pointing elsewhere) already lives and would
+        // shadow the relocated page.
+        enableAdvancedRedirects()
+        const { site, folder } = await setupFolderWithPublishedChild()
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/new-folder/child",
+            destination: "/somewhere-else",
+          })
+          .execute()
+
+        // Act
+        const result = caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+        })
+
+        // Assert — the move is rejected and rolled back (folder keeps its old
+        // permalink), rather than silently shadowing the descendant.
+        await expect(result).rejects.toThrow(
+          expect.objectContaining({ code: "CONFLICT" }),
+        )
+        const unchanged = await db
+          .selectFrom("Resource")
+          .select("permalink")
+          .where("id", "=", folder.id)
+          .executeTakeFirstOrThrow()
+        expect(unchanged.permalink).toBe("old-folder")
+      })
+
+      it("creates a wildcard redirect from the OLD path when a published descendant exists", async () => {
+        // Arrange
+        enableAdvancedRedirects()
+        const { site, folder } = await setupFolderWithPublishedChild()
+
+        // Act
+        await caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+        })
+
+        // Assert — the wildcard source is the folder's OLD full permalink
+        // (captured before Resource.permalink was rewritten), pointing back at
+        // the folder as a reference so it follows future renames.
+        const redirect = await db
+          .selectFrom("Redirect")
+          .select(["source", "destination", "deletedAt"])
+          .where("siteId", "=", site.id)
+          .executeTakeFirstOrThrow()
+        expect(redirect.source).toBe("/old-folder/*")
+        expect(redirect.destination).toBe(
+          getReferenceLink({
+            siteId: String(site.id),
+            resourceId: folder.id,
+          }),
+        )
+        expect(redirect.deletedAt).toBeNull()
+      })
+
+      it("does not create a redirect when the advanced flag is off", async () => {
+        // Arrange — flag left at its (off) baseline.
+        const { site, folder } = await setupFolderWithPublishedChild()
+
+        // Act
+        await caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+        })
+
+        // Assert
+        const redirects = await db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", site.id)
+          .execute()
+        expect(redirects).toHaveLength(0)
+      })
+
+      it("does not create a redirect when the folder has no published descendant", async () => {
+        // Arrange — the only child is a draft, so nothing is live to preserve.
+        enableAdvancedRedirects()
+        const { site, folder } = await setupFolder({ permalink: "old-folder" })
+        await setupPageResource({
+          siteId: site.id,
+          parentId: folder.id,
+          resourceType: ResourceType.Page,
+          permalink: "child",
+          state: ResourceState.Draft,
+        })
+        await setupAdminPermissions({ userId: session.userId, siteId: site.id })
+
+        // Act
+        await caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+        })
+
+        // Assert
+        const redirects = await db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", site.id)
+          .execute()
+        expect(redirects).toHaveLength(0)
+      })
+
+      it("does not create a redirect when shouldCreateRedirect is false", async () => {
+        // Arrange
+        enableAdvancedRedirects()
+        const { site, folder } = await setupFolderWithPublishedChild()
+
+        // Act
+        await caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+          shouldCreateRedirect: false,
+        })
+
+        // Assert
+        const redirects = await db
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", site.id)
+          .execute()
+        expect(redirects).toHaveLength(0)
+      })
     })
   })
 

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -866,6 +866,40 @@ describe("folder.router", async () => {
         expect(redirects).toHaveLength(0)
       })
 
+      it("still blocks the rename when a descendant would be shadowed, even with the advanced flag off", async () => {
+        // Arrange — flag left at its (off) baseline. Only redirect CREATION is
+        // gated behind the flag; validating against an already-existing
+        // redirect must not be.
+        const { site, folder } = await setupFolderWithPublishedChild()
+        await db
+          .insertInto("Redirect")
+          .values({
+            siteId: site.id,
+            source: "/new-folder/child",
+            destination: "/somewhere-else",
+          })
+          .execute()
+
+        // Act
+        const result = caller.editFolder({
+          siteId: String(site.id),
+          resourceId: folder.id,
+          title: "new folder",
+          permalink: "new-folder",
+        })
+
+        // Assert
+        await expect(result).rejects.toThrow(
+          expect.objectContaining({ code: "CONFLICT" }),
+        )
+        const unchanged = await db
+          .selectFrom("Resource")
+          .select("permalink")
+          .where("id", "=", folder.id)
+          .executeTakeFirstOrThrow()
+        expect(unchanged.permalink).toBe("old-folder")
+      })
+
       it("does not create a redirect when the folder has no published descendant", async () => {
         // Arrange — the only child is a draft, so nothing is live to preserve.
         enableAdvancedRedirects()

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -242,13 +242,13 @@ export const folderRouter = router({
           // Capture the folder's CURRENT full permalink BEFORE the update below
           // rewrites Resource.permalink — getResourceFullPermalink walks the live
           // tree, so reading it afterwards would return the NEW path and the
-          // redirect would be a no-op. Only needed on an actual permalink change
-          // with the advanced-redirects flag on.
-          const willCreateRedirect =
-            !!permalink &&
-            permalink !== oldResource.permalink &&
-            ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY)
-          const oldFullPermalink = willCreateRedirect
+          // redirect would be a no-op. Needed on any actual permalink change so
+          // the descendant shadow guard below always runs — the flag only gates
+          // whether a redirect gets CREATED, not whether the move is validated
+          // against redirects that already exist.
+          const permalinkChanged =
+            !!permalink && permalink !== oldResource.permalink
+          const oldFullPermalink = permalinkChanged
             ? await getResourceFullPermalink(
                 Number(siteId),
                 Number(resourceId),
@@ -307,7 +307,10 @@ export const folderRouter = router({
           // them with one wildcard redirect ("/old-folder/*"). oldFullPermalink
           // was captured pre-update; only the last path segment changed, so swap
           // it to derive the new full permalink without re-walking the tree.
-          if (willCreateRedirect && oldFullPermalink !== null) {
+          // Shadow validation always runs on a permalink change; only redirect
+          // creation is gated behind the flag (dark-launched until the edge
+          // resolver ships).
+          if (permalinkChanged && oldFullPermalink !== null) {
             const newFullPermalink =
               oldFullPermalink.slice(0, oldFullPermalink.lastIndexOf("/") + 1) +
               newResource.permalink
@@ -320,7 +323,9 @@ export const folderRouter = router({
                 siteId: Number(siteId),
                 resourceId,
               }),
-              shouldCreateRedirect,
+              shouldCreateRedirect:
+                shouldCreateRedirect &&
+                ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY),
               byUserId: user.id,
             })
           }

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from "@trpc/server"
 import { get, pick } from "lodash-es"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
+import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import {
   createFolderSchema,
   editFolderSchema,
@@ -21,7 +22,12 @@ import {
 import { PG_ERROR_CODES } from "../database/constants"
 import { createFolderIndexPage } from "../page/page.service"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
-import { publishResource } from "../resource/resource.service"
+import { applyFolderPermalinkChangeRedirects } from "../redirect/redirect.service"
+import {
+  getResourceFullPermalink,
+  hasPublishedDescendant,
+  publishResource,
+} from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
 
 export const folderRouter = router({
@@ -198,7 +204,10 @@ export const folderRouter = router({
   editFolder: protectedProcedure
     .input(editFolderSchema)
     .mutation(
-      async ({ ctx, input: { resourceId, permalink, title, siteId } }) => {
+      async ({
+        ctx,
+        input: { resourceId, permalink, title, siteId, shouldCreateRedirect },
+      }) => {
         await bulkValidateUserPermissionsForResources({
           siteId: Number(siteId),
           action: "update",
@@ -276,6 +285,41 @@ export const folderRouter = router({
             },
             by: user,
           })
+
+          // A renamed folder/collection changes every descendant's URL — preserve
+          // them with one wildcard redirect ("/old-folder/*"). Gated behind the
+          // advanced-redirects flag so it stays dark until the edge resolver ships.
+          if (
+            oldResource.permalink !== newResource.permalink &&
+            ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY)
+          ) {
+            const oldFullPermalink = await getResourceFullPermalink(
+              Number(siteId),
+              Number(resourceId),
+              tx,
+            )
+            if (oldFullPermalink !== null) {
+              // Only the last path segment changed, so swap it to derive the new
+              // full permalink without re-walking the ancestor chain.
+              const newFullPermalink =
+                oldFullPermalink.slice(
+                  0,
+                  oldFullPermalink.lastIndexOf("/") + 1,
+                ) + newResource.permalink
+              await applyFolderPermalinkChangeRedirects(tx, {
+                siteId: Number(siteId),
+                oldFullPermalink,
+                newFullPermalink,
+                resourceId,
+                hasLiveContent: await hasPublishedDescendant(tx, {
+                  siteId: Number(siteId),
+                  resourceId,
+                }),
+                shouldCreateRedirect,
+                byUserId: user.id,
+              })
+            }
+          }
 
           return newResource
         })

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -239,6 +239,23 @@ export const folderRouter = router({
             })
           }
 
+          // Capture the folder's CURRENT full permalink BEFORE the update below
+          // rewrites Resource.permalink — getResourceFullPermalink walks the live
+          // tree, so reading it afterwards would return the NEW path and the
+          // redirect would be a no-op. Only needed on an actual permalink change
+          // with the advanced-redirects flag on.
+          const willCreateRedirect =
+            !!permalink &&
+            permalink !== oldResource.permalink &&
+            ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY)
+          const oldFullPermalink = willCreateRedirect
+            ? await getResourceFullPermalink(
+                Number(siteId),
+                Number(resourceId),
+                tx,
+              )
+            : null
+
           const newResource = await tx
             .updateTable("Resource")
             .where("Resource.id", "=", oldResource.id)
@@ -287,38 +304,25 @@ export const folderRouter = router({
           })
 
           // A renamed folder/collection changes every descendant's URL — preserve
-          // them with one wildcard redirect ("/old-folder/*"). Gated behind the
-          // advanced-redirects flag so it stays dark until the edge resolver ships.
-          if (
-            oldResource.permalink !== newResource.permalink &&
-            ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY)
-          ) {
-            const oldFullPermalink = await getResourceFullPermalink(
-              Number(siteId),
-              Number(resourceId),
-              tx,
-            )
-            if (oldFullPermalink !== null) {
-              // Only the last path segment changed, so swap it to derive the new
-              // full permalink without re-walking the ancestor chain.
-              const newFullPermalink =
-                oldFullPermalink.slice(
-                  0,
-                  oldFullPermalink.lastIndexOf("/") + 1,
-                ) + newResource.permalink
-              await applyFolderPermalinkChangeRedirects(tx, {
+          // them with one wildcard redirect ("/old-folder/*"). oldFullPermalink
+          // was captured pre-update; only the last path segment changed, so swap
+          // it to derive the new full permalink without re-walking the tree.
+          if (willCreateRedirect && oldFullPermalink !== null) {
+            const newFullPermalink =
+              oldFullPermalink.slice(0, oldFullPermalink.lastIndexOf("/") + 1) +
+              newResource.permalink
+            await applyFolderPermalinkChangeRedirects(tx, {
+              siteId: Number(siteId),
+              oldFullPermalink,
+              newFullPermalink,
+              resourceId,
+              hasLiveContent: await hasPublishedDescendant(tx, {
                 siteId: Number(siteId),
-                oldFullPermalink,
-                newFullPermalink,
                 resourceId,
-                hasLiveContent: await hasPublishedDescendant(tx, {
-                  siteId: Number(siteId),
-                  resourceId,
-                }),
-                shouldCreateRedirect,
-                byUserId: user.id,
-              })
-            }
+              }),
+              shouldCreateRedirect,
+              byUserId: user.id,
+            })
           }
 
           return newResource

--- a/apps/studio/src/server/modules/redirect/__tests__/shadowingSourceCandidates.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/shadowingSourceCandidates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { shadowingSourceCandidates } from "../redirect.service"
+
+describe("shadowingSourceCandidates", () => {
+  it("lists the exact path then each ancestor wildcard, deepest first", () => {
+    expect(shadowingSourceCandidates("/a/b/c")).toEqual([
+      "/a/b/c",
+      "/a/b/*",
+      "/a/*",
+    ])
+  })
+
+  it("normalises the input before generating candidates", () => {
+    expect(shadowingSourceCandidates("/A/B//C/")).toEqual([
+      "/a/b/c",
+      "/a/b/*",
+      "/a/*",
+    ])
+  })
+
+  it("never emits a root wildcard for a single-segment path", () => {
+    // "/a" could only be shadowed by an exact "/a" — a root "/*" is impossible
+    // (the schema rejects it), so no wildcard candidate is produced.
+    expect(shadowingSourceCandidates("/a")).toEqual(["/a"])
+  })
+})

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -301,7 +301,9 @@ const getLiveRedirectBySource = (
 // first: the exact path, then each ancestor wildcard ("/a/b/*", then "/a/*") —
 // mirroring the edge resolver's deepest-first prefix walk. The root wildcard is
 // impossible (the schema rejects it), so the shallowest candidate is a
-// single-segment "/seg/*". Exported for unit testing.
+// single-segment "/seg/*". Deduped: when `permalink` is itself already a
+// wildcard source, the exact-path entry and the first ancestor produced by the
+// loop are the same string. Exported for unit testing.
 export const shadowingSourceCandidates = (permalink: string): string[] => {
   const source = normalizeRedirectSource(permalink)
   const segments = source.split("/").filter((segment) => segment.length > 0)
@@ -309,13 +311,16 @@ export const shadowingSourceCandidates = (permalink: string): string[] => {
   for (let depth = segments.length - 1; depth >= 1; depth--) {
     candidates.push(`/${segments.slice(0, depth).join("/")}/*`)
   }
-  return candidates
+  return [...new Set(candidates)]
 }
 
 // Finds the live redirect that would shadow `permalink` — an exact-source match
-// or the deepest matching ancestor wildcard — optionally ignoring one whose
-// destination is `excludeDestination` (the redirect pointing back at the page
-// itself, which is the reclaim case, not a shadow). Returns the
+// or the deepest matching ancestor wildcard — optionally ignoring an
+// EXACT-source match whose destination is `excludeDestination` (the redirect
+// pointing back at the page itself, which is the reclaim case, not a shadow).
+// Never excludes an ancestor wildcard match this way: a wildcard's destination
+// is the containing folder, not this page, so a wildcard sharing the excluded
+// reference is still a real shadow, not a reclaim. Returns the
 // highest-precedence match (exact beats wildcard; deeper wildcard beats
 // shallower) or null. Wildcard awareness keeps a page from silently landing
 // under a "/section/*" redirect that would redirect it away.
@@ -328,19 +333,22 @@ const findShadowingRedirect = async (
   }: { siteId: number; permalink: string; excludeDestination?: string },
 ) => {
   const candidates = shadowingSourceCandidates(permalink)
-  let query = dbInstance
+  const [exactSource, ...wildcardCandidates] = candidates
+  const rows = await dbInstance
     .selectFrom("Redirect")
     .selectAll()
     .where("siteId", "=", siteId)
     .where("source", "in", candidates)
     .where("deletedAt", "is", null)
-  if (excludeDestination !== undefined) {
-    query = query.where("destination", "!=", excludeDestination)
-  }
-  const rows = await query.execute()
+    .execute()
   const bySource = new Map(rows.map((row) => [row.source, row]))
+
+  const exactMatch = exactSource ? bySource.get(exactSource) : undefined
+  if (exactMatch && exactMatch.destination !== excludeDestination) {
+    return exactMatch
+  }
   // candidates are ordered most-specific first, so the first hit wins.
-  for (const candidate of candidates) {
+  for (const candidate of wildcardCandidates) {
     const match = bySource.get(candidate)
     if (match) return match
   }
@@ -1589,10 +1597,16 @@ export const assertPermalinkNotShadowed = async (
 // same transaction, so reading the descendants' permalinks through `tx` yields
 // their new paths. Each is checked with its own resourceId excluded, so a
 // redirect pointing back at that same descendant (a reclaim) doesn't count as a
-// shadow — matching assertPermalinkNotShadowed's per-resource semantics.
+// shadow — matching assertPermalinkNotShadowed's per-resource semantics. That
+// reclaimed redirect is a live self-loop otherwise, so clear it the same way
+// the single-resource path does via clearReclaimedRedirect.
 const assertDescendantsNotShadowed = async (
   tx: Transaction<DB>,
-  { siteId, resourceId }: { siteId: number; resourceId: string },
+  {
+    siteId,
+    resourceId,
+    byUserId,
+  }: { siteId: number; resourceId: string; byUserId: string },
 ) => {
   const descendantIds = await getPublishedDescendantResourceIds(tx, {
     siteId,
@@ -1615,6 +1629,12 @@ const assertDescendantsNotShadowed = async (
       siteId,
       newFullPermalink,
       resourceId: descendantId,
+    })
+    await clearReclaimedRedirect(tx, {
+      siteId,
+      newFullPermalink,
+      resourceId: descendantId,
+      byUserId,
     })
   }
 }
@@ -1829,7 +1849,7 @@ export const applyFolderPermalinkChangeRedirects = async (
       newFullPermalink,
       resourceId,
     })
-    await assertDescendantsNotShadowed(tx, { siteId, resourceId })
+    await assertDescendantsNotShadowed(tx, { siteId, resourceId, byUserId })
   }
   await clearReclaimedRedirect(tx, {
     siteId,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -318,16 +318,31 @@ export const shadowingSourceCandidates = (permalink: string): string[] => {
   return [...new Set(candidates)]
 }
 
-// Finds the live redirect that would shadow `permalink` — an exact-source match
-// or the deepest matching ancestor wildcard — optionally ignoring an
-// EXACT-source match whose destination is `excludeDestination` (the redirect
-// pointing back at the page itself, which is the reclaim case, not a shadow).
-// Never excludes an ancestor wildcard match this way: a wildcard's destination
-// is the containing folder, not this page, so a wildcard sharing the excluded
-// reference is still a real shadow, not a reclaim. Returns the
-// highest-precedence match (exact beats wildcard; deeper wildcard beats
-// shallower) or null. Wildcard awareness keeps a page from silently landing
-// under a "/section/*" redirect that would redirect it away.
+// First hit in `candidates` (most-specific first) that `bySource` has, so exact
+// beats wildcard and deeper wildcard beats shallower. `excludeDestination` skips
+// only an EXACT match pointing back at the resource itself (the reclaim case) —
+// a wildcard points at the containing folder, so it stays a real shadow.
+const resolveShadowingMatch = <
+  T extends { source: string; destination: string },
+>(
+  candidates: string[],
+  bySource: Map<string, T>,
+  excludeDestination?: string,
+): T | null => {
+  const [exactSource, ...wildcardCandidates] = candidates
+  const exactMatch = exactSource ? bySource.get(exactSource) : undefined
+  if (exactMatch && exactMatch.destination !== excludeDestination) {
+    return exactMatch
+  }
+  for (const candidate of wildcardCandidates) {
+    const match = bySource.get(candidate)
+    if (match) return match
+  }
+  return null
+}
+
+// Finds the live redirect that would shadow `permalink` — see
+// resolveShadowingMatch for the precedence/exclusion semantics.
 const findShadowingRedirect = async (
   dbInstance: SafeKysely,
   {
@@ -337,7 +352,6 @@ const findShadowingRedirect = async (
   }: { siteId: number; permalink: string; excludeDestination?: string },
 ) => {
   const candidates = shadowingSourceCandidates(permalink)
-  const [exactSource, ...wildcardCandidates] = candidates
   const rows = await dbInstance
     .selectFrom("Redirect")
     .selectAll()
@@ -346,17 +360,7 @@ const findShadowingRedirect = async (
     .where("deletedAt", "is", null)
     .execute()
   const bySource = new Map(rows.map((row) => [row.source, row]))
-
-  const exactMatch = exactSource ? bySource.get(exactSource) : undefined
-  if (exactMatch && exactMatch.destination !== excludeDestination) {
-    return exactMatch
-  }
-  // candidates are ordered most-specific first, so the first hit wins.
-  for (const candidate of wildcardCandidates) {
-    const match = bySource.get(candidate)
-    if (match) return match
-  }
-  return null
+  return resolveShadowingMatch(candidates, bySource, excludeDestination)
 }
 
 // Resolves a stored destination to a comparable/displayable path: a reference
@@ -614,18 +618,10 @@ export const createRedirect = async ({
   const created = await db
     .transaction()
     .execute(async (tx) => {
-      // Bound the wait for the lock so a stalled holder can't block this write
-      // indefinitely; the wait aborts as a retryable CONFLICT (see the .catch).
-      await sql`SET LOCAL lock_timeout = ${sql.lit(REDIRECT_LOCK_TIMEOUT_MS)}`.execute(
-        tx,
-      )
-      // Serialise redirect writes for this site (the same lock bulkCreateRedirects
-      // takes), so a single create and a concurrent bulk create can't each miss
-      // the other's uncommitted row in the loop/shadow guards below and both
-      // publish a loop. Released automatically at commit/rollback.
-      await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
-        tx,
-      )
+      // So a single create and a concurrent bulk create can't each miss the
+      // other's uncommitted row in the loop/shadow guards below and both publish
+      // a loop. The timed-out wait aborts as a CONFLICT (see the .catch).
+      await acquireRedirectWriteLock(tx, siteId)
 
       // Reject creating over a live redirect. A soft-deleted row for the same
       // source still holds the (siteId, source) unique constraint and is revived
@@ -782,6 +778,22 @@ const rethrowLockTimeoutAsConflict = (error: unknown): never => {
     })
   }
   throw error
+}
+
+// Taken by every redirect mutation path before its check-then-write, so a
+// concurrent write can't land on a source another path already read past — the
+// unique constraint only catches two writes racing to the SAME source. Callers
+// turn a timed-out wait into a CONFLICT via rethrowLockTimeoutAsConflict.
+const acquireRedirectWriteLock = async (
+  tx: Transaction<DB>,
+  siteId: number,
+): Promise<void> => {
+  await sql`SET LOCAL lock_timeout = ${sql.lit(REDIRECT_LOCK_TIMEOUT_MS)}`.execute(
+    tx,
+  )
+  await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
+    tx,
+  )
 }
 
 // Thrown inside the bulk insert when a source stopped being publishable between
@@ -1294,20 +1306,13 @@ export const bulkCreateRedirects = async ({
 
   try {
     const created = await db.transaction().execute(async (tx) => {
-      // Bound the wait for the lock so a stalled holder can't block this write
-      // indefinitely; the wait aborts as a retryable CONFLICT (see the catch).
-      await sql`SET LOCAL lock_timeout = ${sql.lit(REDIRECT_LOCK_TIMEOUT_MS)}`.execute(
-        tx,
-      )
-      // Serialise redirect writes for this site: two concurrent bulk creates
-      // could otherwise each miss the other's uncommitted rows in the rechecks
-      // below (READ COMMITTED doesn't see them) and both publish — e.g. one
-      // inserting /a -> /b while the other inserts /b -> /a, forming a loop. The
-      // xact lock makes the later transaction wait, so its recheck sees the
-      // committed rows and aborts. Released automatically at commit/rollback.
-      await sql`SELECT pg_advisory_xact_lock(${REDIRECT_WRITE_LOCK_NAMESPACE}, ${siteId})`.execute(
-        tx,
-      )
+      // Two concurrent bulk creates could otherwise each miss the other's
+      // uncommitted rows in the rechecks below (READ COMMITTED doesn't see them)
+      // and both publish — e.g. one inserting /a -> /b while the other inserts
+      // /b -> /a, forming a loop. The xact lock makes the later transaction
+      // wait, so its recheck sees the committed rows and aborts. The timed-out
+      // wait aborts as a CONFLICT (see the catch).
+      await acquireRedirectWriteLock(tx, siteId)
 
       // Re-read every existing row (live or soft-deleted) for these sources
       // first, so each audit entry's `before` is the real committed row. Chunked
@@ -1651,6 +1656,9 @@ const assertDescendantsNotShadowed = async (
     return
   }
 
+  // Most candidates have no row at all, so `rows` is expected to be far shorter
+  // than `allCandidates`. Keying by `source` is unambiguous: @@unique([siteId,
+  // source]) allows only one row per source, even across soft-deletes.
   const allCandidates = [
     ...new Set(descendants.flatMap(({ candidates }) => candidates)),
   ]
@@ -1669,18 +1677,8 @@ const assertDescendantsNotShadowed = async (
   ).flat()
   const bySource = new Map(rows.map((row) => [row.source, row]))
 
-  // Highest-precedence match first (exact wins over an ancestor wildcard, a
-  // deeper wildcard over a shallower one) — mirrors findShadowingRedirect, but
-  // against the single prefetched map instead of a query per descendant.
   for (const { newFullPermalink, reference, candidates } of descendants) {
-    const [exactSource, ...wildcardCandidates] = candidates
-    const exactMatch = exactSource ? bySource.get(exactSource) : undefined
-    const shadowing =
-      exactMatch && exactMatch.destination !== reference
-        ? exactMatch
-        : wildcardCandidates
-            .map((candidate) => bySource.get(candidate))
-            .find((match) => match !== undefined)
+    const shadowing = resolveShadowingMatch(candidates, bySource, reference)
     if (shadowing) {
       throw new TRPCError({
         code: "CONFLICT",
@@ -1865,6 +1863,8 @@ export const applyPermalinkChangeRedirects = async (
     return
   }
 
+  await acquireRedirectWriteLock(tx, siteId).catch(rethrowLockTimeoutAsConflict)
+
   // A published page must not land on a path a live redirect already points
   // elsewhere from — it would be shadowed (mirror of the publish-block). The
   // throw rolls back the enclosing move/rename.
@@ -1923,6 +1923,7 @@ export const applyFolderPermalinkChangeRedirects = async (
   if (oldFullPermalink === newFullPermalink) {
     return
   }
+  await acquireRedirectWriteLock(tx, siteId).catch(rethrowLockTimeoutAsConflict)
   // Mirror the page guard: a live folder must not land on a path a redirect
   // already covers (exact or wildcard). Throwing rolls back the enclosing move.
   // A folder move relocates every descendant too, so the root permalink alone

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -1619,30 +1619,19 @@ const assertDescendantsNotShadowed = async (
   }
 }
 
-// When a permalink change lands a page on a path whose redirect points back at
-// that same page (a self-shadow/loop), soft-delete it — the page reclaims its
-// URL. Scoped to redirects referencing THIS page; one pointing elsewhere is
-// blocked by assertPermalinkNotShadowed instead.
-export const clearReclaimedRedirect = async (
+// Soft-deletes the live redirect at `source` whose destination is `reference`
+// (the resource reclaiming its own URL), audits the delete, and returns the
+// updated row — or null when there is nothing to reclaim. Shared by the exact
+// (page) and wildcard (folder) reclaim paths so both delete + audit identically.
+const softDeleteReclaimedRedirect = async (
   tx: Transaction<DB>,
   {
     siteId,
-    newFullPermalink,
-    resourceId,
+    source,
+    reference,
     byUserId,
-  }: {
-    siteId: number
-    newFullPermalink: string
-    resourceId: string
-    byUserId: string
-  },
+  }: { siteId: number; source: string; reference: string; byUserId: string },
 ) => {
-  const source = normalizeRedirectSource(newFullPermalink)
-  const reference = getReferenceLink({
-    siteId: String(siteId),
-    resourceId: String(resourceId),
-  })
-
   const reclaimed = await tx
     .selectFrom("Redirect")
     .selectAll()
@@ -1670,6 +1659,65 @@ export const clearReclaimedRedirect = async (
   })
   return after
 }
+
+// When a permalink change lands a page on a path whose redirect points back at
+// that same page (a self-shadow/loop), soft-delete it — the page reclaims its
+// URL. Scoped to redirects referencing THIS page; one pointing elsewhere is
+// blocked by assertPermalinkNotShadowed instead.
+export const clearReclaimedRedirect = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    newFullPermalink,
+    resourceId,
+    byUserId,
+  }: {
+    siteId: number
+    newFullPermalink: string
+    resourceId: string
+    byUserId: string
+  },
+) =>
+  softDeleteReclaimedRedirect(tx, {
+    siteId,
+    source: normalizeRedirectSource(newFullPermalink),
+    reference: getReferenceLink({
+      siteId: String(siteId),
+      resourceId: String(resourceId),
+    }),
+    byUserId,
+  })
+
+// Folder analogue of clearReclaimedRedirect. A folder move that lands back on a
+// path this same folder previously vacated finds its own "/new/*" -> folder
+// wildcard (minted by the earlier move) still live. That is a reclaim — the
+// subtree serves directly again — not a shadow, so soft-delete it. Must run
+// BEFORE assertDescendantsNotShadowed, otherwise the descendant guard sees the
+// wildcard (whose destination is the folder, not the descendant) and wrongly
+// blocks the move.
+const clearReclaimedFolderWildcard = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    newFullPermalink,
+    resourceId,
+    byUserId,
+  }: {
+    siteId: number
+    newFullPermalink: string
+    resourceId: string
+    byUserId: string
+  },
+) =>
+  softDeleteReclaimedRedirect(tx, {
+    siteId,
+    source: normalizeRedirectSource(`${newFullPermalink}/*`),
+    reference: getReferenceLink({
+      siteId: String(siteId),
+      resourceId: String(resourceId),
+    }),
+    byUserId,
+  })
 
 // Single entry point both permalink-change flows (move and rename) call to keep
 // redirects consistent. Owns the ordering the flows depend on so they can't
@@ -1766,6 +1814,16 @@ export const applyFolderPermalinkChangeRedirects = async (
   // is not enough — each published descendant's NEW URL must also be clear of an
   // existing redirect, or the relocated page would be shadowed away.
   if (hasLiveContent) {
+    // Reclaim this folder's own "/new/*" wildcard first (left by an earlier move
+    // that vacated this path), so a move back onto it clears the redirect
+    // instead of tripping the descendant guard below on the folder's own
+    // wildcard.
+    await clearReclaimedFolderWildcard(tx, {
+      siteId,
+      newFullPermalink,
+      resourceId,
+      byUserId,
+    })
     await assertPermalinkNotShadowed(tx, {
       siteId,
       newFullPermalink,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -47,6 +47,7 @@ import { AuditLogEvent, db } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
 import {
   getDescendantResourceIds,
+  getPublishedDescendantResourceIds,
   getResourceByFullPermalink,
   getResourceFullPermalinks,
   getResourceIdByPermalink,
@@ -1582,6 +1583,42 @@ export const assertPermalinkNotShadowed = async (
   }
 }
 
+// Folder analogue of the root guard above: a move/rename relocates every
+// descendant, so each published descendant's NEW full permalink must also be
+// clear of an existing redirect. Runs AFTER Resource.permalink is updated in the
+// same transaction, so reading the descendants' permalinks through `tx` yields
+// their new paths. Each is checked with its own resourceId excluded, so a
+// redirect pointing back at that same descendant (a reclaim) doesn't count as a
+// shadow — matching assertPermalinkNotShadowed's per-resource semantics.
+const assertDescendantsNotShadowed = async (
+  tx: Transaction<DB>,
+  { siteId, resourceId }: { siteId: number; resourceId: string },
+) => {
+  const descendantIds = await getPublishedDescendantResourceIds(tx, {
+    siteId,
+    resourceId,
+  })
+  if (descendantIds.length === 0) {
+    return
+  }
+  const permalinks = await getResourceFullPermalinks(
+    siteId,
+    descendantIds.map(Number),
+    tx,
+  )
+  for (const descendantId of descendantIds) {
+    const newFullPermalink = permalinks.get(Number(descendantId))
+    if (newFullPermalink === undefined) {
+      continue
+    }
+    await assertPermalinkNotShadowed(tx, {
+      siteId,
+      newFullPermalink,
+      resourceId: descendantId,
+    })
+  }
+}
+
 // When a permalink change lands a page on a path whose redirect points back at
 // that same page (a self-shadow/loop), soft-delete it — the page reclaims its
 // URL. Scoped to redirects referencing THIS page; one pointing elsewhere is
@@ -1725,12 +1762,16 @@ export const applyFolderPermalinkChangeRedirects = async (
   }
   // Mirror the page guard: a live folder must not land on a path a redirect
   // already covers (exact or wildcard). Throwing rolls back the enclosing move.
+  // A folder move relocates every descendant too, so the root permalink alone
+  // is not enough — each published descendant's NEW URL must also be clear of an
+  // existing redirect, or the relocated page would be shadowed away.
   if (hasLiveContent) {
     await assertPermalinkNotShadowed(tx, {
       siteId,
       newFullPermalink,
       resourceId,
     })
+    await assertDescendantsNotShadowed(tx, { siteId, resourceId })
   }
   await clearReclaimedRedirect(tx, {
     siteId,
@@ -1810,6 +1851,12 @@ export const deleteRedirect = async ({
 // `destinationResourceId` is the referenced resource (null for literal/external
 // destinations) so the caller can tell whether the redirect points back at the
 // page being edited (which would be reclaimed on save, not a real warning).
+//
+// NOTE: despite the name, this returns the highest-precedence redirect that
+// would INTERCEPT `source` (via findShadowingRedirect) — an exact-source match
+// OR the deepest matching ancestor wildcard ("/news/*" for "/news/2024") — not
+// strictly a redirect whose stored source equals `source`. Callers must not
+// assume exact-match semantics.
 export const getRedirectBySource = async ({
   siteId,
   source,

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -272,8 +272,12 @@ export const resolveRedirectReferences = async ({
   })
 }
 
-const getByUser = async (byUserId: string) =>
-  db
+// Takes the caller's executor (tx when called inside an open transaction) so a
+// callsite mid-transaction doesn't open a second connection against the global
+// pool — that second connection can block indefinitely behind locks the open
+// transaction itself holds, hanging until the outer transaction commits.
+const getByUser = async (dbInstance: SafeKysely, byUserId: string) =>
+  dbInstance
     .selectFrom("User")
     .selectAll()
     .where("id", "=", byUserId)
@@ -605,7 +609,7 @@ export const createRedirect = async ({
   byUserId: string
   logger: Logger<string>
 }) => {
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(db, byUserId)
 
   const created = await db
     .transaction()
@@ -1257,7 +1261,7 @@ export const bulkCreateRedirects = async ({
   byUserId: string
   logger: Logger<string>
 }): Promise<BulkCreateRedirectsResult> => {
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(db, byUserId)
 
   const { fileError, rows } = await runBulkValidation(siteId, csv)
   if (fileError !== null || rows.some((row) => row.error !== null)) {
@@ -1523,7 +1527,7 @@ export const createRedirectForPermalinkChange = async (
     siteId: String(siteId),
     resourceId: String(resourceId),
   })
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(tx, byUserId)
 
   const existing = await tx
     .selectFrom("Redirect")
@@ -1696,7 +1700,7 @@ const assertDescendantsNotShadowed = async (
   if (reclaimed.length === 0) {
     return
   }
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(tx, byUserId)
   const reclaimedIds = reclaimed.map((row) => row.id)
   const afterRows = (
     await Promise.all(
@@ -1755,7 +1759,7 @@ const softDeleteReclaimedRedirect = async (
     return null
   }
 
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(tx, byUserId)
   const after = await tx
     .updateTable("Redirect")
     .set({ deletedAt: dbNow })
@@ -1968,7 +1972,7 @@ export const deleteRedirect = async ({
   byUserId: string
   logger: Logger<string>
 }): Promise<void> => {
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(db, byUserId)
 
   await db.transaction().execute(async (tx) => {
     const before = await tx
@@ -2122,7 +2126,7 @@ export const softDeleteRedirectsPointingToResource = async (
     return []
   }
 
-  const byUser = await getByUser(byUserId)
+  const byUser = await getByUser(tx, byUserId)
   // Soft-delete the whole set in one statement, then emit a per-redirect audit
   // entry (mirroring deleteRedirect) by pairing each before-row with its
   // committed after-row.

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -1598,8 +1598,15 @@ export const assertPermalinkNotShadowed = async (
 // their new paths. Each is checked with its own resourceId excluded, so a
 // redirect pointing back at that same descendant (a reclaim) doesn't count as a
 // shadow — matching assertPermalinkNotShadowed's per-resource semantics. That
-// reclaimed redirect is a live self-loop otherwise, so clear it the same way
-// the single-resource path does via clearReclaimedRedirect.
+// reclaimed redirect is a live self-loop otherwise, so it's cleared the same
+// way the single-resource path does via clearReclaimedRedirect.
+//
+// Batched into a constant number of queries regardless of descendant count —
+// one candidate lookup, one soft-delete, one audit insert (each chunked, like
+// the bulk-upload path) — rather than looping assertPermalinkNotShadowed +
+// clearReclaimedRedirect per descendant. A folder with hundreds of published
+// descendants would otherwise run thousands of sequential round trips inside
+// this one transaction, holding its locks far longer than needed.
 const assertDescendantsNotShadowed = async (
   tx: Transaction<DB>,
   {
@@ -1620,22 +1627,106 @@ const assertDescendantsNotShadowed = async (
     descendantIds.map(Number),
     tx,
   )
-  for (const descendantId of descendantIds) {
+  const descendants = descendantIds.flatMap((descendantId) => {
     const newFullPermalink = permalinks.get(Number(descendantId))
     if (newFullPermalink === undefined) {
-      continue
+      return []
     }
-    await assertPermalinkNotShadowed(tx, {
-      siteId,
-      newFullPermalink,
-      resourceId: descendantId,
-    })
-    await clearReclaimedRedirect(tx, {
-      siteId,
-      newFullPermalink,
-      resourceId: descendantId,
-      byUserId,
-    })
+    return [
+      {
+        newFullPermalink,
+        reference: getReferenceLink({
+          siteId: String(siteId),
+          resourceId: String(descendantId),
+        }),
+        candidates: shadowingSourceCandidates(newFullPermalink),
+      },
+    ]
+  })
+  if (descendants.length === 0) {
+    return
+  }
+
+  const allCandidates = [
+    ...new Set(descendants.flatMap(({ candidates }) => candidates)),
+  ]
+  const rows = (
+    await Promise.all(
+      chunk(allCandidates, BULK_REDIRECT_INSERT_CHUNK_SIZE).map((batch) =>
+        tx
+          .selectFrom("Redirect")
+          .selectAll()
+          .where("siteId", "=", siteId)
+          .where("source", "in", batch)
+          .where("deletedAt", "is", null)
+          .execute(),
+      ),
+    )
+  ).flat()
+  const bySource = new Map(rows.map((row) => [row.source, row]))
+
+  // Highest-precedence match first (exact wins over an ancestor wildcard, a
+  // deeper wildcard over a shallower one) — mirrors findShadowingRedirect, but
+  // against the single prefetched map instead of a query per descendant.
+  for (const { newFullPermalink, reference, candidates } of descendants) {
+    const [exactSource, ...wildcardCandidates] = candidates
+    const exactMatch = exactSource ? bySource.get(exactSource) : undefined
+    const shadowing =
+      exactMatch && exactMatch.destination !== reference
+        ? exactMatch
+        : wildcardCandidates
+            .map((candidate) => bySource.get(candidate))
+            .find((match) => match !== undefined)
+    if (shadowing) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message: `A redirect at ${shadowing.source} already covers ${newFullPermalink}. Remove it on the Redirections page first.`,
+      })
+    }
+  }
+
+  // A descendant reclaiming its own URL (its exact-source redirect points back
+  // at itself) is a self-loop otherwise — soft-delete every one in one update
+  // plus one audit insert, instead of a select+update+insert per descendant.
+  const reclaimed = descendants.flatMap(({ candidates, reference }) => {
+    const exactSource = candidates[0]
+    const match = exactSource ? bySource.get(exactSource) : undefined
+    return match && match.destination === reference ? [match] : []
+  })
+  if (reclaimed.length === 0) {
+    return
+  }
+  const byUser = await getByUser(byUserId)
+  const reclaimedIds = reclaimed.map((row) => row.id)
+  const afterRows = (
+    await Promise.all(
+      chunk(reclaimedIds, BULK_REDIRECT_INSERT_CHUNK_SIZE).map((batch) =>
+        tx
+          .updateTable("Redirect")
+          .set({ deletedAt: dbNow })
+          .where("id", "in", batch)
+          .returningAll()
+          .execute(),
+      ),
+    )
+  ).flat()
+  const beforeById = new Map(reclaimed.map((row) => [row.id, row]))
+  const auditValues = afterRows.flatMap((after) => {
+    const before = beforeById.get(after.id)
+    return before
+      ? [
+          {
+            siteId,
+            eventType: AuditLogEvent.RedirectDelete,
+            delta: { before, after },
+            userId: byUser.id,
+            metadata: {},
+          },
+        ]
+      : []
+  })
+  for (const batch of chunk(auditValues, BULK_REDIRECT_INSERT_CHUNK_SIZE)) {
+    await tx.insertInto("AuditLog").values(batch).execute()
   }
 }
 

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -296,6 +296,56 @@ const getLiveRedirectBySource = (
     .where("deletedAt", "is", null)
     .executeTakeFirst()
 
+// Redirect sources that would intercept a request to `permalink`, most specific
+// first: the exact path, then each ancestor wildcard ("/a/b/*", then "/a/*") —
+// mirroring the edge resolver's deepest-first prefix walk. The root wildcard is
+// impossible (the schema rejects it), so the shallowest candidate is a
+// single-segment "/seg/*". Exported for unit testing.
+export const shadowingSourceCandidates = (permalink: string): string[] => {
+  const source = normalizeRedirectSource(permalink)
+  const segments = source.split("/").filter((segment) => segment.length > 0)
+  const candidates = [source]
+  for (let depth = segments.length - 1; depth >= 1; depth--) {
+    candidates.push(`/${segments.slice(0, depth).join("/")}/*`)
+  }
+  return candidates
+}
+
+// Finds the live redirect that would shadow `permalink` — an exact-source match
+// or the deepest matching ancestor wildcard — optionally ignoring one whose
+// destination is `excludeDestination` (the redirect pointing back at the page
+// itself, which is the reclaim case, not a shadow). Returns the
+// highest-precedence match (exact beats wildcard; deeper wildcard beats
+// shallower) or null. Wildcard awareness keeps a page from silently landing
+// under a "/section/*" redirect that would redirect it away.
+const findShadowingRedirect = async (
+  dbInstance: SafeKysely,
+  {
+    siteId,
+    permalink,
+    excludeDestination,
+  }: { siteId: number; permalink: string; excludeDestination?: string },
+) => {
+  const candidates = shadowingSourceCandidates(permalink)
+  let query = dbInstance
+    .selectFrom("Redirect")
+    .selectAll()
+    .where("siteId", "=", siteId)
+    .where("source", "in", candidates)
+    .where("deletedAt", "is", null)
+  if (excludeDestination !== undefined) {
+    query = query.where("destination", "!=", excludeDestination)
+  }
+  const rows = await query.execute()
+  const bySource = new Map(rows.map((row) => [row.source, row]))
+  // candidates are ordered most-specific first, so the first hit wins.
+  for (const candidate of candidates) {
+    const match = bySource.get(candidate)
+    if (match) return match
+  }
+  return null
+}
+
 // Resolves a stored destination to a comparable/displayable path: a reference
 // to the page's current permalink, a literal path normalised, an external URL
 // (or a reference to a missing page) verbatim.
@@ -1444,14 +1494,22 @@ export const createRedirectForPermalinkChange = async (
     oldFullPermalink,
     resourceId,
     byUserId,
+    wildcard = false,
   }: {
     siteId: number
     oldFullPermalink: string
     resourceId: string
     byUserId: string
+    // When true, store a trailing-"/*" wildcard covering the old subtree (used
+    // by folder/collection moves so one rule redirects every descendant). The
+    // destination reference resolves to the resource's new permalink and the
+    // edge resolver appends the matched remainder.
+    wildcard?: boolean
   },
 ) => {
-  const source = normalizeRedirectSource(oldFullPermalink)
+  const source = normalizeRedirectSource(
+    wildcard ? `${oldFullPermalink}/*` : oldFullPermalink,
+  )
   const destination = getReferenceLink({
     siteId: String(siteId),
     resourceId: String(resourceId),
@@ -1511,18 +1569,15 @@ export const assertPermalinkNotShadowed = async (
     siteId: String(siteId),
     resourceId: String(resourceId),
   })
-  const shadowing = await tx
-    .selectFrom("Redirect")
-    .select("Redirect.id")
-    .where("Redirect.siteId", "=", siteId)
-    .where("Redirect.source", "=", normalizeRedirectSource(newFullPermalink))
-    .where("Redirect.destination", "!=", reference)
-    .where("Redirect.deletedAt", "is", null)
-    .executeTakeFirst()
+  const shadowing = await findShadowingRedirect(tx, {
+    siteId,
+    permalink: newFullPermalink,
+    excludeDestination: reference,
+  })
   if (shadowing) {
     throw new TRPCError({
       code: "CONFLICT",
-      message: `A redirect already exists at ${newFullPermalink}. Remove it on the Redirections page first.`,
+      message: `A redirect at ${shadowing.source} already covers ${newFullPermalink}. Remove it on the Redirections page first.`,
     })
   }
 }
@@ -1638,6 +1693,62 @@ export const applyPermalinkChangeRedirects = async (
   }
 }
 
+// Folder/collection variant of applyPermalinkChangeRedirects. A folder has no URL
+// of its own to redirect, but its move/rename changes every descendant's URL, so
+// one wildcard redirect ("/old-folder/*" -> the folder reference) preserves them
+// all at once. `hasLiveContent` is the folder analogue of a page's `isPublished`
+// — true when at least one descendant is published — so we don't mint redirects
+// for a subtree that was never reachable. Runs in the caller's transaction and
+// publishes nothing.
+export const applyFolderPermalinkChangeRedirects = async (
+  tx: Transaction<DB>,
+  {
+    siteId,
+    oldFullPermalink,
+    newFullPermalink,
+    resourceId,
+    hasLiveContent,
+    shouldCreateRedirect,
+    byUserId,
+  }: {
+    siteId: number
+    oldFullPermalink: string
+    newFullPermalink: string
+    resourceId: string
+    hasLiveContent: boolean
+    shouldCreateRedirect: boolean
+    byUserId: string
+  },
+) => {
+  if (oldFullPermalink === newFullPermalink) {
+    return
+  }
+  // Mirror the page guard: a live folder must not land on a path a redirect
+  // already covers (exact or wildcard). Throwing rolls back the enclosing move.
+  if (hasLiveContent) {
+    await assertPermalinkNotShadowed(tx, {
+      siteId,
+      newFullPermalink,
+      resourceId,
+    })
+  }
+  await clearReclaimedRedirect(tx, {
+    siteId,
+    newFullPermalink,
+    resourceId,
+    byUserId,
+  })
+  if (shouldCreateRedirect && hasLiveContent) {
+    await createRedirectForPermalinkChange(tx, {
+      siteId,
+      oldFullPermalink,
+      resourceId,
+      byUserId,
+      wildcard: true,
+    })
+  }
+}
+
 export const deleteRedirect = async ({
   siteId,
   id,
@@ -1706,9 +1817,9 @@ export const getRedirectBySource = async ({
   destination: string
   destinationResourceId: number | null
 } | null> => {
-  const redirect = await getLiveRedirectBySource(db, {
+  const redirect = await findShadowingRedirect(db, {
     siteId,
-    source: normalizeRedirectSource(source),
+    permalink: source,
   })
   if (!redirect) {
     return null

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -2,6 +2,8 @@ import { TRPCError } from "@trpc/server"
 import { omit, pick } from "lodash-es"
 import { auth } from "tests/integration/helpers/auth"
 import { resetTables } from "tests/integration/helpers/db"
+import { mockFeatureFlags } from "tests/integration/helpers/growthbook/mockFeatureFlags"
+import { mockGrowthBook } from "tests/integration/helpers/growthbook/mockInstance"
 import {
   applyAuthedSession,
   applySession,
@@ -23,6 +25,7 @@ import {
   setUpWhitelist,
 } from "tests/integration/helpers/seed"
 import { USER_VIEWABLE_RESOURCE_TYPES } from "~/constants/resources"
+import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { MAX_BATCH_RESOURCE_IDS } from "~/schemas/resource"
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"
@@ -2075,6 +2078,107 @@ describe("resource.router", async () => {
         expect(redirects[0]!.destination).toBe(
           `[resource:${site.id}:${page.id}]`,
         )
+      })
+
+      describe("folder/collection", () => {
+        const enableAdvancedRedirects = () => {
+          mockGrowthBook.setForcedFeatures(
+            new Map([
+              ...mockFeatureFlags,
+              [IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, true],
+            ]),
+          )
+        }
+
+        afterEach(() => {
+          // Restore the baseline forced features so the flag doesn't leak.
+          mockGrowthBook.setForcedFeatures(mockFeatureFlags)
+        })
+
+        // A folder ("/dest/src-folder") with one published child page,
+        // alongside a sibling destination folder ("/dest") to move it into.
+        const setupMoveWithPublishedChild = async () => {
+          const { site, rootPage, folder: destinationFolder } = await setup()
+          const { folder: sourceFolder } = await setupFolder({
+            siteId: site.id,
+            parentId: rootPage.id,
+            permalink: "src-folder",
+          })
+          await setupPageResource({
+            siteId: site.id,
+            resourceType: ResourceType.Page,
+            parentId: sourceFolder.id,
+            permalink: "child",
+            state: ResourceState.Published,
+            userId: session.userId,
+          })
+          return { site, rootPage, sourceFolder, destinationFolder }
+        }
+
+        it("creates a wildcard redirect from the old path for a published folder", async () => {
+          enableAdvancedRedirects()
+          const { site, sourceFolder, destinationFolder } =
+            await setupMoveWithPublishedChild()
+
+          await caller.move({
+            siteId: site.id,
+            movedResourceId: sourceFolder.id,
+            destinationResourceId: destinationFolder.id,
+            shouldCreateRedirect: true,
+          })
+
+          const redirects = await liveRedirects(site.id)
+          expect(redirects).toHaveLength(1)
+          expect(redirects[0]!.source).toBe("/src-folder/*")
+          expect(redirects[0]!.destination).toBe(
+            `[resource:${site.id}:${sourceFolder.id}]`,
+          )
+        })
+
+        it("does not create a redirect when the advanced flag is off", async () => {
+          // Arrange — flag left at its (off) baseline.
+          const { site, sourceFolder, destinationFolder } =
+            await setupMoveWithPublishedChild()
+
+          await caller.move({
+            siteId: site.id,
+            movedResourceId: sourceFolder.id,
+            destinationResourceId: destinationFolder.id,
+            shouldCreateRedirect: true,
+          })
+
+          expect(await liveRedirects(site.id)).toHaveLength(0)
+        })
+
+        it("still blocks the move when a descendant would be shadowed, even with the flag off", async () => {
+          // Only redirect CREATION is gated behind the flag; validating
+          // against an already-existing redirect must not be.
+          const { site, rootPage, sourceFolder, destinationFolder } =
+            await setupMoveWithPublishedChild()
+          await db
+            .insertInto("Redirect")
+            .values({
+              siteId: site.id,
+              source: "/dest/src-folder/child",
+              destination: "https://example.gov.sg/elsewhere",
+            })
+            .execute()
+
+          const result = caller.move({
+            siteId: site.id,
+            movedResourceId: sourceFolder.id,
+            destinationResourceId: destinationFolder.id,
+            shouldCreateRedirect: false,
+          })
+
+          await expect(result).rejects.toMatchObject({ code: "CONFLICT" })
+          const stillThere = await db
+            .selectFrom("Resource")
+            .select("parentId")
+            .where("id", "=", sourceFolder.id)
+            .executeTakeFirstOrThrow()
+          expect(String(stillThere.parentId)).toBe(String(rootPage.id))
+        })
       })
     })
   })

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -571,25 +571,27 @@ export const resourceRouter = router({
 
             // A Folder/Collection has no URL of its own, but the move changes
             // every descendant's URL — preserve them with one wildcard redirect
-            // ("/old-folder/*"). Gated behind the advanced-redirects flag so it
-            // stays dark until the edge resolver ships (otherwise the flag being
-            // off in the UI still defaults shouldCreateRedirect to true here).
+            // ("/old-folder/*"), and validate no descendant lands on a URL an
+            // existing redirect already covers. Shadow validation always runs on
+            // a move; only redirect creation is gated behind the advanced-
+            // redirects flag so it stays dark until the edge resolver ships.
             if (
               (toMove.type === ResourceType.Folder ||
                 toMove.type === ResourceType.Collection) &&
-              oldFullPermalink !== null &&
-              ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY)
+              oldFullPermalink !== null
             ) {
               await applyFolderPermalinkChangeRedirects(tx, {
                 siteId,
                 oldFullPermalink,
                 newFullPermalink,
                 resourceId: movedResourceId,
+                shouldCreateRedirect:
+                  shouldCreateRedirect &&
+                  ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY),
                 hasLiveContent: await hasPublishedDescendant(tx, {
                   siteId,
                   resourceId: movedResourceId,
                 }),
-                shouldCreateRedirect,
                 byUserId: user.id,
               })
             }

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from "@trpc/server"
 import { jsonObjectFrom } from "kysely/helpers/postgres"
 import { get } from "lodash-es"
 import { USER_LINKABLE_RESOURCE_TYPES } from "~/constants/resources"
+import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import {
   countResourceSchema,
   deleteResourceSchema,
@@ -39,6 +40,7 @@ import {
   getResourcePermission,
 } from "../permissions/permissions.service"
 import {
+  applyFolderPermalinkChangeRedirects,
   applyPermalinkChangeRedirects,
   softDeleteRedirectsPointingToResource,
 } from "../redirect/redirect.service"
@@ -52,6 +54,7 @@ import {
   getSearchResults,
   getSearchWithResourceIds,
   getWithFullPermalink,
+  hasPublishedDescendant,
   publishResource,
 } from "./resource.service"
 
@@ -548,8 +551,8 @@ export const resourceRouter = router({
               by: user,
             })
 
-            // Keep redirects consistent with the new URL — Page/CollectionPage
-            // only (folders/collection links have no URL of their own).
+            // Keep redirects consistent with the new URL. Page/CollectionPage
+            // get a single exact redirect for their own URL.
             if (
               (toMove.type === ResourceType.Page ||
                 toMove.type === ResourceType.CollectionPage) &&
@@ -561,6 +564,31 @@ export const resourceRouter = router({
                 newFullPermalink,
                 resourceId: movedResourceId,
                 isPublished: toMove.publishedVersionId !== null,
+                shouldCreateRedirect,
+                byUserId: user.id,
+              })
+            }
+
+            // A Folder/Collection has no URL of its own, but the move changes
+            // every descendant's URL — preserve them with one wildcard redirect
+            // ("/old-folder/*"). Gated behind the advanced-redirects flag so it
+            // stays dark until the edge resolver ships (otherwise the flag being
+            // off in the UI still defaults shouldCreateRedirect to true here).
+            if (
+              (toMove.type === ResourceType.Folder ||
+                toMove.type === ResourceType.Collection) &&
+              oldFullPermalink !== null &&
+              ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY)
+            ) {
+              await applyFolderPermalinkChangeRedirects(tx, {
+                siteId,
+                oldFullPermalink,
+                newFullPermalink,
+                resourceId: movedResourceId,
+                hasLiveContent: await hasPublishedDescendant(tx, {
+                  siteId,
+                  resourceId: movedResourceId,
+                }),
                 shouldCreateRedirect,
                 byUserId: user.id,
               })

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -765,6 +765,28 @@ export const getResourceFullPermalink = async (
   return `/${permalinkTree.join("/")}`
 }
 
+// The `subtree` CTE shared by the walks below; callers continue with their own
+// `.selectFrom("subtree")`. `union` (not `unionAll`) dedupes rows so a malformed
+// parent chain with a cycle can't drive the recursion forever.
+const withResourceSubtree = (
+  trx: SafeKysely,
+  { siteId, resourceId }: { siteId: number; resourceId: string },
+) =>
+  trx.withRecursive("subtree", (eb) =>
+    eb
+      .selectFrom("Resource")
+      .where("Resource.siteId", "=", siteId)
+      .where("Resource.id", "=", resourceId)
+      .select("Resource.id")
+      .union((fb) =>
+        fb
+          .selectFrom("Resource")
+          .innerJoin("subtree", "subtree.id", "Resource.parentId")
+          .where("Resource.siteId", "=", siteId)
+          .select("Resource.id"),
+      ),
+  )
+
 // Returns the id of `resourceId` plus every descendant in its subtree — the
 // rows a cascading delete (Resource.parentId is onDelete: Cascade) removes.
 // Accepts a tx so the delete path and the count path resolve the same set.
@@ -772,23 +794,7 @@ export const getDescendantResourceIds = async (
   trx: SafeKysely,
   { siteId, resourceId }: { siteId: number; resourceId: string },
 ): Promise<string[]> => {
-  const rows = await trx
-    .withRecursive("subtree", (eb) =>
-      eb
-        .selectFrom("Resource")
-        .where("Resource.siteId", "=", siteId)
-        .where("Resource.id", "=", resourceId)
-        .select("Resource.id")
-        // `union` (not `unionAll`) dedupes rows so a malformed parent chain with
-        // a cycle can't drive the recursion forever.
-        .union((fb) =>
-          fb
-            .selectFrom("Resource")
-            .innerJoin("subtree", "subtree.id", "Resource.parentId")
-            .where("Resource.siteId", "=", siteId)
-            .select("Resource.id"),
-        ),
-    )
+  const rows = await withResourceSubtree(trx, { siteId, resourceId })
     .selectFrom("subtree")
     .select("id")
     .execute()
@@ -798,7 +804,9 @@ export const getDescendantResourceIds = async (
 // True when `resourceId` or any descendant is published — the folder analogue of
 // a page's `publishedVersionId !== null`, used to decide whether a folder/
 // collection move or rename should preserve its old URLs with a redirect (there
-// is nothing to preserve for a subtree that was never live).
+// is nothing to preserve for a subtree that was never live). Keys on
+// publishedVersionId, not `state`: nothing unpublishes a resource today, so the
+// two only ever change together (see version.service.ts).
 export const hasPublishedDescendant = async (
   trx: SafeKysely,
   { siteId, resourceId }: { siteId: number; resourceId: string },
@@ -806,23 +814,7 @@ export const hasPublishedDescendant = async (
   // Fold the published filter into the recursive walk and stop at the first
   // hit — an existence check that never materialises the full subtree id list
   // or issues a second `WHERE id IN (...)` query.
-  const published = await trx
-    .withRecursive("subtree", (eb) =>
-      eb
-        .selectFrom("Resource")
-        .where("Resource.siteId", "=", siteId)
-        .where("Resource.id", "=", resourceId)
-        .select("Resource.id")
-        // `union` (not `unionAll`) dedupes rows so a malformed parent chain with
-        // a cycle can't drive the recursion forever.
-        .union((fb) =>
-          fb
-            .selectFrom("Resource")
-            .innerJoin("subtree", "subtree.id", "Resource.parentId")
-            .where("Resource.siteId", "=", siteId)
-            .select("Resource.id"),
-        ),
-    )
+  const published = await withResourceSubtree(trx, { siteId, resourceId })
     .selectFrom("subtree")
     .innerJoin("Resource", "Resource.id", "subtree.id")
     .where("Resource.publishedVersionId", "is not", null)
@@ -839,21 +831,7 @@ export const getPublishedDescendantResourceIds = async (
   trx: SafeKysely,
   { siteId, resourceId }: { siteId: number; resourceId: string },
 ): Promise<string[]> => {
-  const rows = await trx
-    .withRecursive("subtree", (eb) =>
-      eb
-        .selectFrom("Resource")
-        .where("Resource.siteId", "=", siteId)
-        .where("Resource.id", "=", resourceId)
-        .select("Resource.id")
-        .union((fb) =>
-          fb
-            .selectFrom("Resource")
-            .innerJoin("subtree", "subtree.id", "Resource.parentId")
-            .where("Resource.siteId", "=", siteId)
-            .select("Resource.id"),
-        ),
-    )
+  const rows = await withResourceSubtree(trx, { siteId, resourceId })
     .selectFrom("subtree")
     .innerJoin("Resource", "Resource.id", "subtree.id")
     .where("Resource.id", "!=", resourceId)

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -801,16 +801,64 @@ export const hasPublishedDescendant = async (
   trx: SafeKysely,
   { siteId, resourceId }: { siteId: number; resourceId: string },
 ): Promise<boolean> => {
-  const ids = await getDescendantResourceIds(trx, { siteId, resourceId })
-  if (ids.length === 0) return false
+  // Fold the published filter into the recursive walk and stop at the first
+  // hit — an existence check that never materialises the full subtree id list
+  // or issues a second `WHERE id IN (...)` query.
   const published = await trx
-    .selectFrom("Resource")
-    .select("Resource.id")
-    .where("Resource.siteId", "=", siteId)
-    .where("Resource.id", "in", ids)
+    .withRecursive("subtree", (eb) =>
+      eb
+        .selectFrom("Resource")
+        .where("Resource.siteId", "=", siteId)
+        .where("Resource.id", "=", resourceId)
+        .select("Resource.id")
+        // `union` (not `unionAll`) dedupes rows so a malformed parent chain with
+        // a cycle can't drive the recursion forever.
+        .union((fb) =>
+          fb
+            .selectFrom("Resource")
+            .innerJoin("subtree", "subtree.id", "Resource.parentId")
+            .where("Resource.siteId", "=", siteId)
+            .select("Resource.id"),
+        ),
+    )
+    .selectFrom("subtree")
+    .innerJoin("Resource", "Resource.id", "subtree.id")
     .where("Resource.publishedVersionId", "is not", null)
+    .select("Resource.id")
     .executeTakeFirst()
   return published !== undefined
+}
+
+// Ids of the published resources strictly within `resourceId`'s subtree (the
+// container itself is excluded — its own URL is validated separately). Used to
+// check that a folder move/rename doesn't drop a live descendant onto a path an
+// existing redirect already covers.
+export const getPublishedDescendantResourceIds = async (
+  trx: SafeKysely,
+  { siteId, resourceId }: { siteId: number; resourceId: string },
+): Promise<string[]> => {
+  const rows = await trx
+    .withRecursive("subtree", (eb) =>
+      eb
+        .selectFrom("Resource")
+        .where("Resource.siteId", "=", siteId)
+        .where("Resource.id", "=", resourceId)
+        .select("Resource.id")
+        .union((fb) =>
+          fb
+            .selectFrom("Resource")
+            .innerJoin("subtree", "subtree.id", "Resource.parentId")
+            .where("Resource.siteId", "=", siteId)
+            .select("Resource.id"),
+        ),
+    )
+    .selectFrom("subtree")
+    .innerJoin("Resource", "Resource.id", "subtree.id")
+    .where("Resource.id", "!=", resourceId)
+    .where("Resource.publishedVersionId", "is not", null)
+    .select("Resource.id")
+    .execute()
+  return rows.map((row) => String(row.id))
 }
 
 // Resolves a full permalink path (e.g. "/foo/bar") to the resource that serves
@@ -908,6 +956,7 @@ export const getResourceByFullPermalink = async ({
 export const getResourceFullPermalinks = async (
   siteId: number,
   resourceIds: number[],
+  trx: SafeKysely = db,
 ): Promise<Map<number, string>> => {
   if (resourceIds.length === 0) {
     return new Map()
@@ -916,8 +965,9 @@ export const getResourceFullPermalinks = async (
   // One recursive walk collects every node on the requested ids' ancestor
   // chains. A node's permalink and parentId are intrinsic to its id (not to
   // which chain reached it), so a single id-keyed map lets each requested id
-  // walk from itself up to the root.
-  const rows = await db
+  // walk from itself up to the root. Pass a `trx` to read uncommitted changes
+  // (e.g. a rename mid-transaction) rather than the committed tree.
+  const rows = await trx
     .withRecursive("PermalinkChain", (eb) =>
       eb
         // Base case: the resources we want permalinks for

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -729,7 +729,9 @@ export const getResourcePermalinkTree = async (
           .where("Resource.siteId", "=", siteId)
           .where("Resource.id", "=", String(resourceId))
           .select(defaultResourceSelect)
-          .unionAll((fb) =>
+          // `union` (not `unionAll`) dedupes rows so a malformed parent chain with
+          // a cycle can't drive the recursion forever.
+          .union((fb) =>
             fb
               // Recursive case: Get all the ancestors of the resource
               .selectFrom("Resource")

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -793,6 +793,26 @@ export const getDescendantResourceIds = async (
   return rows.map((row) => String(row.id))
 }
 
+// True when `resourceId` or any descendant is published — the folder analogue of
+// a page's `publishedVersionId !== null`, used to decide whether a folder/
+// collection move or rename should preserve its old URLs with a redirect (there
+// is nothing to preserve for a subtree that was never live).
+export const hasPublishedDescendant = async (
+  trx: SafeKysely,
+  { siteId, resourceId }: { siteId: number; resourceId: string },
+): Promise<boolean> => {
+  const ids = await getDescendantResourceIds(trx, { siteId, resourceId })
+  if (ids.length === 0) return false
+  const published = await trx
+    .selectFrom("Resource")
+    .select("Resource.id")
+    .where("Resource.siteId", "=", siteId)
+    .where("Resource.id", "in", ids)
+    .where("Resource.publishedVersionId", "is not", null)
+    .executeTakeFirst()
+  return published !== undefined
+}
+
 // Resolves a full permalink path (e.g. "/foo/bar") to the resource that serves
 // it, walking permalink segments from the site's root page. A Folder/Collection
 // is resolved to its IndexPage child, since that is what actually renders at the


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 7 | +599 | -90 |
| 🧪 Test | 3 | +395 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Moving or renaming a folder or collection changes the URL of every page underneath it, but Studio created no redirects for those pages — visitors and search engines hitting the old URLs got 404s. Redirect-on-move existed only for individual `Page`/`CollectionPage` resources.

Separately, now that wildcard redirects exist, a wildcard like `/section/*` can shadow a page that later lands under it. The existing "shadow" guard only matched an exact redirect source, so a page moved or renamed onto a wildcard-covered path would be silently redirected away.

Closes [insert issue #]

## Solution

When a folder/collection's URL changes, preserve its whole subtree with a single **wildcard redirect** (`/old-folder/*` → the folder), and extend the shadow guard so wildcard redirects are taken into account when a page arrives at a new URL.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Moving a folder/collection (`MoveResourceModal`) or renaming one (`FolderSettingsModal`) now offers a "create a redirect" checkbox, mirroring the page flow. The copy is subtree-aware ("redirect everything under `/old-folder/` to the new location").
- On confirm, the server creates **one wildcard redirect** `/old-folder/*` whose destination is a `[resource:folderId]` reference, so it follows future moves and the edge resolver appends the matched remainder (`/old-folder/child` → `/new-folder/child`). One rule covers the entire subtree instead of one redirect per descendant page.

**Improvements**:

- The shadow guard (`assertPermalinkNotShadowed`, and the page-settings warning via `getRedirectBySource`) now walks the exact path plus each ancestor wildcard, deepest first — so moving/renaming a published page onto a path covered by `/section/*` is blocked (or warned) instead of being silently redirected elsewhere.
- New `hasPublishedDescendant` helper — the folder analogue of a page's published state — so redirects are only minted for subtrees that were actually live.

**Safety / gating**:

- Folder/collection redirect creation is gated behind the `is-advanced-redirects-enabled` GrowthBook flag **on the server** (not just the UI), so it stays dark until the edge resolver ships. The shadow-guard extension is not flag-gated (it is a pure safety tightening).
- Depends on the wildcard-redirect support in the parent PRs in this stack; the wildcard rules are only resolved once the origin-response Lambda@Edge is deployed (held, separate infra change).

## Before & After Screenshots

**BEFORE**:

Moving/renaming a folder shows only a "the URL will change" notice — no redirect option, no redirects created.

**AFTER**:

A checkbox appears (behind the advanced-redirects flag) to redirect everything under the old folder URL to the new location.

## Tests

**Manual Verification Steps**:

- [ ] With `is-advanced-redirects-enabled` **on**: publish a page inside a folder, then move the folder to a new parent with the checkbox ticked. On the Redirections page, confirm a single wildcard redirect `/<old-folder-path>/*` was created pointing at the folder.
- [ ] Rename that folder's URL with the checkbox ticked and confirm the same wildcard redirect is created for the old path.
- [ ] Untick the checkbox on a folder move/rename and confirm **no** redirect is created.
- [ ] Move/rename a folder that has **no published descendants** and confirm no redirect is created even with the box ticked.
- [ ] With the flag **off**, confirm the checkbox does not appear and no folder redirect is created on move/rename.
- [ ] Shadow guard: create a redirect with source `/section/*`, then move or rename a **published** page so its URL becomes `/section/anything`. Confirm the move is blocked with a message naming the `/section/*` redirect.
- [ ] Open a published page's settings whose URL sits under an existing `/section/*` redirect and confirm the "this URL already redirects…" warning shows.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change adds optional wildcard redirects when folders or collections are renamed or moved, including controls in Studio and validation for redirect-shadowing paths.

The resource move flow still obtains source and destination permalink snapshots outside the transaction that changes `parentId`. A concurrent rename or move can therefore make redirect validation and creation use stale paths, potentially leaving vacated published URLs without redirects or rejecting a valid destination.

### T-Rex validation blocked
- **Missing package:** the generated Prisma client module `~prisma/generated/prisma/client` is unavailable to the focused database mock. The targeted concurrent-move test stopped during setup before it could run assertions or execute the production move path.
- **Missing service:** the normal Studio router integration tests require a Docker-backed PostgreSQL/Testcontainers runtime, which is unavailable in this environment.

[Configure VMs](https://app.greptile.com/-/settings/trex#environments)
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>




</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted targeted Vitest runs with a reduced configuration to avoid Docker and global setup.
- The final invocation reached test discovery but failed during test setup because tests/mocks/db.ts cannot resolve ~prisma/generated/prisma/client.
- A normal Vitest attempt also failed because no container runtime strategy was available.
- Maximum agent steps were reached, so no further commands or validation could be performed in this run.

<a href="https://app.greptile.com/trex/runs/17193456/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `apps/studio/src/server/modules/resource/resource.router.ts`, line 500-508 ([link](https://github.com/opengovsg/isomer/blob/55ad35f4953bff4625427e50520f471efdef7077/apps/studio/src/server/modules/resource/resource.router.ts#L500-L508)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Permalink snapshots escape move transaction**

   When concurrent moves or renames affect the resource or its destination, these permalink reads run in separate database transactions from the subsequent `parentId` update. Redirect processing can therefore use stale old or destination paths, causing the actual vacated descendant URLs to lack redirects or validating the wrong destination subtree.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: apps/studio/src/server/modules/resource/resource.router.ts
   Line: 500-508

   Comment:
   **Permalink snapshots escape move transaction**

   When concurrent moves or renames affect the resource or its destination, these permalink reads run in separate database transactions from the subsequent `parentId` update. Redirect processing can therefore use stale old or destination paths, causing the actual vacated descendant URLs to lack redirects or validating the wrong destination subtree.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%0ALine%3A%20500-508%0A%0AComment%3A%0A**Permalink%20snapshots%20escape%20move%20transaction**%0A%0AWhen%20concurrent%20moves%20or%20renames%20affect%20the%20resource%20or%20its%20destination%2C%20these%20permalink%20reads%20run%20in%20separate%20database%20transactions%20from%20the%20subsequent%20%60parentId%60%20update.%20Redirect%20processing%20can%20therefore%20use%20stale%20old%20or%20destination%20paths%2C%20causing%20the%20actual%20vacated%20descendant%20URLs%20to%20lack%20redirects%20or%20validating%20the%20wrong%20destination%20subtree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2958&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%0ALine%3A%20500-508%0A%0AComment%3A%0A**Permalink%20snapshots%20escape%20move%20transaction**%0A%0AWhen%20concurrent%20moves%20or%20renames%20affect%20the%20resource%20or%20its%20destination%2C%20these%20permalink%20reads%20run%20in%20separate%20database%20transactions%20from%20the%20subsequent%20%60parentId%60%20update.%20Redirect%20processing%20can%20therefore%20use%20stale%20old%20or%20destination%20paths%2C%20causing%20the%20actual%20vacated%20descendant%20URLs%20to%20lack%20redirects%20or%20validating%20the%20wrong%20destination%20subtree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2958&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Ffolder-wildcard-redirects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffolder-wildcard-redirects%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20apps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%0ALine%3A%20500-508%0A%0AComment%3A%0A**Permalink%20snapshots%20escape%20move%20transaction**%0A%0AWhen%20concurrent%20moves%20or%20renames%20affect%20the%20resource%20or%20its%20destination%2C%20these%20permalink%20reads%20run%20in%20separate%20database%20transactions%20from%20the%20subsequent%20%60parentId%60%20update.%20Redirect%20processing%20can%20therefore%20use%20stale%20old%20or%20destination%20paths%2C%20causing%20the%20actual%20vacated%20descendant%20URLs%20to%20lack%20redirects%20or%20validating%20the%20wrong%20destination%20subtree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"><img alt="Fix in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInConductor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%3A500-508%0A**Permalink%20snapshots%20escape%20move%20transaction**%0A%0AWhen%20concurrent%20moves%20or%20renames%20affect%20the%20resource%20or%20its%20destination%2C%20these%20permalink%20reads%20run%20in%20separate%20database%20transactions%20from%20the%20subsequent%20%60parentId%60%20update.%20Redirect%20processing%20can%20therefore%20use%20stale%20old%20or%20destination%20paths%2C%20causing%20the%20actual%20vacated%20descendant%20URLs%20to%20lack%20redirects%20or%20validating%20the%20wrong%20destination%20subtree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2958&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%3A500-508%0A**Permalink%20snapshots%20escape%20move%20transaction**%0A%0AWhen%20concurrent%20moves%20or%20renames%20affect%20the%20resource%20or%20its%20destination%2C%20these%20permalink%20reads%20run%20in%20separate%20database%20transactions%20from%20the%20subsequent%20%60parentId%60%20update.%20Redirect%20processing%20can%20therefore%20use%20stale%20old%20or%20destination%20paths%2C%20causing%20the%20actual%20vacated%20descendant%20URLs%20to%20lack%20redirects%20or%20validating%20the%20wrong%20destination%20subtree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2958&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Ffolder-wildcard-redirects%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Ffolder-wildcard-redirects%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Fserver%2Fmodules%2Fresource%2Fresource.router.ts%3A500-508%0A**Permalink%20snapshots%20escape%20move%20transaction**%0A%0AWhen%20concurrent%20moves%20or%20renames%20affect%20the%20resource%20or%20its%20destination%2C%20these%20permalink%20reads%20run%20in%20separate%20database%20transactions%20from%20the%20subsequent%20%60parentId%60%20update.%20Redirect%20processing%20can%20therefore%20use%20stale%20old%20or%20destination%20paths%2C%20causing%20the%20actual%20vacated%20descendant%20URLs%20to%20lack%20redirects%20or%20validating%20the%20wrong%20destination%20subtree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/server/modules/resource/resource.router.ts:500-508
**Permalink snapshots escape move transaction**

When concurrent moves or renames affect the resource or its destination, these permalink reads run in separate database transactions from the subsequent `parentId` update. Redirect processing can therefore use stale old or destination paths, causing the actual vacated descendant URLs to lack redirects or validating the wrong destination subtree.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (12): Last reviewed commit: ["fix(redirects): serialise permalink-chan..."](https://github.com/opengovsg/isomer/commit/55ad35f4953bff4625427e50520f471efdef7077) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47471359)</sub>

<!-- /greptile_comment -->