### PR TITLE
fix(export-import): ensure unique site names when duplicating a site within the same environment

### DIFF
--- a/tooling/export-import/index.ts
+++ b/tooling/export-import/index.ts
@@ -278,9 +278,12 @@ const main = async () => {
 
       if (!destSiteId) {
         console.log(`Creating new site in ${destEnv}...`);
+        // Site.name is unique per environment, so same-env duplicates need a distinct name.
+        const newSiteName =
+          sourceEnv === destEnv ? `${siteName} (Copy)` : siteName;
         const res = await destClient.query(
           `INSERT INTO "Site" (name, config, theme) VALUES ($1, '{}', '{}') RETURNING id`,
-          [siteName]
+          [newSiteName]
         );
         finalDestSiteId = res.rows[0].id;
         console.log(`Created new site with ID ${finalDestSiteId}`);


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +4 | -1 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The `tooling/export-import` script is used to copy a site (content + assets) from one environment to another. When no destination site ID is given, it creates a new `Site` row in the destination database reusing the source site's name verbatim.

`Site.name` is declared `@unique` in the Prisma schema (`packages/db/prisma/schema.prisma:155`). So when the source and destination environments are the same — i.e. duplicating a site within one environment, which is a common way to clone a site for testing — the `INSERT INTO "Site"` hits a unique constraint violation, the script logs `Error creating new site:` and exits with code 1. The duplication is impossible without manually pre-creating a differently-named site and passing its ID.

Closes N/A — no linked issue.

## Solution

When `sourceEnv === destEnv`, the new site is created with `"<source site name> (Copy)"` instead of the source name, so the insert no longer collides with the site being copied. Cross-environment copies are untouched and still keep the original name, since the name is only unique within a single database.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible
  - Cross-environment export/import (the common path) produces exactly the same site name as before. Only the previously-failing same-environment path changes behaviour, from erroring out to succeeding.

**Bug Fixes**:

- Same-environment site duplication no longer fails with a `Site.name` unique constraint violation. The destination site is named `<source name> (Copy)`.

## Before & After Screenshots

Not applicable — CLI tooling script, no UI surface.

**BEFORE**:

```
Creating new site in LOCAL...
Error creating new site: error: duplicate key value violates unique constraint "Site_name_key"
```

**AFTER**:

```
Creating new site in LOCAL...
Created new site with ID 42
```

## Tests

**Manual Verification Steps**:

This change only affects the developer tooling script in `tooling/export-import`; nothing in the deployed application is touched. Verification is done by running the script locally.

- [ ] From `tooling/export-import`, run the export/import script and pick the **same** environment (e.g. `LOCAL`) as both source and destination.
- [ ] Choose an existing source site ID and leave the destination site ID empty so a new site is created.
- [ ] Confirm the script no longer errors on `Creating new site in ...` and instead logs `Created new site with ID <id>`.
- [ ] In the destination database, confirm a new `Site` row exists named `<source site name> (Copy)`, and that the original site's name is unchanged.
- [ ] Confirm the copied site's resources were imported (the copy's page tree matches the source).
- [ ] Re-run with **different** source and destination environments and confirm the created site still uses the source site's original name, with no `(Copy)` suffix.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes the initial same-environment site-name collision during export/import.
- Appends ` (Copy)` to the source site name when creating a site in the same environment.
- Preserves the source name for cross-environment copies.
</details>

<details><summary><h3>Confidence Score: 3/5</h3></summary>

This should be fixed before merging because repeated duplication of the same site still aborts on the unique-name constraint.

The first same-environment copy can succeed, but every later copy of that source generates the same name and reaches an insert that terminates the script on collision.

**Files Needing Attention:** tooling/export-import/index.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a runnable PostgreSQL harness that uses the repository's anchored name expression and a parameterized insert to reproduce the copy-name collision on PostgreSQL 15, observing that the first insert succeeded and the second failed with a 23505 duplicate key error.
- Validated runtime traces show the INSERT parameter changed from Alpha Site to Alpha Site (Copy), and that a new site was created with ID 777 with a migrate call to (42, 777).
- Noted an environment blocker due to missing database credentials and unavailable Docker/AWS CLI, which prevented full end-to-end validation in this environment.
- Artifacts were prepared for review, including a runnable harness artifact and multiple logs and scripts from both proofs to support inspection.

<a href="https://app.greptile.com/trex/runs/16102992/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tooling/export-import/index.ts | Adds same-environment copy naming, but the fixed suffix collides when the same source is duplicated more than once. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atooling%2Fexport-import%2Findex.ts%3A282-283%0A**Fixed%20copy%20name%20still%20collides**%0A%0AWhen%20the%20same%20source%20site%20is%20duplicated%20again%20after%20%60%3Csource%20name%3E%20%28Copy%29%60%20already%20exists%2C%20this%20branch%20generates%20that%20identical%20name%2C%20causing%20the%20unique-constrained%20insert%20to%20fail%20and%20the%20clone%20operation%20to%20exit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=2985&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atooling%2Fexport-import%2Findex.ts%3A282-283%0A**Fixed%20copy%20name%20still%20collides**%0A%0AWhen%20the%20same%20source%20site%20is%20duplicated%20again%20after%20%60%3Csource%20name%3E%20%28Copy%29%60%20already%20exists%2C%20this%20branch%20generates%20that%20identical%20name%2C%20causing%20the%20unique-constrained%20insert%20to%20fail%20and%20the%20clone%20operation%20to%20exit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=2985&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22chore%2Fexport-import-script-enhancement%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fexport-import-script-enhancement%22.%0A%0A%23%23%23%20Issue%201%0Atooling%2Fexport-import%2Findex.ts%3A282-283%0A**Fixed%20copy%20name%20still%20collides**%0A%0AWhen%20the%20same%20source%20site%20is%20duplicated%20again%20after%20%60%3Csource%20name%3E%20%28Copy%29%60%20already%20exists%2C%20this%20branch%20generates%20that%20identical%20name%2C%20causing%20the%20unique-constrained%20insert%20to%20fail%20and%20the%20clone%20operation%20to%20exit.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tooling/export-import/index.ts:282-283
**Fixed copy name still collides**

When the same source site is duplicated again after `<source name> (Copy)` already exists, this branch generates that identical name, causing the unique-constrained insert to fail and the clone operation to exit.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(export-import): ensure unique site n..."](https://github.com/opengovsg/isomer/commit/956e6e64797b21edf4a4209adb9184393f8777c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47742834)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->