### PR TITLE
fix: address Copilot review findings from PR #2777

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -137,7 +137,7 @@ const FixedBlock = () => {
             description="Define and manage filters for this Collection."
             icon={BiSlider}
           />
-        </CanManageCollectionFilters>{" "}
+        </CanManageCollectionFilters>
       </>
     )
   }

--- a/apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/components/DeleteFilterModal.tsx
@@ -51,7 +51,7 @@ function FilterUsageInfobox({
   return (
     <Text textStyle="body-1" color="base.content.strong">
       {count > 0
-        ? `It’s being used on ${count === 1 ? "1 item" : `${count} items`}.`
+        ? `It’s being used on ${count === 1 ? "1 item" : `${count} items`}. `
         : ""}
       {DELETE_FILTER_UNDO_TEXT}
     </Text>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageRadioControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsImageRadioControl.tsx
@@ -27,11 +27,13 @@ interface ImageRadioSchema {
 interface ImageRadioOptionProps extends UseRadioProps {
   image: string
   isSelected: boolean
+  ariaLabel: string
 }
 
 const ImageRadioOption = ({
   image,
   isSelected,
+  ariaLabel,
   ...rest
 }: ImageRadioOptionProps) => {
   const { getInputProps, getRadioProps } = useRadio(rest)
@@ -39,7 +41,7 @@ const ImageRadioOption = ({
 
   return (
     <Box as="label" cursor="pointer" width="100%" lineHeight={0}>
-      <input {...getInputProps()} />
+      <input {...getInputProps()} aria-label={ariaLabel} />
       <Box
         {...getRadioProps()}
         position="relative"
@@ -124,6 +126,9 @@ function JsonFormsImageRadioControl({
                 {...getRadioProps({ value: option.value })}
                 image={option.image}
                 isSelected={isSelected}
+                ariaLabel={
+                  option.value.charAt(0).toUpperCase() + option.value.slice(1)
+                }
               />
             )
           })}

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTagCategoryOptionsControl.tsx
@@ -46,7 +46,7 @@ function DeleteOptionWarningBody({
   return (
     <Text textStyle="body-1" color="base.content.strong">
       {count > 0
-        ? `This option is being used in ${count === 1 ? "1 item" : `${count} items`}.`
+        ? `This option is being used in ${count === 1 ? "1 item" : `${count} items`}. `
         : ""}
       {DELETE_OPTION_UNDO_TEXT}
     </Text>

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
@@ -78,6 +78,7 @@ const SuspendableJsonFormsTaggedControl = ({
 
             return (
               <FormControl
+                key={label}
                 isRequired={tagIsRequired ?? false}
                 isInvalid={isInvalid}
                 gap="0.5rem"

--- a/apps/studio/src/features/editing-experience/hooks/useCollectionTags.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useCollectionTags.ts
@@ -6,22 +6,17 @@ import { trpc, type RouterOutput } from "~/utils/trpc"
 
 export type CollectionTags = RouterOutput["collection"]["getCollectionTags"]
 
-interface UseCollectionTagsQueryInput {
+interface UseCollectionTagsInput {
   resourceId: number
   siteId: number
   enabled?: boolean
-}
-
-interface UseCollectionTagsSuspenseInput {
-  resourceId: number
-  siteId: number
 }
 
 export function useCollectionTags({
   resourceId,
   siteId,
   enabled = true,
-}: UseCollectionTagsQueryInput) {
+}: UseCollectionTagsInput) {
   return trpc.collection.getCollectionTags.useQuery(
     { resourceId, siteId },
     { enabled },
@@ -31,7 +26,7 @@ export function useCollectionTags({
 export function useSuspenseCollectionTags({
   resourceId,
   siteId,
-}: UseCollectionTagsSuspenseInput) {
+}: Omit<UseCollectionTagsInput, "enabled">) {
   return trpc.collection.getCollectionTags.useSuspenseQuery({
     resourceId,
     siteId,

--- a/apps/studio/src/features/editing-experience/hooks/useCollectionTags.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useCollectionTags.ts
@@ -6,17 +6,22 @@ import { trpc, type RouterOutput } from "~/utils/trpc"
 
 export type CollectionTags = RouterOutput["collection"]["getCollectionTags"]
 
-interface UseCollectionTagsInput {
+interface UseCollectionTagsQueryInput {
   resourceId: number
   siteId: number
   enabled?: boolean
+}
+
+interface UseCollectionTagsSuspenseInput {
+  resourceId: number
+  siteId: number
 }
 
 export function useCollectionTags({
   resourceId,
   siteId,
   enabled = true,
-}: UseCollectionTagsInput) {
+}: UseCollectionTagsQueryInput) {
   return trpc.collection.getCollectionTags.useQuery(
     { resourceId, siteId },
     { enabled },
@@ -26,7 +31,7 @@ export function useCollectionTags({
 export function useSuspenseCollectionTags({
   resourceId,
   siteId,
-}: UseCollectionTagsInput) {
+}: UseCollectionTagsSuspenseInput) {
   return trpc.collection.getCollectionTags.useSuspenseQuery({
     resourceId,
     siteId,

--- a/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
+++ b/packages/components/src/templates/next/layouts/Collection/utils/getTagFilters.ts
@@ -13,9 +13,10 @@ export const getTagFilters = (
   // Hence, we store a map here of the category (eg: Body parts)
   // to the number of occurences of each value (eg: { Brain: 3, Leg: 2 })
   //
-  // NOTE: Tag category `display` (pills vs plaintext) is not attached to
-  // Filter objects. The sidebar always uses checkboxes; `display` is consumed
-  // by card/article tag rendering (PillTags / PlaintextTags) from tagCategories.
+  // NOTE: Tag category `display` (pills vs plaintext) is attached to each
+  // Filter below for consumers that need it, but the sidebar itself always
+  // renders checkboxes regardless of `display` — that value only changes
+  // card/article tag rendering (PillTags / PlaintextTags).
   const tagCategoryLabels = new Map<string, Map<string, number>>()
 
   items.forEach(({ tags }) => {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 7 | +22 | -10 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Fixes the issues raised in Copilot's review on #2777: https://github.com/opengovsg/isomer/pull/2777#pullrequestreview-4804552777

## Solution

Each issue fixed in its own commit:

- Add accessible `aria-label` to pills/plaintext image-radio options
- Fix missing space in delete-filter usage copy ("...2 items.To undo..." → "...2 items. To undo...")
- Fix same missing-space bug in delete-tag-option usage copy
- Add missing `key` prop in tagged control's `.map()`
- Remove stray `{" "}` whitespace artifact in `RootStateDrawer`
- Fix stale comment in `getTagFilters` (said `display` isn't attached to `Filter` objects; it is)
- Split `useCollectionTags` input types so the suspense variant no longer silently ignores an `enabled` flag

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Missing space in delete-filter and delete-tag-option usage copy
- Missing `key` prop in tagged control list
- Stray whitespace artifact in `RootStateDrawer`
- Accessible label missing on tag category display radio options

## Tests

**Manual Verification Steps**:

- [ ] In a Collection's Filters editor, check each pills/plaintext "Show as" option has a distinct accessible name (inspect DOM for `aria-label`, or use a screen reader)
- [ ] Delete a filter with usage (count > 0) and confirm the warning copy has a space: "It's being used on 2 items. To undo this change..."
- [ ] Delete a tag option with usage (count > 0) and confirm the warning copy has a space: "This option is being used in 2 items. To undo this change..."
- [ ] Open a collection item's tag editor with multiple tag categories and confirm no React "missing key" console warning

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change improves collection-tag editing accessibility and presentation, including category rendering. Browser validation reproduced a state-loss issue in `JsonFormsTaggedControl`: categories with duplicate labels can reuse the wrong control instance after one is removed, and renaming a category clears in-progress input and drops focus. This should not merge until category controls are keyed by their stable identifier.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge until T-Rex findings are addressed.

Chromium reproduction exercised duplicate-label removal and category rename interactions, both of which lost user-entered filter text; duplicate labels also retained ownership from the removed category.

T-Rex reproduced 2 failing behaviors at runtime in apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx; the change needs fixes before it is safe to merge.

**Files Needing Attention:** apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Chromium reconciliation harness and produced a proof for the posted P1 finding.
- Reviewed the finding-comment-proof and documented the reconciliation outputs demonstrating how duplicate-label handling and category label rename paths were exercised.
- Validated the duplicate-label removal and label rename behavior via the general-contract-validation-proof, confirming the specific outcome where removing the preceding same-label category A left the surviving B with an empty value while retaining owner category-a, and that renaming a label resets the control to empty.
- Linked and organized the collected artifacts from both proofs to support reviewer inspection of harness execution, logs, videos, and before/after visuals.

<a href="https://app.greptile.com/trex/runs/16536496/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Category labels are unsafe React keys**

   - **Bug**
     - Categories with the same label can reuse the wrong nested control instance when one is removed; renaming a category remounts its control. This drops in-progress MultiSelect state and can associate retained component state with a different category.
   - **Cause**
     - `FormControl` is keyed by mutable, non-unique `label` rather than the category's stable `id`.
   - **Fix**
     - Change line 81 to key the category by its stable identifier, e.g. `key={id}`, retaining `id` in the mapped category destructuring.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsTaggedControl.tsx%3A81%0A**Category%20labels%20are%20unsafe%20React%20keys**%0A%0A%60label%60%20is%20mutable%20and%20not%20guaranteed%20unique%2C%20so%20it%20cannot%20safely%20identify%20these%20category%20controls.%20When%20two%20categories%20share%20a%20label%2C%20removing%20the%20first%20causes%20React%20to%20reuse%20its%20nested%20control%20instance%20for%20the%20surviving%20category%3B%20renaming%20a%20category%20remounts%20its%20control.%20Both%20paths%20discard%20in-progress%20%60MultiSelect%60%20state%20and%20can%20retain%20component%20state%20for%20the%20wrong%20category.%20Destructure%20the%20stable%20category%20%60id%60%20and%20use%20%60key%3D%7Bid%7D%60%20instead.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3003&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsTaggedControl.tsx%3A81%0A**Category%20labels%20are%20unsafe%20React%20keys**%0A%0A%60label%60%20is%20mutable%20and%20not%20guaranteed%20unique%2C%20so%20it%20cannot%20safely%20identify%20these%20category%20controls.%20When%20two%20categories%20share%20a%20label%2C%20removing%20the%20first%20causes%20React%20to%20reuse%20its%20nested%20control%20instance%20for%20the%20surviving%20category%3B%20renaming%20a%20category%20remounts%20its%20control.%20Both%20paths%20discard%20in-progress%20%60MultiSelect%60%20state%20and%20can%20retain%20component%20state%20for%20the%20wrong%20category.%20Destructure%20the%20stable%20category%20%60id%60%20and%20use%20%60key%3D%7Bid%7D%60%20instead.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3003&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22fix%2Fcopilot-review-2777%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcopilot-review-2777%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Fcomponents%2Fform-builder%2Frenderers%2Fcontrols%2FJsonFormsTaggedControl.tsx%3A81%0A**Category%20labels%20are%20unsafe%20React%20keys**%0A%0A%60label%60%20is%20mutable%20and%20not%20guaranteed%20unique%2C%20so%20it%20cannot%20safely%20identify%20these%20category%20controls.%20When%20two%20categories%20share%20a%20label%2C%20removing%20the%20first%20causes%20React%20to%20reuse%20its%20nested%20control%20instance%20for%20the%20surviving%20category%3B%20renaming%20a%20category%20remounts%20its%20control.%20Both%20paths%20discard%20in-progress%20%60MultiSelect%60%20state%20and%20can%20retain%20component%20state%20for%20the%20wrong%20category.%20Destructure%20the%20stable%20category%20%60id%60%20and%20use%20%60key%3D%7Bid%7D%60%20instead.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/features/editing-experience/components/form-builder/renderers/controls/JsonFormsTaggedControl.tsx:81
**Category labels are unsafe React keys**

`label` is mutable and not guaranteed unique, so it cannot safely identify these category controls. When two categories share a label, removing the first causes React to reuse its nested control instance for the surviving category; renaming a category remounts its control. Both paths discard in-progress `MultiSelect` state and can retain component state for the wrong category. Destructure the stable category `id` and use `key={id}` instead.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(studio): use Omit instead of du..."](https://github.com/opengovsg/isomer/commit/fb39deb86c7d821434f257b4c36d14cecf3f4c73) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48598516)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->