### PR TITLE
chore: add ura.gov.sg to audit logs script

### DIFF
--- a/apps/studio/prisma/scripts/getAuditLogs.ts
+++ b/apps/studio/prisma/scripts/getAuditLogs.ts
@@ -138,6 +138,7 @@ const SITES_WITH_AUDIT_LOGS = [
   397, // rp.edu.sg
   406, // svc.gov.sg
   409, // hsa.gov.sg
+  467, // ura.gov.sg
   484, // hpb.gov.sg
   492, // oneservice.gov.sg
   511, // skyrisegreenery.nparks.gov.sg


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The `getAuditLogs` script's `SITES_WITH_AUDIT_LOGS` allowlist did not include ura.gov.sg (site ID 467), so audit logs for that site were not being pulled when the script runs.

## Solution

Added site ID `467` (ura.gov.sg) to the `SITES_WITH_AUDIT_LOGS` list in `apps/studio/prisma/scripts/getAuditLogs.ts`, keeping the list in numeric order.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- ura.gov.sg (site ID 467) is now included when generating audit logs via `getAuditLogs.ts`.

**Bug Fixes**:

- None

## Tests

**Manual Verification Steps**:

- [ ] Run `getAuditLogs.ts` for a month where ura.gov.sg had activity and confirm a row/CSV output is produced for site ID 467
- [ ] Confirm the exported audit log entries for site 467 correspond to ura.gov.sg activity
- [ ] Confirm other sites in the list are unaffected (output still generated for a couple of pre-existing site IDs, e.g. 409, 484)
