### PR TITLE
🎀📊 feat(rte-table): add inline TableCaption with multi-table correctness

### DIFF
--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -3,7 +3,6 @@ import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
-  BiCog,
   BiItalic,
   BiLink,
   BiListOl,
@@ -15,16 +14,10 @@ import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
-import { TableSettingsModal } from "../TableSettingsModal"
 import { MenuBar } from "./MenuBar"
 import { TiptapLinkEditorModal } from "./TiptapLinkEditorModal"
 
 export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
-  const {
-    isOpen: isTableSettingsModalOpen,
-    onOpen: onTableSettingsModalOpen,
-    onClose: onTableSettingsModalClose,
-  } = useDisclosure()
   const {
     isOpen: isLinkModalOpen,
     onOpen: onLinkModalOpen,
@@ -105,17 +98,6 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // "Table settings" (the caption editor) is the one item from the old
-      // table toolbar group not yet covered by TableBubbleMenu. Every other
-      // action (add/delete row/column, merge, split) moved there already.
-      // This stays until the inline TableCaption component replaces it.
-      {
-        type: "item",
-        icon: BiCog,
-        title: "Table settings",
-        isHidden: () => !editor.isActive("table"),
-        action: onTableSettingsModalOpen,
-      },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.
       {
@@ -169,16 +151,10 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         ],
       },
     ],
