### PR TITLE
🎀📊 fix(storybook): import tiptap styles in preview

### DIFF
--- a/apps/studio/.storybook/preview.tsx
+++ b/apps/studio/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 import "@fontsource/ibm-plex-mono"
 import type { EnvContextReturn } from "~/components/AppProviders"
 import "inter-ui/inter.css"
+import "~/styles/tiptap.scss"
 import type { AppRouter } from "~/server/modules/_app"
 import { Skeleton, Stack } from "@chakra-ui/react"
 import { GrowthBookProvider } from "@growthbook/growthbook-react"


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

TipTap editor styles were not applied in Storybook stories. The rich text editor rendered unstyled content — missing heading sizes, list nesting, table borders, cell selection highlights, and placeholder styling.

Storybook boots from `.storybook/preview.tsx` and does not automatically load global styles imported in Next.js `_app.tsx`. `tiptap.scss` was only imported in `_app.tsx`, so it never reached Storybook.

## Solution

Import `~/styles/tiptap.scss` in `.storybook/preview.tsx`, alongside the other global styles already mirrored from `_app.tsx` (fonts, theme providers).

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Storybook stories that render TipTap editors (e.g. Edit Content Page) now display the same editor styles as the running app.

**Bug Fixes**:

- TipTap global styles were missing from Storybook because `tiptap.scss` was only imported in `_app.tsx`.

## Before & After Screenshots

**BEFORE**:

<!-- TipTap editor in Storybook rendered without heading, list, table, and selection styles -->

**AFTER**:

<!-- TipTap editor in Storybook matches app styling after importing tiptap.scss in preview -->

## Tests

- Restart Storybook and open **Pages/Edit Page/Content Page** — verify headings, lists, tables, and table cell selection styling render correctly in the TipTap editor.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Imports the existing TipTap global stylesheet into Storybook preview so editor stories use the same rich-text styling as the application.
- Adds `~/styles/tiptap.scss` alongside Storybook’s existing global style imports.
- Introduces no dependencies, runtime application changes, or breaking API changes.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The change mirrors the application’s existing TipTap stylesheet loading in Storybook, and the repository’s Storybook configuration supports the alias and SCSS import without introducing a concrete failure.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the editor renders before the poster is applied, i.e., without the preview stylesheet.
- Validated that after applying the poster, the editor renders with a visibly structured heading, list, and bordered table content.
- Confirmed both Playwright runs exited with code 0 and the real Storybook iframe route returned HTTP 200.
- Noted that no remaining validation tasks are required, with future coverage suggested for a drag-selected multi-cell table range.

<a href="https://app.greptile.com/trex/runs/16089351/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/.storybook/preview.tsx | Adds the existing TipTap stylesheet to Storybook’s global preview imports; the configured alias and Sass tooling support this usage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(storybook): import tiptap styles in ..."](https://github.com/opengovsg/isomer/commit/9f85b856af989fda3145d8649e7b28421b793fbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47718968)</sub>

<!-- /greptile_comment -->