### PR TITLE
fix(studio): allow Backspace to remove empty paragraph above table

### DIFF
--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/deleteEmptyTextblockBeforeTable.browser.test.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/deleteEmptyTextblockBeforeTable.browser.test.ts
@@ -1,0 +1,151 @@
+import type { JSONContent } from "@tiptap/react"
+import { Editor } from "@tiptap/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { page, userEvent } from "vitest/browser"
+
+import {
+  BASE_EXTENSIONS,
+  HEADING_TYPE,
+  IsomerHeading,
+  IsomerTable,
+  IsomerTableCell,
+  IsomerTableHeader,
+  PARAGRAPH_TYPE,
+  PROSE_EXTENSIONS,
+  TableRow,
+} from "../constants"
+
+const TABLE_BLOCK: JSONContent = {
+  type: "table",
+  content: [
+    {
+      type: "tableRow",
+      content: [
+        {
+          type: "tableHeader",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Header" }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const createEditor = (content: JSONContent) => {
+  const element = document.createElement("div")
+  document.body.append(element)
+
+  return new Editor({
+    element,
+    extensions: [
+      ...BASE_EXTENSIONS,
+      ...PROSE_EXTENSIONS,
+      TableRow,
+      IsomerTable,
+      IsomerTableCell,
+      IsomerTableHeader,
+      IsomerHeading,
+    ],
+    content,
+  })
+}
+
+// Position right inside the empty paragraph's content, wherever it sits.
+const findEmptyParagraphPos = (editor: Editor) => {
+  let pos = -1
+
+  editor.state.doc.descendants((node, nodePos) => {
+    if (pos !== -1) {
+      return false
+    }
+    if (node.type.name !== PARAGRAPH_TYPE || node.content.size > 0) {
+      return
+    }
+    pos = nodePos + 1
+  })
+
+  if (pos === -1) {
+    throw new Error("Empty paragraph not found in document")
+  }
+
+  return pos
+}
+
+// Click so the editable gets real browser focus. Must run BEFORE
+// setTextSelection, since the click otherwise repositions the caret.
+const focusEditor = (editor: Editor) =>
+  userEvent.click(page.elementLocator(editor.view.dom))
+
+// Dispatch a real Backspace keydown through the view (mirrors the browser).
+const pressBackspace = (editor: Editor) => {
+  const event = new KeyboardEvent("keydown", {
+    key: "Backspace",
+    code: "Backspace",
+    bubbles: true,
+    cancelable: true,
+  })
+
+  editor.view.someProp("handleKeyDown", (handler) =>
+    handler(editor.view, event),
+  )
+}
+
+describe("Backspace before a table (real EditorView)", () => {
+  let editor: Editor
+
+  afterEach(() => {
+    editor.destroy()
+    document.body.replaceChildren()
+  })
+
+  it("joins backward into a preceding block instead of jumping into the table", async () => {
+    // Arrange
+    editor = createEditor({
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "before" }],
+        },
+        { type: "paragraph", attrs: { dir: null } },
+        TABLE_BLOCK,
+      ],
+    })
+    await focusEditor(editor)
+    editor.commands.setTextSelection(findEmptyParagraphPos(editor))
+
+    // Act
+    pressBackspace(editor)
+    await userEvent.type(page.elementLocator(editor.view.dom), "X")
+
+    // Assert: caret joined into "before", not into the table cell
+    const json = editor.getJSON()
+    expect(json.content?.[0]).toMatchObject({
+      type: "paragraph",
+      content: [{ type: "text", text: "beforeX" }],
+    })
+    expect(json.content?.[1]).toMatchObject({ type: "table" })
+    expect(editor.state.doc.child(1).textContent).toBe("Header")
+  })
+
+  it("demotes an empty heading instead of deleting it", async () => {
+    // Arrange
+    editor = createEditor({
+      type: "prose",
+      content: [{ type: HEADING_TYPE, attrs: { level: 2 } }, TABLE_BLOCK],
+    })
+    await focusEditor(editor)
+    editor.commands.setTextSelection(1)
+
+    // Act
+    pressBackspace(editor)
+
+    // Assert: heading becomes a paragraph, block is not deleted
+    const types = editor.getJSON().content?.map((node) => node.type)
+    expect(types).toEqual([PARAGRAPH_TYPE, "table"])
+  })
+})

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/deleteEmptyTextblockBeforeTable.test.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/deleteEmptyTextblockBeforeTable.test.ts
@@ -1,0 +1,135 @@
+import type { JSONContent } from "@tiptap/react"
+import { Editor } from "@tiptap/react"
+import TextDirection from "tiptap-text-direction"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  BASE_EXTENSIONS,
+  HEADING_TYPE,
+  IsomerTable,
+  IsomerTableCell,
+  IsomerTableHeader,
+  PARAGRAPH_TYPE,
+  PROSE_EXTENSIONS,
+  TableRow,
+} from "../constants"
+import { deleteEmptyTextblockBeforeTable } from "../deleteEmptyTextblockBeforeTable"
+
+const TABLE_BLOCK: JSONContent = {
+  type: "table",
+  content: [
+    {
+      type: "tableRow",
+      content: [
+        {
+          type: "tableHeader",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Header" }],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+}
+
+const EMPTY_PARAGRAPH_BEFORE_TABLE_DOC: JSONContent = {
+  type: "prose",
+  content: [{ type: "paragraph", attrs: { dir: null } }, TABLE_BLOCK],
+}
+
+const createEditor = (
+  content: JSONContent = EMPTY_PARAGRAPH_BEFORE_TABLE_DOC,
+) =>
+  new Editor({
+    extensions: [
+      ...BASE_EXTENSIONS,
+      ...PROSE_EXTENSIONS,
+      TableRow,
+      IsomerTable,
+      IsomerTableCell,
+      IsomerTableHeader,
+      TextDirection.configure({
+        types: [HEADING_TYPE, PARAGRAPH_TYPE],
+      }),
+    ],
+    content,
+  })
+
+describe("deleteEmptyTextblockBeforeTable", () => {
+  let editor: Editor
+
+  beforeEach(() => {
+    editor = createEditor()
+    editor.commands.setTextSelection(1)
+  })
+
+  afterEach(() => {
+    editor.destroy()
+  })
+
+  it("removes an empty paragraph before a table", () => {
+    // Act
+    const handled = deleteEmptyTextblockBeforeTable(editor)
+
+    // Assert
+    expect(handled).toBe(true)
+    expect(editor.getJSON().content?.map((node) => node.type)).toEqual([
+      "table",
+    ])
+  })
+
+  it("does not remove a paragraph that still has text", () => {
+    // Arrange
+    editor.destroy()
+    editor = createEditor({
+      type: "prose",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "keep me" }],
+        },
+        TABLE_BLOCK,
+      ],
+    })
+    editor.commands.setTextSelection(1)
+
+    // Act
+    const handled = deleteEmptyTextblockBeforeTable(editor)
+
+    // Assert
+    expect(handled).toBe(false)
+    expect(editor.getJSON().content?.map((node) => node.type)).toEqual([
+      "paragraph",
+      "table",
+    ])
+  })
+
+  it("does not remove an empty paragraph when the next block is not a table", () => {
+    // Arrange
+    editor.destroy()
+    editor = createEditor({
+      type: "prose",
+      content: [
+        { type: "paragraph", attrs: { dir: null } },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "after" }],
+        },
+      ],
+    })
+    editor.commands.setTextSelection(1)
+
+    // Act
+    const handled = deleteEmptyTextblockBeforeTable(editor)
+
+    // Assert
+    expect(handled).toBe(false)
+    expect(editor.getJSON().content?.map((node) => node.type)).toEqual([
+      "paragraph",
+      "paragraph",
+    ])
+  })
+})

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -127,7 +127,7 @@ export const IsomerTable = Table.extend({
 
     const handleBackspace = () =>
       deleteEmptyTextblockBeforeTable(this.editor) ||
-      deleteTableWhenAllCellsSelected?.() ||
+      deleteTableWhenAllCellsSelected?.({ editor: this.editor }) ||
       false
 
     return {

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -29,6 +29,7 @@ import {
   createTableSelectionBorderPlugin,
   getHtmlWithRelativeReferenceLinks,
 } from "../../utils"
+import { deleteEmptyTextblockBeforeTable } from "./deleteEmptyTextblockBeforeTable"
 import { selectTableCellContent } from "./selectTableCellContent"
 
 export { TableRow } from "@tiptap/extension-table-row"
@@ -121,10 +122,21 @@ export const IsomerTable = Table.extend({
     }
   },
   addKeyboardShortcuts() {
+    const parentShortcuts = this.parent?.() ?? {}
+    const deleteTableWhenAllCellsSelected = parentShortcuts.Backspace
+
+    const handleBackspace = () =>
+      deleteEmptyTextblockBeforeTable(this.editor) ||
+      deleteTableWhenAllCellsSelected?.() ||
+      false
+
     return {
-      ...this.parent?.(),
+      ...parentShortcuts,
       "Mod-a": () =>
         selectTableCellContent(this.editor) || this.editor.commands.selectAll(),
+      Backspace: handleBackspace,
+      "Mod-Backspace": handleBackspace,
+      "Shift-Backspace": handleBackspace,
     }
   },
   addProseMirrorPlugins() {

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/deleteEmptyTextblockBeforeTable.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/deleteEmptyTextblockBeforeTable.ts
@@ -1,0 +1,28 @@
+import type { Editor } from "@tiptap/react"
+import { Table } from "@tiptap/extension-table"
+
+/** Remove an empty textblock when Backspace cannot join backward into a table. */
+export const deleteEmptyTextblockBeforeTable = (editor: Editor): boolean => {
+  const { state } = editor
+  const { empty, $anchor } = state.selection
+
+  if (!empty) {
+    return false
+  }
+
+  const parent = $anchor.parent
+  if (!parent.type.isTextblock || parent.content.size > 0) {
+    return false
+  }
+
+  const parentDepth = $anchor.depth - 1
+  const nextSibling = $anchor
+    .node(parentDepth)
+    .maybeChild($anchor.index(parentDepth) + 1)
+
+  if (nextSibling?.type.name !== Table.name) {
+    return false
+  }
+
+  return editor.commands.deleteCurrentNode()
+}

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/deleteEmptyTextblockBeforeTable.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/deleteEmptyTextblockBeforeTable.ts
@@ -1,4 +1,5 @@
 import type { Editor } from "@tiptap/react"
+import { Paragraph } from "@tiptap/extension-paragraph"
 import { Table } from "@tiptap/extension-table"
 
 /** Remove an empty textblock when Backspace cannot join backward into a table. */
@@ -11,14 +12,20 @@ export const deleteEmptyTextblockBeforeTable = (editor: Editor): boolean => {
   }
 
   const parent = $anchor.parent
-  if (!parent.type.isTextblock || parent.content.size > 0) {
+  if (parent.type.name !== Paragraph.name || parent.content.size > 0) {
     return false
   }
 
   const parentDepth = $anchor.depth - 1
-  const nextSibling = $anchor
-    .node(parentDepth)
-    .maybeChild($anchor.index(parentDepth) + 1)
+  const index = $anchor.index(parentDepth)
+
+  // Only take over when Backspace has nowhere to join backward into. Otherwise
+  // defer to the default chain so the caret stays in the preceding block.
+  if (index > 0) {
+    return false
+  }
+
+  const nextSibling = $anchor.node(parentDepth).maybeChild(index + 1)
 
   if (nextSibling?.type.name !== Table.name) {
     return false


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +48 | -1 |
| 🧪 Test | 2 | +286 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users could not remove empty space above a table in a Text block using Backspace. After clearing text above a table, an empty paragraph (`{ type: "paragraph", attrs: { dir: null } }`) remained and could only be removed via JSON mode.

Closes https://linear.app/ogp/issue/ISOM-2475/studio-tiptap-unable-to-remove-space-from-1st-line

## Solution

TipTap's default Backspace keymap calls `joinBackward()` but not `deleteCurrentNode()`, so an empty paragraph at the start of a prose block cannot be joined into a preceding table sibling. Delete already worked via `deleteCurrentNode()`, but Backspace did not.

This PR adds `deleteEmptyTextblockBeforeTable`, chained into `IsomerTable`'s Backspace shortcut (before the table extension's own handlers), so Backspace removes an empty textblock when the next sibling is a table.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Backspace now removes an empty paragraph directly above a table in Text block editors

## Before & After Screenshots

**BEFORE**:

Empty paragraph above table persists after Backspace; only removable via JSON mode.

**AFTER**:

Backspace on the empty paragraph removes it, leaving the table as the first block.

https://github.com/user-attachments/assets/47540394-a9ed-46a7-9f36-b9d32b80b095

## Tests

**Manual Verification Steps**:

- [ ] Open a page with a Text block containing a table
- [ ] Add text above the table, then Backspace until the paragraph is empty
- [ ] Press Backspace once more — the empty paragraph should be removed and the table should move up with no extra gap
- [ ] Confirm normal Backspace/typing inside table cells still works
- [ ] Confirm Mod-a cell selection and table deletion via the table picker still work

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://opengovproducts.slack.com/archives/C06R4DX966P/p1785727994344469?thread_ts=1785727994.344469&cid=C06R4DX966P)

<div><a href="https://cursor.com/agents/bc-381347bd-e01c-5ef7-a257-1c87cd47376c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-381347bd-e01c-5ef7-a257-1c87cd47376c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR fixes the Studio rich-text editor so Backspace can remove an empty first paragraph immediately above a table.
- Adds a guarded command that deletes only an empty paragraph whose next sibling is a table.
- Chains the command ahead of the table extension’s existing Backspace behavior.
- Adds unit and browser-level coverage for deletion, fallback joining, and empty-heading behavior.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/hooks/useTextEditor/deleteEmptyTextblockBeforeTable.ts | Adds narrowly guarded deletion of an empty top-level paragraph immediately preceding a table. |
| apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts | Integrates the new deletion command into table Backspace shortcuts while retaining fallback table behavior. |
| apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/deleteEmptyTextblockBeforeTable.test.ts | Covers successful deletion and the principal conditions where the helper must decline handling. |
| apps/studio/src/features/editing-experience/hooks/useTextEditor/__tests__/deleteEmptyTextblockBeforeTable.browser.test.ts | Exercises the real EditorView shortcut flow, including backward joining and heading demotion. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Backspace shortcut] --> B{Empty selection in an empty paragraph?}
  B -- No --> F[Delegate to table Backspace handler]
  B -- Yes --> C{First block and next sibling is a table?}
  C -- No --> F
  C -- Yes --> D[Delete current paragraph]
  D --> E[Table becomes first block]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(studio): join backward past content ..."](https://github.com/opengovsg/isomer/commit/94a30c4e5e0c1097e67984c54318b15d7d000910) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49575750)</sub>

**Context used:**

- Knowledge Base — [Resource Tree and Page Editing](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/resource-page-editing.md)

<!-- /greptile_comment -->