### PR TITLE
feat(permissions): add unpublish as a base CASL action

### DIFF
--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -170,6 +170,72 @@ describe("permissions.service", () => {
       expect(canMoveFrom).toBe(expected)
       expect(canMoveTo).toBe(false)
     })
+
+    it("should allow editors to unpublish non-root resources", () => {
+      // Arrange
+      const page = { parentId: "2" }
+      const expected = true
+      const perms = buildPermissions(RoleType.Editor)
+
+      // Act
+      const canUnpublish = perms.can("unpublish", page)
+
+      // Assert
+      expect(canUnpublish).toBe(expected)
+    })
+
+    it("should disallow editors from unpublishing root resources", () => {
+      // Arrange
+      const rootPage = { parentId: null }
+      const perms = buildPermissions(RoleType.Editor)
+
+      // Act
+      const canUnpublish = perms.can("unpublish", rootPage)
+
+      // Assert
+      expect(canUnpublish).toBe(false)
+    })
+
+    it("should allow publishers to unpublish non-root resources", () => {
+      // Arrange
+      const page = { parentId: "2" }
+      const expected = true
+      const perms = buildPermissions(RoleType.Publisher)
+
+      // Act
+      const canUnpublish = perms.can("unpublish", page)
+
+      // Assert
+      expect(canUnpublish).toBe(expected)
+    })
+
+    it("should disallow publishers from unpublishing root resources", () => {
+      // Arrange
+      const rootPage = { parentId: null }
+      const perms = buildPermissions(RoleType.Publisher)
+
+      // Act
+      const canUnpublish = perms.can("unpublish", rootPage)
+
+      // Assert
+      expect(canUnpublish).toBe(false)
+    })
+
+    it("should allow admins to unpublish any resource, including root resources", () => {
+      // Arrange
+      const page = { parentId: "2" }
+      const rootPage = { parentId: null }
+      const expected = true
+      const perms = buildPermissions(RoleType.Admin)
+
+      // Act
+      const canUnpublishPage = perms.can("unpublish", page)
+      const canUnpublishRootPage = perms.can("unpublish", rootPage)
+
+      // Assert
+      expect(canUnpublishPage).toBe(expected)
+      expect(canUnpublishRootPage).toBe(expected)
+    })
   })
 
   describe("buildUserManagementPermissions", () => {

--- a/apps/studio/src/server/modules/permissions/permissions.type.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.type.ts
@@ -9,7 +9,12 @@ type AllowedResourceActions = (typeof ALL_ACTIONS)[number]
 export type CrudResourceActions = (typeof CRUD_ACTIONS)[number]
 type Subjects = "Resource" | Resource
 
-export const ALL_ACTIONS = [...CRUD_ACTIONS, "move", "publish"] as const
+export const ALL_ACTIONS = [
+  ...CRUD_ACTIONS,
+  "move",
+  "publish",
+  "unpublish",
+] as const
 type ResourcePermissionTuple = [AllowedResourceActions, Subjects]
 export type ResourceAbility = Ability<ResourcePermissionTuple>
 

--- a/apps/studio/src/server/modules/permissions/permissions.util.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.util.ts
@@ -14,6 +14,14 @@ const giveBasePermissions = (
   })
   builder.can("move", "Resource", { parentId: { $ne: null } })
 
+  // NOTE: this "unpublish" action is deliberately a base permission, not
+  // Publisher-gated: Editors must be able to complete the whole unlock ->
+  // edit -> re-archive cycle without a Publisher. It gates both the heavy
+  // Unpublish mutation and the light ArchiveDraft mutation (archiving an
+  // unlocked Draft page back to Archived) — both reuse this same rule
+  // rather than needing their own.
+  builder.can("unpublish", "Resource", { parentId: { $ne: null } })
+
   // NOTE: For root resources, they can only update and read
   builder.can("update", "Resource", { parentId: { $eq: null } })
   builder.can("read", "Resource", { parentId: { $eq: null } })


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +14 | -1 |
| 🧪 Test | 1 | +66 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
Adds `"unpublish"` as a valid action across the permissions module: widens `ALL_ACTIONS`/`bulkValidateUserPermissionsForResources`'s `action` union, and wires an actual base CASL rule granting `unpublish` on non-root resources to Editor/Publisher/Admin roles alike (deliberately a base permission, not Publisher-gated — Editors must be able to complete the whole unlock → edit → re-archive cycle without a Publisher). Covered by unit tests asserting the rule across roles and root vs. non-root resources.

This same `"unpublish"` action gates both the heavy Unpublish mutation and the light ArchiveDraft mutation added later in the stack — both share this one permission check even though only Unpublish's own consumer exists as of this PR; ArchiveDraft is wired up in a later PR in the stack.

Stacked on #3058 (e1).

## Test plan
- [x] Unit tests cover Editor/Publisher/Admin roles and root vs. non-root resources
- [ ] Typecheck passes with the widened `action` union