### PR TITLE
refactor(studio): remove collection tag CSAT tracking from Manage filters

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -97,10 +97,11 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     ajv.compile<Static<ReturnType<typeof getLayoutPageSchema>>>(metadataSchema)
 
   const handleSaveChanges = useCallback(() => {
-    const hadNoTagsBefore = !(savedPageState.page as CollectionPagePageProps)
-      .tagCategories?.length
-    const hasTagsNow = !!(previewPageState.page as CollectionPagePageProps)
-      .tagCategories?.length
+    const savedTags = (savedPageState.page as CollectionPagePageProps)
+      .tagCategories
+    const previewTags = (previewPageState.page as CollectionPagePageProps)
+      .tagCategories
+    const tagCategoriesChanged = !isEqual(savedTags, previewTags)
 
     setSavedPageState(previewPageState)
     mutate(
@@ -112,14 +113,15 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
       {
         onSuccess: () => {
           setDrawerState({ state: "root" })
-          if (hadNoTagsBefore && hasTagsNow) {
-            trackEvent("first_tag_added")
+          if (drawerStateType === "filter" && tagCategoriesChanged) {
+            trackEvent("first_tag_edited")
             triggerCollectionTagCsatSurveyOnce({ userId: me.id })
           }
         },
       },
     )
   }, [
+    drawerStateType,
     mutate,
     pageId,
     previewPageState,

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -15,10 +15,13 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useMe } from "~/features/me/api"
+import { useLocalStorage } from "~/hooks/useLocalStorage"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import {
-  trackFirstTagEditedOnce,
-  triggerCollectionTagCsatSurveyOnce,
+  getCollectionTagCsatSurveyStorageKey,
+  getFirstTagEditedTrackedStorageKey,
+  startCollectionTagCsatSurvey,
+  trackEvent,
 } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
@@ -49,6 +52,14 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { me } = useMe()
+  const [hasTrackedFirstTagEdit, setHasTrackedFirstTagEdit] = useLocalStorage(
+    getFirstTagEditedTrackedStorageKey({ userId: me.id }),
+    false,
+  )
+  const [hasShownTagCsatSurvey, setHasShownTagCsatSurvey] = useLocalStorage(
+    getCollectionTagCsatSurveyStorageKey({ userId: me.id }),
+    false,
+  )
   const canManageFilters = useCanManageCollectionFilters()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
@@ -117,22 +128,31 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
         onSuccess: () => {
           setDrawerState({ state: "root" })
           if (drawerStateType === "filter" && tagCategoriesChanged) {
-            trackFirstTagEditedOnce({ userId: me.id })
-            triggerCollectionTagCsatSurveyOnce({ userId: me.id })
+            if (!hasTrackedFirstTagEdit) {
+              trackEvent("first_tag_edited")
+              setHasTrackedFirstTagEdit(true)
+            }
+            if (!hasShownTagCsatSurvey) {
+              startCollectionTagCsatSurvey()
+              setHasShownTagCsatSurvey(true)
+            }
           }
         },
       },
     )
   }, [
     drawerStateType,
+    hasShownTagCsatSurvey,
+    hasTrackedFirstTagEdit,
     mutate,
     pageId,
     previewPageState,
     savedPageState,
     setDrawerState,
+    setHasShownTagCsatSurvey,
+    setHasTrackedFirstTagEdit,
     setSavedPageState,
     siteId,
-    me.id,
   ])
 
   const handleChange = (data: unknown) => {

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -16,7 +16,10 @@ import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useMe } from "~/features/me/api"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
+import {
+  trackFirstTagEditedOnce,
+  triggerCollectionTagCsatSurveyOnce,
+} from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
 
@@ -114,7 +117,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
         onSuccess: () => {
           setDrawerState({ state: "root" })
           if (drawerStateType === "filter" && tagCategoriesChanged) {
-            trackEvent("first_tag_edited")
+            trackFirstTagEditedOnce({ userId: me.id })
             triggerCollectionTagCsatSurveyOnce({ userId: me.id })
           }
         },

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -1,4 +1,7 @@
-import type { getLayoutPageSchema } from "@opengovsg/isomer-components"
+import type {
+  CollectionPagePageProps,
+  getLayoutPageSchema,
+} from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Flex, Text, useDisclosure } from "@chakra-ui/react"
 import { Button, Infobox, useToast } from "@opengovsg/design-system-react"
@@ -12,7 +15,9 @@ import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
+import { useMe } from "~/features/me/api"
 import { useQueryParse } from "~/hooks/useQueryParse"
