### PR TITLE
feat(page): add editThisPage mutation and guard updatePageBlob against editing archived pages

### DIFF
--- a/apps/studio/src/schemas/page.ts
+++ b/apps/studio/src/schemas/page.ts
@@ -198,3 +198,6 @@ export const getPrefillSchema = z.object({
   siteId: z.number().min(1),
   resourceId: z.string().regex(/^\d+$/),
 })
+
+// "Edit this page": the only exit from Archived (Archived -> Draft).
+export const editThisPageSchema = basePageSchema

--- a/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
+++ b/apps/studio/src/server/modules/page/__tests__/page.router.test.ts
@@ -973,7 +973,7 @@ describe("page.router", async () => {
         siteId: site.id,
       })
       const expected = {
-        ...pick(page, ["permalink", "title", "type"]),
+        ...pick(page, ["permalink", "title", "type", "state"]),
         navbar: omit(navbar, ["createdAt", "updatedAt"]),
         footer: omit(footer, ["createdAt", "updatedAt"]),
         content: blob.content,
@@ -1554,6 +1554,207 @@ describe("page.router", async () => {
             resource: omit(publishedPageToUpdate, ["updatedAt", "createdAt"]),
           },
         },
+      })
+    })
+
+    it("should throw PRECONDITION_FAILED and block edits if the page is archived", async () => {
+      // Arrange
+      const { page: archivedPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Archived,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: archivedPage.siteId,
+      })
+      const pageUpdateArgs = createPageUpdateArgs(archivedPage)
+
+      // Act
+      const result = caller.updatePageBlob(pageUpdateArgs)
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            'This page is archived and can\'t be edited. Use "Edit this page" first.',
+        }),
+      )
+      await assertAuditLogRows()
+    })
+
+    it("should allow edits on a draft page", async () => {
+      // Arrange
+      const { page: draftPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Draft,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: draftPage.siteId,
+      })
+      const pageUpdateArgs = createPageUpdateArgs(draftPage)
+
+      // Act
+      const result = caller.updatePageBlob(pageUpdateArgs)
+
+      // Assert
+      await expect(result).resolves.not.toThrow()
+    })
+
+    it("should allow edits on a published page", async () => {
+      // Arrange
+      const { page: publishedPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: publishedPage.siteId,
+      })
+      const pageUpdateArgs = createPageUpdateArgs(publishedPage)
+
+      // Act
+      const result = caller.updatePageBlob(pageUpdateArgs)
+
+      // Assert
+      await expect(result).resolves.not.toThrow()
+    })
+  })
+
+  describe("editThisPage", () => {
+    it("should throw 401 if not logged in", async () => {
+      // Arrange
+      const { page: archivedPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Archived,
+      })
+      const unauthedSession = applySession()
+      const unauthedCaller = createCaller(createMockRequest(unauthedSession))
+
+      // Act
+      const result = unauthedCaller.editThisPage({
+        pageId: Number(archivedPage.id),
+        siteId: archivedPage.siteId,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+      await assertAuditLogRows()
+    })
+
+    it("should throw 403 if user does not have update access to the page", async () => {
+      // Arrange
+      const { page: archivedPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Archived,
+      })
+
+      // Act
+      const result = caller.editThisPage({
+        pageId: Number(archivedPage.id),
+        siteId: archivedPage.siteId,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+      await assertAuditLogRows()
+    })
+
+    it("should return 404 if page does not exist", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = caller.editThisPage({
+        pageId: 999999,
+        siteId: site.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "NOT_FOUND", message: "Resource not found" }),
+      )
+      await assertAuditLogRows()
+    })
+
+    it("should reject a call on a page that is not currently archived", async () => {
+      // Arrange
+      const { page: draftPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Draft,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: draftPage.siteId,
+      })
+
+      // Act
+      const result = caller.editThisPage({
+        pageId: Number(draftPage.id),
+        siteId: draftPage.siteId,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Unable to edit a page that is not archived",
+        }),
+      )
+      await assertAuditLogRows()
+    })
+
+    it("should flip an archived page's state to draft, leaving publishedVersionId and draftBlobId untouched, and log the audit event", async () => {
+      // Arrange
+      const { page: archivedPage } = await setupPageResource({
+        resourceType: "Page",
+        state: ResourceState.Archived,
+      })
+      await setupAdminPermissions({
+        userId: session.userId ?? undefined,
+        siteId: archivedPage.siteId,
+      })
+      expect(archivedPage.publishedVersionId).toBeNull()
+      expect(archivedPage.draftBlobId).not.toBeNull()
+
+      // Act
+      const result = await caller.editThisPage({
+        pageId: Number(archivedPage.id),
+        siteId: archivedPage.siteId,
+      })
+
+      // Assert
+      expect(result.state).toEqual(ResourceState.Draft)
+      expect(result.publishedVersionId).toBeNull()
+      expect(result.draftBlobId).toEqual(archivedPage.draftBlobId)
+
+      const actual = await db
+        .selectFrom("Resource")
+        .where("id", "=", archivedPage.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(actual.state).toEqual(ResourceState.Draft)
+      expect(actual.publishedVersionId).toBeNull()
+      expect(actual.draftBlobId).toEqual(archivedPage.draftBlobId)
+
+      await assertAuditLogRows(1)
+      const auditLog = await db.selectFrom("AuditLog").selectAll().execute()
+      expect(auditLog[0]).toMatchObject({
+        eventType: "ResourceUpdate",
       })
     })
   })
