### PR TITLE
fix(studio): show collection item in preview for nested collections

### DIFF
--- a/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditLinkPreview.tsx
@@ -1,7 +1,10 @@
-import type { IsomerSitemap } from "@opengovsg/isomer-components"
 import type { CollectionLinkProps } from "~/schemas/collection"
 import { useMemo } from "react"
 import { useSuspenseCollectionTags } from "~/features/editing-experience/hooks/useCollectionTags"
+import {
+  buildCollectionLinkPreviewSitemap,
+  getCollectionPermalink,
+} from "~/features/editing-experience/utils/buildCollectionLinkPreviewSitemap"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { editLinkSchema } from "~/pages/sites/[siteId]/links/[linkId]"
 import { trpc } from "~/utils/trpc"
@@ -39,48 +42,38 @@ export const EditCollectionLinkPreview = ({
     siteId,
   })
 
+  // Ends at the parent collection, so drop it — the collection node is built below.
+  const [ancestry] = trpc.resource.getAncestryStack.useSuspenseQuery({
+    resourceId: String(linkId),
+    siteId: String(siteId),
+    includeSelf: false,
+  })
+
   const parentPermalink = useMemo(
-    () => permalink.split("/").slice(0, -1).join("/"),
+    () => getCollectionPermalink(permalink),
     [permalink],
   )
   const parentTitle = useMemo(
     () => parent?.title || ResourceType.Collection,
     [parent?.title],
   )