+import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
 
@@ -41,6 +46,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     setPreviewPageState,
   } = useEditorDrawerContext()
 
+  const { me } = useMe()
   const canManageFilters = useCanManageCollectionFilters()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
@@ -102,6 +108,11 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   )
 
   const handleSaveChanges = useCallback(() => {
+    const hadNoTagsBefore = !(savedPageState.page as CollectionPagePageProps)
+      .tagCategories?.length
+    const hasTagsNow = !!(previewPageState.page as CollectionPagePageProps)
+      .tagCategories?.length
+
     setSavedPageState(previewPageState)
     mutate(
       {
@@ -112,6 +123,10 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
       {
         onSuccess: () => {
           setDrawerState({ state: "root" })
+          if (hadNoTagsBefore && hasTagsNow) {
+            trackEvent("first_tag_added")
+            triggerCollectionTagCsatSurveyOnce({ userId: me.id })
+          }
         },
       },
     )
@@ -119,9 +134,11 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     mutate,
     pageId,
     previewPageState,
+    savedPageState,
     setDrawerState,
     setSavedPageState,
     siteId,
+    me.id,
   ])
 
   const handleChange = (data: unknown) => {

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -16,10 +16,13 @@ import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useMe } from "~/features/me/api"
+import { useLocalStorage } from "~/hooks/useLocalStorage"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import {
-  trackFirstTagEditedOnce,
-  triggerCollectionTagCsatSurveyOnce,
+  getCollectionTagCsatSurveyStorageKey,
+  getFirstTagEditedTrackedStorageKey,
+  startCollectionTagCsatSurvey,
+  trackEvent,
 } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
@@ -50,6 +53,14 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   } = useEditorDrawerContext()
 
   const { me } = useMe()
+  const [hasTrackedFirstTagEdit, setHasTrackedFirstTagEdit] = useLocalStorage(
+    getFirstTagEditedTrackedStorageKey({ userId: me.id }),
+    false,
+  )
+  const [hasShownTagCsatSurvey, setHasShownTagCsatSurvey] = useLocalStorage(
+    getCollectionTagCsatSurveyStorageKey({ userId: me.id }),
+    false,
+  )
   const canManageFilters = useCanManageCollectionFilters()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
@@ -128,22 +139,31 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
         onSuccess: () => {
           setDrawerState({ state: "root" })
           if (drawerStateType === "filter" && tagCategoriesChanged) {
-            trackFirstTagEditedOnce({ userId: me.id })
-            triggerCollectionTagCsatSurveyOnce({ userId: me.id })
+            if (!hasTrackedFirstTagEdit) {
+              trackEvent("first_tag_edited")
+              setHasTrackedFirstTagEdit(true)
+            }
+            if (!hasShownTagCsatSurvey) {
+              startCollectionTagCsatSurvey()
+              setHasShownTagCsatSurvey(true)
+            }
           }
         },
       },
     )
   }, [
     drawerStateType,
+    hasShownTagCsatSurvey,
+    hasTrackedFirstTagEdit,
     mutate,
     pageId,
     previewPageState,
     savedPageState,
     setDrawerState,
+    setHasShownTagCsatSurvey,
+    setHasTrackedFirstTagEdit,
     setSavedPageState,
     siteId,
-    me.id,
   ])
 
   const handleChange = (data: unknown) => {

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -1,7 +1,4 @@
-import type {
-  CollectionPagePageProps,
-  getLayoutPageSchema,
-} from "@opengovsg/isomer-components"
+import type { getLayoutPageSchema } from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Flex, Text, useDisclosure } from "@chakra-ui/react"
 import { Button, Infobox, useToast } from "@opengovsg/design-system-react"
@@ -15,15 +12,7 @@ import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
-import { useMe } from "~/features/me/api"
-import { useLocalStorage } from "~/hooks/useLocalStorage"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import {
-  getCollectionTagCsatSurveyStorageKey,
-  getFirstTagEditedTrackedStorageKey,
-  startCollectionTagCsatSurvey,
-  trackEvent,
-} from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
 
@@ -52,15 +41,6 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     setPreviewPageState,
   } = useEditorDrawerContext()
 
-  const { me } = useMe()
-  const [hasTrackedFirstTagEdit, setHasTrackedFirstTagEdit] = useLocalStorage(
-    getFirstTagEditedTrackedStorageKey({ userId: me.id }),
-    false,
-  )
-  const [hasShownTagCsatSurvey, setHasShownTagCsatSurvey] = useLocalStorage(
-    getCollectionTagCsatSurveyStorageKey({ userId: me.id }),
-    false,
-  )
   const canManageFilters = useCanManageCollectionFilters()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
