### PR TITLE
(DO NOT MERGE) chore: anti-scam notification migration script

### DIFF
--- a/apps/studio/prisma/scripts/README.md
+++ b/apps/studio/prisma/scripts/README.md
@@ -24,3 +24,11 @@
 
 1. This script updates all users of a site to have a specific `RoleType`
 2. Edit the `siteId` and `role` at the end of the script
+
+## Replace notification banners with anti-scam variant
+
+1. Run a dry run first to review affected sites:
+   `source .env && pnpm exec tsx prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts --dry-run`
+2. Optionally scope to one site with `--site-id <id>`
+3. Apply (you will be prompted for your Studio email):
+   `source .env && pnpm exec tsx prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts`

--- a/apps/studio/prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts
+++ b/apps/studio/prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts
@@ -1,0 +1,49 @@
+/**
+ * Replace active site notification banners with the standard anti-scam variant.
+ *
+ * Only sites with an active notification are updated. Sites already using
+ * `{ type: "antiscam" }` are skipped. Sites without a notification are untouched.
+ *
+ * Usage:
+ *   cd apps/studio
+ *   source .env && pnpm exec tsx prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts --dry-run
+ *   source .env && pnpm exec tsx prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts
+ *   source .env && pnpm exec tsx prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts --site-id 42
+ */
+
+import { input } from "@inquirer/prompts"
+import { db } from "~/server/modules/database"
+
+import {
+  parseArgs,
+  replaceNotificationWithAntiscam,
+  resolveScriptUserIdByEmail,
+} from "./shared"
+
+const main = async () => {
+  const { dryRun, siteId } = parseArgs()
+
+  const scriptUserId = dryRun
+    ? ""
+    : await resolveScriptUserIdByEmail(
+        await input({
+          message: "Enter your email address (e.g. adriangoh@open.gov.sg)",
+          validate: (value) => value.trim().length > 0 || "Email is required",
+        }),
+      )
+
+  await replaceNotificationWithAntiscam({
+    dryRun,
+    siteId,
+    scriptUserId,
+  })
+}
+
+try {
+  await main()
+} catch (err) {
+  console.error("\n✗ Migration failed:", err)
+  process.exitCode = 1
+} finally {
+  await db.destroy()
+}

