### PR TITLE
feat(db): add Archived resource state and unpublish audit events

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -162,6 +162,13 @@ type DisplayableAuditLogEvent = Exclude<
   | "PermissionUpdate"
   | "SchedulePublish"
   | "CancelSchedulePublish"
+  // NOTE: unpublishing-feature events (E1-E4). Not yet surfaced in this
+  // reporting script — add display queries here when this report is
+  // extended to cover them.
+  | "Unpublish"
+  | "ArchiveDraft"
+  | "ScheduleUnpublish"
+  | "CancelScheduleUnpublish"
 >
 
 // NOTE: Only use these queries in the context of the getAuditLogQuery function,

--- a/packages/db/prisma/migrations/20260803103959_add_archived_state_and_audit_events/migration.sql
+++ b/packages/db/prisma/migrations/20260803103959_add_archived_state_and_audit_events/migration.sql
@@ -1,0 +1,15 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "AuditLogEvent" ADD VALUE 'Unpublish';
+ALTER TYPE "AuditLogEvent" ADD VALUE 'ArchiveDraft';
+ALTER TYPE "AuditLogEvent" ADD VALUE 'ScheduleUnpublish';
+ALTER TYPE "AuditLogEvent" ADD VALUE 'CancelScheduleUnpublish';
+
+-- AlterEnum
+ALTER TYPE "ResourceState" ADD VALUE 'Archived';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -114,6 +114,7 @@ model Blob {
 enum ResourceState {
   Draft
   Published
+  Archived
 }
 
 enum ResourceType {
@@ -300,6 +301,10 @@ enum AuditLogEvent {
   NavbarUpdate
   RedirectCreate
   RedirectDelete
+  Unpublish
+  ArchiveDraft
+  ScheduleUnpublish
+  CancelScheduleUnpublish
 }
 
 model AuditLog {

--- a/packages/db/src/generated/generatedEnums.ts
+++ b/packages/db/src/generated/generatedEnums.ts
@@ -1,6 +1,7 @@
 export const ResourceState = {
   Draft: "Draft",
   Published: "Published",
+  Archived: "Archived",
 } as const
 export type ResourceState = (typeof ResourceState)[keyof typeof ResourceState]
 export const ResourceType = {
@@ -47,6 +48,10 @@ export const AuditLogEvent = {
   NavbarUpdate: "NavbarUpdate",
   RedirectCreate: "RedirectCreate",
   RedirectDelete: "RedirectDelete",
+  Unpublish: "Unpublish",
+  ArchiveDraft: "ArchiveDraft",
+  ScheduleUnpublish: "ScheduleUnpublish",
+  CancelScheduleUnpublish: "CancelScheduleUnpublish",
 } as const
 export type AuditLogEvent = (typeof AuditLogEvent)[keyof typeof AuditLogEvent]
 export const BuildStatusType = {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 3 | +27 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 1 | +5 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
Adds the enum values needed for the unpublishing feature:
- `ResourceState.Archived`
- `AuditLogEvent.Unpublish` / `ArchiveDraft` / `ScheduleUnpublish` / `CancelScheduleUnpublish`

`Archived` is the state noun (the 3rd `ResourceState` value); `Unpublish` and `ArchiveDraft` are the two ways a resource gets there — Unpublish from `Published`, ArchiveDraft from `Draft`. (Earlier drafts of this PR used `Unpublished`/`ResourceReLock` — renamed per the finalized terminology lock before anything downstream depended on the old names.)

Purely additive schema change, no application logic yet — this just lays the groundwork for e2/e3/e4.

Stacked on #3057 (pr1).

## Test plan
- [ ] Confirm migration applies cleanly (`prisma migrate deploy`)
- [ ] Confirm `pnpm generate` output matches the committed generated types