@@ -122,12 +102,6 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   )
 
   const handleSaveChanges = useCallback(() => {
-    const savedTags = (savedPageState.page as CollectionPagePageProps)
-      .tagCategories
-    const previewTags = (previewPageState.page as CollectionPagePageProps)
-      .tagCategories
-    const tagCategoriesChanged = !isEqual(savedTags, previewTags)
-
     setSavedPageState(previewPageState)
     mutate(
       {
@@ -138,30 +112,14 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
       {
         onSuccess: () => {
           setDrawerState({ state: "root" })
-          if (drawerStateType === "filter" && tagCategoriesChanged) {
-            if (!hasTrackedFirstTagEdit) {
-              trackEvent("first_tag_edited")
-              setHasTrackedFirstTagEdit(true)
-            }
-            if (!hasShownTagCsatSurvey) {
-              startCollectionTagCsatSurvey()
-              setHasShownTagCsatSurvey(true)
-            }
-          }
         },
       },
     )
   }, [
-    drawerStateType,
-    hasShownTagCsatSurvey,
-    hasTrackedFirstTagEdit,
     mutate,
     pageId,
     previewPageState,
-    savedPageState,
     setDrawerState,
-    setHasShownTagCsatSurvey,
-    setHasTrackedFirstTagEdit,
     setSavedPageState,
     siteId,
   ])

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -17,7 +17,10 @@ import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
 import { useMe } from "~/features/me/api"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
+import {
+  trackFirstTagEditedOnce,
+  triggerCollectionTagCsatSurveyOnce,
+} from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
 
@@ -125,7 +128,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
         onSuccess: () => {
           setDrawerState({ state: "root" })
           if (drawerStateType === "filter" && tagCategoriesChanged) {
-            trackEvent("first_tag_edited")
+            trackFirstTagEditedOnce({ userId: me.id })
             triggerCollectionTagCsatSurveyOnce({ userId: me.id })
           }
         },

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -1,7 +1,4 @@
-import type {
-  CollectionPagePageProps,
-  getLayoutPageSchema,
-} from "@opengovsg/isomer-components"
+import type { getLayoutPageSchema } from "@opengovsg/isomer-components"
 import type { Static } from "@sinclair/typebox"
 import { Box, Flex, Text, useDisclosure } from "@chakra-ui/react"
 import { Button, Infobox, useToast } from "@opengovsg/design-system-react"
@@ -15,9 +12,7 @@ import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useCanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
-import { useMe } from "~/features/me/api"
 import { useQueryParse } from "~/hooks/useQueryParse"
-import { trackEvent, triggerCollectionTagCsatSurveyOnce } from "~/lib/intercom"
 import { ajv } from "~/utils/ajv"
 import { trpc } from "~/utils/trpc"
 
@@ -46,7 +41,6 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     setPreviewPageState,
   } = useEditorDrawerContext()
 
-  const { me } = useMe()
   const canManageFilters = useCanManageCollectionFilters()
   const { pageId, siteId } = useQueryParse(pageSchema)
   const toast = useToast()
