### PR TITLE
🎀📊 fix(studio): remove table cell selection background highlight in TipTap editor

### DIFF
--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -117,7 +117,6 @@ $max-depth: 13;
     width: 100%;
 
     .selectedCell:after {
-      background: rgba(200, 200, 255, 0.2);
       border-color: #2164da;
       border-style: solid;
       border-width: 0;


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +0 | -1 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

When selecting cells, rows, or columns in the Studio rich text editor table, the selection is shown with a semi-transparent blue background fill in addition to the perimeter border. This fill is visually noisy and conflicts with the intended selection treatment.

Closes https://linear.app/ogp/issue/ISOM-2394/rte-remove-background-colour-for-selected-cells

## Solution

Removed the `background` property from the `.selectedCell:after` pseudo-element in `tiptap.scss`. The blue perimeter border (via `createTableSelectionBorderPlugin` and side-specific border classes) is unchanged, so table selections remain visible without the tinted fill.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Table cell/row/column selection in the TipTap editor no longer applies a background fill; only the outer selection border is shown.

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- Selected table cells show a semi-transparent blue background fill -->

<img width="696" height="261" alt="Screenshot 2026-07-28 at 2 24 43 AM" src="https://github.com/user-attachments/assets/c22a972a-87c7-4182-9b26-0151a8b91e43" />

**AFTER**:

<!-- Selected table cells show only the blue perimeter border, with no background fill -->

<img width="606" height="309" alt="Screenshot 2026-07-28 at 2 24 14 AM" src="https://github.com/user-attachments/assets/254f4924-4210-4656-a298-5fbff78f7a01" />

## Tests

**Manual Verification Steps**:

- [ ] Open a page in Studio with a rich text editor block that contains a table (or insert a new table).
- [ ] Click a single cell and confirm the selection shows a blue border outline with no tinted background fill.
- [ ] Drag to select multiple cells and confirm only the outer perimeter border appears, with no background fill inside the selection.
- [ ] Click the row or column handle to select an entire row or column and confirm the same border-only selection styling.
- [ ] Verify the table bubble menu still appears for valid selections and table actions (e.g. background colour, merge, delete) still work as before.

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Removes the semi-transparent background fill from selected table cells in the Studio TipTap editor while preserving the existing selection-border styling.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change is limited to removing a visual background fill while leaving the existing table-selection border declarations intact.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified that Storybook initially failed to start due to an unbuilt workspace package and was resolved after building @opengovsg/isomer-components.
- Confirmed the multi-cell selection UI changed from a tinted ::after background to an unfilled ::after background while maintaining the border color and outer 2px sides.
- Observed that the real toolbar surfaced Delete table and Table controls during selection, expanded Table revealed nine actions, and Add row after was executed successfully.

<a href="https://app.greptile.com/trex/runs/16065374/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/styles/tiptap.scss | Removes only the `.selectedCell:after` background declaration; no actionable correctness issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(styles): remove background color fro..."](https://github.com/opengovsg/isomer/commit/0eb790a0ab411825a0d0658d988060b8f789661b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47669841)</sub>

<!-- /greptile_comment -->