### PR TITLE
chore(ci): classify .claude/skills as Doc in PR breakdown

### DIFF
--- a/.github/scripts/classify-pr-diff.mjs
+++ b/.github/scripts/classify-pr-diff.mjs
@@ -25,7 +25,7 @@ const BUCKET_GLOBS = {
   // are the exception: verified with `git check-ignore` that neither is
   // actually covered by .gitignore, despite living next to dirs that are.
   ignore: ["pnpm-lock.yaml", "packages/db/src/generated/**", "apps/studio/src/theme/generated/**"],
-  doc: [".claude/**", "**/*.md", "**/*.mdx"],
+  doc: [".claude/skills/**", "**/*.md", "**/*.mdx"],
   test: [
     "**/__tests__/**",
     "**/*.test.ts",

--- a/.github/scripts/classify-pr-diff.mjs
+++ b/.github/scripts/classify-pr-diff.mjs
@@ -25,7 +25,7 @@ const BUCKET_GLOBS = {
   // are the exception: verified with `git check-ignore` that neither is
   // actually covered by .gitignore, despite living next to dirs that are.
   ignore: ["pnpm-lock.yaml", "packages/db/src/generated/**", "apps/studio/src/theme/generated/**"],
-  doc: ["**/*.md", "**/*.mdx"],
+  doc: [".claude/**", "**/*.md", "**/*.mdx"],
   test: [
     "**/__tests__/**",
     "**/*.test.ts",


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -1 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Changes under `.claude/skills/` (agent skills) were falling through to the default **App** bucket in the PR diff breakdown workflow, even though they are documentation rather than application code.

## Solution

Add `.claude/skills/**` to the `doc` bucket in `classify-pr-diff.mjs` so skill files are counted as **Doc** instead of **App`. Other `.claude/` paths (e.g. `settings.json`, `plugin.json`) remain **App**.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- PR diff breakdown now correctly classifies `.claude/skills/` changes as Doc.

## Tests

**Manual Verification Steps**:

- [ ] Open a PR that touches `.claude/skills/**` and confirm those files appear under **Doc**, not **App**.
- [ ] Confirm `.claude/settings.json` or `.claude/plugin.json` changes still appear under **App**.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://opengovproducts.slack.com/archives/C06R4DX966P/p1785466831009389?thread_ts=1785466831.009389&cid=C06R4DX966P)

<div><a href="https://cursor.com/agents/bc-c55521ec-f0ea-5f1f-8b01-c1635a53c87a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c55521ec-f0ea-5f1f-8b01-c1635a53c87a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change classifies files under `.claude/skills/**` as documentation in the PR diff breakdown, while other `.claude/` files continue to fall into the application bucket.

The classifier was exercised against an isolated Git diff containing a Claude skill document, a non-skill Claude configuration file, a regular Markdown document, and a TypeScript test. The output counted 2 documentation files, 1 application file, and 1 test file, as intended.

**Merge safety:** Safe to merge.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changed classification behavior matches the intended documentation, application, and test categorization.

No defects were found, and the production classifier produced the expected bucket totals for an isolated Git diff.

**Files Needing Attention:** None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the classify-pr-diff-contract-test.sh script before and after applying the isolated fixture changes, using the production classifier on base/head commits.
- Validated the after-state classifier output against the expected App, Test, and Doc totals for the isolated fixture; Ignore remains zero.

<a href="https://app.greptile.com/trex/runs/16728804/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(ci): classify only .claude/skills ..."](https://github.com/opengovsg/isomer/commit/eb46a9c1e2323cc149b266b4ca1c83b6bfdf4d77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48966744)</sub>

<!-- /greptile_comment -->