### PR TITLE
feat(studio): implement unpublishPageResource and archiveDraftResource as separate service functions

### DIFF
--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -90,6 +90,21 @@ export const publishPageSchema = z.object({
   siteId: z.number().min(1),
 })
 
+// Takes a live page down: Published -> Archived.
+export const unpublishPageSchema = z.object({
+  pageId: z.number().min(1),
+  siteId: z.number().min(1),
+  // Required if an in-progress draft exists: keep it, or overwrite with the
+  // published content. Ignorable otherwise.
+  preserveContent: z.enum(["draft", "published"]).optional(),
+})
+
+// Shelves a Draft page that was never live: Draft -> Archived.
+export const archiveDraftSchema = z.object({
+  pageId: z.number().min(1),
+  siteId: z.number().min(1),
+})
+
 export const createCollectionPageFormSchema = z
   .discriminatedUnion("type", [
     z.object({

--- a/apps/studio/src/server/modules/audit/audit.service.ts
+++ b/apps/studio/src/server/modules/audit/audit.service.ts
@@ -56,6 +56,19 @@ interface ResourceEventDeltaMap {
         before: WithoutMeta<PushDocumentJob>
         after: null
       }
+  // Forward unpublish: Published -> Archived. `before`/`after` are full
+  // resource snapshots so the delta captures the state/publishedVersionId/
+  // draftBlobId changes together, same shape as ResourceUpdate.
+  Unpublish: {
+    before: FullResource
+    after: FullResource
+  }
+  // Shelving a Draft page (never-published, or unlocked via "Edit this
+  // page" and backed out of) without ever publishing: Draft -> Archived.
+  ArchiveDraft: {
+    before: FullResource
+    after: FullResource
+  }
 }
 
 interface BaseResourceEventLogProps {

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -14,6 +14,7 @@ import {
 } from "tests/integration/helpers/iron-session"
 import {
   setupAdminPermissions,
+  setupBlob,
   setupCollection,
   setupEditorPermissions,
   setupFolder,
@@ -2310,6 +2311,547 @@ describe("page.router", async () => {
         .where("source", "=", "/old-url")
         .executeTakeFirstOrThrow()
       expect(redirect.destination).toEqual(`[resource:${site.id}:${folder.id}]`)
+    })
+  })
+
+  describe("unpublishPage", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      const result = unauthedCaller.unpublishPage({ siteId: 1, pageId: 1 })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user has no permissions on the site at all", async () => {
+      // Arrange — `unpublish` is a base permission (Editor/Publisher/Admin all
+      // have it), so the only way to lack it is to have no role at all.
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+
+      // Act
+      const result = caller.unpublishPage({
+        siteId: site.id,
+        pageId: Number(page.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should reject unpublishing a page with no publishedVersionId (never published)", async () => {
+      // Arrange — a fresh draft page has a `draftBlobId` but `publishedVersionId`
+      // is null, so there is genuinely nothing to unpublish.
+      const { site, folder } = await setupFolder({})
+      const { page } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+      })
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.unpublishPage({
+        siteId: site.id,
+        pageId: Number(page.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "This page is not currently published, so there is nothing to unpublish.",
+        }),
+      )
+    })
+
+    it("should reject unpublishing a page that is already Archived (publishedVersionId already null)", async () => {
+      // Arrange — an already-archived page also has publishedVersionId null,
+      // and must be rejected the same way as a never-published page.
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Archived,
+        userId: session.userId ?? undefined,
+      })
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.unpublishPage({
+        siteId: site.id,
+        pageId: Number(page.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            "This page is not currently published, so there is nothing to unpublish.",
+        }),
+      )
+    })
+
+    it("should unpublish a published page: null publishedVersionId, a NEW draft blob (not the Version's), Archived state, Unpublish event, and an untouched Version", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder({})
+      const { page, blob } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      // Base permission — an Editor (not just a Publisher) should be able to
+      // unpublish, per the "unlock -> edit -> re-lock" cycle this exists for.
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      const originalVersion = await db
+        .selectFrom("Version")
+        .where("resourceId", "=", page.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(originalVersion.blobId).toEqual(blob.id)
+
+      // Act
+      await caller.unpublishPage({ siteId: site.id, pageId: Number(page.id) })
+
+      // Assert — resource shape
+      const updatedResource = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(updatedResource?.publishedVersionId).toBeNull()
+      expect(updatedResource?.state).toEqual(ResourceState.Archived)
+      expect(updatedResource?.draftBlobId).not.toBeNull()
+      // The core regression this design exists to prevent: draftBlobId must
+      // be a brand NEW blob, never the Version's own blobId.
+      expect(updatedResource?.draftBlobId).not.toEqual(originalVersion.blobId)
+
+      // Assert — the new draft blob is a clone of the Version's content
+      const newDraftBlob = await db
+        .selectFrom("Blob")
+        .where("id", "=", updatedResource!.draftBlobId!)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(newDraftBlob.content).toEqual(blob.content)
+
+      // Assert — the Version row itself is untouched: same count, same blob,
+      // same (unmutated) content
+      const versionsAfter = await db
+        .selectFrom("Version")
+        .where("resourceId", "=", page.id)
+        .selectAll()
+        .execute()
+      expect(versionsAfter).toHaveLength(1)
+      expect(versionsAfter[0]!.blobId).toEqual(originalVersion.blobId)
+      const originalBlobAfter = await db
+        .selectFrom("Blob")
+        .where("id", "=", originalVersion.blobId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(originalBlobAfter.content).toEqual(blob.content)
+
+      // Assert — audit event
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Unpublish)
+        .selectAll()
+        .execute()
+      expect(auditLogs).toHaveLength(1)
+      expect(auditLogs[0]!.userId).toEqual(session.userId)
+      // No WIP draft existed, so preserveContent is n/a regardless of what
+      // (if anything) was passed in.
+      expect(auditLogs[0]!.metadata).toEqual({ preserveContent: "n/a" })
+    })
+
+    it("should reject unpublishing without preserveContent when a WIP draft already exists", async () => {
+      // Arrange — a page that's live, with a separate in-progress draft
+      // already sitting in draftBlobId (edited via "Edit this page" without
+      // republishing yet).
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      const wipDraftBlob = await setupBlob()
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({ draftBlobId: wipDraftBlob.id })
+        .execute()
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.unpublishPage({
+        siteId: site.id,
+        pageId: Number(page.id),
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "CONFLICT",
+          message:
+            "This page has unsaved draft changes. Please confirm whether to keep the draft or the published version before unpublishing.",
+        }),
+      )
+      // Nothing changed on the rejected attempt
+      const unchanged = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(unchanged?.draftBlobId).toEqual(wipDraftBlob.id)
+      expect(unchanged?.state).toEqual(ResourceState.Published)
+    })
+
+    it("should overwrite the WIP draft with the published content when preserveContent is 'published'", async () => {
+      // Arrange
+      const { site, page, blob } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      const wipDraftBlob = await setupBlob()
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({ draftBlobId: wipDraftBlob.id })
+        .execute()
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.unpublishPage({
+        siteId: site.id,
+        pageId: Number(page.id),
+        preserveContent: "published",
+      })
+
+      // Assert — draftBlobId is a NEW blob (not the WIP one), cloned from
+      // the published content
+      const updatedResource = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(updatedResource?.draftBlobId).not.toEqual(wipDraftBlob.id)
+      const newDraftBlob = await db
+        .selectFrom("Blob")
+        .where("id", "=", updatedResource!.draftBlobId!)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(newDraftBlob.content).toEqual(blob.content)
+
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Unpublish)
+        .selectAll()
+        .execute()
+      expect(auditLogs[0]!.metadata).toEqual({ preserveContent: "published" })
+    })
+
+    it("should leave the WIP draft untouched when preserveContent is 'draft'", async () => {
+      // Arrange
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      const wipDraftBlob = await setupBlob()
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({ draftBlobId: wipDraftBlob.id })
+        .execute()
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.unpublishPage({
+        siteId: site.id,
+        pageId: Number(page.id),
+        preserveContent: "draft",
+      })
+
+      // Assert — draftBlobId is the SAME WIP blob, untouched; only
+      // publishedVersionId/state changed
+      const updatedResource = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(updatedResource?.draftBlobId).toEqual(wipDraftBlob.id)
+      expect(updatedResource?.publishedVersionId).toBeNull()
+      expect(updatedResource?.state).toEqual(ResourceState.Archived)
+
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Unpublish)
+        .selectAll()
+        .execute()
+      expect(auditLogs[0]!.metadata).toEqual({ preserveContent: "draft" })
+    })
+
+    it("should not corrupt the original Version's blob when the discarded draft created by unpublishing is later edited", async () => {
+      // Arrange — the core data-integrity regression this design exists for:
+      // editing the NEW draft left behind by unpublish must never touch the
+      // original (immutable) Version's blob content.
+      const { site, page, blob } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      const originalVersion = await db
+        .selectFrom("Version")
+        .where("resourceId", "=", page.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+
+      await caller.unpublishPage({ siteId: site.id, pageId: Number(page.id) })
+
+      const newContent = {
+        content: [
+          {
+            type: "prose" as const,
+            content: [
+              {
+                type: "paragraph" as const,
+                content: [
+                  { type: "text" as const, text: "Edited after unpublish" },
+                ],
+              },
+            ],
+          },
+        ],
+        layout: "content" as const,
+        page: pick(page, ["title", "permalink"]),
+        version: "0.1.0" as const,
+      }
+
+      // Act — edit the new draft via the existing edit-content path
+      await caller.updatePageBlob({
+        pageId: Number(page.id),
+        siteId: site.id,
+        content: JSON.stringify(newContent),
+      })
+
+      // Assert — the draft blob picked up the edit...
+      const updatedResource = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      const draftBlobAfterEdit = await db
+        .selectFrom("Blob")
+        .where("id", "=", updatedResource!.draftBlobId!)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(draftBlobAfterEdit.content).toEqual(newContent)
+
+      // ...but the original Version's blob content is untouched
+      const originalBlobAfterEdit = await db
+        .selectFrom("Blob")
+        .where("id", "=", originalVersion.blobId)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(originalBlobAfterEdit.content).toEqual(blob.content)
+      expect(originalBlobAfterEdit.content).not.toEqual(newContent)
+    })
+  })
+
+  describe("archiveDraft", () => {
+    it("should throw 401 if not logged in", async () => {
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      const result = unauthedCaller.archiveDraft({ siteId: 1, pageId: 1 })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user has no permissions on the site at all", async () => {
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        userId: session.userId ?? undefined,
+      })
+
+      const result = caller.archiveDraft({
+        siteId: site.id,
+        pageId: Number(page.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should reject archiving a page that is currently Published", async () => {
+      // Arrange — must never silently archive a live page: that would flip
+      // state without clearing publishedVersionId or rebuilding the site.
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      const result = caller.archiveDraft({
+        siteId: site.id,
+        pageId: Number(page.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Only a Draft page can be archived this way.",
+        }),
+      )
+      const unchanged = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(unchanged?.state).toEqual(ResourceState.Published)
+      expect(unchanged?.publishedVersionId).not.toBeNull()
+    })
+
+    it("should archive a never-published Draft page, leaving draftBlobId untouched and logging ArchiveDraft", async () => {
+      // Arrange — a fresh Draft page, never published, no confirmation
+      // needed since there's no live state or WIP edits to protect.
+      const { site, folder } = await setupFolder({})
+      const { page } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+      })
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+      const before = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.archiveDraft({ siteId: site.id, pageId: Number(page.id) })
+
+      // Assert — only `state` changes
+      const after = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(after?.state).toEqual(ResourceState.Archived)
+      expect(after?.draftBlobId).toEqual(before?.draftBlobId)
+      expect(after?.publishedVersionId).toBeNull()
+
+      const archiveDraftLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.ArchiveDraft)
+        .selectAll()
+        .execute()
+      expect(archiveDraftLogs).toHaveLength(1)
+    })
+
+    it("should archive a Draft page reached via 'Edit this page' post-unpublish, without touching the existing draftBlobId or requiring confirmation ('cancel edit' case)", async () => {
+      // Arrange — publish, then unpublish once (leaves a backfilled
+      // `draftBlobId`), then simulate the E4 "Edit this page" flip back to
+      // Draft (still holding that draftBlobId) — same mutation, no
+      // gating logic needed to distinguish this from a never-published Draft.
+      const { site, folder } = await setupFolder({})
+      const { page } = await setupPageResource({
+        siteId: site.id,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+      await setupEditorPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      await caller.unpublishPage({ siteId: site.id, pageId: Number(page.id) })
+      const afterUnpublish = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      const draftBlobId = afterUnpublish!.draftBlobId!
+      expect(draftBlobId).not.toBeNull()
+
+      // Simulate "Edit this page" (E4): flips state back to Draft, leaving
+      // draftBlobId as-is.
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({ state: ResourceState.Draft })
+        .execute()
+
+      // Act — no confirmation param exists on this mutation at all
+      await caller.archiveDraft({ siteId: site.id, pageId: Number(page.id) })
+
+      // Assert — state flips back to Archived, draftBlobId is the SAME row
+      // (not overwritten, unlike unpublishPage's copy-on-write backfill)
+      const final = await getPageById(db, {
+        resourceId: Number(page.id),
+        siteId: site.id,
+      })
+      expect(final?.state).toEqual(ResourceState.Archived)
+      expect(final?.publishedVersionId).toBeNull()
+      expect(final?.draftBlobId).toEqual(draftBlobId)
+
+      const archiveDraftLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.ArchiveDraft)
+        .selectAll()
+        .execute()
+      expect(archiveDraftLogs).toHaveLength(1)
+
+      const unpublishLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Unpublish)
+        .selectAll()
+        .execute()
+      expect(unpublishLogs).toHaveLength(1)
     })
   })
 

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -22,6 +22,7 @@ import {
   getIsSingpassDisabledInNonPreview,
 } from "~/lib/growthbook"
 import {
+  archiveDraftSchema,
   basePageSchema,
   createIndexPageSchema,
   createPageSchema,
@@ -32,6 +33,7 @@ import {
   publishPageSchema,
   readPageOutputSchema,
   reorderBlobSchema,
+  unpublishPageSchema,
   updatePageBlobSchema,
   updatePageMetaSchema,
 } from "~/schemas/page"
@@ -52,6 +54,7 @@ import { PG_ERROR_CODES } from "../database/constants"
 import { bulkValidateUserPermissionsForResources } from "../permissions/permissions.service"
 import { applyPermalinkChangeRedirects } from "../redirect/redirect.service"
 import {
+  archiveDraftResource,
   createResourceWithBlob,
   getBlobOfResource,
   getFooter,
@@ -62,6 +65,7 @@ import {
   getResourcePermalinkTree,
   publishPageResource,
   publishResource,
+  unpublishPageResource,
   updateBlobById,
   updatePageById,
 } from "../resource/resource.service"
@@ -669,6 +673,53 @@ export const pageRouter = router({
         }
       },
     ),
+
+  // Takes a live page down: Published -> Archived.
+  unpublishPage: protectedProcedure
+    .input(unpublishPageSchema)
+    .mutation(
+      async ({
+        ctx: { user, gb, logger },
+        input: { siteId, pageId, preserveContent },
+      }) => {
+        await bulkValidateUserPermissionsForResources({
+          siteId,
+          action: "unpublish",
+          resourceIds: [String(pageId)],
+          userId: user.id,
+        })
+        await unpublishPageResource({
+          logger,
+          siteId,
+          resourceId: String(pageId),
+          userId: user.id,
+          preserveContent,
+          sitePublish: {
+            isScheduled: false,
+            enableCodebuildJobs: gb.isOn(ENABLE_CODEBUILD_JOBS),
+          },
+        })
+      },
+    ),
+
+  // Shelves a Draft page that was never live: Draft -> Archived. Same
+  // permission as unpublishPage — Editors must be able to complete the whole
+  // unlock -> edit -> re-archive cycle without a Publisher.
+  archiveDraft: protectedProcedure
+    .input(archiveDraftSchema)
+    .mutation(async ({ ctx: { user }, input: { siteId, pageId } }) => {
+      await bulkValidateUserPermissionsForResources({
+        siteId,
+        action: "unpublish",
+        resourceIds: [String(pageId)],
+        userId: user.id,
+      })
+      await archiveDraftResource({
+        siteId,
+        resourceId: String(pageId),
+        userId: user.id,
+      })
+    }),
 
   updateMeta: protectedProcedure
     .input(updatePageMetaSchema)

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -89,7 +89,7 @@ export const definePermissionsForSite = async ({
 // TODO: this is using site wide permissions for now
 // we should fetch the oldest `parent` of this resource eventually
 interface BulkValidateUserPermissionsForResourcesProps extends BulkPermissionsProps {
-  action: CrudResourceActions | "publish"
+  action: CrudResourceActions | "publish" | "unpublish"
 }
 export const bulkValidateUserPermissionsForResources = async ({
   action,

--- a/apps/studio/src/server/modules/permissions/permissions.type.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.type.ts
@@ -38,7 +38,7 @@ export interface BulkPermissionsProps extends Omit<
   PermissionsProps,
   "resourceId"
 > {
-  action: CrudResourceActions | "publish"
+  action: CrudResourceActions | "publish" | "unpublish"
   siteId: Site["id"]
   resourceIds?: (string | null)[]
 }

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -38,7 +38,11 @@ import type {
   User,
 } from "../database"
 import type { SearchResultResource } from "./resource.types"
-import { logPublishEvent, logRedirectEvent } from "../audit/audit.service"
+import {
+  logPublishEvent,
+  logRedirectEvent,
+  logResourceEvent,
+} from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
 import { db, jsonb, ResourceState, ResourceType, sql } from "../database"
 import { PG_ERROR_CODES } from "../database/constants"
@@ -1342,6 +1346,224 @@ export const publishPageResource = async ({
           }
         : undefined,
     })
+}
+
+type PreserveContent = "draft" | "published"
+
+interface UnpublishPageResourceArgs {
+  logger: Logger<string>
+  userId: string
+  siteId: number
+  resourceId: string
+  // Required if a WIP draft already exists: "published" overwrites it,
+  // "draft" keeps it. Ignored (and optional) if there's no draft to choose
+  // between.
+  preserveContent?: PreserveContent
+  sitePublish?: {
+    enableCodebuildJobs: boolean
+    isScheduled: boolean
+  }
+}
+
+/**
+ * Takes a live page down: `Published` -> `Archived`, then rebuilds the site.
+ * Heavy path — see `archiveDraftResource` for the light `Draft` -> `Archived`
+ * counterpart.
+ */
+export const unpublishPageResource = async ({
+  logger,
+  siteId,
+  resourceId,
+  userId,
+  preserveContent,
+  sitePublish,
+}: UnpublishPageResourceArgs) => {
+  await db.transaction().execute(async (tx) => {
+    // TODO: unlocked read — races with concurrent publish/unpublish/archive
+    // on the same resource (same known gap as publishPageResource).
+    const resource = await getPageById(tx, {
+      resourceId: Number(resourceId),
+      siteId,
+    })
+
+    if (!resource) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message:
+          "Please ensure you are attempting to unpublish a page that exists",
+      })
+    }
+
+    if (!resource.publishedVersionId) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message:
+          "This page is not currently published, so there is nothing to unpublish.",
+      })
+    }
+
+    // A WIP draft already existing means there's a real choice to make
+    // between keeping it or the published version — require the caller to
+    // have made that choice explicitly rather than silently picking one.
+    if (resource.draftBlobId && !preserveContent) {
+      throw new TRPCError({
+        code: "CONFLICT",
+        message:
+          "This page has unsaved draft changes. Please confirm whether to keep the draft or the published version before unpublishing.",
+      })
+    }
+
+    // Applied choice, for the audit log — "n/a" when there was no draft to
+    // choose between (preserveContent is ignored in that case regardless of
+    // what was passed in).
+    let appliedPreserveContent: PreserveContent | "n/a"
+    let newDraftBlobId = resource.draftBlobId
+
+    if (!resource.draftBlobId || preserveContent === "published") {
+      appliedPreserveContent = resource.draftBlobId ? "published" : "n/a"
+
+      const publishedVersion = await tx
+        .selectFrom("Version")
+        .where("id", "=", resource.publishedVersionId)
+        .select("blobId")
+        .executeTakeFirstOrThrow()
+
+      // Clone (never reference) the published Version's blob content into a
+      // NEW `Blob` row, and point `draftBlobId` at that new row.
+      //
+      // This is NOT `draftBlobId = publishedVersion.blobId`. `updateBlobById`
+      // mutates whatever blob `draftBlobId` currently points at IN PLACE
+      // whenever `draftBlobId` is already set — it only creates a fresh blob
+      // when `draftBlobId` was null. Pointing `draftBlobId` straight at the
+      // Version's `blobId` would mean the very next edit (via "Edit this
+      // page") silently rewrites that Version's supposedly-immutable
+      // content — real data corruption. `Version.blobId` is also `@unique`,
+      // so republishing without editing would additionally hit a constraint
+      // violation trying to insert a new Version reusing that blobId.
+      const publishedBlob = await tx
+        .selectFrom("Blob")
+        .where("id", "=", publishedVersion.blobId)
+        .select("content")
+        .executeTakeFirstOrThrow()
+
+      const clonedBlob = await tx
+        .insertInto("Blob")
+        .values({ content: jsonb(publishedBlob.content) })
+        .returning("id")
+        .executeTakeFirstOrThrow()
+
+      newDraftBlobId = clonedBlob.id
+    } else {
+      // preserveContent === "draft": leave the existing WIP draft's blob
+      // untouched, don't backfill from the published content at all.
+      appliedPreserveContent = "draft"
+    }
+
+    const updatedResource = await updatePageById(
+      {
+        id: Number(resource.id),
+        siteId,
+        publishedVersionId: null,
+        draftBlobId: newDraftBlobId,
+        state: ResourceState.Archived,
+      },
+      tx,
+    )
+
+    if (!updatedResource) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to unpublish page",
+      })
+    }
+
+    await logResourceEvent(tx, {
+      siteId,
+      by: await getUserById(userId),
+      delta: { before: resource, after: updatedResource },
+      eventType: AuditLogEvent.Unpublish,
+      metadata: { preserveContent: appliedPreserveContent },
+    })
+  })
+
+  // Outside the transaction: rebuild the site so the page actually drops
+  // from deployed output.
+  if (sitePublish)
+    await publishSite(logger, {
+      siteId,
+      codebuildJob: sitePublish.enableCodebuildJobs
+        ? {
+            resourceWithUserIds: [{ resourceId, userId }],
+            isScheduled: sitePublish.isScheduled,
+          }
+        : undefined,
+    })
+}
+
+interface ArchiveDraftResourceArgs {
+  userId: string
+  siteId: number
+  resourceId: string
+}
+
+/**
+ * Shelves a `Draft` page that was never live: `Draft` -> `Archived`. Covers
+ * both "archive a never-published draft" and "cancel Edit this page" —
+ * identical mutation either way, since there's no live state to protect and
+ * nothing to publish. Only flips `state`; `draftBlobId`/`publishedVersionId`
+ * are left untouched, and there's no site rebuild since nothing was ever
+ * live. See `unpublishPageResource` for the heavy `Published` -> `Archived`
+ * counterpart.
+ */
+export const archiveDraftResource = async ({
+  userId,
+  siteId,
+  resourceId,
+}: ArchiveDraftResourceArgs) => {
+  await db.transaction().execute(async (tx) => {
+    const resource = await getPageById(tx, {
+      resourceId: Number(resourceId),
+      siteId,
+    })
+
+    if (!resource) {
+      throw new TRPCError({
+        code: "NOT_FOUND",
+        message:
+          "Please ensure you are attempting to archive a page that exists",
+      })
+    }
+
+    if (resource.state !== ResourceState.Draft) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "Only a Draft page can be archived this way.",
+      })
+    }
+
+    const updatedResource = await updatePageById(
+      {
+        id: Number(resource.id),
+        siteId,
+        state: ResourceState.Archived,
+      },
+      tx,
+    )
+
+    if (!updatedResource) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: "Failed to archive page",
+      })
+    }
+
+    await logResourceEvent(tx, {
+      siteId,
+      by: await getUserById(userId),
+      delta: { before: resource, after: updatedResource },
+      eventType: AuditLogEvent.ArchiveDraft,
+    })
+  })
 }
 
 /**


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 6 | +304 | -3 |
| 🧪 Test | 1 | +542 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
Backend core of the unpublish/archive feature. Two independent, single-purpose functions rather than one branching on prior resource state — the changelog's explicit decision, since the two paths' risk profiles differ meaningfully:

- **`unpublishPageResource`** (heavy — `Published -> Archived`): guards on `publishedVersionId` already null, copy-on-write backfills `draftBlobId` from the published Version's content (never points `draftBlobId` directly at a Version's blob — `updateBlobById` mutates in place, which would corrupt immutable published history), clears `publishedVersionId`, sets `state = Archived`, logs `AuditLogEvent.Unpublish`, then rebuilds the site outside the transaction.
  - Takes a `preserveContent: "draft" | "published"` choice, required whenever a WIP draft already exists at call time: `"published"` overwrites it with the published content (the only prior behavior), `"draft"` leaves it untouched. Ignored when no draft exists. Recorded in the audit log's `metadata`.
- **`archiveDraftResource`** (light — `Draft -> Archived`, new): just flips `state`, nothing else — covers both "archive a never-published draft" and "cancel Edit this page" as the identical mutation, no history-lookup gating needed.

New `archiveDraft` router mutation alongside the existing `unpublishPage`, both gated on the same `"unpublish"` base permission action.

Known gap, flagged inline (not fixed here — see risk #1 in the effort budget): neither function's initial resource read is `.forUpdate()`-locked, so concurrent publish/unpublish/archive on the same resource can race. This needs a coordinated fix across every Resource-mutating path, not a partial one in this PR.

Stacked on #3060 (pr2).

## Test plan
- [x] Unit tests: guard rejections (never-published, already-archived), successful unpublish (blob clone correctness, Version untouched), `preserveContent` choice (published/draft/conflict-without-choice), `archiveDraft` (never-published draft, post-unpublish "cancel edit" case), blob-corruption regression (edit-after-unpublish doesn't touch the historical Version's blob)