### PR TITLE
🎀📊 feat(rte-table): add clear contents to TableBubbleMenu

### DIFF
--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -560,12 +560,17 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Delete row")).toBeNull()
   })
 
-  it("shows Split cell for a single cell that came from a merge, and nothing for an ordinary single cell", async () => {
-    const { editor, findByText, findByRole, queryByText, queryByRole } =
+  it("shows Clear contents for a single cell, and Clear plus Split for a merged single cell", async () => {
+    const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
 
-    // Merge two adjacent body cells into one, then re-select just that
-    // resulting cell — the only single-cell case with a bubble menu.
+    selectCells(editor, 6, 6)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(queryByText("Split cell")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+
     selectCells(editor, 3, 4)
     act(() => {
       editor.chain().focus().mergeCells().run()
@@ -573,14 +578,26 @@ describe("TableBubbleMenu", () => {
     selectCells(editor, 3, 3)
     await activateTableBubbleMenu(findByRole)
 
+    expect(await findByText("Clear contents")).toBeTruthy()
     expect(await findByText("Split cell")).toBeTruthy()
     expect(queryByText("Merge cells")).toBeNull()
+  })
 
-    // An ordinary (never-merged) single cell still shows no menu at all.
+  it("clears a single selected cell without removing the cell", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
     selectCells(editor, 6, 6)
-    expect(queryByText("Split cell")).toBeNull()
-    expect(queryByText("Merge cells")).toBeNull()
-    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+
+    await activateTableBubbleMenu(findByRole)
+    const clearCell = await findByText("Clear contents")
+    act(() => {
+      clearCell.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 2)).toEqual(["", "Row 2, B", "Row 2, C"])
+    expect(await findByText("Clear contents")).toBeTruthy()
   })
 
   it("does not show Superscript/Subscript when the text cursor is inside a cell", async () => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -409,6 +409,59 @@ describe("TableBubbleMenu", () => {
     ])
   })
 
+  it("clears every cell in a selected row without removing the row", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    selectCells(editor, 3, 5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+
+    const clearRow = await findByText("Clear contents")
+    act(() => {
+      clearRow.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    expect(await findByText("Clear contents")).toBeTruthy()
+  })
+
+  it("clears every cell in a selected column without removing the column", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    selectCells(editor, 1, 7)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+
+    const clearColumn = await findByText("Clear contents")
+    act(() => {
+      clearColumn.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "", "Row 2, C"])
+    expect(await findByText("Clear contents")).toBeTruthy()
+  })
+
+  it("clears header row content while keeping the header row", async () => {
+    const { editor, findByText } = await renderHarness()
+
+    selectCells(editor, 0, 2)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const clearRow = await findByText("Clear contents")
+    act(() => {
+      clearRow.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "", ""])
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(await findByText("Delete row")).toBeNull()
+  })
+
   it("excludes Delete row when the selection includes the header row", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -410,10 +410,11 @@ describe("TableBubbleMenu", () => {
   })
 
   it("clears every cell in a selected row without removing the row", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole } = await renderHarness()
 
     selectCells(editor, 3, 5)
     expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
 
     const clearRow = await findByText("Clear contents")
     act(() => {
@@ -423,15 +424,15 @@ describe("TableBubbleMenu", () => {
     expect(tableRowCount(editor)).toBe(3)
     expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
     expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
-    expect(await findByText("Clear contents")).toBeTruthy()
   })
 
   it("clears every cell in a selected column without removing the column", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole } = await renderHarness()
 
     selectCells(editor, 1, 7)
     expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
     expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
 
     const clearColumn = await findByText("Clear contents")
     act(() => {
@@ -442,14 +443,15 @@ describe("TableBubbleMenu", () => {
     expect(firstRowTexts(editor)).toEqual(["Column A", "", "Column C"])
     expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "", "Row 1, C"])
     expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "", "Row 2, C"])
-    expect(await findByText("Clear contents")).toBeTruthy()
   })
 
   it("clears header row content while keeping the header row", async () => {
-    const { editor, findByText } = await renderHarness()
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
 
     selectCells(editor, 0, 2)
     expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    await activateTableBubbleMenu(findByRole)
 
     const clearRow = await findByText("Clear contents")
     act(() => {
@@ -458,8 +460,12 @@ describe("TableBubbleMenu", () => {
 
     expect(tableRowCount(editor)).toBe(3)
     expect(firstRowTexts(editor)).toEqual(["", "", ""])
+
+    // Header axes withhold Delete row even after clearing.
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
     expect(await findByText("Clear contents")).toBeTruthy()
-    expect(await findByText("Delete row")).toBeNull()
+    expect(queryByText("Delete row")).toBeNull()
   })
 
   it("excludes Delete row when the selection includes the header row", async () => {
@@ -597,7 +603,6 @@ describe("TableBubbleMenu", () => {
 
     expect(tableRowCount(editor)).toBe(3)
     expect(rowTextsAt(editor, 2)).toEqual(["", "Row 2, B", "Row 2, C"])
-    expect(await findByText("Clear contents")).toBeTruthy()
   })
 
   it("does not show Superscript/Subscript when the text cursor is inside a cell", async () => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
@@ -1,10 +1,88 @@
 import type { Node } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
 import type { Editor } from "@tiptap/react"
 import { CellSelection } from "@tiptap/pm/tables"
 
+interface CellAtPosition {
+  pos: number
+  node: Node
+}
+
+// A table cell node wraps its editable blocks; these are the document
+// positions of everything inside that wrapper (paragraphs, lists, etc.).
+const innerContentRangeOfCell = ({
+  cellPos,
+  cell,
+}: {
+  cellPos: number
+  cell: Node
+}): { from: number; to: number } => ({
+  from: cellPos + 1,
+  to: cellPos + cell.nodeSize - 1,
+})
+
+const collectCellsInSelection = ({
+  selection,
+}: {
+  selection: CellSelection
+}): CellAtPosition[] => {
+  const cells: CellAtPosition[] = []
+  selection.forEachCell((node, pos) => {
+    cells.push({ pos, node })
+  })
+  return cells
+}
+
+const replaceCellInnerContent = ({
+  tr,
+  cell,
+  replacement,
+}: {
+  tr: Transaction
+  cell: CellAtPosition
+  replacement: Node
+}): void => {
+  const { from, to } = innerContentRangeOfCell({
+    cellPos: cell.pos,
+    cell: cell.node,
+  })
+  tr.replaceWith(from, to, replacement)
+}
+
+// Each replacement shortens/lengthens the doc, so later cell positions shift.
+// Clear from the end first so untouched cells keep stable positions.
+const clearCellContentsInReverseDocumentOrder = ({
+  tr,
+  cells,
+  emptyParagraph,
+}: {
+  tr: Transaction
+  cells: CellAtPosition[]
+  emptyParagraph: Node
+}): void => {
+  const cellsFromEndToStart = [...cells].sort((a, b) => b.pos - a.pos)
+  for (const cell of cellsFromEndToStart) {
+    replaceCellInnerContent({ tr, cell, replacement: emptyParagraph })
+  }
+}
+
+// Map the pre-clear anchor/head through the transaction so the same block
+// stays selected after the menu action.
+const restoreCellSelection = ({
+  tr,
+  selection,
+}: {
+  tr: Transaction
+  selection: CellSelection
+}): void => {
+  const anchor = tr.mapping.map(selection.$anchorCell.pos)
+  const head = tr.mapping.map(selection.$headCell.pos)
+  tr.setSelection(CellSelection.create(tr.doc, anchor, head))
+}
+
 // Replace every selected cell's inner content with a single empty paragraph.
 // Cell type (header vs body) and colspan/rowspan are preserved.
-export const clearSelectedCells = (editor: Editor): void => {
+export const clearSelectedCells = ({ editor }: { editor: Editor }): void => {
   const { state, view } = editor
   const { selection, schema } = state
   if (!(selection instanceof CellSelection)) return
@@ -12,25 +90,15 @@ export const clearSelectedCells = (editor: Editor): void => {
   const paragraph = schema.nodes.paragraph
   if (!paragraph) return
 
-  const emptyParagraph = paragraph.create()
-  const cells: { pos: number; node: Node }[] = []
-  selection.forEachCell((node, pos) => {
-    cells.push({ pos, node })
-  })
-
+  const cells = collectCellsInSelection({ selection })
   if (cells.length === 0) return
 
   const tr = state.tr
-  // Replace from the end so earlier cell positions stay valid.
-  cells.sort((a, b) => b.pos - a.pos)
-  for (const { pos, node } of cells) {
-    const innerStart = pos + 1
-    const innerEnd = pos + node.nodeSize - 1
-    tr.replaceWith(innerStart, innerEnd, emptyParagraph)
-  }
-
-  const anchor = tr.mapping.map(selection.$anchorCell.pos)
-  const head = tr.mapping.map(selection.$headCell.pos)
-  tr.setSelection(CellSelection.create(tr.doc, anchor, head))
+  clearCellContentsInReverseDocumentOrder({
+    tr,
+    cells,
+    emptyParagraph: paragraph.create(),
+  })
+  restoreCellSelection({ tr, selection })
   view.dispatch(tr)
 }

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
@@ -1,0 +1,36 @@
+import type { Node } from "@tiptap/pm/model"
+import type { Editor } from "@tiptap/react"
+import { CellSelection } from "@tiptap/pm/tables"
+
+// Replace every selected cell's inner content with a single empty paragraph.
+// Cell type (header vs body) and colspan/rowspan are preserved.
+export const clearSelectedCells = (editor: Editor): void => {
+  const { state, view } = editor
+  const { selection, schema } = state
+  if (!(selection instanceof CellSelection)) return
+
+  const paragraph = schema.nodes.paragraph
+  if (!paragraph) return
+
+  const emptyParagraph = paragraph.create()
+  const cells: { pos: number; node: Node }[] = []
+  selection.forEachCell((node, pos) => {
+    cells.push({ pos, node })
+  })
+
+  if (cells.length === 0) return
+
+  const tr = state.tr
+  // Replace from the end so earlier cell positions stay valid.
+  cells.sort((a, b) => b.pos - a.pos)
+  for (const { pos, node } of cells) {
+    const innerStart = pos + 1
+    const innerEnd = pos + node.nodeSize - 1
+    tr.replaceWith(innerStart, innerEnd, emptyParagraph)
+  }
+
+  const anchor = tr.mapping.map(selection.$anchorCell.pos)
+  const head = tr.mapping.map(selection.$headCell.pos)
+  tr.setSelection(CellSelection.create(tr.doc, anchor, head))
+  view.dispatch(tr)
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -317,7 +317,7 @@ const RowSelectionActions = ({
         <ActionButton
           label="Clear contents"
           icon={<BiX fontSize="1rem" />}
-          onClick={() => clearSelectedCells(editor)}
+          onClick={() => clearSelectedCells({ editor })}
         />
         {canMoveUp && (
           <ActionButton
@@ -390,7 +390,7 @@ const ColumnSelectionActions = ({
         <ActionButton
           label="Clear contents"
           icon={<BiX fontSize="1rem" />}
-          onClick={() => clearSelectedCells(editor)}
+          onClick={() => clearSelectedCells({ editor })}
         />
         {canMoveLeft && (
           <ActionButton

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -54,9 +54,8 @@ export interface TableBubbleMenuProps {
   editor: Editor
 }
 
-// A single selected cell that came from a previous merge (colspan/rowspan >
-// 1) is the only single-cell case that shows a bubble menu — "Split cell" is
-// its sole way back. Ordinary single cells stay menu-less.
+// Single-cell selections show Clear contents; merged single cells also offer
+// Split cell to undo the merge.
 //
 // NOTE: this can't be driven off `selectedRect`'s width/height — those are in
 // TableMap grid units, which count a colspan-2 cell as spanning 2 columns
@@ -458,13 +457,30 @@ const TableSelectionActions = ({
           onClick={() => editor.chain().focus().mergeCells().run()}
         />
       )
+    case "single-cell":
+      return (
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells({ editor })}
+          />
+        </ActionGroup>
+      )
     case "merged-cell":
       return (
-        <ActionButton
-          label="Split cell"
-          icon={<IconSplitCell boxSize="1rem" />}
-          onClick={() => editor.chain().focus().splitCell().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells({ editor })}
+          />
+          <ActionButton
+            label="Split cell"
+            icon={<IconSplitCell boxSize="1rem" />}
+            onClick={() => editor.chain().focus().splitCell().run()}
+          />
+        </ActionGroup>
       )
     default:
       return null
@@ -480,8 +496,8 @@ const TableSelectionActions = ({
 // across renders is what breaks that loop. See
 // .scratch/rte-table-ux/issues/06-prototype-bubble-menu-content-layout.md.
 //
-// Only CellSelections that have table actions (row/column/table/merge/split)
-// show the menu. A plain text cursor inside a cell must not.
+// Only CellSelections that have table actions show the menu. A plain text
+// cursor inside a cell must not.
 // Require editor (or menu) focus — TipTap's default shouldShow does this.
 //
 // Also stay hidden while prosemirror-tables is mid cell-drag
@@ -500,7 +516,7 @@ const hasActionableTableSelection = (
   if (tableEditingKey.getState(view.state) != null) return false
 
   const kind = detectSelectionType(editor)
-  return kind !== "none" && kind !== "single-cell"
+  return kind !== "none"
 }
 
 const shouldShowTableBubbleMenu = ({
@@ -685,8 +701,7 @@ export const TableBubbleMenu = memo(function TableBubbleMenu({
       previous.isDragging === next.isDragging,
   })
 
-  const showTrigger =
-    kind !== "none" && kind !== "single-cell" && !isDragging && isFocused
+  const showTrigger = kind !== "none" && !isDragging && isFocused
 
   const corner = useTableBubbleMenuTriggerCorner(editor, showTrigger)
 

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -22,6 +22,7 @@ import {
   BiRightArrowAlt,
   BiTrash,
   BiUpArrowAlt,
+  BiX,
 } from "react-icons/bi"
 import {
   IconAddColLeft,
@@ -34,6 +35,7 @@ import {
   IconSplitCell,
 } from "~/components/icons"
 
+import { clearSelectedCells } from "./TableBubbleMenu.clear"
 import {
   duplicateSelectedColumns,
   duplicateSelectedRows,
@@ -312,6 +314,11 @@ const RowSelectionActions = ({
           icon={<BiCopy fontSize="1rem" />}
           onClick={() => duplicateSelectedRows(editor)}
         />
+        <ActionButton
+          label="Clear contents"
+          icon={<BiX fontSize="1rem" />}
+          onClick={() => clearSelectedCells(editor)}
+        />
         {canMoveUp && (
           <ActionButton
             label="Move up"
@@ -379,6 +386,11 @@ const ColumnSelectionActions = ({
           label="Duplicate column"
           icon={<BiCopy fontSize="1rem" />}
           onClick={() => duplicateSelectedColumns(editor)}
+        />
+        <ActionButton
+          label="Clear contents"
+          icon={<BiX fontSize="1rem" />}
+          onClick={() => clearSelectedCells(editor)}
         />
         {canMoveLeft && (
           <ActionButton


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +144 | -13 |
| 🧪 Test | 1 | +83 | -8 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

When a full row or column is selected in the rich-text table editor, authors had no way to empty cell content without deleting the row/column structure. That forces unnecessary structural edits (delete + re-add) when users only want to wipe text.

Closes https://linear.app/ogp/issue/ISOM-2395/rte-add-clear-contents-button-for-rowcolumn

## Solution

Adds a **Clear contents** action to the contextual `TableBubbleMenu` for full row and full column selections. The action replaces each selected cell's inner content with a single empty paragraph via a ProseMirror transaction, preserving cell type (header vs body) and colspan/rowspan.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- **Clear contents** button in row and column bubble-menu action groups (cross icon)
- Works on header rows/columns, unlike **Delete row/column**
- Supports multi-row / multi-column selections that span the full table width or height

**Improvements**:

- `TableBubbleMenu.clear.ts` extracts the clear logic into named helpers (`innerContentRangeOfCell`, `clearCellContentsInReverseDocumentOrder`, etc.) with named-argument call sites for readability

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- No clear-contents action when a full row/column is selected -->

**AFTER**:

<!-- TableBubbleMenu shows "Clear contents" for full row/column selections; cells become empty while the row/column remains -->

https://github.com/user-attachments/assets/32310ec6-80a2-48b7-97af-9bb2d9eced0d

## Tests

**Manual Verification Steps**:

- [ ] Open a page in Studio with a rich-text table (e.g. content page editor)
- [ ] Click-drag to select an entire body row — confirm the bubble menu appears with **Clear contents**
- [ ] Click **Clear contents** — confirm all cells in that row are empty but the row still exists
- [ ] Select an entire column and click **Clear contents** — confirm only that column's cells are emptied
- [ ] Select the header row and click **Clear contents** — confirm header cells are emptied and **Delete row** is still withheld

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

---