### PR TITLE
🎀📊 feat(rte-table): add clear contents to TableBubbleMenu

### DIFF
--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
@@ -1,58 +1,22 @@
-import type { Node } from "@tiptap/pm/model"
-import type { Transaction } from "@tiptap/pm/state"
 import type { Editor } from "@tiptap/react"
-import { CellSelection } from "@tiptap/pm/tables"
-
-interface ResolvedCell {
-  pos: number
-  node: Node
-}
-
-/** Document positions of a cell's inner content (excludes the cell node itself). */
-const cellContentRange = (cellPos: number, cell: Node) => ({
-  from: cellPos + 1,
-  to: cellPos + cell.nodeSize - 1,
-})
-
-const collectSelectedCells = (selection: CellSelection): ResolvedCell[] => {
-  const cells: ResolvedCell[] = []
-  selection.forEachCell((node, pos) => {
-    cells.push({ pos, node })
-  })
-  return cells
-}
-
-const restoreCellSelection = (
-  tr: Transaction,
-  selection: CellSelection,
-): Transaction => {
-  const anchor = tr.mapping.map(selection.$anchorCell.pos)
-  const head = tr.mapping.map(selection.$headCell.pos)
-  return tr.setSelection(CellSelection.create(tr.doc, anchor, head))
-}
+import { CellSelection, deleteCellSelection } from "@tiptap/pm/tables"
 
 /**
  * Replace every selected cell's inner content with a single empty paragraph.
  * Cell type (header vs body) and colspan/rowspan are preserved.
+ *
+ * Delegates to prosemirror-tables' deleteCellSelection (also bound to
+ * Backspace/Delete for CellSelection) and restores the cell selection
+ * afterward so the bubble menu stays contextual.
  */
 export const clearSelectedCells = (editor: Editor): void => {
   const { state, view } = editor
-  const { selection, schema } = state
+  const { selection } = state
   if (!(selection instanceof CellSelection)) return
 
-  const paragraph = schema.nodes.paragraph
-  if (!paragraph) return
-
-  const emptyParagraph = paragraph.create()
-  const cells = collectSelectedCells(selection)
-  if (cells.length === 0) return
-
-  let tr = state.tr
-  // Replace from the end so earlier cell positions stay valid.
-  for (const cell of cells.sort((a, b) => b.pos - a.pos)) {
-    const { from, to } = cellContentRange(cell.pos, cell.node)
-    tr = tr.replaceWith(from, to, emptyParagraph)
-  }
-
-  view.dispatch(restoreCellSelection(tr, selection))
+  deleteCellSelection(state, (tr) => {
+    const anchor = tr.mapping.map(selection.$anchorCell.pos)
+    const head = tr.mapping.map(selection.$headCell.pos)
+    view.dispatch(tr.setSelection(CellSelection.create(tr.doc, anchor, head)))
+  })
 }

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
@@ -1,14 +1,6 @@
 import type { Editor } from "@tiptap/react"
 import { CellSelection, deleteCellSelection } from "@tiptap/pm/tables"
 
-/**
- * Replace every selected cell's inner content with a single empty paragraph.
- * Cell type (header vs body) and colspan/rowspan are preserved.
- *
- * Delegates to prosemirror-tables' deleteCellSelection (also bound to
- * Backspace/Delete for CellSelection) and restores the cell selection
- * afterward so the bubble menu stays contextual.
- */
 export const clearSelectedCells = (editor: Editor): void => {
   const { state, view } = editor
   const { selection } = state

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts
@@ -1,0 +1,58 @@
+import type { Node } from "@tiptap/pm/model"
+import type { Transaction } from "@tiptap/pm/state"
+import type { Editor } from "@tiptap/react"
+import { CellSelection } from "@tiptap/pm/tables"
+
+interface ResolvedCell {
+  pos: number
+  node: Node
+}
+
+/** Document positions of a cell's inner content (excludes the cell node itself). */
+const cellContentRange = (cellPos: number, cell: Node) => ({
+  from: cellPos + 1,
+  to: cellPos + cell.nodeSize - 1,
+})
+
+const collectSelectedCells = (selection: CellSelection): ResolvedCell[] => {
+  const cells: ResolvedCell[] = []
+  selection.forEachCell((node, pos) => {
+    cells.push({ pos, node })
+  })
+  return cells
+}
+
+const restoreCellSelection = (
+  tr: Transaction,
+  selection: CellSelection,
+): Transaction => {
+  const anchor = tr.mapping.map(selection.$anchorCell.pos)
+  const head = tr.mapping.map(selection.$headCell.pos)
+  return tr.setSelection(CellSelection.create(tr.doc, anchor, head))
+}
+
+/**
+ * Replace every selected cell's inner content with a single empty paragraph.
+ * Cell type (header vs body) and colspan/rowspan are preserved.
+ */
+export const clearSelectedCells = (editor: Editor): void => {
+  const { state, view } = editor
+  const { selection, schema } = state
+  if (!(selection instanceof CellSelection)) return
+
+  const paragraph = schema.nodes.paragraph
+  if (!paragraph) return
+
+  const emptyParagraph = paragraph.create()
+  const cells = collectSelectedCells(selection)
+  if (cells.length === 0) return
+
+  let tr = state.tr
+  // Replace from the end so earlier cell positions stay valid.
+  for (const cell of cells.sort((a, b) => b.pos - a.pos)) {
+    const { from, to } = cellContentRange(cell.pos, cell.node)
+    tr = tr.replaceWith(from, to, emptyParagraph)
+  }
+
+  view.dispatch(restoreCellSelection(tr, selection))
+}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -239,8 +239,9 @@ export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
   })
 }
 