--- a/apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.test.ts
+++ b/apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.test.ts
@@ -1,0 +1,290 @@
+import { confirm } from "@inquirer/prompts"
+import {
+  isSiteNotificationActive,
+  type SiteNotificationConfig,
+} from "@opengovsg/isomer-components"
+import { resetTables } from "tests/integration/helpers/db"
+import { setupSite, setupUser } from "tests/integration/helpers/seed"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { AuditLogEvent, db, jsonb, sql } from "~/server/modules/database"
+
+import {
+  ANTISCAM_NOTIFICATION,
+  getSitesWithNotifications,
+  isAlreadyAntiscam,
+  parseArgs,
+  replaceNotificationWithAntiscam,
+  resolveScriptUserIdByEmail,
+} from "./shared"
+
+vi.mock("@inquirer/prompts", () => ({
+  confirm: vi.fn(),
+}))
+
+const setSiteNotification = async (
+  siteId: number,
+  notification: SiteNotificationConfig | null,
+) => {
+  await db
+    .updateTable("Site")
+    .set({
+      config:
+        notification === null
+          ? sql`config - 'notification'`
+          : sql`config || ${jsonb({ notification })}`,
+    })
+    .where("id", "=", siteId)
+    .execute()
+}
+
+describe("replace-notification-with-antiscam/shared", () => {
+  describe("isSiteNotificationActive", () => {
+    it("returns false for missing notifications", () => {
+      expect(isSiteNotificationActive(undefined)).toBe(false)
+    })
+
+    it("treats legacy notifications with a title as active", () => {
+      expect(isSiteNotificationActive({ title: "Legacy banner" })).toBe(true)
+      expect(isSiteNotificationActive({ title: "" })).toBe(false)
+    })
+
+    it("treats custom notifications with a title as active", () => {
+      expect(
+        isSiteNotificationActive({ type: "custom", title: "Custom banner" }),
+      ).toBe(true)
+      expect(isSiteNotificationActive({ type: "custom", title: "" })).toBe(
+        false,
+      )
+    })
+
+    it("treats anti-scam notifications as active", () => {
+      expect(isSiteNotificationActive({ type: "antiscam" })).toBe(true)
+    })
+  })
+
+  describe("isAlreadyAntiscam", () => {
+    it("returns true only for anti-scam notifications", () => {
+      expect(isAlreadyAntiscam({ type: "antiscam" })).toBe(true)
+      expect(isAlreadyAntiscam({ type: "custom", title: "x" })).toBe(false)
+      expect(isAlreadyAntiscam({ title: "x" })).toBe(false)
+    })
+  })
+
+  describe("resolveScriptUserIdByEmail", () => {
+    afterEach(async () => {
+      await resetTables("User")
+    })
+
+    it("resolves a Studio user id from their email", async () => {
+      const user = await setupUser({ email: "engineer@open.gov.sg" })
+
+      await expect(
+        resolveScriptUserIdByEmail("  Engineer@open.gov.sg "),
+      ).resolves.toBe(user.id)
+    })
+
+    it("throws when the email does not match a user", async () => {
+      await expect(
+        resolveScriptUserIdByEmail("missing@open.gov.sg"),
+      ).rejects.toThrow("User with email missing@open.gov.sg not found")
+    })
+  })
+
+  describe("parseArgs", () => {
+    it("parses dry run and site id flags", () => {
+      expect(parseArgs(["--dry-run", "--site-id", "42"])).toEqual({
+        dryRun: true,
+        siteId: 42,
+      })
+      expect(parseArgs([])).toEqual({
+        dryRun: false,
+        siteId: undefined,
+      })
+    })
+
+    it("throws when site id is missing or invalid", () => {
+      expect(() => parseArgs(["--site-id"])).toThrow(
+        "Pass a numeric site id after --site-id",
+      )
+      expect(() => parseArgs(["--site-id", "abc"])).toThrow(
+        "Pass a numeric site id after --site-id",
+      )
+    })
+  })
+
+  describe("replaceNotificationWithAntiscam", () => {
+    afterEach(async () => {
+      vi.mocked(confirm).mockReset()
+      await resetTables(
+        "AuditLog",
+        "ResourcePermission",
+        "Resource",
+        "Navbar",
+        "Footer",
+        "Site",
+        "User",
+      )
+    })
+
+    it("updates active custom notifications and writes audit logs", async () => {
+      const user = await setupUser({})
+      const { site: customSite } = await setupSite()
+      const { site: legacySite } = await setupSite()
+      const { site: antiscamSite } = await setupSite()
+      const { site: inactiveSite } = await setupSite()
+
+      await setSiteNotification(customSite.id, {
+        type: "custom",
+        title: "Custom banner",
+      })
+      await setSiteNotification(legacySite.id, {
+        title: "Legacy banner",
+      })
+      await setSiteNotification(antiscamSite.id, ANTISCAM_NOTIFICATION)
+      await setSiteNotification(inactiveSite.id, { type: "custom", title: "" })
+
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const { updatedSiteIds } = await replaceNotificationWithAntiscam({
+        dryRun: false,
+        scriptUserId: user.id,
+      })
+
+      expect(updatedSiteIds).toEqual(
+        expect.arrayContaining([customSite.id, legacySite.id]),
+      )
+      expect(updatedSiteIds).toHaveLength(2)
+
+      const updatedCustomSite = await db
+        .selectFrom("Site")
+        .where("id", "=", customSite.id)
+        .select(
+          sql<SiteNotificationConfig | null>`config->'notification'`.as(
+            "notification",
+          ),
+        )
+        .executeTakeFirstOrThrow()
+      const updatedLegacySite = await db
+        .selectFrom("Site")
+        .where("id", "=", legacySite.id)
+        .select(
+          sql<SiteNotificationConfig | null>`config->'notification'`.as(
+            "notification",
+          ),
+        )
+        .executeTakeFirstOrThrow()
+      const unchangedAntiscamSite = await db
+        .selectFrom("Site")
+        .where("id", "=", antiscamSite.id)
+        .select(
+          sql<SiteNotificationConfig | null>`config->'notification'`.as(
+            "notification",
+          ),
+        )
+        .executeTakeFirstOrThrow()
+      const unchangedInactiveSite = await db
+        .selectFrom("Site")
+        .where("id", "=", inactiveSite.id)
+        .select(
+          sql<SiteNotificationConfig | null>`config->'notification'`.as(
+            "notification",
+          ),
+        )
+        .executeTakeFirstOrThrow()
+
+      expect(updatedCustomSite.notification).toEqual(ANTISCAM_NOTIFICATION)
+      expect(updatedLegacySite.notification).toEqual(ANTISCAM_NOTIFICATION)
+      expect(unchangedAntiscamSite.notification).toEqual(ANTISCAM_NOTIFICATION)
+      expect(unchangedInactiveSite.notification).toEqual({
+        type: "custom",
+        title: "",
+      })
+
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.SiteConfigUpdate)
+        .where("userId", "=", user.id)
+        .selectAll()
+        .execute()
+
+      expect(auditLogs).toHaveLength(2)
+      expect(auditLogs.map((log) => log.siteId).sort()).toEqual(
+        [customSite.id, legacySite.id].sort(),
+      )
+      expect(auditLogs[0]?.metadata).toEqual({
+        script: "replaceNotificationWithAntiscam",
+      })
+    })
+
+    it("does not write changes during dry run", async () => {
+      const user = await setupUser({})
+      const { site } = await setupSite()
+      await setSiteNotification(site.id, {
+        type: "custom",
+        title: "Custom banner",
+      })
+
+      const { updatedSiteIds } = await replaceNotificationWithAntiscam({
+        dryRun: true,
+        scriptUserId: user.id,
+      })
+
+      expect(updatedSiteIds).toEqual([])
+      expect(confirm).not.toHaveBeenCalled()
+
+      const unchangedSite = await db
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .select(
+          sql<SiteNotificationConfig | null>`config->'notification'`.as(
+            "notification",
+          ),
+        )
+        .executeTakeFirstOrThrow()
+
+      expect(unchangedSite.notification).toEqual({
+        type: "custom",
+        title: "Custom banner",
+      })
+    })
+
+    it("scopes updates to a single site when site id is provided", async () => {
+      const user = await setupUser({})
+      const { site: targetSite } = await setupSite()
+      const { site: otherSite } = await setupSite()
+
+      await setSiteNotification(targetSite.id, {
+        type: "custom",
+        title: "Target banner",
+      })
+      await setSiteNotification(otherSite.id, {
+        type: "custom",
+        title: "Other banner",
+      })
+
+      vi.mocked(confirm).mockResolvedValue(true)
+
+      const { updatedSiteIds } = await replaceNotificationWithAntiscam({
+        dryRun: false,
+        siteId: targetSite.id,
+        scriptUserId: user.id,
+      })
+
+      expect(updatedSiteIds).toEqual([targetSite.id])
+
+      const sites = await getSitesWithNotifications()
+      const targetNotification = sites.find(
+        (s) => s.id === targetSite.id,
+      )?.notification
+      const otherNotification = sites.find(
+        (s) => s.id === otherSite.id,
+      )?.notification
+
+      expect(targetNotification).toEqual(ANTISCAM_NOTIFICATION)
+      expect(otherNotification).toEqual({
+        type: "custom",
+        title: "Other banner",
+      })
+    })
+  })
+})

