### PR TITLE
🎀📊 style(rte-table): dim unselected cells during row/column selection

### DIFF
--- a/apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+
+import { shouldDimUnselectedTableCells } from "../shouldDimUnselectedTableCells"
+
+const tableMap = { width: 4, height: 3 }
+
+describe("shouldDimUnselectedTableCells", () => {
+  it("is false for a single-cell selection", () => {
+    expect(
+      shouldDimUnselectedTableCells({
+        left: 1,
+        top: 1,
+        right: 2,
+        bottom: 2,
+        map: tableMap,
+      }),
+    ).toBe(false)
+  })
+
+  it("is false for a full-table selection", () => {
+    expect(
+      shouldDimUnselectedTableCells({
+        left: 0,
+        top: 0,
+        right: 4,
+        bottom: 3,
+        map: tableMap,
+      }),
+    ).toBe(false)
+  })
+
+  it("is true for a single-row selection", () => {
+    expect(
+      shouldDimUnselectedTableCells({
+        left: 0,
+        top: 1,
+        right: 4,
+        bottom: 2,
+        map: tableMap,
+      }),
+    ).toBe(true)
+  })
+
+  it("is true for a single-column selection", () => {
+    expect(
+      shouldDimUnselectedTableCells({
+        left: 2,
+        top: 0,
+        right: 3,
+        bottom: 3,
+        map: tableMap,
+      }),
+    ).toBe(true)
+  })
+
+  it("is true for a multi-row, multi-column block", () => {
+    expect(
+      shouldDimUnselectedTableCells({
+        left: 1,
+        top: 0,
+        right: 3,
+        bottom: 2,
+        map: tableMap,
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts
@@ -2,9 +2,30 @@ import { describe, expect, it } from "vitest"
 
 import { shouldDimUnselectedTableCells } from "../shouldDimUnselectedTableCells"
 
-const tableMap = { width: 4, height: 3 }
+const tableMap = {
+  width: 4,
+  height: 3,
+  map: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+}
 
 describe("shouldDimUnselectedTableCells", () => {
+  it("is false for a single merged-cell selection", () => {
+    expect(
+      shouldDimUnselectedTableCells({
+        left: 1,
+        top: 1,
+        right: 3,
+        bottom: 3,
+        map: {
+          width: 4,
+          height: 3,
+          // One cell node spans this 2×2 block (offsets repeat in TableMap).
+          map: [0, 1, 2, 3, 4, 5, 5, 6, 8, 9, 10, 11],
+        },
+      }),
+    ).toBe(false)
+  })
+
   it("is false for a single-cell selection", () => {
     expect(
       shouldDimUnselectedTableCells({

--- a/apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts
@@ -20,7 +20,7 @@ describe("shouldDimUnselectedTableCells", () => {
           width: 4,
           height: 3,
           // One cell node spans this 2×2 block (offsets repeat in TableMap).
-          map: [0, 1, 2, 3, 4, 5, 5, 6, 8, 9, 10, 11],
+          map: [0, 1, 2, 3, 4, 5, 5, 6, 8, 5, 5, 11],
         },
       }),
     ).toBe(false)

--- a/apps/studio/src/features/editing-experience/utils/createTableSelectionBorderPlugin.ts
+++ b/apps/studio/src/features/editing-experience/utils/createTableSelectionBorderPlugin.ts
@@ -4,6 +4,7 @@ import { CellSelection, selectedRect } from "@tiptap/pm/tables"
 import { Decoration, DecorationSet } from "@tiptap/pm/view"
 
 import { getSelectedCellBorderClasses } from "./getSelectedCellBorderClasses"
+import { shouldDimUnselectedTableCells } from "./shouldDimUnselectedTableCells"
 
 export const tableSelectionBorderPluginKey = new PluginKey(
   "tableSelectionBorder",
@@ -12,7 +13,8 @@ export const tableSelectionBorderPluginKey = new PluginKey(
 /**
  * Draws a single outer primary border around a CellSelection by tagging only
  * the selection's perimeter cells with side-specific classes (merged with the
- * built-in `selectedCell` fill decoration).
+ * built-in `selectedCell` fill decoration). For row/column and multi-cell
+ * selections, also dims text in cells outside the selection.
  */
 export const createTableSelectionBorderPlugin = () =>
   new Plugin({
@@ -37,6 +39,38 @@ export const createTableSelectionBorderPlugin = () =>
             }),
           )
         })
+
+        if (shouldDimUnselectedTableCells(rect)) {
+          const selectedPositions = new Set<number>()
+          state.selection.forEachCell((_node, pos) => {
+            selectedPositions.add(pos)
+          })
+
+          const processedPositions = new Set<number>()
+          const { map, tableStart } = rect
+
+          for (let row = 0; row < map.height; row++) {
+            for (let col = 0; col < map.width; col++) {
+              const cellPos = map.map[row * map.width + col]
+              if (cellPos === undefined) continue
+
+              const docPos = tableStart + cellPos
+              if (processedPositions.has(docPos)) continue
+              processedPositions.add(docPos)
+
+              if (selectedPositions.has(docPos)) continue
+
+              const node = state.doc.nodeAt(docPos)
+              if (!node) continue
+
+              decorations.push(
+                Decoration.node(docPos, docPos + node.nodeSize, {
+                  class: "dimmedCell",
+                }),
+              )
+            }
+          }
+        }
 
         return DecorationSet.create(state.doc, decorations)
       },

--- a/apps/studio/src/features/editing-experience/utils/shouldDimUnselectedTableCells.ts
+++ b/apps/studio/src/features/editing-experience/utils/shouldDimUnselectedTableCells.ts
@@ -6,7 +6,22 @@ export interface TableSelectionRect {
   map: {
     width: number
     height: number
+    map: number[]
   }
+}
+
+const countSelectedCells = (rect: TableSelectionRect): number => {
+  const cellStarts = new Set<number>()
+  const { width, map } = rect.map
+
+  for (let row = rect.top; row < rect.bottom; row++) {
+    for (let col = rect.left; col < rect.right; col++) {
+      const cellStart = map[row * width + col]
+      if (cellStart !== undefined) cellStarts.add(cellStart)
+    }
+  }
+
+  return cellStarts.size
 }
 
 /**
@@ -21,7 +36,8 @@ export const shouldDimUnselectedTableCells = (
   const spanHeight = rect.bottom - rect.top
   const { width, height } = rect.map
 
-  if (spanWidth === 1 && spanHeight === 1) return false
+  // Grid span can exceed 1×1 for a merged cell; count distinct cell nodes instead.
+  if (countSelectedCells(rect) === 1) return false
   if (spanWidth === width && spanHeight === height) return false
   return true
 }

--- a/apps/studio/src/features/editing-experience/utils/shouldDimUnselectedTableCells.ts
+++ b/apps/studio/src/features/editing-experience/utils/shouldDimUnselectedTableCells.ts
@@ -1,0 +1,27 @@
+export interface TableSelectionRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+  map: {
+    width: number
+    height: number
+  }
+}
+
+/**
+ * Whether non-selected cells should be dimmed for the current CellSelection.
+ * Applies to row/column blocks and multi-cell rectangles, but not single cells
+ * or a full-table selection.
+ */
+export const shouldDimUnselectedTableCells = (
+  rect: TableSelectionRect,
+): boolean => {
+  const spanWidth = rect.right - rect.left
+  const spanHeight = rect.bottom - rect.top
+  const { width, height } = rect.map
+
+  if (spanWidth === 1 && spanHeight === 1) return false
+  if (spanWidth === width && spanHeight === height) return false
+  return true
+}

--- a/apps/studio/src/styles/tiptap.scss
+++ b/apps/studio/src/styles/tiptap.scss
@@ -149,6 +149,11 @@ $max-depth: 13;
       border-left-width: 2px;
     }
 
+    // Row/column and multi-cell selections dim text outside the selection.
+    .dimmedCell > * {
+      opacity: 0.5;
+    }
+
     td,
     th {
       border: 1px solid #d6d6d6;


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +83 | -1 |
| 🧪 Test | 1 | +88 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

When editing a table in the rich text editor, selecting a row, column, or multi-cell block does not visually de-emphasise the rest of the table. This makes it harder to see which cells are in scope for row/column actions.

Closes https://linear.app/ogp/issue/ISOM-2393/rte-dim-unselected-cells-during-rowcolumn-selection

## Solution

Extend the existing table selection border plugin to tag unselected cells with a `dimmedCell` class when the selection spans multiple rows and/or columns. A small helper (`shouldDimUnselectedTableCells`) gates dimming so single-cell and full-table selections are unchanged. Cell content is faded to 50% opacity via SCSS, leaving borders and header backgrounds untouched.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Unselected table cells are dimmed to 50% opacity when a row, column, or multi-cell block is selected
- Single-cell and full-table selections are unaffected

**Bug Fixes**:

- N/A

## Before & After Screenshots

https://github.com/user-attachments/assets/e672f80e-173e-4b0e-8ac9-13c695d4bae2

## Tests

**Manual Verification Steps**:

- [ ] Open a page in Studio with a rich text field containing a table (at least 3 rows × 3 columns)
- [ ] Select a single row via the row drag handle — verify text in other rows is 50% opaque while the selected row stays full opacity
- [ ] Select a single column via the column drag handle — verify text in other columns is dimmed
- [ ] Select a multi-cell block (e.g. 2×2) — verify only cells outside the block are dimmed
- [ ] Click into a single cell — verify no dimming is applied
- [ ] Select the entire table — verify no dimming is applied

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Updates table-selection styling in the rich-text editor.
- Dims unselected cell content during row, column, and multi-cell selections.
- Preserves normal styling for single-cell, merged-cell, and full-table selections.
- Adds unit coverage for selection-dimming decisions.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failures remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed the initial table state with a 2×2 selection where all cells had opacity 1 and none showed dimmed decorations.
- After performing a row selection, confirmed that three selected cells remained at opacity 1 while six non-selected cells were dimmed and rendered at opacity 0.5.
- After performing a column selection, confirmed that three selected cells remained at opacity 1 while six non-selected cells were dimmed and rendered at opacity 0.5.
- After a 2×2 selection, confirmed four selected cells remained at opacity 1 and five outside cells were dimmed to opacity 0.5.
- Noted that single-cell and full-table selections produced no dimmed decorations and kept opacity at 1.

<a href="https://app.greptile.com/trex/runs/16092836/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/utils/shouldDimUnselectedTableCells.ts | Counts distinct selected cell nodes so merged single-cell selections do not trigger dimming. |
| apps/studio/src/features/editing-experience/utils/createTableSelectionBorderPlugin.ts | Adds decorations to dim each unique unselected table cell during qualifying selections. |
| apps/studio/src/features/editing-experience/utils/__tests__/shouldDimUnselectedTableCells.test.ts | Covers merged, single-cell, full-table, row, column, and rectangular selection cases. |
| apps/studio/src/styles/tiptap.scss | Fades content within dimmed cells while leaving cell borders and backgrounds unchanged. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(rte-table): fix merged-cell TableMa..."](https://github.com/opengovsg/isomer/commit/789590425d881d53fbdb4ddb32bc858bc2db0f89) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47674852)</sub>

<!-- /greptile_comment -->