+// Any CellSelection (including a single cell) has at least Clear contents.
 export const isActionableTableSelectionKind = (kind: SelectionKind) =>
-  kind !== "none" && kind !== "single-cell"
+  kind !== "none"
 
 export const isEditorModalOpen = () =>
   document.querySelector('[role="dialog"][aria-modal="true"]') != null

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -265,9 +265,9 @@ export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
   })
 }
 
-// Ordinary single-cell text cursors show no bubble menu.
+// Any CellSelection (including a single cell) has at least Clear contents.
 export const isActionableTableSelectionKind = (kind: SelectionKind) =>
-  kind !== "none" && kind !== "single-cell"
+  kind !== "none"
 
 // Hide the menu while a Chakra/modal dialog has focus.
 export const isEditorModalOpen = () =>

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts
@@ -239,9 +239,6 @@ export const detectTableSelectionKind = (editor: Editor): SelectionKind => {
   })
 }
 
-// Any CellSelection (including a single cell) has at least Clear contents.
-export const isActionableTableSelectionKind = (kind: SelectionKind) =>
-  kind !== "none"
-
+// Hide the menu while a Chakra/modal dialog has focus.
 export const isEditorModalOpen = () =>
   document.querySelector('[role="dialog"][aria-modal="true"]') != null

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -10,6 +10,7 @@ import {
   BiRightArrowAlt,
   BiTrash,
   BiUpArrowAlt,
+  BiX,
 } from "react-icons/bi"
 import {
   IconAddColLeft,
@@ -27,6 +28,7 @@ import type {
   TableMoveAxis,
   TableMovePlan,
 } from "./TableBubbleMenu.types"
+import { clearSelectedCells } from "./TableBubbleMenu.clear"
 import {
   duplicateSelectedColumns,
   duplicateSelectedRows,
@@ -180,6 +182,11 @@ const RowSelectionActions = ({
           onClick={() => duplicateSelectedRows(editor)}
         />
       )}
+      <ActionButton
+        label="Clear contents"
+        icon={<BiX fontSize="1rem" />}
+        onClick={() => clearSelectedCells(editor)}
+      />
       {rowMoveUpPlan && !includesHeader && (
         <ActionButton
           label="Move up"
@@ -252,6 +259,11 @@ const ColumnSelectionActions = ({
           onClick={() => duplicateSelectedColumns(editor)}
         />
       )}
+      <ActionButton
+        label="Clear contents"
+        icon={<BiX fontSize="1rem" />}
+        onClick={() => clearSelectedCells(editor)}
+      />
       {columnMoveLeftPlan && !includesHeader && (
         <ActionButton
           label="Move left"
@@ -295,27 +307,58 @@ export const TableBubbleMenuActions = ({
       return <ColumnSelectionActions editor={editor} rect={rect} />
     case "table":
       return (
-        <ActionButton
-          label="Delete table"
-          icon={<BiTrash fontSize="1rem" />}
-          onClick={() => editor.chain().focus().deleteTable().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+          <ActionButton
+            label="Delete table"
+            icon={<BiTrash fontSize="1rem" />}
+            onClick={() => editor.chain().focus().deleteTable().run()}
+          />
+        </ActionGroup>
       )
     case "multi-cell":
       return (
-        <ActionButton
-          label="Merge cells"
-          icon={<IconMergeCells boxSize="1rem" />}
-          onClick={() => editor.chain().focus().mergeCells().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+          <ActionButton
+            label="Merge cells"
+            icon={<IconMergeCells boxSize="1rem" />}
+            onClick={() => editor.chain().focus().mergeCells().run()}
+          />
+        </ActionGroup>
+      )
+    case "single-cell":
+      return (
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+        </ActionGroup>
       )
     case "merged-cell":
       return (
-        <ActionButton
-          label="Split cell"
-          icon={<IconSplitCell boxSize="1rem" />}
-          onClick={() => editor.chain().focus().splitCell().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+          <ActionButton
+            label="Split cell"
+            icon={<IconSplitCell boxSize="1rem" />}
+            onClick={() => editor.chain().focus().splitCell().run()}
+          />
+        </ActionGroup>
       )
     default:
       return null

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -105,6 +105,14 @@ const ActionGroup = ({ children }: { children: ReactNode }) => (
   </VStack>
 )
 
+const ClearContentsButton = ({ editor }: { editor: Editor }) => (
+  <ActionButton
+    label="Clear contents"
+    icon={<BiX fontSize="1rem" />}
+    onClick={() => clearSelectedCells(editor)}
+  />
+)
+
 const HeaderToggle = ({
   label,
   isChecked,
@@ -182,11 +190,7 @@ const RowSelectionActions = ({
           onClick={() => duplicateSelectedRows(editor)}
         />
       )}
-      <ActionButton
-        label="Clear contents"
-        icon={<BiX fontSize="1rem" />}
-        onClick={() => clearSelectedCells(editor)}
-      />
+      <ClearContentsButton editor={editor} />
       {rowMoveUpPlan && !includesHeader && (
         <ActionButton
           label="Move up"
@@ -259,11 +263,7 @@ const ColumnSelectionActions = ({
           onClick={() => duplicateSelectedColumns(editor)}
         />
       )}
-      <ActionButton
-        label="Clear contents"
-        icon={<BiX fontSize="1rem" />}
-        onClick={() => clearSelectedCells(editor)}
-      />
+      <ClearContentsButton editor={editor} />
       {columnMoveLeftPlan && !includesHeader && (
         <ActionButton
           label="Move left"
@@ -308,11 +308,7 @@ export const TableBubbleMenuActions = ({
     case "table":
       return (
         <ActionGroup>
-          <ActionButton
-            label="Clear contents"
-            icon={<BiX fontSize="1rem" />}
-            onClick={() => clearSelectedCells(editor)}
-          />
+          <ClearContentsButton editor={editor} />
           <ActionButton
             label="Delete table"
             icon={<BiTrash fontSize="1rem" />}
@@ -323,11 +319,7 @@ export const TableBubbleMenuActions = ({
     case "multi-cell":
       return (
         <ActionGroup>
-          <ActionButton
-            label="Clear contents"
-            icon={<BiX fontSize="1rem" />}
-            onClick={() => clearSelectedCells(editor)}
-          />
+          <ClearContentsButton editor={editor} />
           <ActionButton
             label="Merge cells"
             icon={<IconMergeCells boxSize="1rem" />}
@@ -338,21 +330,13 @@ export const TableBubbleMenuActions = ({
     case "single-cell":
       return (
         <ActionGroup>
-          <ActionButton
-            label="Clear contents"
-            icon={<BiX fontSize="1rem" />}
-            onClick={() => clearSelectedCells(editor)}
-          />
+          <ClearContentsButton editor={editor} />
         </ActionGroup>
       )
     case "merged-cell":
       return (
         <ActionGroup>
-          <ActionButton
-            label="Clear contents"
-            icon={<BiX fontSize="1rem" />}
-            onClick={() => clearSelectedCells(editor)}
-          />
+          <ClearContentsButton editor={editor} />
           <ActionButton
             label="Split cell"
             icon={<IconSplitCell boxSize="1rem" />}

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx
@@ -10,6 +10,7 @@ import {
   BiRightArrowAlt,
   BiTrash,
   BiUpArrowAlt,
+  BiX,
 } from "react-icons/bi"
 import {
   IconAddColLeft,
@@ -27,6 +28,7 @@ import type {
   TableMoveAxis,
   TableMovePlan,
 } from "./TableBubbleMenu.types"
+import { clearSelectedCells } from "./TableBubbleMenu.clear"
 import {
   duplicateSelectedColumns,
   duplicateSelectedRows,
@@ -185,6 +187,11 @@ const RowSelectionActions = ({
           onClick={() => duplicateSelectedRows(editor)}
         />
       )}
+      <ActionButton
+        label="Clear contents"
+        icon={<BiX fontSize="1rem" />}
+        onClick={() => clearSelectedCells(editor)}
+      />
       {rowMoveUpPlan && !includesHeader && (
         <ActionButton
           label="Move up"
@@ -256,6 +263,11 @@ const ColumnSelectionActions = ({
           onClick={() => duplicateSelectedColumns(editor)}
         />
       )}
+      <ActionButton
+        label="Clear contents"
+        icon={<BiX fontSize="1rem" />}
+        onClick={() => clearSelectedCells(editor)}
+      />
       {columnMoveLeftPlan && !includesHeader && (
         <ActionButton
           label="Move left"
@@ -300,27 +312,58 @@ export const TableBubbleMenuActions = ({
       return <ColumnSelectionActions editor={editor} rect={rect} />
     case "table":
       return (
-        <ActionButton
-          label="Delete table"
-          icon={<BiTrash fontSize="1rem" />}
-          onClick={() => editor.chain().focus().deleteTable().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+          <ActionButton
+            label="Delete table"
+            icon={<BiTrash fontSize="1rem" />}
+            onClick={() => editor.chain().focus().deleteTable().run()}
+          />
+        </ActionGroup>
       )
     case "multi-cell":
       return (
-        <ActionButton
-          label="Merge cells"
-          icon={<IconMergeCells boxSize="1rem" />}
-          onClick={() => editor.chain().focus().mergeCells().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+          <ActionButton
+            label="Merge cells"
+            icon={<IconMergeCells boxSize="1rem" />}
+            onClick={() => editor.chain().focus().mergeCells().run()}
+          />
+        </ActionGroup>
+      )
+    case "single-cell":
+      return (
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+        </ActionGroup>
       )
     case "merged-cell":
       return (
-        <ActionButton
-          label="Split cell"
-          icon={<IconSplitCell boxSize="1rem" />}
-          onClick={() => editor.chain().focus().splitCell().run()}
-        />
+        <ActionGroup>
+          <ActionButton
+            label="Clear contents"
+            icon={<BiX fontSize="1rem" />}
+            onClick={() => clearSelectedCells(editor)}
+          />
+          <ActionButton
+            label="Split cell"
+            icon={<IconSplitCell boxSize="1rem" />}
+            onClick={() => editor.chain().focus().splitCell().run()}
+          />
+        </ActionGroup>
       )
     default:
       return null

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -4,7 +4,7 @@
 import type { Editor, JSONContent } from "@tiptap/react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
 import { act, cleanup, render, waitFor } from "@testing-library/react"
-import { tableEditingKey } from "@tiptap/pm/tables"
+import { CellSelection, tableEditingKey } from "@tiptap/pm/tables"
 import { EditorContent } from "@tiptap/react"
 import { useEffect, useState } from "react"
 import { afterEach, describe, expect, it } from "vitest"
@@ -13,6 +13,7 @@ import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor
 import { theme } from "~/theme"
 
 import { TableBubbleMenu } from "../TableBubbleMenu"
+import { clearSelectedCells } from "../TableBubbleMenu.clear"
 import {
   duplicateSelectedColumns,
   duplicateSelectedRows,
@@ -272,6 +273,76 @@ const rowCellCount = (editor: Editor, rowIndex: number): number => {
     return false
   })
   return count
+}
+
+const columnCellTypesAt = (editor: Editor, colIndex: number): string[] => {
+  const types: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    for (let row = 0; row < node.childCount; row++) {
+      types.push(node.child(row).child(colIndex).type.name)
+    }
+    return false
+  })
+  return types
+}
+
+const cellIndexAtPos = (editor: Editor, cellPos: number): number => {
+  let seen = 0
+  let found = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== -1) return false
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      if (pos === cellPos) {
+        found = seen
+        return false
+      }
+      seen += 1
+    }
+    return true
+  })
+  if (found === -1)
+    throw new Error(`Could not find cell at position ${cellPos}`)
+  return found
+}
+
+const cellSelectionIndices = (
+  editor: Editor,
+): { start: number; end: number } | null => {
+  const { selection } = editor.state
+  if (!(selection instanceof CellSelection)) return null
+  const anchor = cellIndexAtPos(editor, selection.$anchorCell.pos)
+  const head = cellIndexAtPos(editor, selection.$headCell.pos)
+  return { start: Math.min(anchor, head), end: Math.max(anchor, head) }
+}
+
+const cellBlockCountAt = (editor: Editor, cellIndex: number): number => {
+  const cell = editor.state.doc.nodeAt(nthCellPos(editor, cellIndex))
+  return cell?.childCount ?? 0
+}
+
+const insertParagraphInCell = (
+  editor: Editor,
+  cellIndex: number,
+  text: string,
+) => {
+  const cellPos = nthCellPos(editor, cellIndex)
+  const cell = editor.state.doc.nodeAt(cellPos)
+  if (!cell) throw new Error(`Could not find cell at index ${cellIndex}`)
+  const insertPos = cellPos + cell.nodeSize - 1
+  act(() => {
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(insertPos, {
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      })
+      .run()
+  })
 }
 
 describe("TableBubbleMenu", () => {
@@ -548,6 +619,65 @@ describe("TableBubbleMenu", () => {
     expect(tableColumnCount(editor)).toBe(3)
   })
 
+  it("clears every cell in a selected row without removing the row", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 3, 5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearRow = await findByText("Clear contents")
+    act(() => {
+      clearRow.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("clears every cell in a selected column without removing the column", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 1, 7)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearColumn = await findByText("Clear contents")
+    act(() => {
+      clearColumn.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "", "Row 2, C"])
+  })
+
+  it("clears header row content while keeping the header row", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 0, 2)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearRow = await findByText("Clear contents")
+    act(() => {
+      clearRow.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "", ""])
+
+    // Header axes withhold Delete row even after clearing.
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
   it("withholds Add above, Delete and Move when selection includes header row", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
@@ -646,8 +776,7 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Move right")).toBeNull()
   })
 
-  it("shows only Merge cells for an irregular multi-cell selection", async () => {
-    // Arrange
+  it("shows Clear contents and Merge cells for an irregular multi-cell selection", async () => {
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
     selectCells(editor, 3, 7) // irregular 2x2-ish block, not a full row/column
@@ -655,10 +784,60 @@ describe("TableBubbleMenu", () => {
     // Act
     await activateTableBubbleMenu(findByRole)
 
-    // Assert
+    expect(await findByText("Clear contents")).toBeTruthy()
     expect(await findByText("Merge cells")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
+  })
+
+  it("clears every cell in a multi-cell block without removing cells", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 3, 7)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearBlock = await findByText("Clear contents")
+    act(() => {
+      clearBlock.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["", "", "Row 2, C"])
+  })
+
+  it("shows Clear contents and Delete table for a whole-table selection", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 0, 8)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(await findByText("Delete table")).toBeTruthy()
+    expect(queryByText("Merge cells")).toBeNull()
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("clears every cell in a whole-table selection without removing the table", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 0, 8)
+    await activateTableBubbleMenu(findByRole)
+
+    const clearTable = await findByText("Clear contents")
+    act(() => {
+      clearTable.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 2)).toEqual(["", "", ""])
   })
 
   it("shows no menu content for a plain cursor outside any selection", async () => {
@@ -757,11 +936,17 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Delete row")).toBeNull()
   })
 
-  it("shows Split cell for a single cell that came from a merge, and nothing for an ordinary single cell", async () => {
-    const { editor, findByText, findByRole, queryByText, queryByRole } =
+  it("shows Clear contents for a single cell, and Clear plus Split for a merged single cell", async () => {
+    const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
 
-    // Arrange: merge two adjacent body cells, then re-select the result
+    selectCells(editor, 6, 6)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(queryByText("Split cell")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+
     selectCells(editor, 3, 4)
     act(() => {
       editor.chain().focus().mergeCells().run()
@@ -771,17 +956,107 @@ describe("TableBubbleMenu", () => {
     // Act
     await activateTableBubbleMenu(findByRole)
 
-    // Assert: merged single cell
+    expect(await findByText("Clear contents")).toBeTruthy()
     expect(await findByText("Split cell")).toBeTruthy()
     expect(queryByText("Merge cells")).toBeNull()
+  })
 
-    // Arrange / Act: ordinary single cell
+  it("clears a single selected cell without removing the cell", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
     selectCells(editor, 6, 6)
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
 
-    // Assert: no menu
-    expect(queryByText("Split cell")).toBeNull()
-    expect(queryByText("Merge cells")).toBeNull()
-    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+    await activateTableBubbleMenu(findByRole)
+    const clearCell = await findByText("Clear contents")
+    act(() => {
+      clearCell.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 2)).toEqual(["", "Row 2, B", "Row 2, C"])
+  })
+
+  it("clears a merged cell without splitting it", async () => {
+    const { editor } = await renderHarness()
+
+    selectCells(editor, 3, 4)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    expect(rowCellCount(editor, 1)).toBe(2)
+    const mergedCell = editor.state.doc.nodeAt(nthCellPos(editor, 3))
+    expect(mergedCell?.attrs.colspan).toBe(2)
+
+    selectCells(editor, 3, 3)
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(rowCellCount(editor, 1)).toBe(2)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "Row 1, C"])
+    const clearedMergedCell = editor.state.doc.nodeAt(nthCellPos(editor, 3))
+    expect(clearedMergedCell?.attrs.colspan).toBe(2)
+    expect(clearedMergedCell?.attrs.rowspan).toBe(1)
+  })
+
+  it("keeps the cell selection after clearing", async () => {
+    const { editor } = await renderHarness()
+
+    selectCells(editor, 3, 5)
+    expect(cellSelectionIndices(editor)).toEqual({ start: 3, end: 5 })
+
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(cellSelectionIndices(editor)).toEqual({ start: 3, end: 5 })
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+  })
+
+  it("clears header column content while preserving header column cells", async () => {
+    const { editor } = await renderHarness()
+
+    act(() => {
+      editor.chain().focus().toggleHeaderColumn().run()
+    })
+    selectCells(editor, 0, 6)
+    expect(columnCellTypesAt(editor, 0)).toEqual([
+      "tableHeader",
+      "tableHeader",
+      "tableHeader",
+    ])
+
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "Column B", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["", "Row 1, B", "Row 1, C"])
+    expect(columnCellTypesAt(editor, 0)).toEqual([
+      "tableHeader",
+      "tableHeader",
+      "tableHeader",
+    ])
+  })
+
+  it("replaces multi-paragraph cell content with a single empty paragraph", async () => {
+    const { editor } = await renderHarness()
+
+    selectCells(editor, 6, 6)
+    insertParagraphInCell(editor, 6, "Second paragraph")
+    expect(cellBlockCountAt(editor, 6)).toBe(2)
+    expect(rowTextsAt(editor, 2)[0]).toContain("Row 2, A")
+    expect(rowTextsAt(editor, 2)[0]).toContain("Second paragraph")
+
+    selectCells(editor, 6, 6)
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(cellBlockCountAt(editor, 6)).toBe(1)
+    expect(rowTextsAt(editor, 2)).toEqual(["", "Row 2, B", "Row 2, C"])
   })
 
   it("hides when focus moves outside the editor (e.g. Table Settings modal)", async () => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx
@@ -4,7 +4,7 @@
 import type { Editor, JSONContent } from "@tiptap/react"
 import { ThemeProvider } from "@opengovsg/design-system-react"
 import { act, cleanup, render, waitFor } from "@testing-library/react"
-import { tableEditingKey } from "@tiptap/pm/tables"
+import { CellSelection, tableEditingKey } from "@tiptap/pm/tables"
 import { EditorContent } from "@tiptap/react"
 import { useEffect, useState } from "react"
 import { afterEach, describe, expect, it } from "vitest"
@@ -13,6 +13,7 @@ import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor
 import { theme } from "~/theme"
 
 import { TableBubbleMenu } from "../TableBubbleMenu"
+import { clearSelectedCells } from "../TableBubbleMenu.clear"
 import {
   duplicateSelectedColumns,
   duplicateSelectedRows,
@@ -282,6 +283,76 @@ const rowCellCount = (editor: Editor, rowIndex: number): number => {
     return false
   })
   return count
+}
+
+const columnCellTypesAt = (editor: Editor, colIndex: number): string[] => {
+  const types: string[] = []
+  let foundTable = false
+  editor.state.doc.descendants((node) => {
+    if (foundTable) return false
+    if (node.type.name !== "table") return true
+    foundTable = true
+    for (let row = 0; row < node.childCount; row++) {
+      types.push(node.child(row).child(colIndex).type.name)
+    }
+    return false
+  })
+  return types
+}
+
+const cellIndexAtPos = (editor: Editor, cellPos: number): number => {
+  let seen = 0
+  let found = -1
+  editor.state.doc.descendants((node, pos) => {
+    if (found !== -1) return false
+    if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+      if (pos === cellPos) {
+        found = seen
+        return false
+      }
+      seen += 1
+    }
+    return true
+  })
+  if (found === -1)
+    throw new Error(`Could not find cell at position ${cellPos}`)
+  return found
+}
+
+const cellSelectionIndices = (
+  editor: Editor,
+): { start: number; end: number } | null => {
+  const { selection } = editor.state
+  if (!(selection instanceof CellSelection)) return null
+  const anchor = cellIndexAtPos(editor, selection.$anchorCell.pos)
+  const head = cellIndexAtPos(editor, selection.$headCell.pos)
+  return { start: Math.min(anchor, head), end: Math.max(anchor, head) }
+}
+
+const cellBlockCountAt = (editor: Editor, cellIndex: number): number => {
+  const cell = editor.state.doc.nodeAt(nthCellPos(editor, cellIndex))
+  return cell?.childCount ?? 0
+}
+
+const insertParagraphInCell = (
+  editor: Editor,
+  cellIndex: number,
+  text: string,
+) => {
+  const cellPos = nthCellPos(editor, cellIndex)
+  const cell = editor.state.doc.nodeAt(cellPos)
+  if (!cell) throw new Error(`Could not find cell at index ${cellIndex}`)
+  const insertPos = cellPos + cell.nodeSize - 1
+  act(() => {
+    editor
+      .chain()
+      .focus()
+      .insertContentAt(insertPos, {
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      })
+      .run()
+  })
 }
 
 describe("TableBubbleMenu", () => {
@@ -558,6 +629,65 @@ describe("TableBubbleMenu", () => {
     expect(tableColumnCount(editor)).toBe(3)
   })
 
+  it("clears every cell in a selected row without removing the row", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 3, 5)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearRow = await findByText("Clear contents")
+    act(() => {
+      clearRow.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+  })
+
+  it("clears every cell in a selected column without removing the column", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 1, 7)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearColumn = await findByText("Clear contents")
+    act(() => {
+      clearColumn.click()
+    })
+
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "", "Row 2, C"])
+  })
+
+  it("clears header row content while keeping the header row", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 0, 2)
+    expect(firstRowTexts(editor)).toEqual(["Column A", "Column B", "Column C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearRow = await findByText("Clear contents")
+    act(() => {
+      clearRow.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "", ""])
+
+    // Header axes withhold Delete row even after clearing.
+    selectCells(editor, 0, 2)
+    await activateTableBubbleMenu(findByRole)
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
   it("withholds Delete and Move when selection includes header row", async () => {
     const { editor, findByText, findByRole, queryByText, queryByRole } =
       await renderHarness()
@@ -653,8 +783,7 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Move right")).toBeNull()
   })
 
-  it("shows only Merge cells for an irregular multi-cell selection", async () => {
-    // Arrange
+  it("shows Clear contents and Merge cells for an irregular multi-cell selection", async () => {
     const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
     selectCells(editor, 3, 7) // irregular 2x2-ish block, not a full row/column
@@ -662,10 +791,60 @@ describe("TableBubbleMenu", () => {
     // Act
     await activateTableBubbleMenu(findByRole)
 
-    // Assert
+    expect(await findByText("Clear contents")).toBeTruthy()
     expect(await findByText("Merge cells")).toBeTruthy()
     expect(queryByText("Delete row")).toBeNull()
     expect(queryByText("Delete column")).toBeNull()
+  })
+
+  it("clears every cell in a multi-cell block without removing cells", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 3, 7)
+    expect(rowTextsAt(editor, 1)).toEqual(["Row 1, A", "Row 1, B", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
+    await activateTableBubbleMenu(findByRole)
+
+    const clearBlock = await findByText("Clear contents")
+    act(() => {
+      clearBlock.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", "Row 1, C"])
+    expect(rowTextsAt(editor, 2)).toEqual(["", "", "Row 2, C"])
+  })
+
+  it("shows Clear contents and Delete table for a whole-table selection", async () => {
+    const { editor, findByText, findByRole, queryByText } =
+      await renderHarness()
+
+    selectCells(editor, 0, 8)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(await findByText("Delete table")).toBeTruthy()
+    expect(queryByText("Merge cells")).toBeNull()
+    expect(queryByText("Delete row")).toBeNull()
+  })
+
+  it("clears every cell in a whole-table selection without removing the table", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
+    selectCells(editor, 0, 8)
+    await activateTableBubbleMenu(findByRole)
+
+    const clearTable = await findByText("Clear contents")
+    act(() => {
+      clearTable.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+    expect(rowTextsAt(editor, 2)).toEqual(["", "", ""])
   })
 
   it("shows no menu content for a plain cursor outside any selection", async () => {
@@ -764,11 +943,17 @@ describe("TableBubbleMenu", () => {
     expect(queryByText("Delete row")).toBeNull()
   })
 
-  it("shows Split cell for a single cell that came from a merge, and nothing for an ordinary single cell", async () => {
-    const { editor, findByText, findByRole, queryByText, queryByRole } =
+  it("shows Clear contents for a single cell, and Clear plus Split for a merged single cell", async () => {
+    const { editor, findByText, findByRole, queryByText } =
       await renderHarness()
 
-    // Arrange — merge two adjacent body cells, then re-select the result
+    selectCells(editor, 6, 6)
+    await activateTableBubbleMenu(findByRole)
+
+    expect(await findByText("Clear contents")).toBeTruthy()
+    expect(queryByText("Split cell")).toBeNull()
+    expect(queryByText("Merge cells")).toBeNull()
+
     selectCells(editor, 3, 4)
     act(() => {
       editor.chain().focus().mergeCells().run()
@@ -778,17 +963,107 @@ describe("TableBubbleMenu", () => {
     // Act
     await activateTableBubbleMenu(findByRole)
 
-    // Assert — merged single cell
+    expect(await findByText("Clear contents")).toBeTruthy()
     expect(await findByText("Split cell")).toBeTruthy()
     expect(queryByText("Merge cells")).toBeNull()
+  })
 
-    // Arrange / Act — ordinary single cell
+  it("clears a single selected cell without removing the cell", async () => {
+    const { editor, findByText, findByRole } = await renderHarness()
+
     selectCells(editor, 6, 6)
+    expect(rowTextsAt(editor, 2)).toEqual(["Row 2, A", "Row 2, B", "Row 2, C"])
 
-    // Assert — no menu
-    expect(queryByText("Split cell")).toBeNull()
-    expect(queryByText("Merge cells")).toBeNull()
-    expect(queryByRole("button", { name: "Table actions" })).toBeNull()
+    await activateTableBubbleMenu(findByRole)
+    const clearCell = await findByText("Clear contents")
+    act(() => {
+      clearCell.click()
+    })
+
+    expect(tableRowCount(editor)).toBe(3)
+    expect(rowTextsAt(editor, 2)).toEqual(["", "Row 2, B", "Row 2, C"])
+  })
+
+  it("clears a merged cell without splitting it", async () => {
+    const { editor } = await renderHarness()
+
+    selectCells(editor, 3, 4)
+    act(() => {
+      editor.chain().focus().mergeCells().run()
+    })
+    expect(rowCellCount(editor, 1)).toBe(2)
+    const mergedCell = editor.state.doc.nodeAt(nthCellPos(editor, 3))
+    expect(mergedCell?.attrs.colspan).toBe(2)
+
+    selectCells(editor, 3, 3)
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(rowCellCount(editor, 1)).toBe(2)
+    expect(rowTextsAt(editor, 1)).toEqual(["", "Row 1, C"])
+    const clearedMergedCell = editor.state.doc.nodeAt(nthCellPos(editor, 3))
+    expect(clearedMergedCell?.attrs.colspan).toBe(2)
+    expect(clearedMergedCell?.attrs.rowspan).toBe(1)
+  })
+
+  it("keeps the cell selection after clearing", async () => {
+    const { editor } = await renderHarness()
+
+    selectCells(editor, 3, 5)
+    expect(cellSelectionIndices(editor)).toEqual({ start: 3, end: 5 })
+
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(cellSelectionIndices(editor)).toEqual({ start: 3, end: 5 })
+    expect(rowTextsAt(editor, 1)).toEqual(["", "", ""])
+  })
+
+  it("clears header column content while preserving header column cells", async () => {
+    const { editor } = await renderHarness()
+
+    act(() => {
+      editor.chain().focus().toggleHeaderColumn().run()
+    })
+    selectCells(editor, 0, 6)
+    expect(columnCellTypesAt(editor, 0)).toEqual([
+      "tableHeader",
+      "tableHeader",
+      "tableHeader",
+    ])
+
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(tableColumnCount(editor)).toBe(3)
+    expect(firstRowTexts(editor)).toEqual(["", "Column B", "Column C"])
+    expect(rowTextsAt(editor, 1)).toEqual(["", "Row 1, B", "Row 1, C"])
+    expect(columnCellTypesAt(editor, 0)).toEqual([
+      "tableHeader",
+      "tableHeader",
+      "tableHeader",
+    ])
+  })
+
+  it("replaces multi-paragraph cell content with a single empty paragraph", async () => {
+    const { editor } = await renderHarness()
+
+    selectCells(editor, 6, 6)
+    insertParagraphInCell(editor, 6, "Second paragraph")
+    expect(cellBlockCountAt(editor, 6)).toBe(2)
+    expect(rowTextsAt(editor, 2)[0]).toContain("Row 2, A")
+    expect(rowTextsAt(editor, 2)[0]).toContain("Second paragraph")
+
+    selectCells(editor, 6, 6)
+    act(() => {
+      clearSelectedCells(editor)
+    })
+
+    expect(cellBlockCountAt(editor, 6)).toBe(1)
+    expect(rowTextsAt(editor, 2)).toEqual(["", "Row 2, B", "Row 2, C"])
   })
 
   it("hides when focus moves outside the editor (e.g. Table Settings modal)", async () => {

--- a/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
+++ b/apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts
@@ -14,7 +14,6 @@ import {
 import type { SelectionKind } from "./TableBubbleMenu.types"
 import {
   detectTableSelectionKind,
-  isActionableTableSelectionKind,
   isEditorModalOpen,
 } from "./TableBubbleMenu.utils"
 import {
@@ -73,7 +72,7 @@ export const useTableBubbleMenu = (editor: Editor): TableBubbleMenuUiState => {
   })
 
   const show =
-    isActionableTableSelectionKind(kind) &&
+    kind !== "none" &&
     !isDragging &&
     !isEditorModalOpen() &&
     (isFocused || menuHasFocus)


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +58 | -20 |
| 🧪 Test | 1 | +288 | -13 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

When a full row or column is selected in the rich-text table editor, authors had no way to empty cell content without deleting the row/column structure. That forces unnecessary structural edits (delete + re-add) when users only want to wipe text.

Closes https://linear.app/ogp/issue/ISOM-2395/rte-add-clear-contents-button-for-rowcolumn

## Solution

Adds a **Clear contents** action to the contextual `TableBubbleMenu` for full row and full column selections. The action replaces each selected cell's inner content with a single empty paragraph via a ProseMirror transaction, preserving cell type (header vs body) and colspan/rowspan.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- **Clear contents** button in row and column bubble-menu action groups (cross icon)
- Works on header rows/columns, unlike **Delete row/column**
- Supports multi-row / multi-column selections that span the full table width or height

**Improvements**:

- `TableBubbleMenu.clear.ts` extracts the clear logic into named helpers (`innerContentRangeOfCell`, `clearCellContentsInReverseDocumentOrder`, etc.) with named-argument call sites for readability

**Bug Fixes**:

- N/A

## Before & After Screenshots

**BEFORE**:

<!-- No clear-contents action when a full row/column is selected -->

**AFTER**:

<!-- TableBubbleMenu shows "Clear contents" for full row/column selections; cells become empty while the row/column remains -->

https://github.com/user-attachments/assets/32310ec6-80a2-48b7-97af-9bb2d9eced0d

## Tests

**Manual Verification Steps**:

- [ ] Open a page in Studio with a rich-text table (e.g. content page editor)
- [ ] Click-drag to select an entire body row — confirm the bubble menu appears with **Clear contents**
- [ ] Click **Clear contents** — confirm all cells in that row are empty but the row still exists
- [ ] Select an entire column and click **Clear contents** — confirm only that column's cells are emptied
- [ ] Select the header row and click **Clear contents** — confirm header cells are emptied and **Delete row** is still withheld

**New scripts**:

- N/A

**New dependencies**:

- N/A

**New dev dependencies**:

- N/A

---









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds a contextual action that clears selected rich-text table cells while retaining their structure and selection.
- Uses ProseMirror’s cell-selection deletion transaction and restores the mapped cell selection.
- Exposes the action across row, column, table, multi-cell, single-cell, and merged-cell menu states.
- Adds browser coverage for structural preservation, header cells, merged cells, multi-paragraph content, and selection retention.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.clear.ts | Adds the transaction helper that clears a CellSelection and restores its mapped selection. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenu.utils.ts | Removes a redundant selection-kind predicate while retaining the modal visibility helper. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/TableBubbleMenuActions.tsx | Adds and shares the Clear contents action across supported table-selection menus. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/__tests__/TableBubbleMenu.browser.test.tsx | Expands browser tests for clearing varied selections while preserving table and cell structure. |
| apps/studio/src/features/editing-experience/components/TableBubbleMenu/useTableBubbleMenu.ts | Inlines the existing non-none selection check used to determine menu visibility. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Author selects table cells] --> B[Table bubble menu]
  B --> C[Clear contents]
  C --> D[deleteCellSelection transaction]
  D --> E[Map anchor and head positions]
  E --> F[Restore CellSelection]
  F --> G[Cells remain selected with empty paragraphs]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["chore(rte-table): dedupe clear-contents ..."](https://github.com/opengovsg/isomer/commit/4900669e04370a287ea34b963aec20578c25cab2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50004649)</sub>

<!-- /greptile_comment -->