### PR TITLE
feat(db): add concurrent index on Version(resourceId, versionNum)

### DIFF
--- a/packages/db/prisma/custom/migration.sql
+++ b/packages/db/prisma/custom/migration.sql
@@ -17,3 +17,16 @@ DROP INDEX "User_email_deletedAt_key";
 CREATE UNIQUE INDEX IF NOT EXISTS "User_email_deletedAt_key" ON "User"("email", "deletedAt") NULLS NOT DISTINCT;
 
 ---------------------------------
+
+
+---------------------------------
+-- Adds an index on Version(resourceId, versionNum DESC) to support finding
+-- the latest version for a resource (WHERE resourceId = $1 ORDER BY
+-- versionNum DESC LIMIT 1), a query that runs on every publish, unpublish,
+-- and archive-draft for every resource on the platform. Version is a large,
+-- append-only, platform-shared table, so this index is created
+-- CONCURRENTLY to avoid taking a write lock on the table.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Version_resourceId_versionNum_idx" ON "Version"("resourceId", "versionNum" DESC);
+
+---------------------------------

--- a/packages/db/prisma/migrations/20260803104350_custom_migration/migration.sql
+++ b/packages/db/prisma/migrations/20260803104350_custom_migration/migration.sql
@@ -1,0 +1,13 @@
+---------------------------------
+
+
+---------------------------------
+-- Adds an index on Version(resourceId, versionNum DESC) to support finding
+-- the latest version for a resource (WHERE resourceId = $1 ORDER BY
+-- versionNum DESC LIMIT 1), a query that runs on every publish, unpublish,
+-- and archive-draft for every resource on the platform. Version is a large,
+-- append-only, platform-shared table, so this index is created
+-- CONCURRENTLY to avoid taking a write lock on the table.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Version_resourceId_versionNum_idx" ON "Version"("resourceId", "versionNum" DESC);
+

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -47,6 +47,12 @@ model Version {
   publisher   User       @relation(fields: [publishedBy], references: [id])
 
   updatedAt DateTime @default(now()) @updatedAt
+
+  // Supports querying WHERE resourceId = $1 ORDER BY versionNum DESC LIMIT 1
+  // to find the latest version for a resource. Created CONCURRENTLY via a
+  // custom migration since Version is a large, append-only, platform-shared
+  // table (see prisma/custom/migration.sql).
+  @@index([resourceId, versionNum(sort: Desc)])
 }
 
 model Resource {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +32 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
Adds a concurrent index on `Version(resourceId, versionNum DESC)` to support `getLatestVersionByResourceId`, which today runs a full table scan on every publish (and will run on unpublish/re-lock once those ship).

`Version` is large, append-only, and shared across every site, so the index is built via `CREATE INDEX CONCURRENTLY` (hand-written in `packages/db/prisma/custom/migration.sql`, since Prisma's schema DSL has no way to request `CONCURRENTLY`) to avoid locking writers during the build.

## Test plan
- [ ] Confirm `pnpm generate` / `prisma migrate deploy` picks up the new migration cleanly in a fresh DB
- [ ] Confirm `EXPLAIN ANALYZE` on `getLatestVersionByResourceId`'s query uses the new index post-deploy