### PR TITLE
chore: remove is-advanced-redirects feature flag

### DIFF
--- a/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
+++ b/apps/studio/src/features/dashboard/components/FolderSettingsModal/FolderSettingsModal.tsx
@@ -29,7 +29,6 @@ import { Controller } from "react-hook-form"
 import { BiLink } from "react-icons/bi"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { generateResourceUrl } from "~/features/editing-experience/components/utils"
-import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { useZodForm } from "~/lib/form"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
@@ -108,7 +107,6 @@ const SuspendableModalContent = ({
       siteId,
       resourceId: Number(folderId),
     })
-  const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
   const { register, handleSubmit, watch, control, formState } = useZodForm({
     mode: "onChange",
     defaultValues: {
@@ -243,7 +241,7 @@ const SuspendableModalContent = ({
                 characters left
               </FormHelperText>
             </FormControl>
-            {isAdvancedRedirectsEnabled && permalink !== originalPermalink && (
+            {permalink !== originalPermalink && (
               <FormControl>
                 <Controller
                   control={control}

--- a/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/MoveResourceModal/MoveResourceModal.tsx
@@ -19,7 +19,6 @@ import { ResourceSelector } from "~/components/ResourceSelector/ResourceSelector
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { usePermissions } from "~/features/permissions"
 import { withSuspense } from "~/hocs/withSuspense"
-import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useQueryParse } from "~/hooks/useQueryParse"
 import { sitePageSchema } from "~/pages/sites/[siteId]"
 import { normalizeRedirectPath } from "~/schemas/redirect"
@@ -129,19 +128,16 @@ const MoveResourceContent = withSuspense(
       { enabled: !!curResourceId },
     )
 
-    const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
-
     // Only published Page/CollectionPage have a live URL worth preserving — the
     // server skips redirect creation for unpublished pages, so don't offer it.
     const isPageRedirectable =
       (type === ResourceType.Page || type === ResourceType.CollectionPage) &&
       publishedVersionId !== null
     // A Folder/Collection preserves its subtree with one wildcard redirect. It
-    // has no publishedVersionId of its own, so the server decides (on published
-    // descendants); here we only gate on the advanced-redirects flag.
+    // has no publishedVersionId of its own, so the server decides based on
+    // published descendants.
     const isFolderRedirect =
-      (type === ResourceType.Folder || type === ResourceType.Collection) &&
-      isAdvancedRedirectsEnabled
+      type === ResourceType.Folder || type === ResourceType.Collection
     const isRedirectableType = isPageRedirectable || isFolderRedirect
     const oldFullPermalink = normalizeRedirectPath(movedFullPermalink)
     const newFullPermalink = normalizeRedirectPath(

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -27,7 +27,6 @@ import {
   BRIEF_TOAST_SETTINGS,
   SETTINGS_TOAST_MESSAGES,
 } from "~/constants/toast"
-import { useIsAdvancedRedirectsEnabled } from "~/hooks/useIsAdvancedRedirectsEnabled"
 import { useZodForm } from "~/lib/form"
 import { normalizeRedirectSource, redirectKind } from "~/schemas/redirect"
 
@@ -85,7 +84,6 @@ export const AddRedirectCard = ({
   })
   const toast = useToast(BRIEF_TOAST_SETTINGS)
   const { mutate: createRedirect, isPending } = useCreateRedirect()
-  const isAdvancedRedirectsEnabled = useIsAdvancedRedirectsEnabled()
   const {
     isOpen: isPageModalOpen,
     onOpen: onPageModalOpen,
@@ -106,10 +104,7 @@ export const AddRedirectCard = ({
 
   // Live preview: /old/* + /dest → /old/example → /dest/example
   const wildcardPreview =
-    isAdvancedRedirectsEnabled &&
-    kind === "wildcard" &&
-    normalizedSource &&
-    destination
+    kind === "wildcard" && normalizedSource && destination
       ? buildWildcardPreview(normalizedSource, destination)
       : null
 
@@ -191,42 +186,40 @@ export const AddRedirectCard = ({
         effect on your live site.
       </Text>
 
-      {isAdvancedRedirectsEnabled && (
-        <Flex
-          align="center"
-          gap="0.5rem"
-          bg="utility.feedback.info-subtle"
-          borderRadius="4px"
-          p="0.75rem"
-          mb="1.25rem"
-        >
-          <Icon
-            as={BiBulb}
-            boxSize="1.25rem"
-            color="base.content.default"
-            flexShrink={0}
-          />
-          <Text textStyle="subhead-2" color="base.content.default">
-            Have more than 10 redirects to add? You can{" "}
-            <Link
-              as="button"
-              type="button"
-              variant="inline"
-              textStyle="subhead-2"
-              color="interaction.links.default"
-              onClick={() => {
-                posthog.capture("redirect_bulk_upload_modal_opened", {
-                  site_id: siteId,
-                })
-                onBulkUploadOpen()
-              }}
-            >
-              bulk upload with a .csv instead
-            </Link>
-            .
-          </Text>
-        </Flex>
-      )}
+      <Flex
+        align="center"
+        gap="0.5rem"
+        bg="utility.feedback.info-subtle"
+        borderRadius="4px"
+        p="0.75rem"
+        mb="1.25rem"
+      >
+        <Icon
+          as={BiBulb}
+          boxSize="1.25rem"
+          color="base.content.default"
+          flexShrink={0}
+        />
+        <Text textStyle="subhead-2" color="base.content.default">
+          Have more than 10 redirects to add? You can{" "}
+          <Link
+            as="button"
+            type="button"
+            variant="inline"
+            textStyle="subhead-2"
+            color="interaction.links.default"
+            onClick={() => {
+              posthog.capture("redirect_bulk_upload_modal_opened", {
+                site_id: siteId,
+              })
+              onBulkUploadOpen()
+            }}
+          >
+            bulk upload with a .csv instead
+          </Link>
+          .
+        </Text>
+      </Flex>
 
       <HStack as="form" align="flex-start" onSubmit={handleSubmit(onSubmit)}>
         <FormControl
@@ -244,11 +237,7 @@ export const AddRedirectCard = ({
               /
             </InputLeftAddon>
             <Input
-              placeholder={
-                isAdvancedRedirectsEnabled
-                  ? "redirect-from or path/*"
-                  : "redirect-from"
-              }
+              placeholder="redirect-from or path/*"
               {...register("source", {
                 onChange: clearFieldFeedback("source"),
               })}
@@ -263,7 +252,7 @@ export const AddRedirectCard = ({
               props, so an `mt` prop is silently dropped. Colour and font size
               come from the theme (base.content.medium, body-2) for the same
               reason. */}
-          {isAdvancedRedirectsEnabled && !errors.source && (
+          {!errors.source && (
             <FormHelperText sx={{ mt: "0.75rem" }}>
               {wildcardPreview ? `e.g. ${wildcardPreview}` : WILDCARD_HINT}
             </FormHelperText>
@@ -373,13 +362,11 @@ export const AddRedirectCard = ({
         }
       />
 
-      {isAdvancedRedirectsEnabled && (
-        <BulkUploadRedirectsModal
-          siteId={siteId}
-          isOpen={isBulkUploadOpen}
-          onClose={onBulkUploadClose}
-        />
-      )}
+      <BulkUploadRedirectsModal
+        siteId={siteId}
+        isOpen={isBulkUploadOpen}
+        onClose={onBulkUploadClose}
+      />
     </Box>
   )
 }

--- a/apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts
+++ b/apps/studio/src/hooks/useIsAdvancedRedirectsEnabled.ts
@@ -1,5 +1,0 @@
-import { useFeatureValue } from "@growthbook/growthbook-react"
-import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
-
-export const useIsAdvancedRedirectsEnabled = () =>
-  useFeatureValue<boolean>(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, false)

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -13,8 +13,6 @@ export const IS_SINGPASS_ENABLED_FEATURE_KEY = "is-singpass-enabled"
 export const IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY =
   "homepage-antiscam-banner-enabled"
 export const EGAZETTE_INFO_FEATURE_KEY = "egazette-info"
-export const IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY =
-  "is-advanced-redirects-enabled"
 // Gates the audit-log export surface (settings sidenav entry + page). OFF by
 // default so the feature can ship dark and be enabled per-environment.
 export const IS_AUDIT_LOG_ENABLED_FEATURE_KEY = "is-audit-log-enabled"

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -49,7 +49,7 @@ export const baseEditFolderSchema = baseFolderSchema.extend({
     }),
   // When the permalink changes, preserve the old URLs of everything under this
   // folder with a wildcard redirect. Defaults true (matches the move flow); the
-  // UI only surfaces the choice behind the advanced-redirects flag.
+  // UI only surfaces the choice when the permalink actually changes.
   shouldCreateRedirect: z.boolean().optional().default(true),
 })
 

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -1,8 +1,6 @@
 import { TRPCError } from "@trpc/server"
 import { auth } from "tests/integration/helpers/auth"
 import { resetTables } from "tests/integration/helpers/db"
-import { mockFeatureFlags } from "tests/integration/helpers/growthbook/mockFeatureFlags"
-import { mockGrowthBook } from "tests/integration/helpers/growthbook/mockInstance"
 import {
   applyAuthedSession,
   applySession,
@@ -16,7 +14,6 @@ import {
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
-import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { createCallerFactory } from "~/server/trpc"
 import { getReferenceLink } from "~/utils/link"
 
@@ -746,20 +743,6 @@ describe("folder.router", async () => {
     })
 
     describe("redirects on rename", () => {
-      const enableAdvancedRedirects = () => {
-        mockGrowthBook.setForcedFeatures(
-          new Map([
-            ...mockFeatureFlags,
-            [IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, true],
-          ]),
-        )
-      }
-
-      afterEach(() => {
-        // Restore the baseline forced features so the flag doesn't leak.
-        mockGrowthBook.setForcedFeatures(mockFeatureFlags)
-      })
-
       // Sets up a root folder with one published child page, plus admin
       // permissions on the site. Returns the ids needed to rename it.
       const setupFolderWithPublishedChild = async ({
@@ -786,7 +769,6 @@ describe("folder.router", async () => {
         // folder to /new-folder would move it to /new-folder/child, where an
         // existing exact redirect (pointing elsewhere) already lives and would
         // shadow the relocated page.
-        enableAdvancedRedirects()
         const { site, folder } = await setupFolderWithPublishedChild()
         await db
           .insertInto("Redirect")
@@ -820,7 +802,6 @@ describe("folder.router", async () => {
 
       it("creates a wildcard redirect from the OLD path when a published descendant exists", async () => {
         // Arrange
-        enableAdvancedRedirects()
         const { site, folder } = await setupFolderWithPublishedChild()
 
         // Act
@@ -849,64 +830,8 @@ describe("folder.router", async () => {
         expect(redirect.deletedAt).toBeNull()
       })
 
-      it("does not create a redirect when the advanced flag is off", async () => {
-        // Arrange — flag left at its (off) baseline.
-        const { site, folder } = await setupFolderWithPublishedChild()
-
-        // Act
-        await caller.editFolder({
-          siteId: String(site.id),
-          resourceId: folder.id,
-          title: "new folder",
-          permalink: "new-folder",
-        })
-
-        // Assert
-        const redirects = await db
-          .selectFrom("Redirect")
-          .selectAll()
-          .where("siteId", "=", site.id)
-          .execute()
-        expect(redirects).toHaveLength(0)
-      })
-
-      it("still blocks the rename when a descendant would be shadowed, even with the advanced flag off", async () => {
-        // Arrange — flag left at its (off) baseline. Only redirect CREATION is
-        // gated behind the flag; validating against an already-existing
-        // redirect must not be.
-        const { site, folder } = await setupFolderWithPublishedChild()
-        await db
-          .insertInto("Redirect")
-          .values({
-            siteId: site.id,
-            source: "/new-folder/child",
-            destination: "/somewhere-else",
-          })
-          .execute()
-
-        // Act
-        const result = caller.editFolder({
-          siteId: String(site.id),
-          resourceId: folder.id,
-          title: "new folder",
-          permalink: "new-folder",
-        })
-
-        // Assert
-        await expect(result).rejects.toThrow(
-          expect.objectContaining({ code: "CONFLICT" }),
-        )
-        const unchanged = await db
-          .selectFrom("Resource")
-          .select("permalink")
-          .where("id", "=", folder.id)
-          .executeTakeFirstOrThrow()
-        expect(unchanged.permalink).toBe("old-folder")
-      })
-
       it("does not create a redirect when the folder has no published descendant", async () => {
         // Arrange — the only child is a draft, so nothing is live to preserve.
-        enableAdvancedRedirects()
         const { site, folder } = await setupFolder({ permalink: "old-folder" })
         await setupPageResource({
           siteId: site.id,
@@ -936,7 +861,6 @@ describe("folder.router", async () => {
 
       it("does not create a redirect when shouldCreateRedirect is false", async () => {
         // Arrange
-        enableAdvancedRedirects()
         const { site, folder } = await setupFolderWithPublishedChild()
 
         // Act
@@ -960,7 +884,6 @@ describe("folder.router", async () => {
       it("allows moving a folder back to its old path, reclaiming its own wildcard", async () => {
         // Arrange — first move /old-folder -> /new-folder creates the wildcard
         // /old-folder/* -> folder.
-        enableAdvancedRedirects()
         const { site, folder } = await setupFolderWithPublishedChild()
         await caller.editFolder({
           siteId: String(site.id),

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,7 +1,6 @@
 import { TRPCError } from "@trpc/server"
 import { get, pick } from "lodash-es"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
-import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import {
   createFolderSchema,
   editFolderSchema,
@@ -307,9 +306,6 @@ export const folderRouter = router({
           // them with one wildcard redirect ("/old-folder/*"). oldFullPermalink
           // was captured pre-update; only the last path segment changed, so swap
           // it to derive the new full permalink without re-walking the tree.
-          // Shadow validation always runs on a permalink change; only redirect
-          // creation is gated behind the flag (dark-launched until the edge
-          // resolver ships).
           if (permalinkChanged && oldFullPermalink !== null) {
             const newFullPermalink =
               oldFullPermalink.slice(0, oldFullPermalink.lastIndexOf("/") + 1) +
@@ -323,9 +319,7 @@ export const folderRouter = router({
                 siteId: Number(siteId),
                 resourceId,
               }),
-              shouldCreateRedirect:
-                shouldCreateRedirect &&
-                ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY),
+              shouldCreateRedirect,
               byUserId: user.id,
             })
           }

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -2,8 +2,6 @@ import { TRPCError } from "@trpc/server"
 import { omit, pick } from "lodash-es"
 import { auth } from "tests/integration/helpers/auth"
 import { resetTables } from "tests/integration/helpers/db"
-import { mockFeatureFlags } from "tests/integration/helpers/growthbook/mockFeatureFlags"
-import { mockGrowthBook } from "tests/integration/helpers/growthbook/mockInstance"
 import {
   applyAuthedSession,
   applySession,
@@ -25,7 +23,6 @@ import {
   setUpWhitelist,
 } from "tests/integration/helpers/seed"
 import { USER_VIEWABLE_RESOURCE_TYPES } from "~/constants/resources"
-import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import { MAX_BATCH_RESOURCE_IDS } from "~/schemas/resource"
 import * as auditService from "~/server/modules/audit/audit.service"
 import { createCallerFactory } from "~/server/trpc"
@@ -2081,20 +2078,6 @@ describe("resource.router", async () => {
       })
 
       describe("folder/collection", () => {
-        const enableAdvancedRedirects = () => {
-          mockGrowthBook.setForcedFeatures(
-            new Map([
-              ...mockFeatureFlags,
-              [IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, true],
-            ]),
-          )
-        }
-
-        afterEach(() => {
-          // Restore the baseline forced features so the flag doesn't leak.
-          mockGrowthBook.setForcedFeatures(mockFeatureFlags)
-        })
-
         // A folder ("/dest/src-folder") with one published child page,
         // alongside a sibling destination folder ("/dest") to move it into.
         const setupMoveWithPublishedChild = async () => {
@@ -2116,7 +2099,6 @@ describe("resource.router", async () => {
         }
 
         it("creates a wildcard redirect from the old path for a published folder", async () => {
-          enableAdvancedRedirects()
           const { site, sourceFolder, destinationFolder } =
             await setupMoveWithPublishedChild()
 
@@ -2135,24 +2117,7 @@ describe("resource.router", async () => {
           )
         })
 
-        it("does not create a redirect when the advanced flag is off", async () => {
-          // Arrange — flag left at its (off) baseline.
-          const { site, sourceFolder, destinationFolder } =
-            await setupMoveWithPublishedChild()
-
-          await caller.move({
-            siteId: site.id,
-            movedResourceId: sourceFolder.id,
-            destinationResourceId: destinationFolder.id,
-            shouldCreateRedirect: true,
-          })
-
-          expect(await liveRedirects(site.id)).toHaveLength(0)
-        })
-
-        it("still blocks the move when a descendant would be shadowed, even with the flag off", async () => {
-          // Only redirect CREATION is gated behind the flag; validating
-          // against an already-existing redirect must not be.
+        it("still blocks the move when a descendant would be shadowed, even when shouldCreateRedirect is false", async () => {
           const { site, rootPage, sourceFolder, destinationFolder } =
             await setupMoveWithPublishedChild()
           await db

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -2,7 +2,6 @@ import { TRPCError } from "@trpc/server"
 import { jsonObjectFrom } from "kysely/helpers/postgres"
 import { get } from "lodash-es"
 import { USER_LINKABLE_RESOURCE_TYPES } from "~/constants/resources"
-import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
 import {
   countResourceSchema,
   deleteResourceSchema,
@@ -572,9 +571,7 @@ export const resourceRouter = router({
             // A Folder/Collection has no URL of its own, but the move changes
             // every descendant's URL — preserve them with one wildcard redirect
             // ("/old-folder/*"), and validate no descendant lands on a URL an
-            // existing redirect already covers. Shadow validation always runs on
-            // a move; only redirect creation is gated behind the advanced-
-            // redirects flag so it stays dark until the edge resolver ships.
+            // existing redirect already covers.
             if (
               (toMove.type === ResourceType.Folder ||
                 toMove.type === ResourceType.Collection) &&
@@ -585,9 +582,7 @@ export const resourceRouter = router({
                 oldFullPermalink,
                 newFullPermalink,
                 resourceId: movedResourceId,
-                shouldCreateRedirect:
-                  shouldCreateRedirect &&
-                  ctx.gb.isOn(IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY),
+                shouldCreateRedirect,
                 hasLiveContent: await hasPublishedDescendant(tx, {
                   siteId,
                   resourceId: movedResourceId,

--- a/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/Redirects.stories.tsx
@@ -6,7 +6,6 @@ import { sitesHandlers } from "tests/msw/handlers/sites"
 import RedirectsSettingsPage from "~/pages/sites/[siteId]/settings/redirects"
 import { MAX_BULK_REDIRECT_CSV_BYTES } from "~/schemas/redirect"
 import { ADMIN_HANDLERS } from "~/stories/handlers"
-import { createAdvancedRedirectsEnabledGbParameters } from "~/stories/utils/growthbook"
 
 const COMMON_HANDLERS = [
   ...ADMIN_HANDLERS,
@@ -72,7 +71,9 @@ export const Empty: Story = {
 // so the server's response drives the inline error states below.
 const submitNewRedirect = async (canvasElement: HTMLElement) => {
   const screen = within(canvasElement.ownerDocument.body)
-  const sourceInput = await screen.findByPlaceholderText("redirect-from")
+  const sourceInput = await screen.findByPlaceholderText(
+    "redirect-from or path/*",
+  )
   await userEvent.type(sourceInput, "old-page")
   await userEvent.type(
     screen.getByPlaceholderText("/path-to-page or https://www.google.com"),
@@ -158,7 +159,6 @@ const openModalAndUpload = async (canvasElement: HTMLElement) => {
 // Clicking the inline bulk-upload CTA opens the modal at its initial upload state.
 export const BulkUploadModal: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -182,7 +182,6 @@ export const BulkUploadModal: Story = {
 // A fully valid file lands on the ready-to-publish screen.
 export const BulkUploadReadyToPublish: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -224,7 +223,6 @@ export const BulkUploadReadyToPublish: Story = {
 // slow machine.
 export const BulkUploadFileSwappedWhileProcessing: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -275,7 +273,6 @@ export const BulkUploadFileSwappedWhileProcessing: Story = {
 // A file with a bad row lands on the errors screen with the download affordance.
 export const BulkUploadWithErrors: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -303,7 +300,6 @@ const OVERSIZE_MESSAGE =
 
 export const BulkUploadOversizeFile: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -347,10 +343,9 @@ export const BulkUploadOversizeFile: Story = {
   },
 }
 
-// Advanced flag on: wildcard source typed — shows the live preview help text.
+// Wildcard source typed — shows the live preview help text.
 export const AdvancedWildcardPreview: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),
@@ -375,11 +370,10 @@ export const AdvancedWildcardPreview: Story = {
   },
 }
 
-// Advanced flag on: a destination pasted with surrounding whitespace still
-// previews the trimmed value the schema submits, not the raw padded input.
+// A destination pasted with surrounding whitespace still previews the
+// trimmed value the schema submits, not the raw padded input.
 export const AdvancedWildcardPreviewTrimsDestination: Story = {
   parameters: {
-    growthbook: [createAdvancedRedirectsEnabledGbParameters(true)],
     msw: {
       handlers: [
         redirectHandlers.list.default(),

--- a/apps/studio/src/stories/utils/growthbook.ts
+++ b/apps/studio/src/stories/utils/growthbook.ts
@@ -3,7 +3,6 @@ import { GrowthBook } from "@growthbook/growthbook"
 import {
   BANNER_FEATURE_KEY,
   EGAZETTE_INFO_FEATURE_KEY,
-  IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY,
   IS_AUDIT_LOG_ENABLED_FEATURE_KEY,
   IS_HOMEPAGE_ANTI_SCAM_BANNER_ENABLED_FEATURE_KEY,
   IS_SINGPASS_ENABLED_FEATURE_KEY,
@@ -34,12 +33,6 @@ export const createBannerGbParameters = ({
 
 export const createSingpassEnabledGbParameters = (isEnabled: boolean) => {
   return [IS_SINGPASS_ENABLED_FEATURE_KEY, isEnabled]
-}
-
-export const createAdvancedRedirectsEnabledGbParameters = (
-  isEnabled: boolean,
-) => {
-  return [IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY, isEnabled]
 }
 
 export const createAntiScamBannerEnabledGbParameters = (isEnabled: boolean) => {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 8 | +50 | -87 |
| 🧪 Test | 4 | +7 | -132 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The `is-advanced-redirects-enabled` GrowthBook flag has been fully rolled out, so the gating around advanced redirects (wildcard redirects, folder/collection redirect on move or rename, and bulk CSV upload) is now dead weight.

## Solution

Removed the flag constant, the `useIsAdvancedRedirectsEnabled` hook, and every conditional built around it in `AddRedirectCard`, `FolderSettingsModal`, and `MoveResourceModal`, so the advanced-redirects UI always renders. Removed the matching `ctx.gb.isOn(...)` checks in the folder and resource tRPC routers so redirect creation on rename/move is gated only by the existing `shouldCreateRedirect` input and published-descendant checks. Cleaned up the related Storybook helper and story parameters, and dropped the now-redundant "flag off" test cases from both router test suites while keeping the shadow-validation regression tests.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Improvements**:

- Advanced redirects (wildcards, folder/collection redirects, bulk CSV upload) are now always on for every site, with no flag-related code paths left to maintain.

## Tests

Ran `pnpm typecheck`, `pnpm lint`, `pnpm format`, the Studio unit test suite, and the `folder.router`, `resource.router`, and `redirect` integration test suites — all pass.

**Manual Verification Steps**:

- [ ] On the Redirects settings page, confirm the "bulk upload with a .csv" callout and modal are visible and functional without needing any flag toggle.
- [ ] Add a redirect source with a trailing `/*` wildcard and confirm the live preview help text renders correctly.
- [ ] Rename a folder with a published descendant and confirm a wildcard redirect from the old path is created; verify the redirect checkbox appears in the folder settings modal.
- [ ] Move a folder/collection with a published descendant to a new location and confirm the move modal offers the redirect checkbox and creates the wildcard redirect on confirmation.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change removes the advanced-redirects feature flag so redirect creation, wildcard redirect guidance, CSV upload, and redirect options during eligible folder renames and content moves are available without the rollout gate. No product defect was demonstrated.

## T-Rex validation blocked

The focused folder rename and resource move router tests could not start because the required Docker-compatible container runtime for Testcontainers is unavailable. The tests stopped during global setup before exercising redirect persistence, opt-out handling, unpublished-content guards, or shadow validation.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No author action is required based on the final findings.

No final defect finding was emitted. Focused redirect router coverage was attempted but could not execute because its database test environment requires an unavailable container runtime.

**Files Needing Attention:** No files require changes from this review. When a Docker-compatible runtime is available, rerun the focused folder and resource redirect router tests covering the changed persistence paths.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the pre-change focused redirect validation tests for folder rename and resource move router, but the run stopped during Vitest global setup due to the container runtime blocker.
- Ran the PR head version of the same focused redirect validation tests; the run stopped during Vitest global setup due to the container runtime blocker.
- Uploaded command captures show the same dependency blocker: Could not find a working container runtime strategy; no authored script was created, and the existing focused tests were invoked directly.

<a href="https://app.greptile.com/trex/runs/18470694/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(redirects): update stale flag comm..."](https://github.com/opengovsg/isomer/commit/609732c672b05bc8eeb6c3970ddeb91e20db68b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52521709)</sub>

<!-- /greptile_comment -->