### PR TITLE
🧹 chore(studio): remove collection tags GrowthBook feature flag

### DIFF
--- a/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/IndexpageRow.tsx
@@ -10,7 +10,6 @@ import { Badge, BadgeLeftIcon } from "@opengovsg/design-system-react"
 import Link from "next/link"
 import { useEffect } from "react"
 import { BiChevronRight, BiSolidCircle } from "react-icons/bi"
-import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { trpc } from "~/utils/trpc"
 import { ResourceState } from "~prisma/generated/generatedEnums"
 
@@ -48,8 +47,6 @@ export const IndexpageRow = ({
     siteId,
     resourceId,
   ])
-
-  const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
 
   return (
     <Skeleton w="full" isLoaded={!isPending && !!data}>
@@ -89,10 +86,7 @@ export const IndexpageRow = ({
           {/* as a relative time. */}
           {/* we also need to give the user who did the update */}
           <Text textStyle="caption-2" textColor="base.content.medium">
-            {getIndexPageSubtitle({
-              type,
-              isNewCollectionTagsManagementEnabled,
-            })}
+            {getIndexPageSubtitle({ type })}
           </Text>
         </VStack>
         <Text

--- a/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
+++ b/apps/studio/src/features/dashboard/components/IndexpageRow/utils.ts
@@ -19,16 +19,12 @@ export const getIndexPageIcon = (
 
 export const getIndexPageSubtitle = ({
   type,
-  isNewCollectionTagsManagementEnabled = false,
 }: {
   type: ResourceTypesWithIndexPage
-  isNewCollectionTagsManagementEnabled: boolean
 }) => {
   switch (type) {
     case "collection":
-      return isNewCollectionTagsManagementEnabled
-        ? "Manage the Collection’s layout, filters, and sorting."
-        : "Manage how your Collection looks like and behaves"
+      return "Manage the Collection’s layout, filters, and sorting."
     case "folder":
       return "Customise the index page for this folder"
     default:

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -35,7 +35,6 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { CanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
-import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
@@ -87,7 +86,6 @@ const FixedBlock = () => {
     useEditorDrawerContext()
   const pageLayout = previewPageState.layout
   const isHeroFixedBlock = getIsHeroFirstBlock(pageLayout, previewPageState)
-  const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
 
   if (isHeroFixedBlock) {
     // Assuming only one fixedBlock can exist at a time for now
@@ -109,11 +107,7 @@ const FixedBlock = () => {
     )
   }
 
-  if (
-    pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
-    isNewCollectionTagsManagementEnabled
-  ) {
-    // New collection editing UI introduced in https://github.com/opengovsg/isomer/pull/2002
+  if (pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection) {
     return (
       <>
         <BaseBlock
@@ -139,20 +133,6 @@ const FixedBlock = () => {
           />
         </CanManageCollectionFilters>
       </>
-    )
-  }
-
-  if (pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection) {
-    return (
-      <BaseBlock
-        onClick={() => {
-          setCurrActiveIdx(0)
-          setDrawerState({ state: "collectionEditor", type: "display" })
-        }}
-        label="Collection settings"
-        description="Summary, style, categories and sorting"
-        icon={BiPin}
-      />
     )
   }
 
@@ -385,8 +365,6 @@ export default function RootStateDrawer() {
   // for collection index pages
   const canAddBlocks = pageLayout !== "collection"
 
-  const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
-
   return (
     <Flex direction="column" h="full">
       <ConfirmConvertIndexPageModal
@@ -460,21 +438,13 @@ export default function RootStateDrawer() {
             </Infobox>
           )}
 
-          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection &&
-          isNewCollectionTagsManagementEnabled ? (
-            // New collection editing UI introduced in https://github.com/opengovsg/isomer/pull/2002
+          {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection ? (
             <Disable when={disableBlocks}>
               <VStack gap="1rem" w="100%" align="start">
                 <VStack gap="0.25rem" align="start">
-                  <Text textStyle="subhead-1">
-                    {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection
-                      ? "Manage Collection"
-                      : "Fixed blocks"}
-                  </Text>
+                  <Text textStyle="subhead-1">Manage Collection</Text>
                   <Text textStyle="caption-2" color="base.content.medium">
-                    {pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection
-                      ? "Modify the Collection’s look and feel or manage filters."
-                      : "These are built into the layout, so you can’t delete them."}
+                    Modify the Collection’s look and feel or manage filters.
                   </Text>
                 </VStack>
 

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -496,17 +496,12 @@ export default function RootStateDrawer() {
                 <VStack gap="1.5rem" w="100%">
                   <VStack w="100%" h="100%" gap="1rem">
                     <Flex flexDirection="row" w="100%">
-                      {pageLayout !== ISOMER_USABLE_PAGE_LAYOUTS.Collection && (
-                        <VStack gap="0.25rem" align="start" flex={1}>
-                          <Text textStyle="subhead-1">Custom blocks</Text>
-                          <Text
-                            textStyle="caption-2"
-                            color="base.content.medium"
-                          >
-                            Use blocks to display your content.
-                          </Text>
-                        </VStack>
-                      )}
+                      <VStack gap="0.25rem" align="start" flex={1}>
+                        <Text textStyle="subhead-1">Custom blocks</Text>
+                        <Text textStyle="caption-2" color="base.content.medium">
+                          Use blocks to display your content.
+                        </Text>
+                      </VStack>
                       {/* TODO: we should swap over to using the `resource.type` */}
                       {/* rather than the `page.layout` but we are unable to do so due */}
                       {/* to the existence of custom index page that are `layout: */}

--- a/apps/studio/src/hooks/useNewCollectionTagsManagement.ts
+++ b/apps/studio/src/hooks/useNewCollectionTagsManagement.ts
@@ -1,8 +1,0 @@
-import { useFeatureValue } from "@growthbook/growthbook-react"
-import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
-
-export const useNewCollectionTagsManagement = () =>
-  useFeatureValue<boolean>(
-    IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY,
-    false,
-  )

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -7,8 +7,6 @@ export const ENABLE_EMAILS_FOR_SCHEDULED_PUBLISHES_FEATURE_KEY =
 export const ENABLE_EMAILS_FOR_REGULAR_PUBLISHES_FEATURE_KEY =
   "enable-emails-for-regular-publishes"
 export const BANNER_FEATURE_KEY = "isomer-next-banner"
-export const IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY =
-  "is-new-collection-tags-management-enabled"
 export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 export const IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY =
   "homepage-antiscam-banner-enabled"

--- a/apps/studio/src/stories/Page/CollectionPage.stories.tsx
+++ b/apps/studio/src/stories/Page/CollectionPage.stories.tsx
@@ -6,7 +6,6 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
-import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import CollectionPage from "~/pages/sites/[siteId]/collections/[collectionId]"
 
 import {
@@ -137,9 +136,6 @@ export const ExpandedProfileDropdown: Story = {
 }
 
 export const NewCollectionTagsManagement: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPage.stories.tsx
@@ -4,7 +4,6 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
-import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 import { createBannerGbParameters } from "~/stories/utils/growthbook"
 import { ResourceState } from "~prisma/generated/generatedEnums"
@@ -62,7 +61,7 @@ export const EditFixedBlockState: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const button = await canvas.findByRole("button", {
-      name: /Collection settings/i,
+      name: /Collection display/i,
     })
     await userEvent.click(button)
   },
@@ -110,9 +109,6 @@ export const WithBanner: Story = {
 }
 
 export const NewCollectionIndexEditingExperienceAsAdmin: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
@@ -122,7 +118,6 @@ export const NewCollectionIndexEditingExperienceAsAdmin: Story = {
 
 export const NewCollectionIndexEditingExperienceAsEditor: Story = {
   parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
       handlers: [resourceHandlers.getRolesFor.editor(), ...COMMON_HANDLERS],
     },
@@ -138,9 +133,6 @@ export const NewCollectionIndexEditingExperienceAsEditor: Story = {
 }
 
 export const NewCollectionIndexEditingExperienceForDisplay: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
@@ -148,9 +140,6 @@ export const NewCollectionIndexEditingExperienceForDisplay: Story = {
 }
 
 export const NewCollectionIndexEditingExperienceForFilters: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const button = await canvas.findByRole("button", {

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionIndexPageNewExperience.stories.tsx
@@ -5,7 +5,6 @@ import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
 import { sitesHandlers } from "tests/msw/handlers/sites"
-import { IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import EditPage from "~/pages/sites/[siteId]/pages/[pageId]"
 
 const COMMON_HANDLERS = [
@@ -55,12 +54,9 @@ const meta: Meta<typeof EditPage> = {
 export default meta
 type Story = StoryObj<typeof EditPage>
 
-const newCollectionFiltersParameters = {
-  growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-} satisfies Story["parameters"]
+const newCollectionFiltersParameters = {} satisfies Story["parameters"]
 
 const zeroTagOptionsUsageParameters = {
-  growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
   msw: {
     handlers: [
       ...COMMON_HANDLERS.slice(0, -1),
@@ -238,9 +234,7 @@ async function playOpenDeleteFilterModal(canvasElement: HTMLElement) {
 }
 
 export const ManageCollection: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
+  parameters: {},
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText(/Manage Collection/i)
@@ -254,7 +248,6 @@ export const ManageCollection: Story = {
 /** Editors can open Collection display but cannot manage Filters. */
 export const ManageCollectionAsEditor: Story = {
   parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
       handlers: [resourceHandlers.getRolesFor.editor(), ...COMMON_HANDLERS],
     },
@@ -272,9 +265,7 @@ export const ManageCollectionAsEditor: Story = {
 }
 
 export const CollectionDisplay: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
+  parameters: {},
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const button = await canvas.findByRole("button", {
@@ -430,7 +421,6 @@ export const FiltersDeleteFilterModalZeroUsage: Story = {
 
 export const FiltersDeleteFilterModalManyOptions: Story = {
   parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
       handlers: [
         pageHandlers.readPageAndBlob.collectionWithManyFilterOptions(),
@@ -458,7 +448,6 @@ export const FiltersDeleteFilterModalManyOptions: Story = {
 
 export const CollectionDisplaySaveToast: Story = {
   parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
     msw: {
       handlers: COMMON_HANDLERS,
     },
@@ -485,9 +474,7 @@ export const CollectionDisplaySaveToast: Story = {
 }
 
 export const ManageFiltersSaveToast: Story = {
-  parameters: {
-    growthbook: [[IS_NEW_COLLECTION_TAGS_MANAGEMENT_ENABLED_FEATURE_KEY, true]],
-  },
+  parameters: {},
   play: async ({ canvasElement }) => {
     await playOpenManageFilters(canvasElement)
     const canvas = within(canvasElement)


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 5 | +12 | -67 |
| 🧪 Test | 3 | +5 | -33 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Remove the `is-new-collection-tags-management-enabled` GrowthBook flag now that tag/category migration is complete.

- Delete `useNewCollectionTagsManagement` hook and feature key constant
- Always show the collection index "Manage Collection" / Filters UX in `RootStateDrawer`
- Always use the new index page subtitle copy in `IndexpageRow`
- Remove flag overrides from collection-related Storybook stories

Closes https://linear.app/ogp/issue/ISOM-2285/delete-feature-flags

## Stack

Top of the post-migration cleanup stack. Merge after publishing cleanup PR.

## Test plan

- [ ] Verify collection index page drawer shows "Collection display" and "Filters" without GrowthBook override
- [ ] Collection dashboard row shows updated subtitle
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-659086d7-462c-41c1-b00d-79a8948eea14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-659086d7-462c-41c1-b00d-79a8948eea14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change removes the completed GrowthBook rollout flag for collection tags and makes the migrated collection-management experience the default. Browser rendering confirmed that administrators can manage collection display and filters without a GrowthBook override, while editors can access collection display settings but cannot access filter management. No defects were found.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification for the pull request and noted that local artifact references were not uploaded.
- T-Rex re-ran the requested verification as part of the subsequent validation pass and again observed that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(studio): drop redundant collection l..."](https://github.com/opengovsg/isomer/commit/f259b4abc21b23df361733d060bb2d04458e875c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48492532)</sub>

<!-- /greptile_comment -->