### PR TITLE
Add mobile.onemap.gov.sg to Studio CSP frame-src

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -38,6 +38,7 @@ const ContentSecurityPolicy = `
     https://www.googletagmanager.com
     https://td.doubleclick.net
     https://www.onemap.gov.sg
+    https://mobile.onemap.gov.sg
     https://www.youtube-nocookie.com
     https://player.vimeo.com
     https://m.facebook.com

--- a/packages/components/src/utils/__tests__/validation.test.ts
+++ b/packages/components/src/utils/__tests__/validation.test.ts
@@ -4,6 +4,7 @@ import {
   AUDIO_EMBED_URL_PATTERN,
   GTM_ID_STRING_REGEX,
   isValidAudioEmbedUrl,
+  isValidMapEmbedUrl,
   LINK_HREF_PATTERN,
   MAPS_EMBED_URL_PATTERN,
   VIDEO_EMBED_URL_PATTERN,
@@ -152,11 +153,24 @@ describe("validation", () => {
       const testCases = [
         "https://www.onemap.gov.sg/minimap/minimap.html?mapStyle=Default&zoomLevel=15&latLng=1.29793747849037,103.850182257356&ewt=JTNDcCUzRSUzQ3N0cm9uZyUzRU9wZW4lMjBHb3Zlcm5tZW50JTIwUHJvZHVjdHMlMjBvZmZpY2UlM0MlMkZzdHJvbmclM0UlM0MlMkZwJTNF&popupWidth=200&showPopup=true",
         "https://www.onemap.gov.sg/amm/amm.html?mapStyle=Default&zoomLevel=15&marker=postalcode:189554!colour:darkblue&marker=postalcode:068877!colour:red&marker=postalcode:179097!colour:red&popupWidth=200",
+        "https://mobile.onemap.gov.sg/nparks/heritageTrees.html",
+        "https://mobile.onemap.gov.sg/minimap/minimap.html?mapStyle=Default&zoomLevel=15",
       ]
 
       testCases.forEach((testCase) => {
         const result = new RegExp(MAPS_EMBED_URL_PATTERN).test(testCase)
         expect(result).toBe(true)
+      })
+    })
+
+    it("should allow mobile OneMap embed URLs via isValidMapEmbedUrl", () => {
+      const testCases = [
+        "https://mobile.onemap.gov.sg/nparks/heritageTrees.html",
+        "https://mobile.onemap.gov.sg/minimap/minimap.html?mapStyle=Default&zoomLevel=15",
+      ]
+
+      testCases.forEach((testCase) => {
+        expect(isValidMapEmbedUrl(testCase)).toBe(true)
       })
     })
 
@@ -183,6 +197,8 @@ describe("validation", () => {
         "https://www.google.com/maps/eee/embed?mid=1Mgnp3R1e7rYXGY2Vn1efD-AWXlfZa8o&ehbc=2E312F",
         "https://www.google.fakesite.com/maps/embed?pb=!1m18!1m12!1m3!1d3961.473373876674!2d103.8486973142665!3d1.3035969990313745!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x31da19b8b4c6e1e1%3A0x2f1f6b8f0a1b2a7d!2sMinistry%20of%20Communications%20and%20Information!5e0!3m2!1sen!2ssg!4v1632291134655!5m2!1en!2sg",
         "https://www.onemap.gov.sg/minimap/amm.html?mapStyle=Default&zoomLevel=15&marker=postalcode:189554!colour:darkblue&marker=postalcode:068877!colour:red&marker=postalcode:179097!colour:red&popupWidth=200",
+        "https://mobile.onemap.gov.sg/",
+        "https://evil.onemap.gov.sg/nparks/heritageTrees.html",
       ]
 
       testCases.forEach((testCase) => {

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -55,11 +55,18 @@ const isValidGoogleMapsEmbedUrl = (urlObject: URL) => {
 }
 
 const isValidOneMapEmbedUrl = (urlObject: URL) => {
-  return (
-    urlObject.hostname === "www.onemap.gov.sg" &&
-    (urlObject.pathname === "/minimap/minimap.html" ||
-      urlObject.pathname === "/amm/amm.html")
-  )
+  if (urlObject.hostname === "www.onemap.gov.sg") {
+    return (
+      urlObject.pathname === "/minimap/minimap.html" ||
+      urlObject.pathname === "/amm/amm.html"
+    )
+  }
+
+  if (urlObject.hostname === "mobile.onemap.gov.sg") {
+    return urlObject.pathname.length > 1
+  }
+
+  return false
 }
 
 export const isValidOGPMapsEmbedUrl = (urlObject: URL) => {
@@ -93,7 +100,7 @@ export const isValidMapEmbedUrl = (url: string) => {
 export const MAPS_EMBED_URL_REGEXES = {
   googlemaps: "^https://www\\.google\\.com/maps(?:/d)?/embed(?:\\?.*)?$",
   onemap:
-    "^https://www\\.onemap\\.gov\\.sg(/minimap/minimap\\.html|/amm/amm\\.html).*$",
+    "^https://www\\.onemap\\.gov\\.sg(/minimap/minimap\\.html|/amm/amm\\.html).*$|^https://mobile\\.onemap\\.gov\\.sg/.+$",
   ogpmaps: `^https://maps\\.gov\\.sg/.*$`,
 } as const
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +14 | -6 |
| 🧪 Test | 1 | +16 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Allows mobile OneMap embeds to be saved and rendered in Studio.

