### PR TITLE
🎀📊 feat(rte-table): add contextual TableBubbleMenu for table actions

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -116,71 +105,16 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/HorizontalList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/HorizontalList.tsx
@@ -31,8 +31,10 @@ export const MenubarHorizontalList = ({
     return null
   }
   return (
-    <Popover placement="bottom">
-      {({ isOpen }) => (
+    // closeOnBlur=false pairs with mousedown preventDefault below — otherwise
+    // focus stays in the editor and Chakra dismisses the popover immediately.
+    <Popover placement="bottom" closeOnBlur={false} isLazy>
+      {({ isOpen, onClose }) => (
         <>
           <PopoverTrigger>
             <HStack>
@@ -47,6 +49,8 @@ export const MenubarHorizontalList = ({
                 _active={{
                   bg: "interaction.muted.main.active",
                 }}
+                // TipTap toolbar pattern: keep editor selection on open.
+                onMouseDown={(event) => event.preventDefault()}
               >
                 <HStack spacing={0}>
                   <Icon
@@ -71,7 +75,10 @@ export const MenubarHorizontalList = ({
                     key={index}
                     icon={subItem.icon}
                     title={subItem.title}
-                    action={subItem.action}
+                    action={() => {
+                      subItem.action()
+                      onClose()
+                    }}
                     isActive={subItem.isActive}
                   />
                 ))}

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
@@ -25,8 +25,12 @@ export const MenubarOverflowList = ({
     return null
   }
   return (
-    <Popover placement="bottom">
-      {({ isOpen }) => (
+    // TipTap toolbar pattern: preventDefault on mousedown so the trigger
+    // does not steal focus from the editor. Pair with closeOnBlur=false —
+    // otherwise focus never enters the popover and closeOnBlur immediately
+    // dismisses (or fights) the open state.
+    <Popover placement="bottom" closeOnBlur={false} isLazy>
+      {({ isOpen, onClose }) => (
         <>
           <PopoverTrigger>
             <IconButton
@@ -42,6 +46,7 @@ export const MenubarOverflowList = ({
               minW="1.75rem"
               p="0.25rem"
               aria-label="More options"
+              onMouseDown={(event) => event.preventDefault()}
             >
               <Icon
                 as={BiDotsHorizontalRounded}
@@ -58,7 +63,10 @@ export const MenubarOverflowList = ({
                     key={index}
                     icon={subItem.icon}
                     title={subItem.title}
-                    action={subItem.action}
+                    action={() => {
+                      subItem.action()
+                      onClose()
+                    }}
                     isActive={subItem.isActive}
                   />
                 ))}

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -165,72 +154,16 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // Table-specific commands
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.

--- a/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
+++ b/apps/studio/src/components/PageEditor/TableSettingsModal.tsx
@@ -68,7 +68,11 @@ export const TableSettingsModal = ({
   }, [isOpen])
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    // trapFocus=false: with TableBubbleMenu mounted, Chakra's FocusLock and
+    // TipTap's BubbleMenu (tabIndex=0 + blur/focus handlers) fight when the
+    // editor blurs into this modal — hanging the tab. Keep autoFocus so the
+    // textarea still receives focus; just don't run the focus trap.
+    <Modal isOpen={isOpen} onClose={onClose} trapFocus={false}>
       <ModalOverlay />
 
       <ModalContent>

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -1,0 +1,518 @@
+// Renders a real TipTap editor (ProseMirror needs a real DOM to construct an
+// EditorView), so this runs under Vitest Browser Mode rather than jsdom — see
+// the `*.browser.test.{ts,tsx}` convention in apps/studio/vitest.config.ts.
+import type { Editor, JSONContent } from "@tiptap/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { act, render, waitFor } from "@testing-library/react"
+import { tableEditingKey } from "@tiptap/pm/tables"
+import { EditorContent } from "@tiptap/react"
+import { describe, expect, it } from "vitest"
+import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor"
+import { theme } from "~/theme"
+
+import { TableBubbleMenu } from "./TableBubbleMenu"
+
+const SEED_CONTENT: JSONContent = {
+  type: "prose",
+  content: [
+    {
+      type: "table",
+      attrs: { caption: "Test table" },
+      content: [
+        {
+          type: "tableRow",
+          content: ["Column A", "Column B", "Column C"].map((text) => ({
+            type: "tableHeader",
+            content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+          })),
+        },
+        ...[1, 2].map((row) => ({
+          type: "tableRow",
+          content: ["A", "B", "C"].map((col) => ({
+            type: "tableCell",
+            content: [
+              {
+                type: "paragraph",
+                content: [{ type: "text", text: `Row ${row}, ${col}` }],
+              },
+            ],
+          })),
+        })),
+      ],
+    },
+  ],
+}
+
+// Finds the document position at the start boundary of the nth cell
+// (tableCell or tableHeader) in reading order, 0-indexed. This is the
+// position CellSelection.create expects: resolving it yields a ResolvedPos
+// whose parent is the cell's tableRow, so `$pos.node(-1)` is the table (as
+// prosemirror-tables' CellSelection constructor requires) — resolving one
+// position later (i.e. *inside* the cell) would instead make the row the
+// `node(-1)` ancestor and throw "Not a table node".
+const nthCellPos = (editor: Editor, index: number): number => {
+  let seen = 0
+  let found: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== null) return false
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      if (seen === index) {
+        found = pos
+        return false
+      }
+      seen += 1
+    }
+    return true
+  })
+  if (found === null) throw new Error(`Could not find cell at index ${index}`)
+  return found
+}
+
+// Selects the cell range [startIndex, endIndex] (inclusive, 0-indexed reading
+// order) and flushes the resulting transaction inside `act`, since this
+// dispatches synchronously outside of React's own event handling.
+const selectCells = (editor: Editor, startIndex: number, endIndex: number) => {
+  const anchorCell = nthCellPos(editor, startIndex)
+  const headCell = nthCellPos(editor, endIndex)
+  act(() => {
+    // A real pointer selection focuses the editor. Make that precondition
+    // explicit instead of relying on menu rendering to steal focus.
+    editor.chain().focus().setCellSelection({ anchorCell, headCell }).run()
+  })
+}
+
+const activateTableBubbleMenu = async (
+  findByRole: (role: string, options: { name: string }) => Promise<HTMLElement>,
+) => {
+  const trigger = await findByRole("button", { name: "Table actions" })
+  act(() => {
+    trigger.click()
+  })
+}
+
+const Harness = ({ onReady }: { onReady: (editor: Editor) => void }) => {
+  const editor = useTextEditor({ data: SEED_CONTENT, handleChange: () => null })
+  if (editor) onReady(editor)
+  return (
+    <>
+      {editor && <TableBubbleMenu editor={editor} />}
+      {editor && <EditorContent editor={editor} />}
+    </>
+  )
+}
+
+const renderHarness = async () => {
+  let editor: Editor | undefined
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <Harness onReady={(e) => (editor = e)} />
+    </ThemeProvider>,
+  )
+  await waitFor(() => {
+    if (!editor) throw new Error("editor not ready")
+  })
+  // Non-null by the waitFor above.
+  return { ...utils, editor: editor! }
+}
+
+// First-row cell text contents in left-to-right order — used to assert
+// column reordering after Move left/right.
+const firstRowTexts = (editor: Editor): string[] => {
+  const texts: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    const firstRow = node.child(0)
+    firstRow.forEach((cell) => {
+      texts.push(cell.textContent)
+    })
+    return false
+  })
+  return texts
+}
+
+describe("TableBubbleMenu", () => {
+  it("stacks the menu above the selected-cell highlight", async () => {
+    const { editor, findByText, findByRole, container } = await renderHarness()
+
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+
+    const action = await findByText("Add row above")
+    const menuSurface = action.closest("button")?.parentElement?.parentElement
+    const selectedCell = container.querySelector(".selectedCell")
+
+    expect(menuSurface).not.toBeNull()
+    expect(selectedCell).not.toBeNull()
+
+    const menuZIndex = Number(getComputedStyle(menuSurface!).zIndex)
+    // The `.selectedCell::after` highlight in tiptap.scss uses z-index: 2.
+    expect(menuZIndex).toBeGreaterThan(2)
+  })
+
+  it("shows row actions (including Delete row) when a body row is selected", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5) // the full body row (not the first row)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(queryByText("Header row")).toBeNull()
+    expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Move up")).toBeTruthy()
+    expect(await findByText("Move down")).toBeTruthy()
+    expect(await findByText("Delete row")).toBeTruthy()
+  })
+
+  it("shows Header row/column only for the exact top row / leftmost column", async () => {
+    const { editor, findByRole, queryByRole } = await renderHarness()
+
+    // Body row — not the top row
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+
+    // Exact header / top row
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByRole("checkbox", { name: "Header row" })).toBeChecked()
+
+    // Top row + body row — overlaps the top row but is not exactly it
+    selectCells(editor, 0, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+
+    // Middle column — not the leftmost column
+    selectCells(editor, 1, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
+
+    // Exact leftmost column
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+    expect(
+      await findByRole("checkbox", { name: "Header column" }),
+    ).not.toBeChecked()
+
+    // Leftmost + next column — overlaps leftmost but is not exactly it
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
+  })
+
+  it("places the Header row/column toggle above other actions when shown", async () => {
+    const { editor, findByRole, findByText } = await renderHarness()
+
+    selectCells(editor, 0, 2) // header row (includes first row)
+    await activateTableBubbleMenu(findByRole)
+    const rowToggle = await findByRole("checkbox", { name: "Header row" })
+    const addRow = await findByText("Add row above")
+    expect(
+      rowToggle.compareDocumentPosition(addRow) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    selectCells(editor, 0, 6) // leftmost column (includes first column)
+    await activateTableBubbleMenu(findByRole)
+    const colToggle = await findByRole("checkbox", { name: "Header column" })
+    const addCol = await findByText("Add column left")
+    expect(
+      colToggle.compareDocumentPosition(addCol) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+  })
+
+  it("hides Move left/right (and up/down) when the selection is already at that edge", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    // Leftmost column (A): cells 0, 3, 6
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByText("Move left")).toBeNull()
+    expect(await findByText("Move right")).toBeTruthy()
+
+    // Rightmost column (C): cells 2, 5, 8
+    selectCells(editor, 2, 8)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByText("Move right")).toBeNull()
+    expect(await findByText("Move left")).toBeTruthy()
+
+    // Leftmost two columns (A+B): anchor header A → bottom of B
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByText("Move left")).toBeNull()
+    expect(await findByText("Move right")).toBeTruthy()
+
+    // Bottom body row
+    selectCells(editor, 6, 8)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByText("Move down")).toBeNull()
+    expect(await findByText("Move up")).toBeTruthy()
+
+    // Header row (top)
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByText("Move up")).toBeNull()
+    expect(await findByText("Move down")).toBeTruthy()
+  })
+
+  it("moves a multi-column selection as a block (A,B → right becomes C,A,B)", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    // Full columns A+B
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const moveRight = await findByText("Move right")
+    act(() => {
+      moveRight.click()
+    })
+
+    expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
+  })
+
+  it("excludes Delete row when the selection includes the header row", async () => {
+    const { editor, findByText, findByRole, queryByText, queryByRole } =
+      await renderHarness()
+
+    selectCells(editor, 0, 2) // the full header row
+    await activateTableBubbleMenu(findByRole)
+
+    const headerToggle = await findByRole("checkbox", { name: "Header row" })
+    expect(headerToggle).toBeChecked()
+    expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Add row below")).toBeTruthy()
+    expect(await findByText("Move down")).toBeTruthy()
+    // Header axes withhold Delete — unset the header first, then delete as a
+    // body row/column — including when the selection also spans body rows.
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Move up")).toBeNull()
+
+    // Header row + first body row: still withhold Delete, but the Header
+    // switch is only for the exact top row.
+    selectCells(editor, 0, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("excludes Delete column when the selection includes a header column", async () => {
+    const { editor, findByText, findByRole, queryByText, queryByRole } =
+      await renderHarness()
+
+    // Seed table has a header row only — leftmost column is still deletable.
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+    expect(
+      await findByRole("checkbox", { name: "Header column" }),
+    ).not.toBeChecked()
+    expect(await findByText("Delete column")).toBeTruthy()
+
+    act(() => {
+      editor.chain().focus().toggleHeaderColumn().run()
+    })
+
+    selectCells(editor, 0, 6) // header column alone
+    await activateTableBubbleMenu(findByRole)
+    expect(
+      await findByRole("checkbox", { name: "Header column" }),
+    ).toBeChecked()
+    expect(queryByText("Delete column")).toBeNull()
+
+    // Header column + next column: still withhold Delete; Header switch only
+    // for the exact leftmost column.
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
+    expect(queryByText("Delete column")).toBeNull()
+  })
+
+  it("shows only Merge cells for an irregular multi-cell selection", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 7) // an irregular 2x2-ish block, not a full row/column
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Merge cells")).toBeTruthy()
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Delete column")).toBeNull()
+  })
+
+  it("shows no menu content for a plain cursor outside any selection", async () => {
+    const { queryByText, queryByRole } = await renderHarness()
+
+    expect(queryByText("Delete table")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+    expect(queryByText("Add row above")).toBeNull()
+    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+  })
+
+  it("shows the pencil trigger without the action menu until it is activated", async () => {
+    const { editor, findByRole, findByText, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+
+    const trigger = await findByRole("button", { name: "Table actions" })
+    expect(trigger).toHaveAttribute("aria-pressed", "false")
+    expect(queryByText("Delete row")).toBeNull()
+
+    await activateTableBubbleMenu(findByRole)
+
+    expect(trigger).toHaveAttribute("aria-pressed", "true")
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    await activateTableBubbleMenu(findByRole)
+
+    expect(trigger).toHaveAttribute("aria-pressed", "false")
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("shows Split cell for a single cell that came from a merge, and nothing for an ordinary single cell", async () => {
+    const { editor, findByText, findByRole, queryByText, queryByRole } =
+      await renderHarness()
+
+    // Merge two adjacent body cells into one, then re-select just that
+    // resulting cell — the only single-cell case with a bubble menu.
+    selectCells(editor, 3, 4)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    selectCells(editor, 3, 3)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Split cell")).toBeTruthy()
+    expect(queryByText("Merge cells")).toBeNull()
+
+    // An ordinary (never-merged) single cell still shows no menu at all.
+    selectCells(editor, 6, 6)
+    expect(queryByText("Split cell")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+  })
+
+  it("does not show Superscript/Subscript when the text cursor is inside a cell", async () => {
+    // Arrange
+    const { editor, queryByText } = await renderHarness()
+    const cellPos = nthCellPos(editor, 3)
+
+    // Act — place a plain text cursor inside the cell (what a click does),
+    // not a CellSelection.
+    act(() => {
+      editor.commands.setTextSelection(cellPos + 1)
+    })
+
+    // Assert
+    expect(queryByText("Superscript")).toBeNull()
+    expect(queryByText("Subscript")).toBeNull()
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("hides when focus moves outside the editor (e.g. Table Settings modal)", async () => {
+    // TipTap's blur handler hides the menu when focus leaves the editor.
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    act(() => {
+      const outside = document.createElement("button")
+      outside.type = "button"
+      outside.textContent = "outside"
+      document.body.appendChild(outside)
+      editor.view.dom.dispatchEvent(
+        new FocusEvent("blur", { bubbles: true, relatedTarget: outside }),
+      )
+      outside.focus()
+    })
+
+    await waitFor(() => {
+      expect(queryByText("Delete row")).toBeNull()
+    })
+  })
+
+  it("does not resync BubbleMenu on blur/focus meta traffic after a CellSelection", async () => {
+    // Hang path: Modal FocusLock ↔ TipTap blur/focus meta transactions
+    // re-render BubbleMenu; useMenuElementProps rebinds listeners each
+    // render. memo + selection-only kind updates must keep this finite.
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    const outside = document.createElement("button")
+    outside.type = "button"
+    outside.textContent = "outside"
+    document.body.appendChild(outside)
+
+    act(() => {
+      editor.view.dom.dispatchEvent(
+        new FocusEvent("blur", { bubbles: true, relatedTarget: outside }),
+      )
+      outside.focus()
+    })
+
+    await waitFor(() => {
+      expect(queryByText("Delete row")).toBeNull()
+    })
+
+    act(() => {
+      for (let i = 0; i < 40; i += 1) {
+        editor.view.dispatch(
+          editor.state.tr
+            .setMeta("blur", { event: new FocusEvent("blur") })
+            .setMeta("addToHistory", false),
+        )
+        editor.view.dispatch(
+          editor.state.tr
+            .setMeta("focus", { event: new FocusEvent("focus") })
+            .setMeta("addToHistory", false),
+        )
+      }
+    })
+
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("stays hidden while a cell drag-select is in progress, then shows after it commits", async () => {
+    // prosemirror-tables sets `tableEditingKey` for the duration of a cell
+    // drag (mousemove) and clears it on mouseup. The menu must not appear for
+    // intermediate selection rects during that window.
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    act(() => {
+      editor.view.dispatch(
+        editor.state.tr.setMeta(tableEditingKey, nthCellPos(editor, 3)),
+      )
+    })
+    await waitFor(() => {
+      expect(queryByText("Delete row")).toBeNull()
+    })
+
+    // Intermediate selection expansion while still "dragging"
+    selectCells(editor, 3, 7)
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+
+    // mouseup clears selectingCells state (meta -1 → null)
+    act(() => {
+      editor.view.dispatch(editor.state.tr.setMeta(tableEditingKey, -1))
+    })
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Merge cells")).toBeTruthy()
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
@@ -3,10 +3,10 @@
 // the `*.browser.test.{ts,tsx}` convention in apps/studio/vitest.config.ts.
 import type { Editor, JSONContent } from "@tiptap/react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
-import { act, render, waitFor } from "@testing-library/react"
+import { act, cleanup, render, waitFor } from "@testing-library/react"
 import { tableEditingKey } from "@tiptap/pm/tables"
 import { EditorContent } from "@tiptap/react"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor"
 import { theme } from "~/theme"
 
@@ -134,6 +134,10 @@ const firstRowTexts = (editor: Editor): string[] => {
 }
 
 describe("TableBubbleMenu", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   it("stacks the menu above the selected-cell highlight", async () => {
     const { editor, findByText, findByRole, container } = await renderHarness()
 

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -1,0 +1,760 @@
+import type { Editor } from "@tiptap/react"
+import type { ReactElement, ReactNode } from "react"
+import { Flex, Icon, Portal, Text, VStack } from "@chakra-ui/react"
+import { Button, Switch } from "@opengovsg/design-system-react"
+import { PluginKey } from "@tiptap/pm/state"
+import {
+  CellSelection,
+  moveTableColumn,
+  moveTableRow,
+  selectedRect,
+  TableMap,
+  tableEditingKey,
+} from "@tiptap/pm/tables"
+import { useEditorState } from "@tiptap/react"
+import { BubbleMenu } from "@tiptap/react/menus"
+import { memo, useCallback, useEffect, useState } from "react"
+import {
+  BiDownArrowAlt,
+  BiLeftArrowAlt,
+  BiPencil,
+  BiRightArrowAlt,
+  BiTrash,
+  BiUpArrowAlt,
+} from "react-icons/bi"
+import {
+  IconAddColLeft,
+  IconAddColRight,
+  IconAddRowAbove,
+  IconAddRowBelow,
+  IconDelCol,
+  IconDelRow,
+  IconMergeCells,
+  IconSplitCell,
+} from "~/components/icons"
+
+import {
+  getColumnMovePlan,
+  getRowMovePlan,
+  getTableSelectionKind,
+  selectionIncludesHeaderColumn,
+  selectionIncludesHeaderRow,
+  type SelectionKind,
+} from "./TableBubbleMenu.utils"
+import { useTableBubbleMenuTriggerCorner } from "./useTableBubbleMenuTriggerCorner"
+
+export interface TableBubbleMenuProps {
+  editor: Editor
+}
+
+// A single selected cell that came from a previous merge (colspan/rowspan >
+// 1) is the only single-cell case that shows a bubble menu — "Split cell" is
+// its sole way back. Ordinary single cells stay menu-less.
+//
+// NOTE: this can't be driven off `selectedRect`'s width/height — those are in
+// TableMap grid units, which count a colspan-2 cell as spanning 2 columns
+// even though only one cell NODE is selected. "Exactly one cell selected" is
+// instead "anchor and head resolve to the same cell", which holds regardless
+// of that cell's own colspan/rowspan.
+const isSingleCellSelection = (selection: CellSelection): boolean =>
+  selection.$anchorCell.pos === selection.$headCell.pos
+
+const isMergedCell = (rect: ReturnType<typeof selectedRect>): boolean => {
+  const cellStart = rect.map.map[rect.top * rect.map.width + rect.left]
+  if (cellStart === undefined) return false
+  const node = rect.table.nodeAt(cellStart)
+  if (!node) return false
+  return (
+    (node.attrs.colspan as number) > 1 || (node.attrs.rowspan as number) > 1
+  )
+}
+
+// Detects what kind of table selection (if any) the editor currently holds.
+// Mirrors the verified prototype at `prototype/rte-table-bubble-menu`
+// (apps/studio/src/pages/prototype/rte-table-bubble-menu.tsx) — see
+// .scratch/rte-table-ux/issues/06-prototype-bubble-menu-content-layout.md for
+// the content matrix this drives.
+const detectSelectionType = (editor: Editor): SelectionKind => {
+  const { selection } = editor.state
+  if (!(selection instanceof CellSelection)) return "none"
+
+  const rect = selectedRect(editor.state)
+
+  let allHeader = true
+  selection.forEachCell((node) => {
+    if (node.type.name !== "tableHeader") allHeader = false
+  })
+
+  const selectsSingleCellNode = isSingleCellSelection(selection)
+  return getTableSelectionKind({
+    spansEntireTableWidth: rect.left === 0 && rect.right === rect.map.width,
+    spansEntireTableHeight: rect.top === 0 && rect.bottom === rect.map.height,
+    allCellsAreHeaders: allHeader,
+    // Exactly the first row/column (half-open span of 1). Broader selections
+    // that merely overlap that edge stay ordinary row/column kinds.
+    isTopRow: rect.top === 0 && rect.bottom === 1,
+    isLeftmostColumn: rect.left === 0 && rect.right === 1,
+    selectsSingleCellNode,
+    selectedCellIsMerged: selectsSingleCellNode && isMergedCell(rect),
+  })
+}
+
+// Move a selected block of rows/columns by swapping the adjacent neighbour
+// past the whole block. `moveTableRow`/`moveTableColumn` expand around a
+// single index (colspan/rowspan only), so passing `from: rect.left` for a
+// multi-column selection only moves the first column — e.g. A,B right of
+// A,B,C becomes B,A,C instead of C,A,B. Moving the neighbour into the
+// selection's far edge relocates the entire block in one step.
+const moveRow = (editor: Editor, direction: "up" | "down") => {
+  const { state, view } = editor
+  const rect = selectedRect(state)
+  const plan = getRowMovePlan(
+    {
+      top: rect.top,
+      bottom: rect.bottom,
+      tableHeight: rect.map.height,
+    },
+    direction,
+  )
+  if (!plan) return
+
+  // selectedRect.tableStart points inside the table; nodeAt needs the table's
+  // own document position, one position earlier.
+  const tablePos = rect.tableStart - 1
+
+  moveTableRow({
+    from: plan.from,
+    to: plan.to,
+    select: false,
+    pos: rect.tableStart,
+  })(state, (tr) => {
+    const table = tr.doc.nodeAt(tablePos)
+    if (!table) {
+      view.dispatch(tr)
+      return
+    }
+    const map = TableMap.get(table)
+    const tableStart = tablePos + 1
+    const newBottom = plan.newStart + plan.span
+    // Reselect the moved block from its top-left to bottom-right cells.
+    const anchor = map.positionAt(plan.newStart, 0, table)
+    const head = map.positionAt(newBottom - 1, map.width - 1, table)
+    tr.setSelection(
+      CellSelection.create(tr.doc, tableStart + anchor, tableStart + head),
+    )
+    view.dispatch(tr)
+  })
+}
+
+const moveColumn = (editor: Editor, direction: "left" | "right") => {
+  const { state, view } = editor
+  const rect = selectedRect(state)
+  const plan = getColumnMovePlan(
+    {
+      left: rect.left,
+      right: rect.right,
+      tableWidth: rect.map.width,
+    },
+    direction,
+  )
+  if (!plan) return
+
+  // selectedRect.tableStart points inside the table; nodeAt needs the table's
+  // own document position, one position earlier.
+  const tablePos = rect.tableStart - 1
+
+  moveTableColumn({
+    from: plan.from,
+    to: plan.to,
+    select: false,
+    pos: rect.tableStart,
+  })(state, (tr) => {
+    const table = tr.doc.nodeAt(tablePos)
+    if (!table) {
+      view.dispatch(tr)
+      return
+    }
+    const map = TableMap.get(table)
+    const tableStart = tablePos + 1
+    const newRight = plan.newStart + plan.span
+    // CellSelection accepts either diagonal. Starting at the bottom-left
+    // preserves TipTap's full-column selection orientation after the move.
+    const anchor = map.positionAt(map.height - 1, plan.newStart, table)
+    const head = map.positionAt(0, newRight - 1, table)
+    tr.setSelection(
+      CellSelection.create(tr.doc, tableStart + anchor, tableStart + head),
+    )
+    view.dispatch(tr)
+  })
+}
+
+const ActionButton = ({
+  label,
+  icon,
+  onClick,
+}: {
+  label: string
+  icon: ReactElement
+  onClick: () => void
+}) => (
+  <Button
+    size="xs"
+    variant="clear"
+    colorScheme="neutral"
+    onClick={onClick}
+    w="100%"
+    h="auto"
+    minH="unset"
+    px="0.75rem"
+    py="0.625rem"
+    color="base.content.strong"
+    textAlign="left"
+    sx={{
+      justifyContent: "flex-start",
+    }}
+  >
+    <Flex as="span" align="center" gap="0.5rem">
+      {icon}
+      <Text as="span" textStyle="body-2" color="base.content.strong">
+        {label}
+      </Text>
+    </Flex>
+  </Button>
+)
+
+const ActionGroup = ({ children }: { children: ReactNode }) => (
+  <VStack align="stretch" gap="0" w="100%">
+    {children}
+  </VStack>
+)
+
+// Label + switch — one control for set/unset instead of separate action
+// buttons. TipTap toolbar pattern: preventDefault on mousedown so the click
+// does not steal focus (and thus CellSelection) from the editor.
+// Text uses the same body-2 sizing as ActionButton; Switch `sm` is the
+// smallest size in the design system.
+const HeaderToggle = ({
+  label,
+  isChecked,
+  onToggle,
+}: {
+  label: string
+  isChecked: boolean
+  onToggle: () => void
+}) => (
+  <Flex
+    w="100%"
+    minH="2.25rem"
+    align="center"
+    justify="space-between"
+    px="0.75rem"
+    gap="0.5rem"
+    onMouseDown={(event) => event.preventDefault()}
+  >
+    <Text textStyle="body-2" color="base.content.strong">
+      {label}
+    </Text>
+    <Switch
+      size="sm"
+      isChecked={isChecked}
+      onChange={onToggle}
+      aria-label={label}
+    />
+  </Flex>
+)
+
+type SelectionRect = ReturnType<typeof selectedRect>
+
+const RowSelectionActions = ({
+  editor,
+  rect,
+}: {
+  editor: Editor
+  rect: SelectionRect
+}) => {
+  const canMoveUp = rect.top > 0
+  const canMoveDown = rect.bottom < rect.map.height
+  // TipTap's toggleHeaderRow always rewrites the first table row only — show
+  // the switch for that exact row, not for a multi-row selection that merely
+  // overlaps it.
+  const showHeaderToggle = rect.top === 0 && rect.bottom === 1
+  const includesHeaderRow = selectionIncludesHeaderRow(rect)
+
+  return (
+    <>
+      {showHeaderToggle && (
+        <ActionGroup>
+          <HeaderToggle
+            label="Header row"
+            isChecked={includesHeaderRow}
+            onToggle={() => editor.chain().focus().toggleHeaderRow().run()}
+          />
+        </ActionGroup>
+      )}
+      <ActionGroup>
+        <ActionButton
+          label="Add row above"
+          icon={<IconAddRowAbove boxSize="1rem" />}
+          onClick={() => editor.chain().focus().addRowBefore().run()}
+        />
+        <ActionButton
+          label="Add row below"
+          icon={<IconAddRowBelow boxSize="1rem" />}
+          onClick={() => editor.chain().focus().addRowAfter().run()}
+        />
+        {canMoveUp && (
+          <ActionButton
+            label="Move up"
+            icon={<BiUpArrowAlt fontSize="1rem" />}
+            onClick={() => moveRow(editor, "up")}
+          />
+        )}
+        {canMoveDown && (
+          <ActionButton
+            label="Move down"
+            icon={<BiDownArrowAlt fontSize="1rem" />}
+            onClick={() => moveRow(editor, "down")}
+          />
+        )}
+        {!includesHeaderRow && (
+          <ActionButton
+            label="Delete row"
+            icon={<IconDelRow boxSize="1rem" />}
+            onClick={() => editor.chain().focus().deleteRow().run()}
+          />
+        )}
+      </ActionGroup>
+    </>
+  )
+}
+
+const ColumnSelectionActions = ({
+  editor,
+  rect,
+}: {
+  editor: Editor
+  rect: SelectionRect
+}) => {
+  const canMoveLeft = rect.left > 0
+  const canMoveRight = rect.right < rect.map.width
+  // TipTap's toggleHeaderColumn always rewrites the first table column only —
+  // show the switch for that exact column, not for a multi-column selection
+  // that merely overlaps it.
+  const showHeaderToggle = rect.left === 0 && rect.right === 1
+  const includesHeaderColumn = selectionIncludesHeaderColumn(rect)
+
+  return (
+    <>
+      {showHeaderToggle && (
+        <ActionGroup>
+          <HeaderToggle
+            label="Header column"
+            isChecked={includesHeaderColumn}
+            onToggle={() => editor.chain().focus().toggleHeaderColumn().run()}
+          />
+        </ActionGroup>
+      )}
+      <ActionGroup>
+        <ActionButton
+          label="Add column left"
+          icon={<IconAddColLeft boxSize="1rem" />}
+          onClick={() => editor.chain().focus().addColumnBefore().run()}
+        />
+        <ActionButton
+          label="Add column right"
+          icon={<IconAddColRight boxSize="1rem" />}
+          onClick={() => editor.chain().focus().addColumnAfter().run()}
+        />
+        {canMoveLeft && (
+          <ActionButton
+            label="Move left"
+            icon={<BiLeftArrowAlt fontSize="1rem" />}
+            onClick={() => moveColumn(editor, "left")}
+          />
+        )}
+        {canMoveRight && (
+          <ActionButton
+            label="Move right"
+            icon={<BiRightArrowAlt fontSize="1rem" />}
+            onClick={() => moveColumn(editor, "right")}
+          />
+        )}
+        {!includesHeaderColumn && (
+          <ActionButton
+            label="Delete column"
+            icon={<IconDelCol boxSize="1rem" />}
+            onClick={() => editor.chain().focus().deleteColumn().run()}
+          />
+        )}
+      </ActionGroup>
+    </>
+  )
+}
+
+const TableSelectionActions = ({
+  editor,
+  kind,
+}: {
+  editor: Editor
+  kind: SelectionKind
+}) => {
+  switch (kind) {
+    case "row":
+    case "header-row":
+      return (
+        <RowSelectionActions
+          editor={editor}
+          rect={selectedRect(editor.state)}
+        />
+      )
+    case "column":
+    case "header-column":
+      return (
+        <ColumnSelectionActions
+          editor={editor}
+          rect={selectedRect(editor.state)}
+        />
+      )
+    case "table":
+      return (
+        <ActionButton
+          label="Delete table"
+          icon={<BiTrash fontSize="1rem" />}
+          onClick={() => editor.chain().focus().deleteTable().run()}
+        />
+      )
+    case "multi-cell":
+      return (
+        <ActionButton
+          label="Merge cells"
+          icon={<IconMergeCells boxSize="1rem" />}
+          onClick={() => editor.chain().focus().mergeCells().run()}
+        />
+      )
+    case "merged-cell":
+      return (
+        <ActionButton
+          label="Split cell"
+          icon={<IconSplitCell boxSize="1rem" />}
+          onClick={() => editor.chain().focus().splitCell().run()}
+        />
+      )
+    default:
+      return null
+  }
+}
+
+// Stable module-level reference. `useTextEditor` runs with
+// `shouldRerenderOnTransaction: true`, so every transaction re-renders every
+// editor consumer, including this component. If `shouldShow` were a fresh
+// inline closure on each render, TipTap's BubbleMenu would treat it as changed
+// props and re-register its plugin, which dispatches a transaction — which
+// triggers another re-render, forever. Keeping this function reference stable
+// across renders is what breaks that loop. See
+// .scratch/rte-table-ux/issues/06-prototype-bubble-menu-content-layout.md.
+//
+// Only CellSelections that have table actions (row/column/table/merge/split)
+// show the menu. A plain text cursor inside a cell must not.
+// Require editor (or menu) focus — TipTap's default shouldShow does this.
+//
+// Also stay hidden while prosemirror-tables is mid cell-drag
+// (`tableEditingKey` is set in mousemove, cleared to null on mouseup) so the
+// menu only settles after the drag commits — not for every intermediate rect.
+const TABLE_BUBBLE_MENU_TRIGGER_SELECTOR = "[data-table-bubble-menu-trigger]"
+const TABLE_BUBBLE_MENU_SELECTOR = "[data-table-bubble-menu]"
+
+const isTableBubbleMenuTriggerFocused = () =>
+  document.activeElement?.closest(TABLE_BUBBLE_MENU_TRIGGER_SELECTOR) != null
+
+const hasActionableTableSelection = (
+  editor: Editor,
+  view: Editor["view"],
+): boolean => {
+  if (tableEditingKey.getState(view.state) != null) return false
+
+  const kind = detectSelectionType(editor)
+  return kind !== "none" && kind !== "single-cell"
+}
+
+const shouldShowTableBubbleMenu = ({
+  editor,
+  view,
+  element,
+}: {
+  editor: Editor
+  view: Editor["view"]
+  element: HTMLElement
+}) => {
+  if (!hasActionableTableSelection(editor, view)) return false
+
+  const isChildOfMenu = element.contains(document.activeElement)
+  return view.hasFocus() || isChildOfMenu || isTableBubbleMenuTriggerFocused()
+}
+
+const tableBubbleMenuActivation = new WeakMap<Editor, boolean>()
+
+const setTableBubbleMenuActivated = (editor: Editor, activated: boolean) => {
+  tableBubbleMenuActivation.set(editor, activated)
+}
+
+const isTableBubbleMenuActivated = (editor: Editor): boolean =>
+  tableBubbleMenuActivation.get(editor) ?? false
+
+// Stable module-level reference — see `shouldShowTableBubbleMenu` above.
+const shouldShowTableBubbleMenuActions = ({
+  editor,
+  view,
+  element,
+}: {
+  editor: Editor
+  view: Editor["view"]
+  element: HTMLElement
+}) =>
+  shouldShowTableBubbleMenu({ editor, view, element }) &&
+  isTableBubbleMenuActivated(editor)
+
+// Immediate show/hide once `shouldShow` flips — TipTap's default 250ms delay
+// would keep a stale menu visible into the start of a drag, then lag the
+// post-mouseup reveal. Drag gating is handled by `tableEditingKey` above.
+const TABLE_BUBBLE_MENU_UPDATE_DELAY = 0
+
+// `fixed` escapes the editor's overflow:auto clipping (absolute positioning
+// anchors inside EditorContent and the menu gets clipped above the selection).
+// Do NOT appendTo document.body — TipTap's blur handler treats any body focus
+// target as "inside the menu" via parentNode.contains and hangs FocusLock.
+const TABLE_BUBBLE_MENU_OPTIONS = {
+  strategy: "fixed" as const,
+  placement: "top" as const,
+  offset: 8,
+}
+
+// Stable explicit plugin key so we can nudge TipTap's show/hide when
+// `tableEditingKey` flips without a selection/doc change (mouseup only clears
+// the selectingCells meta — TipTap's BubbleMenu early-returns on those and
+// would otherwise never re-run `shouldShow`).
+const TABLE_BUBBLE_MENU_PLUGIN_KEY = new PluginKey("tableBubbleMenu")
+
+// TipTap's `show` meta runs `updatePosition()` *before* `show()`, and
+// `updatePosition` no-ops while `!isVisible` — so a bare `show` meta leaves
+// the menu unpositioned (often effectively invisible). Show first, then
+// position.
+const revealTableBubbleMenuActions = (editor: Editor) => {
+  if (
+    !isTableBubbleMenuActivated(editor) ||
+    !hasActionableTableSelection(editor, editor.view)
+  ) {
+    editor.view.dispatch(
+      editor.state.tr.setMeta(TABLE_BUBBLE_MENU_PLUGIN_KEY, "hide"),
+    )
+    return
+  }
+  editor.view.dispatch(
+    editor.state.tr.setMeta(TABLE_BUBBLE_MENU_PLUGIN_KEY, "show"),
+  )
+  editor.view.dispatch(
+    editor.state.tr.setMeta(TABLE_BUBBLE_MENU_PLUGIN_KEY, "updatePosition"),
+  )
+}
+
+const useTableBubbleMenuDragSync = (editor: Editor) => {
+  useEffect(() => {
+    const onTransaction = ({
+      transaction,
+    }: {
+      transaction: { getMeta: (key: typeof tableEditingKey) => unknown }
+    }) => {
+      if (transaction.getMeta(tableEditingKey) === undefined) return
+
+      queueMicrotask(() => {
+        if (editor.isDestroyed) return
+        if (tableEditingKey.getState(editor.state) != null) {
+          editor.view.dispatch(
+            editor.state.tr.setMeta(TABLE_BUBBLE_MENU_PLUGIN_KEY, "hide"),
+          )
+          return
+        }
+        revealTableBubbleMenuActions(editor)
+      })
+    }
+    editor.on("transaction", onTransaction)
+    return () => {
+      editor.off("transaction", onTransaction)
+    }
+  }, [editor])
+}
+
+const TableBubbleMenuTrigger = ({
+  corner,
+  isActivated,
+  onToggle,
+}: {
+  corner: { x: number; y: number }
+  isActivated: boolean
+  onToggle: () => void
+}) => (
+  <Portal>
+    <Flex
+      as="button"
+      type="button"
+      aria-label="Table actions"
+      aria-pressed={isActivated}
+      data-table-bubble-menu-trigger
+      position="fixed"
+      left={`${corner.x}px`}
+      top={`${corner.y}px`}
+      zIndex="dropdown"
+      transform="translate(-50%, -50%)"
+      p="0.5rem"
+      borderRadius="full"
+      cursor="pointer"
+      bg={isActivated ? "interaction.main.default" : "base.canvas.default"}
+      boxShadow="0 0 10px 0 rgba(191, 191, 191, 0.50)"
+      transition="background-color 0.15s, box-shadow 0.15s, filter 0.15s"
+      sx={{
+        _hover: isActivated
+          ? {
+              filter: "brightness(0.92)",
+              boxShadow: "0 0 12px 0 rgba(191, 191, 191, 0.65)",
+            }
+          : {
+              bg: "interaction.main-subtle.default",
+              boxShadow: "0 0 12px 0 rgba(191, 191, 191, 0.65)",
+            },
+      }}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={onToggle}
+    >
+      <Icon
+        as={BiPencil}
+        fontSize="0.75rem"
+        color={isActivated ? "white" : "interaction.main.default"}
+      />
+    </Flex>
+  </Portal>
+)
+
+export const TableBubbleMenu = memo(function TableBubbleMenu({
+  editor,
+}: TableBubbleMenuProps) {
+  // TipTap's selector replaces manual event subscriptions. Document identity
+  // represents `update`; Selection.eq represents `selectionUpdate`. Include
+  // `isFocused` so the pencil trigger reappears when focus returns without a
+  // selection change. Meta-only blur/focus transactions compare equal on doc
+  // + selection and therefore do not re-render.
+  const { kind, selection, isFocused, isDragging } = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => ({
+      kind: detectSelectionType(currentEditor),
+      doc: currentEditor.state.doc,
+      selection: currentEditor.state.selection,
+      isFocused: currentEditor.isFocused,
+      isDragging: tableEditingKey.getState(currentEditor.state) != null,
+    }),
+    equalityFn: (previous, next) =>
+      next !== null &&
+      previous.doc === next.doc &&
+      previous.selection.eq(next.selection) &&
+      previous.isFocused === next.isFocused &&
+      previous.isDragging === next.isDragging,
+  })
+
+  const showTrigger =
+    kind !== "none" && kind !== "single-cell" && !isDragging && isFocused
+
+  const corner = useTableBubbleMenuTriggerCorner(editor, showTrigger)
+
+  const [isActivated, setIsActivated] = useState(false)
+
+  const resetActivation = useCallback(() => {
+    setIsActivated(false)
+    setTableBubbleMenuActivated(editor, false)
+  }, [editor])
+
+  // A new CellSelection deactivates the menu so the pencil trigger reappears
+  // without the action list until the user clicks again.
+  useEffect(() => {
+    resetActivation()
+    editor.view.dispatch(
+      editor.state.tr.setMeta(TABLE_BUBBLE_MENU_PLUGIN_KEY, "hide"),
+    )
+  }, [editor, resetActivation, selection])
+
+  useEffect(() => {
+    const onBlur = ({ event }: { event?: FocusEvent }) => {
+      const relatedTarget = event?.relatedTarget
+      if (
+        relatedTarget instanceof Element &&
+        (relatedTarget.closest(TABLE_BUBBLE_MENU_TRIGGER_SELECTOR) ||
+          relatedTarget.closest(TABLE_BUBBLE_MENU_SELECTOR))
+      ) {
+        return
+      }
+      resetActivation()
+    }
+    editor.on("blur", onBlur)
+    return () => {
+      editor.off("blur", onBlur)
+    }
+  }, [editor, resetActivation])
+
+  const deactivateMenu = useCallback(() => {
+    resetActivation()
+    editor.view.dispatch(
+      editor.state.tr.setMeta(TABLE_BUBBLE_MENU_PLUGIN_KEY, "hide"),
+    )
+  }, [editor, resetActivation])
+
+  const toggleMenu = useCallback(() => {
+    if (isActivated) {
+      deactivateMenu()
+      return
+    }
+    setIsActivated(true)
+    setTableBubbleMenuActivated(editor, true)
+    // Clicking the portaled trigger blurs the editor; refocus so BubbleMenu's
+    // own blur handler and shouldShow keep the action menu visible.
+    editor.commands.focus()
+    revealTableBubbleMenuActions(editor)
+  }, [deactivateMenu, editor, isActivated])
+
+  // TipTap early-returns when selection/doc are unchanged, so mouseup's
+  // meta-only `tableEditingKey: -1` never re-runs `shouldShow`. After that
+  // (or an explicit hide while selecting) force hide/reveal.
+  useTableBubbleMenuDragSync(editor)
+
+  return (
+    <>
+      {showTrigger && corner && (
+        <TableBubbleMenuTrigger
+          corner={corner}
+          isActivated={isActivated}
+          onToggle={toggleMenu}
+        />
+      )}
+      <BubbleMenu
+        editor={editor}
+        pluginKey={TABLE_BUBBLE_MENU_PLUGIN_KEY}
+        shouldShow={shouldShowTableBubbleMenuActions}
+        updateDelay={TABLE_BUBBLE_MENU_UPDATE_DELAY}
+        options={TABLE_BUBBLE_MENU_OPTIONS}
+      >
+        <VStack
+          align="stretch"
+          textAlign="left"
+          position="relative"
+          zIndex="dropdown"
+          data-table-bubble-menu
+          bg="base.canvas.default"
+          boxShadow="sm"
+          borderRadius="0.25rem"
+          border="1px solid"
+          borderColor="base.divider.medium"
+          py="0.5rem"
+          gap="0"
+        >
+          <TableSelectionActions editor={editor} kind={kind} />
+        </VStack>
+      </BubbleMenu>
+    </>
+  )
+})

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.test.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.test.ts
@@ -1,0 +1,304 @@
+import type { Node } from "@tiptap/pm/model"
+import { describe, expect, it } from "vitest"
+
+import {
+  getColumnMovePlan,
+  getRowMovePlan,
+  getTableSelectionKind,
+  selectionIncludesHeaderColumn,
+  selectionIncludesHeaderRow,
+  type TableHeaderOverlapRect,
+} from "./TableBubbleMenu.utils"
+
+// Builds a rect whose map offsets are 0..n-1 and whose table.nodeAt(i) returns
+// the ith cell type — enough for the header-overlap helpers without a live editor.
+const overlapRect = ({
+  top,
+  left,
+  width,
+  height,
+  cellTypes,
+}: {
+  top: number
+  left: number
+  width: number
+  height: number
+  cellTypes: string[]
+}): TableHeaderOverlapRect => {
+  const map = cellTypes.map((_, index) => index)
+  const table = {
+    nodeAt: (pos: number) => {
+      const typeName = cellTypes[pos]
+      return typeName ? { type: { name: typeName } } : null
+    },
+  } as Node
+
+  return {
+    top,
+    left,
+    map: { width, height, map },
+    table,
+  }
+}
+
+describe("getTableSelectionKind", () => {
+  const partialSelection = {
+    spansEntireTableWidth: false,
+    spansEntireTableHeight: false,
+    allCellsAreHeaders: false,
+    isTopRow: false,
+    isLeftmostColumn: false,
+    selectsSingleCellNode: false,
+    selectedCellIsMerged: false,
+  }
+
+  it("classifies selections that span the entire table before either axis", () => {
+    expect(
+      getTableSelectionKind({
+        ...partialSelection,
+        spansEntireTableWidth: true,
+        spansEntireTableHeight: true,
+      }),
+    ).toBe("table")
+  })
+
+  it.each([
+    {
+      facts: { spansEntireTableWidth: true },
+      expected: "row",
+    },
+    {
+      facts: {
+        spansEntireTableWidth: true,
+        allCellsAreHeaders: true,
+        isTopRow: true,
+      },
+      expected: "header-row",
+    },
+    {
+      // A full-width body row that happens to be all header cells is still a
+      // normal row — TipTap's header-row toggle only targets the first row.
+      facts: {
+        spansEntireTableWidth: true,
+        allCellsAreHeaders: true,
+        isTopRow: false,
+      },
+      expected: "row",
+    },
+    {
+      facts: { spansEntireTableHeight: true },
+      expected: "column",
+    },
+    {
+      facts: {
+        spansEntireTableHeight: true,
+        allCellsAreHeaders: true,
+        isLeftmostColumn: true,
+      },
+      expected: "header-column",
+    },
+    {
+      facts: {
+        spansEntireTableHeight: true,
+        allCellsAreHeaders: true,
+        isLeftmostColumn: false,
+      },
+      expected: "column",
+    },
+  ])("classifies an axis selection as $expected", ({ facts, expected }) => {
+    expect(getTableSelectionKind({ ...partialSelection, ...facts })).toBe(
+      expected,
+    )
+  })
+
+  it.each([
+    {
+      selectedCellIsMerged: false,
+      expected: "single-cell",
+    },
+    {
+      selectedCellIsMerged: true,
+      expected: "merged-cell",
+    },
+  ])(
+    "classifies a single selected node as $expected",
+    ({ selectedCellIsMerged, expected }) => {
+      expect(
+        getTableSelectionKind({
+          ...partialSelection,
+          selectsSingleCellNode: true,
+          selectedCellIsMerged,
+        }),
+      ).toBe(expected)
+    },
+  )
+
+  it("classifies the remaining selection shape as multi-cell", () => {
+    expect(getTableSelectionKind(partialSelection)).toBe("multi-cell")
+  })
+})
+
+describe("selectionIncludesHeaderRow", () => {
+  const headerThenBody = [
+    "tableHeader",
+    "tableHeader",
+    "tableHeader",
+    "tableCell",
+    "tableCell",
+    "tableCell",
+  ]
+
+  it("is true when the selection overlaps a header row at the top", () => {
+    expect(
+      selectionIncludesHeaderRow(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 3,
+          height: 2,
+          cellTypes: headerThenBody,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("is false when the selection starts below the header row", () => {
+    expect(
+      selectionIncludesHeaderRow(
+        overlapRect({
+          top: 1,
+          left: 0,
+          width: 3,
+          height: 2,
+          cellTypes: headerThenBody,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false when the top row is ordinary body cells", () => {
+    expect(
+      selectionIncludesHeaderRow(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 2,
+          height: 1,
+          cellTypes: ["tableCell", "tableCell"],
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("selectionIncludesHeaderColumn", () => {
+  // Header row + header column (intersection and first body cell are headers).
+  const headerRowAndColumn = [
+    "tableHeader",
+    "tableHeader",
+    "tableHeader",
+    "tableCell",
+    "tableHeader",
+    "tableCell",
+  ]
+
+  it("is true when the selection overlaps a header column at the left", () => {
+    expect(
+      selectionIncludesHeaderColumn(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 2,
+          height: 3,
+          cellTypes: headerRowAndColumn,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("is false when the selection starts to the right of the header column", () => {
+    expect(
+      selectionIncludesHeaderColumn(
+        overlapRect({
+          top: 0,
+          left: 1,
+          width: 2,
+          height: 3,
+          cellTypes: headerRowAndColumn,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false when only the first row is headers (header row, not column)", () => {
+    expect(
+      selectionIncludesHeaderColumn(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 2,
+          height: 2,
+          cellTypes: ["tableHeader", "tableHeader", "tableCell", "tableCell"],
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("getRowMovePlan", () => {
+  it.each([
+    {
+      direction: "up" as const,
+      expected: { from: 0, to: 2, newStart: 0, span: 2 },
+    },
+    {
+      direction: "down" as const,
+      expected: { from: 3, to: 1, newStart: 2, span: 2 },
+    },
+  ])(
+    "moves the adjacent row $direction past the block",
+    ({ direction, expected }) => {
+      expect(
+        getRowMovePlan({ top: 1, bottom: 3, tableHeight: 4 }, direction),
+      ).toEqual(expected)
+    },
+  )
+
+  it("does not move beyond the top or bottom table edge", () => {
+    expect(
+      getRowMovePlan({ top: 0, bottom: 2, tableHeight: 4 }, "up"),
+    ).toBeNull()
+    expect(
+      getRowMovePlan({ top: 2, bottom: 4, tableHeight: 4 }, "down"),
+    ).toBeNull()
+  })
+})
+
+describe("getColumnMovePlan", () => {
+  it.each([
+    {
+      direction: "left" as const,
+      expected: { from: 0, to: 2, newStart: 0, span: 2 },
+    },
+    {
+      direction: "right" as const,
+      expected: { from: 3, to: 1, newStart: 2, span: 2 },
+    },
+  ])(
+    "moves the adjacent column $direction past the block",
+    ({ direction, expected }) => {
+      expect(
+        getColumnMovePlan({ left: 1, right: 3, tableWidth: 4 }, direction),
+      ).toEqual(expected)
+    },
+  )
+
+  it("does not move beyond the left or right table edge", () => {
+    expect(
+      getColumnMovePlan({ left: 0, right: 2, tableWidth: 4 }, "left"),
+    ).toBeNull()
+    expect(
+      getColumnMovePlan({ left: 2, right: 4, tableWidth: 4 }, "right"),
+    ).toBeNull()
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -1,0 +1,205 @@
+import type { Node } from "@tiptap/pm/model"
+import type { EditorState } from "@tiptap/pm/state"
+import { CellSelection, selectedRect, type TableMap } from "@tiptap/pm/tables"
+
+export type SelectionKind =
+  | "none"
+  | "single-cell"
+  | "merged-cell"
+  | "row"
+  | "header-row"
+  | "column"
+  | "header-column"
+  | "table"
+  | "multi-cell"
+
+// Slice of selectedRect() needed to tell whether a selection overlaps a
+// TipTap header row/column. Kept structural so unit tests don't need a live
+// EditorView.
+export interface TableHeaderOverlapRect {
+  top: number
+  left: number
+  map: Pick<TableMap, "width" | "height" | "map">
+  table: Node
+}
+
+const cellTypeAt = (
+  rect: TableHeaderOverlapRect,
+  row: number,
+  col: number,
+): string | null => {
+  const cellPos = rect.map.map[row * rect.map.width + col]
+  if (cellPos === undefined) return null
+  return rect.table.nodeAt(cellPos)?.type.name ?? null
+}
+
+const isHeaderRowAtTop = (rect: TableHeaderOverlapRect): boolean => {
+  for (let col = 0; col < rect.map.width; col++) {
+    if (cellTypeAt(rect, 0, col) !== "tableHeader") return false
+  }
+  return rect.map.width > 0
+}
+
+const isHeaderColumnAtLeft = (rect: TableHeaderOverlapRect): boolean => {
+  for (let row = 0; row < rect.map.height; row++) {
+    if (cellTypeAt(rect, row, 0) !== "tableHeader") return false
+  }
+  return rect.map.height > 0
+}
+
+// Delete is withheld whenever the selection overlaps a header axis — not only
+// when the selection is exclusively that header — so users unset the header
+// first rather than accidentally leaving the table headerless.
+export const selectionIncludesHeaderRow = (
+  rect: TableHeaderOverlapRect,
+): boolean => rect.top === 0 && isHeaderRowAtTop(rect)
+
+export const selectionIncludesHeaderColumn = (
+  rect: TableHeaderOverlapRect,
+): boolean => rect.left === 0 && isHeaderColumnAtLeft(rect)
+
+// ProseMirror-specific selection details are normalized into these facts so
+// the menu's classification rules can stay independent of editor state.
+export interface TableSelectionFacts {
+  spansEntireTableWidth: boolean
+  spansEntireTableHeight: boolean
+  allCellsAreHeaders: boolean
+  // True when the selection is exactly the table's first row / first column
+  // (half-open rect starting at 0 with span 1). TipTap header toggles only
+  // rewrite that edge, so "header-*" kinds match the same scope.
+  isTopRow: boolean
+  isLeftmostColumn: boolean
+  selectsSingleCellNode: boolean
+  selectedCellIsMerged: boolean
+}
+
+// Order matters: a whole-table selection spans both axes, and a merged cell
+// can span multiple grid rows/columns while still selecting only one cell node.
+export const getTableSelectionKind = ({
+  spansEntireTableWidth,
+  spansEntireTableHeight,
+  allCellsAreHeaders,
+  isTopRow,
+  isLeftmostColumn,
+  selectsSingleCellNode,
+  selectedCellIsMerged,
+}: TableSelectionFacts): Exclude<SelectionKind, "none"> => {
+  if (spansEntireTableWidth && spansEntireTableHeight) return "table"
+  if (spansEntireTableWidth) {
+    return allCellsAreHeaders && isTopRow ? "header-row" : "row"
+  }
+  if (spansEntireTableHeight) {
+    return allCellsAreHeaders && isLeftmostColumn ? "header-column" : "column"
+  }
+  if (selectsSingleCellNode) {
+    return selectedCellIsMerged ? "merged-cell" : "single-cell"
+  }
+  return "multi-cell"
+}
+
+export interface TableMovePlan {
+  // `from` is the adjacent row/column moved past the selected block.
+  from: number
+  // `to` is the selected block's far edge, expressed as TipTap's move target.
+  to: number
+  // The selected block's first row/column after the move.
+  newStart: number
+  // Number of rows/columns in the selected block, used to restore selection.
+  span: number
+}
+
+// Bounds are half-open: `top` is included and `bottom` is excluded. TipTap's
+// row mover operates on one row, so moving a block means moving its adjacent
+// neighbour past the block and then reselecting the block at `newStart`.
+export const getRowMovePlan = (
+  {
+    top,
+    bottom,
+    tableHeight,
+  }: {
+    top: number
+    bottom: number
+    tableHeight: number
+  },
+  direction: "up" | "down",
+): TableMovePlan | null => {
+  const span = bottom - top
+
+  if (direction === "up") {
+    // Move the row above to the block's final row.
+    if (top === 0) return null
+    return {
+      from: top - 1,
+      to: bottom - 1,
+      newStart: top - 1,
+      span,
+    }
+  }
+
+  // Move the row below to the block's first row.
+  if (bottom >= tableHeight) return null
+  return {
+    from: bottom,
+    to: top,
+    newStart: top + 1,
+    span,
+  }
+}
+
+// Column movement mirrors row movement. `left` is included and `right` is
+// excluded; the adjacent column is moved across the selected block.
+// Document position of the bottom-right perimeter cell in a CellSelection.
+// Used to anchor the table action trigger at the selection's outer corner.
+export const getBottomRightCellDocumentPos = (
+  state: EditorState,
+): number | null => {
+  const { selection } = state
+  if (!(selection instanceof CellSelection)) return null
+
+  const rect = selectedRect(state)
+  let bottomRightPos: number | null = null
+
+  selection.forEachCell((node, pos) => {
+    const cellRect = rect.map.findCell(pos - rect.tableStart)
+    if (cellRect.right === rect.right && cellRect.bottom === rect.bottom) {
+      bottomRightPos = pos
+    }
+  })
+
+  return bottomRightPos
+}
+
+export const getColumnMovePlan = (
+  {
+    left,
+    right,
+    tableWidth,
+  }: {
+    left: number
+    right: number
+    tableWidth: number
+  },
+  direction: "left" | "right",
+): TableMovePlan | null => {
+  const span = right - left
+
+  if (direction === "left") {
+    // Move the column on the left to the block's final column.
+    if (left === 0) return null
+    return {
+      from: left - 1,
+      to: right - 1,
+      newStart: left - 1,
+      span,
+    }
+  }
+
+  // Move the column on the right to the block's first column.
+  if (right >= tableWidth) return null
+  return {
+    from: right,
+    to: left,
+    newStart: left + 1,
+    span,
+  }
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuTriggerCorner.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuTriggerCorner.ts
@@ -1,0 +1,87 @@
+import type { EditorState } from "@tiptap/pm/state"
+import type { EditorView } from "@tiptap/pm/view"
+import type { Editor } from "@tiptap/react"
+import { useEffect, useState } from "react"
+
+import { getBottomRightCellDocumentPos } from "./TableBubbleMenu.utils"
+
+export interface TableBubbleMenuCorner {
+  x: number
+  y: number
+}
+
+export const getEditorScrollParent = (
+  view: EditorView,
+): HTMLElement | Window => {
+  let element: HTMLElement | null = view.dom.parentElement
+  while (element) {
+    const { overflowY } = getComputedStyle(element)
+    if (overflowY === "auto" || overflowY === "scroll") {
+      return element
+    }
+    element = element.parentElement
+  }
+  return window
+}
+
+export const getBottomRightCellRect = (
+  view: EditorView,
+  state: EditorState,
+): DOMRect | null => {
+  const cellPos = getBottomRightCellDocumentPos(state)
+  if (cellPos === null) return null
+
+  const dom = view.nodeDOM(cellPos)
+  if (!(dom instanceof HTMLElement)) return null
+
+  return dom.getBoundingClientRect()
+}
+
+// Tracks the screen-space bottom-right corner of the current CellSelection.
+// Listens to the editor's scroll parent (not just window) so the trigger stays
+// glued to the table while the content area scrolls.
+export const useTableBubbleMenuTriggerCorner = (
+  editor: Editor,
+  enabled: boolean,
+): TableBubbleMenuCorner | null => {
+  const [corner, setCorner] = useState<TableBubbleMenuCorner | null>(null)
+
+  useEffect(() => {
+    if (!enabled) {
+      setCorner(null)
+      return
+    }
+
+    const updateCorner = () => {
+      const rect = getBottomRightCellRect(editor.view, editor.state)
+      if (!rect) {
+        setCorner(null)
+        return
+      }
+      setCorner({ x: rect.right, y: rect.bottom })
+    }
+
+    const scheduleUpdate = () => {
+      requestAnimationFrame(updateCorner)
+    }
+
+    scheduleUpdate()
+
+    const scrollTarget = getEditorScrollParent(editor.view)
+    scrollTarget.addEventListener("scroll", scheduleUpdate, { passive: true })
+    window.addEventListener("resize", scheduleUpdate, { passive: true })
+    editor.on("selectionUpdate", scheduleUpdate)
+    editor.on("transaction", scheduleUpdate)
+    editor.on("focus", scheduleUpdate)
+
+    return () => {
+      scrollTarget.removeEventListener("scroll", scheduleUpdate)
+      window.removeEventListener("resize", scheduleUpdate)
+      editor.off("selectionUpdate", scheduleUpdate)
+      editor.off("transaction", scheduleUpdate)
+      editor.off("focus", scheduleUpdate)
+    }
+  }, [editor, enabled])
+
+  return corner
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuTriggerCorner.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuTriggerCorner.ts
@@ -52,7 +52,13 @@ export const useTableBubbleMenuTriggerCorner = (
       return
     }
 
+    let rafId = 0
+    let cancelled = false
+
     const updateCorner = () => {
+      rafId = 0
+      if (cancelled || editor.isDestroyed) return
+
       const rect = getBottomRightCellRect(editor.view, editor.state)
       if (!rect) {
         setCorner(null)
@@ -62,7 +68,8 @@ export const useTableBubbleMenuTriggerCorner = (
     }
 
     const scheduleUpdate = () => {
-      requestAnimationFrame(updateCorner)
+      if (rafId) cancelAnimationFrame(rafId)
+      rafId = requestAnimationFrame(updateCorner)
     }
 
     scheduleUpdate()
@@ -75,6 +82,8 @@ export const useTableBubbleMenuTriggerCorner = (
     editor.on("focus", scheduleUpdate)
 
     return () => {
+      cancelled = true
+      if (rafId) cancelAnimationFrame(rafId)
       scrollTarget.removeEventListener("scroll", scheduleUpdate)
       window.removeEventListener("resize", scheduleUpdate)
       editor.off("selectionUpdate", scheduleUpdate)

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/TiptapAccordionEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/TiptapAccordionEditor.tsx
@@ -11,5 +11,12 @@ export function TiptapAccordionEditor({
   // TODO: Add a loading state or use suspense
   if (!editor) return null
 
-  return <Editor isNested menubar={AccordionMenuBar} editor={editor} />
+  return (
+    <Editor
+      isNested
+      menubar={AccordionMenuBar}
+      editor={editor}
+      showTableExtras
+    />
+  )
 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/TiptapTextEditor.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/TiptapTextEditor.tsx
@@ -11,5 +11,5 @@ export function TiptapTextEditor({
   // TODO: Add a loading state or use suspense
   if (!editor) return null
 
-  return <Editor menubar={TextMenuBar} editor={editor} />
+  return <Editor menubar={TextMenuBar} editor={editor} showTableExtras />
 }

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
@@ -5,6 +5,7 @@ import type { EditorMenuBar } from "~/components/PageEditor/MenuBar/MenuBar"
 import { Box, VStack } from "@chakra-ui/react"
 import { EditorContent } from "@tiptap/react"
 import { useMemo } from "react"
+import { TableBubbleMenu } from "~/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu"
 
 const EditorContainer = ({
   children,
@@ -65,11 +66,22 @@ interface EditorProps {
   menubar: EditorMenuBar
   editor: TiptapEditor
   isNested?: boolean
+  /**
+   * Mount the contextual table bubble menu. Only set on editors whose
+   * extensions include tables (`TiptapTextEditor`, `TiptapAccordionEditor`).
+   */
+  showTableExtras?: boolean
 }
-export const Editor = ({ editor, menubar, isNested }: EditorProps) => {
+export const Editor = ({
+  editor,
+  menubar,
+  isNested,
+  showTableExtras,
+}: EditorProps) => {
   return (
     <EditorContainer isNested={isNested}>
       {menubar({ editor })}
+      {showTableExtras && <TableBubbleMenu editor={editor} />}
       <EditorContentWrapper editor={editor} />
     </EditorContainer>
   )

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -266,12 +266,21 @@ export const TableBubbleMenu: Story = {
 
     const editor = getEditorFromCanvas(canvasElement)
     // Default insertTable is 3x3 with a header row; cells 3–5 are the first body row.
-    editor.commands.setCellSelection({
-      anchorCell: nthCellPos(editor, 3),
-      headCell: nthCellPos(editor, 5),
-    })
+    editor
+      .chain()
+      .focus()
+      .setCellSelection({
+        anchorCell: nthCellPos(editor, 3),
+        headCell: nthCellPos(editor, 5),
+      })
+      .run()
 
     const portals = withinPortals(canvasElement)
+    // Row/column actions live behind the portaled pencil trigger — click to open.
+    await userEvent.click(
+      await portals.findByRole("button", { name: "Table actions" }),
+    )
+
     await waitFor(() =>
       expect(portals.getByText("Delete row")).toBeInTheDocument(),
     )

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { expect, userEvent, within } from "storybook/test"
+import type { Editor } from "@tiptap/react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -53,6 +54,43 @@ const meta: Meta<typeof EditPage> = {
 
 export default meta
 type Story = StoryObj<typeof EditPage>
+
+/** TipTap BubbleMenu portals into the story iframe body. */
+function withinPortals(canvasElement: HTMLElement) {
+  return within(canvasElement.ownerDocument.body)
+}
+
+// Document position at the start of the nth table cell (tableCell /
+// tableHeader), 0-indexed in reading order. Used to forge a CellSelection
+// in play functions — Storybook can't drive a real mouse drag across cells.
+const nthCellPos = (editor: Editor, index: number): number => {
+  let seen = 0
+  let found: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== null) return false
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      if (seen === index) {
+        found = pos
+        return false
+      }
+      seen += 1
+    }
+    return true
+  })
+  if (found === null) {
+    throw new Error(`Could not find cell at index ${index}`)
+  }
+  return found
+}
+
+const getEditorFromCanvas = (canvasElement: HTMLElement): Editor => {
+  const proseMirrorEl = canvasElement.querySelector<
+    HTMLElement & { editor?: Editor }
+  >(".ProseMirror")
+  const editor = proseMirrorEl?.editor
+  if (!editor) throw new Error("Editor did not mount")
+  return editor
+}
 
 export const Default: Story = {}
 export const Wordbreak: Story = {
@@ -204,5 +242,39 @@ export const ActiveTableToolbar: Story = {
     await expect(
       canvas.getAllByRole("button", { name: /more options/i }),
     ).toHaveLength(1)
+  },
+}
+
+// Navigate into a text block, insert a table, select a body row — the
+// contextual TableBubbleMenu should appear with row actions.
+export const TableBubbleMenu: Story = {
+  play: async (context) => {
+    const { canvasElement } = context
+    const canvas = within(canvasElement)
+    await AddTextBlock.play?.(context)
+
+    // Clicking "Table" only opens the size-picker popover — a cell still
+    // needs to be picked to actually insert a table (see TableSizePicker.tsx).
+    await userEvent.click(canvas.getByRole("button", { name: /^table$/i }))
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /^3 by 3 table$/i }),
+    )
+
+    await waitFor(() =>
+      expect(canvasElement.querySelector("table")).toBeTruthy(),
+    )
+
+    const editor = getEditorFromCanvas(canvasElement)
+    // Default insertTable is 3x3 with a header row; cells 3–5 are the first body row.
+    editor.commands.setCellSelection({
+      anchorCell: nthCellPos(editor, 3),
+      headCell: nthCellPos(editor, 5),
+    })
+
+    const portals = withinPortals(canvasElement)
+    await waitFor(() =>
+      expect(portals.getByText("Delete row")).toBeInTheDocument(),
+    )
+    await expect(portals.getByText("Add row above")).toBeInTheDocument()
   },
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 11 | +1127 | -161 |
| 🧪 Test | 3 | +908 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Table actions (add/delete row or column, merge/split, move, header toggles) need a contextual surface that appears only for meaningful table selections — not for a plain text cursor inside a cell. Building this required (1) selection-classification logic reviewable on its own, (2) the bubble menu UI wired on top of it, and (3) removal of the legacy toolbar actions it replaces.

Closes https://linear.app/ogp/issue/ISOM-2365/rte-add-inline-bubble-menu-for-table-actions

(Previously split across #2980, #2981, #2982 — consolidated into this single PR since the stack was overly granular for review.)

## Solution

**Selection classification**

Pure selection helpers in `TableBubbleMenu.utils.ts`:

- `getTableSelectionKind` — maps normalized selection facts to a `SelectionKind`
- `selectionIncludesHeaderRow` / `selectionIncludesHeaderColumn` — guard delete when a header axis is overlapped
- `getRowMovePlan` / `getColumnMovePlan` — block move math for multi-row/column selections

**Contextual TableBubbleMenu**

Adds and wires `TableBubbleMenu` on table-enabled TipTap editors (`TiptapTextEditor`, `TiptapAccordionEditor`):

- Selection-aware action matrix (row, header row, column, header column, whole table, multi-cell, merged cell)
- Pencil trigger → action menu activation pattern
- `useTableBubbleMenuTriggerCorner` for positioning
- Menubar/modal focus fixes (`HorizontalList`, `OverflowList`, `TableSettingsModal`) so overflow popovers and Table Settings coexist with the bubble menu
- Edit Page Storybook story: `Content Page → TableBubbleMenu`

**Legacy toolbar cleanup**

Removes legacy table toolbar entries from `TextMenuBar` and `AccordionMenuBar` now that the bubble menu covers them. Keeps only:

- **Insert table** (size picker)
- **Table settings** (caption modal — until `TableCaption` lands in a follow-up stack PR)

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Contextual `TableBubbleMenu` with a full per-selection action matrix.
- Storybook coverage for row-selection bubble menu.

**Improvements**:

- Selection classification is unit-tested without a live TipTap editor.
- Slimmer toolbar when editing inside a table; table actions live exclusively on the bubble menu.

**Bug Fixes**:

- Bubble menu hidden for plain text cursor inside a cell.
- Table Settings modal and overflow popovers no longer fight bubble menu focus.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**What to verify in this PR**

- Selection-kind priority order (whole table → header row/col → row/col → merged single cell → multi-cell)
- Header-overlap delete guards
- Row/column move plans at table edges and for multi-cell blocks
- Action matrix per selection type (row, header, column, merge, split, whole table)
- Pencil trigger activation; no menu for plain cursor in cell
- Table Settings opens without hang; overflow popover stays open and preserves selection
- Toolbar parity: every removed action is reachable via `TableBubbleMenu`

```bash
cd apps/studio
pnpm test:unit -- src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.test.ts
pnpm test:unit -- src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
```

**Manual Verification Steps**:

- [ ] In a Text block RTE: insert a table, select a body row, click the pencil trigger, and confirm row actions appear and work (add row, move, delete).
- [ ] Select header row / leftmost column and confirm header toggles; confirm delete is withheld when a header axis is included.
- [ ] Select multiple cells → Merge; select merged single cell → Split.
- [ ] Click inside cell text (no selection) → no bubble menu.
- [ ] Open Table settings → edit caption → no focus trap hang.
- [ ] Open toolbar overflow (⋯) inside a table → action runs, popover closes, selection preserved.
- [ ] Inside a table: toolbar shows only Insert table + Table settings — no row/col/merge/split icons.
- [ ] Repeat key checks in an Accordion RTE block.