@@ -108,11 +102,6 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   )
 
   const handleSaveChanges = useCallback(() => {
-    const hadNoTagsBefore = !(savedPageState.page as CollectionPagePageProps)
-      .tagCategories?.length
-    const hasTagsNow = !!(previewPageState.page as CollectionPagePageProps)
-      .tagCategories?.length
-
     setSavedPageState(previewPageState)
     mutate(
       {
@@ -123,10 +112,6 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
       {
         onSuccess: () => {
           setDrawerState({ state: "root" })
-          if (hadNoTagsBefore && hasTagsNow) {
-            trackEvent("first_tag_added")
-            triggerCollectionTagCsatSurveyOnce({ userId: me.id })
-          }
         },
       },
     )
@@ -134,11 +119,9 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     mutate,
     pageId,
     previewPageState,
-    savedPageState,
     setDrawerState,
     setSavedPageState,
     siteId,
-    me.id,
   ])
 
   const handleChange = (data: unknown) => {

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -108,10 +108,11 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
   )
 
   const handleSaveChanges = useCallback(() => {
-    const hadNoTagsBefore = !(savedPageState.page as CollectionPagePageProps)
-      .tagCategories?.length
-    const hasTagsNow = !!(previewPageState.page as CollectionPagePageProps)
-      .tagCategories?.length
+    const savedTags = (savedPageState.page as CollectionPagePageProps)
+      .tagCategories
+    const previewTags = (previewPageState.page as CollectionPagePageProps)
+      .tagCategories
+    const tagCategoriesChanged = !isEqual(savedTags, previewTags)
 
     setSavedPageState(previewPageState)
     mutate(
@@ -123,14 +124,15 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
       {
         onSuccess: () => {
           setDrawerState({ state: "root" })
-          if (hadNoTagsBefore && hasTagsNow) {
-            trackEvent("first_tag_added")
+          if (drawerStateType === "filter" && tagCategoriesChanged) {
+            trackEvent("first_tag_edited")
             triggerCollectionTagCsatSurveyOnce({ userId: me.id })
           }
         },
       },
     )
   }, [
+    drawerStateType,
     mutate,
     pageId,
     previewPageState,

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -26,6 +26,25 @@ export const trackEvent = (eventName: string): void => {
   trackEventSdk(eventName)
 }
 
+interface TrackEventOnceProps {
+  eventName: string
+  userId: string
+}
+
+const trackEventOnce = ({ eventName, userId }: TrackEventOnceProps): void => {
+  const key = `intercom_event_${eventName}_${userId}_tracked`
+  if (localStorage.getItem(key)) return
+
+  trackEvent(eventName)
+  localStorage.setItem(key, "1")
+}
+
+export const trackFirstTagEditedOnce = ({
+  userId,
+}: Omit<TrackEventOnceProps, "eventName">): void => {
+  trackEventOnce({ eventName: "first_tag_edited", userId })
+}
+
 interface TriggerSurveyOnceProps {
   surveyId: string
   userId: string

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -26,47 +26,25 @@ export const trackEvent = (eventName: string): void => {
   trackEventSdk(eventName)
 }
 
-interface TrackEventOnceProps {
-  eventName: string
-  userId: string
-}
+export const COLLECTION_TAG_CSAT_SURVEY_ID = "65029624"
 
-const trackEventOnce = ({ eventName, userId }: TrackEventOnceProps): void => {
-  const key = `intercom_event_${eventName}_${userId}_tracked`
-  if (localStorage.getItem(key)) return
-
-  trackEvent(eventName)
-  localStorage.setItem(key, "1")
-}
-
-export const trackFirstTagEditedOnce = ({
+export const getFirstTagEditedTrackedStorageKey = ({
   userId,
-}: Omit<TrackEventOnceProps, "eventName">): void => {
-  trackEventOnce({ eventName: "first_tag_edited", userId })
-}
-
-interface TriggerSurveyOnceProps {
-  surveyId: string
+}: {
   userId: string
-}
+}): string => `intercom_event_first_tag_edited_${userId}_tracked`
 
-const triggerSurveyOnce = ({
-  surveyId,
+export const getCollectionTagCsatSurveyStorageKey = ({
   userId,
-}: TriggerSurveyOnceProps): void => {
-  const key = `intercom_survey_${surveyId}_${userId}_shown`
-  if (localStorage.getItem(key)) return
+}: {
+  userId: string
+}): string => `intercom_survey_${COLLECTION_TAG_CSAT_SURVEY_ID}_${userId}_shown`
 
+export const startCollectionTagCsatSurvey = (): void => {
   if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-    console.log("[Intercom mock] startSurvey", surveyId)
-  } else {
-    startSurvey(surveyId)
+    console.log("[Intercom mock] startSurvey", COLLECTION_TAG_CSAT_SURVEY_ID)
+    return
   }
-  localStorage.setItem(key, "1")
-}
 
-export const triggerCollectionTagCsatSurveyOnce = ({
-  userId,
-}: Omit<TriggerSurveyOnceProps, "surveyId">): void => {
-  triggerSurveyOnce({ surveyId: "65029624", userId })
+  startSurvey(COLLECTION_TAG_CSAT_SURVEY_ID)
 }

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -1,7 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports
 import {
   Intercom as bootIntercomSdk,
-  startSurvey,
   trackEvent as trackEventSdk,
 } from "@intercom/messenger-js-sdk"
 import { env } from "~/env.mjs"
@@ -24,27 +23,4 @@ export const trackEvent = (eventName: string): void => {
   }
 
   trackEventSdk(eventName)
-}
-
-export const COLLECTION_TAG_CSAT_SURVEY_ID = "65029624"
-
-export const getFirstTagEditedTrackedStorageKey = ({
-  userId,
-}: {
-  userId: string
-}): string => `intercom_event_first_tag_edited_${userId}_tracked`
-
-export const getCollectionTagCsatSurveyStorageKey = ({
-  userId,
-}: {
-  userId: string
-}): string => `intercom_survey_${COLLECTION_TAG_CSAT_SURVEY_ID}_${userId}_shown`
-
-export const startCollectionTagCsatSurvey = (): void => {
-  if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-    console.log("[Intercom mock] startSurvey", COLLECTION_TAG_CSAT_SURVEY_ID)
-    return
-  }
-
-  startSurvey(COLLECTION_TAG_CSAT_SURVEY_ID)
 }

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -1,7 +1,6 @@
 // oxlint-disable-next-line no-restricted-imports
 import {
   Intercom as bootIntercomSdk,
-  startSurvey,
   trackEvent as trackEventSdk,
 } from "@intercom/messenger-js-sdk"
 import { env } from "~/env.mjs"
@@ -24,30 +23,4 @@ export const trackEvent = (eventName: string): void => {
   }
 
   trackEventSdk(eventName)
-}
-
-interface TriggerSurveyOnceProps {
-  surveyId: string
-  userId: string
-}
-
-const triggerSurveyOnce = ({
-  surveyId,
-  userId,
-}: TriggerSurveyOnceProps): void => {
-  const key = `intercom_survey_${surveyId}_${userId}_shown`
-  if (localStorage.getItem(key)) return
-
-  if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
-    console.log("[Intercom mock] startSurvey", surveyId)
-  } else {
-    startSurvey(surveyId)
-  }
-  localStorage.setItem(key, "1")
-}
-
-export const triggerCollectionTagCsatSurveyOnce = ({
-  userId,
-}: Omit<TriggerSurveyOnceProps, "surveyId">): void => {
-  triggerSurveyOnce({ surveyId: "65029624", userId })
 }

--- a/apps/studio/src/lib/intercom.ts
+++ b/apps/studio/src/lib/intercom.ts
@@ -1,6 +1,7 @@
 // oxlint-disable-next-line no-restricted-imports
 import {
   Intercom as bootIntercomSdk,
+  startSurvey,
   trackEvent as trackEventSdk,
 } from "@intercom/messenger-js-sdk"
 import { env } from "~/env.mjs"
@@ -23,4 +24,30 @@ export const trackEvent = (eventName: string): void => {
   }
 
   trackEventSdk(eventName)
+}
+
+interface TriggerSurveyOnceProps {
+  surveyId: string
+  userId: string
+}
+
+const triggerSurveyOnce = ({
+  surveyId,
+  userId,
+}: TriggerSurveyOnceProps): void => {
+  const key = `intercom_survey_${surveyId}_${userId}_shown`
+  if (localStorage.getItem(key)) return
+
+  if (!env.NEXT_PUBLIC_INTERCOM_APP_ID) {
+    console.log("[Intercom mock] startSurvey", surveyId)
+  } else {
+    startSurvey(surveyId)
+  }
+  localStorage.setItem(key, "1")
+}
+
+export const triggerCollectionTagCsatSurveyOnce = ({
+  userId,
+}: Omit<TriggerSurveyOnceProps, "surveyId">): void => {
+  triggerSurveyOnce({ surveyId: "65029624", userId })
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +1 | -45 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

This branch originally added a collection tag CSAT survey trigger on the first manual tag edit in **Manage filters**, to cover collections that already had migrated `tagCategories`. That CSAT flow is no longer needed.

## Solution

Remove collection tag CSAT and first-tag Intercom tracking from the collection editor save path:

- Stop emitting the `first_tag_added` Intercom event when saving tag categories
- Stop triggering the collection tag CSAT survey from **Manage filters**
- Remove the unused `triggerCollectionTagCsatSurveyOnce` helper and related `startSurvey` plumbing from `intercom.ts`

Save behaviour in **Manage filters** and **Collection display** is otherwise unchanged.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- Removes Intercom survey and event noise during collection tag editing

## Tests

**Manual Verification Steps**:

- [ ] Open a Collection index page, go to **Manage filters**, add or edit tag categories, and save — confirm the save succeeds and no Intercom CSAT survey appears
- [ ] Save tag changes again — confirm no survey appears on subsequent saves
- [ ] Open **Collection display**, change a display setting, and save — confirm the save still succeeds as before