### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -32,8 +32,7 @@ ENV NEXT_PUBLIC_INTERCOM_APP_ID=$NEXT_PUBLIC_INTERCOM_APP_ID
 ENV KEEP_ALIVE_TIMEOUT 70000
 
 FROM base AS builder
-RUN apk update
-RUN apk add --no-cache libc6-compat
+RUN apk update && apk add --no-cache libc6-compat
 
 # Set working directory
 WORKDIR /app
@@ -51,8 +50,7 @@ RUN turbo prune isomer-studio --docker
 
 # Add lockfile and package.json's of isolated subworkspace
 FROM base AS installer
-RUN apk update
-RUN apk add --no-cache libc6-compat
+RUN apk update && apk add --no-cache libc6-compat
 WORKDIR /app
 
 RUN corepack enable && corepack install -g pnpm@11.5.1


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +2 | -4 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

_This PR applies 1/2 suggestions from code quality [AI findings](https://github.com/opengovsg/isomer/security/quality/ai-findings). 1 suggestion was skipped to avoid creating conflicts._

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change combines the Alpine package-index refresh and `libc6-compat` installation into one Docker layer in the Studio builder and installer sections.

A focused comparison exercised update failure, package-install failure, and successful installation for the previous and updated command forms. Both forms preserved command ordering, failure propagation, exit status, and `libc6-compat` availability.

## T-Rex validation blocked

A real image build and runtime inspection could not run because the `docker` tool is unavailable. BuildKit (`buildctl`) and Podman are also unavailable.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR is safe to merge; no blocking failure remains.

The focused before-and-after command comparison showed equivalent package-install success and failure behavior in both affected Dockerfile sections. A container-runtime build could not be performed because no supported container-build tool is installed.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the APK shell-semantics comparison script to compare builder and installer package setup for HEAD^ and HEAD Dockerfiles.
- Observed identical behavior across both Dockerfile forms: update failure stops before installation, installation failure leaves libc6-compat unavailable, and success makes libc6-compat available.
- Checked for container-build runtimes and confirmed docker, buildctl, and podman were unavailable, so no actual image build could be performed.
- Reviewed the PR Dockerfile diff and changed line locations to identify where the builder and installer changes were applied.

<a href="https://app.greptile.com/trex/runs/17202129/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["Apply suggested fix to apps/studio/Docke..."](https://github.com/opengovsg/isomer/commit/28121a570810334d176ef82e3f3b015c6ecf2fd8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49559247)</sub>

<!-- /greptile_comment -->