--- a/apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.ts
+++ b/apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.ts
@@ -1,0 +1,163 @@
+import { confirm } from "@inquirer/prompts"
+import {
+  isSiteNotificationActive,
+  type SiteNotificationConfig,
+} from "@opengovsg/isomer-components"
+import { AuditLogEvent, db, jsonb, sql } from "~/server/modules/database"
+
+export const ANTISCAM_NOTIFICATION = {
+  type: "antiscam",
+} satisfies SiteNotificationConfig
+
+export const isAlreadyAntiscam = (notification: SiteNotificationConfig) =>
+  notification.type === "antiscam"
+
+export const parseArgs = (args = process.argv.slice(2)) => {
+  const dryRun = args.includes("--dry-run")
+  const siteIdIndex = args.indexOf("--site-id")
+  const siteId = siteIdIndex === -1 ? undefined : Number(args[siteIdIndex + 1])
+
+  if (siteIdIndex !== -1 && (!siteId || Number.isNaN(siteId))) {
+    throw new Error("Pass a numeric site id after --site-id")
+  }
+
+  return { dryRun, siteId }
+}
+
+export const resolveScriptUserIdByEmail = async (email: string) => {
+  const normalizedEmail = email.trim().toLowerCase()
+  const user = await db
+    .selectFrom("User")
+    .where("email", "=", normalizedEmail)
+    .where("deletedAt", "is", null)
+    .select("id")
+    .executeTakeFirst()
+
+  if (!user) {
+    throw new Error(`User with email ${email} not found`)
+  }
+
+  return user.id
+}
+
+export const getSitesWithNotifications = async (siteId?: number) => {
+  let query = db
+    .selectFrom("Site")
+    .select([
+      "id",
+      "name",
+      sql<SiteNotificationConfig | null>`config->'notification'`.as(
+        "notification",
+      ),
+    ])
+
+  if (siteId !== undefined) {
+    query = query.where("id", "=", siteId)
+  }
+
+  return query.execute()
+}
+
+export const replaceNotificationWithAntiscam = async ({
+  dryRun,
+  siteId,
+  scriptUserId,
+}: {
+  dryRun: boolean
+  siteId?: number
+  scriptUserId: string
+}) => {
+  const sites = await getSitesWithNotifications(siteId)
+
+  const toUpdate = sites.filter((site) => {
+    const notification = site.notification ?? undefined
+    return (
+      isSiteNotificationActive(notification) && !isAlreadyAntiscam(notification)
+    )
+  })
+  const alreadyAntiscam = sites.filter((site) => {
+    const notification = site.notification ?? undefined
+    return (
+      isSiteNotificationActive(notification) && isAlreadyAntiscam(notification)
+    )
+  })
+  const inactive = sites.filter(
+    (site) => !isSiteNotificationActive(site.notification ?? undefined),
+  )
+
+  console.log(`Found ${sites.length} site(s) matching filter`)
+  console.log(`  ${toUpdate.length} to update`)
+  console.log(`  ${alreadyAntiscam.length} already on anti-scam`)
+  console.log(`  ${inactive.length} without an active notification`)
+
+  if (toUpdate.length === 0) {
+    console.log("\nNothing to update.")
+    return { updatedSiteIds: [] as number[] }
+  }
+
+  console.log("\nSites to update:")
+  for (const site of toUpdate) {
+    console.log(
+      `  - [${site.id}] ${site.name}: ${JSON.stringify(site.notification)} -> ${JSON.stringify(ANTISCAM_NOTIFICATION)}`,
+    )
+  }
+
+  if (dryRun) {
+    console.log("\nDry run only — no changes written.")
+    return { updatedSiteIds: [] as number[] }
+  }
+
+  const shouldProceed = await confirm({
+    message: `Update ${toUpdate.length} site notification banner(s) to the anti-scam variant?`,
+    default: false,
+  })
+
+  if (!shouldProceed) {
+    console.log("Aborted.")
+    return { updatedSiteIds: [] as number[] }
+  }
+
+  const updatedSiteIds: number[] = []
+
+  for (const site of toUpdate) {
+    await db.transaction().execute(async (tx) => {
+      const oldSite = await tx
+        .selectFrom("Site")
+        .where("id", "=", site.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+
+      const newSite = await tx
+        .updateTable("Site")
+        .set({
+          config: sql`config || ${jsonb({ notification: ANTISCAM_NOTIFICATION })}`,
+        })
+        .where("id", "=", site.id)
+        .returningAll()
+        .executeTakeFirstOrThrow()
+
+      await tx
+        .insertInto("AuditLog")
+        .values({
+          siteId: site.id,
+          eventType: AuditLogEvent.SiteConfigUpdate,
+          delta: {
+            before: oldSite,
+            after: newSite,
+          },
+          userId: scriptUserId,
+          metadata: {
+            script: "replaceNotificationWithAntiscam",
+          },
+        })
+        .execute()
+    })
+
+    updatedSiteIds.push(site.id)
+    console.log(`✓ Updated [${site.id}] ${site.name}`)
+  }
+
+  console.log(`\nDone. Updated ${toUpdate.length} site(s).`)
+
+  return { updatedSiteIds }
+}

--- a/packages/components/src/interfaces/internal/index.ts
+++ b/packages/components/src/interfaces/internal/index.ts
@@ -37,6 +37,7 @@ export {
   NotificationSettingsSchema,
   type NotificationProps,
   type NotificationClientProps,
+  type SiteNotificationConfig,
 } from "./Notification"
 export type { SearchProps } from "./Search"
 export {


### PR DESCRIPTION
## Problem

After the GOIS anti-scam site notification ships (#1995), existing sites with active custom notification banners need a safe, auditable way to migrate to `{ type: "antiscam" }` in bulk.

**Stacked on:** #1995 (`feat/gois-notification`)

## Solution

Adds a one-off Prisma script to replace active custom/legacy site notification banners with the standard GOIS anti-scam variant.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- `replace-notification-with-antiscam` script with `--dry-run`, optional `--site-id`, and email prompt for audit attribution
- Idempotent: skips sites already on anti-scam and sites without an active notification
- Integration tests for email resolution and migration behaviour

**Improvements**:

- Export `SiteNotificationConfig` from components for script type safety

**Bug Fixes**:

- N/A

## Before & After Screenshots

N/A (data migration script)

## Tests

**Manual Verification Steps**:

- [ ] Run dry-run against staging: `cd apps/studio && source .env && pnpm exec tsx prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts --dry-run`
- [ ] Verify listed sites match expectations (active custom/legacy banners only)
- [ ] Run against a test site with `--site-id <id>` and confirm `Site.config.notification` becomes `{ "type": "antiscam" }`
- [ ] Confirm audit log entries are written with the prompted engineer email
- [ ] Republish affected sites so live `config.json` picks up the change (script does not trigger CodeBuild)

**New scripts**:

- `apps/studio/prisma/scripts/replace-notification-with-antiscam/replaceNotificationWithAntiscam.ts` : bulk migration for active site notification banners. Does **not** touch page blobs or trigger publish.

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a standard anti-scam site notification and a bulk migration path.
- Extends the notification schema, published-site renderer, and Studio settings UI with an anti-scam variant.
- Adds an optional-union JSONForms control with a master toggle and variant selector.
- Adds a dry-runnable, audited Prisma script for replacing active notification configurations.
- Adds utility, integration, Storybook, and MSW coverage for the new notification behavior.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The migration should not be run or merged until each site’s current notification eligibility is checked atomically before replacement.

Candidate sites are selected before an interactive delay and then updated unconditionally, allowing a concurrent Studio edit or disable action to be overwritten by the migration.

**Files Needing Attention:** apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.ts
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the stale-eligibility overwrite scenario by running the migration function in a focused Vitest harness against an in-memory database, selecting site 4242 with an active persisted notification, removing it via a mocked interactive confirmation, and then persisting the antiscam type to mark the site as updated.
- Validated the UI flow from the default notification form to the AntiScamDisclaimer state after choosing Custom notification, including the custom title and the rendered preview as captured by the UI artifacts.
- Generated a proof for a posted P1 finding and linked it to the corresponding review comment.

<a href="https://app.greptile.com/trex/runs/15980007/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.ts | Implements the bulk migration and audit trail, but uses stale eligibility when applying each update. |
| apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsOptionalCombinatorControl.tsx | Adds the optional combinator toggle and delegates enabled values to the existing JsonForms union renderer. |
| packages/components/src/interfaces/internal/Notification.ts | Introduces backward-compatible custom and anti-scam notification variants. |
| packages/components/src/templates/next/components/internal/Notification/Notification.tsx | Renders standardized anti-scam content while preserving legacy and custom notification rendering. |
| apps/studio/src/server/modules/site/site.service.ts | Bypasses legacy prose normalization for the fieldless anti-scam notification shape. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Operator
participant Script
participant StudioUser
participant DB
Operator->>Script: Start migration
Script->>DB: Read eligible notifications
Script-->>Operator: Display candidates and request confirmation
StudioUser->>DB: Change or disable notification
Operator->>Script: Confirm migration
Script->>DB: Re-read site row
Script->>DB: Unconditionally replace notification
Script->>DB: Insert audit log
Note over DB: Newer Studio configuration is overwritten
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Custom notification edits do not propagate to the preview**

   - **Bug**
     - In the real AntiScamDisclaimer Storybook story, selecting “Custom notification” successfully renders the Notification title input. After filling it with “Important custom update”, the text remains absent from the preview iframe, so the manual-plan requirement that custom content can be entered and rendered is not met.
   - **Cause**
     - The custom variant form state is updated enough to display and accept the custom fields, but the resulting custom notification value is not propagated through the settings preview render path after changing away from the anti-scam union variant.
   - **Fix**
     - Ensure the optional combinator control dispatches the complete custom notification object and that `EditSettingsPreview` receives the updated `state.notification`. Add a Storybook interaction test that switches from `antiscam` to `custom`, fills the title, and asserts that the title appears inside the preview iframe.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fprisma%2Fscripts%2Freplace-notification-with-antiscam%2Fshared.ts%3A130-137%0A**Stale%20eligibility%20overwrites%20newer%20changes**%0A%0AWhen%20a%20Studio%20user%20changes%20or%20disables%20a%20notification%20after%20the%20script%20selects%20candidates%20but%20before%20its%20per-site%20transaction%20runs%2C%20this%20unconditional%20update%20replaces%20the%20newer%20configuration%2C%20causing%20the%20user's%20change%20to%20be%20lost%20or%20an%20intentionally%20disabled%20banner%20to%20be%20re-enabled.%0A%0A&repo=opengovsg%2Fisomer&pr=2960&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fprisma%2Fscripts%2Freplace-notification-with-antiscam%2Fshared.ts%3A130-137%0A**Stale%20eligibility%20overwrites%20newer%20changes**%0A%0AWhen%20a%20Studio%20user%20changes%20or%20disables%20a%20notification%20after%20the%20script%20selects%20candidates%20but%20before%20its%20per-site%20transaction%20runs%2C%20this%20unconditional%20update%20replaces%20the%20newer%20configuration%2C%20causing%20the%20user's%20change%20to%20be%20lost%20or%20an%20intentionally%20disabled%20banner%20to%20be%20re-enabled.%0A%0A&pr=2960&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22chore%2Fgois-notification-script%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fgois-notification-script%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fstudio%2Fprisma%2Fscripts%2Freplace-notification-with-antiscam%2Fshared.ts%3A130-137%0A**Stale%20eligibility%20overwrites%20newer%20changes**%0A%0AWhen%20a%20Studio%20user%20changes%20or%20disables%20a%20notification%20after%20the%20script%20selects%20candidates%20but%20before%20its%20per-site%20transaction%20runs%2C%20this%20unconditional%20update%20replaces%20the%20newer%20configuration%2C%20causing%20the%20user's%20change%20to%20be%20lost%20or%20an%20intentionally%20disabled%20banner%20to%20be%20re-enabled.%0A%0A&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
apps/studio/prisma/scripts/replace-notification-with-antiscam/shared.ts:130-137
**Stale eligibility overwrites newer changes**

When a Studio user changes or disables a notification after the script selects candidates but before its per-site transaction runs, this unconditional update replaces the newer configuration, causing the user's change to be lost or an intentionally disabled banner to be re-enabled.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(studio): add anti-scam notificatio..."](https://github.com/opengovsg/isomer/commit/2d1bc91dd96a2877665458e11896ea7fe17e64b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47490776)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - apps/studio/prisma/CLAUDE.md ([source](https://github.com/opengovsg/isomer/blob/main/apps/studio/prisma/CLAUDE.md))

<!-- /greptile_comment -->