### PR TITLE
🎀📊 feat(rte-table): remove legacy table toolbar actions (3/3)

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -116,71 +105,16 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -165,72 +154,16 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // Table-specific commands
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +18 | -151 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Once `TableBubbleMenu` (part 2) covers table row/column/merge/split actions, the main RTE toolbar duplicates those controls and adds clutter.

This is **part 3/3** of splitting the contextual `TableBubbleMenu` work for [ISOM-2365](https://linear.app/ogp/issue/ISOM-2365/rte-add-inline-bubble-menu-for-table-actions).

Closes https://linear.app/ogp/issue/ISOM-2365/rte-add-inline-bubble-menu-for-table-actions

## Solution

Remove legacy table toolbar entries from `TextMenuBar` and `AccordionMenuBar`. Keep only:

- **Insert table** (size picker)
- **Table settings** (caption modal — until `TableCaption` lands in a follow-up stack PR)

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None new — deletion-only cleanup.

**Improvements**:

- Slimmer toolbar when editing inside a table; table actions live exclusively on the bubble menu.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

**What to verify in this PR**

- Toolbar parity: every removed action is reachable via `TableBubbleMenu`
- Superscript/subscript promotion inside tables still works (`ActiveTableToolbar` story)

```bash
pnpm storybook
# Pages / Edit Page / Content Page → ActiveTableToolbar
```

**Manual Verification Steps**:

- [ ] Inside a table: toolbar shows only Insert table + Table settings — no row/col/merge/split icons.
- [ ] For each removed toolbar action, confirm the bubble-menu equivalent works (add/delete row/col, merge, split, delete table).
- [ ] Table settings still opens and saves caption.
- [ ] Outside a table: toolbar unchanged except table group is insert-only.
- [ ] Repeat in Accordion RTE block.