### PR TITLE
fix(studio): key incrementVersion off Version history, not publishedVersionId

### DIFF
--- a/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
+++ b/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
@@ -7,7 +7,10 @@ import {
 import { ResourceType } from "~prisma/generated/prisma/client"
 
 import { db, ResourceState } from "../../database"
-import { getLatestVersionByResourceId } from "../version.service"
+import {
+  getLatestVersionByResourceId,
+  incrementVersion,
+} from "../version.service"
 
 describe("version.service", () => {
   beforeEach(async () => {
@@ -196,6 +199,137 @@ describe("version.service", () => {
       // Assert
       expect(result?.resourceId).toBe(pageA.id)
       expect(result?.id).toBe(pageA.publishedVersionId)
+    })
+  })
+
+  describe("incrementVersion", () => {
+    it("should create versionNum 1 with a null previousVersion for a never-published resource", async () => {
+      // Arrange: a fresh draft resource, never published before.
+      const user = await setupUser({})
+      const { page, site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Draft,
+        userId: user.id,
+      })
+      expect(page.publishedVersionId).toBeNull()
+
+      // Act
+      const result = await db.transaction().execute((tx) =>
+        incrementVersion({
+          siteId: site.id,
+          resourceId: page.id,
+          userId: user.id,
+          tx,
+        }),
+      )
+
+      // Assert
+      expect(result).not.toBeNull()
+      expect(result?.newVersion.versionNum).toBe(1)
+      expect(result?.previousVersion).toBeNull()
+    })
+
+    it("should increment versionNum and reference the prior version on a normal republish", async () => {
+      // Arrange: an already-published resource (versionNum 1), now edited
+      // again (has a new draft blob to publish).
+      const user = await setupUser({})
+      const { page, site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+      const firstVersionId = page.publishedVersionId
+      expect(firstVersionId).not.toBeNull()
+
+      const newDraftBlob = await setupBlob()
+      const editedPage = await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({ draftBlobId: newDraftBlob.id })
+        .returningAll()
+        .executeTakeFirstOrThrow()
+      expect(editedPage.draftBlobId).toBe(newDraftBlob.id)
+
+      // Act
+      const result = await db.transaction().execute((tx) =>
+        incrementVersion({
+          siteId: site.id,
+          resourceId: page.id,
+          userId: user.id,
+          tx,
+        }),
+      )
+
+      // Assert
+      expect(result).not.toBeNull()
+      expect(result?.newVersion.versionNum).toBe(2)
+      expect(result?.previousVersion?.id).toBe(firstVersionId)
+      expect(result?.previousVersion?.versionNum).toBe(1)
+    })
+
+    it("should continue the real version history (not reset to 1) when republishing after an unpublish", async () => {
+      // Arrange: Version history (1, 2, 3) but currently archived —
+      // publishedVersionId is null despite real history existing.
+      const user = await setupUser({})
+      const { page, site } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+
+      const secondBlob = await setupBlob()
+      await db
+        .insertInto("Version")
+        .values({
+          versionNum: 2,
+          resourceId: page.id,
+          blobId: secondBlob.id,
+          publishedBy: user.id,
+        })
+        .returning(["id", "versionNum"])
+        .executeTakeFirstOrThrow()
+
+      const thirdBlob = await setupBlob()
+      const thirdVersion = await db
+        .insertInto("Version")
+        .values({
+          versionNum: 3,
+          resourceId: page.id,
+          blobId: thirdBlob.id,
+          publishedBy: user.id,
+        })
+        .returning(["id", "versionNum"])
+        .executeTakeFirstOrThrow()
+
+      // Simulate unpublishing followed by a fresh edit: `publishedVersionId`
+      // is cleared, and a new draft blob is set for the upcoming re-publish.
+      const draftBlob = await setupBlob()
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({
+          publishedVersionId: null,
+          state: ResourceState.Draft,
+          draftBlobId: draftBlob.id,
+        })
+        .executeTakeFirstOrThrow()
+
+      // Act
+      const result = await db.transaction().execute((tx) =>
+        incrementVersion({
+          siteId: site.id,
+          resourceId: page.id,
+          userId: user.id,
+          tx,
+        }),
+      )
+
+      // Assert: the bug would have produced versionNum 1 and a null
+      // previousVersion here, colliding with the existing history.
+      expect(result).not.toBeNull()
+      expect(result?.newVersion.versionNum).toBe(4)
+      expect(result?.previousVersion?.id).toBe(thirdVersion.id)
+      expect(result?.previousVersion?.versionNum).toBe(3)
     })
   })
 })

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -4,7 +4,6 @@ import { ResourceState } from "~prisma/generated/generatedEnums"
 import { type DB } from "~prisma/generated/generatedTypes"
 
 import type { SafeKysely, Transaction } from "../database"
-import { db } from "../database"
 import { getPageById, updatePageById } from "../resource/resource.service"
 
 interface Version {
@@ -19,13 +18,6 @@ const defaultVersionSelect: SelectExpression<DB, "Version">[] = [
   "Version.blobId",
   "Version.publishedAt",
 ]
-
-const getVersionById = ({ versionId }: { versionId: string }) =>
-  db
-    .selectFrom("Version")
-    .where("Version.id", "=", versionId)
-    .select(defaultVersionSelect)
-    .executeTakeFirstOrThrow()
 
 // Latest `Version` for a resource, even if not currently published —
 // unlike `Resource.publishedVersionId`, this still finds history after unpublish.
@@ -100,12 +92,14 @@ export const incrementVersion = async ({
   // If there's no draft, we don't create a new version
   if (!page.draftBlobId) return null
 
+  // Derive from actual Version history, not publishedVersionId — the latter
+  // is null both pre-first-publish and post-unpublish, which would wrongly
+  // reset the version count on a republish after unpublishing.
   let newVersionNum = 1
   let previousVersion: Version | null = null
-  if (page.publishedVersionId) {
-    previousVersion = await getVersionById({
-      versionId: page.publishedVersionId,
-    })
+  const latestVersion = await getLatestVersionByResourceId(tx, { resourceId })
+  if (latestVersion) {
+    previousVersion = latestVersion
     newVersionNum = previousVersion.versionNum + 1
   }
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +6 | -12 |
| 🧪 Test | 1 | +135 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
`incrementVersion` derived `newVersionNum`/`previousVersion` from `page.publishedVersionId`, which is null both for a resource that's never been published and one that was published before but has since been unpublished. On a republish in that second case it would wrongly reset `versionNum` back to 1 and drop `previousVersion`, colliding with the resource's real Version history.

Fix: use `getLatestVersionByResourceId` (keyed on the resource's actual `Version` rows) instead, so "never published" and "published before, now archived" are distinguished correctly.

Fixes `publishPageResource`'s audit-log `delta.before` field for free, since it's derived directly from `incrementVersion`'s `previousVersion` return value with no other logic in between.

Removes the now-unused `getVersionById` helper (and its `db` import), superseded by `getLatestVersionByResourceId`.

Stacked on #3067 (e4).

## Test plan
- [x] Unit test: republishing after an unpublish continues the real version history instead of resetting to 1