### PR TITLE
fix(collection): publish index page when creating a collection

### DIFF
--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -222,7 +222,7 @@ describe("collection.router", async () => {
       })
       expect(result).toMatchObject({ id: actualCollection.id })
       expect(auditSpy).toHaveBeenCalled()
-      await assertAuditLogRows(3)
+      await assertAuditLogRows(4)
       const auditEntry = await db
         .selectFrom("AuditLog")
         .where("eventType", "=", "ResourceCreate")
@@ -256,7 +256,7 @@ describe("collection.router", async () => {
       })
       expect(result).toMatchObject({ id: actualCollection.id })
       expect(auditSpy).toHaveBeenCalled()
-      await assertAuditLogRows(3)
+      await assertAuditLogRows(4)
       const auditEntry = await db
         .selectFrom("AuditLog")
         .where("eventType", "=", "ResourceCreate")
@@ -264,6 +264,35 @@ describe("collection.router", async () => {
         .executeTakeFirstOrThrow()
       expect(auditEntry.delta.after!).toMatchObject(result)
       expect(auditEntry.userId).toBe(session.userId)
+    })
+
+    it("should create a published index page for the collection", async () => {
+      // Arrange
+      const permalinkToUse = "published-index-collection"
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.create({
+        collectionTitle: "Published Index Collection",
+        siteId: site.id,
+        permalink: permalinkToUse,
+      })
+
+      // Assert
+      const indexPage = await db
+        .selectFrom("Resource")
+        .where("Resource.parentId", "=", result.id)
+        .where("Resource.type", "=", ResourceType.IndexPage)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+
+      expect(indexPage.state).toBe(ResourceState.Published)
+      expect(indexPage.publishedVersionId).not.toBeNull()
+      expect(indexPage.draftBlobId).toBeNull()
     })
 
     it("should create a nested collection if `parentFolderId` is provided and the user is an admin", async () => {
@@ -290,7 +319,7 @@ describe("collection.router", async () => {
       })
       expect(actualCollection.parentId).toEqual(parent.id)
       expect(result).toMatchObject({ id: actualCollection.id })
-      await assertAuditLogRows(3)
+      await assertAuditLogRows(4)
       expect(auditSpy).toHaveBeenCalled()
       const auditEntry = await db
         .selectFrom("AuditLog")
@@ -325,7 +354,7 @@ describe("collection.router", async () => {
       })
       expect(actualCollection.parentId).toEqual(parent.id)
       expect(result).toMatchObject({ id: actualCollection.id })
-      await assertAuditLogRows(3)
+      await assertAuditLogRows(4)
       expect(auditSpy).toHaveBeenCalled()
       const auditEntry = await db
         .selectFrom("AuditLog")

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -31,6 +31,7 @@ import {
   defaultResourceSelect,
   getBlobOfResource,
   getSiteResourceById,
+  publishPageResource,
   publishResource,
   updateBlobById,
 } from "../resource/resource.service"
@@ -178,13 +179,18 @@ export const collectionRouter = router({
             eventType: AuditLogEvent.ResourceCreate,
           })
 
-          return collection
+          return { collection, indexPage }
         })
 
-        // TODO: Create the index page for the collection and publish it
-        await publishResource(user.id, result, ctx.logger)
+        await publishPageResource({
+          logger: ctx.logger,
+          siteId,
+          resourceId: result.indexPage.id,
+          userId: user.id,
+        })
+        await publishResource(user.id, result.collection, ctx.logger)
 
-        return pick(result, defaultCollectionSelect)
+        return pick(result.collection, defaultCollectionSelect)
       },
     ),
   createCollectionPage: protectedProcedure


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +10 | -4 |
| 🧪 Test | 1 | +33 | -4 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When creating a collection, an index page is auto-generated but left in **draft** state. The collection itself is created as published, so the collection URL is not live until someone manually publishes the index page.

## Fix

After creating the collection and its index page in the transaction, call `publishPageResource` on the index page before triggering the site publish via `publishResource` on the collection.

This matches the existing TODO in `collection.router.ts` and the behaviour of admin tooling (`create-content-from-local.ts`), which creates published index pages for collections.

## Changes

- `collection.router.ts`: return both `collection` and `indexPage` from the create transaction; publish the index page with `publishPageResource`
- `collection.router.test.ts`: add test asserting the index page is published; update audit log row counts (now includes a publish event for the index page)

## Verification

- Typecheck passes locally
- Unit tests could not be run in this environment (no Docker for testcontainers); CI should run `collection.router.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb67a79c-71e5-43a0-86a1-ae6a8736baed?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb67a79c-71e5-43a0-86a1-ae6a8736baed&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