@@ -2640,6 +2841,9 @@ describe("page.router", async () => {
         .executeTakeFirstOrThrow()
 
       await caller.unpublishPage({ siteId: site.id, pageId: Number(page.id) })
+      // "Edit this page": unlock the now-Archived page before editing it,
+      // per the updatePageBlob guard this PR adds.
+      await caller.editThisPage({ siteId: site.id, pageId: Number(page.id) })
 
       const newContent = {
         content: [

--- a/apps/studio/src/server/modules/page/page.router.ts
+++ b/apps/studio/src/server/modules/page/page.router.ts
@@ -26,6 +26,7 @@ import {
   basePageSchema,
   createIndexPageSchema,
   createPageSchema,
+  editThisPageSchema,
   getPrefillSchema,
   getRootPageSchema,
   listPagesSchema,
@@ -243,7 +244,7 @@ export const pageRouter = router({
           })
         }
 
-        const { title, type, permalink, content, updatedAt } = page
+        const { title, type, permalink, content, updatedAt, state } = page
 
         if (
           type !== ResourceType.Page &&
@@ -273,6 +274,7 @@ export const pageRouter = router({
           title,
           type,
           updatedAt,
+          state,
           ...siteMeta,
         }
       })
@@ -511,6 +513,21 @@ export const pageRouter = router({
         })
       }
 
+      if (resource.state === ResourceState.Archived) {
+        // Should be impossible; log drift, don't let it change the outcome.
+        if (resource.publishedVersionId !== null) {
+          ctx.logger.error(
+            { resourceId: input.pageId },
+            "Resource is Archived but publishedVersionId is not null — state/relational drift detected",
+          )
+        }
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message:
+            'This page is archived and can\'t be edited. Use "Edit this page" first.',
+        })
+      }
+
       const by = await db
         .selectFrom("User")
         .where("id", "=", ctx.user.id)
@@ -543,6 +560,77 @@ export const pageRouter = router({
       })
 
       return input
+    }),
+
+  // The only exit from Archived: flips state to Draft only, nothing else.
+  editThisPage: protectedProcedure
+    .input(editThisPageSchema)
+    .mutation(async ({ input, ctx }) => {
+      await bulkValidateUserPermissionsForResources({
+        siteId: input.siteId,
+        action: "update",
+        userId: ctx.user.id,
+      })
+
+      const resource = await getPageById(db, {
+        resourceId: input.pageId,
+        siteId: input.siteId,
+      })
+
+      if (!resource) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Resource not found",
+        })
+      }
+
+      if (resource.state !== ResourceState.Archived) {
+        throw new TRPCError({
+          code: "BAD_REQUEST",
+          message: "Unable to edit a page that is not archived",
+        })
+      }
+
+      const by = await db
+        .selectFrom("User")
+        .where("id", "=", ctx.user.id)
+        .selectAll()
+        .executeTakeFirstOrThrow(
+          () =>
+            new TRPCError({
+              code: "BAD_REQUEST",
+              message: "Please ensure that you are authenticated",
+            }),
+        )
+
+      const updatedResource = await db.transaction().execute(async (tx) => {
+        const updated = await updatePageById(
+          {
+            id: input.pageId,
+            siteId: input.siteId,
+            state: ResourceState.Draft,
+          },
+          tx,
+        )
+
+        if (!updated) {
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to unlock page for editing",
+          })
+        }
+
+        await logResourceEvent(tx, {
+          siteId: input.siteId,
+          by,
+          delta: { before: resource, after: updated },
+          eventType: AuditLogEvent.ResourceUpdate,
+        })
+
+        return updated
+      })
+
+      return updatedResource
     }),
 
   createPage: protectedProcedure


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +92 | -1 |
| 🧪 Test | 1 | +205 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
The only exit from `Archived`: `editThisPage` flips `state` back to `Draft`, leaving `publishedVersionId`/`draftBlobId` untouched — once flipped, the page behaves like an ordinary Draft page.

`updatePageBlob` now rejects edits on an Archived page with `PRECONDITION_FAILED`, with a non-fatal contradiction-check log if `publishedVersionId` is unexpectedly non-null in that state (should be structurally impossible).

Also exposes `state` on `readPageAndBlob`'s output — the main page-editor route sources its data exclusively from this query, and previously had no way to know a page was Archived without an extra round-trip. Lets the frontend gate the editor UI proactively instead of only discovering it via `updatePageBlob`'s guard on save.

Stacked on #3066 (e3).

## Test plan
- [x] Unit tests: `editThisPage` (401/403/404, reject on non-Archived state, successful Archived -> Draft flip with untouched publishedVersionId/draftBlobId), `updatePageBlob` guard (blocks edits when Archived), `readPageAndBlob` returns `state`