-    [editor, onLinkModalOpen, onTableSettingsModalOpen],
+    [editor, onLinkModalOpen],
   )
   return (
     <>
-      <TableSettingsModal
-        editor={editor}
-        isOpen={isTableSettingsModalOpen}
-        onClose={onTableSettingsModalClose}
-      />
-
       <TiptapLinkEditorModal
         editor={editor}
         isOpen={isLinkModalOpen}

--- a/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx
@@ -3,7 +3,6 @@ import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
-  BiCog,
   BiItalic,
   BiLink,
   BiListOl,
@@ -15,16 +14,10 @@ import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
-import { TableSettingsModal } from "../TableSettingsModal"
 import { MenuBar } from "./MenuBar"
 import { TiptapLinkEditorModal } from "./TiptapLinkEditorModal"
 
 export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
-  const {
-    isOpen: isTableSettingsModalOpen,
-    onOpen: onTableSettingsModalOpen,
-    onClose: onTableSettingsModalClose,
-  } = useDisclosure()
   const {
     isOpen: isLinkModalOpen,
     onOpen: onLinkModalOpen,
@@ -105,17 +98,6 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // "Table settings" (the caption editor) is the one item from the old
-      // table toolbar group not yet covered by TableBubbleMenu — every other
-      // action (add/delete row/column, merge, split) moved there already.
-      // This stays until the inline TableCaption component replaces it.
-      {
-        type: "item",
-        icon: BiCog,
-        title: "Table settings",
-        isHidden: () => !editor.isActive("table"),
-        action: onTableSettingsModalOpen,
-      },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.
       {
@@ -169,16 +151,10 @@ export const AccordionMenuBar = ({ editor }: { editor: Editor }) => {
         ],
       },
     ],
-    [editor, onLinkModalOpen, onTableSettingsModalOpen],
+    [editor, onLinkModalOpen],
   )
   return (
     <>
-      <TableSettingsModal
-        editor={editor}
-        isOpen={isTableSettingsModalOpen}
-        onClose={onTableSettingsModalClose}
-      />
-
       <TiptapLinkEditorModal
         editor={editor}
         isOpen={isLinkModalOpen}

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -3,7 +3,6 @@ import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
-  BiCog,
   BiItalic,
   BiLink,
   BiListOl,
@@ -15,16 +14,10 @@ import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
-import { TableSettingsModal } from "../TableSettingsModal"
 import { MenuBar } from "./MenuBar"
 import { TiptapLinkEditorModal } from "./TiptapLinkEditorModal"
 
 export const TextMenuBar = ({ editor }: { editor: Editor }) => {
-  const {
-    isOpen: isTableSettingsModalOpen,
-    onOpen: onTableSettingsModalOpen,
-    onClose: onTableSettingsModalClose,
-  } = useDisclosure()
   const {
     isOpen: isLinkModalOpen,
     onOpen: onLinkModalOpen,
@@ -154,17 +147,6 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // "Table settings" (the caption editor) is the one item from the old
-      // table toolbar group not yet covered by TableBubbleMenu — every other
-      // action (add/delete row/column, merge, split) moved there already.
-      // This stays until the inline TableCaption component replaces it.
-      {
-        type: "item",
-        icon: BiCog,
-        title: "Table settings",
-        isHidden: () => !editor.isActive("table"),
-        action: onTableSettingsModalOpen,
-      },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.
       {
@@ -218,16 +200,10 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         ],
       },
     ],
-    [editor, onLinkModalOpen, onTableSettingsModalOpen],
+    [editor, onLinkModalOpen],
   )
   return (
     <>
-      <TableSettingsModal
-        editor={editor}
-        isOpen={isTableSettingsModalOpen}
-        onClose={onTableSettingsModalClose}
-      />
-
       <TiptapLinkEditorModal
         editor={editor}
         isOpen={isLinkModalOpen}

--- a/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
+++ b/apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx
@@ -3,7 +3,6 @@ import { useDisclosure } from "@chakra-ui/react"
 import { useMemo } from "react"
 import {
   BiBold,
-  BiCog,
   BiItalic,
   BiLink,
   BiListOl,
@@ -15,17 +14,11 @@ import { MdHorizontalRule, MdSubscript, MdSuperscript } from "react-icons/md"
 import { TableSizePicker } from "~/features/editing-experience/components/TableSizePicker/TableSizePicker"
 
 import type { PossibleMenubarItemProps } from "./MenubarItem/types"
-import { TableSettingsModal } from "../TableSettingsModal"
 import { MenuBar } from "./MenuBar"
 import { TiptapLinkBubbleMenu } from "./TiptapLinkBubbleMenu"
 import { TiptapLinkEditorModal } from "./TiptapLinkEditorModal"
 
 export const TextMenuBar = ({ editor }: { editor: Editor }) => {
-  const {
-    isOpen: isTableSettingsModalOpen,
-    onOpen: onTableSettingsModalOpen,
-    onClose: onTableSettingsModalClose,
-  } = useDisclosure()
   const {
     isOpen: isLinkModalOpen,
     onOpen: onLinkModalOpen,
@@ -155,17 +148,6 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         type: "custom",
         render: () => <TableSizePicker editor={editor} />,
       },
-      // "Table settings" (the caption editor) is the one item from the old
-      // table toolbar group not yet covered by TableBubbleMenu. Every other
-      // action (add/delete row/column, merge, split) moved there already.
-      // This stays until the inline TableCaption component replaces it.
-      {
-        type: "item",
-        icon: BiCog,
-        title: "Table settings",
-        isHidden: () => !editor.isActive("table"),
-        action: onTableSettingsModalOpen,
-      },
       // Table-scoped: promoted onto the main toolbar instead of the overflow
       // menu while editing inside a table, same as the "Table" group above.
       {
@@ -219,16 +201,10 @@ export const TextMenuBar = ({ editor }: { editor: Editor }) => {
         ],
       },
     ],
-    [editor, onLinkModalOpen, onTableSettingsModalOpen],
+    [editor, onLinkModalOpen],
   )
   return (
     <>
-      <TableSettingsModal
-        editor={editor}
-        isOpen={isTableSettingsModalOpen}
-        onClose={onTableSettingsModalClose}
-      />
-
       <TiptapLinkEditorModal
         editor={editor}
         isOpen={isLinkModalOpen}

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.browser.test.tsx
@@ -1,0 +1,333 @@
+import type { JSONContent } from "@tiptap/react"
+import type { Editor as TiptapEditor } from "@tiptap/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { render, screen, waitFor } from "@testing-library/react"
+import { EditorContent } from "@tiptap/react"
+import { useState } from "react"
+import { describe, expect, it } from "vitest"
+import { userEvent } from "vitest/browser"
+import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor"
+import { theme } from "~/theme"
+
+import { DEFAULT_TABLE_CAPTION, LEGACY_DEFAULT_TABLE_CAPTION } from "./utils"
+
+const tableContent = (caption: string) => ({
+  type: "table",
+  attrs: { caption },
+  content: [
+    {
+      type: "tableRow",
+      content: ["Column A", "Column B"].map((text) => ({
+        type: "tableHeader",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      })),
+    },
+    {
+      type: "tableRow",
+      content: ["Row 1, A", "Row 1, B"].map((text) => ({
+        type: "tableCell",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      })),
+    },
+  ],
+})
+
+const Harness = ({
+  initialContent,
+  onEditorReady,
+}: {
+  initialContent: JSONContent
+  onEditorReady?: (editor: TiptapEditor) => void
+}) => {
+  const [content, setContent] = useState<JSONContent | undefined>(
+    initialContent,
+  )
+  const editor = useTextEditor({ data: content, handleChange: setContent })
+
+  if (editor) onEditorReady?.(editor)
+
+  // Captions are rendered by the `table` node view, so mounting the editor
+  // content is all that is needed here.
+  return <EditorContent editor={editor} />
+}
+
+const renderHarness = (initialContent: JSONContent) => {
+  let editor: TiptapEditor | undefined
+  const utils = render(
+    <ThemeProvider theme={theme}>
+      <Harness
+        initialContent={initialContent}
+        onEditorReady={(e) => {
+          editor = e
+        }}
+      />
+    </ThemeProvider>,
+  )
+  return { ...utils, getEditor: () => editor }
+}
+
+const getTableCaptions = (editor: TiptapEditor): string[] => {
+  const captions: string[] = []
+  editor.state.doc.descendants((node) => {
+    if (node.type.name === "table") {
+      captions.push((node.attrs.caption as string | undefined) ?? "")
+      return false
+    }
+    return true
+  })
+  return captions
+}
+
+const getCaptionButton = async (name?: string | RegExp) =>
+  screen.findByRole("button", {
+    name: name ?? /add table caption|edit table caption/i,
+  })
+
+describe("TableCaption", () => {
+  it("renders an Add caption button when the table has no caption", async () => {
+    // Arrange
+    renderHarness({ type: "prose", content: [tableContent("")] })
+
+    // Assert
+    expect(await getCaptionButton("Add table caption")).toHaveTextContent(
+      "Add caption",
+    )
+  })
+
+  it("renders Add caption for legacy and current default placeholder captions", async () => {
+    // Arrange
+    renderHarness({
+      type: "prose",
+      content: [
+        tableContent(LEGACY_DEFAULT_TABLE_CAPTION),
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "between tables" }],
+        },
+        tableContent(DEFAULT_TABLE_CAPTION),
+      ],
+    })
+
+    // Assert
+    expect(
+      await screen.findByText(LEGACY_DEFAULT_TABLE_CAPTION),
+    ).toBeInTheDocument()
+    expect(await screen.findByText(DEFAULT_TABLE_CAPTION)).toBeInTheDocument()
+
+    const buttons = await screen.findAllByRole("button", {
+      name: "Add table caption",
+    })
+    expect(buttons).toHaveLength(2)
+    for (const button of buttons) {
+      expect(button).toHaveTextContent("Add caption")
+    }
+  })
+
+  it("renders the caption text inline with an Edit button when a real caption exists", async () => {
+    // Arrange
+    renderHarness({
+      type: "prose",
+      content: [tableContent("Existing caption")],
+    })
+
+    // Assert
+    const captionText = await screen.findByText("Existing caption")
+    expect(captionText).toBeInTheDocument()
+    expect(await getCaptionButton("Edit table caption")).toHaveTextContent(
+      "Edit",
+    )
+  })
+
+  it("wraps long caption text across multiple lines", async () => {
+    // Arrange
+    const longCaption =
+      "This is a very long table caption that should wrap onto multiple lines when rendered above the table in the editor"
+
+    renderHarness({
+      type: "prose",
+      content: [tableContent(longCaption)],
+    })
+
+    // Assert
+    const captionText = await screen.findByText(longCaption)
+    expect(captionText).toHaveStyle({ whiteSpace: "normal" })
+    expect(captionText).toHaveStyle({ wordBreak: "break-word" })
+  })
+
+  it("shows the default placeholder caption for newly inserted tables", async () => {
+    // Arrange
+    const { getEditor } = renderHarness({ type: "prose", content: [] })
+
+    await waitFor(() => {
+      expect(getEditor()).toBeDefined()
+    })
+
+    // Act
+    getEditor()!
+      .chain()
+      .focus()
+      .insertTable({ rows: 2, cols: 2, withHeaderRow: true })
+      .run()
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText(DEFAULT_TABLE_CAPTION)).toBeInTheDocument()
+    })
+    expect(
+      await screen.findByRole("button", { name: "Add table caption" }),
+    ).toHaveTextContent("Add caption")
+  })
+
+  it("opens the table settings modal and saves a new caption", async () => {
+    // Arrange
+    const { getEditor } = renderHarness({
+      type: "prose",
+      content: [tableContent("")],
+    })
+
+    // Act
+    await userEvent.click(await getCaptionButton())
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.type(textarea, "A new caption")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.queryByText("Table settings")).not.toBeInTheDocument()
+    })
+    expect(getTableCaptions(getEditor()!)).toEqual(["A new caption"])
+    expect(screen.getByText("A new caption")).toBeInTheDocument()
+  })
+
+  it("opens the modal pre-filled with the placeholder caption text", async () => {
+    // Arrange
+    renderHarness({
+      type: "prose",
+      content: [tableContent(DEFAULT_TABLE_CAPTION)],
+    })
+
+    // Act
+    await userEvent.click(await getCaptionButton())
+
+    // Assert
+    expect(
+      await screen.findByPlaceholderText("This is the caption for your table"),
+    ).toHaveValue(DEFAULT_TABLE_CAPTION)
+  })
+
+  it("opens the modal pre-filled when editing an existing caption", async () => {
+    // Arrange
+    renderHarness({
+      type: "prose",
+      content: [tableContent("Existing caption")],
+    })
+
+    // Act
+    await userEvent.click(await getCaptionButton("Edit table caption"))
+
+    // Assert
+    expect(
+      await screen.findByPlaceholderText("This is the caption for your table"),
+    ).toHaveValue("Existing caption")
+  })
+
+  it("updates the caption when saving changes in the modal", async () => {
+    // Arrange
+    const { getEditor } = renderHarness({
+      type: "prose",
+      content: [tableContent("Old caption")],
+    })
+
+    // Act
+    await userEvent.click(await getCaptionButton("Edit table caption"))
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Updated caption")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
+
+    // Assert
+    await waitFor(() => {
+      expect(getTableCaptions(getEditor()!)).toEqual(["Updated caption"])
+    })
+    expect(screen.getByText("Updated caption")).toBeInTheDocument()
+  })
+
+  it("does not save when closing the modal without saving", async () => {
+    // Arrange
+    const { getEditor } = renderHarness({
+      type: "prose",
+      content: [tableContent("Kept caption")],
+    })
+
+    // Act
+    await userEvent.click(await getCaptionButton("Edit table caption"))
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Discarded caption")
+    await userEvent.click(
+      screen.getByRole("button", { name: "Go back to editing" }),
+    )
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.queryByText("Table settings")).not.toBeInTheDocument()
+    })
+    expect(getTableCaptions(getEditor()!)).toEqual(["Kept caption"])
+    expect(screen.getByText("Kept caption")).toBeInTheDocument()
+  })
+
+  it("renders one caption control per table and scopes edits to the correct table instance", async () => {
+    // Arrange
+    const { getEditor } = renderHarness({
+      type: "prose",
+      content: [
+        tableContent("First table caption"),
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "text between tables" }],
+        },
+        tableContent(""),
+      ],
+    })
+
+    expect(await screen.findByText("First table caption")).toBeInTheDocument()
+    const addSecond = await screen.findByRole("button", {
+      name: "Add table caption",
+    })
+
+    // Act
+    await userEvent.click(addSecond)
+
+    const textarea = await screen.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    await userEvent.type(textarea, "Second table caption")
+    await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
+
+    // Assert
+    await waitFor(() => {
+      expect(getTableCaptions(getEditor()!)).toEqual([
+        "First table caption",
+        "Second table caption",
+      ])
+    })
+    expect(screen.getByText("Second table caption")).toBeInTheDocument()
+    // Both tables now carry a real caption, so both controls read "Edit".
+    const editButtons = await screen.findAllByRole("button", {
+      name: "Edit table caption",
+    })
+    expect(editButtons).toHaveLength(2)
+    for (const editButton of editButtons) {
+      expect(editButton).toHaveTextContent("Edit")
+    }
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.browser.test.tsx
@@ -46,8 +46,6 @@ const Harness = ({
 
   if (editor) onEditorReady?.(editor)
 
-  // Captions are rendered by the `table` node view, so mounting the editor
-  // content is all that is needed here.
   return <EditorContent editor={editor} />
 }
 
@@ -85,17 +83,14 @@ const getCaptionButton = async (name?: string | RegExp) =>
 
 describe("TableCaption", () => {
   it("renders an Add caption button when the table has no caption", async () => {
-    // Arrange
     renderHarness({ type: "prose", content: [tableContent("")] })
 
-    // Assert
     expect(await getCaptionButton("Add table caption")).toHaveTextContent(
       "Add caption",
     )
   })
 
   it("renders Add caption for legacy and current default placeholder captions", async () => {
-    // Arrange
     renderHarness({
       type: "prose",
       content: [
@@ -108,7 +103,6 @@ describe("TableCaption", () => {
       ],
     })
 
-    // Assert
     expect(
       await screen.findByText(LEGACY_DEFAULT_TABLE_CAPTION),
     ).toBeInTheDocument()
@@ -124,13 +118,11 @@ describe("TableCaption", () => {
   })
 
   it("renders the caption text inline with an Edit button when a real caption exists", async () => {
-    // Arrange
     renderHarness({
       type: "prose",
       content: [tableContent("Existing caption")],
     })
 
-    // Assert
     const captionText = await screen.findByText("Existing caption")
     expect(captionText).toBeInTheDocument()
     expect(await getCaptionButton("Edit table caption")).toHaveTextContent(
@@ -139,7 +131,6 @@ describe("TableCaption", () => {
   })
 
   it("wraps long caption text across multiple lines", async () => {
-    // Arrange
     const longCaption =
       "This is a very long table caption that should wrap onto multiple lines when rendered above the table in the editor"
 
@@ -148,28 +139,24 @@ describe("TableCaption", () => {
       content: [tableContent(longCaption)],
     })
 
-    // Assert
     const captionText = await screen.findByText(longCaption)
     expect(captionText).toHaveStyle({ whiteSpace: "normal" })
     expect(captionText).toHaveStyle({ wordBreak: "break-word" })
   })
 
   it("shows the default placeholder caption for newly inserted tables", async () => {
-    // Arrange
     const { getEditor } = renderHarness({ type: "prose", content: [] })
 
     await waitFor(() => {
       expect(getEditor()).toBeDefined()
     })
 
-    // Act
     getEditor()!
       .chain()
       .focus()
       .insertTable({ rows: 2, cols: 2, withHeaderRow: true })
       .run()
 
-    // Assert
     await waitFor(() => {
       expect(screen.getByText(DEFAULT_TABLE_CAPTION)).toBeInTheDocument()
     })
@@ -179,13 +166,11 @@ describe("TableCaption", () => {
   })
 
   it("opens the table settings modal and saves a new caption", async () => {
-    // Arrange
     const { getEditor } = renderHarness({
       type: "prose",
       content: [tableContent("")],
     })
 
-    // Act
     await userEvent.click(await getCaptionButton())
 
     const textarea = await screen.findByPlaceholderText(
@@ -194,7 +179,6 @@ describe("TableCaption", () => {
     await userEvent.type(textarea, "A new caption")
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
 
-    // Assert
     await waitFor(() => {
       expect(screen.queryByText("Table settings")).not.toBeInTheDocument()
     })
@@ -203,45 +187,37 @@ describe("TableCaption", () => {
   })
 
   it("opens the modal pre-filled with the placeholder caption text", async () => {
-    // Arrange
     renderHarness({
       type: "prose",
       content: [tableContent(DEFAULT_TABLE_CAPTION)],
     })
 
-    // Act
     await userEvent.click(await getCaptionButton())
 
-    // Assert
     expect(
       await screen.findByPlaceholderText("This is the caption for your table"),
     ).toHaveValue(DEFAULT_TABLE_CAPTION)
   })
 
   it("opens the modal pre-filled when editing an existing caption", async () => {
-    // Arrange
     renderHarness({
       type: "prose",
       content: [tableContent("Existing caption")],
     })
 
-    // Act
     await userEvent.click(await getCaptionButton("Edit table caption"))
 
-    // Assert
     expect(
       await screen.findByPlaceholderText("This is the caption for your table"),
     ).toHaveValue("Existing caption")
   })
 
   it("updates the caption when saving changes in the modal", async () => {
-    // Arrange
     const { getEditor } = renderHarness({
       type: "prose",
       content: [tableContent("Old caption")],
     })
 
-    // Act
     await userEvent.click(await getCaptionButton("Edit table caption"))
 
     const textarea = await screen.findByPlaceholderText(
@@ -251,7 +227,6 @@ describe("TableCaption", () => {
     await userEvent.type(textarea, "Updated caption")
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
 
-    // Assert
     await waitFor(() => {
       expect(getTableCaptions(getEditor()!)).toEqual(["Updated caption"])
     })
@@ -259,13 +234,11 @@ describe("TableCaption", () => {
   })
 
   it("does not save when closing the modal without saving", async () => {
-    // Arrange
     const { getEditor } = renderHarness({
       type: "prose",
       content: [tableContent("Kept caption")],
     })
 
-    // Act
     await userEvent.click(await getCaptionButton("Edit table caption"))
 
     const textarea = await screen.findByPlaceholderText(
@@ -277,7 +250,6 @@ describe("TableCaption", () => {
       screen.getByRole("button", { name: "Go back to editing" }),
     )
 
-    // Assert
     await waitFor(() => {
       expect(screen.queryByText("Table settings")).not.toBeInTheDocument()
     })
@@ -286,7 +258,6 @@ describe("TableCaption", () => {
   })
 
   it("renders one caption control per table and scopes edits to the correct table instance", async () => {
-    // Arrange
     const { getEditor } = renderHarness({
       type: "prose",
       content: [
@@ -304,7 +275,6 @@ describe("TableCaption", () => {
       name: "Add table caption",
     })
 
-    // Act
     await userEvent.click(addSecond)
 
     const textarea = await screen.findByPlaceholderText(
@@ -313,7 +283,6 @@ describe("TableCaption", () => {
     await userEvent.type(textarea, "Second table caption")
     await userEvent.click(screen.getByRole("button", { name: "Save changes" }))
 
-    // Assert
     await waitFor(() => {
       expect(getTableCaptions(getEditor()!)).toEqual([
         "First table caption",
@@ -321,7 +290,6 @@ describe("TableCaption", () => {
       ])
     })
     expect(screen.getByText("Second table caption")).toBeInTheDocument()
-    // Both tables now carry a real caption, so both controls read "Edit".
     const editButtons = await screen.findAllByRole("button", {
       name: "Edit table caption",
     })

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.stories.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.stories.tsx
@@ -1,0 +1,127 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import type { JSONContent } from "@tiptap/react"
+import { Box } from "@chakra-ui/react"
+import { useState } from "react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
+import { TiptapProseEditor } from "~/features/editing-experience/components/form-builder/renderers/TipTapEditor"
+import { useTextEditor } from "~/features/editing-experience/hooks/useTextEditor"
+
+import { DEFAULT_TABLE_CAPTION } from "./utils"
+
+const tableContent = (caption: string) => ({
+  type: "table",
+  attrs: { caption },
+  content: [
+    {
+      type: "tableRow",
+      content: ["Column A", "Column B"].map((text) => ({
+        type: "tableHeader",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      })),
+    },
+    {
+      type: "tableRow",
+      content: ["Row 1, A", "Row 1, B"].map((text) => ({
+        type: "tableCell",
+        content: [{ type: "paragraph", content: [{ type: "text", text }] }],
+      })),
+    },
+  ],
+})
+
+const SINGLE_TABLE_PLACEHOLDER_CAPTION: JSONContent = {
+  type: "prose",
+  content: [tableContent(DEFAULT_TABLE_CAPTION)],
+}
+
+const SINGLE_TABLE_WITH_CAPTION: JSONContent = {
+  type: "prose",
+  content: [tableContent("Figure 1: Quarterly revenue by department")],
+}
+
+const TableCaptionHarness = ({
+  initialContent,
+}: {
+  initialContent: JSONContent
+}) => {
+  const [content, setContent] = useState<JSONContent | undefined>(
+    initialContent,
+  )
+  const editor = useTextEditor({ data: content, handleChange: setContent })
+
+  return (
+    <Box p="3rem" maxW="48rem" mx="auto">
+      <TiptapProseEditor editor={editor} />
+    </Box>
+  )
+}
+
+const meta: Meta<typeof TableCaptionHarness> = {
+  title: "Features/EditingExperience/TableCaption",
+  component: TableCaptionHarness,
+}
+
+export default meta
+type Story = StoryObj<typeof TableCaptionHarness>
+
+export const PlaceholderCaption: Story = {
+  args: { initialContent: SINGLE_TABLE_PLACEHOLDER_CAPTION },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Assert
+    await expect(
+      await canvas.findByText(DEFAULT_TABLE_CAPTION),
+    ).toBeInTheDocument()
+    await expect(
+      await canvas.findByRole("button", { name: "Add table caption" }),
+    ).toHaveTextContent("Add caption")
+  },
+}
+
+export const PopulatedCaption: Story = {
+  args: { initialContent: SINGLE_TABLE_WITH_CAPTION },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Assert
+    await expect(
+      await canvas.findByText("Figure 1: Quarterly revenue by department"),
+    ).toBeInTheDocument()
+    await expect(
+      await canvas.findByRole("button", { name: "Edit table caption" }),
+    ).toHaveTextContent("Edit")
+  },
+}
+
+export const EditCaptionViaModal: Story = {
+  args: { initialContent: SINGLE_TABLE_PLACEHOLDER_CAPTION },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const body = within(canvasElement.ownerDocument.body)
+
+    // Act
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Add table caption" }),
+    )
+
+    const textarea = await body.findByPlaceholderText(
+      "This is the caption for your table",
+    )
+    // Modal is pre-filled with the placeholder caption; clear so we don't append.
+    await userEvent.clear(textarea)
+    await userEvent.type(textarea, "Revenue breakdown by quarter")
+    await userEvent.click(body.getByRole("button", { name: "Save changes" }))
+
+    // Assert
+    await waitFor(async () => {
+      await expect(body.queryByText("Table settings")).not.toBeInTheDocument()
+    })
+    await expect(
+      await canvas.findByText("Revenue breakdown by quarter"),
+    ).toBeInTheDocument()
+    await expect(
+      await canvas.findByRole("button", { name: "Edit table caption" }),
+    ).toBeInTheDocument()
+  },
+}

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.stories.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.stories.tsx
@@ -69,7 +69,6 @@ export const PlaceholderCaption: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // Assert
     await expect(
       await canvas.findByText(DEFAULT_TABLE_CAPTION),
     ).toBeInTheDocument()
@@ -84,7 +83,6 @@ export const PopulatedCaption: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // Assert
     await expect(
       await canvas.findByText("Figure 1: Quarterly revenue by department"),
     ).toBeInTheDocument()
@@ -100,7 +98,6 @@ export const EditCaptionViaModal: Story = {
     const canvas = within(canvasElement)
     const body = within(canvasElement.ownerDocument.body)
 
-    // Act
     await userEvent.click(
       await canvas.findByRole("button", { name: "Add table caption" }),
     )
@@ -108,12 +105,10 @@ export const EditCaptionViaModal: Story = {
     const textarea = await body.findByPlaceholderText(
       "This is the caption for your table",
     )
-    // Modal is pre-filled with the placeholder caption; clear so we don't append.
     await userEvent.clear(textarea)
     await userEvent.type(textarea, "Revenue breakdown by quarter")
     await userEvent.click(body.getByRole("button", { name: "Save changes" }))
 
-    // Assert
     await waitFor(async () => {
       await expect(body.queryByText("Table settings")).not.toBeInTheDocument()
     })

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
@@ -10,15 +10,6 @@ export interface TableCaptionProps {
   onCaptionChange: (caption: string) => void
 }
 
-/**
- * Read-only caption line for a single table with a right-aligned control that
- * opens the table settings modal — "Add caption" for placeholder defaults,
- * "Edit" when a real caption exists.
- *
- * Rendered by `TableNodeView`, so the caption it shows and the caption it
- * writes back always belong to the same `table` node — no document positions
- * to track, even when a document contains several tables.
- */
 export const TableCaption = ({
   caption,
   onCaptionChange,
@@ -65,8 +56,7 @@ export const TableCaption = ({
         </Button>
       </Flex>
 
-      {/* Mounted only while open so the form always initialises from the
-          caption as it stands when the author opens the modal. */}
+      {/* Unmount while closed so defaultValues match the caption at open time. */}
       {isTableSettingsModalOpen && (
         <TableSettingsModal
           caption={caption}

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx
@@ -1,0 +1,80 @@
+import { Flex, Icon, Text, useDisclosure } from "@chakra-ui/react"
+import { Button } from "@opengovsg/design-system-react"
+import { BiPencil } from "react-icons/bi"
+import { TableSettingsModal } from "~/features/editing-experience/components/TableSettingsModal/TableSettingsModal"
+
+import { isPlaceholderTableCaption } from "./utils"
+
+export interface TableCaptionProps {
+  caption: string
+  onCaptionChange: (caption: string) => void
+}
+
+/**
+ * Read-only caption line for a single table with a right-aligned control that
+ * opens the table settings modal — "Add caption" for placeholder defaults,
+ * "Edit" when a real caption exists.
+ *
+ * Rendered by `TableNodeView`, so the caption it shows and the caption it
+ * writes back always belong to the same `table` node — no document positions
+ * to track, even when a document contains several tables.
+ */
+export const TableCaption = ({
+  caption,
+  onCaptionChange,
+}: TableCaptionProps) => {
+  const {
+    isOpen: isTableSettingsModalOpen,
+    onOpen: onTableSettingsModalOpen,
+    onClose: onTableSettingsModalClose,
+  } = useDisclosure()
+
+  const hasCaption = !isPlaceholderTableCaption(caption)
+
+  return (
+    <>
+      <Flex align="center" justify="space-between" gap="0.25rem" w="100%">
+        <Text
+          flex="1"
+          minW={0}
+          textStyle="caption-2"
+          color={hasCaption ? "base.content.default" : "base.content.medium"}
+          whiteSpace="normal"
+          wordBreak="break-word"
+        >
+          {caption}
+        </Text>
+        <Button
+          variant="clear"
+          size="xs"
+          leftIcon={
+            <Icon
+              as={BiPencil}
+              color="interaction.links.default"
+              boxSize="1rem"
+            />
+          }
+          color="interaction.links.default"
+          textStyle="caption-1"
+          padding="0.5rem"
+          flexShrink={0}
+          onClick={onTableSettingsModalOpen}
+          aria-label={hasCaption ? "Edit table caption" : "Add table caption"}
+        >
+          {hasCaption ? "Edit" : "Add caption"}
+        </Button>
+      </Flex>
+
+      {/* Mounted only while open so the form always initialises from the
+          caption as it stands when the author opens the modal. */}
+      {isTableSettingsModalOpen && (
+        <TableSettingsModal
+          caption={caption}
+          isOpen
+          onClose={onTableSettingsModalClose}
+          onSave={onCaptionChange}
+        />
+      )}
+    </>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableNodeView.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableNodeView.tsx
@@ -1,0 +1,43 @@
+import type { NodeViewProps } from "@tiptap/react"
+import { Box } from "@chakra-ui/react"
+import { NodeViewContent, NodeViewWrapper } from "@tiptap/react"
+
+import { TableCaption } from "./TableCaption"
+
+/**
+ * React node view for the `table` node: the caption sits above the table in
+ * normal document flow, rendered by the same component that renders the table
+ * itself.
+ *
+ * `NodeViewContent as="table"` hands the `<table>` element to ProseMirror,
+ * which appends its own `<tbody>` (see `contentDOMElementTag` where this view
+ * is registered) and manages the rows inside it. Everything outside that
+ * element — the caption — is ours to render, and TipTap keeps it out of the
+ * editable region.
+ */
+export const TableNodeView = ({ node, updateAttributes }: NodeViewProps) => {
+  const caption = (node.attrs.caption as string | undefined) ?? ""
+
+  return (
+    <Box
+      as={NodeViewWrapper}
+      display="flex"
+      flexDirection="column"
+      gap="0.5rem"
+    >
+      {/* contentEditable=false keeps the caption row out of the editable
+          region, so clicks reach the button instead of moving the cursor. */}
+      <Box contentEditable={false}>
+        <TableCaption
+          caption={caption}
+          onCaptionChange={(nextCaption) =>
+            updateAttributes({ caption: nextCaption })
+          }
+        />
+      </Box>
+      {/* Explicit type argument: `NodeViewContent`'s `as` prop is `NoInfer`ed,
+          so the tag has to be named on both sides. */}
+      <NodeViewContent<"table"> as="table" />
+    </Box>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/TableCaption/TableNodeView.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/TableNodeView.tsx
@@ -4,17 +4,6 @@ import { NodeViewContent, NodeViewWrapper } from "@tiptap/react"
 
 import { TableCaption } from "./TableCaption"
 
-/**
- * React node view for the `table` node: the caption sits above the table in
- * normal document flow, rendered by the same component that renders the table
- * itself.
- *
- * `NodeViewContent as="table"` hands the `<table>` element to ProseMirror,
- * which appends its own `<tbody>` (see `contentDOMElementTag` where this view
- * is registered) and manages the rows inside it. Everything outside that
- * element — the caption — is ours to render, and TipTap keeps it out of the
- * editable region.
- */
 export const TableNodeView = ({ node, updateAttributes }: NodeViewProps) => {
   const caption = (node.attrs.caption as string | undefined) ?? ""
 
@@ -25,8 +14,6 @@ export const TableNodeView = ({ node, updateAttributes }: NodeViewProps) => {
       flexDirection="column"
       gap="0.5rem"
     >
-      {/* contentEditable=false keeps the caption row out of the editable
-          region, so clicks reach the button instead of moving the cursor. */}
       <Box contentEditable={false}>
         <TableCaption
           caption={caption}
@@ -35,8 +22,6 @@ export const TableNodeView = ({ node, updateAttributes }: NodeViewProps) => {
           }
         />
       </Box>
-      {/* Explicit type argument: `NodeViewContent`'s `as` prop is `NoInfer`ed,
-          so the tag has to be named on both sides. */}
       <NodeViewContent<"table"> as="table" />
     </Box>
   )

--- a/apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts
@@ -6,7 +6,6 @@ import {
 
 describe("isPlaceholderTableCaption", () => {
   it("treats empty and default captions as placeholders", () => {
-    // Arrange / Act / Assert
     expect(isPlaceholderTableCaption("")).toBe(true)
     expect(isPlaceholderTableCaption("   ")).toBe(true)
     expect(isPlaceholderTableCaption(DEFAULT_TABLE_CAPTION)).toBe(true)
@@ -14,10 +13,6 @@ describe("isPlaceholderTableCaption", () => {
   })
 
   it("treats real captions as non-placeholder", () => {
-    // Arrange / Act
-    const result = isPlaceholderTableCaption("Quarterly revenue")
-
-    // Assert
-    expect(result).toBe(false)
+    expect(isPlaceholderTableCaption("Quarterly revenue")).toBe(false)
   })
 })

--- a/apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import {
+  DEFAULT_TABLE_CAPTION,
+  isPlaceholderTableCaption,
+  LEGACY_DEFAULT_TABLE_CAPTION,
+} from "../utils"
+
+describe("isPlaceholderTableCaption", () => {
+  it("treats empty and default captions as placeholders", () => {
+    // Arrange / Act / Assert
+    expect(isPlaceholderTableCaption("")).toBe(true)
+    expect(isPlaceholderTableCaption("   ")).toBe(true)
+    expect(isPlaceholderTableCaption(DEFAULT_TABLE_CAPTION)).toBe(true)
+    expect(isPlaceholderTableCaption(LEGACY_DEFAULT_TABLE_CAPTION)).toBe(true)
+  })
+
+  it("treats real captions as non-placeholder", () => {
+    // Arrange / Act
+    const result = isPlaceholderTableCaption("Quarterly revenue")
+
+    // Assert
+    expect(result).toBe(false)
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/TableCaption/utils.ts
+++ b/apps/studio/src/features/editing-experience/components/TableCaption/utils.ts
@@ -1,0 +1,16 @@
+export const MAX_CAPTION_LENGTH = 200
+
+/** Default caption written onto new tables until the author adds a real one. */
+export const DEFAULT_TABLE_CAPTION = "Table caption is required"
+
+/** Legacy default kept so older documents still show "Add caption". */
+export const LEGACY_DEFAULT_TABLE_CAPTION = "Table caption"
+
+export const isPlaceholderTableCaption = (caption: string): boolean => {
+  const trimmed = caption.trim()
+  return (
+    trimmed === "" ||
+    trimmed === DEFAULT_TABLE_CAPTION ||
+    trimmed === LEGACY_DEFAULT_TABLE_CAPTION
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx
@@ -1,4 +1,3 @@
-import type { Editor } from "@tiptap/react"
 import {
   FormControl,
   HStack,
@@ -17,16 +16,16 @@ import {
   ModalCloseButton,
   Textarea,
 } from "@opengovsg/design-system-react"
-import { useEffect } from "react"
 import { z } from "zod"
+import { MAX_CAPTION_LENGTH } from "~/features/editing-experience/components/TableCaption/utils"
 import { useZodForm } from "~/lib/form"
 
-const MAX_CAPTION_LENGTH = 200
 const tableSettingsSchema = z.object({
   caption: z
     .string({
       error: "Enter a caption for this table",
     })
+    .trim()
     .min(1, { message: "Enter a caption for this table" })
     .max(MAX_CAPTION_LENGTH, {
       message: `Table caption should be shorter than ${MAX_CAPTION_LENGTH} characters.`,
@@ -34,41 +33,39 @@ const tableSettingsSchema = z.object({
 })
 
 interface TableSettingsModalProps {
-  editor: Editor
+  /** The table's current caption, used to seed the form. */
+  caption: string
   isOpen: boolean
   onClose: () => void
+  onSave: (caption: string) => void
 }
 
 export const TableSettingsModal = ({
-  editor,
+  caption: currentCaption,
   isOpen,
   onClose,
+  onSave,
 }: TableSettingsModalProps): JSX.Element => {
   const {
     register,
     watch,
     formState: { errors, isValid },
-    setValue,
     handleSubmit,
   } = useZodForm({
     schema: tableSettingsSchema,
+    // Keep isValid in sync while typing so Save enables after clear → type.
+    mode: "onChange",
     defaultValues: {
-      caption: "",
+      caption: currentCaption,
     },
   })
 
   const caption = watch("caption")
 
-  useEffect(() => {
-    // set default values here instead
-    const { caption } = editor.getAttributes("table")
-    setValue("caption", String(caption || ""))
-    // only done once per every time the modal is opened
-    // oxlint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
-
+  // Chakra's FocusLock (trapFocus) fights TipTap's BubbleMenu when the editor
+  // blurs into this modal, hanging Tab — so the built-in trap stays off.
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} trapFocus={false}>
       <ModalOverlay />
 
       <ModalContent>
@@ -106,15 +103,11 @@ export const TableSettingsModal = ({
             </Button>
             <Button
               variant="solid"
-              type="submit"
+              type="button"
               isDisabled={!isValid}
               onClick={handleSubmit(({ caption }) => {
+                onSave(caption)
                 onClose()
-                editor
-                  .chain()
-                  .focus()
-                  .updateAttributes("table", { caption })
-                  .run()
               })}
             >
               Save changes

--- a/apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx
@@ -103,7 +103,7 @@ export const TableSettingsModal = ({
             </Button>
             <Button
               variant="solid"
-              type="button"
+              type="submit"
               isDisabled={!isValid}
               onClick={handleSubmit(({ caption }) => {
                 onSave(caption)

--- a/apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx
@@ -33,7 +33,6 @@ const tableSettingsSchema = z.object({
 })
 
 interface TableSettingsModalProps {
-  /** The table's current caption, used to seed the form. */
   caption: string
   isOpen: boolean
   onClose: () => void
@@ -53,7 +52,6 @@ export const TableSettingsModal = ({
     handleSubmit,
   } = useZodForm({
     schema: tableSettingsSchema,
-    // Keep isValid in sync while typing so Save enables after clear → type.
     mode: "onChange",
     defaultValues: {
       caption: currentCaption,
@@ -62,8 +60,7 @@ export const TableSettingsModal = ({
 
   const caption = watch("caption")
 
-  // Chakra's FocusLock (trapFocus) fights TipTap's BubbleMenu when the editor
-  // blurs into this modal, hanging Tab — so the built-in trap stays off.
+  // trapFocus off: Chakra FocusLock hangs Tab when focus moves from TipTap's BubbleMenu into this modal.
   return (
     <Modal isOpen={isOpen} onClose={onClose} trapFocus={false}>
       <ModalOverlay />

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -136,12 +136,7 @@ export const IsomerTable = Table.extend({
       },
     }
   },
-  // Replaces TipTap's built-in `TableView` so the caption renders above the
-  // table as part of the node itself. `contentDOMElementTag: "tbody"` keeps the
-  // structure ProseMirror expects — `<table><tbody>` with the rows inside the
-  // tbody. Column resizing is off (`resizable` defaults to false), so there is
-  // no `<colgroup>` to maintain: widths come from `table-layout: fixed` in
-  // `styles/tiptap.scss`, as before.
+  // Custom node view renders the caption above the table.
   addNodeView() {
     return ReactNodeViewRenderer(TableNodeView, {
       contentDOMElementTag: "tbody",

--- a/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
@@ -24,7 +24,9 @@ import { TableHeader } from "@tiptap/extension-table-header"
 import { Text } from "@tiptap/extension-text"
 import { Underline } from "@tiptap/extension-underline"
 import { Plugin, PluginKey } from "@tiptap/pm/state"
-import { textblockTypeInputRule } from "@tiptap/react"
+import { ReactNodeViewRenderer, textblockTypeInputRule } from "@tiptap/react"
+import { TableNodeView } from "~/features/editing-experience/components/TableCaption/TableNodeView"
+import { DEFAULT_TABLE_CAPTION } from "~/features/editing-experience/components/TableCaption/utils"
 
 import {
   focusTableBubbleMenuTrigger,
@@ -130,9 +132,20 @@ export const IsomerTable = Table.extend({
   addAttributes() {
     return {
       caption: {
-        default: "Table caption",
+        default: DEFAULT_TABLE_CAPTION,
       },
     }
+  },
+  // Replaces TipTap's built-in `TableView` so the caption renders above the
+  // table as part of the node itself. `contentDOMElementTag: "tbody"` keeps the
+  // structure ProseMirror expects — `<table><tbody>` with the rows inside the
+  // tbody. Column resizing is off (`resizable` defaults to false), so there is
+  // no `<colgroup>` to maintain: widths come from `table-layout: fixed` in
+  // `styles/tiptap.scss`, as before.
+  addNodeView() {
+    return ReactNodeViewRenderer(TableNodeView, {
+      contentDOMElementTag: "tbody",
+    })
   },
   addKeyboardShortcuts() {
     const parentShortcuts = this.parent?.() ?? {}


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 7 | +137 | -73 |
| 🧪 Test | 3 | +441 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Table captions were buried in TableSettingsModal, two clicks from the table (toolbar table group → "Table settings"). You couldn't see the caption while editing the table itself.

Closes [ISOM-2366](https://linear.app/ogp/issue/ISOM-2366/rte-add-inline-table-caption-editing)

## What changed

Each table gets a caption row above it in the editor. Empty tables show the default placeholder with an "Add caption" button; tables with a real caption show the text and "Edit". Both open TableSettingsModal.

TableNodeView renders the row as part of the table node, so two tables in one block each read and write their own `caption` attribute.

Removed the "Table settings" toolbar entry and the menu-bar wiring for TableSettingsModal. The modal still exists; TableCaption opens it.

## Tests

* Unit tests for caption utils
* Browser tests for caption display and modal save/cancel
* Storybook: placeholder, populated, edit via modal

Manual checks:

- [ ] Insert a table in a text block: caption row appears, no "Table settings" in the toolbar
- [ ] Add a second table: each caption edits independently
- [ ] Same in an Accordion block RTE

## Before & after

https://github.com/user-attachments/assets/9cda73e7-368c-4ab8-b2ff-fdf83fcef8e6

<details><summary>Greptile Summary</summary>

This change adds inline caption controls for individual tables in the Studio editor. Authors can add or edit a caption above a table, save it through the table settings dialog, and keep captions independent when a document contains multiple tables.

</details>

<details><summary>Confidence Score: 5/5</summary>

No blocking failure remains.

The exercised caption workflows completed successfully: placeholder controls open the dialog, saved captions persist, existing captions are editable, and edits remain scoped to the selected table.

</details>

<details><summary> T-Rex Logs</summary>

**What T-Rex did**

* The TableCaption browser tests were executed and all 11/11 tests passed, with flows covering placeholder controls, caption creation, editing, cancellation, and a two-table document where only the selected table changes.
* The Playwright UI capture script was run to record the caption dialog states before and after saving a real caption, and the capture completed successfully.
* It was verified that no product source changes were made; only review artifacts were created.

![View all artifacts](https://camo.githubusercontent.com/2df545b98d526040049e752b73a8366206c8a2591d54b68dc253f630f0b06fb3/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f747265782f747265785f677265656e2e737667)

<img src="https://camo.githubusercontent.com/223063a8acd7e71fd1deaaa741d9d06948338e590a1cc633c9305234794edec8/68747470733a2f2f6772657074696c652d7374617469632d6173736574732e73332e616d617a6f6e6177732e636f6d2f6261646765732f56696577416c6c4172746966616374732e7376673f763d34 " alt="T-Rex" height="14" /> Ran code and verified through T-Rex

</details>

Reviews (6): Last reviewed commit: ["feat(rte-table): add inline TableCaption..."](<https://github.com/opengovsg/isomer/commit/213a3af56a929604458cd25ee6ebb1cd355433fc>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=50004673>)







<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds inline caption controls to each rich-text table and moves caption editing from the shared toolbar into the table’s node view.

- Adds placeholder and populated caption states with an Add/Edit action.
- Updates captions through a table-scoped settings dialog to support multiple tables.
- Removes the former menu-bar table-settings entry.
- Adds browser, unit, and Storybook coverage for caption workflows.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the previously reported Add-caption placeholder behavior is resolved or explicitly accepted for release.

The current code still initializes newly inserted tables with the internal placeholder, copies that value into the editable field, and permits it to flow through the save callback as caption content; although a reply stated this could be deferred to dogfooding, the implementation retains the reported behavior.

**Files Needing Attention:** apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx; apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/TableCaption/TableCaption.tsx | Adds the inline placeholder/populated caption display and table-settings dialog trigger. |
| apps/studio/src/features/editing-experience/components/TableCaption/TableNodeView.tsx | Wraps each TipTap table in a node view that renders and updates its own caption attribute. |
| apps/studio/src/features/editing-experience/components/TableSettingsModal/TableSettingsModal.tsx | Refactors the dialog to accept a caption and table-scoped save callback. |
| apps/studio/src/features/editing-experience/hooks/useTextEditor/constants.ts | Registers the custom table node view and changes the default table caption. |
| apps/studio/src/components/PageEditor/MenuBar/TextMenuBar.tsx | Removes the redundant toolbar entry and shared table-settings dialog wiring. |
| apps/studio/src/components/PageEditor/MenuBar/AccordionMenuBar.tsx | Removes the redundant table-settings controls from the accordion editor toolbar. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Author
  participant Caption as TableCaption
  participant Modal as TableSettingsModal
  participant Node as TableNodeView
  participant Editor as TipTap document
  Author->>Caption: Select Add/Edit caption
  Caption->>Modal: Open with table caption
  Author->>Modal: Enter caption and save
  Modal->>Node: onCaptionChange(caption)
  Node->>Editor: "updateAttributes({ caption })"
  Editor-->>Caption: Render updated table caption
```
</details>

<sub>Reviews (10): Last reviewed commit: ["chore(rte-table): trim comments and test..."](https://github.com/opengovsg/isomer/commit/43682f6998d401306313a711846fd342e64cfe5e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50004673)</sub>

**Context used:**

- Knowledge Base — [Page authoring experience](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/page-authoring.md)

<!-- /greptile_comment -->