### PR TITLE
fix(studio): observe promise rejection before intervening await in page.router tests

### DIFF
--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -1640,13 +1640,13 @@ describe("page.router", async () => {
       })
 
       // Assert
-      await assertAuditLogRows()
       await expect(result).rejects.toThrow(
         new TRPCError({
           code: "CONFLICT",
           message: "A resource with the same permalink already exists",
         }),
       )
+      await assertAuditLogRows()
     })
 
     it("should create a new page with Content layout successfully", async () => {
@@ -1868,7 +1868,6 @@ describe("page.router", async () => {
       const result = caller.createPage({ ...expectedPageArgs })
 
       // Assert
-      await assertAuditLogRows()
       await expect(result).rejects.toThrow(
         new TRPCError({
           code: "NOT_FOUND",
@@ -1876,6 +1875,7 @@ describe("page.router", async () => {
             "Parent not found or parentId is not a valid collection or folder",
         }),
       )
+      await assertAuditLogRows()
     })
 
     it("should throw 404 if folderId is not a Folder resource", async () => {
@@ -1896,7 +1896,6 @@ describe("page.router", async () => {
       const result = caller.createPage({ ...expectedPageArgs })
 
       // Assert
-      await assertAuditLogRows()
       await expect(result).rejects.toThrow(
         new TRPCError({
           code: "NOT_FOUND",
@@ -1904,6 +1903,7 @@ describe("page.router", async () => {
             "Parent not found or parentId is not a valid collection or folder",
         }),
       )
+      await assertAuditLogRows()
     })
 
     // TODO: Implement tests when permissions are implemented
@@ -2593,7 +2593,6 @@ describe("page.router", async () => {
       })
 
       // Assert
-      await assertAuditLogRows()
       await expect(result).rejects.toThrow(
         new TRPCError({
           code: "NOT_FOUND",
@@ -2601,6 +2600,7 @@ describe("page.router", async () => {
             "Unable to load content for the requested page, please contact Isomer Support",
         }),
       )
+      await assertAuditLogRows()
     })
 
     it("should update page settings successfully", async () => {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 0 | +0 | -0 |
| 🧪 Test | 1 | +4 | -4 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

📄 **[Full explainer with diagrams & quiz](https://app.notion.com/p/3b377dbba7888145b156c4a1034b4541)**

## Problem

Four tests in `apps/studio/src/server/modules/page/__tests__/page.router.test.ts` intermittently fail with an "unhandled promise rejection" error, even though their actual assertions pass. This is a flaky-test race, not a real regression: each affected test called `await assertAuditLogRows()` *before* `await expect(result).rejects.toThrow(...)`. Since `assertAuditLogRows()` performs its own `await`, it yields control back to the event loop — and if the `result` promise happens to reject during that window, Node flags it as unhandled before the test ever gets to its `.rejects.toThrow()` check.

## Solution

Reordered the two assertion lines in each affected test so the rejection is observed immediately, with no intervening `await`, and other assertions (like the audit-log check) run afterward:

```diff
  // Assert
- await assertAuditLogRows()
  await expect(result).rejects.toThrow(...)
+ await assertAuditLogRows()
```

Grepped all ~60 `.rejects.toThrow(` call sites in the file for this exact shape (an intervening `await` before the rejects assertion) — only 4 sites had it:

- `createPage` — "should throw 409 if permalink is not unique"
- `createPage` — "should throw 404 if folderId does not exist"
- `createPage` — "should throw 404 if folderId is not a Folder resource"
- `updateSettings` — "should return 404 if page does not exist"

Also verified `assertAuditLogRows` (`apps/studio/src/server/modules/audit/__tests__/utils.ts`) has no ordering dependency — it's a plain, independent DB read/count assertion, so moving it after the rejects check doesn't change its correctness.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixes flaky "unhandled rejection" failures in 4 `page.router.test.ts` tests, unrelated to any other in-flight work (e.g. the unpublishing PR stack).

## Tests

Test-only change — no production code touched. Verified by code inspection (pure line reordering, no logic change) and by tracing `assertAuditLogRows`'s implementation to confirm the reorder doesn't affect what it asserts. Could not execute the suite in the sandbox used to prepare this change (missing local `vitest` install + private registry auth); recommend running the following a few times back-to-back in a normal dev environment to confirm the flakiness is gone, since the race doesn't reproduce on every run:

```
pnpm test:unit -- src/server/modules/page/__tests__/page.router.test.ts
```