- Adds `https://mobile.onemap.gov.sg` to Studio CSP `frame-src`
- Extends `isValidOneMapEmbedUrl` to accept `mobile.onemap.gov.sg` paths (e.g. `/nparks/heritageTrees.html`) while keeping `www.onemap.gov.sg` restricted to `/minimap/minimap.html` and `/amm/amm.html`
- Updates `MAPS_EMBED_URL_REGEXES.onemap` to match both hosts with the same path rules
- Adds unit test coverage for mobile OneMap URLs

## Test plan

- [x] `pnpm exec vitest run src/utils/__tests__/validation.test.ts` in `packages/components`
- [ ] Paste `https://mobile.onemap.gov.sg/nparks/heritageTrees.html` embed in Studio map block and confirm it saves
- [ ] Confirm published page renders the mobile OneMap iframe without CSP violations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-781d304b-2396-4c96-ae87-95b69e617f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-781d304b-2396-4c96-ae87-95b69e617f15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds support for mobile OneMap embeds in Studio, extends the gazette deletion window to 30 minutes, isolates Turbo cache keys across CI matrix jobs, and adds an administrative tool for importing local Collection or Folder content.

A focused executable Collection import verified published resource creation, version attachment, encoded asset rewriting, internal-link conversion, and legacy tag migration. The exercised flow completed successfully: the imported index and pages were studioified, and collection tags were converted into sorted tag categories with item-level tag references. No defects were found.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The reviewed changes are safe to merge based on the exercised Collection import flow and existing URL-validation coverage.

The verified import flow created published resources and preserved asset, link, and tag behavior without demonstrating a regression.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The parent commit was captured to establish that the local-content importer was newly introduced.
- A focused TypeScript harness was run to exercise a normal Collection import, which created a published index and child resources, attached published versions, rewrote /images/hero%20image.png, converted internal links to resource references, and migrated legacy tags.
- The harness reported three studioified pages and three migrated pages, and a TypeScript no-emit check completed successfully.
- Validation showed that the after harness persisted published resources and performed asset/link and tag migrations, with a sorted Topic category and item-level tag IDs.
- The validation inspected specific code paths in isomer-admin and utils packages to verify the exercised flows, including create-content-from-local.ts, studioify.ts, and migrate-tags.ts.

<a href="https://app.greptile.com/trex/runs/16578588/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Allow mobile OneMap embed URLs in map va..."](https://github.com/opengovsg/isomer/commit/f2908328e4c31a26f1a877325988a28130b6092c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48666765)</sub>

<!-- /greptile_comment -->