+  const ancestorTitles = useMemo(
+    () => ancestry.slice(0, -1).map(({ title }) => title),
+    [ancestry],
+  )
 
   const siteMap = useMemo(
     () =>
-      ({
-        id: "root",
-        permalink: "/",
+      buildCollectionLinkPreviewSitemap({
+        permalink,
+        title,
+        link,
+        collectionTitle: parentTitle,
+        ancestorTitles,
+        tagCategories,
         lastModified: currentDate,
-        layout: "homepage",
-        title: "An Isomer Site",
-        summary: "",
-        children: [
-          {
-            id: "collection",
-            permalink: parentPermalink,
-            lastModified: currentDate,
-            layout: "collection",
-            title: parentTitle,
-            summary: "",
-            collectionPagePageProps: { tagCategories },
-            children: [
-              {
-                id: "9999999",
-                title,
-                summary: link.description ?? "",
-                layout: "link",
-                permalink,
-                lastModified: currentDate,
-                ...link,
-              },
-            ],
-          },
-        ],
-      }) satisfies IsomerSitemap,
-    [parentPermalink, parentTitle, tagCategories, link, permalink, title],
+      }),
+    [permalink, title, link, parentTitle, ancestorTitles, tagCategories],
   )
 
   return (

--- a/apps/studio/src/features/editing-experience/utils/__tests__/buildCollectionLinkPreviewSitemap.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/buildCollectionLinkPreviewSitemap.test.ts
@@ -1,0 +1,109 @@
+import type { IsomerSitemap } from "@opengovsg/isomer-components"
+import type { CollectionLinkProps } from "~/schemas/collection"
+import { describe, expect, it } from "vitest"
+
+import { buildCollectionLinkPreviewSitemap } from "../buildCollectionLinkPreviewSitemap"
+
+const LINK: CollectionLinkProps = {
+  ref: "[resource:1:2]",
+  category: "",
+  description: "A summary",
+}
+
+const buildSitemap = (
+  overrides: Partial<
+    Parameters<typeof buildCollectionLinkPreviewSitemap>[0]
+  > = {},
+) =>
+  buildCollectionLinkPreviewSitemap({
+    permalink: "/circulars/my-link",
+    title: "My link",
+    link: LINK,
+    collectionTitle: "Circulars",
+    ancestorTitles: [],
+    tagCategories: undefined,
+    lastModified: "2024-01-01",
+    ...overrides,
+  })
+
+// The Collection layout walks the sitemap one permalink segment at a time from
+// the root, so a node must exist at every prefix of the collection's permalink.
+const collectNodePermalinks = (node: IsomerSitemap): string[] => [
+  node.permalink,
+  ...(node.children?.flatMap(collectNodePermalinks) ?? []),
+]
+
+describe("buildCollectionLinkPreviewSitemap", () => {
+  describe("collection at the top level", () => {
+    it("nests the link directly under the collection", () => {
+      // Arrange / Act
+      const result = buildSitemap()
+
+      // Assert
+      expect(collectNodePermalinks(result)).toEqual([
+        "/",
+        "/circulars",
+        "/circulars/my-link",
+      ])
+    })
+  })
+
+  describe("collection nested inside folders", () => {
+    it("creates a node for every permalink prefix so the walk can reach the link", () => {
+      // Arrange / Act
+      const result = buildSitemap({
+        permalink: "/a/b/circulars/my-link",
+        ancestorTitles: ["A", "B"],
+      })
+
+      // Assert
+      expect(collectNodePermalinks(result)).toEqual([
+        "/",
+        "/a",
+        "/a/b",
+        "/a/b/circulars",
+        "/a/b/circulars/my-link",
+      ])
+    })
+
+    it("titles the intermediate nodes with the real resource titles", () => {
+      // Arrange / Act
+      const result = buildSitemap({
+        permalink: "/resources/circulars/my-link",
+        ancestorTitles: ["Resources"],
+      })
+
+      // Assert
+      expect(result.children?.[0]?.title).toBe("Resources")
+      expect(result.children?.[0]?.children?.[0]?.title).toBe("Circulars")
+    })
+
+    it("falls back to the permalink segment when a title is unavailable", () => {
+      // Arrange / Act
+      const result = buildSitemap({
+        permalink: "/resources/circulars/my-link",
+        ancestorTitles: [],
+      })
+
+      // Assert
+      expect(result.children?.[0]?.title).toBe("resources")
+    })
+  })
+
+  describe("the link node", () => {
+    it("keeps the link layout so the collection picks it up as an item", () => {
+      // Arrange / Act
+      const result = buildSitemap()
+      const linkNode = result.children?.[0]?.children?.[0]
+
+      // Assert
+      expect(linkNode).toMatchObject({
+        layout: "link",
+        title: "My link",
+        summary: "A summary",
+        permalink: "/circulars/my-link",
+        ref: "[resource:1:2]",
+      })
+    })
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/buildCollectionLinkPreviewSitemap.ts
+++ b/apps/studio/src/features/editing-experience/utils/buildCollectionLinkPreviewSitemap.ts
@@ -1,0 +1,92 @@
+import type { IsomerSitemap } from "@opengovsg/isomer-components"
+import type { CollectionLinkProps } from "~/schemas/collection"
+import { ISOMER_USABLE_PAGE_LAYOUTS } from "@opengovsg/isomer-components"
+
+import type { CollectionTags } from "../hooks/useCollectionTags"
+
+interface BuildCollectionLinkPreviewSitemapProps {
+  /** Full permalink of the link being edited, e.g. `/resources/circulars/my-link`. */
+  permalink: string
+  title: string
+  link: CollectionLinkProps
+  collectionTitle: string
+  /** Titles of the folders between the site root and the collection, root-first. */
+  ancestorTitles: string[]
+  tagCategories: CollectionTags | undefined
+  lastModified: string
+}
+
+// The permalink of the collection a link belongs to. Must stay in step with the
+// collection node's permalink in the sitemap below, or the preview renders a page
+// that no node matches.
+export const getCollectionPermalink = (linkPermalink: string): string =>
+  linkPermalink.split("/").slice(0, -1).join("/")
+
+// A collection link has no page of its own — it only ever renders as a card in its
+// parent collection's index page. So the preview renders that collection index page
+// against a stand-in sitemap containing just the link being edited.
+export const buildCollectionLinkPreviewSitemap = ({
+  permalink,
+  title,
+  link,
+  collectionTitle,
+  ancestorTitles,
+  tagCategories,
+  lastModified,
+}: BuildCollectionLinkPreviewSitemapProps): IsomerSitemap => {
+  const collectionPermalink = getCollectionPermalink(permalink)
+  const collectionSegments = collectionPermalink.split("/").filter(Boolean)
+
+  const collectionNode: IsomerSitemap = {
+    id: "collection",
+    permalink: collectionPermalink,
+    lastModified,
+    layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
+    title: collectionTitle,
+    summary: "",
+    collectionPagePageProps: { tagCategories },
+    children: [
+      {
+        id: "9999999",
+        title,
+        summary: link.description ?? "",
+        layout: ISOMER_USABLE_PAGE_LAYOUTS.Link,
+        permalink,
+        lastModified,
+        ...link,
+      },
+    ],
+  }
+
+  // The collection index page resolves both its items and its breadcrumb by walking
+  // the sitemap one permalink segment at a time from the root, so a node has to exist
+  // at every prefix for it to reach a collection that sits inside folders.
+  const ancestors = collectionSegments.slice(0, -1).map((segment, index) => ({
+    permalink: `/${collectionSegments.slice(0, index + 1).join("/")}`,
+    title: ancestorTitles[index] ?? segment,
+  }))
+
+  // Fold innermost-first, so the outermost ancestor ends up directly under the root.
+  const node = ancestors.reduceRight<IsomerSitemap>(
+    (child, ancestor, index) => ({
+      id: `ancestor-${index}`,
+      permalink: ancestor.permalink,
+      lastModified,
+      layout: ISOMER_USABLE_PAGE_LAYOUTS.Content,
+      title: ancestor.title,
+      summary: "",
+      children: [child],
+    }),
+    collectionNode,
+  )
+
+  return {
+    id: "root",
+    permalink: "/",
+    lastModified,
+    layout: ISOMER_USABLE_PAGE_LAYOUTS.Homepage,
+    title: "An Isomer Site",
+    summary: "",
+    children: [node],
+  }
+}

--- a/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
+++ b/apps/studio/src/stories/Page/EditPage/EditCollectionLink.stories.tsx
@@ -96,6 +96,20 @@ export const WithBanner: Story = {
   },
 }
 
+// The collection index page walks the sitemap segment by segment from the root, so a
+// collection sitting inside folders needs a node at every permalink prefix to render.
+export const NestedCollection: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        pageHandlers.getFullPermalink.nestedCollectionLink(),
+        resourceHandlers.getAncestryStack.nestedCollection(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+}
+
 export const WithModal: Story = {
   play: async (context) => {
     const { canvasElement } = context

--- a/apps/studio/tests/msw/handlers/page.ts
+++ b/apps/studio/tests/msw/handlers/page.ts
@@ -1618,6 +1618,10 @@ export const pageHandlers = {
       trpcMsw.page.getFullPermalink.query(() => {
         return "/collection"
       }),
+    nestedCollectionLink: () =>
+      trpcMsw.page.getFullPermalink.query(() => {
+        return "/resources/circulars/my-link"
+      }),
     index: () =>
       trpcMsw.page.getFullPermalink.query(() => {
         return "parent"

--- a/apps/studio/tests/msw/handlers/resource.ts
+++ b/apps/studio/tests/msw/handlers/resource.ts
@@ -92,6 +92,27 @@ export const resourceHandlers = {
         return []
       })
     },
+    // Ancestors of a collection item sitting in `/resources/circulars`, root-first.
+    nestedCollection: () => {
+      return trpcMsw.resource.getAncestryStack.query(() => {
+        return [
+          {
+            id: "10",
+            parentId: null,
+            title: "Resources",
+            permalink: "resources",
+            type: "Folder",
+          },
+          {
+            id: "11",
+            parentId: "10",
+            title: "Circulars",
+            permalink: "circulars",
+            type: "Collection",
+          },
+        ]
+      })
+    },
   },
   getBatchAncestryWithSelf: {
     default: () => {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +117 | -32 |
| 🧪 Test | 4 | +148 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Collection links whose parent collection sits inside one or more folders render an empty preview — **"There are no articles here."** — instead of the item card. The preview breadcrumb also collapses to just "Home".

Closes ISOM-2443

Reported in [Slack](https://opengovproducts.slack.com/archives/C06R4DX966P/p1785752683473789) (e.g. `studio.isomer.gov.sg/sites/338/links/387461`).

**Root cause**

A collection link has no page of its own — it only ever renders as a card in its parent collection's index page. So the preview renders that collection index page against a stand-in sitemap containing just the link being edited:

```
root  "/"
└── collection  /resources/circulars
    └── link    /resources/circulars/my-link
```

But the Collection layout resolves its items by walking the sitemap **one permalink segment at a time from the root**, requiring a node at every prefix (`getCollectionItems.ts`). The stand-in sitemap jumps straight from `/` to `/resources/circulars`, so with no `/resources` node the walk fails on the very first segment and returns no items.

`getBreadcrumbFromSiteMap` does the same segment-walk, which is why the breadcrumb stopped at "Home" — independent corroboration of the same cause.

Collections at the top level were unaffected (their permalink is a single segment, so the walk succeeds immediately), which is why this went unnoticed. The flat stand-in sitemap has been there since collection links were introduced, so this is a long-standing bug rather than a recent regression.

## Solution

Build the stand-in sitemap with a stub node for every ancestor prefix, so the walk can reach a collection nested at any depth. Ancestor titles come from `resource.getAncestryStack` so the breadcrumb reads correctly, falling back to the permalink segment if a title is unavailable.

Sitemap construction moved out of the component into a pure, unit-tested helper.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

Top-level collections produce a byte-identical sitemap to before, so that path cannot regress.

**Features**:

- None

**Improvements**:

- Preview breadcrumb now shows the full ancestor path (`Home › Resources › Circulars`) instead of stopping at "Home"
- Extracted `buildCollectionLinkPreviewSitemap` as a pure helper with unit tests, and de-duplicated the parent-permalink derivation that previously existed in two places — drift between them would have reintroduced this exact bug

**Bug Fixes**:

- Collection links inside nested collections now show the item card in the preview instead of "There are no articles here."

## Before & After Screenshots

**BEFORE**:

See the [screenshot in the Slack thread](https://opengovproducts.slack.com/archives/C06R4DX966P/p1785752683473789) — empty collection body reading "There are no articles here.", breadcrumb showing only "Home".

**AFTER**:

Not captured — Playwright browsers are not installed in the authoring environment, so the Storybook story could not be rendered locally. The new `NestedCollection` story (below) exercises this path and will render in CI/Chromatic.

## Tests

Automated:

- `apps/studio/src/features/editing-experience/utils/__tests__/buildCollectionLinkPreviewSitemap.test.ts` — 5 unit tests. The key one asserts the invariant the Collection layout depends on: a node exists at **every** prefix of the collection permalink, i.e. `["/", "/a", "/a/b", "/a/b/circulars", "/a/b/circulars/my-link"]`. Also covers real-title vs segment-fallback and the top-level (unchanged) shape.
- New Storybook story `Pages/Edit Page/Collection Link Page → NestedCollection`, with `getFullPermalink.nestedCollectionLink` and `getAncestryStack.nestedCollection` MSW handlers.

Verified locally: 34/34 unit tests in `src/features/editing-experience/utils` pass, `tsc --noEmit` clean, oxlint clean, oxfmt clean.

**Manual Verification Steps**:

- [ ] Open a site that has a collection nested inside a folder (e.g. site 338, collection "Circulars" under `/resources`)
- [ ] Open any collection link inside that collection (e.g. `/sites/338/links/387461`)
- [ ] Confirm the preview shows the item as a card (title, thumbnail, date) instead of "There are no articles here."
- [ ] Confirm the preview breadcrumb reads `Home › <folder> › <collection>` rather than just "Home"
- [ ] Edit the item's title/summary/thumbnail in the left drawer and confirm the preview card updates live
- [ ] Regression check: open a collection link in a **top-level** collection and confirm the preview still renders exactly as before
- [ ] Regression check: confirm tag pills/plaintext tags still render on the preview card where the collection has tag categories

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change constructs a preview sitemap with nodes for every folder prefix, allowing collection links nested under folders to resolve their collection page and breadcrumb correctly. It also adds focused sitemap-shape coverage and Storybook fixtures for nested collection links.

No product defects were found.

### T-Rex validation blocked
Rendered verification of the nested Storybook preview was blocked by the browser-validation tool's execution-step limit before it could open the preview iframe and assert the rendered breadcrumb and link card. Storybook and Chromium started successfully, but the collected recordings show only the editor shell rather than the final preview.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The change is safe to merge based on the absence of identified defects and the focused implementation for nested collection sitemap construction.

The sitemap helper creates each permalink prefix required for nested collection traversal, and the ancestry handling separates folder titles from the collection title. No defect was established.

**Files Needing Attention:** No files need changes. The nested Storybook preview could benefit from a completed rendered assertion when browser-validation capacity is available.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted rendered verification by building the local component distribution, starting Storybook, and running Chromium against the default and nested collection-link stories; the browser-validation tool reached its execution-step limit before the preview mode could be opened.
- The reviewer documented the expected ancestry behavior and the nested fixture structure, noting that includeSelf: false returns the parent-ending ancestry and ancestry.slice(0, -1) provides only folder titles while the parent collection title is retrieved separately, and that the nested fixture resolves to /resources/circulars/my-link with prefix nodes /resources and /resources/circulars.

<a href="https://app.greptile.com/trex/runs/17181374/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(studio): show collection item in pre..."](https://github.com/opengovsg/isomer/commit/fa69a05d62aec2ff8107fa353c84a82e171171df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49926092)</sub>

<!-- /greptile_comment -->