### PR TITLE
feat(studio): add getLatestVersionByResourceId helper for version service

### DIFF
--- a/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
+++ b/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
@@ -1,0 +1,167 @@
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupBlob,
+  setupPageResource,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { ResourceType } from "~prisma/generated/prisma/client"
+
+import { db, ResourceState } from "../../database"
+import { getLatestVersionByResourceId } from "../version.service"
+
+describe("version.service", () => {
+  beforeEach(async () => {
+    await resetTables("Site", "Resource", "Blob", "Version", "User")
+  })
+
+  describe("getLatestVersionByResourceId", () => {
+    it("should return undefined if the resource has no `Version` rows at all", async () => {
+      // Arrange
+      const { page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Draft,
+      })
+
+      // Act
+      const result = await getLatestVersionByResourceId(db, {
+        resourceId: page.id,
+      })
+
+      // Assert
+      expect(result).toBeUndefined()
+    })
+
+    it("should return the single `Version` row if only one exists", async () => {
+      // Arrange
+      const user = await setupUser({})
+      const { page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+
+      // Act
+      const result = await getLatestVersionByResourceId(db, {
+        resourceId: page.id,
+      })
+
+      // Assert
+      expect(result).toBeDefined()
+      expect(result?.resourceId).toBe(page.id)
+      expect(result?.versionNum).toBe(1)
+      expect(result?.id).toBe(page.publishedVersionId)
+    })
+
+    it("should return the row with the highest `versionNum`, not the most recently inserted one", async () => {
+      // Arrange
+      const user = await setupUser({})
+      const { page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+
+      // Insert a higher versionNum row first...
+      const higherVersionBlob = await setupBlob()
+      const higherVersion = await db
+        .insertInto("Version")
+        .values({
+          versionNum: 3,
+          resourceId: page.id,
+          blobId: higherVersionBlob.id,
+          publishedBy: user.id,
+        })
+        .returning(["id", "versionNum"])
+        .executeTakeFirstOrThrow()
+
+      // ...then insert a lower versionNum row afterwards, so insertion order
+      // and versionNum order disagree.
+      const lowerVersionBlob = await setupBlob()
+      await db
+        .insertInto("Version")
+        .values({
+          versionNum: 2,
+          resourceId: page.id,
+          blobId: lowerVersionBlob.id,
+          publishedBy: user.id,
+        })
+        .returning(["id", "versionNum"])
+        .executeTakeFirstOrThrow()
+
+      // Act
+      const result = await getLatestVersionByResourceId(db, {
+        resourceId: page.id,
+      })
+
+      // Assert
+      expect(result?.id).toBe(higherVersion.id)
+      expect(result?.versionNum).toBe(3)
+    })
+
+    it("should return the latest historical `Version` even if the resource is currently archived (publishedVersionId is null)", async () => {
+      // Arrange: simulate a resource that was published before, then archived.
+      const user = await setupUser({})
+      const { page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+
+      const secondVersionBlob = await setupBlob()
+      const latestVersion = await db
+        .insertInto("Version")
+        .values({
+          versionNum: 2,
+          resourceId: page.id,
+          blobId: secondVersionBlob.id,
+          publishedBy: user.id,
+        })
+        .returning(["id", "versionNum"])
+        .executeTakeFirstOrThrow()
+
+      // Simulate unpublishing: clear `publishedVersionId` on the resource
+      // while leaving its `Version` history intact.
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({ publishedVersionId: null, state: ResourceState.Archived })
+        .executeTakeFirstOrThrow()
+
+      // Act
+      const result = await getLatestVersionByResourceId(db, {
+        resourceId: page.id,
+      })
+
+      // Assert: even though `publishedVersionId` is null, the helper should
+      // still surface the latest historical version.
+      expect(result).toBeDefined()
+      expect(result?.id).toBe(latestVersion.id)
+      expect(result?.versionNum).toBe(2)
+    })
+
+    it("should scope to the given `resourceId` and not return another resource's versions", async () => {
+      // Arrange
+      const user = await setupUser({})
+      const { page: pageA } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+      const { page: pageB } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+      expect(pageA.id).not.toBe(pageB.id)
+
+      // Act
+      const result = await getLatestVersionByResourceId(db, {
+        resourceId: pageA.id,
+      })
+
+      // Assert
+      expect(result?.resourceId).toBe(pageA.id)
+      expect(result?.id).toBe(pageA.publishedVersionId)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
+++ b/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
@@ -98,6 +98,40 @@ describe("version.service", () => {
       expect(result?.versionNum).toBe(3)
     })
 
+    it("should deterministically break ties on `id` when versionNum is duplicated", async () => {
+      // Arrange — no DB constraint prevents duplicate versionNums today, so
+      // this must resolve deterministically rather than depend on scan order.
+      const user = await setupUser({})
+      const { page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+
+      // Insert a second row with the SAME versionNum as the one
+      // setupPageResource already created.
+      const duplicateBlob = await setupBlob()
+      const duplicateVersion = await db
+        .insertInto("Version")
+        .values({
+          versionNum: 1,
+          resourceId: page.id,
+          blobId: duplicateBlob.id,
+          publishedBy: user.id,
+        })
+        .returning(["id", "versionNum"])
+        .executeTakeFirstOrThrow()
+
+      // Act
+      const result = await getLatestVersionByResourceId(db, {
+        resourceId: page.id,
+      })
+
+      // Assert — the later-inserted (higher `id`) row wins the tie
+      expect(result?.id).toBe(duplicateVersion.id)
+      expect(result?.versionNum).toBe(1)
+    })
+
     it("should return the latest historical `Version` even if the resource is currently archived (publishedVersionId is null)", async () => {
       // Arrange: simulate a resource that was published before, then archived.
       const user = await setupUser({})

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -27,6 +27,19 @@ const getVersionById = ({ versionId }: { versionId: string }) =>
     .select(defaultVersionSelect)
     .executeTakeFirstOrThrow()
 
+// Latest `Version` for a resource, even if not currently published —
+// unlike `Resource.publishedVersionId`, this still finds history after unpublish.
+export const getLatestVersionByResourceId = (
+  db: SafeKysely,
+  { resourceId }: { resourceId: string },
+) =>
+  db
+    .selectFrom("Version")
+    .where("Version.resourceId", "=", resourceId)
+    .orderBy("Version.versionNum", "desc")
+    .select(defaultVersionSelect)
+    .executeTakeFirst()
+
 const createVersion = async (
   db: SafeKysely,
   props: {

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -37,6 +37,7 @@ export const getLatestVersionByResourceId = (
     .selectFrom("Version")
     .where("Version.resourceId", "=", resourceId)
     .orderBy("Version.versionNum", "desc")
+    .orderBy("Version.id", "desc")
     .select(defaultVersionSelect)
     .executeTakeFirst()
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +14 | -0 |
| 🧪 Test | 1 | +201 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
Adds `getLatestVersionByResourceId`, which fetches a resource's latest `Version` row regardless of current publish state. Unlike following `Resource.publishedVersionId`, this distinguishes "never published" from "published before, now unpublished" — the latter still has historical `Version` rows even though `publishedVersionId` is null. This is the helper e3's unpublish/re-lock logic depends on.

Stacked on #3059 (e2).

## Test plan
- [x] Unit tests cover: no versions, single version, highest-versionNum-not-most-recent, unpublished-with-history, and resource scoping