### PR TITLE
fix(redirects): address bulk upload dogfooding feedback

### DIFF
--- a/apps/studio/src/features/settings/Redirects/api.ts
+++ b/apps/studio/src/features/settings/Redirects/api.ts
@@ -66,14 +66,14 @@ export function useDeleteRedirect() {
 // Validates an uploaded CSV without writing. Uses the mutation (not a query) so
 // the large CSV travels in the POST body — a query serialises its input into the
 // request URL, which the server rejects near the size cap (connection reset).
-// Read-only server-side; `validate` is a one-shot call returning the verdicts,
-// and `isPending` drives the Process button's inline spinner (validation is
-// quick, so it does not warrant a full-screen loading state).
+// Read-only server-side; `validate` is a one-shot call returning the verdicts.
+// The Process button's spinner is not driven off this mutation's `isPending`:
+// the modal holds it for a minimum duration so a fast validation still reads as
+// a run, so it owns that state itself.
 export function useBulkValidateRedirects(siteId: number) {
-  const { mutateAsync, isPending } = trpc.redirect.bulkValidate.useMutation()
+  const { mutateAsync } = trpc.redirect.bulkValidate.useMutation()
   return {
     validate: (csv: string) => mutateAsync({ siteId, csv }),
-    isPending,
   }
 }
 

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -36,9 +36,37 @@ import { formatFileSizeLimit } from "~/utils/formatFileSizeLimit"
 import { useBulkCreateRedirects, useBulkValidateRedirects } from "../api"
 
 type BulkValidation = RouterOutput["redirect"]["bulkValidate"]
+type FileRejections = NonNullable<AttachmentProps<false>["rejections"]>
 
 // Path to the header-only template shipped as a static public asset.
 const TEMPLATE_HREF = "/redirects-template.csv"
+
+// Validation is quick enough that the screen can change before the click
+// registers, so a process reads as "nothing happened" — worst on a re-upload
+// that lands back on the errors screen, which looks unchanged. Hold the spinner
+// to this floor so every run is visible; 2s registers without feeling sluggish.
+const MIN_PROCESSING_MS = 2000
+
+// Keyed by react-dropzone's ErrorCode values, inlined rather than imported since
+// react-dropzone is the design system's dependency and not one we declare. Same
+// voice as the parse-time file errors, since both render in the same place.
+const REJECTION_MESSAGES: Record<string, string | undefined> = {
+  "file-too-large": `This file is too big. Upload a file under ${formatFileSizeLimit({ bytes: MAX_BULK_REDIRECT_CSV_BYTES })} and try again.`,
+  "file-invalid-type":
+    "This file isn't a .csv. Upload a .csv file and try again.",
+  "too-many-files": "Upload one file at a time.",
+}
+
+// First mapped error wins, mirroring the dropzone's own ordering. Falls back to
+// the generic unreadable copy so an unmapped code can never leave the file on
+// screen with no explanation.
+const rejectionMessage = (rejection: FileRejections[number]): string => {
+  for (const { code } of rejection.errors) {
+    const message = REJECTION_MESSAGES[code]
+    if (message !== undefined) return message
+  }
+  return "We couldn't read this file. Upload a valid .csv file."
+}
 
 interface BulkUploadRedirectsModalProps {
   siteId: number
@@ -71,27 +99,31 @@ export const BulkUploadRedirectsModal = ({
   onClose,
 }: BulkUploadRedirectsModalProps): JSX.Element => {
   const toast = useToast(BRIEF_TOAST_SETTINGS)
-  const { validate, isPending: isValidating } = useBulkValidateRedirects(siteId)
+  const { validate } = useBulkValidateRedirects(siteId)
   const { mutateAsync: publish } = useBulkCreateRedirects()
 
   const [stage, setStage] = useState<Stage>("upload")
   const [file, setFile] = useState<File | null>(null)
   const [csv, setCsv] = useState<string | null>(null)
-  // A file-level problem caught in the browser (empty / missing column), shown
-  // inline under the chip before the user can process.
+  // A file-level problem caught in the browser (empty / missing column / too big
+  // / not a csv), shown inline under the chip before the user can process.
   const [fileError, setFileError] = useState<string | null>(null)
   const [validation, setValidation] = useState<BulkValidation | null>(null)
   const [showSlowMessage, setShowSlowMessage] = useState(false)
-  // Oversize / wrong-type files rejected by the dropzone; surfaced by Attachment.
-  const [rejections, setRejections] = useState<
-    AttachmentProps<false>["rejections"]
-  >([])
+  // Covers the validation request plus MIN_PROCESSING_MS, so the button keeps
+  // its spinner for the whole visible wait rather than the request alone.
+  const [isProcessing, setIsProcessing] = useState(false)
 
   // Tracks the most recently picked file. `file.text()` is async, so if the user
   // picks A then B before A finishes reading, A could resolve last — this lets
   // the handler drop the stale read instead of committing A's contents while the
   // chip shows B.
   const latestFileRef = useRef<File | null>(null)
+  // react-dropzone reports a rejected file through onRejection and then calls
+  // onChange(undefined) in the same event. Set while handling the rejection so
+  // that trailing reset can't wipe the chip and message we just put up; the next
+  // onChange(undefined) consumes it, so removing the file still clears.
+  const hasPendingRejectionRef = useRef(false)
 
   const resetState = () => {
     setStage("upload")
@@ -100,8 +132,9 @@ export const BulkUploadRedirectsModal = ({
     setFileError(null)
     setValidation(null)
     setShowSlowMessage(false)
-    setRejections([])
+    setIsProcessing(false)
     latestFileRef.current = null
+    hasPendingRejectionRef.current = false
   }
 
   // Start fresh every time the modal opens, so a previous run's file or errors
@@ -128,20 +161,25 @@ export const BulkUploadRedirectsModal = ({
 
   const handleFileChange = async (selected: File | undefined) => {
     if (!selected) {
+      // The reset that trails a rejection — keep what handleRejection just set.
+      if (hasPendingRejectionRef.current) {
+        hasPendingRejectionRef.current = false
+        return
+      }
       latestFileRef.current = null
       setFile(null)
       setCsv(null)
       setFileError(null)
       return
     }
+    hasPendingRejectionRef.current = false
     latestFileRef.current = selected
     setFile(selected)
-    // Clear the previous file's parsed csv, error, and any dropzone rejections
-    // synchronously, so nothing stale is shown or processed during the async
-    // read below (Process stays disabled until the new csv is parsed).
+    // Clear the previous file's parsed csv and error synchronously, so nothing
+    // stale is shown or processed during the async read below (Process stays
+    // disabled until the new csv is parsed).
     setCsv(null)
     setFileError(null)
-    setRejections([])
     try {
       const text = await selected.text()
       // A newer file was picked while this one was being read — drop the stale
@@ -156,6 +194,23 @@ export const BulkUploadRedirectsModal = ({
     }
   }
 
+  // Files the dropzone rejects (oversize, wrong type, more than one) never reach
+  // onChange, so fold them into the same chip-plus-inline-error the parse checks
+  // use. Attachment's own rejection UI keeps the picker open and puts the reason
+  // in a dismissable chip, which read as a different component for the same
+  // class of problem.
+  const handleRejection = (fileRejections: FileRejections) => {
+    const rejection = fileRejections[0]
+    if (!rejection) return
+    hasPendingRejectionRef.current = true
+    // Also marks any in-flight read of an earlier file stale, so it can't
+    // overwrite this message when it resolves.
+    latestFileRef.current = rejection.file
+    setFile(rejection.file)
+    setCsv(null)
+    setFileError(rejectionMessage(rejection))
+  }
+
   // Show the errors screen with a fresh, empty re-upload zone (the design's
   // "re-upload the file with fixes"), so the corrected file can be dropped in.
   const enterErrorsStage = (result: BulkValidation) => {
@@ -163,16 +218,23 @@ export const BulkUploadRedirectsModal = ({
     setFile(null)
     setCsv(null)
     setFileError(null)
-    setRejections([])
+    hasPendingRejectionRef.current = false
     setStage("errors")
   }
 
   const handleProcess = async () => {
     if (!csv) return
-    // Validation is quick, so the Process button's inline spinner (isValidating)
-    // is enough — no full-screen stage. Stay put so a failure keeps the file.
+    // Validation is quick, so the Process button's inline spinner is enough —
+    // no full-screen stage. Stay put so a failure keeps the file.
+    setIsProcessing(true)
+    // Started alongside the request rather than after it, so the floor and the
+    // validation overlap instead of adding up.
+    const loadingFloor = new Promise<void>((resolve) =>
+      setTimeout(resolve, MIN_PROCESSING_MS),
+    )
     try {
       const result = await validate(csv)
+      await loadingFloor
       if (result.fileError !== null || result.errorCount > 0) {
         enterErrorsStage(result)
         return
@@ -180,11 +242,14 @@ export const BulkUploadRedirectsModal = ({
       setValidation(result)
       setStage("success")
     } catch {
+      await loadingFloor
       toast({
         title: "We couldn't check your redirects",
         description: "Please try again.",
         status: "error",
       })
+    } finally {
+      setIsProcessing(false)
     }
   }
 
@@ -243,9 +308,8 @@ export const BulkUploadRedirectsModal = ({
             validRows={validRows}
             file={file}
             fileError={fileError}
-            rejections={rejections}
             onFileChange={handleFileChange}
-            onRejection={setRejections}
+            onRejection={handleRejection}
             onDownloadErrors={handleDownloadErrors}
           />
         </ModalBody>
@@ -261,7 +325,7 @@ export const BulkUploadRedirectsModal = ({
               <Button
                 onClick={() => void handleProcess()}
                 isDisabled={isProcessDisabled}
-                isLoading={isValidating}
+                isLoading={isProcessing}
               >
                 {isProcessDisabled
                   ? "Upload file to continue"
@@ -282,9 +346,8 @@ interface BulkUploadModalBodyProps {
   validRows: BulkValidation["rows"]
   file: File | null
   fileError: string | null
-  rejections: AttachmentProps<false>["rejections"]
   onFileChange: (selected: File | undefined) => void
-  onRejection: (rejections: AttachmentProps<false>["rejections"]) => void
+  onRejection: (rejections: FileRejections) => void
   onDownloadErrors: () => void
 }
 
@@ -297,7 +360,6 @@ const BulkUploadModalBody = ({
   validRows,
   file,
   fileError,
-  rejections,
   onFileChange,
   onRejection,
   onDownloadErrors,
@@ -442,7 +504,9 @@ const BulkUploadModalBody = ({
               multiple={false}
               value={file ?? undefined}
               onChange={(selected) => void onFileChange(selected)}
-              rejections={rejections}
+              // `rejections` is deliberately not passed: a rejected file is
+              // rendered as the attached chip with its reason in `fileError`
+              // below, so Attachment must not also render its own error chip.
               onRejection={onRejection}
               accept={[".csv", "text/csv"]}
               maxSize={MAX_BULK_REDIRECT_CSV_BYTES}

--- a/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx
@@ -109,6 +109,10 @@ export const BulkUploadRedirectsModal = ({
   // / not a csv), shown inline under the chip before the user can process.
   const [fileError, setFileError] = useState<string | null>(null)
   const [validation, setValidation] = useState<BulkValidation | null>(null)
+  // The csv those verdicts were computed from. Publishing sends this rather than
+  // whatever is in the picker now, so the batch that gets created is always the
+  // one the editor reviewed on the success screen.
+  const [reviewedCsv, setReviewedCsv] = useState<string | null>(null)
   const [showSlowMessage, setShowSlowMessage] = useState(false)
   // Covers the validation request plus MIN_PROCESSING_MS, so the button keeps
   // its spinner for the whole visible wait rather than the request alone.
@@ -119,18 +123,29 @@ export const BulkUploadRedirectsModal = ({
   // the handler drop the stale read instead of committing A's contents while the
   // chip shows B.
   const latestFileRef = useRef<File | null>(null)
+  // Mirrors `csv` for the same reason, but for `handleProcess`: the csv it reads
+  // is the one captured when it started, so it can't tell on its own whether the
+  // file has since been swapped or removed. Every write goes through `applyCsv`
+  // so the ref and the state can't drift apart.
+  const latestCsvRef = useRef<string | null>(null)
   // react-dropzone reports a rejected file through onRejection and then calls
   // onChange(undefined) in the same event. Set while handling the rejection so
   // that trailing reset can't wipe the chip and message we just put up; the next
   // onChange(undefined) consumes it, so removing the file still clears.
   const hasPendingRejectionRef = useRef(false)
 
+  const applyCsv = (next: string | null) => {
+    latestCsvRef.current = next
+    setCsv(next)
+  }
+
   const resetState = () => {
     setStage("upload")
     setFile(null)
-    setCsv(null)
+    applyCsv(null)
     setFileError(null)
     setValidation(null)
+    setReviewedCsv(null)
     setShowSlowMessage(false)
     setIsProcessing(false)
     latestFileRef.current = null
@@ -168,7 +183,7 @@ export const BulkUploadRedirectsModal = ({
       }
       latestFileRef.current = null
       setFile(null)
-      setCsv(null)
+      applyCsv(null)
       setFileError(null)
       return
     }
@@ -178,18 +193,18 @@ export const BulkUploadRedirectsModal = ({
     // Clear the previous file's parsed csv and error synchronously, so nothing
     // stale is shown or processed during the async read below (Process stays
     // disabled until the new csv is parsed).
-    setCsv(null)
+    applyCsv(null)
     setFileError(null)
     try {
       const text = await selected.text()
       // A newer file was picked while this one was being read — drop the stale
       // result so the parsed csv can't disagree with the chip.
       if (latestFileRef.current !== selected) return
-      setCsv(text)
+      applyCsv(text)
       setFileError(parseRedirectCsv(text).fileError ?? null)
     } catch {
       if (latestFileRef.current !== selected) return
-      setCsv(null)
+      applyCsv(null)
       setFileError("We couldn't read this file. Upload a valid .csv file.")
     }
   }
@@ -207,7 +222,7 @@ export const BulkUploadRedirectsModal = ({
     // overwrite this message when it resolves.
     latestFileRef.current = rejection.file
     setFile(rejection.file)
-    setCsv(null)
+    applyCsv(null)
     setFileError(rejectionMessage(rejection))
   }
 
@@ -215,15 +230,20 @@ export const BulkUploadRedirectsModal = ({
   // "re-upload the file with fixes"), so the corrected file can be dropped in.
   const enterErrorsStage = (result: BulkValidation) => {
     setValidation(result)
+    setReviewedCsv(null)
     setFile(null)
-    setCsv(null)
+    applyCsv(null)
     setFileError(null)
     hasPendingRejectionRef.current = false
     setStage("errors")
   }
 
   const handleProcess = async () => {
-    if (!csv) return
+    // Pin the csv this run is about. The picker stays live while we wait — the
+    // chip's remove button is never disabled — so the editor can swap in another
+    // file before these verdicts come back.
+    const processedCsv = csv
+    if (!processedCsv) return
     // Validation is quick, so the Process button's inline spinner is enough —
     // no full-screen stage. Stay put so a failure keeps the file.
     setIsProcessing(true)
@@ -232,17 +252,24 @@ export const BulkUploadRedirectsModal = ({
     const loadingFloor = new Promise<void>((resolve) =>
       setTimeout(resolve, MIN_PROCESSING_MS),
     )
+    // The file on screen moved on while this ran (swapped, removed, or the modal
+    // was closed and reopened), so these verdicts describe something the editor
+    // is no longer looking at. Drop them and leave the picker as they left it.
+    const isStale = () => latestCsvRef.current !== processedCsv
     try {
-      const result = await validate(csv)
+      const result = await validate(processedCsv)
       await loadingFloor
+      if (isStale()) return
       if (result.fileError !== null || result.errorCount > 0) {
         enterErrorsStage(result)
         return
       }
       setValidation(result)
+      setReviewedCsv(processedCsv)
       setStage("success")
     } catch {
       await loadingFloor
+      if (isStale()) return
       toast({
         title: "We couldn't check your redirects",
         description: "Please try again.",
@@ -254,12 +281,14 @@ export const BulkUploadRedirectsModal = ({
   }
 
   const handlePublish = async () => {
-    if (!csv) return
+    // Publish exactly what the success screen reviewed, never the current picker
+    // contents, so the created batch can't differ from the listed redirects.
+    if (!reviewedCsv) return
     // Creating the batch and republishing the site is the slow step, so switch
     // to the full-screen spinner once the user commits.
     setStage("publishing")
     try {
-      const result = await publish({ siteId, csv })
+      const result = await publish({ siteId, csv: reviewedCsv })
       if (result.ok) {
         toast({
           title: `${result.publishedCount} redirect${result.publishedCount === 1 ? "" : "s"} published`,

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -4,6 +4,7 @@ import { pageHandlers } from "tests/msw/handlers/page"
 import { redirectHandlers } from "tests/msw/handlers/redirect"
 import { sitesHandlers } from "tests/msw/handlers/sites"
 import RedirectsSettingsPage from "~/pages/sites/[siteId]/settings/redirects"
+import { MAX_BULK_REDIRECT_CSV_BYTES } from "~/schemas/redirect"
 import { ADMIN_HANDLERS } from "~/stories/handlers"
 import { createAdvancedRedirectsEnabledGbParameters } from "~/stories/utils/growthbook"
 
@@ -108,15 +109,24 @@ export const AlreadyExistsError: Story = {
 const VALID_CSV =
   "When someone visits,Redirect them to\n/old-one,/new-one\n/old-two,https://www.example.gov.sg"
 
-const openModalAndUpload = async (canvasElement: HTMLElement) => {
+// Processing holds its spinner for a deliberate minimum duration, so anything
+// asserted after "Process redirects" needs longer than the 1s default.
+const AFTER_PROCESSING = { timeout: 10000 }
+
+const openBulkUploadModal = async (canvasElement: HTMLElement) => {
   const body = canvasElement.ownerDocument.body
   const screen = within(body)
   await userEvent.click(
     await screen.findByRole("button", { name: /bulk upload with a \.csv/i }),
   )
-  // The dropzone's file input has no stable accessible label, so grab it
-  // directly once the modal has mounted. Scope to the modal dialog so an
-  // unrelated file input elsewhere on the page can't be picked up by mistake.
+  return { body, screen }
+}
+
+// The dropzone's file input has no stable accessible label, so grab it directly.
+// Scope to the modal dialog so an unrelated file input elsewhere on the page
+// can't be picked up by mistake, and re-query per pick: the dropzone unmounts
+// while a file is attached, so each pick sees a freshly mounted input.
+const pickFileInModal = async (body: HTMLElement, file: File) => {
   const fileInput = await waitFor(() => {
     const input = body.querySelector<HTMLInputElement>(
       "[role='dialog'] input[type='file']",
@@ -124,8 +134,13 @@ const openModalAndUpload = async (canvasElement: HTMLElement) => {
     if (!input) throw new Error("file input not found")
     return input
   })
-  await userEvent.upload(
-    fileInput,
+  await userEvent.upload(fileInput, file)
+}
+
+const openModalAndUpload = async (canvasElement: HTMLElement) => {
+  const { body, screen } = await openBulkUploadModal(canvasElement)
+  await pickFileInModal(
+    body,
     new File([VALID_CSV], "redirects.csv", { type: "text/csv" }),
   )
   const processButton = await screen.findByRole("button", {
@@ -176,8 +191,18 @@ export const BulkUploadReadyToPublish: Story = {
   },
   play: async ({ canvasElement }) => {
     const screen = await openModalAndUpload(canvasElement)
+    // The mocked validation resolves near-instantly; the minimum spinner
+    // duration is what keeps the result off screen for a beat, so the
+    // transition is noticeable rather than a flicker.
     await expect(
-      await screen.findByText("All 2 redirects are good to go."),
+      screen.queryByText("All 2 redirects are good to go."),
+    ).toBeNull()
+    await expect(
+      await screen.findByText(
+        "All 2 redirects are good to go.",
+        {},
+        AFTER_PROCESSING,
+      ),
     ).toBeVisible()
     await expect(
       screen.getByRole("button", { name: "Publish 2 redirects" }),
@@ -200,10 +225,63 @@ export const BulkUploadWithErrors: Story = {
   },
   play: async ({ canvasElement }) => {
     const screen = await openModalAndUpload(canvasElement)
-    await expect(await screen.findByText(/1 redirect has errors/)).toBeVisible()
+    await expect(
+      await screen.findByText(/1 redirect has errors/, {}, AFTER_PROCESSING),
+    ).toBeVisible()
     await expect(
       screen.getByRole("button", { name: "Download errors file (.csv)" }),
     ).toBeVisible()
+  },
+}
+
+// A file the dropzone rejects outright reads the same as one that fails the
+// content checks: attached chip, reason inline under the size/type hints.
+const OVERSIZE_MESSAGE =
+  "This file is too big. Upload a file under 1 MB and try again."
+
+export const BulkUploadOversizeFile: Story = {
+  parameters: {
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const { body, screen } = await openBulkUploadModal(canvasElement)
+    const tooBig = new File(
+      ["a".repeat(MAX_BULK_REDIRECT_CSV_BYTES + 1)],
+      "too-big.csv",
+      { type: "text/csv" },
+    )
+    await pickFileInModal(body, tooBig)
+
+    await expect(await screen.findByText(OVERSIZE_MESSAGE)).toBeVisible()
+    // Shown as the attached chip: the dropzone is replaced, and the design
+    // system's own dismissable error chip must not appear alongside it.
+    await expect(
+      screen.getByRole("button", { name: "Remove file" }),
+    ).toBeVisible()
+    await expect(
+      screen.queryByRole("button", { name: "Dismiss error" }),
+    ).toBeNull()
+    await expect(
+      body.querySelector("[role='dialog'] input[type='file']"),
+    ).toBeNull()
+
+    // Removing clears the message — the guard that keeps a rejection on screen
+    // through the dropzone's trailing reset must not swallow a real removal.
+    await userEvent.click(screen.getByRole("button", { name: "Remove file" }), {
+      pointerEventsCheck: 0,
+    })
+    await waitFor(() => expect(screen.queryByText(OVERSIZE_MESSAGE)).toBeNull())
+
+    // Re-picking lands back on the same state, which is what this story shows.
+    await pickFileInModal(body, tooBig)
+    await expect(await screen.findByText(OVERSIZE_MESSAGE)).toBeVisible()
   },
 }
 

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -109,6 +109,10 @@ export const AlreadyExistsError: Story = {
 const VALID_CSV =
   "When someone visits,Redirect them to\n/old-one,/new-one\n/old-two,https://www.example.gov.sg"
 
+// Distinct contents, so swapping it in genuinely changes what would be published.
+const SWAPPED_CSV =
+  "When someone visits,Redirect them to\n/other-old,/other-new"
+
 // Processing holds its spinner for a deliberate minimum duration, so anything
 // asserted after "Process redirects" needs longer than the 1s default.
 const AFTER_PROCESSING = { timeout: 10000 }
@@ -207,6 +211,64 @@ export const BulkUploadReadyToPublish: Story = {
     await expect(
       screen.getByRole("button", { name: "Publish 2 redirects" }),
     ).toBeVisible()
+  },
+}
+
+// Regression: the chip's remove button stays live while processing, so the file
+// can be swapped mid-process. The first run's verdicts must not open the review
+// screen for a file that is no longer attached — otherwise the editor reviews one
+// batch and publishes another.
+//
+// Validation is held open so the swap lands before the response rather than
+// racing the client's own minimum duration, which would make this flaky on a
+// slow machine.
+export const BulkUploadFileSwappedWhileProcessing: Story = {
+  parameters: {
+    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
+    msw: {
+      handlers: [
+        redirectHandlers.list.default(),
+        redirectHandlers.count.default(),
+        redirectHandlers.bulkValidate.allValid({ wait: 3000 }),
+        redirectHandlers.bulkCreate.success(),
+        ...COMMON_HANDLERS,
+      ],
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const { body, screen } = await openBulkUploadModal(canvasElement)
+    await pickFileInModal(
+      body,
+      new File([VALID_CSV], "first.csv", { type: "text/csv" }),
+    )
+    const processButton = await screen.findByRole("button", {
+      name: "Process redirects",
+    })
+    await waitFor(() => expect(processButton).toBeEnabled())
+    await userEvent.click(processButton, { pointerEventsCheck: 0 })
+
+    // Still inside the floor: drop the file being processed and attach another.
+    await userEvent.click(screen.getByRole("button", { name: "Remove file" }), {
+      pointerEventsCheck: 0,
+    })
+    await pickFileInModal(
+      body,
+      new File([SWAPPED_CSV], "second.csv", { type: "text/csv" }),
+    )
+
+    // Once the floor elapses the spinner clears, and the stale verdicts are
+    // dropped: the modal stays on the upload step with the newly attached file
+    // instead of showing the first file's review screen.
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole("button", { name: "Process redirects" }),
+        ).toBeEnabled(),
+      AFTER_PROCESSING,
+    )
+    await expect(screen.queryByText(/good to go/)).toBeNull()
+    await expect(screen.queryByRole("button", { name: /^Publish/ })).toBeNull()
+    await expect(screen.getByText("second.csv")).toBeVisible()
   },
 }
 

--- a/apps/studio/tests/msw/handlers/redirect.ts
+++ b/apps/studio/tests/msw/handlers/redirect.ts
@@ -1,4 +1,6 @@
+import type { DelayMode } from "msw"
 import { TRPCError } from "@trpc/server"
+import { delay } from "msw"
 
 import { MOCK_STORY_DATE } from "../constants"
 import { trpcMsw } from "../mockTrpc"
@@ -45,27 +47,35 @@ export const redirectHandlers = {
       }),
   },
   bulkValidate: {
-    // Every row passes — drives the ready-to-publish preview.
-    allValid: () =>
-      trpcMsw.redirect.bulkValidate.mutation(() => ({
-        fileError: null,
-        rows: [
-          {
-            rowNumber: 2,
-            source: "/old-one",
-            destination: "/new-one",
-            error: null,
-          },
-          {
-            rowNumber: 3,
-            source: "/old-two",
-            destination: "https://www.example.gov.sg",
-            error: null,
-          },
-        ],
-        validCount: 2,
-        errorCount: 0,
-      })),
+    // Every row passes — drives the ready-to-publish preview. `wait` holds the
+    // response open so a story can act on the modal mid-process without racing
+    // the client's own minimum processing duration.
+    allValid: ({ wait }: { wait?: DelayMode | number } = {}) =>
+      trpcMsw.redirect.bulkValidate.mutation(async () => {
+        if (wait !== undefined) {
+          await delay(wait)
+        }
+
+        return {
+          fileError: null,
+          rows: [
+            {
+              rowNumber: 2,
+              source: "/old-one",
+              destination: "/new-one",
+              error: null,
+            },
+            {
+              rowNumber: 3,
+              source: "/old-two",
+              destination: "https://www.example.gov.sg",
+              error: null,
+            },
+          ],
+          validCount: 2,
+          errorCount: 0,
+        }
+      }),
     // A mix of a failing and a passing row — drives the errors screen.
     withErrors: () =>
       trpcMsw.redirect.bulkValidate.mutation(() => ({


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +130 | -37 |
| 🧪 Test | 2 | +179 | -29 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Two items were raised during the [bulk upload & wildcard redirects dogfooding session](https://app.notion.com/p/opengov/Dogfooding-Bulk-upload-wildcard-redirects-3a077dbba7888183b56ce588dfc939b4), both in the **Bulk upload redirects** modal:

1. **Processing feels instantaneous.** Validation is fast enough that the screen changes before the click registers, so it reads as "nothing happened". This is worst on a re-upload that lands back on the errors screen, because the modal looks unchanged — the editor cannot tell whether their corrected file was actually processed.

2. **The file upload component behaves inconsistently.** An *empty* file was flagged one way (the file stays attached as a chip, and the reason appears in red under the size/type hints), but an *oversize* file was flagged a completely different way: the dropzone stayed open and the reason went into a separate dismissable chip reading "Failed to upload. This file exceeds the size limit…". The same class of problem looked like two different components, and "Failed to upload" is misleading when the chip is still shown as attached.

Item 1 was raised as an improvement; item 2 as a bug, with the empty-file rendering explicitly confirmed as the desired one.

## Solution

Both fixes are in `BulkUploadRedirectsModal`.

**1. Minimum processing duration.** `handleProcess` now starts a 2 second timer alongside the validation request and awaits it on both the success and failure paths. Starting the timer alongside the request rather than after it means the floor and the network call overlap instead of adding up, so processing takes `max(request, 2s)` rather than `request + 2s`. The Process button's spinner is now driven by the modal's own `isProcessing` state instead of the mutation's `isPending`, so it covers the whole visible wait. Both steps named in the feedback — the initial upload and the re-upload after fixing errors — go through this one handler.

**2. One error surface for every bad file.** Files the dropzone rejects (oversize, wrong type, or more than one at a time) are now folded into the same `fileError` path the content checks already use: the rejected file is rendered as the attached chip with a remove button, the dropzone hides, and the reason renders in red under the "Accepted file type: .csv" line — identical to the empty-file case. `Attachment` is no longer given a `rejections` prop, so it cannot also render its own chip. Rejection copy was rewritten into the same voice as the existing parse-time file errors.

One implementation detail worth flagging for review: react-dropzone reports a rejection through `onRejection` and then immediately calls `onChange(undefined)` in the same event, which would otherwise wipe the chip and message we just set. A one-shot `hasPendingRejectionRef` swallows that single trailing reset, while a genuine removal (the trash button) still clears. Both directions are asserted in the new story so this stays locked.

`too-many-files` is handled too. It was not mentioned in the feedback, but dropping two files onto the single-file dropzone produces that rejection code and it would otherwise have been mislabelled "isn't a .csv".

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- The "Process redirects" step holds its spinner for a minimum of 2 seconds, so a fast validation still reads as a run and the transition into the errors or ready-to-publish screen is noticeable.
- Rejection messages now match the voice of the existing file-level errors, e.g. "This file is too big. Upload a file under 1 MB and try again." instead of "Failed to upload. This file exceeds the size limit. Please upload a file that is under 1 MB".

**Bug Fixes**:

- An oversize or wrong-type file is now flagged the same way as a file that fails the content checks: shown as the attached chip with the reason inline under the size/type hints, rather than leaving the dropzone open with a separate dismissable error chip.
- Dropping more than one file at a time now gets its own message ("Upload one file at a time.") instead of being reported as a wrong file type.

## Before & After Screenshots

**BEFORE**: uploading a file over 1 MB left the dropzone open and put the reason in a separate chip with its own "Dismiss" action, while an empty file kept the chip and showed the reason under the hints. Two renderings for the same class of problem — see the screenshots on the dogfooding page linked above.

**AFTER**: both cases render identically — the file stays attached as a chip with a trash button, the dropzone is hidden, and the reason appears in red under "Accepted file type: .csv". Captured by the new `Bulk Upload Oversize File` story, so the state is visible in this PR's Chromatic build.

## Tests

Storybook interaction tests in `Redirects.stories.tsx`:

- **New** `BulkUploadOversizeFile` — uploads a file over the 1 MB cap and asserts the unified rendering: the inline size message is shown, the file is present as the attached chip with its remove button, the dropzone's file input is gone, and no "Dismiss error" chip exists. It then removes the file and asserts the message clears (the regression guard for the pending-rejection ref), and re-picks the file so the story settles on the error state for the Chromatic snapshot.
- **Updated** `BulkUploadReadyToPublish` — now also asserts the result is *not* on screen immediately after clicking Process, which is the executable guard on the minimum processing duration.
- **Updated** `BulkUploadWithErrors` and `BulkUploadReadyToPublish` — post-process assertions were given an explicit timeout, since the 2 second floor exceeds the 1 second default.

All four bulk-upload stories were run locally and pass. `pnpm typecheck` is clean, `oxlint --type-aware` is clean on the changed files, and `pnpm test:unit src/features/settings src/lib` passes (56 tests).

**Manual Verification Steps**:

- [ ] As a **site admin** on a site with the advanced redirects flag enabled, go to **Site Settings → Redirects** and click **"bulk upload with a .csv instead"**.
- [ ] Attach a valid CSV and click **"Process redirects"**. Confirm the button shows a spinner for roughly 2 seconds before the **"Redirects are ready to publish"** screen appears — the transition should be clearly noticeable, not instant.
- [ ] Repeat with a CSV containing at least one invalid row. On the **"There are errors in your redirects"** screen, re-upload a file that *still* has errors and confirm the spinner again holds for roughly 2 seconds, so it is obvious the new file was processed.
- [ ] Attach a CSV **larger than 1 MB**. Confirm the file is shown as an attached chip with a trash icon, the dropzone is hidden, and **"This file is too big. Upload a file under 1 MB and try again."** appears in red directly below "Accepted file type: .csv". Confirm there is **no** separate error chip with a "Dismiss" link.
- [ ] Click the trash icon on that chip. Confirm the message disappears and the dropzone returns, and that attaching another file afterwards works.
- [ ] Attach a non-CSV file (e.g. a `.xlsx`). Confirm **"This file isn't a .csv. Upload a .csv file and try again."** appears in the same position, in the same style.
- [ ] Regression check: attach an empty CSV and confirm **"This file is empty. Add your redirects and try again."** still appears in that same position, unchanged.
- [ ] Confirm the primary button stays disabled and reads **"Upload file to continue"** for every rejected file above.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change standardizes rejected-file feedback in the bulk redirects modal and keeps the processing indicator visible for a minimum of two seconds.

A previous bulk-validation request can still update the modal after it has been closed and reopened. This can replace the new upload session's screen with the old file's validation result.

## T-Rex validation blocked

- **Tool:** The rendered close-and-reopen check could not complete because the UI validation tool reached its maximum step limit after Playwright timed out waiting for the Process redirects button. The CSV upload rendered, but validation was never started, so the stale-result path was not executed.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The race-playwright script for PR 3044 exited with code 1 due to a timeout while waiting for the 'Process redirects' button.
- BulkUploadRedirectsModal.tsx sections 236-243 were observed to lack a lifecycle/session token check between the awaited work and setValidation/setStage.
- I opened the PR 3044 Upload Debug image to guide adjustments to the rendered upload/button selector or wait condition.
- Next, inspect the retained PR-3044-upload-debug.png to correct the selector or wait condition, re-run the race-playwright script, and capture the mandatory before/after videos plus poster PNGs.

<a href="https://app.greptile.com/trex/runs/17198739/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fsettings%2FRedirects%2Fcomponents%2FBulkUploadRedirectsModal.tsx%3A236-243%0A**Stale%20validation%20overwrites%20new%20sessions**%0A%0AWhen%20an%20editor%20starts%20processing%2C%20closes%20the%20modal%20during%20the%20two-second%20floor%2C%20and%20reopens%20it%20before%20the%20original%20run%20completes%2C%20the%20old%20continuation%20still%20applies%20its%20validation%20result.%20The%20fresh%20upload%20session%20can%20therefore%20switch%20to%20the%20previous%20file's%20success%20or%20error%20screen.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3044&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fsettings%2FRedirects%2Fcomponents%2FBulkUploadRedirectsModal.tsx%3A236-243%0A**Stale%20validation%20overwrites%20new%20sessions**%0A%0AWhen%20an%20editor%20starts%20processing%2C%20closes%20the%20modal%20during%20the%20two-second%20floor%2C%20and%20reopens%20it%20before%20the%20original%20run%20completes%2C%20the%20old%20continuation%20still%20applies%20its%20validation%20result.%20The%20fresh%20upload%20session%20can%20therefore%20switch%20to%20the%20previous%20file's%20success%20or%20error%20screen.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3044&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22fix%2Fadvanced-redirects-dogfood%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fadvanced-redirects-dogfood%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fsettings%2FRedirects%2Fcomponents%2FBulkUploadRedirectsModal.tsx%3A236-243%0A**Stale%20validation%20overwrites%20new%20sessions**%0A%0AWhen%20an%20editor%20starts%20processing%2C%20closes%20the%20modal%20during%20the%20two-second%20floor%2C%20and%20reopens%20it%20before%20the%20original%20run%20completes%2C%20the%20old%20continuation%20still%20applies%20its%20validation%20result.%20The%20fresh%20upload%20session%20can%20therefore%20switch%20to%20the%20previous%20file's%20success%20or%20error%20screen.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/features/settings/Redirects/components/BulkUploadRedirectsModal.tsx:236-243
**Stale validation overwrites new sessions**

When an editor starts processing, closes the modal during the two-second floor, and reopens it before the original run completes, the old continuation still applies its validation result. The fresh upload session can therefore switch to the previous file's success or error screen.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(redirects): address bulk upload dogf..."](https://github.com/opengovsg/isomer/commit/42d6a812318b2d4a75ffeffbec5573b1a4d94056) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49962281)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - apps/studio/src/features/CLAUDE.md ([source](https://github.com/opengovsg/isomer/blob/main/apps/studio/src/features/CLAUDE.md))

<!-- /greptile_comment -->