### PR TITLE
feat(rte-table): restore caption modal with Add/Edit button UX

### DIFF
--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -1,0 +1,138 @@
+import type { Editor } from "@tiptap/react"
+import {
+  FormControl,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from "@chakra-ui/react"
+import {
+  Button,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  ModalCloseButton,
+  Textarea,
+} from "@opengovsg/design-system-react"
+import { useEffect } from "react"
+import { z } from "zod"
+import {
+  CAPTION_MAX_LENGTH,
+  setTableCaptionAtPos,
+} from "~/features/editing-experience/components/TableCaption/utils"
+import { useZodForm } from "~/lib/form"
+
+const tableSettingsSchema = z.object({
+  caption: z
+    .string({
+      error: "Enter a caption for this table",
+    })
+    .min(1, { message: "Enter a caption for this table" })
+    .max(CAPTION_MAX_LENGTH, {
+      message: `Table caption should be shorter than ${CAPTION_MAX_LENGTH} characters.`,
+    }),
+})
+
+interface TableSettingsModalProps {
+  editor: Editor
+  /** ProseMirror document position of the `table` node being edited. */
+  tablePos: number
+  isOpen: boolean
+  onClose: () => void
+}
+
+export const TableSettingsModal = ({
+  editor,
+  tablePos,
+  isOpen,
+  onClose,
+}: TableSettingsModalProps): JSX.Element => {
+  const {
+    register,
+    watch,
+    formState: { errors, isValid },
+    setValue,
+    handleSubmit,
+  } = useZodForm({
+    schema: tableSettingsSchema,
+    defaultValues: {
+      caption: "",
+    },
+  })
+
+  const caption = watch("caption")
+
+  useEffect(() => {
+    if (!isOpen) return
+
+    const node = editor.state.doc.nodeAt(tablePos)
+    const currentCaption =
+      node?.type.name === "table"
+        ? ((node.attrs.caption as string | undefined) ?? "")
+        : ""
+    setValue("caption", currentCaption)
+    // only done once per every time the modal is opened
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, tablePos])
+
+  return (
+    // trapFocus=false: with TableBubbleMenu mounted, Chakra's FocusLock and
+    // TipTap's BubbleMenu (tabIndex=0 + blur/focus handlers) fight when the
+    // editor blurs into this modal — hanging the tab. Keep autoFocus so the
+    // textarea still receives focus; just don't run the focus trap.
+    <Modal isOpen={isOpen} onClose={onClose} trapFocus={false}>
+      <ModalOverlay />
+
+      <ModalContent>
+        <ModalHeader mr="3.5rem">Table settings</ModalHeader>
+        <ModalCloseButton size="lg" />
+
+        <ModalBody>
+          <FormControl isRequired isInvalid={!!errors.caption}>
+            <FormLabel color="base.content.strong">
+              Table caption
+              <FormHelperText color="base.content.default">
+                Caption should describe the contents of your table
+              </FormHelperText>
+            </FormLabel>
+
+            <Textarea
+              placeholder="This is the caption for your table"
+              {...register("caption")}
+            />
+
+            {errors.caption?.message ? (
+              <FormErrorMessage>{errors.caption.message}</FormErrorMessage>
+            ) : (
+              <FormHelperText mt="0.5rem" color="base.content.medium">
+                {CAPTION_MAX_LENGTH - caption.length} characters left
+              </FormHelperText>
+            )}
+          </FormControl>
+        </ModalBody>
+
+        <ModalFooter>
+          <HStack spacing="1rem">
+            <Button variant="clear" colorScheme="neutral" onClick={onClose}>
+              Go back to editing
+            </Button>
+            <Button
+              variant="solid"
+              type="submit"
+              isDisabled={!isValid}
+              onClick={handleSubmit(({ caption }) => {
+                setTableCaptionAtPos(editor, tablePos, caption)
+                onClose()
+              })}
+            >
+              Save changes
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.browser.test.tsx
@@ -82,129 +82,108 @@ const getTableCaptions = (editor: TiptapEditor): string[] => {
   return captions
 }
 
-const getCaptionInput = async (name?: string | RegExp) =>
-  screen.findByRole("textbox", {
-    name: name ?? /add a caption|edit table caption/i,
+const getCaptionButton = async (name?: string | RegExp) =>
+  screen.findByRole("button", {
+    name: name ?? /add table caption|edit table caption/i,
   })
 
 describe("TableCaption", () => {
-  it("renders an always-editable input with placeholder when empty", async () => {
+  it("renders an Add caption button when the table has no caption", async () => {
     renderHarness({ type: "prose", content: [tableContent("")] })
 
-    const input = await getCaptionInput("Add a caption")
-    expect(input).toHaveAttribute("placeholder", "Add a caption...")
-    expect(input).toHaveValue("")
+    expect(await getCaptionButton("Add table caption")).toHaveTextContent(
+      "Add caption",
+    )
   })
 
-  it("renders the existing caption text when the table already has one", async () => {
+  it("renders an Edit button when the table already has a caption", async () => {
     renderHarness({
       type: "prose",
       content: [tableContent("Existing caption")],
     })
 
+    expect(await getCaptionButton("Edit table caption")).toHaveTextContent(
+      "Edit",
+    )
+  })
+
+  it("opens the table settings modal and saves a new caption", async () => {
+    const { getEditor } = renderHarness({
+      type: "prose",
+      content: [tableContent("")],
+    })
+
+    await userEvent.click(await getCaptionButton())
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.type(textarea, "A new caption")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
+
+    await waitFor(() => {
+      expect(screen.queryByText("Table settings")).not.toBeInTheDocument()
+    })
+    expect(getTableCaptions(getEditor()!)).toEqual(["A new caption"])
+  })
+
+  it("opens the modal pre-filled when editing an existing caption", async () => {
+    renderHarness({
+      type: "prose",
+      content: [tableContent("Existing caption")],
+    })
+
+    await userEvent.click(await getCaptionButton("Edit table caption"))
+
     expect(
-      await getCaptionInput(/edit table caption: Existing caption/i),
+      await screen.findByPlaceholderText("This is the caption for your table"),
     ).toHaveValue("Existing caption")
   })
 
-  it("updates the table caption attribute as the user types", async () => {
+  it("updates the caption when saving changes in the modal", async () => {
     const { getEditor } = renderHarness({
       type: "prose",
-      content: [tableContent("")],
+      content: [tableContent("Old caption")],
     })
 
-    const input = await getCaptionInput()
-    await userEvent.click(input)
-    await userEvent.type(input, "Live")
+    await userEvent.click(await getCaptionButton("Edit table caption"))
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Updated caption")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
 
     await waitFor(() => {
-      expect(getTableCaptions(getEditor()!)).toEqual(["Live"])
+      expect(getTableCaptions(getEditor()!)).toEqual(["Updated caption"])
     })
   })
 
-  it("commits an edited caption to the table's attribute on blur", async () => {
-    const { getEditor } = renderHarness({
-      type: "prose",
-      content: [tableContent("")],
-    })
-
-    const input = await getCaptionInput()
-    await userEvent.click(input)
-    await userEvent.type(input, "A new caption")
-    await userEvent.tab()
-
-    await waitFor(() => {
-      expect(input).toHaveValue("A new caption")
-    })
-
-    const editor = getEditor()
-    expect(editor).toBeDefined()
-    expect(getTableCaptions(editor!)).toEqual(["A new caption"])
-  })
-
-  it("commits on Enter and restores the focus-time caption on Escape", async () => {
-    const { getEditor } = renderHarness({
-      type: "prose",
-      content: [tableContent("")],
-    })
-
-    const input = await getCaptionInput()
-
-    // Escape: live writes are undone back to the baseline from focus.
-    await userEvent.click(input)
-    await userEvent.type(input, "should not be saved")
-    await userEvent.keyboard("{Escape}")
-
-    await waitFor(() => {
-      expect(input).toHaveValue("")
-    })
-    expect(getTableCaptions(getEditor()!)).toEqual([""])
-
-    // Enter: keeps the live-written value (trimmed on blur).
-    await userEvent.click(input)
-    await userEvent.type(input, "saved via enter")
-    await userEvent.keyboard("{Enter}")
-
-    await waitFor(() => {
-      expect(input).toHaveValue("saved via enter")
-    })
-    expect(getTableCaptions(getEditor()!)).toEqual(["saved via enter"])
-  })
-
-  it("truncates input at 200 characters and shows a counter while focused", async () => {
-    renderHarness({ type: "prose", content: [tableContent("")] })
-
-    const input = await getCaptionInput()
-    await userEvent.click(input)
-
-    // Paste a long string once — typing 200+ keystrokes is slow and noisy
-    // under browser testing (per-keystroke remeasures).
-    await userEvent.fill(input, "a".repeat(185))
-    expect(await screen.findByText("185/200 characters")).toBeInTheDocument()
-
-    await userEvent.fill(input, "a".repeat(250))
-    expect(await screen.findByText("200/200 characters")).toBeInTheDocument()
-    expect(input).toHaveValue("a".repeat(200))
-  })
-
-  it("does not save an empty caption and restores the previous value on blur", async () => {
+  it("does not save when closing the modal without saving", async () => {
     const { getEditor } = renderHarness({
       type: "prose",
       content: [tableContent("Kept caption")],
     })
 
-    const input = await getCaptionInput(/edit table caption: Kept caption/i)
-    await userEvent.click(input)
-    await userEvent.clear(input)
-    await userEvent.tab()
+    await userEvent.click(await getCaptionButton("Edit table caption"))
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Discarded caption")
+    await userEvent.click(
+      screen.getByRole("button", { name: "Go back to editing" }),
+    )
 
     await waitFor(() => {
-      expect(input).toHaveValue("Kept caption")
+      expect(screen.queryByText("Table settings")).not.toBeInTheDocument()
     })
     expect(getTableCaptions(getEditor()!)).toEqual(["Kept caption"])
   })
 
-  it("renders one caption per table and scopes edits to the correct table instance", async () => {
+  it("renders one caption control per table and scopes edits to the correct table instance", async () => {
     const { getEditor } = renderHarness({
       type: "prose",
       content: [
@@ -217,28 +196,26 @@ describe("TableCaption", () => {
       ],
     })
 
-    const first = await getCaptionInput(
-      /edit table caption: First table caption/i,
-    )
-    const second = await getCaptionInput("Add a caption")
-    expect(first).toHaveValue("First table caption")
-    expect(second).toHaveValue("")
+    const editFirst = await getCaptionButton("Edit table caption")
+    const addSecond = await screen.findByRole("button", {
+      name: "Add table caption",
+    })
+    expect(editFirst).toHaveTextContent("Edit")
+    expect(addSecond).toHaveTextContent("Add caption")
 
-    // Edit only the second table's (empty) caption.
-    await userEvent.click(second)
-    await userEvent.type(second, "Second table caption")
-    await userEvent.tab()
+    await userEvent.click(addSecond)
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.type(textarea, "Second table caption")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
 
     await waitFor(() => {
-      expect(second).toHaveValue("Second table caption")
+      expect(getTableCaptions(getEditor()!)).toEqual([
+        "First table caption",
+        "Second table caption",
+      ])
     })
-    // The first table's caption must be untouched.
-    expect(first).toHaveValue("First table caption")
-
-    const editor = getEditor()
-    expect(getTableCaptions(editor!)).toEqual([
-      "First table caption",
-      "Second table caption",
-    ])
   })
 })

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
@@ -1,22 +1,19 @@
 import type { Editor as TiptapEditor } from "@tiptap/react"
 import type { RefObject } from "react"
-import { Box, Input, Text } from "@chakra-ui/react"
+import { Box, Icon, Text, useDisclosure } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
 import { useEditorState } from "@tiptap/react"
-import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { useLayoutEffect, useRef, useState } from "react"
+import { BiPencil } from "react-icons/bi"
+import { TableSettingsModal } from "~/components/PageEditor/TableSettingsModal"
 
 import {
-  CAPTION_MAX_LENGTH,
   CAPTION_TABLE_GAP_PX,
   captionRectsEqual,
-  clampCaptionLength,
   computeCaptionLayout,
   getTableInstances,
-  resolveCaptionOnBlur,
-  setTableCaptionAtPos,
   type CaptionLayoutRect,
 } from "./utils"
-
-const CAPTION_PLACEHOLDER = "Add a caption..."
 
 export interface TableCaptionProps {
   editor: TiptapEditor | null
@@ -29,132 +26,39 @@ export interface TableCaptionProps {
   containerRef: RefObject<HTMLElement>
 }
 
-const CounterText = ({ length }: { length: number }) => {
-  const isAtLimit = length >= CAPTION_MAX_LENGTH
-
-  return (
-    <Text
-      as="span"
-      fontSize="xs"
-      color={isAtLimit ? "utility.feedback.critical" : "base.content.medium"}
-      fontWeight={isAtLimit ? "semibold" : "normal"}
-    >
-      {length}/{CAPTION_MAX_LENGTH} characters
-    </Text>
-  )
-}
-
 interface SingleTableCaptionProps {
-  editor: TiptapEditor
-  pos: number
   caption: string
+  onEdit: () => void
 }
 
 /**
- * Always-editable caption line for a single table instance, scoped to `pos`.
- * Renders a borderless single-line input styled as quiet caption text
- * (italic placeholder when empty). Writes to the table attribute on every
- * keystroke so the live preview stays in sync. Escape restores the caption
- * from when focus began; blur/Enter with an empty draft also restores that
- * baseline (empty captions are not persisted). A character counter is shown
- * only while focused. At the character limit the counter turns red.
- *
- * `draft` / `isFocused` stay as React state: the caption is a React `<Input>`
- * overlay outside the ProseMirror editable, so TipTap does not own this
- * focus/draft UX.
+ * Right-aligned caption control for a single table instance. Opens the table
+ * settings modal on click — "Add caption" when empty, "Edit" when a caption
+ * already exists.
  */
-const SingleTableCaption = ({
-  editor,
-  pos,
-  caption,
-}: SingleTableCaptionProps) => {
-  const [isFocused, setIsFocused] = useState(false)
-  const [draft, setDraft] = useState(caption)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const draftRef = useRef(draft)
-  const baselineRef = useRef(caption)
-  const isCancellingRef = useRef(false)
-
-  draftRef.current = draft
-
-  // Keep the visible value in sync with the document when not focused
-  // (e.g. undo, or another path updating the caption attr).
-  useEffect(() => {
-    if (!isFocused) {
-      setDraft(caption)
-    }
-  }, [caption, isFocused])
-
-  const finish = (next: string) => {
-    setTableCaptionAtPos(editor, pos, next)
-    setDraft(next)
-    setIsFocused(false)
-  }
+const SingleTableCaption = ({ caption, onEdit }: SingleTableCaptionProps) => {
+  const label = caption ? "Edit" : "Add caption"
 
   return (
-    <Box>
-      <Input
-        ref={inputRef}
-        value={draft}
-        onChange={(e) => {
-          const value = clampCaptionLength(e.target.value)
-          setDraft(value)
-          // Live-write so the right-hand preview updates as the user types.
-          setTableCaptionAtPos(editor, pos, value)
-        }}
-        onFocus={() => {
-          baselineRef.current = caption
-          setIsFocused(true)
-        }}
-        onBlur={() => {
-          if (isCancellingRef.current) {
-            isCancellingRef.current = false
-            finish(baselineRef.current)
-            return
-          }
-          finish(resolveCaptionOnBlur(draftRef.current, baselineRef.current))
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Escape") {
-            e.preventDefault()
-            isCancellingRef.current = true
-            inputRef.current?.blur()
-            return
-          }
-          if (e.key === "Enter") {
-            e.preventDefault()
-            inputRef.current?.blur()
-          }
-        }}
-        placeholder={CAPTION_PLACEHOLDER}
-        aria-label={
-          caption ? `Edit table caption: ${caption}` : "Add a caption"
-        }
-        variant="unstyled"
-        size="sm"
-        px="0.25rem"
-        py="0.125rem"
-        borderRadius="0.25rem"
-        cursor="text"
-        fontStyle={draft ? "normal" : "italic"}
-        color={draft ? "base.content.strong" : "base.content.medium"}
-        _placeholder={{
-          fontStyle: "italic",
-          color: "base.content.medium",
-        }}
-        _hover={{ bg: "interaction.muted.main.hover" }}
-        _focus={{ bg: "interaction.muted.main.hover" }}
-      />
-      {isFocused && (
-        <Box textAlign="right" mt="0.25rem">
-          <CounterText length={draft.length} />
-        </Box>
-      )}
+    <Box textAlign="right">
+      <Button
+        variant="link"
+        gap="0.25rem"
+        onClick={onEdit}
+        aria-label={caption ? "Edit table caption" : "Add table caption"}
+      >
+        <Icon as={BiPencil} color="interaction.links.default" boxSize="1rem" />
+        <Text textStyle="caption-1" color="interaction.links.default">
+          {label}
+        </Text>
+      </Button>
     </Box>
   )
 }
 
 interface TableCaptionSlotProps extends SingleTableCaptionProps {
+  editor: TiptapEditor
+  pos: number
   containerRef: RefObject<HTMLElement>
 }
 
@@ -179,17 +83,15 @@ interface TableCaptionSlotProps extends SingleTableCaptionProps {
  *
  * Caption `top` is the table's margin-edge (border-box top minus the margin
  * currently on the table), not `borderBoxTop - newMargin`. That keeps the
- * input line stable when the caption box grows/shrinks — e.g. when the
- * character counter mounts on focus — instead of jumping the whole caption
- * up and later dropping it into the table on blur.
+ * caption line stable when the caption box grows/shrinks instead of jumping
+ * the whole caption up and later dropping it into the table on blur.
  *
  * Measurement happens in `useLayoutEffect`, not inline during render — doing
  * it in a plain `useMemo`/render body can capture an all-zero rect if the
  * browser hasn't flushed layout yet, and (since deps may not change again)
  * that zero rect would never get recomputed. Re-measuring runs on every
  * editor transaction so a caption stays correctly positioned and sized as
- * rows/columns are added, removed, or reordered, or as the caption itself
- * wraps to more/fewer lines.
+ * rows/columns are added, removed, or reordered.
  *
  * `rect` stays as React state: it is DOM layout measurement, not editor JSON.
  */
@@ -198,6 +100,7 @@ const TableCaptionSlot = ({
   pos,
   caption,
   containerRef,
+  onEdit,
 }: TableCaptionSlotProps) => {
   const [rect, setRect] = useState<CaptionLayoutRect | null>(null)
   const captionRef = useRef<HTMLDivElement>(null)
@@ -215,13 +118,7 @@ const TableCaptionSlot = ({
         return
       }
 
-      // Caption box is always mounted (just hidden until positioned), so it
-      // already has a real height on the first measurement.
       const captionHeight = captionRef.current?.offsetHeight ?? 0
-      // Peel off the margin we last wrote so the caption anchors to the
-      // margin-edge origin. Using the *new* reserved height here instead
-      // would jump the input up when the focus counter appears, and drop it
-      // into the table when the counter disappears.
       const currentMarginTop = Number.parseFloat(tableDom.style.marginTop) || 0
       const { rect: next, marginTop } = computeCaptionLayout({
         tableRect: tableDom.getBoundingClientRect(),
@@ -234,16 +131,12 @@ const TableCaptionSlot = ({
       })
       tableDom.style.marginTop = `${marginTop}px`
 
-      // Bail when nothing moved — otherwise ResizeObserver ↔ setRect can
-      // feedback-loop (marginTop / position changes re-fire the observer).
       setRect((prev) => (captionRectsEqual(prev, next) ? prev : next))
     }
 
     measure()
     editor.on("transaction", measure)
 
-    // Re-measure when the caption box grows/shrinks (e.g. counter
-    // appearing on focus), which does not emit an editor transaction.
     const resizeObserver = new ResizeObserver(measure)
     if (captionRef.current) {
       resizeObserver.observe(captionRef.current)
@@ -260,21 +153,13 @@ const TableCaptionSlot = ({
     <Box
       ref={captionRef}
       position="absolute"
-      // Always mounted (even before the first measurement completes) so
-      // `captionRef.current?.offsetHeight` reflects the caption's real
-      // rendered height as soon as `measure()` runs — if this were only
-      // rendered once `rect` is known, the very first measurement could
-      // never see a real height (the box wouldn't exist in the DOM yet),
-      // which would under-reserve space above the table on first mount.
-      // Hidden (rather than unmounted) until positioned, so it never
-      // flashes at the wrong spot or intercepts a click at (0, 0).
       visibility={rect ? "visible" : "hidden"}
       top={`${rect?.top ?? 0}px`}
       left={`${rect?.left ?? 0}px`}
       width={rect ? `${rect.width}px` : undefined}
       zIndex="1"
     >
-      <SingleTableCaption editor={editor} pos={pos} caption={caption} />
+      <SingleTableCaption caption={caption} onEdit={onEdit} />
     </Box>
   )
 }
@@ -295,9 +180,13 @@ const TableCaptionReady = ({
   editor,
   containerRef,
 }: TableCaptionReadyProps) => {
-  // TipTap's selector replaces manual event subscriptions for document-
-  // derived state. Document identity represents `update`; meta-only
-  // transactions compare equal and therefore do not re-render.
+  const {
+    isOpen: isTableSettingsModalOpen,
+    onOpen: onTableSettingsModalOpen,
+    onClose: onTableSettingsModalClose,
+  } = useDisclosure()
+  const [activeTablePos, setActiveTablePos] = useState<number | null>(null)
+
   const { tables } = useEditorState({
     editor,
     selector: ({ editor: currentEditor }) => ({
@@ -307,32 +196,42 @@ const TableCaptionReady = ({
     equalityFn: (previous, next) => next !== null && previous.doc === next.doc,
   })
 
+  const openTableSettings = (pos: number) => {
+    setActiveTablePos(pos)
+    onTableSettingsModalOpen()
+  }
+
   return (
     <>
       {tables.map((table) => (
         <TableCaptionSlot
-          // A table's `pos` shifts when content earlier in the document
-          // changes, but within a single transaction batch it uniquely
-          // identifies one table instance, and useEditorState re-derives
-          // fresh positions/captions whenever `doc` identity changes.
           key={table.pos}
           editor={editor}
           pos={table.pos}
           caption={table.caption}
           containerRef={containerRef}
+          onEdit={() => openTableSettings(table.pos)}
         />
       ))}
+      {activeTablePos !== null && (
+        <TableSettingsModal
+          editor={editor}
+          tablePos={activeTablePos}
+          isOpen={isTableSettingsModalOpen}
+          onClose={onTableSettingsModalClose}
+        />
+      )}
     </>
   )
 }
 
 /**
- * Renders one always-editable caption above EACH `table` node in the
- * editor's document — not just the first. Each caption's position is
- * re-derived from the live document on every transaction (so it stays
- * correct as tables are inserted, removed, or reordered), and every
- * read/write is scoped to that specific table's document position rather
- * than "the table at the current selection".
+ * Renders one caption control above EACH `table` node in the editor's
+ * document — not just the first. Each caption's position is re-derived from
+ * the live document on every transaction (so it stays correct as tables are
+ * inserted, removed, or reordered), and every read/write is scoped to that
+ * specific table's document position rather than "the table at the current
+ * selection".
  *
  * Must be rendered as a child of `containerRef`'s element (or otherwise
  * absolutely positioned relative to it), since captions are positioned


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +195 | -158 |
| 🧪 Test | 1 | +68 | -91 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The inline click-and-edit table caption UX replaced the caption modal, but we want to keep the modal flow while still showing a lightweight caption control above each table in the editor.

## Solution

Restore `TableSettingsModal` and replace the always-editable caption input with a right-aligned link button above each table:

- Shows **Add caption** when the table has no caption
- Shows **Edit** when a caption exists
- Uses the design-system `Button` (`variant="link"`) with a `BiPencil` icon and `interaction.links.default` blue text
- Opens the restored modal to add or edit the caption
- Saves via `setTableCaptionAtPos` so multi-table documents remain correct

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Restored table caption modal for add/edit flows
- Right-aligned caption button with pencil icon in the RTE

**Improvements**:

- Modal writes captions by table document position instead of selection

## Tests

- Updated `TableCaption.browser.test.tsx` for button + modal interactions
- Existing `utils.test.ts` layout helpers unchanged

**Manual Verification Steps**:

- [ ] Insert a table in the page editor and confirm an **Add caption** button appears above it (right-aligned, blue, with pencil icon)
- [ ] Click **Add caption**, enter text in the modal, save, and confirm the button changes to **Edit**
- [ ] Click **Edit**, change the caption in the modal, save, and confirm the table attribute updates
- [ ] Add two tables and confirm each has its own caption button; editing one does not affect the other

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8cbe7872-50cf-426d-9158-e504ff5872e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8cbe7872-50cf-426d-9158-e504ff5872e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

