### PR TITLE
🎀📊 feat(rte-table): add contextual TableBubbleMenu for table actions

### DIFF
--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -70,6 +70,7 @@
     "@chakra-ui/theme-tools": "catalog:chakra",
     "@chakra-ui/utils": "catalog:chakra",
     "@datadog/browser-rum": "catalog:",
+    "@floating-ui/dom": "catalog:",
     "@fontsource/ibm-plex-mono": "catalog:",
     "@formkit/auto-animate": "catalog:",
     "@growthbook/growthbook": "catalog:growthbook",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -71,6 +71,7 @@
     "@chakra-ui/theme-tools": "catalog:chakra",
     "@chakra-ui/utils": "catalog:chakra",
     "@datadog/browser-rum": "catalog:",
+    "@floating-ui/dom": "catalog:",
     "@fontsource/ibm-plex-mono": "catalog:",
     "@formkit/auto-animate": "catalog:",
     "@growthbook/growthbook": "catalog:growthbook",

--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -116,71 +105,16 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/HorizontalList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/HorizontalList.tsx
@@ -31,8 +31,10 @@ export const MenubarHorizontalList = ({
     return null
   }
   return (
-    <Popover placement="bottom">
-      {({ isOpen }) => (
+    // closeOnBlur=false pairs with mousedown preventDefault below — otherwise
+    // focus stays in the editor and Chakra dismisses the popover immediately.
+    <Popover placement="bottom" closeOnBlur={false} isLazy>
+      {({ isOpen, onClose }) => (
         <>
           <PopoverTrigger>
             <HStack>
@@ -47,6 +49,8 @@ export const MenubarHorizontalList = ({
                 _active={{
                   bg: "interaction.muted.main.active",
                 }}
+                // TipTap toolbar pattern: keep editor selection on open.
+                onMouseDown={(event) => event.preventDefault()}
               >
                 <HStack spacing={0}>
                   <Icon
@@ -71,7 +75,10 @@ export const MenubarHorizontalList = ({
                     key={index}
                     icon={subItem.icon}
                     title={subItem.title}
-                    action={subItem.action}
+                    action={() => {
+                      subItem.action()
+                      onClose()
+                    }}
                     isActive={subItem.isActive}
                   />
                 ))}

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
@@ -25,8 +25,12 @@ export const MenubarOverflowList = ({
     return null
   }
   return (
-    <Popover placement="bottom">
-      {({ isOpen }) => (
+    // TipTap toolbar pattern: preventDefault on mousedown so the trigger
+    // does not steal focus from the editor. Pair with closeOnBlur=false —
+    // otherwise focus never enters the popover and closeOnBlur immediately
+    // dismisses (or fights) the open state.
+    <Popover placement="bottom" closeOnBlur={false} isLazy>
+      {({ isOpen, onClose }) => (
         <>
           <PopoverTrigger>
             <IconButton
@@ -42,6 +46,7 @@ export const MenubarOverflowList = ({
               minW="1.75rem"
               p="0.25rem"
               aria-label="More options"
+              onMouseDown={(event) => event.preventDefault()}
             >
               <Icon
                 as={BiDotsHorizontalRounded}
@@ -58,7 +63,10 @@ export const MenubarOverflowList = ({
                     key={index}
                     icon={subItem.icon}
                     title={subItem.title}
-                    action={subItem.action}
+                    action={() => {
+                      subItem.action()
+                      onClose()
+                    }}
                     isActive={subItem.isActive}
                   />
                 ))}

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -166,72 +155,16 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // Table-specific commands
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -1,5 +1,5 @@
 import type { Editor } from "@tiptap/react"
-import { Icon, useDisclosure } from "@chakra-ui/react"
+import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
@@ -10,19 +10,8 @@ import {
   BiListUl,
   BiStrikethrough,
   BiUnderline,
-  BiWrench,
 } from "react-icons/bi"
 import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
-import {
-  IconAddColLeft,
-  IconAddColRight,
-  IconAddRowAbove,
-  IconAddRowBelow,
-  IconDelCol,
-  IconDelRow,
-  IconMergeCells,
-  IconSplitCell,
-} from "~/components/icons"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
@@ -165,72 +154,16 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // Table-specific commands
+      // "Table settings" (the caption editor) is the one item from the old
+      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // action (add/delete row/column, merge, split) moved there already.
+      // This stays until the inline TableCaption component replaces it.
       {
-        type: "horizontal-list",
-        label: "Table",
-        defaultIcon: BiWrench,
+        type: "item",
+        icon: BiCog,
+        title: "Table settings",
         isHidden: () => !editor.isActive("table"),
-        items: [
-          {
-            type: "item",
-            icon: () => (
-              <Icon color="base.content.medium" as={IconAddColRight} />
-            ),
-            title: "Add column after",
-            action: () => editor.chain().focus().addColumnAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => (
-              <Icon as={IconAddColLeft} color="base.content.medium" />
-            ),
-            title: "Add column before",
-            action: () => editor.chain().focus().addColumnBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelCol} />,
-            title: "Delete column",
-            action: () => editor.chain().focus().deleteColumn().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowAbove} />,
-            title: "Add row before",
-            action: () => editor.chain().focus().addRowBefore().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconAddRowBelow} />,
-            title: "Add row after",
-            action: () => editor.chain().focus().addRowAfter().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconDelRow} />,
-            title: "Delete row",
-            action: () => editor.chain().focus().deleteRow().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconMergeCells} />,
-            title: "Merge cells",
-            action: () => editor.chain().focus().mergeCells().run(),
-          },
-          {
-            type: "item",
-            icon: () => <Icon as={IconSplitCell} />,
-            title: "Split cell",
-            action: () => editor.chain().focus().splitCell().run(),
-          },
-          {
-            type: "item",
-            icon: BiCog,
-            title: "Table settings",
-            action: onTableSettingsModalOpen,
-          },
-        ],
+        action: onTableSettingsModalOpen,
       },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -1,0 +1,106 @@
+import type { Editor } from "@tiptap/react"
+import { Flex, Icon, Portal, VStack } from "@chakra-ui/react"
+import { memo } from "react"
+import { BiPencil } from "react-icons/bi"
+
+import { TableBubbleMenuActions } from "./TableBubbleMenuActions"
+import { useTableBubbleMenu } from "./useTableBubbleMenu"
+
+export interface TableBubbleMenuProps {
+  editor: Editor
+}
+
+export const TableBubbleMenu = memo(function TableBubbleMenu({
+  editor,
+}: TableBubbleMenuProps) {
+  const {
+    show,
+    kind,
+    isActivated,
+    menuRef,
+    triggerRef,
+    position,
+    onMenuFocus,
+    onMenuBlur,
+    toggleMenu,
+  } = useTableBubbleMenu(editor)
+
+  if (!show) {
+    return null
+  }
+
+  return (
+    <Portal>
+      <VStack
+        ref={menuRef}
+        align="flex-end"
+        gap="0.25rem"
+        data-table-bubble-menu
+        // Exempts the portaled trigger/content from Chakra Modal's FocusLock
+        // (e.g. Table Settings): react-focus-lock lets focus move freely
+        // to/from any element bearing this attribute instead of pulling it
+        // back into the modal.
+        data-no-focus-lock
+        position="fixed"
+        left={position ? `${position.x}px` : 0}
+        top={position ? `${position.y}px` : 0}
+        // Hide until position is computed (async after Portal mount).
+        visibility={position ? "visible" : "hidden"}
+        zIndex="dropdown"
+        onFocus={onMenuFocus}
+        onBlur={onMenuBlur}
+      >
+        {isActivated && (
+          <VStack
+            align="stretch"
+            textAlign="left"
+            position="relative"
+            zIndex="dropdown"
+            data-table-bubble-menu-actions
+            bg="base.canvas.default"
+            boxShadow="sm"
+            borderRadius="0.25rem"
+            border="1px solid"
+            borderColor="base.divider.medium"
+            py="0.5rem"
+            gap="0"
+            minW="10rem"
+          >
+            <TableBubbleMenuActions editor={editor} kind={kind} />
+          </VStack>
+        )}
+        <Flex
+          ref={triggerRef}
+          as="button"
+          type="button"
+          aria-label="Table actions"
+          aria-pressed={isActivated}
+          data-table-bubble-menu-trigger
+          p="0.5rem"
+          borderRadius="full"
+          cursor="pointer"
+          bg={isActivated ? "interaction.main.default" : "base.canvas.default"}
+          boxShadow="0 0 10px 0 rgba(191, 191, 191, 0.50)"
+          transition="background-color 0.15s, box-shadow 0.15s, filter 0.15s"
+          sx={{
+            _hover: {
+              boxShadow: "0 0 12px 0 rgba(191, 191, 191, 0.65)",
+              ...(isActivated
+                ? { filter: "brightness(0.92)" }
+                : { bg: "interaction.main-subtle.default" }),
+            },
+          }}
+          // Keep editor focus on cell selection; open menu via click instead.
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={toggleMenu}
+        >
+          <Icon
+            as={BiPencil}
+            fontSize="0.75rem"
+            color={isActivated ? "white" : "interaction.main.default"}
+          />
+        </Flex>
+      </VStack>
+    </Portal>
+  )
+})

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx
@@ -36,15 +36,11 @@ export const TableBubbleMenu = memo(function TableBubbleMenu({
         align="flex-end"
         gap="0.25rem"
         data-table-bubble-menu
-        // Exempts the portaled trigger/content from Chakra Modal's FocusLock
-        // (e.g. Table Settings): react-focus-lock lets focus move freely
-        // to/from any element bearing this attribute instead of pulling it
-        // back into the modal.
+        // Lets focus move between this portaled menu and Chakra modals (e.g. Table Settings).
         data-no-focus-lock
         position="fixed"
         left={position ? `${position.x}px` : 0}
         top={position ? `${position.y}px` : 0}
-        // Hide until position is computed (async after Portal mount).
         visibility={position ? "visible" : "hidden"}
         zIndex="dropdown"
         onFocus={onMenuFocus}
@@ -90,7 +86,6 @@ export const TableBubbleMenu = memo(function TableBubbleMenu({
                 : { bg: "interaction.main-subtle.default" }),
             },
           }}
-          // Keep editor focus on cell selection; open menu via click instead.
           onMouseDown={(event) => event.preventDefault()}
           onClick={toggleMenu}
         >

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.types.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.types.ts
@@ -1,0 +1,23 @@
+export type SelectionKind =
+  | "none"
+  | "single-cell"
+  | "merged-cell"
+  | "row"
+  | "header-row"
+  | "column"
+  | "header-column"
+  | "table"
+  | "multi-cell"
+
+export interface TableMovePlan {
+  // `from` is the adjacent row/column moved past the selected block.
+  from: number
+  // `to` is the selected block's far edge, expressed as TipTap's move target.
+  to: number
+  // The selected block's first row/column after the move.
+  newStart: number
+  // Number of rows/columns in the selected block, used to restore selection.
+  span: number
+}
+
+export type TableMoveAxis = "row" | "column"

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.types.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.types.ts
@@ -10,13 +10,9 @@ export type SelectionKind =
   | "multi-cell"
 
 export interface TableMovePlan {
-  // `from` is the adjacent row/column moved past the selected block.
   from: number
-  // `to` is the selected block's far edge, expressed as TipTap's move target.
   to: number
-  // The selected block's first row/column after the move.
   newStart: number
-  // Number of rows/columns in the selected block, used to restore selection.
   span: number
 }
 

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -10,9 +10,7 @@ import type {
   TableMovePlan,
 } from "./TableBubbleMenu.types"
 
-// Slice of selectedRect() needed to tell whether a selection overlaps a
-// TipTap header row/column. Kept structural so unit tests don't need a live
-// EditorView.
+// Structural slice of selectedRect() for header overlap checks (no live EditorView).
 export interface TableHeaderOverlapRect {
   top: number
   left: number
@@ -20,15 +18,10 @@ export interface TableHeaderOverlapRect {
   table: Node
 }
 
-// ProseMirror-specific selection details are normalized into these facts so
-// the menu's classification rules can stay independent of editor state.
 interface TableSelectionFacts {
   spansEntireTableWidth: boolean
   spansEntireTableHeight: boolean
   allCellsAreHeaders: boolean
-  // True when the selection is exactly the table's first row / first column
-  // (half-open rect starting at 0 with span 1). TipTap header toggles only
-  // rewrite that edge, so "header-*" kinds match the same scope.
   isTopRow: boolean
   isLeftmostColumn: boolean
   selectsSingleCellNode: boolean
@@ -61,9 +54,7 @@ const isHeaderColumnAtLeft = (rect: TableHeaderOverlapRect): boolean => {
   return rect.map.height > 0
 }
 
-// Delete is withheld whenever the selection overlaps a header axis — not only
-// when the selection is exclusively that header — so users unset the header
-// first rather than accidentally leaving the table headerless.
+// Withhold delete/move when the selection overlaps a header axis so users unset the header first.
 export const selectionIncludesHeaderRow = (
   rect: TableHeaderOverlapRect,
 ): boolean => rect.top === 0 && isHeaderRowAtTop(rect)
@@ -72,8 +63,6 @@ export const selectionIncludesHeaderColumn = (
   rect: TableHeaderOverlapRect,
 ): boolean => rect.left === 0 && isHeaderColumnAtLeft(rect)
 
-// Half-open span: included start at 0 with extent 1 — the first row/column only.
-// TipTap header toggles only rewrite that table edge.
 export const selectionIsTopRow = (rect: {
   top: number
   bottom: number
@@ -84,8 +73,6 @@ export const selectionIsLeftmostColumn = (rect: {
   right: number
 }): boolean => rect.left === 0 && rect.right === 1
 
-// Order matters: a whole-table selection spans both axes, and a merged cell
-// can span multiple grid rows/columns while still selecting only one cell node.
 export const getTableSelectionKind = ({
   spansEntireTableWidth,
   spansEntireTableHeight,
@@ -108,9 +95,6 @@ export const getTableSelectionKind = ({
   return "multi-cell"
 }
 
-// Bounds are half-open: `top` is included and `bottom` is excluded. TipTap's
-// row mover operates on one row, so moving a block means moving its adjacent
-// neighbour past the block and then reselecting the block at `newStart`.
 export const getRowMovePlan = (
   {
     top,
@@ -126,7 +110,6 @@ export const getRowMovePlan = (
   const span = bottom - top
 
   if (direction === "up") {
-    // Move the row above to the block's final row.
     if (top === 0) return null
     return {
       from: top - 1,
@@ -136,7 +119,6 @@ export const getRowMovePlan = (
     }
   }
 
-  // Move the row below to the block's first row.
   if (bottom >= tableHeight) return null
   return {
     from: bottom,
@@ -146,8 +128,6 @@ export const getRowMovePlan = (
   }
 }
 
-// Column movement mirrors row movement; `left` included and `right` excluded;
-// the adjacent column is moved across the selected block.
 export const getColumnMovePlan = (
   {
     left,
@@ -163,7 +143,6 @@ export const getColumnMovePlan = (
   const span = right - left
 
   if (direction === "left") {
-    // Move the column on the left to the block's final column.
     if (left === 0) return null
     return {
       from: left - 1,
@@ -173,7 +152,6 @@ export const getColumnMovePlan = (
     }
   }
 
-  // Move the column on the right to the block's first column.
   if (right >= tableWidth) return null
   return {
     from: right,
@@ -183,8 +161,6 @@ export const getColumnMovePlan = (
   }
 }
 
-// CellSelection corners for a moved row/column block. Offsets are relative to
-// the table node's content start (i.e. document position tableStart).
 export const getMovedBlockCellCorners = (
   map: MovedBlockTableMap,
   table: Node,
@@ -204,9 +180,6 @@ export const getMovedBlockCellCorners = (
   }
 }
 
-// moveTableRow/Column with select:false leaves nothing selected; reselect the
-// moved block so the bubble menu stays open. Runs inside the move transaction
-// callback once the table structure has been updated.
 export const restoreMovedBlockSelection = (
   view: EditorView,
   tr: Transaction,
@@ -241,7 +214,6 @@ const isMergedCell = (rect: ReturnType<typeof selectedRect>): boolean => {
   )
 }
 
-// Maps the current CellSelection to a SelectionKind for action menu routing.
 export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
   const { selection } = editor.state
   if (!(selection instanceof CellSelection)) return "none"
@@ -267,10 +239,8 @@ export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
   })
 }
 
-// Ordinary single-cell text cursors show no bubble menu.
 export const isActionableTableSelectionKind = (kind: SelectionKind) =>
   kind !== "none" && kind !== "single-cell"
 
-// Hide the menu while a Chakra/modal dialog has focus.
 export const isEditorModalOpen = () =>
   document.querySelector('[role="dialog"][aria-modal="true"]') != null

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -1,0 +1,274 @@
+import type { Node } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
+import type { EditorView } from "@tiptap/pm/view"
+import type { Editor } from "@tiptap/react"
+import { CellSelection, selectedRect, TableMap } from "@tiptap/pm/tables"
+
+import type {
+  SelectionKind,
+  TableMoveAxis,
+  TableMovePlan,
+} from "./TableBubbleMenu.types"
+
+// Slice of selectedRect() needed to tell whether a selection overlaps a
+// TipTap header row/column. Kept structural so unit tests don't need a live
+// EditorView.
+export interface TableHeaderOverlapRect {
+  top: number
+  left: number
+  map: Pick<TableMap, "width" | "height" | "map">
+  table: Node
+}
+
+// ProseMirror-specific selection details are normalized into these facts so
+// the menu's classification rules can stay independent of editor state.
+interface TableSelectionFacts {
+  spansEntireTableWidth: boolean
+  spansEntireTableHeight: boolean
+  allCellsAreHeaders: boolean
+  // True when the selection is exactly the table's first row / first column
+  // (half-open rect starting at 0 with span 1). TipTap header toggles only
+  // rewrite that edge, so "header-*" kinds match the same scope.
+  isTopRow: boolean
+  isLeftmostColumn: boolean
+  selectsSingleCellNode: boolean
+  selectedCellIsMerged: boolean
+}
+
+type MovedBlockTableMap = Pick<TableMap, "width" | "height" | "positionAt">
+
+const cellTypeAt = (
+  rect: TableHeaderOverlapRect,
+  row: number,
+  col: number,
+): string | null => {
+  const cellPos = rect.map.map[row * rect.map.width + col]
+  if (cellPos === undefined) return null
+  return rect.table.nodeAt(cellPos)?.type.name ?? null
+}
+
+const isHeaderRowAtTop = (rect: TableHeaderOverlapRect): boolean => {
+  for (let col = 0; col < rect.map.width; col++) {
+    if (cellTypeAt(rect, 0, col) !== "tableHeader") return false
+  }
+  return rect.map.width > 0
+}
+
+const isHeaderColumnAtLeft = (rect: TableHeaderOverlapRect): boolean => {
+  for (let row = 0; row < rect.map.height; row++) {
+    if (cellTypeAt(rect, row, 0) !== "tableHeader") return false
+  }
+  return rect.map.height > 0
+}
+
+// Delete is withheld whenever the selection overlaps a header axis — not only
+// when the selection is exclusively that header — so users unset the header
+// first rather than accidentally leaving the table headerless.
+export const selectionIncludesHeaderRow = (
+  rect: TableHeaderOverlapRect,
+): boolean => rect.top === 0 && isHeaderRowAtTop(rect)
+
+export const selectionIncludesHeaderColumn = (
+  rect: TableHeaderOverlapRect,
+): boolean => rect.left === 0 && isHeaderColumnAtLeft(rect)
+
+// Half-open span: included start at 0 with extent 1 — the first row/column only.
+// TipTap header toggles only rewrite that table edge.
+export const selectionIsTopRow = (rect: {
+  top: number
+  bottom: number
+}): boolean => rect.top === 0 && rect.bottom === 1
+
+export const selectionIsLeftmostColumn = (rect: {
+  left: number
+  right: number
+}): boolean => rect.left === 0 && rect.right === 1
+
+// Order matters: a whole-table selection spans both axes, and a merged cell
+// can span multiple grid rows/columns while still selecting only one cell node.
+export const getTableSelectionKind = ({
+  spansEntireTableWidth,
+  spansEntireTableHeight,
+  allCellsAreHeaders,
+  isTopRow,
+  isLeftmostColumn,
+  selectsSingleCellNode,
+  selectedCellIsMerged,
+}: TableSelectionFacts): Exclude<SelectionKind, "none"> => {
+  if (spansEntireTableWidth && spansEntireTableHeight) return "table"
+  if (spansEntireTableWidth) {
+    return allCellsAreHeaders && isTopRow ? "header-row" : "row"
+  }
+  if (spansEntireTableHeight) {
+    return allCellsAreHeaders && isLeftmostColumn ? "header-column" : "column"
+  }
+  if (selectsSingleCellNode) {
+    return selectedCellIsMerged ? "merged-cell" : "single-cell"
+  }
+  return "multi-cell"
+}
+
+// Bounds are half-open: `top` is included and `bottom` is excluded. TipTap's
+// row mover operates on one row, so moving a block means moving its adjacent
+// neighbour past the block and then reselecting the block at `newStart`.
+export const getRowMovePlan = (
+  {
+    top,
+    bottom,
+    tableHeight,
+  }: {
+    top: number
+    bottom: number
+    tableHeight: number
+  },
+  direction: "up" | "down",
+): TableMovePlan | null => {
+  const span = bottom - top
+
+  if (direction === "up") {
+    // Move the row above to the block's final row.
+    if (top === 0) return null
+    return {
+      from: top - 1,
+      to: bottom - 1,
+      newStart: top - 1,
+      span,
+    }
+  }
+
+  // Move the row below to the block's first row.
+  if (bottom >= tableHeight) return null
+  return {
+    from: bottom,
+    to: top,
+    newStart: top + 1,
+    span,
+  }
+}
+
+// Column movement mirrors row movement; `left` included and `right` excluded;
+// the adjacent column is moved across the selected block.
+export const getColumnMovePlan = (
+  {
+    left,
+    right,
+    tableWidth,
+  }: {
+    left: number
+    right: number
+    tableWidth: number
+  },
+  direction: "left" | "right",
+): TableMovePlan | null => {
+  const span = right - left
+
+  if (direction === "left") {
+    // Move the column on the left to the block's final column.
+    if (left === 0) return null
+    return {
+      from: left - 1,
+      to: right - 1,
+      newStart: left - 1,
+      span,
+    }
+  }
+
+  // Move the column on the right to the block's first column.
+  if (right >= tableWidth) return null
+  return {
+    from: right,
+    to: left,
+    newStart: left + 1,
+    span,
+  }
+}
+
+// CellSelection corners for a moved row/column block. Offsets are relative to
+// the table node's content start (i.e. document position tableStart).
+export const getMovedBlockCellCorners = (
+  map: MovedBlockTableMap,
+  table: Node,
+  plan: TableMovePlan,
+  axis: TableMoveAxis,
+) => {
+  const newEnd = plan.newStart + plan.span
+  if (axis === "row") {
+    return {
+      anchor: map.positionAt(plan.newStart, 0, table),
+      head: map.positionAt(newEnd - 1, map.width - 1, table),
+    }
+  }
+  return {
+    anchor: map.positionAt(map.height - 1, plan.newStart, table),
+    head: map.positionAt(0, newEnd - 1, table),
+  }
+}
+
+// moveTableRow/Column with select:false leaves nothing selected; reselect the
+// moved block so the bubble menu stays open. Runs inside the move transaction
+// callback once the table structure has been updated.
+export const restoreMovedBlockSelection = (
+  view: EditorView,
+  tr: Transaction,
+  tablePos: number,
+  plan: TableMovePlan,
+  axis: TableMoveAxis,
+) => {
+  const table = tr.doc.nodeAt(tablePos)
+  if (!table) {
+    view.dispatch(tr)
+    return
+  }
+  const map = TableMap.get(table)
+  const tableStart = tablePos + 1
+  const { anchor, head } = getMovedBlockCellCorners(map, table, plan, axis)
+  tr.setSelection(
+    CellSelection.create(tr.doc, tableStart + anchor, tableStart + head),
+  )
+  view.dispatch(tr)
+}
+
+const isSingleCellSelection = (selection: CellSelection): boolean =>
+  selection.$anchorCell.pos === selection.$headCell.pos
+
+const isMergedCell = (rect: ReturnType<typeof selectedRect>): boolean => {
+  const cellStart = rect.map.map[rect.top * rect.map.width + rect.left]
+  if (cellStart === undefined) return false
+  const node = rect.table.nodeAt(cellStart)
+  if (!node) return false
+  return (
+    (node.attrs.colspan as number) > 1 || (node.attrs.rowspan as number) > 1
+  )
+}
+
+// Maps the current CellSelection to a SelectionKind for action menu routing.
+export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
+  const { selection } = editor.state
+  if (!(selection instanceof CellSelection)) return "none"
+
+  const rect = selectedRect(editor.state)
+
+  let allHeader = true
+  selection.forEachCell((node) => {
+    if (node.type.name !== "tableHeader") allHeader = false
+  })
+
+  const selectsSingleCellNode = isSingleCellSelection(selection)
+  return getTableSelectionKind({
+    spansEntireTableWidth: rect.left === 0 && rect.right === rect.map.width,
+    spansEntireTableHeight: rect.top === 0 && rect.bottom === rect.map.height,
+    allCellsAreHeaders: allHeader,
+    isTopRow: selectionIsTopRow(rect),
+    isLeftmostColumn: selectionIsLeftmostColumn(rect),
+    selectsSingleCellNode,
+    selectedCellIsMerged: selectsSingleCellNode && isMergedCell(rect),
+  })
+}
+
+// Ordinary single-cell text cursors show no bubble menu.
+export const isActionableTableSelectionKind = (kind: SelectionKind) =>
+  kind !== "none" && kind !== "single-cell"
+
+// Hide the menu while a Chakra/modal dialog has focus.
+export const isEditorModalOpen = () =>
+  document.querySelector('[role="dialog"][aria-modal="true"]') != null

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -250,7 +250,9 @@ export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
 
   let allHeader = true
   selection.forEachCell((node) => {
-    if (node.type.name !== "tableHeader") allHeader = false
+    if (node.type.name !== "tableHeader") {
+      allHeader = false
+    }
   })
 
   const selectsSingleCellNode = isSingleCellSelection(selection)

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -1,0 +1,309 @@
+import type { Editor } from "@tiptap/react"
+import type { ReactElement, ReactNode } from "react"
+import { Flex, Text, VStack } from "@chakra-ui/react"
+import { Button, Switch } from "@opengovsg/design-system-react"
+import { moveTableColumn, moveTableRow, selectedRect } from "@tiptap/pm/tables"
+import {
+  BiDownArrowAlt,
+  BiLeftArrowAlt,
+  BiRightArrowAlt,
+  BiTrash,
+  BiUpArrowAlt,
+} from "react-icons/bi"
+import {
+  IconAddColLeft,
+  IconAddColRight,
+  IconAddRowAbove,
+  IconAddRowBelow,
+  IconDelCol,
+  IconDelRow,
+  IconMergeCells,
+  IconSplitCell,
+} from "~/components/icons"
+
+import type {
+  SelectionKind,
+  TableMoveAxis,
+  TableMovePlan,
+} from "./TableBubbleMenu.types"
+import {
+  getColumnMovePlan,
+  getRowMovePlan,
+  restoreMovedBlockSelection,
+  selectionIncludesHeaderColumn,
+  selectionIncludesHeaderRow,
+  selectionIsLeftmostColumn,
+  selectionIsTopRow,
+} from "./TableBubbleMenu.utils"
+
+const moveTableBlock = (
+  editor: Editor,
+  plan: TableMovePlan,
+  axis: TableMoveAxis,
+) => {
+  const { state, view } = editor
+  const rect = selectedRect(state)
+  const tablePos = rect.tableStart - 1
+  const move = axis === "row" ? moveTableRow : moveTableColumn
+
+  move({
+    from: plan.from,
+    to: plan.to,
+    select: false,
+    pos: rect.tableStart,
+  })(state, (tr) => {
+    restoreMovedBlockSelection(view, tr, tablePos, plan, axis)
+  })
+  // Unlike every sibling action, this dispatches its own transaction instead
+  // of `.chain().focus()...run()` — restore focus explicitly so a real
+  // mousedown-triggered blur doesn't strand it on the button.
+  editor.commands.focus()
+}
+
+const ActionButton = ({
+  label,
+  icon,
+  onClick,
+}: {
+  label: string
+  icon: ReactElement
+  onClick: () => void
+}) => (
+  <Button
+    size="xs"
+    variant="clear"
+    colorScheme="neutral"
+    onClick={onClick}
+    // TipTap toolbar pattern: preventDefault on mousedown so the click does
+    // not steal focus (and thus CellSelection) from the editor.
+    onMouseDown={(event) => event.preventDefault()}
+    w="100%"
+    h="auto"
+    minH="unset"
+    px="0.75rem"
+    py="0.625rem"
+    color="base.content.strong"
+    textAlign="left"
+    sx={{
+      justifyContent: "flex-start",
+    }}
+  >
+    <Flex as="span" align="center" gap="0.5rem">
+      {icon}
+      <Text as="span" textStyle="body-2" color="base.content.strong">
+        {label}
+      </Text>
+    </Flex>
+  </Button>
+)
+
+const ActionGroup = ({ children }: { children: ReactNode }) => (
+  <VStack align="stretch" gap="0" w="100%">
+    {children}
+  </VStack>
+)
+
+const HeaderToggle = ({
+  label,
+  isChecked,
+  onToggle,
+}: {
+  label: string
+  isChecked: boolean
+  onToggle: () => void
+}) => (
+  <Flex
+    w="100%"
+    minH="2.25rem"
+    align="center"
+    justify="space-between"
+    px="0.75rem"
+    gap="0.5rem"
+    // Prevent editor blur when toggling header switches.
+    onMouseDown={(event) => event.preventDefault()}
+  >
+    <Text textStyle="body-2" color="base.content.strong">
+      {label}
+    </Text>
+    <Switch
+      size="sm"
+      isChecked={isChecked}
+      onChange={onToggle}
+      aria-label={label}
+    />
+  </Flex>
+)
+
+type SelectionRect = ReturnType<typeof selectedRect>
+
+// Row-axis actions: header toggle only when the selection is exactly one row.
+const RowSelectionActions = ({
+  editor,
+  rect,
+}: {
+  editor: Editor
+  rect: SelectionRect
+}) => {
+  const includesHeader = selectionIncludesHeaderRow(rect)
+  const rowMoveUpPlan = getRowMovePlan(
+    { top: rect.top, bottom: rect.bottom, tableHeight: rect.map.height },
+    "up",
+  )
+  const rowMoveDownPlan = getRowMovePlan(
+    { top: rect.top, bottom: rect.bottom, tableHeight: rect.map.height },
+    "down",
+  )
+
+  return (
+    <ActionGroup>
+      {selectionIsTopRow(rect) && (
+        <HeaderToggle
+          label="Header row"
+          isChecked={includesHeader}
+          onToggle={() => editor.chain().focus().toggleHeaderRow().run()}
+        />
+      )}
+      <ActionButton
+        label="Add row above"
+        icon={<IconAddRowAbove boxSize="1rem" />}
+        onClick={() => editor.chain().focus().addRowBefore().run()}
+      />
+      <ActionButton
+        label="Add row below"
+        icon={<IconAddRowBelow boxSize="1rem" />}
+        onClick={() => editor.chain().focus().addRowAfter().run()}
+      />
+      {rowMoveUpPlan && !includesHeader && (
+        <ActionButton
+          label="Move up"
+          icon={<BiUpArrowAlt fontSize="1rem" />}
+          onClick={() => moveTableBlock(editor, rowMoveUpPlan, "row")}
+        />
+      )}
+      {rowMoveDownPlan && !includesHeader && (
+        <ActionButton
+          label="Move down"
+          icon={<BiDownArrowAlt fontSize="1rem" />}
+          onClick={() => moveTableBlock(editor, rowMoveDownPlan, "row")}
+        />
+      )}
+      {!includesHeader && (
+        <ActionButton
+          label="Delete row"
+          icon={<IconDelRow boxSize="1rem" />}
+          onClick={() => editor.chain().focus().deleteRow().run()}
+        />
+      )}
+    </ActionGroup>
+  )
+}
+
+// Column-axis actions: header toggle only when the selection is exactly one column.
+const ColumnSelectionActions = ({
+  editor,
+  rect,
+}: {
+  editor: Editor
+  rect: SelectionRect
+}) => {
+  const includesHeader = selectionIncludesHeaderColumn(rect)
+
+  const columnMoveLeftPlan = getColumnMovePlan(
+    { left: rect.left, right: rect.right, tableWidth: rect.map.width },
+    "left",
+  )
+
+  const columnMoveRightPlan = getColumnMovePlan(
+    { left: rect.left, right: rect.right, tableWidth: rect.map.width },
+    "right",
+  )
+
+  return (
+    <ActionGroup>
+      {selectionIsLeftmostColumn(rect) && (
+        <HeaderToggle
+          label="Header column"
+          isChecked={includesHeader}
+          onToggle={() => editor.chain().focus().toggleHeaderColumn().run()}
+        />
+      )}
+      <ActionButton
+        label="Add column left"
+        icon={<IconAddColLeft boxSize="1rem" />}
+        onClick={() => editor.chain().focus().addColumnBefore().run()}
+      />
+      <ActionButton
+        label="Add column right"
+        icon={<IconAddColRight boxSize="1rem" />}
+        onClick={() => editor.chain().focus().addColumnAfter().run()}
+      />
+      {columnMoveLeftPlan && !includesHeader && (
+        <ActionButton
+          label="Move left"
+          icon={<BiLeftArrowAlt fontSize="1rem" />}
+          onClick={() => moveTableBlock(editor, columnMoveLeftPlan, "column")}
+        />
+      )}
+      {columnMoveRightPlan && !includesHeader && (
+        <ActionButton
+          label="Move right"
+          icon={<BiRightArrowAlt fontSize="1rem" />}
+          onClick={() => moveTableBlock(editor, columnMoveRightPlan, "column")}
+        />
+      )}
+      {!includesHeader && (
+        <ActionButton
+          label="Delete column"
+          icon={<IconDelCol boxSize="1rem" />}
+          onClick={() => editor.chain().focus().deleteColumn().run()}
+        />
+      )}
+    </ActionGroup>
+  )
+}
+
+// Action list rendered above the pencil trigger when the menu is activated.
+export const TableBubbleMenuActions = ({
+  editor,
+  kind,
+}: {
+  editor: Editor
+  kind: SelectionKind
+}) => {
+  const rect = selectedRect(editor.state)
+
+  switch (kind) {
+    case "row":
+    case "header-row":
+      return <RowSelectionActions editor={editor} rect={rect} />
+    case "column":
+    case "header-column":
+      return <ColumnSelectionActions editor={editor} rect={rect} />
+    case "table":
+      return (
+        <ActionButton
+          label="Delete table"
+          icon={<BiTrash fontSize="1rem" />}
+          onClick={() => editor.chain().focus().deleteTable().run()}
+        />
+      )
+    case "multi-cell":
+      return (
+        <ActionButton
+          label="Merge cells"
+          icon={<IconMergeCells boxSize="1rem" />}
+          onClick={() => editor.chain().focus().mergeCells().run()}
+        />
+      )
+    case "merged-cell":
+      return (
+        <ActionButton
+          label="Split cell"
+          icon={<IconSplitCell boxSize="1rem" />}
+          onClick={() => editor.chain().focus().splitCell().run()}
+        />
+      )
+    default:
+      return null
+  }
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -54,9 +54,6 @@ const moveTableBlock = (
   })(state, (tr) => {
     restoreMovedBlockSelection(view, tr, tablePos, plan, axis)
   })
-  // Unlike every sibling action, this dispatches its own transaction instead
-  // of `.chain().focus()...run()` — restore focus explicitly so a real
-  // mousedown-triggered blur doesn't strand it on the button.
   editor.commands.focus()
 }
 
@@ -74,8 +71,6 @@ const ActionButton = ({
     variant="clear"
     colorScheme="neutral"
     onClick={onClick}
-    // TipTap toolbar pattern: preventDefault on mousedown so the click does
-    // not steal focus (and thus CellSelection) from the editor.
     onMouseDown={(event) => event.preventDefault()}
     w="100%"
     h="auto"
@@ -119,7 +114,6 @@ const HeaderToggle = ({
     justify="space-between"
     px="0.75rem"
     gap="0.5rem"
-    // Prevent editor blur when toggling header switches.
     onMouseDown={(event) => event.preventDefault()}
   >
     <Text textStyle="body-2" color="base.content.strong">
@@ -136,7 +130,6 @@ const HeaderToggle = ({
 
 type SelectionRect = ReturnType<typeof selectedRect>
 
-// Row-axis actions: header toggle only when the selection is exactly one row.
 const RowSelectionActions = ({
   editor,
   rect,
@@ -200,7 +193,6 @@ const RowSelectionActions = ({
   )
 }
 
-// Column-axis actions: header toggle only when the selection is exactly one column.
 const ColumnSelectionActions = ({
   editor,
   rect,
@@ -266,7 +258,6 @@ const ColumnSelectionActions = ({
   )
 }
 
-// Action list rendered above the pencil trigger when the menu is activated.
 export const TableBubbleMenuActions = ({
   editor,
   kind,

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -163,11 +163,13 @@ const RowSelectionActions = ({
           onToggle={() => editor.chain().focus().toggleHeaderRow().run()}
         />
       )}
-      <ActionButton
-        label="Add row above"
-        icon={<IconAddRowAbove boxSize="1rem" />}
-        onClick={() => editor.chain().focus().addRowBefore().run()}
-      />
+      {!includesHeader && (
+        <ActionButton
+          label="Add row above"
+          icon={<IconAddRowAbove boxSize="1rem" />}
+          onClick={() => editor.chain().focus().addRowBefore().run()}
+        />
+      )}
       <ActionButton
         label="Add row below"
         icon={<IconAddRowBelow boxSize="1rem" />}
@@ -227,11 +229,13 @@ const ColumnSelectionActions = ({
           onToggle={() => editor.chain().focus().toggleHeaderColumn().run()}
         />
       )}
-      <ActionButton
-        label="Add column left"
-        icon={<IconAddColLeft boxSize="1rem" />}
-        onClick={() => editor.chain().focus().addColumnBefore().run()}
-      />
+      {!includesHeader && (
+        <ActionButton
+          label="Add column left"
+          icon={<IconAddColLeft boxSize="1rem" />}
+          onClick={() => editor.chain().focus().addColumnBefore().run()}
+        />
+      )}
       <ActionButton
         label="Add column right"
         icon={<IconAddColRight boxSize="1rem" />}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -1,0 +1,655 @@
+// Renders a real TipTap editor (ProseMirror needs a real DOM to construct an
+// EditorView), so this runs under Vitest Browser Mode rather than jsdom — see
+// the `*.browser.test.{ts,tsx}` convention in apps/studio/vitest.config.ts.
+import type { Editor, JSONContent } from "@tiptap/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { act, cleanup, render, waitFor } from "@testing-library/react"
+import { tableEditingKey } from "@tiptap/pm/tables"
+import { EditorContent } from "@tiptap/react"
+import { useEffect, useState } from "react"
+import { afterEach, describe, expect, it } from "vitest"
+import { userEvent } from "vitest/browser"
+import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor"
+import { theme } from "~/theme"
+
+import { TableBubbleMenu } from "../TableBubbleMenu"
+
+const createSeedTable = (caption: string): JSONContent => ({
+  type: "table",
+  attrs: { caption },
+  content: [
+    {
+      type: "tableRow",
+      content: ["Column A", "Column B", "Column C"].map((text) => ({
+        type: "tableHeader",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      })),
+    },
+    ...[1, 2].map((row) => ({
+      type: "tableRow",
+      content: ["A", "B", "C"].map((col) => ({
+        type: "tableCell",
+        content: [
+          {
+            type: "paragraph",
+            content: [{ type: "text", text: `Row ${row}, ${col}` }],
+          },
+        ],
+      })),
+    })),
+  ],
+})
+
+const SEED_TABLE = createSeedTable("Test table")
+
+const SEED_CONTENT: JSONContent = {
+  type: "prose",
+  content: [SEED_TABLE],
+}
+
+// Two identical 3x3 tables (9 cells each) separated by a paragraph. The
+// second table's first body row is cells 12..14 in reading order.
+const TWO_TABLES_CONTENT: JSONContent = {
+  type: "prose",
+  content: [
+    createSeedTable("Test table"),
+    {
+      type: "paragraph",
+      content: [{ type: "text", text: "Between tables" }],
+    },
+    createSeedTable("Second table"),
+  ],
+}
+
+// Finds the document position at the start boundary of the nth cell
+// (tableCell or tableHeader) in reading order, 0-indexed. This is the
+// position CellSelection.create expects: resolving it yields a ResolvedPos
+// whose parent is the cell's tableRow, so `$pos.node(-1)` is the table (as
+// prosemirror-tables' CellSelection constructor requires) — resolving one
+// position later (i.e. *inside* the cell) would instead make the row the
+// `node(-1)` ancestor and throw "Not a table node".
+const nthCellPos = (editor: Editor, index: number): number => {
+  let seen = 0
+  let found: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== null) return false
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      if (seen === index) {
+        found = pos
+        return false
+      }
+      seen += 1
+    }
+    return true
+  })
+  if (found === null) throw new Error(`Could not find cell at index ${index}`)
+  return found
+}
+
+// Selects the cell range [startIndex, endIndex] (inclusive, 0-indexed reading
+// order) and flushes the resulting transaction inside `act`, since this
+// dispatches synchronously outside of React's own event handling.
+const selectCells = (editor: Editor, startIndex: number, endIndex: number) => {
+  const anchorCell = nthCellPos(editor, startIndex)
+  const headCell = nthCellPos(editor, endIndex)
+  act(() => {
+    // A real pointer selection focuses the editor. Make that precondition
+    // explicit instead of relying on menu rendering to steal focus.
+    editor.chain().focus().setCellSelection({ anchorCell, headCell }).run()
+  })
+}
+
+const activateTableBubbleMenu = async (
+  findByRole: (role: string, options: { name: string }) => Promise<HTMLElement>,
+) => {
+  const trigger = await findByRole("button", { name: "Table actions" })
+  act(() => {
+    trigger.click()
+  })
+}
+
+const tabToTableActionsTrigger = async (
+  editor: Editor,
+  findByRole: (role: string, options: { name: string }) => Promise<HTMLElement>,
+  { expectInactive = true }: { expectInactive?: boolean } = {},
+) => {
+  const trigger = await findByRole("button", { name: "Table actions" })
+  expect(editor.view.dom.contains(document.activeElement)).toBe(true)
+
+  for (
+    let tabs = 0;
+    tabs < 10 && document.activeElement !== trigger;
+    tabs += 1
+  ) {
+    await userEvent.tab()
+  }
+
+  expect(document.activeElement).toBe(trigger)
+  if (expectInactive) {
+    expect(trigger).toHaveAttribute("aria-pressed", "false")
+  }
+  return trigger
+}
+
+const expectKeyboardActivationOpensMenu = async ({
+  editor,
+  findByRole,
+  findByText,
+  queryByText,
+  activationKey,
+}: {
+  editor: Editor
+  findByRole: (role: string, options: { name: string }) => Promise<HTMLElement>
+  findByText: (text: string) => Promise<HTMLElement>
+  queryByText: (text: string) => HTMLElement | null
+  activationKey: "{Enter}" | "{Space}"
+}) => {
+  selectCells(editor, 3, 5)
+  const trigger = await tabToTableActionsTrigger(editor, findByRole)
+
+  expect(trigger).toBeTruthy()
+  expect(document.activeElement).toBe(trigger)
+  expect(queryByText("Delete row")).toBeNull()
+
+  await userEvent.keyboard(activationKey)
+
+  expect(editor.view.dom.contains(document.activeElement)).toBe(true)
+  expect(await findByText("Delete row")).toBeTruthy()
+}
+
+const Harness = ({
+  onReady,
+  showMenu = true,
+  data = SEED_CONTENT,
+}: {
+  onReady: (editor: Editor) => void
+  showMenu?: boolean
+  data?: JSONContent
+}) => {
+  const editor = useTextEditor({ data, handleChange: () => null })
+  useEffect(() => {
+    if (editor) onReady(editor)
+  }, [editor, onReady])
+  return (
+    <>
+      {editor && showMenu && <TableBubbleMenu editor={editor} />}
+      {editor && <EditorContent editor={editor} />}
+    </>
+  )
+}
+
+const renderHarness = async (data: JSONContent = SEED_CONTENT) => {
+  let editor: Editor | undefined
+  let setShowMenu: ((showMenu: boolean) => void) | undefined
+
+  const ControlledHarness = () => {
+    const [showMenu, setShowMenuState] = useState(true)
+    setShowMenu = setShowMenuState
+    return (
+      <Harness onReady={(e) => (editor = e)} showMenu={showMenu} data={data} />
+    )
+  }
+
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <ControlledHarness />
+    </ThemeProvider>,
+  )
+  await waitFor(() => {
+    if (!editor || !setShowMenu) throw new Error("editor not ready")
+  })
+  // Non-null by the waitFor above.
+  return {
+    ...utils,
+    editor: editor!,
+    setShowMenu: (showMenu: boolean) => {
+      setShowMenu!(showMenu)
+    },
+  }
+}
+
+// First-row cell text contents in left-to-right order — used to assert
+// column reordering after Move left/right.
+const firstRowTexts = (editor: Editor): string[] => {
+  const texts: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    const firstRow = node.child(0)
+    firstRow.forEach((cell) => {
+      texts.push(cell.textContent)
+    })
+    return false
+  })
+  return texts
+}
+
+describe("TableBubbleMenu", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("shows row actions (including Delete row) when a body row is selected", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5) // the full body row (not the first row)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(queryByText("Header row")).toBeNull()
+    expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Move up")).toBeTruthy()
+    expect(await findByText("Move down")).toBeTruthy()
+    expect(await findByText("Delete row")).toBeTruthy()
+  })
+
+  it("shows Header row/column only for the exact top row / leftmost column", async () => {
+    const { editor, findByRole, queryByRole } = await renderHarness()
+
+    // Body row — not the top row
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+
+    // Exact header / top row
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByRole("checkbox", { name: "Header row" })).toBeChecked()
+
+    // Top row + body row — overlaps the top row but is not exactly it
+    selectCells(editor, 0, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+
+    // Middle column — not the leftmost column
+    selectCells(editor, 1, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
+
+    // Exact leftmost column
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+    expect(
+      await findByRole("checkbox", { name: "Header column" }),
+    ).not.toBeChecked()
+
+    // Leftmost + next column — overlaps leftmost but is not exactly it
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
+  })
+
+  it("moves a multi-column selection as a block (A,B → right becomes C,A,B)", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    // Full columns A+B
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    const moveRight = await findByText("Move right")
+    act(() => {
+      moveRight.click()
+    })
+
+    expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
+  })
+
+  it("withholds Delete and Move when selection includes header row", async () => {
+    const { editor, findByText, findByRole, queryByText, queryByRole } =
+      await renderHarness()
+
+    selectCells(editor, 0, 2) // the full header row
+    await activateTableBubbleMenu(findByRole)
+
+    const headerToggle = await findByRole("checkbox", { name: "Header row" })
+    expect(headerToggle).toBeChecked()
+    expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Add row below")).toBeTruthy()
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Move up")).toBeNull()
+    expect(queryByText("Move down")).toBeNull()
+
+    selectCells(editor, 0, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Move up")).toBeNull()
+    expect(queryByText("Move down")).toBeNull()
+  })
+
+  it("refreshes row actions when header row is toggled off without reselecting", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+
+    const headerToggle = await findByRole("checkbox", { name: "Header row" })
+    expect(headerToggle).toBeChecked()
+    expect(queryByText("Delete row")).toBeNull()
+
+    act(() => {
+      headerToggle.click()
+    })
+
+    await waitFor(() => {
+      expect(headerToggle).not.toBeChecked()
+    })
+    expect(await findByText("Delete row")).toBeTruthy()
+    expect(await findByText("Move down")).toBeTruthy()
+  })
+
+  it("withholds Delete and Move when selection includes header column", async () => {
+    const { editor, findByText, findByRole, queryByText, queryByRole } =
+      await renderHarness()
+
+    // Seed table has a header row only — leftmost column is still deletable.
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+    expect(
+      await findByRole("checkbox", { name: "Header column" }),
+    ).not.toBeChecked()
+    expect(await findByText("Delete column")).toBeTruthy()
+    expect(await findByText("Move right")).toBeTruthy()
+
+    act(() => {
+      editor.chain().focus().toggleHeaderColumn().run()
+    })
+
+    selectCells(editor, 0, 6) // header column alone
+    expect(
+      await findByRole("checkbox", { name: "Header column" }),
+    ).toBeChecked()
+    expect(queryByText("Delete column")).toBeNull()
+    expect(queryByText("Move left")).toBeNull()
+    expect(queryByText("Move right")).toBeNull()
+
+    selectCells(editor, 0, 7)
+    await activateTableBubbleMenu(findByRole)
+    expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
+    expect(queryByText("Delete column")).toBeNull()
+    expect(queryByText("Move left")).toBeNull()
+    expect(queryByText("Move right")).toBeNull()
+  })
+
+  it("shows only Merge cells for an irregular multi-cell selection", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 7) // an irregular 2x2-ish block, not a full row/column
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Merge cells")).toBeTruthy()
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Delete column")).toBeNull()
+  })
+
+  it("shows no menu content for a plain cursor outside any selection", async () => {
+    const { queryByText, queryByRole } = await renderHarness()
+
+    expect(queryByText("Delete table")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+    expect(queryByText("Add row above")).toBeNull()
+    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+  })
+
+  it.each([
+    { activationKey: "{Enter}" as const, label: "Enter" },
+    { activationKey: "{Space}" as const, label: "Space" },
+  ])(
+    "keeps the trigger mounted when tabbing to it and opens the menu with $label",
+    async ({ activationKey }) => {
+      const { editor, findByRole, findByText, queryByText } =
+        await renderHarness()
+
+      await expectKeyboardActivationOpensMenu({
+        editor,
+        findByRole,
+        findByText,
+        queryByText,
+        activationKey,
+      })
+    },
+  )
+
+  it("deactivates when tabbing from the trigger through menu controls to outside", async () => {
+    const { editor, findByRole, findByText, queryByText, queryByRole } =
+      await renderHarness()
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    const trigger = await tabToTableActionsTrigger(editor, findByRole, {
+      expectInactive: false,
+    })
+    expect(trigger).toHaveAttribute("aria-pressed", "true")
+
+    const outside = document.createElement("button")
+    outside.type = "button"
+    outside.textContent = "outside"
+    document.body.appendChild(outside)
+
+    try {
+      for (
+        let tabs = 0;
+        tabs < 30 && document.activeElement !== outside;
+        tabs += 1
+      ) {
+        await userEvent.tab()
+      }
+
+      expect(document.activeElement).toBe(outside)
+      // Focus has left the trigger, the menu, and the editor entirely, so
+      // both the action list and the now-irrelevant pencil trigger hide.
+      await waitFor(() => {
+        expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+      })
+      await waitFor(() => {
+        expect(queryByText("Delete row")).toBeNull()
+      })
+    } finally {
+      outside.remove()
+    }
+  })
+
+  it("shows the pencil trigger without the action menu until it is activated", async () => {
+    const { editor, findByRole, findByText, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+
+    const trigger = await findByRole("button", { name: "Table actions" })
+    expect(trigger).toHaveAttribute("aria-pressed", "false")
+    expect(queryByText("Delete row")).toBeNull()
+
+    await activateTableBubbleMenu(findByRole)
+
+    expect(trigger).toHaveAttribute("aria-pressed", "true")
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    await activateTableBubbleMenu(findByRole)
+
+    expect(trigger).toHaveAttribute("aria-pressed", "false")
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("shows Split cell for a single cell that came from a merge, and nothing for an ordinary single cell", async () => {
+    const { editor, findByText, findByRole, queryByText, queryByRole } =
+      await renderHarness()
+
+    // Merge two adjacent body cells into one, then re-select just that
+    // resulting cell — the only single-cell case with a bubble menu.
+    selectCells(editor, 3, 4)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    selectCells(editor, 3, 3)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Split cell")).toBeTruthy()
+    expect(queryByText("Merge cells")).toBeNull()
+
+    // An ordinary (never-merged) single cell still shows no menu at all.
+    selectCells(editor, 6, 6)
+    expect(queryByText("Split cell")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+  })
+
+  it("hides when focus moves outside the editor (e.g. Table Settings modal)", async () => {
+    // TipTap's blur handler hides the menu when focus leaves the editor.
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    act(() => {
+      const outside = document.createElement("button")
+      outside.type = "button"
+      outside.textContent = "outside"
+      document.body.appendChild(outside)
+      editor.view.dom.dispatchEvent(
+        new FocusEvent("blur", { bubbles: true, relatedTarget: outside }),
+      )
+      outside.focus()
+    })
+
+    await waitFor(() => {
+      expect(queryByText("Delete row")).toBeNull()
+    })
+  })
+
+  it("stays hidden while a cell drag-select is in progress, then shows after it commits", async () => {
+    // prosemirror-tables sets `tableEditingKey` for the duration of a cell
+    // drag (mousemove) and clears it on mouseup. The menu must not appear for
+    // intermediate selection rects during that window.
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    act(() => {
+      editor.view.dispatch(
+        editor.state.tr.setMeta(tableEditingKey, nthCellPos(editor, 3)),
+      )
+    })
+    await waitFor(() => {
+      expect(queryByText("Delete row")).toBeNull()
+    })
+
+    // Intermediate selection expansion while still "dragging"
+    selectCells(editor, 3, 7)
+    expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+
+    // mouseup clears selectingCells state (meta -1 → null)
+    act(() => {
+      editor.view.dispatch(editor.state.tr.setMeta(tableEditingKey, -1))
+    })
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Merge cells")).toBeTruthy()
+  })
+
+  it("starts deactivated after remounting with the same editor", async () => {
+    const { editor, findByRole, findByText, queryByText, setShowMenu } =
+      await renderHarness()
+    selectCells(editor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    act(() => {
+      setShowMenu(false)
+    })
+    act(() => {
+      setShowMenu(true)
+    })
+
+    const trigger = await findByRole("button", { name: "Table actions" })
+    expect(trigger).toHaveAttribute("aria-pressed", "false")
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("repositions the menu when the editor's own scroll container scrolls (not just window)", async () => {
+    // EditorContentWrapper (the real production wrapper) has its own
+    // `overflowY: auto` — scrolling *inside* it must reposition the menu,
+    // not just scrolling the window.
+    let editor: Editor | undefined
+
+    const ScrollingHarness = () => {
+      const e = useTextEditor({ data: SEED_CONTENT, handleChange: () => null })
+      useEffect(() => {
+        if (e) editor = e
+      }, [e])
+      return (
+        <div
+          data-testid="scroll-parent"
+          style={{ height: "80px", overflowY: "auto" }}
+        >
+          <div style={{ height: "600px" }} />
+          {e && <TableBubbleMenu editor={e} />}
+          {e && <EditorContent editor={e} />}
+        </div>
+      )
+    }
+
+    const { findByRole, findByText, container } = render(
+      <ThemeProvider theme={theme}>
+        <ScrollingHarness />
+      </ThemeProvider>,
+    )
+    await waitFor(() => {
+      if (!editor) throw new Error("editor not ready")
+    })
+    const readyEditor = editor!
+
+    selectCells(readyEditor, 3, 5)
+    await activateTableBubbleMenu(findByRole)
+    await findByText("Delete row")
+
+    const menuEl = document.querySelector(
+      "[data-table-bubble-menu]",
+    ) as HTMLElement | null
+    expect(menuEl).not.toBeNull()
+
+    await waitFor(() => {
+      expect(menuEl?.getBoundingClientRect().top).toBeGreaterThan(0)
+    })
+    const initialTop = menuEl?.getBoundingClientRect().top
+
+    const scrollParent = container.querySelector(
+      '[data-testid="scroll-parent"]',
+    ) as HTMLElement
+
+    act(() => {
+      scrollParent.scrollTop = 300
+      scrollParent.dispatchEvent(new Event("scroll"))
+    })
+
+    await waitFor(() => {
+      expect(menuEl?.getBoundingClientRect().top).not.toBe(initialTop)
+    })
+  })
+
+  it("keeps one trigger and deactivates when selection moves to another table", async () => {
+    const { editor, findByRole, findByText, findAllByRole, queryByText } =
+      await renderHarness(TWO_TABLES_CONTENT)
+
+    selectCells(editor, 3, 5) // first table, first body row
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Delete row")).toBeTruthy()
+
+    selectCells(editor, 12, 14) // second table, first body row
+
+    const triggers = await findAllByRole("button", { name: "Table actions" })
+    expect(triggers).toHaveLength(1)
+    expect(triggers[0]).toHaveAttribute("aria-pressed", "false")
+    expect(queryByText("Delete row")).toBeNull()
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -297,7 +297,7 @@ describe("TableBubbleMenu", () => {
     expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
   })
 
-  it("withholds Delete and Move when selection includes header row", async () => {
+  it("withholds Add above, Delete and Move when selection includes header row", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
@@ -306,7 +306,7 @@ describe("TableBubbleMenu", () => {
 
     const headerToggle = await findByRole("checkbox", { name: "Header row" })
     expect(headerToggle).toBeChecked()
-    expect(await findByText("Add row above")).toBeTruthy()
+    expect(queryByText("Add row above")).toBeNull()
     expect(await findByText("Add row below")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Move up")).toBeNull()
@@ -315,6 +315,7 @@ describe("TableBubbleMenu", () => {
     selectCells(editor, 0, 5)
     await activateTableBubbleMenu(findByRole)
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
+    expect(queryByText("Add row above")).toBeNull()
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Move up")).toBeNull()
     expect(queryByText("Move down")).toBeNull()
@@ -338,11 +339,12 @@ describe("TableBubbleMenu", () => {
     await waitFor(() => {
       expect(headerToggle).not.toBeChecked()
     })
+    expect(await findByText("Add row above")).toBeTruthy()
     expect(await findByText("Delete row")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
   })
 
-  it("withholds Delete and Move when selection includes header column", async () => {
+  it("withholds Add left, Delete and Move when selection includes header column", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
@@ -363,6 +365,7 @@ describe("TableBubbleMenu", () => {
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).toBeChecked()
+    expect(queryByText("Add column left")).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
     expect(queryByText("Move left")).toBeNull()
     expect(queryByText("Move right")).toBeNull()

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -61,13 +61,7 @@ const TWO_TABLES_CONTENT: JSONContent = {
   ],
 }
 
-// Finds the document position at the start boundary of the nth cell
-// (tableCell or tableHeader) in reading order, 0-indexed. This is the
-// position CellSelection.create expects: resolving it yields a ResolvedPos
-// whose parent is the cell's tableRow, so `$pos.node(-1)` is the table (as
-// prosemirror-tables' CellSelection constructor requires) — resolving one
-// position later (i.e. *inside* the cell) would instead make the row the
-// `node(-1)` ancestor and throw "Not a table node".
+// Cell start position for CellSelection.create (must resolve to tableRow, not cell content).
 const nthCellPos = (editor: Editor, index: number): number => {
   let seen = 0
   let found: number | null = null
@@ -86,15 +80,11 @@ const nthCellPos = (editor: Editor, index: number): number => {
   return found
 }
 
-// Selects the cell range [startIndex, endIndex] (inclusive, 0-indexed reading
-// order) and flushes the resulting transaction inside `act`, since this
-// dispatches synchronously outside of React's own event handling.
+// Selects cells [startIndex, endIndex] in reading order inside act().
 const selectCells = (editor: Editor, startIndex: number, endIndex: number) => {
   const anchorCell = nthCellPos(editor, startIndex)
   const headCell = nthCellPos(editor, endIndex)
   act(() => {
-    // A real pointer selection focuses the editor. Make that precondition
-    // explicit instead of relying on menu rendering to steal focus.
     editor.chain().focus().setCellSelection({ anchorCell, headCell }).run()
   })
 }

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.utils.test.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.utils.test.ts
@@ -12,8 +12,7 @@ import {
   type TableHeaderOverlapRect,
 } from "../TableBubbleMenu.utils"
 
-// Builds a rect whose map offsets are 0..n-1 and whose table.nodeAt(i) returns
-// the ith cell type — enough for the header-overlap helpers without a live editor.
+// Builds a minimal rect for header-overlap helpers (no live editor).
 const overlapRect = ({
   top,
   left,
@@ -78,8 +77,7 @@ describe("getTableSelectionKind", () => {
       expected: "header-row",
     },
     {
-      // A full-width body row that happens to be all header cells is still a
-      // normal row — TipTap's header-row toggle only targets the first row.
+      // All-header row below row 0 is still a normal row selection.
       facts: {
         spansEntireTableWidth: true,
         allCellsAreHeaders: true,
@@ -194,7 +192,6 @@ describe("selectionIncludesHeaderRow", () => {
 })
 
 describe("selectionIncludesHeaderColumn", () => {
-  // Header row + header column (intersection and first body cell are headers).
   const headerRowAndColumn = [
     "tableHeader",
     "tableHeader",

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.utils.test.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.utils.test.ts
@@ -1,0 +1,340 @@
+import type { Node } from "@tiptap/pm/model"
+import type { TableMap } from "@tiptap/pm/tables"
+import { describe, expect, it } from "vitest"
+
+import {
+  getColumnMovePlan,
+  getMovedBlockCellCorners,
+  getRowMovePlan,
+  getTableSelectionKind,
+  selectionIncludesHeaderColumn,
+  selectionIncludesHeaderRow,
+  type TableHeaderOverlapRect,
+} from "../TableBubbleMenu.utils"
+
+// Builds a rect whose map offsets are 0..n-1 and whose table.nodeAt(i) returns
+// the ith cell type — enough for the header-overlap helpers without a live editor.
+const overlapRect = ({
+  top,
+  left,
+  width,
+  height,
+  cellTypes,
+}: {
+  top: number
+  left: number
+  width: number
+  height: number
+  cellTypes: string[]
+}): TableHeaderOverlapRect => {
+  const map = cellTypes.map((_, index) => index)
+  const table = {
+    nodeAt: (pos: number) => {
+      const typeName = cellTypes[pos]
+      return typeName ? { type: { name: typeName } } : null
+    },
+  } as Node
+
+  return {
+    top,
+    left,
+    map: { width, height, map },
+    table,
+  }
+}
+
+describe("getTableSelectionKind", () => {
+  const partialSelection = {
+    spansEntireTableWidth: false,
+    spansEntireTableHeight: false,
+    allCellsAreHeaders: false,
+    isTopRow: false,
+    isLeftmostColumn: false,
+    selectsSingleCellNode: false,
+    selectedCellIsMerged: false,
+  }
+
+  it("classifies selections that span the entire table before either axis", () => {
+    expect(
+      getTableSelectionKind({
+        ...partialSelection,
+        spansEntireTableWidth: true,
+        spansEntireTableHeight: true,
+      }),
+    ).toBe("table")
+  })
+
+  it.each([
+    {
+      facts: { spansEntireTableWidth: true },
+      expected: "row",
+    },
+    {
+      facts: {
+        spansEntireTableWidth: true,
+        allCellsAreHeaders: true,
+        isTopRow: true,
+      },
+      expected: "header-row",
+    },
+    {
+      // A full-width body row that happens to be all header cells is still a
+      // normal row — TipTap's header-row toggle only targets the first row.
+      facts: {
+        spansEntireTableWidth: true,
+        allCellsAreHeaders: true,
+        isTopRow: false,
+      },
+      expected: "row",
+    },
+    {
+      facts: { spansEntireTableHeight: true },
+      expected: "column",
+    },
+    {
+      facts: {
+        spansEntireTableHeight: true,
+        allCellsAreHeaders: true,
+        isLeftmostColumn: true,
+      },
+      expected: "header-column",
+    },
+    {
+      facts: {
+        spansEntireTableHeight: true,
+        allCellsAreHeaders: true,
+        isLeftmostColumn: false,
+      },
+      expected: "column",
+    },
+  ])("classifies an axis selection as $expected", ({ facts, expected }) => {
+    expect(getTableSelectionKind({ ...partialSelection, ...facts })).toBe(
+      expected,
+    )
+  })
+
+  it.each([
+    {
+      selectedCellIsMerged: false,
+      expected: "single-cell",
+    },
+    {
+      selectedCellIsMerged: true,
+      expected: "merged-cell",
+    },
+  ])(
+    "classifies a single selected node as $expected",
+    ({ selectedCellIsMerged, expected }) => {
+      expect(
+        getTableSelectionKind({
+          ...partialSelection,
+          selectsSingleCellNode: true,
+          selectedCellIsMerged,
+        }),
+      ).toBe(expected)
+    },
+  )
+
+  it("classifies the remaining selection shape as multi-cell", () => {
+    expect(getTableSelectionKind(partialSelection)).toBe("multi-cell")
+  })
+})
+
+describe("selectionIncludesHeaderRow", () => {
+  const headerThenBody = [
+    "tableHeader",
+    "tableHeader",
+    "tableHeader",
+    "tableCell",
+    "tableCell",
+    "tableCell",
+  ]
+
+  it("is true when the selection overlaps a header row at the top", () => {
+    expect(
+      selectionIncludesHeaderRow(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 3,
+          height: 2,
+          cellTypes: headerThenBody,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("is false when the selection starts below the header row", () => {
+    expect(
+      selectionIncludesHeaderRow(
+        overlapRect({
+          top: 1,
+          left: 0,
+          width: 3,
+          height: 2,
+          cellTypes: headerThenBody,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false when the top row is ordinary body cells", () => {
+    expect(
+      selectionIncludesHeaderRow(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 2,
+          height: 1,
+          cellTypes: ["tableCell", "tableCell"],
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("selectionIncludesHeaderColumn", () => {
+  // Header row + header column (intersection and first body cell are headers).
+  const headerRowAndColumn = [
+    "tableHeader",
+    "tableHeader",
+    "tableHeader",
+    "tableCell",
+    "tableHeader",
+    "tableCell",
+  ]
+
+  it("is true when the selection overlaps a header column at the left", () => {
+    expect(
+      selectionIncludesHeaderColumn(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 2,
+          height: 3,
+          cellTypes: headerRowAndColumn,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("is false when the selection starts to the right of the header column", () => {
+    expect(
+      selectionIncludesHeaderColumn(
+        overlapRect({
+          top: 0,
+          left: 1,
+          width: 2,
+          height: 3,
+          cellTypes: headerRowAndColumn,
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it("is false when only the first row is headers (header row, not column)", () => {
+    expect(
+      selectionIncludesHeaderColumn(
+        overlapRect({
+          top: 0,
+          left: 0,
+          width: 2,
+          height: 2,
+          cellTypes: ["tableHeader", "tableHeader", "tableCell", "tableCell"],
+        }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("getRowMovePlan", () => {
+  it.each([
+    {
+      direction: "up" as const,
+      expected: { from: 0, to: 2, newStart: 0, span: 2 },
+    },
+    {
+      direction: "down" as const,
+      expected: { from: 3, to: 1, newStart: 2, span: 2 },
+    },
+  ])(
+    "moves the adjacent row $direction past the block",
+    ({ direction, expected }) => {
+      expect(
+        getRowMovePlan({ top: 1, bottom: 3, tableHeight: 4 }, direction),
+      ).toEqual(expected)
+    },
+  )
+
+  it("does not move beyond the top or bottom table edge", () => {
+    expect(
+      getRowMovePlan({ top: 0, bottom: 2, tableHeight: 4 }, "up"),
+    ).toBeNull()
+    expect(
+      getRowMovePlan({ top: 2, bottom: 4, tableHeight: 4 }, "down"),
+    ).toBeNull()
+  })
+})
+
+const tableMap = ({
+  width,
+  height,
+}: {
+  width: number
+  height: number
+}): Pick<TableMap, "width" | "height" | "positionAt"> => ({
+  width,
+  height,
+  positionAt: (row, col) => row * width + col,
+})
+
+const emptyTable = {} as Node
+
+describe("getMovedBlockCellCorners", () => {
+  const plan = { from: 0, to: 1, newStart: 1, span: 2 }
+
+  it("selects top-left to bottom-right for a moved row block", () => {
+    const map = tableMap({ width: 4, height: 3 })
+    expect(getMovedBlockCellCorners(map, emptyTable, plan, "row")).toEqual({
+      anchor: 4,
+      head: 11,
+    })
+  })
+
+  it("selects bottom-left to top-right for a moved column block", () => {
+    const map = tableMap({ width: 4, height: 3 })
+    expect(getMovedBlockCellCorners(map, emptyTable, plan, "column")).toEqual({
+      anchor: 9,
+      head: 2,
+    })
+  })
+})
+
+describe("getColumnMovePlan", () => {
+  it.each([
+    {
+      direction: "left" as const,
+      expected: { from: 0, to: 2, newStart: 0, span: 2 },
+    },
+    {
+      direction: "right" as const,
+      expected: { from: 3, to: 1, newStart: 2, span: 2 },
+    },
+  ])(
+    "moves the adjacent column $direction past the block",
+    ({ direction, expected }) => {
+      expect(
+        getColumnMovePlan({ left: 1, right: 3, tableWidth: 4 }, direction),
+      ).toEqual(expected)
+    },
+  )
+
+  it("does not move beyond the left or right table edge", () => {
+    expect(
+      getColumnMovePlan({ left: 0, right: 2, tableWidth: 4 }, "left"),
+    ).toBeNull()
+    expect(
+      getColumnMovePlan({ left: 2, right: 4, tableWidth: 4 }, "right"),
+    ).toBeNull()
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/tableBubbleMenuFocus.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/tableBubbleMenuFocus.ts
@@ -9,14 +9,11 @@ type EditorWithTableBubbleMenuCommand = Editor["commands"] & {
 export const runTableBubbleMenuFocusTrigger = (editor: Editor): boolean =>
   focusTriggerByEditor.get(editor)?.() ?? false
 
-// Invokes the IsomerTable command; typed wrapper until @tiptap/core augmentation.
 export const focusTableBubbleMenuTrigger = (editor: Editor): boolean =>
   (
     editor.commands as EditorWithTableBubbleMenuCommand
   ).focusTableBubbleMenuTrigger()
 
-// React registers the trigger ref; IsomerTable's focusTableBubbleMenuTrigger
-// command reads it for the Tab keymap.
 export const registerTableBubbleMenuFocusTrigger = (
   editor: Editor,
   focusTrigger: () => boolean,

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/tableBubbleMenuFocus.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/tableBubbleMenuFocus.ts
@@ -1,0 +1,29 @@
+import type { Editor } from "@tiptap/react"
+
+const focusTriggerByEditor = new WeakMap<Editor, () => boolean>()
+
+type EditorWithTableBubbleMenuCommand = Editor["commands"] & {
+  focusTableBubbleMenuTrigger: () => boolean
+}
+
+export const runTableBubbleMenuFocusTrigger = (editor: Editor): boolean =>
+  focusTriggerByEditor.get(editor)?.() ?? false
+
+// Invokes the IsomerTable command; typed wrapper until @tiptap/core augmentation.
+export const focusTableBubbleMenuTrigger = (editor: Editor): boolean =>
+  (
+    editor.commands as EditorWithTableBubbleMenuCommand
+  ).focusTableBubbleMenuTrigger()
+
+// React registers the trigger ref; IsomerTable's focusTableBubbleMenuTrigger
+// command reads it for the Tab keymap.
+export const registerTableBubbleMenuFocusTrigger = (
+  editor: Editor,
+  focusTrigger: () => boolean,
+) => {
+  focusTriggerByEditor.set(editor, focusTrigger)
+}
+
+export const unregisterTableBubbleMenuFocusTrigger = (editor: Editor) => {
+  focusTriggerByEditor.delete(editor)
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
@@ -23,8 +23,6 @@ import {
 } from "./tableBubbleMenuFocus"
 import { useTableBubbleMenuPosition } from "./useTableBubbleMenuPosition"
 
-// UI state for the table bubble menu: visibility, activation, positioning, and
-// keyboard-focus bridge to the IsomerTable Tab handler.
 export interface TableBubbleMenuUiState {
   show: boolean
   kind: SelectionKind
@@ -40,7 +38,6 @@ export interface TableBubbleMenuUiState {
 const isElement = (target: EventTarget | null): target is Element =>
   target instanceof Element
 
-// Header toggles rewrite cell types in place; anchor/head positions stay put.
 const getSelectionRangeKey = (selection: Editor["state"]["selection"]) =>
   selection instanceof CellSelection
     ? `${selection.$anchorCell.pos}:${selection.$headCell.pos}`
@@ -51,16 +48,12 @@ export const useTableBubbleMenu = (editor: Editor): TableBubbleMenuUiState => {
   const [menuEl, setMenuEl] = useState<HTMLDivElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
 
-  // Callback ref: Portal mounts asynchronously, so menuEl state retriggers
-  // positioning once the container is in the DOM.
   const menuRef = useCallback((node: HTMLDivElement | null) => {
     menuElRef.current = node
     setMenuEl(node)
   }, [])
 
   const [isActivated, setIsActivated] = useState(false)
-  // Keeps the menu visible while focus is on the trigger or action list, even
-  // when the editor itself has blurred (e.g. Tab from cell to trigger).
   const [menuHasFocus, setMenuHasFocus] = useState(false)
 
   const { kind, selection, isDragging, isFocused } = useEditorState({
@@ -69,7 +62,6 @@ export const useTableBubbleMenu = (editor: Editor): TableBubbleMenuUiState => {
       kind: detectTableSelectionKind(currentEditor),
       selection: currentEditor.state.selection,
       isFocused: currentEditor.isFocused,
-      // prosemirror-tables sets this meta while a cell drag-select is in progress.
       isDragging: tableEditingKey.getState(currentEditor.state) != null,
     }),
     equalityFn: (previous, next) =>
@@ -105,7 +97,6 @@ export const useTableBubbleMenu = (editor: Editor): TableBubbleMenuUiState => {
     selection,
   })
 
-  // Register trigger ref for IsomerTable's focusTableBubbleMenuTrigger command.
   useEffect(() => {
     registerTableBubbleMenuFocusTrigger(editor, () => {
       const trigger = triggerRef.current
@@ -118,8 +109,6 @@ export const useTableBubbleMenu = (editor: Editor): TableBubbleMenuUiState => {
     }
   }, [editor])
 
-  // Editor blur fires before menu focusin; relatedTarget tells us whether
-  // focus moved into the menu or left the editor entirely.
   useEffect(() => {
     const isMenuElement = (target: EventTarget | null) =>
       isElement(target) && (menuElRef.current?.contains(target) ?? false)

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
@@ -1,0 +1,183 @@
+import type { Editor } from "@tiptap/react"
+import { CellSelection, tableEditingKey } from "@tiptap/pm/tables"
+import { useEditorState } from "@tiptap/react"
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type FocusEvent,
+  type RefCallback,
+  type RefObject,
+} from "react"
+
+import type { SelectionKind } from "./TableBubbleMenu.types"
+import {
+  detectTableSelectionKind,
+  isActionableTableSelectionKind,
+  isEditorModalOpen,
+} from "./TableBubbleMenu.utils"
+import {
+  registerTableBubbleMenuFocusTrigger,
+  unregisterTableBubbleMenuFocusTrigger,
+} from "./tableBubbleMenuFocus"
+import { useTableBubbleMenuPosition } from "./useTableBubbleMenuPosition"
+
+// UI state for the table bubble menu: visibility, activation, positioning, and
+// keyboard-focus bridge to the IsomerTable Tab handler.
+export interface TableBubbleMenuUiState {
+  show: boolean
+  kind: SelectionKind
+  isActivated: boolean
+  menuRef: RefCallback<HTMLDivElement>
+  triggerRef: RefObject<HTMLButtonElement>
+  position: { x: number; y: number } | null
+  onMenuFocus: () => void
+  onMenuBlur: (event: FocusEvent<HTMLElement>) => void
+  toggleMenu: () => void
+}
+
+const isElement = (target: EventTarget | null): target is Element =>
+  target instanceof Element
+
+// Header toggles rewrite cell types in place; anchor/head positions stay put.
+const getSelectionRangeKey = (selection: Editor["state"]["selection"]) =>
+  selection instanceof CellSelection
+    ? `${selection.$anchorCell.pos}:${selection.$headCell.pos}`
+    : `${selection.from}:${selection.to}`
+
+export const useTableBubbleMenu = (editor: Editor): TableBubbleMenuUiState => {
+  const menuElRef = useRef<HTMLDivElement | null>(null)
+  const [menuEl, setMenuEl] = useState<HTMLDivElement | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  // Callback ref: Portal mounts asynchronously, so menuEl state retriggers
+  // positioning once the container is in the DOM.
+  const menuRef = useCallback((node: HTMLDivElement | null) => {
+    menuElRef.current = node
+    setMenuEl(node)
+  }, [])
+
+  const [isActivated, setIsActivated] = useState(false)
+  // Keeps the menu visible while focus is on the trigger or action list, even
+  // when the editor itself has blurred (e.g. Tab from cell to trigger).
+  const [menuHasFocus, setMenuHasFocus] = useState(false)
+
+  const { kind, selection, isDragging, isFocused } = useEditorState({
+    editor,
+    selector: ({ editor: currentEditor }) => ({
+      kind: detectTableSelectionKind(currentEditor),
+      selection: currentEditor.state.selection,
+      isFocused: currentEditor.isFocused,
+      // prosemirror-tables sets this meta while a cell drag-select is in progress.
+      isDragging: tableEditingKey.getState(currentEditor.state) != null,
+    }),
+    equalityFn: (previous, next) =>
+      next !== null &&
+      previous.kind === next.kind &&
+      previous.selection.eq(next.selection) &&
+      previous.isFocused === next.isFocused &&
+      previous.isDragging === next.isDragging,
+  })
+
+  const show =
+    isActionableTableSelectionKind(kind) &&
+    !isDragging &&
+    !isEditorModalOpen() &&
+    (isFocused || menuHasFocus)
+
+  const selectionRangeKey = getSelectionRangeKey(selection)
+
+  useEffect(() => {
+    setIsActivated(false)
+  }, [selectionRangeKey])
+
+  useEffect(() => {
+    if (!show) {
+      setIsActivated(false)
+    }
+  }, [show])
+
+  const position = useTableBubbleMenuPosition({
+    editor,
+    menuEl,
+    show,
+    selection,
+  })
+
+  // Register trigger ref for IsomerTable's focusTableBubbleMenuTrigger command.
+  useEffect(() => {
+    registerTableBubbleMenuFocusTrigger(editor, () => {
+      const trigger = triggerRef.current
+      if (!trigger) return false
+      trigger.focus()
+      return true
+    })
+    return () => {
+      unregisterTableBubbleMenuFocusTrigger(editor)
+    }
+  }, [editor])
+
+  // Editor blur fires before menu focusin; relatedTarget tells us whether
+  // focus moved into the menu or left the editor entirely.
+  useEffect(() => {
+    const isMenuElement = (target: EventTarget | null) =>
+      isElement(target) && (menuElRef.current?.contains(target) ?? false)
+
+    const isWithinFocusScope = (target: EventTarget | null) =>
+      isElement(target) &&
+      (isMenuElement(target) || editor.view.dom.contains(target))
+
+    const onBlur = ({ event }: { event?: globalThis.FocusEvent }) => {
+      const relatedTarget = event?.relatedTarget ?? null
+      if (isWithinFocusScope(relatedTarget)) {
+        if (isMenuElement(relatedTarget)) {
+          setMenuHasFocus(true)
+        }
+        return
+      }
+      setMenuHasFocus(false)
+    }
+    editor.on("blur", onBlur)
+    return () => {
+      editor.off("blur", onBlur)
+    }
+  }, [editor])
+
+  const onMenuFocus = () => setMenuHasFocus(true)
+
+  const onMenuBlur = (event: FocusEvent<HTMLElement>) => {
+    const relatedTarget = event.relatedTarget
+    if (
+      isElement(relatedTarget) &&
+      ((menuElRef.current?.contains(relatedTarget) ?? false) ||
+        editor.view.dom.contains(relatedTarget))
+    ) {
+      return
+    }
+    setMenuHasFocus(false)
+    setIsActivated(false)
+  }
+
+  const toggleMenu = () => {
+    setIsActivated((activated) => {
+      const next = !activated
+      if (next) {
+        editor.commands.focus()
+      }
+      return next
+    })
+  }
+
+  return {
+    show,
+    kind,
+    isActivated,
+    menuRef,
+    triggerRef,
+    position,
+    onMenuFocus,
+    onMenuBlur,
+    toggleMenu,
+  }
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuPosition.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuPosition.ts
@@ -1,0 +1,191 @@
+import type { EditorState, Selection } from "@tiptap/pm/state"
+import type { EditorView } from "@tiptap/pm/view"
+import type { Editor } from "@tiptap/react"
+import { autoUpdate } from "@floating-ui/dom"
+import { CellSelection, selectedRect } from "@tiptap/pm/tables"
+import { useEffect, useRef, useState } from "react"
+
+interface TableBubbleMenuPosition {
+  x: number
+  y: number
+}
+
+const getEditorScrollParent = (view: EditorView): HTMLElement | Window => {
+  let element: HTMLElement | null = view.dom.parentElement
+  while (element) {
+    const { overflowY } = getComputedStyle(element)
+    if (overflowY === "auto" || overflowY === "scroll") {
+      return element
+    }
+    element = element.parentElement
+  }
+  return window
+}
+
+// Document position of the bottom-right perimeter cell in a CellSelection
+// (anchors the table action trigger).
+const getBottomRightCellDocumentPos = (state: EditorState): number | null => {
+  const { selection } = state
+  if (!(selection instanceof CellSelection)) return null
+
+  const rect = selectedRect(state)
+  let bottomRightPos: number | null = null
+
+  selection.forEachCell((node, pos) => {
+    const cellRect = rect.map.findCell(pos - rect.tableStart)
+    if (cellRect.right === rect.right && cellRect.bottom === rect.bottom) {
+      bottomRightPos = pos
+    }
+  })
+
+  return bottomRightPos
+}
+
+const getBottomRightCellRect = (
+  view: EditorView,
+  state: EditorState,
+): DOMRect | null => {
+  const cellPos = getBottomRightCellDocumentPos(state)
+  if (cellPos === null) return null
+
+  const dom = view.nodeDOM(cellPos)
+  if (!(dom instanceof HTMLElement)) return null
+
+  return dom.getBoundingClientRect()
+}
+
+// Positions the menu container so the pencil trigger's center sits on the
+// bottom-right corner of the selected cell block.
+const computeTableBubbleMenuContainerPosition = (
+  cellRect: DOMRect,
+  menuEl: HTMLElement,
+): TableBubbleMenuPosition | null => {
+  const triggerEl = menuEl.querySelector("[data-table-bubble-menu-trigger]")
+  if (!(triggerEl instanceof HTMLElement)) return null
+
+  const { offsetWidth: triggerWidth, offsetHeight: triggerHeight } = triggerEl
+
+  return {
+    x: cellRect.right - triggerWidth / 2 - triggerEl.offsetLeft,
+    y: cellRect.bottom - triggerHeight / 2 - triggerEl.offsetTop,
+  }
+}
+
+// Point anchor for Floating UI autoUpdate scroll/resize detection.
+const createTableBubbleMenuVirtualReference = (
+  getView: () => EditorView,
+  getState: () => EditorState,
+) => {
+  const virtualReference = {
+    getBoundingClientRect: () => {
+      const rect = getBottomRightCellRect(getView(), getState())
+      if (!rect) return new DOMRect()
+      return new DOMRect(rect.right, rect.bottom, 0, 0)
+    },
+    getClientRects: () => [virtualReference.getBoundingClientRect()],
+  }
+
+  return virtualReference
+}
+
+// Updates the menu position when the selected cell block changes.
+const createTableBubbleMenuPositionUpdater = (
+  getView: () => EditorView,
+  getState: () => EditorState,
+  menuEl: HTMLElement,
+  onPosition: (position: TableBubbleMenuPosition) => void,
+): (() => void) => {
+  return () => {
+    const cellRect = getBottomRightCellRect(getView(), getState())
+    if (!cellRect) return
+
+    const nextPosition = computeTableBubbleMenuContainerPosition(
+      cellRect,
+      menuEl,
+    )
+    if (nextPosition) {
+      onPosition(nextPosition)
+    }
+  }
+}
+
+// autoUpdate does not always track nested editor scroll containers.
+const attachTableBubbleMenuScrollListeners = (
+  view: EditorView,
+  onUpdate: () => void,
+): (() => void) => {
+  const scrollTarget = getEditorScrollParent(view)
+
+  if (scrollTarget instanceof HTMLElement) {
+    scrollTarget.addEventListener("scroll", onUpdate, { passive: true })
+  }
+  window.addEventListener("resize", onUpdate, { passive: true })
+
+  return () => {
+    if (scrollTarget instanceof HTMLElement) {
+      scrollTarget.removeEventListener("scroll", onUpdate)
+    }
+    window.removeEventListener("resize", onUpdate)
+  }
+}
+
+interface UseTableBubbleMenuPositionOptions {
+  editor: Editor
+  menuEl: HTMLDivElement | null
+  show: boolean
+  selection: Selection
+}
+
+// Anchors the menu to the bottom-right of the selected cell block and keeps
+// position in sync on scroll, resize, and selection changes.
+export const useTableBubbleMenuPosition = ({
+  editor,
+  menuEl,
+  show,
+  selection,
+}: UseTableBubbleMenuPositionOptions): TableBubbleMenuPosition | null => {
+  const editorRef = useRef(editor)
+  editorRef.current = editor
+
+  const [position, setPosition] = useState<TableBubbleMenuPosition | null>(null)
+
+  useEffect(() => {
+    if (!show) {
+      setPosition(null)
+      return
+    }
+
+    if (!menuEl) {
+      // Portal may not have mounted yet; menuEl state update will retry.
+      return
+    }
+
+    const getView = () => editorRef.current.view
+    const getState = () => editorRef.current.state
+    const virtualReference = createTableBubbleMenuVirtualReference(
+      getView,
+      getState,
+    )
+    const updatePosition = createTableBubbleMenuPositionUpdater(
+      getView,
+      getState,
+      menuEl,
+      setPosition,
+    )
+
+    updatePosition()
+
+    const stopAutoUpdate = autoUpdate(virtualReference, menuEl, updatePosition)
+    const detachScrollListeners = attachTableBubbleMenuScrollListeners(
+      getView(),
+      updatePosition,
+    )
+
+    return () => {
+      stopAutoUpdate()
+      detachScrollListeners()
+    }
+  }, [show, selection, menuEl])
+
+  return position
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuPosition.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuPosition.ts
@@ -22,8 +22,6 @@ const getEditorScrollParent = (view: EditorView): HTMLElement | Window => {
   return window
 }
 
-// Document position of the bottom-right perimeter cell in a CellSelection
-// (anchors the table action trigger).
 const getBottomRightCellDocumentPos = (state: EditorState): number | null => {
   const { selection } = state
   if (!(selection instanceof CellSelection)) return null
@@ -54,9 +52,7 @@ const getBottomRightCellRect = (
   return dom.getBoundingClientRect()
 }
 
-// Positions the menu container so the pencil trigger's center sits on the
-// bottom-right corner of the selected cell block.
-const computeTableBubbleMenuContainerPosition = (
+const computeMenuPosition = (
   cellRect: DOMRect,
   menuEl: HTMLElement,
 ): TableBubbleMenuPosition | null => {
@@ -71,8 +67,7 @@ const computeTableBubbleMenuContainerPosition = (
   }
 }
 
-// Point anchor for Floating UI autoUpdate scroll/resize detection.
-const createTableBubbleMenuVirtualReference = (
+const createVirtualReference = (
   getView: () => EditorView,
   getState: () => EditorState,
 ) => {
@@ -88,8 +83,7 @@ const createTableBubbleMenuVirtualReference = (
   return virtualReference
 }
 
-// Updates the menu position when the selected cell block changes.
-const createTableBubbleMenuPositionUpdater = (
+const createPositionUpdater = (
   getView: () => EditorView,
   getState: () => EditorState,
   menuEl: HTMLElement,
@@ -99,18 +93,15 @@ const createTableBubbleMenuPositionUpdater = (
     const cellRect = getBottomRightCellRect(getView(), getState())
     if (!cellRect) return
 
-    const nextPosition = computeTableBubbleMenuContainerPosition(
-      cellRect,
-      menuEl,
-    )
+    const nextPosition = computeMenuPosition(cellRect, menuEl)
     if (nextPosition) {
       onPosition(nextPosition)
     }
   }
 }
 
-// autoUpdate does not always track nested editor scroll containers.
-const attachTableBubbleMenuScrollListeners = (
+// autoUpdate does not track nested editor scroll containers.
+const attachScrollListeners = (
   view: EditorView,
   onUpdate: () => void,
 ): (() => void) => {
@@ -136,8 +127,6 @@ interface UseTableBubbleMenuPositionOptions {
   selection: Selection
 }
 
-// Anchors the menu to the bottom-right of the selected cell block and keeps
-// position in sync on scroll, resize, and selection changes.
 export const useTableBubbleMenuPosition = ({
   editor,
   menuEl,
@@ -156,17 +145,13 @@ export const useTableBubbleMenuPosition = ({
     }
 
     if (!menuEl) {
-      // Portal may not have mounted yet; menuEl state update will retry.
       return
     }
 
     const getView = () => editorRef.current.view
     const getState = () => editorRef.current.state
-    const virtualReference = createTableBubbleMenuVirtualReference(
-      getView,
-      getState,
-    )
-    const updatePosition = createTableBubbleMenuPositionUpdater(
+    const virtualReference = createVirtualReference(getView, getState)
+    const updatePosition = createPositionUpdater(
       getView,
       getState,
       menuEl,
@@ -176,7 +161,7 @@ export const useTableBubbleMenuPosition = ({
     updatePosition()
 
     const stopAutoUpdate = autoUpdate(virtualReference, menuEl, updatePosition)
-    const detachScrollListeners = attachTableBubbleMenuScrollListeners(
+    const detachScrollListeners = attachScrollListeners(
       getView(),
       updatePosition,
     )

--- a/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
+++ b/apps/studio/src/features/editing-experience/components/form-builder/renderers/TipTapEditor/components.tsx
@@ -5,6 +5,7 @@ import type { EditorMenuBar } from "~/components/PageEditor/MenuBar/MenuBar"
 import { Box, VStack } from "@chakra-ui/react"
 import { EditorContent } from "@tiptap/react"
 import { useMemo } from "react"
+import { TableBubbleMenu } from "~/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu"
 
 const EditorContainer = ({
   children,
@@ -66,10 +67,16 @@ interface EditorProps {
   editor: TiptapEditor
   isNested?: boolean
 }
+
 export const Editor = ({ editor, menubar, isNested }: EditorProps) => {
+  const isTableEditor = editor.extensionManager.extensions.some(
+    (ext) => ext.name === "table",
+  )
+
   return (
     <EditorContainer isNested={isNested}>
       {menubar({ editor })}
+      {isTableEditor && <TableBubbleMenu editor={editor} />}
       <EditorContentWrapper editor={editor} />
     </EditorContainer>
   )

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -140,10 +140,6 @@ export const IsomerTable = Table.extend({
       ...parentShortcuts,
       "Mod-a": () =>
         selectTableCellContent(this.editor) || this.editor.commands.selectAll(),
-      // The base extension's Tab always calls goToNextCell, which keeps
-      // keyboard focus trapped inside the table. When the bubble menu's
-      // trigger is showing (an actionable multi-cell selection), send focus
-      // there instead so the trigger stays keyboard-reachable.
       Tab: ({ editor }) => {
         if (focusTableBubbleMenuTrigger(editor)) {
           return true

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -1,5 +1,6 @@
 import type { Level } from "@tiptap/extension-heading"
 import type { Extensions } from "@tiptap/react"
+import type { Editor } from "@tiptap/react"
 import { Bold } from "@tiptap/extension-bold"
 import { BulletList } from "@tiptap/extension-bullet-list"
 import { Document } from "@tiptap/extension-document"
@@ -25,6 +26,10 @@ import { Underline } from "@tiptap/extension-underline"
 import { Plugin, PluginKey } from "@tiptap/pm/state"
 import { textblockTypeInputRule } from "@tiptap/react"
 
+import {
+  focusTableBubbleMenuTrigger,
+  runTableBubbleMenuFocusTrigger,
+} from "../../components/TableBubbleMenu/tableBubbleMenuFocus"
 import {
   createTableSelectionBorderPlugin,
   getHtmlWithRelativeReferenceLinks,
@@ -113,6 +118,15 @@ export const PROSE_EXTENSIONS: Extensions = [
 export const IsomerTable = Table.extend({
   // Higher than TipTap's default keymap so Mod-a is handled here first.
   priority: 101,
+  addCommands() {
+    return {
+      ...this.parent?.(),
+      focusTableBubbleMenuTrigger:
+        () =>
+        ({ editor }: { editor: Editor }) =>
+          runTableBubbleMenuFocusTrigger(editor),
+    }
+  },
   addAttributes() {
     return {
       caption: {
@@ -121,10 +135,21 @@ export const IsomerTable = Table.extend({
     }
   },
   addKeyboardShortcuts() {
+    const parentShortcuts = this.parent?.() ?? {}
     return {
-      ...this.parent?.(),
+      ...parentShortcuts,
       "Mod-a": () =>
         selectTableCellContent(this.editor) || this.editor.commands.selectAll(),
+      // The base extension's Tab always calls goToNextCell, which keeps
+      // keyboard focus trapped inside the table. When the bubble menu's
+      // trigger is showing (an actionable multi-cell selection), send focus
+      // there instead so the trigger stays keyboard-reachable.
+      Tab: ({ editor }) => {
+        if (focusTableBubbleMenuTrigger(editor)) {
+          return true
+        }
+        return parentShortcuts.Tab?.({ editor }) ?? false
+      },
     }
   },
   addProseMirrorPlugins() {

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs"
-import { expect, userEvent, within } from "storybook/test"
+import type { Editor } from "@tiptap/react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import { meHandlers } from "tests/msw/handlers/me"
 import { pageHandlers } from "tests/msw/handlers/page"
 import { resourceHandlers } from "tests/msw/handlers/resource"
@@ -53,6 +54,43 @@ const meta: Meta<typeof EditPage> = {
 
 export default meta
 type Story = StoryObj<typeof EditPage>
+
+/** TipTap BubbleMenu portals into the story iframe body. */
+function withinPortals(canvasElement: HTMLElement) {
+  return within(canvasElement.ownerDocument.body)
+}
+
+// Document position at the start of the nth table cell (tableCell /
+// tableHeader), 0-indexed in reading order. Used to forge a CellSelection
+// in play functions — Storybook can't drive a real mouse drag across cells.
+const nthCellPos = (editor: Editor, index: number): number => {
+  let seen = 0
+  let found: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== null) return false
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      if (seen === index) {
+        found = pos
+        return false
+      }
+      seen += 1
+    }
+    return true
+  })
+  if (found === null) {
+    throw new Error(`Could not find cell at index ${index}`)
+  }
+  return found
+}
+
+const getEditorFromCanvas = (canvasElement: HTMLElement): Editor => {
+  const proseMirrorEl = canvasElement.querySelector<
+    HTMLElement & { editor?: Editor }
+  >(".ProseMirror")
+  const editor = proseMirrorEl?.editor
+  if (!editor) throw new Error("Editor did not mount")
+  return editor
+}
 
 export const Default: Story = {}
 export const Wordbreak: Story = {
@@ -204,5 +242,48 @@ export const ActiveTableToolbar: Story = {
     await expect(
       canvas.getAllByRole("button", { name: /more options/i }),
     ).toHaveLength(1)
+  },
+}
+
+// Navigate into a text block, insert a table, select a body row — the
+// contextual TableBubbleMenu should appear with row actions.
+export const TableBubbleMenu: Story = {
+  play: async (context) => {
+    const { canvasElement } = context
+    const canvas = within(canvasElement)
+    await AddTextBlock.play?.(context)
+
+    // Clicking "Table" only opens the size-picker popover — a cell still
+    // needs to be picked to actually insert a table (see TableSizePicker.tsx).
+    await userEvent.click(canvas.getByRole("button", { name: /^table$/i }))
+    await userEvent.click(
+      await canvas.findByRole("button", { name: /^3 by 3 table$/i }),
+    )
+
+    await waitFor(() =>
+      expect(canvasElement.querySelector("table")).toBeTruthy(),
+    )
+
+    const editor = getEditorFromCanvas(canvasElement)
+    // Default insertTable is 3x3 with a header row; cells 3–5 are the first body row.
+    editor
+      .chain()
+      .focus()
+      .setCellSelection({
+        anchorCell: nthCellPos(editor, 3),
+        headCell: nthCellPos(editor, 5),
+      })
+      .run()
+
+    const portals = withinPortals(canvasElement)
+    // Row/column actions live behind the portaled pencil trigger — click to open.
+    await userEvent.click(
+      await portals.findByRole("button", { name: "Table actions" }),
+    )
+
+    await waitFor(() =>
+      expect(portals.getByText("Delete row")).toBeInTheDocument(),
+    )
+    await expect(portals.getByText("Add row above")).toBeInTheDocument()
   },
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ catalogs:
     '@datadog/browser-rum':
       specifier: ^7.7.0
       version: 7.8.0
+    '@floating-ui/dom':
+      specifier: ^1.8.0
+      version: 1.8.0
     '@fontsource/ibm-plex-mono':
       specifier: ^5.3.0
       version: 5.3.0
@@ -130,7 +133,7 @@ catalogs:
       version: 4.17.12
     '@types/node':
       specifier: ^26.1.2
-      version: 26.1.2
+      version: 26.2.0
     '@types/papaparse':
       specifier: ^5.5.0
       version: 5.5.2
@@ -709,6 +712,9 @@ importers:
       '@datadog/browser-rum':
         specifier: 'catalog:'
         version: 7.8.0
+      '@floating-ui/dom':
+        specifier: 'catalog:'
+        version: 1.8.0
       '@fontsource/ibm-plex-mono':
         specifier: 'catalog:'
         version: 5.3.0
@@ -855,7 +861,7 @@ importers:
         version: 3.29.2
       '@tiptap/react':
         specifier: catalog:tiptap
-        version: 3.29.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@trpc/client':
         specifier: catalog:trpc
         version: 11.18.0(@trpc/server@11.18.0(typescript@6.0.3))(typescript@6.0.3)
@@ -1018,7 +1024,7 @@ importers:
         version: 2.5.8(react@18.3.1)(ws@8.21.3)
       '@inquirer/prompts':
         specifier: 'catalog:'
-        version: 8.5.2(@types/node@26.1.2)
+        version: 8.5.2(@types/node@26.2.0)
       '@isomer/oxlint-config':
         specifier: workspace:*
         version: link:../../tooling/oxlint
@@ -1036,7 +1042,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1054,7 +1060,7 @@ importers:
         version: 4.17.12
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@types/papaparse':
         specifier: 'catalog:'
         version: 5.5.2
@@ -1078,7 +1084,7 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 4.1.10(vitest@4.1.10)
@@ -1099,22 +1105,22 @@ importers:
         version: 11.0.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
       msw:
         specifier: 'catalog:'
-        version: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+        version: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
       msw-storybook-addon:
         specifier: 'catalog:'
-        version: 3.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 3.0.0(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       msw-trpc:
         specifier: 'catalog:'
-        version: 2.0.1(@trpc/server@11.18.0(typescript@6.0.3))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(typescript@6.0.3)
+        version: 2.0.1(@trpc/server@11.18.0(typescript@6.0.3))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(typescript@6.0.3)
       node-mocks-http:
         specifier: 'catalog:'
-        version: 1.18.1(@types/node@26.1.2)
+        version: 1.18.1(@types/node@26.2.0)
       npm-run-all2:
         specifier: 'catalog:'
         version: 9.0.3
@@ -1129,7 +1135,7 @@ importers:
         version: 8.5.26
       postcss-load-config:
         specifier: 'catalog:'
-        version: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3)
+        version: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3)
       start-server-and-test:
         specifier: 'catalog:'
         version: 3.0.11
@@ -1150,10 +1156,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+        version: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       webpack-cli:
         specifier: 'catalog:'
         version: 7.2.2(js-yaml@4.3.1)(json5@2.2.3)(webpack@5.105.4)
@@ -1175,7 +1181,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260707.2
@@ -1278,7 +1284,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1287,7 +1293,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-vite':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1305,10 +1311,10 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitejs/plugin-react':
         specifier: catalog:vitest
-        version: 6.0.5(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 6.0.5(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+        version: 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 4.1.10(vitest@4.1.10)
@@ -1323,7 +1329,7 @@ importers:
         version: 18.1.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1371,10 +1377,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+        version: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -1399,7 +1405,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@types/pg':
         specifier: catalog:pg
         version: 8.21.0
@@ -1454,7 +1460,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260707.2
@@ -1472,7 +1478,7 @@ importers:
         version: 12.26.4
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -1485,7 +1491,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260707.2
@@ -1509,7 +1515,7 @@ importers:
         version: link:../../tooling/typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260707.2
@@ -1524,7 +1530,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
 
   tooling/build:
     devDependencies:
@@ -1579,7 +1585,7 @@ importers:
         version: link:../../../../packages/db
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@types/pg':
         specifier: catalog:pg
         version: 8.21.0
@@ -1588,13 +1594,13 @@ importers:
         version: 12.1.0
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
 
   tooling/export-import:
     dependencies:
       '@inquirer/prompts':
         specifier: 'catalog:'
-        version: 8.5.2(@types/node@26.1.2)
+        version: 8.5.2(@types/node@26.2.0)
       dotenv:
         specifier: 'catalog:'
         version: 16.6.1
@@ -1607,7 +1613,7 @@ importers:
         version: link:../typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@types/pg':
         specifier: catalog:pg
         version: 8.21.0
@@ -1631,7 +1637,7 @@ importers:
         version: 3.1102.0
       '@inquirer/prompts':
         specifier: 'catalog:'
-        version: 8.5.2(@types/node@26.1.2)
+        version: 8.5.2(@types/node@26.2.0)
       '@isomer/seed-from-repo':
         specifier: workspace:*
         version: link:../seed-from-repo
@@ -1643,7 +1649,7 @@ importers:
         version: link:../../packages/components
       axios:
         specifier: 'catalog:'
-        version: 1.19.0
+        version: 1.19.0(debug@4.4.3)
       lodash-es:
         specifier: 'catalog:'
         version: 4.18.1
@@ -1659,7 +1665,7 @@ importers:
         version: 4.17.12
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1816,7 +1822,7 @@ importers:
         version: link:../typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@types/pg':
         specifier: catalog:pg
         version: 8.21.0
@@ -1840,7 +1846,7 @@ importers:
         version: 3.1102.0
       '@inquirer/prompts':
         specifier: 'catalog:'
-        version: 8.5.2(@types/node@26.1.2)
+        version: 8.5.2(@types/node@26.2.0)
       '@isomer/seed-from-repo':
         specifier: workspace:*
         version: link:../seed-from-repo
@@ -1849,7 +1855,7 @@ importers:
         version: 22.0.1
       axios:
         specifier: 'catalog:'
-        version: 1.19.0
+        version: 1.19.0(debug@4.4.3)
       dotenv-cli:
         specifier: 'catalog:'
         version: 11.0.0
@@ -1868,7 +1874,7 @@ importers:
         version: link:../typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -1932,7 +1938,7 @@ importers:
         version: link:../typescript
       '@types/node':
         specifier: 'catalog:'
-        version: 26.1.2
+        version: 26.2.0
       '@types/react':
         specifier: catalog:react
         version: 18.3.28
@@ -1944,7 +1950,7 @@ importers:
         version: 7.0.0-dev.20260707.2
       vitest:
         specifier: catalog:vitest
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
 
   tooling/typescript: {}
 
@@ -4115,11 +4121,11 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
 
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
@@ -4133,8 +4139,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@fontsource/ibm-plex-mono@5.3.0':
     resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
@@ -6819,9 +6825,6 @@ packages:
   '@types/node@18.19.130':
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
-  '@types/node@26.1.2':
-    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
-
   '@types/node@26.2.0':
     resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
@@ -6833,9 +6836,6 @@ packages:
 
   '@types/pg-cursor@2.7.2':
     resolution: {integrity: sha512-m3xT8bVFCvx98LuzbvXyuCdT/Hjdd/v8ml4jL4K1QF70Y8clOfCFdgoaEB1FWdcSwcpoFYZTJQaMD9/GQ27efQ==}
-
-  '@types/pg@8.20.0':
-    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/pg@8.21.0':
     resolution: {integrity: sha512-AYdtudzabjLZgVgRZmAnU8bAnVUXzuJX2IYHeSIiIHm68olD+LgQYCGWdtcNYnP0uq9c4S4NibVG3Ni7VbKW7Q==}
@@ -7399,9 +7399,6 @@ packages:
   axe-core@4.11.1:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
-
-  axios@1.18.1:
-    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   axios@1.19.0:
     resolution: {integrity: sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==}
@@ -10089,11 +10086,6 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.18:
     resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -10887,10 +10879,6 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.23:
-    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.26:
@@ -12700,18 +12688,6 @@ packages:
 
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-
-  ws@8.21.2:
-    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.21.3:
     resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
@@ -15377,30 +15353,30 @@ snapshots:
     optionalDependencies:
       '@noble/hashes': 2.2.0
 
-  '@floating-ui/core@1.7.5':
+  '@floating-ui/core@1.8.0':
     dependencies:
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
 
-  '@floating-ui/dom@1.7.6':
+  '@floating-ui/dom@1.8.0':
     dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
   '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/react@0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@floating-ui/utils': 0.2.11
+      '@floating-ui/utils': 0.2.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.4.0
 
-  '@floating-ui/utils@0.2.11': {}
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource/ibm-plex-mono@5.3.0': {}
 
@@ -15601,15 +15577,6 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.2.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/checkbox@5.2.1(@types/node@26.2.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -15619,31 +15586,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@inquirer/confirm@6.1.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/confirm@6.1.1(@types/node@26.2.0)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.2.0)
       '@inquirer/type': 4.0.7(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@inquirer/core@11.2.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-      cli-width: 4.1.0
-      fast-wrap-ansi: 0.2.0
-      mute-stream: 3.0.0
-      signal-exit: 4.1.0
-    optionalDependencies:
-      '@types/node': 26.1.2
 
   '@inquirer/core@11.2.1(@types/node@26.2.0)':
     dependencies:
@@ -15657,14 +15605,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@inquirer/editor@5.2.2(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/external-editor': 3.0.3(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/editor@5.2.2(@types/node@26.2.0)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.2.0)
@@ -15673,26 +15613,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@inquirer/expand@5.1.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/expand@5.1.1(@types/node@26.2.0)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.2.0)
       '@inquirer/type': 4.0.7(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@inquirer/external-editor@3.0.3(@types/node@26.1.2)':
-    dependencies:
-      chardet: 2.1.1
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 26.1.2
 
   '@inquirer/external-editor@3.0.3(@types/node@26.2.0)':
     dependencies:
@@ -15703,26 +15629,12 @@ snapshots:
 
   '@inquirer/figures@2.0.7': {}
 
-  '@inquirer/input@5.1.2(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/input@5.1.2(@types/node@26.2.0)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.2.0)
       '@inquirer/type': 4.0.7(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@inquirer/number@4.1.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
 
   '@inquirer/number@4.1.1(@types/node@26.2.0)':
     dependencies:
@@ -15731,14 +15643,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@inquirer/password@5.1.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/password@5.1.1(@types/node@26.2.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -15746,21 +15650,6 @@ snapshots:
       '@inquirer/type': 4.0.7(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@inquirer/prompts@8.5.2(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/checkbox': 5.2.1(@types/node@26.1.2)
-      '@inquirer/confirm': 6.1.1(@types/node@26.1.2)
-      '@inquirer/editor': 5.2.2(@types/node@26.1.2)
-      '@inquirer/expand': 5.1.1(@types/node@26.1.2)
-      '@inquirer/input': 5.1.2(@types/node@26.1.2)
-      '@inquirer/number': 4.1.1(@types/node@26.1.2)
-      '@inquirer/password': 5.1.1(@types/node@26.1.2)
-      '@inquirer/rawlist': 5.3.1(@types/node@26.1.2)
-      '@inquirer/search': 4.2.1(@types/node@26.1.2)
-      '@inquirer/select': 5.2.1(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
 
   '@inquirer/prompts@8.5.2(@types/node@26.2.0)':
     dependencies:
@@ -15777,27 +15666,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@inquirer/rawlist@5.3.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/rawlist@5.3.1(@types/node@26.2.0)':
     dependencies:
       '@inquirer/core': 11.2.1(@types/node@26.2.0)
       '@inquirer/type': 4.0.7(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@inquirer/search@4.2.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
 
   '@inquirer/search@4.2.1(@types/node@26.2.0)':
     dependencies:
@@ -15807,15 +15681,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.2.0
 
-  '@inquirer/select@5.2.1(@types/node@26.1.2)':
-    dependencies:
-      '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@26.1.2)
-      '@inquirer/figures': 2.0.7
-      '@inquirer/type': 4.0.7(@types/node@26.1.2)
-    optionalDependencies:
-      '@types/node': 26.1.2
-
   '@inquirer/select@5.2.1(@types/node@26.2.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
@@ -15824,10 +15689,6 @@ snapshots:
       '@inquirer/type': 4.0.7(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
-
-  '@inquirer/type@4.0.7(@types/node@26.1.2)':
-    optionalDependencies:
-      '@types/node': 26.1.2
 
   '@inquirer/type@4.0.7(@types/node@26.2.0)':
     optionalDependencies:
@@ -15858,11 +15719,11 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -16089,7 +15950,7 @@ snapshots:
       inter-ui: 3.19.3
       libphonenumber-js: 1.12.41
       lodash: 4.18.1
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-dropzone: 11.7.1(react@18.3.1)
@@ -16573,7 +16434,7 @@ snapshots:
   '@prisma/adapter-pg@7.9.1':
     dependencies:
       '@prisma/driver-adapter-utils': 7.9.1
-      '@types/pg': 8.20.0
+      '@types/pg': 8.21.0
       pg: 8.22.0
       postgres-array: 3.0.4
     transitivePeerDependencies:
@@ -17072,10 +16933,10 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17091,10 +16952,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17123,12 +16984,12 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17166,17 +17027,7 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
-    dependencies:
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      unplugin: 2.3.11
-    optionalDependencies:
-      esbuild: 0.28.1
-      rollup: 4.60.1
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
-      webpack: 5.105.4(esbuild@0.28.1)(webpack-cli@7.2.2)
-
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
@@ -17184,6 +17035,16 @@ snapshots:
       esbuild: 0.28.1
       rollup: 4.60.1
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      webpack: 5.105.4(esbuild@0.28.1)(webpack-cli@7.2.2)
+
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+    dependencies:
+      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.28.1
+      rollup: 4.60.1
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)
 
   '@storybook/global@5.0.0': {}
@@ -17219,8 +17080,8 @@ snapshots:
       loader-utils: 3.3.1
       next: 16.2.11(patch_hash=96c056d3c2fe2195b5487aa4adf46a46a96f6dc0e872c060e5563e3c74b51409)(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.102.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.105.4)
-      postcss: 8.5.23
-      postcss-loader: 8.2.1(postcss@8.5.23)(typescript@6.0.3)(webpack@5.105.4)
+      postcss: 8.5.26
+      postcss-loader: 8.2.1(postcss@8.5.26)(typescript@6.0.3)(webpack@5.105.4)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
@@ -17301,11 +17162,11 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -17315,7 +17176,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -17437,7 +17298,7 @@ snapshots:
 
   '@tiptap/extension-bubble-menu@3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
     optional: true
@@ -17458,9 +17319,9 @@ snapshots:
     dependencies:
       '@tiptap/extensions': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
 
-  '@tiptap/extension-floating-menu@3.29.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
+  '@tiptap/extension-floating-menu@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
     optional: true
@@ -17583,7 +17444,7 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.42.2
 
-  '@tiptap/react@3.29.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tiptap/react@3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tiptap/core': 3.29.2(@tiptap/pm@3.29.2)
       '@tiptap/pm': 3.29.2
@@ -17596,7 +17457,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
-      '@tiptap/extension-floating-menu': 3.29.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
+      '@tiptap/extension-floating-menu': 3.29.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)
     transitivePeerDependencies:
       - '@floating-ui/dom'
 
@@ -17806,30 +17667,20 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/node@26.1.2':
-    dependencies:
-      undici-types: 8.3.0
-
   '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
   '@types/papaparse@5.5.2':
     dependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
 
   '@types/parse-json@4.0.2': {}
 
   '@types/pg-cursor@2.7.2':
     dependencies:
-      '@types/node': 26.1.2
-      '@types/pg': 8.20.0
-
-  '@types/pg@8.20.0':
-    dependencies:
-      '@types/node': 26.1.2
-      pg-protocol: 1.15.0
-      pg-types: 2.2.0
+      '@types/node': 26.2.0
+      '@types/pg': 8.21.0
 
   '@types/pg@8.21.0':
     dependencies:
@@ -17857,7 +17708,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.6
 
@@ -18096,23 +17947,10 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.5(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
-
-  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
-    dependencies:
-      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
-      playwright: 1.62.1
-      tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
 
   '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
@@ -18127,17 +17965,13 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
     dependencies:
-      '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
-      '@vitest/utils': 4.1.10
-      magic-string: 0.30.21
-      pngjs: 7.0.0
-      sirv: 3.0.2
+      '@vitest/browser': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      playwright: 1.62.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
-      ws: 8.21.2
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -18154,7 +17988,24 @@ snapshots:
       sirv: 3.0.2
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
-      ws: 8.21.2
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -18173,7 +18024,7 @@ snapshots:
       magicast: 0.5.3
       obug: 2.1.3
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
     transitivePeerDependencies:
       - supports-color
 
@@ -18194,15 +18045,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
-
   '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -18211,6 +18053,15 @@ snapshots:
     optionalDependencies:
       msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
       vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+
+  '@vitest/mocker@4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -18562,17 +18413,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.18.1(debug@4.4.3):
-    dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.6
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  axios@1.19.0:
+  axios@1.19.0(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.6
@@ -19302,12 +19143,12 @@ snapshots:
 
   css-loader@6.11.0(webpack@5.105.4):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.23)
-      postcss: 8.5.23
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.23)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.23)
-      postcss-modules-scope: 3.2.1(postcss@8.5.23)
-      postcss-modules-values: 4.0.0(postcss@8.5.23)
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
@@ -19315,12 +19156,12 @@ snapshots:
 
   css-loader@7.1.4(webpack@5.105.4):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.23)
-      postcss: 8.5.23
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.23)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.23)
-      postcss-modules-scope: 3.2.1(postcss@8.5.23)
-      postcss-modules-values: 4.0.0(postcss@8.5.23)
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
@@ -20588,9 +20429,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.23):
+  icss-utils@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
 
   ieee754@1.2.1: {}
 
@@ -21461,48 +21302,18 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw-storybook-addon@3.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
-    dependencies:
-      msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
-      storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-
   msw-storybook-addon@3.0.0(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)):
     dependencies:
       msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  msw-trpc@2.0.1(@trpc/server@11.18.0(typescript@6.0.3))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(typescript@6.0.3):
+  msw-trpc@2.0.1(@trpc/server@11.18.0(typescript@6.0.3))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
       '@trpc/client': 11.18.0(@trpc/server@11.18.0(typescript@6.0.3))(typescript@6.0.3)
       '@trpc/server': 11.18.0(typescript@6.0.3)
-      msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      msw: 2.15.0(@types/node@26.2.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
-
-  msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3):
-    dependencies:
-      '@inquirer/confirm': 6.1.1(@types/node@26.1.2)
-      '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.13.2
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.2
-      type-fest: 5.8.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/node'
 
   msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3):
     dependencies:
@@ -21557,8 +21368,6 @@ snapshots:
 
   nan@2.26.2:
     optional: true
-
-  nanoid@3.3.16: {}
 
   nanoid@3.3.18: {}
 
@@ -21626,7 +21435,7 @@ snapshots:
   node-gyp-build@4.8.4:
     optional: true
 
-  node-mocks-http@1.18.1(@types/node@26.1.2):
+  node-mocks-http@1.18.1(@types/node@26.2.0):
     dependencies:
       accepts: 1.3.8
       content-disposition: 0.5.4
@@ -21638,7 +21447,7 @@ snapshots:
       range-parser: 1.2.1
       type-is: 1.6.18
     optionalDependencies:
-      '@types/node': 26.1.2
+      '@types/node': 26.2.0
 
   node-polyfill-webpack-plugin@2.0.1(webpack@5.105.4):
     dependencies:
@@ -22316,17 +22125,17 @@ snapshots:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-import@15.1.0(postcss@8.5.23):
+  postcss-import@15.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.23):
+  postcss-js@4.1.0(postcss@8.5.26):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.23
+      postcss: 8.5.26
 
   postcss-lab-function@8.0.6(postcss@8.5.26):
     dependencies:
@@ -22337,29 +22146,20 @@ snapshots:
       '@csstools/utilities': 3.0.0(postcss@8.5.26)
       postcss: 8.5.26
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.23.11)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.23
-      tsx: 4.23.11
-      yaml: 2.8.3
-
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 2.7.0
       postcss: 8.5.26
       tsx: 4.23.11
       yaml: 2.8.3
 
-  postcss-loader@8.2.1(postcss@8.5.23)(typescript@6.0.3)(webpack@5.105.4):
+  postcss-loader@8.2.1(postcss@8.5.26)(typescript@6.0.3)(webpack@5.105.4):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
       jiti: 2.7.0
-      postcss: 8.5.23
+      postcss: 8.5.26
       semver: 7.8.5
     optionalDependencies:
       webpack: 5.105.4(esbuild@0.28.1)(webpack-cli@7.2.2)
@@ -22371,30 +22171,30 @@ snapshots:
       postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.23):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.23):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.26):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.23)
-      postcss: 8.5.23
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.23):
+  postcss-modules-scope@3.2.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
       postcss-selector-parser: 7.1.1
 
-  postcss-modules-values@4.0.0(postcss@8.5.23):
+  postcss-modules-values@4.0.0(postcss@8.5.26):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.23)
-      postcss: 8.5.23
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-nested@6.2.0(postcss@8.5.23):
+  postcss-nested@6.2.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.23
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.2
 
   postcss-nesting@14.0.0(postcss@8.5.26):
@@ -22529,13 +22329,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.23:
-    dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -23026,7 +22820,7 @@ snapshots:
       '@babel/runtime': 7.29.7
       '@emotion/cache': 11.14.0
       '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@types/react-transition-group': 4.4.12(@types/react@18.3.28)
       memoize-one: 6.0.0
       prop-types: 15.8.1
@@ -23243,7 +23037,7 @@ snapshots:
       adjust-sourcemap-loader: 4.0.0
       convert-source-map: 1.9.0
       loader-utils: 2.0.4
-      postcss: 8.5.23
+      postcss: 8.5.26
       source-map: 0.6.1
 
   resolve@1.22.11:
@@ -23667,7 +23461,7 @@ snapshots:
       recast: 0.23.11
       semver: 7.8.5
       use-sync-external-store: 1.6.0(react@18.3.1)
-      ws: 8.21.2
+      ws: 8.21.3
     optionalDependencies:
       '@types/react': 18.3.28
       prettier: 3.8.1
@@ -23855,11 +23649,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.23
-      postcss-import: 15.1.0(postcss@8.5.23)
-      postcss-js: 4.1.0(postcss@8.5.23)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.23)(tsx@4.23.11)(yaml@2.8.3)
-      postcss-nested: 6.2.0(postcss@8.5.23)
+      postcss: 8.5.26
+      postcss-import: 15.1.0(postcss@8.5.26)
+      postcss-js: 4.1.0(postcss@8.5.26)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.11)(yaml@2.8.3)
+      postcss-nested: 6.2.0(postcss@8.5.26)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -24318,28 +24112,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
-    dependencies:
-      lightningcss: 1.33.0
-      picomatch: 4.0.5
-      postcss: 8.5.23
-      rolldown: 1.2.3
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.1.2
-      esbuild: 0.28.1
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      sass: 1.102.0
-      terser: 5.46.1
-      tsx: 4.23.11
-      yaml: 2.8.3
-
   vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.23
+      postcss: 8.5.26
       rolldown: 1.2.3
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -24352,37 +24129,22 @@ snapshots:
       tsx: 4.23.11
       yaml: 2.8.3
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
+  vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
+      lightningcss: 1.33.0
       picomatch: 4.0.5
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.2
+      postcss: 8.5.26
+      rolldown: 1.2.3
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
     optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 26.1.2
-      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
-      '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
-      happy-dom: 20.10.6
-      jsdom: 30.0.1(@noble/hashes@2.2.0)
-    transitivePeerDependencies:
-      - msw
+      '@types/node': 26.2.0
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      sass: 1.102.0
+      terser: 5.46.1
+      tsx: 4.23.11
+      yaml: 2.8.3
 
   vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
     dependencies:
@@ -24416,6 +24178,38 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.2.0
+      '@vitest/browser-playwright': 4.1.10(msw@2.15.0(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.102.0)(terser@5.46.1)(tsx@4.23.11)(yaml@2.8.3))(vitest@4.1.10)
+      '@vitest/coverage-istanbul': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.10.6
+      jsdom: 30.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
   vm-browserify@1.1.2: {}
 
   w3c-keyname@2.2.8: {}
@@ -24426,7 +24220,7 @@ snapshots:
 
   wait-on@9.0.10(debug@4.4.3):
     dependencies:
-      axios: 1.18.1(debug@4.4.3)
+      axios: 1.19.0(debug@4.4.3)
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8
@@ -24655,8 +24449,6 @@ snapshots:
       is-typedarray: 1.0.0
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
-
-  ws@8.21.2: {}
 
   ws@8.21.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ catalogs:
     '@datadog/browser-rum':
       specifier: ^7.7.0
       version: 7.8.0
+    '@floating-ui/dom':
+      specifier: ^1.8.0
+      version: 1.8.0
     '@fontsource/ibm-plex-mono':
       specifier: ^5.3.0
       version: 5.3.0
@@ -718,6 +721,9 @@ importers:
       '@datadog/browser-rum':
         specifier: 'catalog:'
         version: 7.8.0
+      '@floating-ui/dom':
+        specifier: 'catalog:'
+        version: 1.8.0
       '@fontsource/ibm-plex-mono':
         specifier: 'catalog:'
         version: 5.3.0
@@ -864,7 +870,7 @@ importers:
         version: 3.31.2
       '@tiptap/react':
         specifier: catalog:tiptap
-        version: 3.31.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.31.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@trpc/client':
         specifier: catalog:trpc
         version: 11.18.0(@trpc/server@11.18.0(typescript@6.0.3))(typescript@6.0.3)
@@ -1048,7 +1054,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1090,7 +1096,7 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
+        version: 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 5.0.0(vitest@5.0.0)
@@ -1111,7 +1117,7 @@ importers:
         version: 11.0.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1141,7 +1147,7 @@ importers:
         version: 8.5.26
       postcss-load-config:
         specifier: 'catalog:'
-        version: 6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(yaml@2.8.3)
+        version: 6.0.1(jiti@1.21.7)(postcss@8.5.26)(tsx@4.23.13)(yaml@2.8.3)
       start-server-and-test:
         specifier: 'catalog:'
         version: 3.0.12
@@ -1162,10 +1168,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+        version: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+        version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       webpack-cli:
         specifier: 'catalog:'
         version: 7.2.2(js-yaml@4.3.2)(json5@2.2.3)(webpack@5.105.4)
@@ -1308,7 +1314,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/addon-links':
         specifier: catalog:storybook
         version: 10.4.6(@types/react@18.3.28)(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -1317,7 +1323,7 @@ importers:
         version: 10.4.6(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-vite':
         specifier: catalog:storybook
-        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@testing-library/react':
         specifier: 'catalog:'
         version: 16.3.3(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1335,10 +1341,10 @@ importers:
         version: 7.0.0-dev.20260707.2
       '@vitejs/plugin-react':
         specifier: catalog:vitest
-        version: 6.1.1(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+        version: 6.1.1(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       '@vitest/browser-playwright':
         specifier: catalog:vitest
-        version: 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
+        version: 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
       '@vitest/coverage-istanbul':
         specifier: catalog:vitest
         version: 5.0.0(vitest@5.0.0)
@@ -1353,7 +1359,7 @@ importers:
         version: 18.2.0
       eslint-plugin-storybook:
         specifier: catalog:storybook
-        version: 10.4.6(eslint@9.39.4(jiti@1.21.7))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
+        version: 10.4.6(eslint@9.39.4(jiti@2.7.0))(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       mockdate:
         specifier: 'catalog:'
         version: 3.0.5
@@ -1401,10 +1407,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: catalog:vitest
-        version: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+        version: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
       vitest:
         specifier: catalog:vitest
-        version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+        version: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
 
   packages/db:
     dependencies:
@@ -4203,8 +4209,14 @@ packages:
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
   '@floating-ui/dom@1.7.6':
     resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
 
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
@@ -4220,6 +4232,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
 
   '@fontsource/ibm-plex-mono@5.3.0':
     resolution: {integrity: sha512-eTgnZjZEGk1QtD3ZstF+Vclo2HLAni8YMy34/DxllwZvyz1lR/1RF/xTiAquOBO7MvqBx8D2Ig2WCPMVfdZu7Q==}
@@ -15613,10 +15628,19 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.11
 
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
   '@floating-ui/dom@1.7.6':
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
 
   '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -15633,6 +15657,8 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@fontsource/ibm-plex-mono@5.3.0': {}
 
@@ -16131,11 +16157,11 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@6.0.3)
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
     optionalDependencies:
       typescript: 6.0.3
 
@@ -17346,10 +17372,10 @@ snapshots:
       axe-core: 4.11.1
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17365,10 +17391,10 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/addon-docs@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/icons': 2.0.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -17397,12 +17423,12 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/builder-vite@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/csf-plugin': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -17440,24 +17466,24 @@ snapshots:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4)':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.60.1
-      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)(webpack-cli@7.2.2)
 
-  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/csf-plugin@10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.28.1
       rollup: 4.60.1
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
       webpack: 5.105.4(esbuild@0.28.1)
 
   '@storybook/global@5.0.0': {}
@@ -17575,11 +17601,11 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
-  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
+  '@storybook/react-vite@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(esbuild@0.28.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@6.0.3)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.1)
-      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
+      '@storybook/builder-vite': 10.4.6(esbuild@0.28.1)(rollup@4.60.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(webpack@5.105.4(esbuild@0.28.1))
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -17589,7 +17615,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.4.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@18.3.28)(prettier@3.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -17745,9 +17771,9 @@ snapshots:
     dependencies:
       '@tiptap/extensions': 3.31.2(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)
 
-  '@tiptap/extension-floating-menu@3.31.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)':
+  '@tiptap/extension-floating-menu@3.31.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)':
     dependencies:
-      '@floating-ui/dom': 1.7.6
+      '@floating-ui/dom': 1.8.0
       '@tiptap/core': 3.31.2(@tiptap/pm@3.31.2)
       '@tiptap/pm': 3.31.2
     optional: true
@@ -17870,7 +17896,7 @@ snapshots:
       prosemirror-transform: 1.12.1
       prosemirror-view: 1.42.3
 
-  '@tiptap/react@3.31.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@tiptap/react@3.31.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@tiptap/core': 3.31.2(@tiptap/pm@3.31.2)
       '@tiptap/pm': 3.31.2
@@ -17883,7 +17909,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.3.1)
     optionalDependencies:
       '@tiptap/extension-bubble-menu': 3.31.2(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)
-      '@tiptap/extension-floating-menu': 3.31.2(@floating-ui/dom@1.7.6)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)
+      '@tiptap/extension-floating-menu': 3.31.2(@floating-ui/dom@1.8.0)(@tiptap/core@3.31.2(@tiptap/pm@3.31.2))(@tiptap/pm@3.31.2)
     transitivePeerDependencies:
       - '@floating-ui/dom'
 
@@ -18394,10 +18420,23 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@6.1.1(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.1.1(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+
+  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
+    dependencies:
+      '@vitest/browser': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      playwright: 1.62.1
+      tinyrainbow: 3.1.1
+      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
 
   '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
     dependencies:
@@ -18411,14 +18450,33 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
+  '@vitest/browser-playwright@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
     dependencies:
-      '@vitest/browser': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
-      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      '@vitest/browser': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
+    dependencies:
+      '@blazediff/core': 1.10.0
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      '@vitest/ui': 5.0.0(vitest@5.0.0)
+      '@vitest/utils': 5.0.0
+      magic-string: 1.2.3
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.1
+      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -18442,18 +18500,19 @@ snapshots:
       - msw
       - utf-8-validate
       - vite
+    optional: true
 
-  '@vitest/browser@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
+  '@vitest/browser@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)':
     dependencies:
       '@blazediff/core': 1.10.0
-      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       '@vitest/ui': 5.0.0(vitest@5.0.0)
       '@vitest/utils': 5.0.0
       magic-string: 1.2.3
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -18472,7 +18531,7 @@ snapshots:
       magicast: 0.5.4
       obug: 2.1.4
       tinyrainbow: 3.1.1
-      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -18502,6 +18561,16 @@ snapshots:
       '@vitest/istanbul-lib-coverage': 1.0.1
       obug: 2.1.4
 
+  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      '@vitest/spy': 5.0.0
+      estree-walker: 3.0.3
+      magic-string: 1.2.3
+    optionalDependencies:
+      msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
+      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+
   '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -18512,7 +18581,7 @@ snapshots:
       msw: 2.15.0(@types/node@26.1.2)(typescript@6.0.3)
       vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
 
-  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
+  '@vitest/mocker@5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       '@vitest/spy': 5.0.0
@@ -18520,7 +18589,7 @@ snapshots:
       magic-string: 1.2.3
     optionalDependencies:
       msw: 2.15.0(@types/node@26.5.0)(typescript@6.0.3)
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -18544,7 +18613,7 @@ snapshots:
       pathe: 2.0.3
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      vitest: 5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -22660,15 +22729,6 @@ snapshots:
       tsx: 4.23.13
       yaml: 2.8.3
 
-  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.13)(yaml@2.8.3):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 2.7.0
-      postcss: 8.5.26
-      tsx: 4.23.13
-      yaml: 2.8.3
-
   postcss-loader@8.2.1(postcss@8.5.26)(typescript@6.0.3)(webpack@5.105.4):
     dependencies:
       cosmiconfig: 9.0.1(typescript@6.0.3)
@@ -24638,6 +24698,23 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.1.2
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.103.1
+      terser: 5.46.1
+      tsx: 4.23.13
+      yaml: 2.8.3
+
   vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
@@ -24655,7 +24732,7 @@ snapshots:
       tsx: 4.23.13
       yaml: 2.8.3
 
-  vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3):
+  vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.5
@@ -24666,11 +24743,38 @@ snapshots:
       '@types/node': 26.5.0
       esbuild: 0.28.1
       fsevents: 2.3.3
-      jiti: 1.21.7
+      jiti: 2.7.0
       sass: 1.103.1
       terser: 5.46.1
       tsx: 4.23.13
       yaml: 2.8.3
+
+  vitest@5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      chai: 6.2.2
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 1.2.3
+      obug: 2.1.4
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 6.1.4
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      vite: 8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.1.2
+      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
+      '@vitest/coverage-istanbul': 5.0.0(vitest@5.0.0)
+      '@vitest/ui': 5.0.0(vitest@5.0.0)
+      happy-dom: 20.10.6
+      jsdom: 30.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
 
   vitest@5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.1.2)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.1.2)(typescript@6.0.3))(vite@8.2.2(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)):
     dependencies:
@@ -24699,10 +24803,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)):
+  vitest@5.0.0(@opentelemetry/api@1.9.1)(@types/node@26.5.0)(@vitest/browser-playwright@5.0.0)(@vitest/coverage-istanbul@5.0.0)(@vitest/ui@5.0.0)(happy-dom@20.10.6)(jsdom@30.0.1(@noble/hashes@2.2.0))(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)):
     dependencies:
       '@types/chai': 5.2.3
-      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
+      '@vitest/mocker': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))
       chai: 6.2.2
       es-module-lexer: 2.3.2
       expect-type: 1.4.0
@@ -24713,12 +24817,12 @@ snapshots:
       tinybench: 6.1.4
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
+      vite: 8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.5.0
-      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@1.21.7)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
+      '@vitest/browser-playwright': 5.0.0(msw@2.15.0(@types/node@26.5.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.5.0)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.103.1)(terser@5.46.1)(tsx@4.23.13)(yaml@2.8.3))(vitest@5.0.0)
       '@vitest/coverage-istanbul': 5.0.0(vitest@5.0.0)
       '@vitest/ui': 5.0.0(vitest@5.0.0)
       happy-dom: 20.10.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,6 +119,7 @@ catalog:
   "@1password/sdk": ^0.5.0
   "@datadog/browser-rum": ^7.7.0
   "@fontsource/ibm-plex-mono": ^5.3.0
+  "@floating-ui/dom": ^1.8.0
   "@formkit/auto-animate": ^0.10.0
   "@headlessui/react": ^2.2.10
   "@hello-pangea/dnd": ^18.0.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,6 +119,7 @@ catalog:
   "@1password/sdk": ^0.4.1
   "@datadog/browser-rum": ^7.7.0
   "@fontsource/ibm-plex-mono": ^5.3.0
+  "@floating-ui/dom": ^1.8.0
   "@formkit/auto-animate": ^0.10.0
   "@headlessui/react": ^2.2.10
   "@hello-pangea/dnd": ^18.0.1
@@ -252,6 +253,7 @@ catalogs:
     "@tanstack/react-query": ^5.101.3
     "@tanstack/react-query-devtools": ^5.101.3
   tiptap:
+    "@floating-ui/dom": ^1.8.0
     "@tiptap/core": ^3.29.0
     "@tiptap/extension-bold": ^3.29.0
     "@tiptap/extension-bullet-list": ^3.29.0


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 15 | +1114 | -158 |
| 🧪 Test | 3 | +1067 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 1 | +167 | -63 |
<!-- pr-diff-breakdown:end -->

## Problem

Table actions (add/delete row or column, merge/split, move, header toggles) need a contextual surface that appears only for meaningful table selections — not for a plain text cursor inside a cell. Building this required (1) selection-classification logic reviewable on its own, (2) the bubble menu UI wired on top of it, and (3) removal of the legacy toolbar actions it replaces.

Closes https://linear.app/ogp/issue/ISOM-2365/rte-add-inline-bubble-menu-for-table-actions

(Previously split across #2980, #2981, #2982 — consolidated into this single PR since the stack was overly granular for review.)

## Solution

**Selection classification**

Pure selection helpers in `TableBubbleMenu.utils.ts`:

- `getTableSelectionKind` / `detectTableSelectionKind` — map normalized selection facts to a `SelectionKind`
- `selectionIncludesHeaderRow` / `selectionIncludesHeaderColumn` — guard delete and move when a header axis is overlapped
- `selectionIsTopRow` / `selectionIsLeftmostColumn` — scope header toggles to the exact first row/column
- `getRowMovePlan` / `getColumnMovePlan` — block move math for multi-row/column selections
- `restoreMovedBlockSelection` — reselect moved blocks so the menu stays open after move commands

**Contextual TableBubbleMenu**

Adds and wires `TableBubbleMenu` on table-enabled TipTap editors (`TiptapTextEditor`, `TiptapAccordionEditor`):

- Selection-aware action matrix (row, header row, column, header column, whole table, multi-cell, merged cell)
- Pencil trigger → action menu activation pattern
- `useTableBubbleMenu` for show/hide, activation, and focus bridging (`menuHasFocus`, `getSelectionRangeKey` so header toggles refresh actions without reselecting)
- `useTableBubbleMenuPosition` — Portal positioning anchored to the selection's bottom-right cell (Floating UI `autoUpdate` + editor scroll-parent detection)
- `tableBubbleMenuFocus.ts` — WeakMap bridge so `IsomerTable` Tab focuses the pencil trigger
- Menubar/modal focus fixes (`HorizontalList`, `OverflowList`, `TableSettingsModal`) so overflow popovers and Table Settings coexist with the bubble menu
- Edit Page Storybook story: `Content Page → TableBubbleMenu`

**Legacy toolbar cleanup**

Removes legacy table toolbar entries from `TextMenuBar` and `AccordionMenuBar` now that the bubble menu covers them. Keeps only:

- **Insert table** (size picker)
- **Table settings** (caption modal — until `TableCaption` lands in a follow-up stack PR)

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Contextual `TableBubbleMenu` with a full per-selection action matrix.
- Storybook coverage for row-selection bubble menu.

**Improvements**:

- Selection classification is unit-tested without a live TipTap editor.
- Slimmer toolbar when editing inside a table; table actions live exclusively on the bubble menu.
- Keyboard path: Tab from a cell selection reaches the pencil trigger; Enter/Space opens the action panel.

**Bug Fixes**:

- Bubble menu hidden for plain text cursor inside a cell.
- Table Settings modal and overflow popovers no longer fight bubble menu focus.
- Menu repositions when the editor scrolls inside its own overflow container (not only `window` scroll).
- Delete and move withheld when selection overlaps a header axis; actions refresh after toggling header off without reselecting.

## Before & After Screenshots

https://github.com/user-attachments/assets/778e8a10-10d8-40e1-9be7-b73574488f73

## Tests

**What to verify in this PR**

- Selection-kind priority order (whole table → header row/col → row/col → merged single cell → multi-cell)
- Header-overlap delete and move guards
- Header toggle scoped to exact top row / leftmost column only
- Row/column move plans at table edges and for multi-cell blocks; selection restored after move
- Action matrix per selection type (row, header, column, merge, split, whole table)
- Pencil trigger activation; no menu for plain cursor in cell
- Tab → trigger focus; Enter/Space opens menu; deactivates when focus leaves editor scope
- Table Settings opens without hang; overflow popover stays open and preserves selection
- Menu repositions on editor-internal scroll
- Toolbar parity: every removed action is reachable via `TableBubbleMenu`

```bash
cd apps/studio
pnpm test:unit -- src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.test.ts
pnpm test:unit -- src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.browser.test.tsx
```

**Manual Verification Steps**:

- [ ] In a Text block RTE: insert a table, select a body row, click the pencil trigger, and confirm row actions appear and work (add row, move, delete).
- [ ] Select header row / leftmost column and confirm header toggles; confirm delete and move are withheld when a header axis is included.
- [ ] Toggle header row off without changing selection → delete/move actions appear.
- [ ] Select multiple cells → Merge; select merged single cell → Split.
- [ ] Click inside cell text (no selection) → no bubble menu.
- [ ] Tab from cell selection → pencil trigger; Enter/Space opens actions.
- [ ] Scroll the editor content area → pencil stays pinned to the selection.
- [ ] Open Table settings → edit caption → no focus trap hang.
- [ ] Open toolbar overflow (⋯) inside a table → action runs, popover closes, selection preserved.
- [ ] Inside a table: toolbar shows only Insert table + Table settings — no row/col/merge/split icons.
- [ ] Repeat key checks in an Accordion RTE block.

---

<!-- table-bubble-menu-teach:start -->

# Walkthrough of this PR

- Floating **pencil button** on table selections in the Isomer editor
- Click it → row/column/merge/delete actions
- Lives in `apps/studio/src/features/editing-experience/components/TableBubbleMenu/`

---

## What it is

- TipTap tables = edit one cell at a time by default
- Isomer adds a **shortcut menu** pinned to the bottom-right of your selection
- **Shows** when you select a row, column, multiple cells, a merged cell, or the whole table
- **Hidden** when you're just typing in a single cell (normal text cursor)

### Three jobs, three files

- **Classify the selection** → `TableBubbleMenu.utils.ts`
  - Looks at what cells are selected
  - Returns a label like `row`, `column`, `table`, etc. (`SelectionKind`)
- **Control show/hide + focus** → `useTableBubbleMenu.ts`
- **Pin the pencil to the selection** → `useTableBubbleMenuPosition.ts`

### UI files

- `TableBubbleMenu.tsx` — renders the pencil + popup (via Portal)
- `TableBubbleMenuActions.tsx` — the actual action buttons

---

## How it works

### 1. You select cells

- Drag or shift-click across cells
- Editor creates a `CellSelection` (TipTap/ProseMirror term for "these cells are selected")
- `detectTableSelectionKind()` figures out what you picked:

```mermaid
flowchart LR
  A[Select cells] --> B[CellSelection]
  B --> C[detectTableSelectionKind]
  C --> D[SelectionKind]
```

**What it checks:**
- Does the selection span the full width? height? both? → row / column / whole table
- Are all selected cells header cells?
- One cell or many? Merged (colspan/rowspan)?

**Order matters** when classifying: whole table → row/column → single cell

---

### 2. Should the pencil show?

All must be true:

- Selection is **actionable** (not `none`, not `single-cell`)
- User is **not** mid drag-select
- No **modal dialog** is open
- **Editor focused** OR **menu focused** (see focus section below)

```mermaid
flowchart TD
  A[SelectionKind] --> B{Actionable?}
  B -->|no| Z[hide]
  B -->|yes| C{Dragging?}
  C -->|yes| Z
  C -->|no| D{Modal open?}
  D -->|yes| Z
  D -->|no| E{Editor or menu focused?}
  E -->|no| Z
  E -->|yes| F[show pencil]
```

**Why `menuHasFocus`?**
- Tab moves focus from the cell → pencil button
- Editor blurs first
- Without tracking menu focus, the pencil would disappear as soon as you Tab away

---

### 3. Tab key + focus bridge

**Problem:** React owns the pencil DOM. TipTap owns keyboard shortcuts. They need to talk.

**Solution:** `tableBubbleMenuFocus.ts`

```
React hook registers focus fn  →  stored in WeakMap  →  IsomerTable Tab calls it
```

```mermaid
sequenceDiagram
  participant User
  participant IsomerTable
  participant Bridge as tableBubbleMenuFocus
  participant React

  User->>IsomerTable: Tab
  IsomerTable->>Bridge: focusTableBubbleMenuTrigger
  Bridge->>React: call registered fn
  React->>User: focus pencil
```

- `IsomerTable` (in `constants.ts`) overrides Tab so focus goes to the pencil instead of the next cell
- `onMouseDown preventDefault` on the pencil = clicking it won't kill your cell selection

---

### 4. Where the pencil sits

- Anchored to the **bottom-right corner** of the selected block
- Multi-cell selection → bottom-right cell of the rectangle

```
  ┌───────┬───────┐
  │ sel   │ sel   │
  ├───────┼───────┤
  │ sel   │ sel ● │  ← anchor here
  └───────┴───────┘
                    [pencil]
```

**Position hook does:**
- Find bottom-right cell
- Read its screen position (`getBoundingClientRect`)
- Place the Portal so the pencil center hits that corner
- Re-run on scroll/resize (Floating UI + extra scroll listener)

**Why extra scroll listener?**
- Editor scrolls inside its own container, not the whole page
- Default behavior only watched `window` scroll → menu got stuck (fixed in commit `0f9ae0795`)

**Portal timing:**
- Menu renders in a Portal (outside normal DOM tree) → mounts async
- Hidden until position is calculated (`visibility: hidden`)

```mermaid
flowchart LR
  A[Selection] --> B[Find bottom-right cell]
  B --> C[Compute x/y]
  C --> D[Place Portal]
  E[Scroll or resize] --> C
```

---

### 5. Click pencil → actions

- `isActivated` = action panel open or closed
- Resets when selection changes or menu hides

**Actions by selection type:**

| Selection | What you get |
|-----------|--------------|
| Row | Header toggle, add/move/delete row |
| Column | Header toggle, add/move/delete column |
| Whole table | Delete table |
| Multiple cells | Merge |
| Merged cell | Split |

**Move row/column:**
- TipTap's move command clears selection afterward
- We call `restoreMovedBlockSelection` so the menu stays open

**Header safety:**
- Can't delete or move a row/column that includes a header
- Must turn off header first
- Stops you from accidentally leaving a table with no header row/column

---

## Why it's built this way

| Decision | Reason |
|----------|--------|
| Custom scroll tracking | Editor has its own scroll area; window-only tracking left menu in wrong place |
| WeakMap for focus (not TipTap storage) | React holds the real button ref; TipTap just asks "focus the trigger" on Tab |
| `SelectionKind` labels | Raw editor state is messy; named kinds keep the action list simple |
| Hide on single-cell cursor | Typing in one cell shouldn't show a floating menu |
| `menuHasFocus` + `relatedTarget` checks | Editor blur fires before menu focus; need to know focus didn't leave entirely |

---

## Files

```
TableBubbleMenu/
├── TableBubbleMenu.tsx           # pencil + popup UI
├── useTableBubbleMenu.ts         # show/hide, activation, focus
├── useTableBubbleMenuPosition.ts # anchor to selection
├── TableBubbleMenu.utils.ts      # selection labels, move math, header checks
├── TableBubbleMenuActions.tsx    # buttons
├── TableBubbleMenu.types.ts      # types
├── tableBubbleMenuFocus.ts       # React ↔ TipTap Tab bridge
└── __tests__/
```

**Also relevant:**
- `hooks/useTextEditor/constants.ts` — `IsomerTable` Tab shortcut

---

## Gotchas

- **Grid bounds are half-open** — `top`/`left` count, `bottom`/`right` don't. Easy to get off-by-one in header detection.
- **Portal mounts late** — `menuEl` can be null on first paint; position effect retries when ref attaches.
- **Drag-select hides menu** — avoids pencil flashing while you're still selecting.
- **Open modal hides menu** — any `[role="dialog"][aria-modal="true"]`.
- **After move, reselect** — or the menu vanishes.
- **Check whole table before row/column** — merged cells can cover multiple grid slots but still be one cell.

---

## Happy path (step by step)

1. Drag to select a full row
2. Kind = `row`, pencil appears
3. Position hook pins it to bottom-right cell
4. Click pencil → action panel opens
5. Click "Delete row" → row gone
6. Selection changed → panel closes

```mermaid
sequenceDiagram
  participant User
  participant Editor
  participant Hook as useTableBubbleMenu
  participant Pos as position hook
  participant UI

  User->>Editor: select row
  Editor->>Hook: CellSelection
  Hook->>Pos: compute position
  Pos->>UI: show pencil
  User->>UI: click pencil
  UI->>User: action panel
  User->>Editor: delete row
  Editor->>Hook: selection changed
  Hook->>UI: close panel
```

---

*Want more detail on positioning math, header rules, or move logic? Just ask.*

<!-- table-bubble-menu-teach:end -->

















<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a contextual bubble menu for table selections in TipTap editors and removes the table commands it supersedes from the legacy toolbars.
- Classifies table selections and exposes selection-specific row, column, header, merge, split, move, and delete actions.
- Adds menu focus bridging, portal positioning, internal-scroll tracking, and browser/unit coverage.
- Retains table insertion and caption settings in the existing toolbars.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR does not appear safe to merge until keyboard users can move from the Table actions trigger into the opened command list.

The prior keyboard-accessibility issue remains: the commands render before the focused trigger, activation does not move focus into the command list, and forward Tab can leave the menu and close it. A thread reply explicitly deferred the fix, so the current implementation still leaves normal keyboard navigation unable to reach the table commands.

**Files Needing Attention:** apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx; apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.tsx | Renders the contextual trigger and action panel, but retains the previously reported keyboard tab-order defect. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts | Controls selection-aware visibility, activation, focus retention, and trigger registration. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx | Implements the selection-specific table command matrix and block-movement actions. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts | Adds selection classification, header-overlap checks, movement plans, and moved-selection restoration. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenuPosition.ts | Positions the portaled menu against the selected table block and tracks scrolling and layout changes. |
| apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts | Extends table keyboard handling so Tab can focus the contextual-menu trigger. |
| apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx | Removes table manipulation commands now supplied by the contextual menu while retaining insertion and settings. |
| apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx | Applies the same legacy table-toolbar cleanup to accordion editors. |

</details>

<sub>Reviews (11): Last reviewed commit: ["chore(rte-table): trim TableBubbleMenu c..."](https://github.com/opengovsg/isomer/commit/74f4375a899f0682bfe1a9f5e8d5a62337647445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50004568)</sub>

<!-- /greptile_comment -->