### PR TITLE
feat(studio): add URL sort option for collection and folder pages

### DIFF
--- a/apps/studio/src/features/dashboard/components/ResourceTable/constants.ts
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/constants.ts
@@ -6,4 +6,5 @@ export const RESOURCE_TABLE_SORT_OPTIONS: Record<
 > = {
   "updated-desc": "Recently edited",
   "title-asc": "Alphabetical",
+  "permalink-asc": "URL",
 }

--- a/apps/studio/src/schemas/resource.ts
+++ b/apps/studio/src/schemas/resource.ts
@@ -62,7 +62,11 @@ export const getParentSchema = z.object({
   resourceId: bigIntSchema,
 })
 
-export const resourceOrderByOptions = ["updated-desc", "title-asc"] as const
+export const resourceOrderByOptions = [
+  "updated-desc",
+  "title-asc",
+  "permalink-asc",
+] as const
 
 export type ResourceOrderByOption = (typeof resourceOrderByOptions)[number]
 

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -878,6 +878,7 @@ describe("collection.router", async () => {
     })
 
     it("should sort case-insensitively when orderBy is permalink-asc", async () => {
+      // Arrange
       const { collection, site } = await setupCollection()
       await setupEditorPermissions({ userId: session.userId, siteId: site.id })
 

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -838,6 +838,83 @@ describe("collection.router", async () => {
       expect(titles).toEqual(["apple", "Banana", "cherry"])
     })
 
+    it("should sort by permalink ascending when orderBy is permalink-asc", async () => {
+      // Arrange: titles are intentionally out of permalink order
+      const { collection, site } = await setupCollection()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Zulu",
+        permalink: "charlie",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Alpha",
+        permalink: "alpha",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Mike",
+        permalink: "bravo",
+      })
+
+      // Act
+      const result = await caller.list({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+        orderBy: "permalink-asc",
+      })
+
+      // Assert
+      const permalinks = result.map((r) => r.permalink)
+      expect(permalinks).toEqual(["alpha", "bravo", "charlie"])
+    })
+
+    it("should sort case-insensitively when orderBy is permalink-asc", async () => {
+      const { collection, site } = await setupCollection()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Page C",
+        permalink: "Cherry",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Page A",
+        permalink: "apple",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Page B",
+        permalink: "Banana",
+      })
+
+      // Act
+      const result = await caller.list({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+        orderBy: "permalink-asc",
+      })
+
+      // Assert
+      const permalinks = result.map((r) => r.permalink)
+      expect(permalinks).toEqual(["apple", "Banana", "Cherry"])
+    })
+
     it("should sort by updatedAt descending when orderBy is updated-desc", async () => {
       // Arrange
       const { collection, site } = await setupCollection()

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -916,6 +916,48 @@ describe("collection.router", async () => {
       expect(permalinks).toEqual(["apple", "Banana", "Cherry"])
     })
 
+    it("should sort CollectionLinks by title and CollectionPages by permalink when orderBy is permalink-asc", async () => {
+      // Arrange: link permalink is hidden and random; ordering must use title
+      const { collection, site } = await setupCollection()
+      await setupEditorPermissions({ userId: session.userId, siteId: site.id })
+
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Zulu",
+        permalink: "alpha",
+      })
+      await setupCollectionLink({
+        siteId: site.id,
+        collectionId: collection.id,
+        title: "Bravo",
+        permalink: "zzz-hidden-link-permalink",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.CollectionPage,
+        parentId: collection.id,
+        title: "Alpha",
+        permalink: "charlie",
+      })
+
+      // Act
+      const result = await caller.list({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+        orderBy: "permalink-asc",
+      })
+
+      // Assert
+      expect(result.map((r) => r.title)).toEqual(["Zulu", "Bravo", "Alpha"])
+      expect(result.map((r) => r.type)).toEqual([
+        ResourceType.CollectionPage,
+        ResourceType.CollectionLink,
+        ResourceType.CollectionPage,
+      ])
+    })
+
     it("should sort by updatedAt descending when orderBy is updated-desc", async () => {
       // Arrange
       const { collection, site } = await setupCollection()

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -2675,6 +2675,7 @@ describe("resource.router", async () => {
     })
 
     it("should sort by permalink ascending when orderBy is permalink-asc", async () => {
+      // Arrange
       const { site } = await setupSite()
       await setupEditorPermissions({
         siteId: site.id,
@@ -2700,11 +2701,13 @@ describe("resource.router", async () => {
         permalink: "bravo",
       })
 
+      // Act
       const result = await caller.listWithoutRoot({
         siteId: site.id,
         orderBy: "permalink-asc",
       })
 
+      // Assert
       expect(result.map((r) => r.permalink)).toEqual([
         "alpha",
         "bravo",
@@ -2713,6 +2716,7 @@ describe("resource.router", async () => {
     })
 
     it("should sort folder children by permalink ascending when orderBy is permalink-asc", async () => {
+      // Arrange
       const { folder, site } = await setupFolder({
         permalink: "parent-folder",
         title: "Parent folder",
@@ -2744,12 +2748,14 @@ describe("resource.router", async () => {
         permalink: "bravo",
       })
 
+      // Act
       const result = await caller.listWithoutRoot({
         siteId: site.id,
         resourceId: Number(folder.id),
         orderBy: "permalink-asc",
       })
 
+      // Assert
       expect(result.map((r) => r.permalink)).toEqual([
         "alpha",
         "bravo",

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -2674,6 +2674,89 @@ describe("resource.router", async () => {
       expect(result.map((r) => r.title)).toEqual(["apple", "Banana", "cherry"])
     })
 
+    it("should sort by permalink ascending when orderBy is permalink-asc", async () => {
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        title: "Zulu",
+        permalink: "charlie",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        title: "Alpha",
+        permalink: "alpha",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        resourceType: "Page",
+        title: "Mike",
+        permalink: "bravo",
+      })
+
+      const result = await caller.listWithoutRoot({
+        siteId: site.id,
+        orderBy: "permalink-asc",
+      })
+
+      expect(result.map((r) => r.permalink)).toEqual([
+        "alpha",
+        "bravo",
+        "charlie",
+      ])
+    })
+
+    it("should sort folder children by permalink ascending when orderBy is permalink-asc", async () => {
+      const { folder, site } = await setupFolder({
+        permalink: "parent-folder",
+        title: "Parent folder",
+      })
+      await setupEditorPermissions({
+        siteId: site.id,
+        userId: session.userId,
+      })
+
+      await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: "Page",
+        title: "Zulu",
+        permalink: "charlie",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: "Page",
+        title: "Alpha",
+        permalink: "alpha",
+      })
+      await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: "Page",
+        title: "Mike",
+        permalink: "bravo",
+      })
+
+      const result = await caller.listWithoutRoot({
+        siteId: site.id,
+        resourceId: Number(folder.id),
+        orderBy: "permalink-asc",
+      })
+
+      expect(result.map((r) => r.permalink)).toEqual([
+        "alpha",
+        "bravo",
+        "charlie",
+      ])
+    })
+
     it("should throw 403 if user does not have read access to site", async () => {
       // Arrange
       const { site } = await setupSite()

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -76,6 +76,10 @@ export const applyResourceOrderBy = <O>(
       return query
         .orderBy(sql`lower("Resource"."title")`, "asc")
         .orderBy("Resource.id", "asc")
+    case "permalink-asc":
+      return query
+        .orderBy(sql`lower("Resource"."permalink")`, "asc")
+        .orderBy("Resource.id", "asc")
     case "updated-desc":
     default:
       return query

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -77,8 +77,13 @@ export const applyResourceOrderBy = <O>(
         .orderBy(sql`lower("Resource"."title")`, "asc")
         .orderBy("Resource.id", "asc")
     case "permalink-asc":
+      // CollectionLink permalinks are random UUIDs and hidden in the CMS, so
+      // sort links by title and pages by permalink in one combined list.
       return query
-        .orderBy(sql`lower("Resource"."permalink")`, "asc")
+        .orderBy(
+          sql`lower(CASE WHEN "Resource"."type" = ${ResourceType.CollectionLink} THEN "Resource"."title" ELSE "Resource"."permalink" END)`,
+          "asc",
+        )
         .orderBy("Resource.id", "asc")
     case "updated-desc":
     default:


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +15 | -1 |
| 🧪 Test | 2 | +209 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

URA feedback requested the ability to sort collection pages by URL in the CMS. The collection and folder tables currently only support sorting by recently edited and alphabetical (title).

## Solution

Add a `permalink-asc` order option to the shared resource listing sort, exposed in the sort menu as **URL**.

Because collections and folders both use the same `ResourceSortMenu` and `applyResourceOrderBy` helper, this applies to:
- Site root page/folder listings
- Folder child listings
- Collection item listings

For collections with mixed `CollectionPage` and `CollectionLink` items, links are sorted by title (their visible label) rather than permalink, since link permalinks are random UUIDs hidden from users.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- New "URL" sort option in collection and folder tables
- Case-insensitive permalink ordering with `id` as tie-breaker, matching the existing title sort behaviour
- Collection links sorted by title when URL sort is selected

**Improvements**:

- N/A

**Bug Fixes**:

- N/A

## Tests

- Added `collection.router.test.ts` coverage for `permalink-asc` (basic order + case-insensitive + mixed link/page)
- Added `resource.router.test.ts` coverage for `permalink-asc` at site root and inside folders
- `pnpm typecheck` and `pnpm lint` pass locally
- Integration tests require Docker (not available in cloud agent environment)

**Manual Verification Steps**:

- [ ] Open a collection in Studio dashboard
- [ ] Open the sort dropdown and confirm **URL** appears alongside Recently edited and Alphabetical
- [ ] Select URL and verify pages are ordered by permalink (A → Z), not title
- [ ] In a collection with both pages and links, verify links sort by title
- [ ] Repeat inside a folder and at site root
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://opengovproducts.slack.com/archives/C06R4DX966P/p1785469616294589?thread_ts=1785469616.294589&cid=C06R4DX966P)

<div><a href="https://cursor.com/agents/bc-c5c951b2-704b-50e6-859e-11389a9ba750?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5c951b2-704b-50e6-859e-11389a9ba750&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a URL-based sorting option to Studio resource listings. Pages are ordered case-insensitively by permalink, while collection links use their visible titles because their generated permalinks are not shown to editors.

A focused before-and-after execution exercised root, folder, and mixed collection listings, including case-insensitive values and resource-ID tie-breaking. The updated ordering produced the expected root `[10,20,30]`, folder `[31,21,41]`, and mixed collection `[11,12,60,40,50]` results, with all assertions passing. No defects were found.

## T-Rex validation blocked
Database-backed router tests could not start because the required Docker-compatible Testcontainers service is unavailable. Direct invocation of the exported ordering function also stopped before database access because required Studio environment variables are not configured. [Configure VMs](https://app.greptile.com/-/settings/trex#environments)
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The URL sorting change is safe to merge based on the exercised ordering behavior.

The executed comparison confirmed the intended ordering for root, folder, and mixed collection listings, including case-insensitive values and deterministic ties, and found no defect.

**Files Needing Attention:** No changed files require follow-up.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the before-and-after permalink-ordering harness with root, folder, and mixed fixtures to validate the new ordering behavior.
- The updated implementation produced root \[10,20,30\], folder \[31,21,41\], and mixed collection \[11,12,60,40,50\], and all assertions passed, confirming case-insensitive ordering, collection-link title ordering, and deterministic ID ties.
- A direct invocation of the exported ordering function was attempted but blocked due to missing Studio environment variables; the attempt output was retained for future runs.

<a href="https://app.greptile.com/trex/runs/17082440/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(studio): sort CollectionLinks by tit..."](https://github.com/opengovsg/isomer/commit/cdb4116bfa80cb7cb73e946bbad3254e0859ef7b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48966847)</sub>

<!-- /greptile_comment -->