### PR TITLE
🎀📊 feat(rte-table): add duplicate row/column to TableBubbleMenu

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -101,12 +101,12 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
       },
       {
         // A grid-based size picker when not in a table (insert), or a plain
-        // delete button when a table is selected — see TableSizePicker.
+        // delete button when a table is selected. See TableSizePicker.
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
       // "Table settings" (the caption editor) is the one item from the old
-      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // table toolbar group not yet covered by TableBubbleMenu. Every other
       // action (add/delete row/column, merge, split) moved there already.
       // This stays until the inline TableCaption component replaces it.
       {

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/HorizontalList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/HorizontalList.tsx
@@ -31,7 +31,7 @@ export const MenubarHorizontalList = ({
     return null
   }
   return (
-    // closeOnBlur=false pairs with mousedown preventDefault below — otherwise
+    // closeOnBlur=false pairs with mousedown preventDefault below. Otherwise
     // focus stays in the editor and Chakra dismisses the popover immediately.
     <Popover placement="bottom" closeOnBlur={false} isLazy>
       {({ isOpen, onClose }) => (

--- a/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/MenubarItem/OverflowList.tsx
@@ -26,8 +26,8 @@ export const MenubarOverflowList = ({
   }
   return (
     // TipTap toolbar pattern: preventDefault on mousedown so the trigger
-    // does not steal focus from the editor. Pair with closeOnBlur=false —
-    // otherwise focus never enters the popover and closeOnBlur immediately
+    // does not steal focus from the editor. Pair with closeOnBlur=false.
+    // Otherwise focus never enters the popover and closeOnBlur immediately
     // dismisses (or fights) the open state.
     <Popover placement="bottom" closeOnBlur={false} isLazy>
       {({ isOpen, onClose }) => (

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -151,12 +151,12 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
       },
       {
         // A grid-based size picker when not in a table (insert), or a plain
-        // delete button when a table is selected — see TableSizePicker.
+        // delete button when a table is selected. See TableSizePicker.
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
       // "Table settings" (the caption editor) is the one item from the old
-      // table toolbar group not yet covered by TableBubbleMenu — every other
+      // table toolbar group not yet covered by TableBubbleMenu. Every other
       // action (add/delete row/column, merge, split) moved there already.
       // This stays until the inline TableCaption component replaces it.
       {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
@@ -19,7 +19,7 @@ import {
  * Duplicate selected rows/columns with cell content preserved.
  *
  * prosemirror-tables (via `@tiptap/pm/tables`) ships `addRow` / `addColumn` but
- * no duplicate — those commands insert empty cells (`createAndFill`). The insert
+ * no duplicate. Those commands insert empty cells (`createAndFill`). The insert
  * loops below mirror that package's TableMap handling; we reference source content
  * instead and flatten merges along the duplicate axis.
  *
@@ -214,7 +214,7 @@ const selectBlockAndDispatch = ({
   }
   editor.view.dispatch(tr)
   // Unlike every sibling action, this dispatches its own transaction instead
-  // of `.chain().focus()...run()` — restore focus explicitly so a real
+  // of `.chain().focus()...run()`. Restore focus explicitly so a real
   // mousedown-triggered blur doesn't strand it on the button.
   editor.commands.focus()
 }

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
@@ -1,0 +1,451 @@
+import type { Node } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
+import type { Editor } from "@tiptap/react"
+import {
+  addColSpan,
+  CellSelection,
+  isInTable,
+  selectedRect,
+  TableMap,
+  tableNodeTypes,
+} from "@tiptap/pm/tables"
+
+import {
+  selectionIncludesHeaderColumn,
+  selectionIncludesHeaderRow,
+} from "./TableBubbleMenu.utils"
+
+/**
+ * Duplicate selected rows/columns with cell content preserved.
+ *
+ * prosemirror-tables (via `@tiptap/pm/tables`) ships `addRow` / `addColumn` but
+ * no duplicate — those commands insert empty cells (`createAndFill`). The insert
+ * loops below mirror that package's TableMap handling; we reference source content
+ * instead and flatten merges along the duplicate axis.
+ *
+ * @see https://github.com/ProseMirror/prosemirror-tables/blob/v1.8.5/src/commands.ts
+ *      (`addRow`, `addColumn`)
+ */
+
+interface TableInfo {
+  map: TableMap
+  tableStart: number
+  table: Node
+}
+
+interface ResolvedCell {
+  pos: number
+  node: Node
+}
+
+type SelectionRect = ReturnType<typeof selectedRect>
+
+const tableInfoAt = ({
+  tr,
+  tablePos,
+}: {
+  tr: Transaction
+  tablePos: number
+}): TableInfo | null => {
+  const table = tr.doc.nodeAt(tablePos)
+  if (!table) return null
+  return {
+    table,
+    tableStart: tablePos + 1,
+    map: TableMap.get(table),
+  }
+}
+
+const resolveCell = ({
+  table,
+  map,
+  index,
+}: {
+  table: Node
+  map: TableMap
+  index: number
+}): ResolvedCell | null => {
+  const pos = map.map[index]
+  if (pos === undefined) return null
+  const node = table.nodeAt(pos)
+  if (!node) return null
+  return { pos, node }
+}
+
+const isSlotCoveredFromRowAbove = ({
+  map,
+  insertAt,
+  col,
+}: {
+  map: TableMap
+  insertAt: number
+  col: number
+}): boolean => {
+  const insertIndex = insertAt * map.width + col
+  return (
+    insertAt > 0 &&
+    insertAt < map.height &&
+    map.map[insertIndex] === map.map[insertIndex - map.width]
+  )
+}
+
+const isSlotCoveredFromColumnLeft = ({
+  map,
+  row,
+  insertAt,
+}: {
+  map: TableMap
+  row: number
+  insertAt: number
+}): boolean => {
+  const insertIndex = row * map.width + insertAt
+  return (
+    insertAt > 0 &&
+    insertAt < map.width &&
+    map.map[insertIndex - 1] === map.map[insertIndex]
+  )
+}
+
+const isSourceRowOwned = ({
+  map,
+  sourcePos,
+  sourceRow,
+}: {
+  map: TableMap
+  sourcePos: number
+  sourceRow: number
+}): boolean => map.findCell(sourcePos).top === sourceRow
+
+const isSourceColumnOwned = ({
+  map,
+  sourcePos,
+  sourceCol,
+}: {
+  map: TableMap
+  sourcePos: number
+  sourceCol: number
+}): boolean => map.findCell(sourcePos).left === sourceCol
+
+const placeholderCell = (sourceCell: Node): Node | null =>
+  sourceCell.type.createAndFill({
+    ...sourceCell.attrs,
+    rowspan: 1,
+    colspan: 1,
+    colwidth: null,
+  })
+
+const cloneCellForRowDuplicate = (sourceCell: Node): Node =>
+  sourceCell.type.create(
+    { ...sourceCell.attrs, rowspan: 1 },
+    sourceCell.content,
+  )
+
+const cloneCellForColumnDuplicate = (sourceCell: Node): Node => {
+  const colwidth = sourceCell.attrs.colwidth as number[] | null
+  return sourceCell.type.create(
+    {
+      ...sourceCell.attrs,
+      colspan: 1,
+      colwidth: colwidth ? [colwidth[0] ?? 0] : null,
+    },
+    sourceCell.content,
+  )
+}
+
+const expandRowspan = ({
+  tr,
+  tableStart,
+  cell,
+}: {
+  tr: Transaction
+  tableStart: number
+  cell: ResolvedCell
+}): void => {
+  tr.setNodeMarkup(tableStart + cell.pos, null, {
+    ...cell.node.attrs,
+    rowspan: (cell.node.attrs.rowspan as number) + 1,
+  })
+}
+
+const expandColspan = ({
+  tr,
+  tableStart,
+  map,
+  cell,
+  insertAt,
+}: {
+  tr: Transaction
+  tableStart: number
+  map: TableMap
+  cell: ResolvedCell
+  insertAt: number
+}): void => {
+  tr.setNodeMarkup(
+    tableStart + cell.pos,
+    null,
+    addColSpan(
+      cell.node.attrs as Parameters<typeof addColSpan>[0],
+      insertAt - map.colCount(cell.pos),
+    ),
+  )
+}
+
+const selectBlockAndDispatch = ({
+  editor,
+  tr,
+  tablePos,
+  corners,
+}: {
+  editor: Editor
+  tr: Transaction
+  tablePos: number
+  corners: (info: TableInfo) => { anchor: number; head: number }
+}): void => {
+  const info = tableInfoAt({ tr, tablePos })
+  if (info) {
+    const { anchor, head } = corners(info)
+    tr.setSelection(
+      CellSelection.create(
+        tr.doc,
+        info.tableStart + anchor,
+        info.tableStart + head,
+      ),
+    )
+  }
+  editor.view.dispatch(tr)
+  // Unlike every sibling action, this dispatches its own transaction instead
+  // of `.chain().focus()...run()` — restore focus explicitly so a real
+  // mousedown-triggered blur doesn't strand it on the button.
+  editor.commands.focus()
+}
+
+// Same TableMap loop as prosemirror-tables `addRow`, but references source content.
+const insertDuplicateRow = ({
+  tr,
+  info: { map, tableStart, table },
+  sourceRow,
+  insertAt,
+}: {
+  tr: Transaction
+  info: TableInfo
+  sourceRow: number
+  insertAt: number
+}): Transaction => {
+  let rowPos = tableStart
+  for (let i = 0; i < insertAt; i++) {
+    rowPos += table.child(i).nodeSize
+  }
+
+  const cells: Node[] = []
+  for (let col = 0; col < map.width;) {
+    if (isSlotCoveredFromRowAbove({ map, insertAt, col })) {
+      const resolved = resolveCell({
+        table,
+        map,
+        index: insertAt * map.width + col,
+      })
+      if (!resolved) {
+        col += 1
+        continue
+      }
+      expandRowspan({ tr, tableStart, cell: resolved })
+      col += resolved.node.attrs.colspan as number
+      continue
+    }
+
+    const resolvedSource = resolveCell({
+      table,
+      map,
+      index: sourceRow * map.width + col,
+    })
+    if (!resolvedSource) {
+      col += 1
+      continue
+    }
+    const { node: sourceCell, pos: sourcePos } = resolvedSource
+
+    if (!isSourceRowOwned({ map, sourcePos, sourceRow })) {
+      const cell = placeholderCell(sourceCell)
+      if (cell) cells.push(cell)
+      col += 1
+      continue
+    }
+
+    cells.push(cloneCellForRowDuplicate(sourceCell))
+    col += sourceCell.attrs.colspan as number
+  }
+
+  tr.insert(rowPos, tableNodeTypes(table.type.schema).row.create(null, cells))
+  return tr
+}
+
+// Same TableMap loop as prosemirror-tables `addColumn`, but references source content.
+// Refreshes the map each row because column inserts shift later positions.
+const insertDuplicateColumn = ({
+  tr,
+  tablePos,
+  sourceCol,
+  insertAt,
+}: {
+  tr: Transaction
+  tablePos: number
+  sourceCol: number
+  insertAt: number
+}): boolean => {
+  let row = 0
+
+  while (true) {
+    const info = tableInfoAt({ tr, tablePos })
+    if (!info) return false
+
+    const { map, tableStart, table } = info
+    if (row >= map.height) return true
+
+    if (isSlotCoveredFromColumnLeft({ map, row, insertAt })) {
+      const resolved = resolveCell({
+        table,
+        map,
+        index: row * map.width + insertAt,
+      })
+      if (!resolved) {
+        row += 1
+        continue
+      }
+      expandColspan({ tr, tableStart, map, cell: resolved, insertAt })
+      row += resolved.node.attrs.rowspan as number
+      continue
+    }
+
+    const resolvedSource = resolveCell({
+      table,
+      map,
+      index: row * map.width + sourceCol,
+    })
+    if (!resolvedSource) {
+      row += 1
+      continue
+    }
+    const { node: sourceCell, pos: sourcePos } = resolvedSource
+    const insertPos = map.positionAt(row, insertAt, table)
+    const rowspan = sourceCell.attrs.rowspan as number
+
+    if (!isSourceColumnOwned({ map, sourcePos, sourceCol })) {
+      const cell = placeholderCell(sourceCell)
+      if (cell) {
+        tr.insert(tableStart + insertPos, cell)
+      }
+      row += 1
+      continue
+    }
+
+    tr.insert(tableStart + insertPos, cloneCellForColumnDuplicate(sourceCell))
+    row += rowspan
+  }
+}
+
+const duplicateSelectedBlock = ({
+  editor,
+  rect,
+  span,
+  mutate,
+  selectCorners,
+}: {
+  editor: Editor
+  rect: SelectionRect
+  span: number
+  mutate: (args: { tr: Transaction; tablePos: number }) => Transaction | false
+  selectCorners: (args: { info: TableInfo; rect: SelectionRect }) => {
+    anchor: number
+    head: number
+  }
+}): void => {
+  if (span <= 0) return
+
+  const tablePos = rect.tableStart - 1
+  const result = mutate({ tr: editor.state.tr, tablePos })
+  if (result === false) return
+
+  selectBlockAndDispatch({
+    editor,
+    tr: result,
+    tablePos,
+    corners: (info) => selectCorners({ info, rect }),
+  })
+}
+
+export const duplicateSelectedRows = (editor: Editor): void => {
+  if (!isInTable(editor.state)) return
+
+  const rect = selectedRect(editor.state)
+  if (selectionIncludesHeaderRow(rect)) return
+  const span = rect.bottom - rect.top
+
+  duplicateSelectedBlock({
+    editor,
+    rect,
+    span,
+    mutate: ({ tr, tablePos }) => {
+      let next = tr
+      for (
+        let sourceRow = rect.bottom - 1;
+        sourceRow >= rect.top;
+        sourceRow--
+      ) {
+        const info = tableInfoAt({ tr: next, tablePos })
+        if (!info) return false
+        next = insertDuplicateRow({
+          tr: next,
+          info,
+          sourceRow,
+          insertAt: rect.bottom,
+        })
+      }
+      return next
+    },
+    selectCorners: ({ info, rect: selectionRect }) => ({
+      anchor: info.map.positionAt(selectionRect.bottom, 0, info.table),
+      head: info.map.positionAt(
+        selectionRect.bottom + span - 1,
+        info.map.width - 1,
+        info.table,
+      ),
+    }),
+  })
+}
+
+export const duplicateSelectedColumns = (editor: Editor): void => {
+  if (!isInTable(editor.state)) return
+
+  const rect = selectedRect(editor.state)
+  if (selectionIncludesHeaderColumn(rect)) return
+  const span = rect.right - rect.left
+
+  duplicateSelectedBlock({
+    editor,
+    rect,
+    span,
+    mutate: ({ tr, tablePos }) => {
+      for (let i = 0; i < span; i++) {
+        if (
+          !insertDuplicateColumn({
+            tr,
+            tablePos,
+            sourceCol: rect.left + i,
+            insertAt: rect.right + i,
+          })
+        ) {
+          return false
+        }
+      }
+      return tr
+    },
+    selectCorners: ({ info, rect: selectionRect }) => ({
+      anchor: info.map.positionAt(
+        info.map.height - 1,
+        selectionRect.right,
+        info.table,
+      ),
+      head: info.map.positionAt(0, selectionRect.right + span - 1, info.table),
+    }),
+  })
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -4,6 +4,7 @@ import { Flex, Text, VStack } from "@chakra-ui/react"
 import { Button, Switch } from "@opengovsg/design-system-react"
 import { moveTableColumn, moveTableRow, selectedRect } from "@tiptap/pm/tables"
 import {
+  BiCopy,
   BiDownArrowAlt,
   BiLeftArrowAlt,
   BiRightArrowAlt,
@@ -26,6 +27,10 @@ import type {
   TableMoveAxis,
   TableMovePlan,
 } from "./TableBubbleMenu.types"
+import {
+  duplicateSelectedColumns,
+  duplicateSelectedRows,
+} from "./TableBubbleMenu.duplicate"
 import {
   getColumnMovePlan,
   getRowMovePlan,
@@ -173,6 +178,13 @@ const RowSelectionActions = ({
         icon={<IconAddRowBelow boxSize="1rem" />}
         onClick={() => editor.chain().focus().addRowAfter().run()}
       />
+      {!includesHeader && (
+        <ActionButton
+          label="Duplicate row"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedRows(editor)}
+        />
+      )}
       {rowMoveUpPlan && !includesHeader && (
         <ActionButton
           label="Move up"
@@ -237,6 +249,13 @@ const ColumnSelectionActions = ({
         icon={<IconAddColRight boxSize="1rem" />}
         onClick={() => editor.chain().focus().addColumnAfter().run()}
       />
+      {!includesHeader && (
+        <ActionButton
+          label="Duplicate column"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedColumns(editor)}
+        />
+      )}
       {columnMoveLeftPlan && !includesHeader && (
         <ActionButton
           label="Move left"

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -4,6 +4,7 @@ import { Flex, Text, VStack } from "@chakra-ui/react"
 import { Button, Switch } from "@opengovsg/design-system-react"
 import { moveTableColumn, moveTableRow, selectedRect } from "@tiptap/pm/tables"
 import {
+  BiCopy,
   BiDownArrowAlt,
   BiLeftArrowAlt,
   BiRightArrowAlt,
@@ -26,6 +27,10 @@ import type {
   TableMoveAxis,
   TableMovePlan,
 } from "./TableBubbleMenu.types"
+import {
+  duplicateSelectedColumns,
+  duplicateSelectedRows,
+} from "./TableBubbleMenu.duplicate"
 import {
   getColumnMovePlan,
   getRowMovePlan,
@@ -168,6 +173,13 @@ const RowSelectionActions = ({
         icon={<IconAddRowBelow boxSize="1rem" />}
         onClick={() => editor.chain().focus().addRowAfter().run()}
       />
+      {!includesHeader && (
+        <ActionButton
+          label="Duplicate row"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedRows(editor)}
+        />
+      )}
       {rowMoveUpPlan && !includesHeader && (
         <ActionButton
           label="Move up"
@@ -233,6 +245,13 @@ const ColumnSelectionActions = ({
         icon={<IconAddColRight boxSize="1rem" />}
         onClick={() => editor.chain().focus().addColumnAfter().run()}
       />
+      {!includesHeader && (
+        <ActionButton
+          label="Duplicate column"
+          icon={<BiCopy fontSize="1rem" />}
+          onClick={() => duplicateSelectedColumns(editor)}
+        />
+      )}
       {columnMoveLeftPlan && !includesHeader && (
         <ActionButton
           label="Move left"

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -13,6 +13,10 @@ import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor
 import { theme } from "~/theme"
 
 import { TableBubbleMenu } from "../TableBubbleMenu"
+import {
+  duplicateSelectedColumns,
+  duplicateSelectedRows,
+} from "../TableBubbleMenu.duplicate"
 
 const createSeedTable = (caption: string): JSONContent => ({
   type: "table",
@@ -134,15 +138,19 @@ const expectKeyboardActivationOpensMenu = async ({
   queryByText: (text: string) => HTMLElement | null
   activationKey: "{Enter}" | "{Space}"
 }) => {
+  // Arrange
   selectCells(editor, 3, 5)
   const trigger = await tabToTableActionsTrigger(editor, findByRole)
 
+  // Assert — pre-activation
   expect(trigger).toBeTruthy()
   expect(document.activeElement).toBe(trigger)
   expect(queryByText("Delete row")).toBeNull()
 
+  // Act
   await userEvent.keyboard(activationKey)
 
+  // Assert
   expect(editor.view.dom.contains(document.activeElement)).toBe(true)
   expect(await findByText("Delete row")).toBeTruthy()
 }
@@ -216,20 +224,74 @@ const firstRowTexts = (editor: Editor): string[] => {
   return texts
 }
 
+// Cell text contents for the nth table row (0-indexed), left-to-right.
+const rowTextsAt = (editor: Editor, rowIndex: number): string[] => {
+  const texts: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    const row = node.child(rowIndex)
+    row.forEach((cell) => {
+      texts.push(cell.textContent)
+    })
+    return false
+  })
+  return texts
+}
+
+const tableRowCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.childCount
+    return false
+  })
+  return count
+}
+
+const tableColumnCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.child(0).childCount
+    return false
+  })
+  return count
+}
+
+const rowCellCount = (editor: Editor, rowIndex: number): number => {
+  let count = 0
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    count = node.child(rowIndex).childCount
+    return false
+  })
+  return count
+}
+
 describe("TableBubbleMenu", () => {
   afterEach(() => {
     cleanup()
   })
 
   it("shows row actions (including Delete row) when a body row is selected", async () => {
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
-
     selectCells(editor, 3, 5) // the full body row (not the first row)
+
+    // Act
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(queryByText("Header row")).toBeNull()
     expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Duplicate row")).toBeTruthy()
     expect(await findByText("Move up")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
     expect(await findByText("Delete row")).toBeTruthy()
@@ -238,99 +300,307 @@ describe("TableBubbleMenu", () => {
   it("shows Header row/column only for the exact top row / leftmost column", async () => {
     const { editor, findByRole, queryByRole } = await renderHarness()
 
-    // Body row — not the top row
+    // Arrange — body row, not the top row
     selectCells(editor, 3, 5)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
 
-    // Exact header / top row
+    // Arrange — exact header / top row
     selectCells(editor, 0, 2)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(await findByRole("checkbox", { name: "Header row" })).toBeChecked()
 
-    // Top row + body row — overlaps the top row but is not exactly it
+    // Arrange — top row + body row (overlaps top row but is not exactly it)
     selectCells(editor, 0, 5)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
 
-    // Middle column — not the leftmost column
+    // Arrange — middle column, not the leftmost column
     selectCells(editor, 1, 7)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
 
-    // Exact leftmost column
+    // Arrange — exact leftmost column
     selectCells(editor, 0, 6)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).not.toBeChecked()
 
-    // Leftmost + next column — overlaps leftmost but is not exactly it
+    // Arrange — leftmost + next column (overlaps leftmost but is not exactly it)
     selectCells(editor, 0, 7)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
   })
 
   it("moves a multi-column selection as a block (A,B → right becomes C,A,B)", async () => {
+    // Arrange
     const { editor, findByText, findByRole } = await renderHarness()
-
-    // Full columns A+B
-    selectCells(editor, 0, 7)
+    selectCells(editor, 0, 7) // full columns A+B
     await activateTableBubbleMenu(findByRole)
     expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
-
     const moveRight = await findByText("Move right")
+
+    // Act
     act(() => {
       moveRight.click()
     })
 
+    // Assert
     expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
+  })
+
+  it("duplicates a body row immediately below with the same cell content", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 5) // first body row: cells 3–5 ("Row 1, A/B/C")
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert
+    expect(tableRowCount(editor)).toBe(4)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a multi-row selection as a contiguous block", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 8) // both body rows: cells 3–8
+    expect(tableRowCount(editor)).toBe(3)
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert
+    expect(tableRowCount(editor)).toBe(5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 4)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a column immediately to the right with the same cell content", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 1, 7) // column B: header cell 1 + body cells 4 and 7
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert
+    expect(tableColumnCount(editor)).toBe(4)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column B",
+      "Column C",
+    ])
+    expect(rowTextsAt(editor, 1)).toEqual([
+      "Row 1, A",
+      "Row 1, B",
+      "Row 1, B",
+      "Row 1, C",
+    ])
+  })
+
+  it("duplicates a multi-column selection as a contiguous block", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 0, 7) // columns A+B
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert
+    expect(tableColumnCount(editor)).toBe(5)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column A",
+      "Column B",
+      "Column C",
+    ])
+  })
+
+  it("duplicates a row that contains a horizontal merge", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 4)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    const sourceRowTexts = rowTextsAt(editor, 1)
+    expect(rowCellCount(editor, 1)).toBe(2)
+    selectCells(editor, 3, 4)
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert
+    expect(tableRowCount(editor)).toBe(4)
+    expect(rowCellCount(editor, 1)).toBe(2)
+    expect(rowCellCount(editor, 2)).toBe(2)
+    expect(rowTextsAt(editor, 1)).toEqual(sourceRowTexts)
+    expect(rowTextsAt(editor, 2)).toEqual(sourceRowTexts)
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a column that contains a vertical merge", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 6)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(rowCellCount(editor, 1)).toBe(3)
+    expect(rowCellCount(editor, 2)).toBe(2)
+    selectCells(editor, 0, 3)
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert
+    expect(tableColumnCount(editor)).toBe(4)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column A",
+      "Column B",
+      "Column C",
+    ])
+    expect(rowCellCount(editor, 1)).toBe(4)
+    expect(rowCellCount(editor, 2)).toBe(2)
+
+    const [originalMerged, duplicatedMerged] = rowTextsAt(editor, 1)
+    expect(duplicatedMerged).toBe(originalMerged)
+    expect(originalMerged).toContain("Row 1, A")
+    expect(originalMerged).toContain("Row 2, A")
+  })
+
+  it("withholds Duplicate row for header row selections", async () => {
+    // Arrange
+    const { editor, findByRole, queryByText } = await renderHarness()
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+
+    // Assert — menu
+    expect(queryByText("Duplicate row")).toBeNull()
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert — table unchanged
+    expect(tableRowCount(editor)).toBe(3)
+  })
+
+  it("withholds Duplicate column for header column selections", async () => {
+    // Arrange
+    const { editor, findByRole, queryByText } = await renderHarness()
+    act(() => {
+      editor.chain().focus().toggleHeaderColumn().run()
+    })
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+
+    // Assert — menu
+    expect(queryByText("Duplicate column")).toBeNull()
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert — table unchanged
+    expect(tableColumnCount(editor)).toBe(3)
   })
 
   it("withholds Add above, Delete and Move when selection includes header row", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    selectCells(editor, 0, 2) // the full header row
+    // Arrange — full header row
+    selectCells(editor, 0, 2)
+    // Act
     await activateTableBubbleMenu(findByRole)
-
+    // Assert
     const headerToggle = await findByRole("checkbox", { name: "Header row" })
     expect(headerToggle).toBeChecked()
     expect(queryByText("Add row above")).toBeNull()
     expect(await findByText("Add row below")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Duplicate row")).toBeNull()
     expect(queryByText("Move up")).toBeNull()
     expect(queryByText("Move down")).toBeNull()
 
+    // Arrange — header row + body row
     selectCells(editor, 0, 5)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
     expect(queryByText("Add row above")).toBeNull()
     expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Duplicate row")).toBeNull()
     expect(queryByText("Move up")).toBeNull()
     expect(queryByText("Move down")).toBeNull()
   })
 
   it("refreshes row actions when header row is toggled off without reselecting", async () => {
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
-
     selectCells(editor, 0, 2)
     await activateTableBubbleMenu(findByRole)
-
     const headerToggle = await findByRole("checkbox", { name: "Header row" })
     expect(headerToggle).toBeChecked()
     expect(queryByText("Delete row")).toBeNull()
 
+    // Act
     act(() => {
       headerToggle.click()
     })
 
+    // Assert
     await waitFor(() => {
       expect(headerToggle).not.toBeChecked()
     })
     expect(await findByText("Add row above")).toBeTruthy()
     expect(await findByText("Delete row")).toBeTruthy()
+    expect(await findByText("Duplicate row")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
   })
 
@@ -338,51 +608,64 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Seed table has a header row only — leftmost column is still deletable.
+    // Arrange — leftmost column before header column is enabled
     selectCells(editor, 0, 6)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).not.toBeChecked()
     expect(await findByText("Delete column")).toBeTruthy()
     expect(await findByText("Move right")).toBeTruthy()
 
+    // Arrange — enable header column; same cell range stays selected, so the
+    // menu (already open from above) refreshes in place without reactivating.
     act(() => {
       editor.chain().focus().toggleHeaderColumn().run()
     })
-
-    selectCells(editor, 0, 6) // header column alone
+    // Assert
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).toBeChecked()
     expect(queryByText("Add column left")).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
+    expect(queryByText("Duplicate column")).toBeNull()
     expect(queryByText("Move left")).toBeNull()
     expect(queryByText("Move right")).toBeNull()
 
+    // Arrange — header column + next column
     selectCells(editor, 0, 7)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
+    expect(queryByText("Duplicate column")).toBeNull()
     expect(queryByText("Move left")).toBeNull()
     expect(queryByText("Move right")).toBeNull()
   })
 
   it("shows only Merge cells for an irregular multi-cell selection", async () => {
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
+    selectCells(editor, 3, 7) // irregular 2x2-ish block, not a full row/column
 
-    selectCells(editor, 3, 7) // an irregular 2x2-ish block, not a full row/column
+    // Act
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(await findByText("Merge cells")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
   })
 
   it("shows no menu content for a plain cursor outside any selection", async () => {
+    // Arrange / Act
     const { queryByText, queryByRole } = await renderHarness()
 
+    // Assert
     expect(queryByText("Delete table")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
     expect(queryByText("Add row above")).toBeNull()
@@ -395,6 +678,7 @@ describe("TableBubbleMenu", () => {
   ])(
     "keeps the trigger mounted when tabbing to it and opens the menu with $label",
     async ({ activationKey }) => {
+      // Arrange / Act / Assert
       const { editor, findByRole, findByText, queryByText } =
         await renderHarness()
 
@@ -409,6 +693,7 @@ describe("TableBubbleMenu", () => {
   )
 
   it("deactivates when tabbing from the trigger through menu controls to outside", async () => {
+    // Arrange
     const { editor, findByRole, findByText, queryByText, queryByRole } =
       await renderHarness()
     selectCells(editor, 3, 5)
@@ -426,6 +711,7 @@ describe("TableBubbleMenu", () => {
     document.body.appendChild(outside)
 
     try {
+      // Act
       for (
         let tabs = 0;
         tabs < 30 && document.activeElement !== outside;
@@ -434,9 +720,8 @@ describe("TableBubbleMenu", () => {
         await userEvent.tab()
       }
 
+      // Assert
       expect(document.activeElement).toBe(outside)
-      // Focus has left the trigger, the menu, and the editor entirely, so
-      // both the action list and the now-irrelevant pencil trigger hide.
       await waitFor(() => {
         expect(queryByRole("button", { name: "Table actions" })).toBeNull()
       })
@@ -449,22 +734,25 @@ describe("TableBubbleMenu", () => {
   })
 
   it("shows the pencil trigger without the action menu until it is activated", async () => {
+    // Arrange
     const { editor, findByRole, findByText, queryByText } =
       await renderHarness()
-
     selectCells(editor, 3, 5)
-
     const trigger = await findByRole("button", { name: "Table actions" })
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
 
+    // Act — open menu
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(trigger).toHaveAttribute("aria-pressed", "true")
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act — close menu
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
   })
@@ -473,34 +761,38 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Merge two adjacent body cells into one, then re-select just that
-    // resulting cell — the only single-cell case with a bubble menu.
+    // Arrange — merge two adjacent body cells, then re-select the result
     selectCells(editor, 3, 4)
     act(() => {
       editor.chain().focus().mergeCells().run()
     })
     selectCells(editor, 3, 3)
+
+    // Act
     await activateTableBubbleMenu(findByRole)
 
+    // Assert — merged single cell
     expect(await findByText("Split cell")).toBeTruthy()
     expect(queryByText("Merge cells")).toBeNull()
 
-    // An ordinary (never-merged) single cell still shows no menu at all.
+    // Arrange / Act — ordinary single cell
     selectCells(editor, 6, 6)
+
+    // Assert — no menu
     expect(queryByText("Split cell")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
     expect(queryByRole("button", { name: "Table actions" })).toBeNull()
   })
 
   it("hides when focus moves outside the editor (e.g. Table Settings modal)", async () => {
-    // TipTap's blur handler hides the menu when focus leaves the editor.
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
-
     selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act
     act(() => {
       const outside = document.createElement("button")
       outside.type = "button"
@@ -512,51 +804,55 @@ describe("TableBubbleMenu", () => {
       outside.focus()
     })
 
+    // Assert
     await waitFor(() => {
       expect(queryByText("Delete row")).toBeNull()
     })
   })
 
   it("stays hidden while a cell drag-select is in progress, then shows after it commits", async () => {
-    // prosemirror-tables sets `tableEditingKey` for the duration of a cell
-    // drag (mousemove) and clears it on mouseup. The menu must not appear for
-    // intermediate selection rects during that window.
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
 
+    // Arrange
     selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act — start cell drag
     act(() => {
       editor.view.dispatch(
         editor.state.tr.setMeta(tableEditingKey, nthCellPos(editor, 3)),
       )
     })
+
+    // Assert — menu hidden during drag
     await waitFor(() => {
       expect(queryByText("Delete row")).toBeNull()
     })
-
-    // Intermediate selection expansion while still "dragging"
     selectCells(editor, 3, 7)
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
 
-    // mouseup clears selectingCells state (meta -1 → null)
+    // Act — end cell drag
     act(() => {
       editor.view.dispatch(editor.state.tr.setMeta(tableEditingKey, -1))
     })
     await activateTableBubbleMenu(findByRole)
+
+    // Assert — menu reflects new selection
     expect(await findByText("Merge cells")).toBeTruthy()
   })
 
   it("starts deactivated after remounting with the same editor", async () => {
+    // Arrange
     const { editor, findByRole, findByText, queryByText, setShowMenu } =
       await renderHarness()
     selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act
     act(() => {
       setShowMenu(false)
     })
@@ -564,15 +860,14 @@ describe("TableBubbleMenu", () => {
       setShowMenu(true)
     })
 
+    // Assert
     const trigger = await findByRole("button", { name: "Table actions" })
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
   })
 
   it("repositions the menu when the editor's own scroll container scrolls (not just window)", async () => {
-    // EditorContentWrapper (the real production wrapper) has its own
-    // `overflowY: auto` — scrolling *inside* it must reposition the menu,
-    // not just scrolling the window.
+    // Arrange
     let editor: Editor | undefined
 
     const ScrollingHarness = () => {
@@ -620,26 +915,30 @@ describe("TableBubbleMenu", () => {
       '[data-testid="scroll-parent"]',
     ) as HTMLElement
 
+    // Act
     act(() => {
       scrollParent.scrollTop = 300
       scrollParent.dispatchEvent(new Event("scroll"))
     })
 
+    // Assert
     await waitFor(() => {
       expect(menuEl?.getBoundingClientRect().top).not.toBe(initialTop)
     })
   })
 
   it("keeps one trigger and deactivates when selection moves to another table", async () => {
+    // Arrange
     const { editor, findByRole, findByText, findAllByRole, queryByText } =
       await renderHarness(TWO_TABLES_CONTENT)
-
-    selectCells(editor, 3, 5) // first table, first body row
+    selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
-    selectCells(editor, 12, 14) // second table, first body row
+    // Act
+    selectCells(editor, 12, 14)
 
+    // Assert
     const triggers = await findAllByRole("button", { name: "Table actions" })
     expect(triggers).toHaveLength(1)
     expect(triggers[0]).toHaveAttribute("aria-pressed", "false")

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -1,5 +1,5 @@
 // Renders a real TipTap editor (ProseMirror needs a real DOM to construct an
-// EditorView), so this runs under Vitest Browser Mode rather than jsdom — see
+// EditorView), so this runs under Vitest Browser Mode rather than jsdom. See
 // the `*.browser.test.{ts,tsx}` convention in apps/studio/vitest.config.ts.
 import type { Editor, JSONContent } from "@tiptap/react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
@@ -142,7 +142,7 @@ const expectKeyboardActivationOpensMenu = async ({
   selectCells(editor, 3, 5)
   const trigger = await tabToTableActionsTrigger(editor, findByRole)
 
-  // Assert — pre-activation
+  // Assert: pre-activation
   expect(trigger).toBeTruthy()
   expect(document.activeElement).toBe(trigger)
   expect(queryByText("Delete row")).toBeNull()
@@ -206,7 +206,7 @@ const renderHarness = async (data: JSONContent = SEED_CONTENT) => {
   }
 }
 
-// First-row cell text contents in left-to-right order — used to assert
+// First-row cell text contents in left-to-right order, used to assert
 // column reordering after Move left/right.
 const firstRowTexts = (editor: Editor): string[] => {
   const texts: string[] = []
@@ -300,35 +300,35 @@ describe("TableBubbleMenu", () => {
   it("shows Header row/column only for the exact top row / leftmost column", async () => {
     const { editor, findByRole, queryByRole } = await renderHarness()
 
-    // Arrange — body row, not the top row
+    // Arrange: body row, not the top row
     selectCells(editor, 3, 5)
     // Act
     await activateTableBubbleMenu(findByRole)
     // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
 
-    // Arrange — exact header / top row
+    // Arrange: exact header / top row
     selectCells(editor, 0, 2)
     // Act
     await activateTableBubbleMenu(findByRole)
     // Assert
     expect(await findByRole("checkbox", { name: "Header row" })).toBeChecked()
 
-    // Arrange — top row + body row (overlaps top row but is not exactly it)
+    // Arrange: top row + body row (overlaps top row but is not exactly it)
     selectCells(editor, 0, 5)
     // Act
     await activateTableBubbleMenu(findByRole)
     // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
 
-    // Arrange — middle column, not the leftmost column
+    // Arrange: middle column, not the leftmost column
     selectCells(editor, 1, 7)
     // Act
     await activateTableBubbleMenu(findByRole)
     // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
 
-    // Arrange — exact leftmost column
+    // Arrange: exact leftmost column
     selectCells(editor, 0, 6)
     // Act
     await activateTableBubbleMenu(findByRole)
@@ -337,7 +337,7 @@ describe("TableBubbleMenu", () => {
       await findByRole("checkbox", { name: "Header column" }),
     ).not.toBeChecked()
 
-    // Arrange — leftmost + next column (overlaps leftmost but is not exactly it)
+    // Arrange: leftmost + next column (overlaps leftmost but is not exactly it)
     selectCells(editor, 0, 7)
     // Act
     await activateTableBubbleMenu(findByRole)
@@ -365,7 +365,7 @@ describe("TableBubbleMenu", () => {
   it("duplicates a body row immediately below with the same cell content", async () => {
     // Arrange
     const { editor } = await renderHarness()
-    selectCells(editor, 3, 5) // first body row: cells 3–5 ("Row 1, A/B/C")
+    selectCells(editor, 3, 5) // first body row: cells 3-5 ("Row 1, A/B/C")
     expect(tableRowCount(editor)).toBe(3)
     expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
 
@@ -384,7 +384,7 @@ describe("TableBubbleMenu", () => {
   it("duplicates a multi-row selection as a contiguous block", async () => {
     // Arrange
     const { editor } = await renderHarness()
-    selectCells(editor, 3, 8) // both body rows: cells 3–8
+    selectCells(editor, 3, 8) // both body rows: cells 3-8
     expect(tableRowCount(editor)).toBe(3)
 
     // Act
@@ -515,7 +515,7 @@ describe("TableBubbleMenu", () => {
     selectCells(editor, 0, 2)
     await activateTableBubbleMenu(findByRole)
 
-    // Assert — menu
+    // Assert: menu
     expect(queryByText("Duplicate row")).toBeNull()
 
     // Act
@@ -523,7 +523,7 @@ describe("TableBubbleMenu", () => {
       duplicateSelectedRows(editor)
     })
 
-    // Assert — table unchanged
+    // Assert: table unchanged
     expect(tableRowCount(editor)).toBe(3)
   })
 
@@ -536,7 +536,7 @@ describe("TableBubbleMenu", () => {
     selectCells(editor, 0, 6)
     await activateTableBubbleMenu(findByRole)
 
-    // Assert — menu
+    // Assert: menu
     expect(queryByText("Duplicate column")).toBeNull()
 
     // Act
@@ -544,7 +544,7 @@ describe("TableBubbleMenu", () => {
       duplicateSelectedColumns(editor)
     })
 
-    // Assert — table unchanged
+    // Assert: table unchanged
     expect(tableColumnCount(editor)).toBe(3)
   })
 
@@ -552,7 +552,7 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Arrange — full header row
+    // Arrange: full header row
     selectCells(editor, 0, 2)
     // Act
     await activateTableBubbleMenu(findByRole)
@@ -566,7 +566,7 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Move up")).toBeNull()
     expect(queryByText("Move down")).toBeNull()
 
-    // Arrange — header row + body row
+    // Arrange: header row + body row
     selectCells(editor, 0, 5)
     // Act
     await activateTableBubbleMenu(findByRole)
@@ -608,7 +608,7 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Arrange — leftmost column before header column is enabled
+    // Arrange: leftmost column before header column is enabled
     selectCells(editor, 0, 6)
     // Act
     await activateTableBubbleMenu(findByRole)
@@ -619,7 +619,7 @@ describe("TableBubbleMenu", () => {
     expect(await findByText("Delete column")).toBeTruthy()
     expect(await findByText("Move right")).toBeTruthy()
 
-    // Arrange — enable header column; same cell range stays selected, so the
+    // Arrange: enable header column; same cell range stays selected, so the
     // menu (already open from above) refreshes in place without reactivating.
     act(() => {
       editor.chain().focus().toggleHeaderColumn().run()
@@ -634,7 +634,7 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Move left")).toBeNull()
     expect(queryByText("Move right")).toBeNull()
 
-    // Arrange — header column + next column
+    // Arrange: header column + next column
     selectCells(editor, 0, 7)
     // Act
     await activateTableBubbleMenu(findByRole)
@@ -742,14 +742,14 @@ describe("TableBubbleMenu", () => {
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
 
-    // Act — open menu
+    // Act: open menu
     await activateTableBubbleMenu(findByRole)
 
     // Assert
     expect(trigger).toHaveAttribute("aria-pressed", "true")
     expect(await findByText("Delete row")).toBeTruthy()
 
-    // Act — close menu
+    // Act: close menu
     await activateTableBubbleMenu(findByRole)
 
     // Assert
@@ -761,7 +761,7 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Arrange — merge two adjacent body cells, then re-select the result
+    // Arrange: merge two adjacent body cells, then re-select the result
     selectCells(editor, 3, 4)
     act(() => {
       editor.chain().focus().mergeCells().run()
@@ -771,14 +771,14 @@ describe("TableBubbleMenu", () => {
     // Act
     await activateTableBubbleMenu(findByRole)
 
-    // Assert — merged single cell
+    // Assert: merged single cell
     expect(await findByText("Split cell")).toBeTruthy()
     expect(queryByText("Merge cells")).toBeNull()
 
-    // Arrange / Act — ordinary single cell
+    // Arrange / Act: ordinary single cell
     selectCells(editor, 6, 6)
 
-    // Assert — no menu
+    // Assert: no menu
     expect(queryByText("Split cell")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
     expect(queryByRole("button", { name: "Table actions" })).toBeNull()
@@ -819,14 +819,14 @@ describe("TableBubbleMenu", () => {
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
-    // Act — start cell drag
+    // Act: start cell drag
     act(() => {
       editor.view.dispatch(
         editor.state.tr.setMeta(tableEditingKey, nthCellPos(editor, 3)),
       )
     })
 
-    // Assert — menu hidden during drag
+    // Assert: menu hidden during drag
     await waitFor(() => {
       expect(queryByText("Delete row")).toBeNull()
     })
@@ -834,13 +834,13 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
 
-    // Act — end cell drag
+    // Act: end cell drag
     act(() => {
       editor.view.dispatch(editor.state.tr.setMeta(tableEditingKey, -1))
     })
     await activateTableBubbleMenu(findByRole)
 
-    // Assert — menu reflects new selection
+    // Assert: menu reflects new selection
     expect(await findByText("Merge cells")).toBeTruthy()
   })
 

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -13,6 +13,10 @@ import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor
 import { theme } from "~/theme"
 
 import { TableBubbleMenu } from "../TableBubbleMenu"
+import {
+  duplicateSelectedColumns,
+  duplicateSelectedRows,
+} from "../TableBubbleMenu.duplicate"
 
 const createSeedTable = (caption: string): JSONContent => ({
   type: "table",
@@ -144,15 +148,19 @@ const expectKeyboardActivationOpensMenu = async ({
   queryByText: (text: string) => HTMLElement | null
   activationKey: "{Enter}" | "{Space}"
 }) => {
+  // Arrange
   selectCells(editor, 3, 5)
   const trigger = await tabToTableActionsTrigger(editor, findByRole)
 
+  // Assert — pre-activation
   expect(trigger).toBeTruthy()
   expect(document.activeElement).toBe(trigger)
   expect(queryByText("Delete row")).toBeNull()
 
+  // Act
   await userEvent.keyboard(activationKey)
 
+  // Assert
   expect(editor.view.dom.contains(document.activeElement)).toBe(true)
   expect(await findByText("Delete row")).toBeTruthy()
 }
@@ -226,20 +234,74 @@ const firstRowTexts = (editor: Editor): string[] => {
   return texts
 }
 
+// Cell text contents for the nth table row (0-indexed), left-to-right.
+const rowTextsAt = (editor: Editor, rowIndex: number): string[] => {
+  const texts: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    const row = node.child(rowIndex)
+    row.forEach((cell) => {
+      texts.push(cell.textContent)
+    })
+    return false
+  })
+  return texts
+}
+
+const tableRowCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.childCount
+    return false
+  })
+  return count
+}
+
+const tableColumnCount = (editor: Editor): number => {
+  let count = 0
+  editor.state.doc.descendants((node) => {
+    if (node.type.name !== "table") return true
+    count = node.child(0).childCount
+    return false
+  })
+  return count
+}
+
+const rowCellCount = (editor: Editor, rowIndex: number): number => {
+  let count = 0
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    count = node.child(rowIndex).childCount
+    return false
+  })
+  return count
+}
+
 describe("TableBubbleMenu", () => {
   afterEach(() => {
     cleanup()
   })
 
   it("shows row actions (including Delete row) when a body row is selected", async () => {
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
-
     selectCells(editor, 3, 5) // the full body row (not the first row)
+
+    // Act
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(queryByText("Header row")).toBeNull()
     expect(await findByText("Add row above")).toBeTruthy()
+    expect(await findByText("Duplicate row")).toBeTruthy()
     expect(await findByText("Move up")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
     expect(await findByText("Delete row")).toBeTruthy()
@@ -248,97 +310,305 @@ describe("TableBubbleMenu", () => {
   it("shows Header row/column only for the exact top row / leftmost column", async () => {
     const { editor, findByRole, queryByRole } = await renderHarness()
 
-    // Body row — not the top row
+    // Arrange — body row, not the top row
     selectCells(editor, 3, 5)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
 
-    // Exact header / top row
+    // Arrange — exact header / top row
     selectCells(editor, 0, 2)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(await findByRole("checkbox", { name: "Header row" })).toBeChecked()
 
-    // Top row + body row — overlaps the top row but is not exactly it
+    // Arrange — top row + body row (overlaps top row but is not exactly it)
     selectCells(editor, 0, 5)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
 
-    // Middle column — not the leftmost column
+    // Arrange — middle column, not the leftmost column
     selectCells(editor, 1, 7)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
 
-    // Exact leftmost column
+    // Arrange — exact leftmost column
     selectCells(editor, 0, 6)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).not.toBeChecked()
 
-    // Leftmost + next column — overlaps leftmost but is not exactly it
+    // Arrange — leftmost + next column (overlaps leftmost but is not exactly it)
     selectCells(editor, 0, 7)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
   })
 
   it("moves a multi-column selection as a block (A,B → right becomes C,A,B)", async () => {
+    // Arrange
     const { editor, findByText, findByRole } = await renderHarness()
-
-    // Full columns A+B
-    selectCells(editor, 0, 7)
+    selectCells(editor, 0, 7) // full columns A+B
     await activateTableBubbleMenu(findByRole)
     expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
-
     const moveRight = await findByText("Move right")
+
+    // Act
     act(() => {
       moveRight.click()
     })
 
+    // Assert
     expect(firstRowTexts(editor)).toEqual(["Column C", "Column A", "Column B"])
+  })
+
+  it("duplicates a body row immediately below with the same cell content", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 5) // first body row: cells 3–5 ("Row 1, A/B/C")
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert
+    expect(tableRowCount(editor)).toBe(4)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a multi-row selection as a contiguous block", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 8) // both body rows: cells 3–8
+    expect(tableRowCount(editor)).toBe(3)
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert
+    expect(tableRowCount(editor)).toBe(5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 4)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a column immediately to the right with the same cell content", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 1, 7) // column B: header cell 1 + body cells 4 and 7
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert
+    expect(tableColumnCount(editor)).toBe(4)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column B",
+      "Column C",
+    ])
+    expect(rowTextsAt(editor, 1)).toEqual([
+      "Row 1, A",
+      "Row 1, B",
+      "Row 1, B",
+      "Row 1, C",
+    ])
+  })
+
+  it("duplicates a multi-column selection as a contiguous block", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 0, 7) // columns A+B
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert
+    expect(tableColumnCount(editor)).toBe(5)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column B",
+      "Column A",
+      "Column B",
+      "Column C",
+    ])
+  })
+
+  it("duplicates a row that contains a horizontal merge", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 4)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    const sourceRowTexts = rowTextsAt(editor, 1)
+    expect(rowCellCount(editor, 1)).toBe(2)
+    selectCells(editor, 3, 4)
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert
+    expect(tableRowCount(editor)).toBe(4)
+    expect(rowCellCount(editor, 1)).toBe(2)
+    expect(rowCellCount(editor, 2)).toBe(2)
+    expect(rowTextsAt(editor, 1)).toEqual(sourceRowTexts)
+    expect(rowTextsAt(editor, 2)).toEqual(sourceRowTexts)
+    expect(rowTextsAt(editor, 3)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("duplicates a column that contains a vertical merge", async () => {
+    // Arrange
+    const { editor } = await renderHarness()
+    selectCells(editor, 3, 6)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(rowCellCount(editor, 1)).toBe(3)
+    expect(rowCellCount(editor, 2)).toBe(2)
+    selectCells(editor, 0, 3)
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert
+    expect(tableColumnCount(editor)).toBe(4)
+    expect(firstRowTexts(editor)).toEqual([
+      "Column A",
+      "Column A",
+      "Column B",
+      "Column C",
+    ])
+    expect(rowCellCount(editor, 1)).toBe(4)
+    expect(rowCellCount(editor, 2)).toBe(2)
+
+    const [originalMerged, duplicatedMerged] = rowTextsAt(editor, 1)
+    expect(duplicatedMerged).toBe(originalMerged)
+    expect(originalMerged).toContain("Row 1, A")
+    expect(originalMerged).toContain("Row 2, A")
+  })
+
+  it("withholds Duplicate row for header row selections", async () => {
+    // Arrange
+    const { editor, findByRole, queryByText } = await renderHarness()
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+
+    // Assert — menu
+    expect(queryByText("Duplicate row")).toBeNull()
+
+    // Act
+    act(() => {
+      duplicateSelectedRows(editor)
+    })
+
+    // Assert — table unchanged
+    expect(tableRowCount(editor)).toBe(3)
+  })
+
+  it("withholds Duplicate column for header column selections", async () => {
+    // Arrange
+    const { editor, findByRole, queryByText } = await renderHarness()
+    act(() => {
+      editor.chain().focus().toggleHeaderColumn().run()
+    })
+    selectCells(editor, 0, 6)
+    await activateTableBubbleMenu(findByRole)
+
+    // Assert — menu
+    expect(queryByText("Duplicate column")).toBeNull()
+
+    // Act
+    act(() => {
+      duplicateSelectedColumns(editor)
+    })
+
+    // Assert — table unchanged
+    expect(tableColumnCount(editor)).toBe(3)
   })
 
   it("withholds Delete and Move when selection includes header row", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    selectCells(editor, 0, 2) // the full header row
+    // Arrange — full header row
+    selectCells(editor, 0, 2)
+    // Act
     await activateTableBubbleMenu(findByRole)
-
+    // Assert
     const headerToggle = await findByRole("checkbox", { name: "Header row" })
     expect(headerToggle).toBeChecked()
     expect(await findByText("Add row above")).toBeTruthy()
     expect(await findByText("Add row below")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Duplicate row")).toBeNull()
     expect(queryByText("Move up")).toBeNull()
     expect(queryByText("Move down")).toBeNull()
 
+    // Arrange — header row + body row
     selectCells(editor, 0, 5)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header row" })).toBeNull()
     expect(queryByText("Delete row")).toBeNull()
+    expect(queryByText("Duplicate row")).toBeNull()
     expect(queryByText("Move up")).toBeNull()
     expect(queryByText("Move down")).toBeNull()
   })
 
   it("refreshes row actions when header row is toggled off without reselecting", async () => {
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
-
     selectCells(editor, 0, 2)
     await activateTableBubbleMenu(findByRole)
-
     const headerToggle = await findByRole("checkbox", { name: "Header row" })
     expect(headerToggle).toBeChecked()
     expect(queryByText("Delete row")).toBeNull()
 
+    // Act
     act(() => {
       headerToggle.click()
     })
 
+    // Assert
     await waitFor(() => {
       expect(headerToggle).not.toBeChecked()
     })
     expect(await findByText("Delete row")).toBeTruthy()
+    expect(await findByText("Duplicate row")).toBeTruthy()
     expect(await findByText("Move down")).toBeTruthy()
   })
 
@@ -346,50 +616,63 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Seed table has a header row only — leftmost column is still deletable.
+    // Arrange — leftmost column before header column is enabled
     selectCells(editor, 0, 6)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).not.toBeChecked()
     expect(await findByText("Delete column")).toBeTruthy()
     expect(await findByText("Move right")).toBeTruthy()
 
+    // Arrange — enable header column; same cell range stays selected, so the
+    // menu (already open from above) refreshes in place without reactivating.
     act(() => {
       editor.chain().focus().toggleHeaderColumn().run()
     })
-
-    selectCells(editor, 0, 6) // header column alone
+    // Assert
     expect(
       await findByRole("checkbox", { name: "Header column" }),
     ).toBeChecked()
     expect(queryByText("Delete column")).toBeNull()
+    expect(queryByText("Duplicate column")).toBeNull()
     expect(queryByText("Move left")).toBeNull()
     expect(queryByText("Move right")).toBeNull()
 
+    // Arrange — header column + next column
     selectCells(editor, 0, 7)
+    // Act
     await activateTableBubbleMenu(findByRole)
+    // Assert
     expect(queryByRole("checkbox", { name: "Header column" })).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
+    expect(queryByText("Duplicate column")).toBeNull()
     expect(queryByText("Move left")).toBeNull()
     expect(queryByText("Move right")).toBeNull()
   })
 
   it("shows only Merge cells for an irregular multi-cell selection", async () => {
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
+    selectCells(editor, 3, 7) // irregular 2x2-ish block, not a full row/column
 
-    selectCells(editor, 3, 7) // an irregular 2x2-ish block, not a full row/column
+    // Act
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(await findByText("Merge cells")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
   })
 
   it("shows no menu content for a plain cursor outside any selection", async () => {
+    // Arrange / Act
     const { queryByText, queryByRole } = await renderHarness()
 
+    // Assert
     expect(queryByText("Delete table")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
     expect(queryByText("Add row above")).toBeNull()
@@ -402,6 +685,7 @@ describe("TableBubbleMenu", () => {
   ])(
     "keeps the trigger mounted when tabbing to it and opens the menu with $label",
     async ({ activationKey }) => {
+      // Arrange / Act / Assert
       const { editor, findByRole, findByText, queryByText } =
         await renderHarness()
 
@@ -416,6 +700,7 @@ describe("TableBubbleMenu", () => {
   )
 
   it("deactivates when tabbing from the trigger through menu controls to outside", async () => {
+    // Arrange
     const { editor, findByRole, findByText, queryByText, queryByRole } =
       await renderHarness()
     selectCells(editor, 3, 5)
@@ -433,6 +718,7 @@ describe("TableBubbleMenu", () => {
     document.body.appendChild(outside)
 
     try {
+      // Act
       for (
         let tabs = 0;
         tabs < 30 && document.activeElement !== outside;
@@ -441,9 +727,8 @@ describe("TableBubbleMenu", () => {
         await userEvent.tab()
       }
 
+      // Assert
       expect(document.activeElement).toBe(outside)
-      // Focus has left the trigger, the menu, and the editor entirely, so
-      // both the action list and the now-irrelevant pencil trigger hide.
       await waitFor(() => {
         expect(queryByRole("button", { name: "Table actions" })).toBeNull()
       })
@@ -456,22 +741,25 @@ describe("TableBubbleMenu", () => {
   })
 
   it("shows the pencil trigger without the action menu until it is activated", async () => {
+    // Arrange
     const { editor, findByRole, findByText, queryByText } =
       await renderHarness()
-
     selectCells(editor, 3, 5)
-
     const trigger = await findByRole("button", { name: "Table actions" })
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
 
+    // Act — open menu
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(trigger).toHaveAttribute("aria-pressed", "true")
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act — close menu
     await activateTableBubbleMenu(findByRole)
 
+    // Assert
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
   })
@@ -480,34 +768,38 @@ describe("TableBubbleMenu", () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
 
-    // Merge two adjacent body cells into one, then re-select just that
-    // resulting cell — the only single-cell case with a bubble menu.
+    // Arrange — merge two adjacent body cells, then re-select the result
     selectCells(editor, 3, 4)
     act(() => {
       editor.chain().focus().mergeCells().run()
     })
     selectCells(editor, 3, 3)
+
+    // Act
     await activateTableBubbleMenu(findByRole)
 
+    // Assert — merged single cell
     expect(await findByText("Split cell")).toBeTruthy()
     expect(queryByText("Merge cells")).toBeNull()
 
-    // An ordinary (never-merged) single cell still shows no menu at all.
+    // Arrange / Act — ordinary single cell
     selectCells(editor, 6, 6)
+
+    // Assert — no menu
     expect(queryByText("Split cell")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
     expect(queryByRole("button", { name: "Table actions" })).toBeNull()
   })
 
   it("hides when focus moves outside the editor (e.g. Table Settings modal)", async () => {
-    // TipTap's blur handler hides the menu when focus leaves the editor.
+    // Arrange
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
-
     selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act
     act(() => {
       const outside = document.createElement("button")
       outside.type = "button"
@@ -519,51 +811,55 @@ describe("TableBubbleMenu", () => {
       outside.focus()
     })
 
+    // Assert
     await waitFor(() => {
       expect(queryByText("Delete row")).toBeNull()
     })
   })
 
   it("stays hidden while a cell drag-select is in progress, then shows after it commits", async () => {
-    // prosemirror-tables sets `tableEditingKey` for the duration of a cell
-    // drag (mousemove) and clears it on mouseup. The menu must not appear for
-    // intermediate selection rects during that window.
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
 
+    // Arrange
     selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act — start cell drag
     act(() => {
       editor.view.dispatch(
         editor.state.tr.setMeta(tableEditingKey, nthCellPos(editor, 3)),
       )
     })
+
+    // Assert — menu hidden during drag
     await waitFor(() => {
       expect(queryByText("Delete row")).toBeNull()
     })
-
-    // Intermediate selection expansion while still "dragging"
     selectCells(editor, 3, 7)
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Merge cells")).toBeNull()
 
-    // mouseup clears selectingCells state (meta -1 → null)
+    // Act — end cell drag
     act(() => {
       editor.view.dispatch(editor.state.tr.setMeta(tableEditingKey, -1))
     })
     await activateTableBubbleMenu(findByRole)
+
+    // Assert — menu reflects new selection
     expect(await findByText("Merge cells")).toBeTruthy()
   })
 
   it("starts deactivated after remounting with the same editor", async () => {
+    // Arrange
     const { editor, findByRole, findByText, queryByText, setShowMenu } =
       await renderHarness()
     selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
+    // Act
     act(() => {
       setShowMenu(false)
     })
@@ -571,15 +867,14 @@ describe("TableBubbleMenu", () => {
       setShowMenu(true)
     })
 
+    // Assert
     const trigger = await findByRole("button", { name: "Table actions" })
     expect(trigger).toHaveAttribute("aria-pressed", "false")
     expect(queryByText("Delete row")).toBeNull()
   })
 
   it("repositions the menu when the editor's own scroll container scrolls (not just window)", async () => {
-    // EditorContentWrapper (the real production wrapper) has its own
-    // `overflowY: auto` — scrolling *inside* it must reposition the menu,
-    // not just scrolling the window.
+    // Arrange
     let editor: Editor | undefined
 
     const ScrollingHarness = () => {
@@ -627,26 +922,30 @@ describe("TableBubbleMenu", () => {
       '[data-testid="scroll-parent"]',
     ) as HTMLElement
 
+    // Act
     act(() => {
       scrollParent.scrollTop = 300
       scrollParent.dispatchEvent(new Event("scroll"))
     })
 
+    // Assert
     await waitFor(() => {
       expect(menuEl?.getBoundingClientRect().top).not.toBe(initialTop)
     })
   })
 
   it("keeps one trigger and deactivates when selection moves to another table", async () => {
+    // Arrange
     const { editor, findByRole, findByText, findAllByRole, queryByText } =
       await renderHarness(TWO_TABLES_CONTENT)
-
-    selectCells(editor, 3, 5) // first table, first body row
+    selectCells(editor, 3, 5)
     await activateTableBubbleMenu(findByRole)
     expect(await findByText("Delete row")).toBeTruthy()
 
-    selectCells(editor, 12, 14) // second table, first body row
+    // Act
+    selectCells(editor, 12, 14)
 
+    // Assert
     const triggers = await findAllByRole("button", { name: "Table actions" })
     expect(triggers).toHaveLength(1)
     expect(triggers[0]).toHaveAttribute("aria-pressed", "false")

--- a/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditContentPage.stories.tsx
@@ -62,7 +62,7 @@ function withinPortals(canvasElement: HTMLElement) {
 
 // Document position at the start of the nth table cell (tableCell /
 // tableHeader), 0-indexed in reading order. Used to forge a CellSelection
-// in play functions — Storybook can't drive a real mouse drag across cells.
+// in play functions. Storybook can't drive a real mouse drag across cells.
 const nthCellPos = (editor: Editor, index: number): number => {
   let seen = 0
   let found: number | null = null
@@ -220,7 +220,7 @@ export const ActiveTableToolbar: Story = {
     ).toHaveLength(1)
     await userEvent.keyboard("{Escape}")
 
-    // Clicking "Table" only opens the size-picker popover — a cell still
+    // Clicking "Table" only opens the size-picker popover. A cell still
     // needs to be picked to actually insert a table and put the cursor
     // inside it (see TableSizePicker.tsx).
     await userEvent.click(canvas.getByRole("button", { name: /^table$/i }))
@@ -237,7 +237,7 @@ export const ActiveTableToolbar: Story = {
     ).toHaveLength(1)
 
     // Divider is also table-inapplicable, so "More options" has nothing left
-    // to show and disappears entirely — only the unrelated page-actions menu
+    // to show and disappears entirely. Only the unrelated page-actions menu
     // button remains.
     await expect(
       canvas.getAllByRole("button", { name: /more options/i }),
@@ -245,7 +245,7 @@ export const ActiveTableToolbar: Story = {
   },
 }
 
-// Navigate into a text block, insert a table, select a body row — the
+// Navigate into a text block, insert a table, select a body row. The
 // contextual TableBubbleMenu should appear with row actions.
 export const TableBubbleMenu: Story = {
   play: async (context) => {
@@ -253,7 +253,7 @@ export const TableBubbleMenu: Story = {
     const canvas = within(canvasElement)
     await AddTextBlock.play?.(context)
 
-    // Clicking "Table" only opens the size-picker popover — a cell still
+    // Clicking "Table" only opens the size-picker popover. A cell still
     // needs to be picked to actually insert a table (see TableSizePicker.tsx).
     await userEvent.click(canvas.getByRole("button", { name: /^table$/i }))
     await userEvent.click(
@@ -265,7 +265,7 @@ export const TableBubbleMenu: Story = {
     )
 
     const editor = getEditorFromCanvas(canvasElement)
-    // Default insertTable is 3x3 with a header row; cells 3–5 are the first body row.
+    // Default insertTable is 3x3 with a header row; cells 3-5 are the first body row.
     editor
       .chain()
       .focus()
@@ -276,7 +276,7 @@ export const TableBubbleMenu: Story = {
       .run()
 
     const portals = withinPortals(canvasElement)
-    // Row/column actions live behind the portaled pencil trigger — click to open.
+    // Row/column actions live behind the portaled pencil trigger. Click to open.
     await userEvent.click(
       await portals.findByRole("button", { name: "Table actions" }),
     )


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 6 | +477 | -7 |
| 🧪 Test | 2 | +348 | -49 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Duplicating a row or column currently requires manually adding a new one and recreating its contents by hand — there's no way to just copy an existing row/column.

Closes https://linear.app/ogp/issue/ISOM-2371/p2-rte-add-duplicate-rowcolumn-to-table-bubble-menu

## Solution

Adds "Duplicate row" and "Duplicate column" actions to `TableBubbleMenu`, stacked on top of #2794. Copies the selected block (including multi-row/column selections) and inserts the copy immediately after the selection.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- New "Duplicate row" action on the row-selection bubble menu, and "Duplicate column" on the column-selection bubble menu (`TableBubbleMenu.duplicate.ts`). Both support multi-row/multi-column selections, duplicating the whole selected block in one action.

**Improvements**:

- None.

**Bug Fixes**:

- None.

## Before & After Screenshots

**BEFORE**:

Row/column selection bubble menu only offers add/move/delete — no way to duplicate.

**AFTER**:

<!-- [insert screenshot here] -->

Row/column selection bubble menu now also shows a "Duplicate" action next to add-row/add-column.

https://github.com/user-attachments/assets/ec2f599f-7146-4cf4-bd5e-ca9e1ed1edc0

## Tests

**Manual Verification Steps**:

- [ ] Open a page's rich text block, insert a table, select a single row, and confirm a "Duplicate row" action appears in the bubble menu; click it and confirm a copy of the row is inserted immediately below.
- [ ] Select multiple contiguous rows and confirm duplicating copies the whole selected block in order, inserted right after the selection.
- [ ] Repeat both checks for column selection ("Duplicate column").
- [ ] Repeat inside an Accordion block's rich text editor, since both editors share this change.

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds row and column duplication to the rich-text table bubble menu, including multi-row and multi-column selections.
- Clones selected table content and inserts it immediately after the selected block.
- Adds duplicate actions to the row and column menus.
- Adds browser tests for basic duplication, merged cells, and header restrictions.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

This PR does not yet appear safe to merge because duplicating columns through a colspan can leave the selection on the wrong cells.

The previously reported selection-restoration issue remains in current HEAD: fixed grid coordinates are resolved against the mutated table map, so merged cells can cause subsequent table actions to target cells outside the duplicated block.

**Files Needing Attention:** apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.duplicate.ts | Implements duplication and post-mutation selection restoration; the previously reported merged-column selection defect remains at current HEAD. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx | Exposes the new duplicate commands for eligible body-row and body-column selections. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx | Adds broad duplication coverage, but does not assert the restored selection for columns intersecting a colspan. |

</details>

<sub>Reviews (6): Last reviewed commit: ["chore(rte-table): replace em dashes in T..."](https://github.com/opengovsg/isomer/commit/d5a05ddc1cf14f6a8ddbaad5a2c613a9cea5ce82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50004622)</sub>

<!-- /greptile_comment -->