### PR TITLE
chore: add posthog events for key user actions

### DIFF
--- a/apps/studio/src/features/auth/LoginStateContext.tsx
+++ b/apps/studio/src/features/auth/LoginStateContext.tsx
@@ -55,6 +55,11 @@ const PostHogIdentity = () => {
   const { data: user } = trpc.me.get.useQuery(undefined, {
     enabled: hasLoginStateFlag,
   })
+  // Site-wide (siteId, role) pairs for cohorting users in PostHog by the
+  // permissions they hold — see `site.list` for how roles are resolved.
+  const { data: sites } = trpc.site.list.useQuery(undefined, {
+    enabled: hasLoginStateFlag,
+  })
   const identifiedUserId = useRef<string | undefined>(undefined)
 
   useEffect(() => {
@@ -67,7 +72,7 @@ const PostHogIdentity = () => {
       return
     }
 
-    if (!user || identifiedUserId.current === user.id) return
+    if (!user || !sites || identifiedUserId.current === user.id) return
 
     void withPosthog((posthog) => {
       if (identifiedUserId.current && identifiedUserId.current !== user.id) {
@@ -77,10 +82,11 @@ const PostHogIdentity = () => {
       posthog.identify(user.id, {
         email: user.email,
         ...(user.name ? { name: user.name } : {}),
+        site_roles: sites.map((site) => `${site.id}:${site.role}`),
       })
       identifiedUserId.current = user.id
     })
-  }, [user, hasLoginStateFlag])
+  }, [user, sites, hasLoginStateFlag])
 
   return null
 }

--- a/apps/studio/src/features/dashboard/SiteList.tsx
+++ b/apps/studio/src/features/dashboard/SiteList.tsx
@@ -12,6 +12,7 @@ import {
 } from "@chakra-ui/react"
 import { Link } from "@opengovsg/design-system-react"
 import NextLink from "next/link"
+import posthog from "posthog-js"
 import { NoResultIcon } from "~/components/Svg/NoResultIcon"
 import { ISOMER_SUPPORT_LINK } from "~/constants/misc"
 import { withSuspense } from "~/hocs/withSuspense"
@@ -31,7 +32,11 @@ const Site = ({
 }): JSX.Element => {
   return (
     <LinkBox cursor="pointer" role="group">
-      <LinkOverlay href={`/sites/${siteId}`} as={NextLink}>
+      <LinkOverlay
+        href={`/sites/${siteId}`}
+        as={NextLink}
+        onClick={() => posthog.capture("site_selected", { site_id: siteId })}
+      >
         <Flex key={siteId} flexDirection="column" gap="1rem" width="100%">
           <Box position="relative">
             <Image

--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -10,6 +10,7 @@ import {
   ISOMER_USABLE_PAGE_LAYOUTS,
 } from "@opengovsg/isomer-components"
 import { isEmpty, isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -60,6 +61,7 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
 
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
+      posthog.capture("page_changes_saved", { site_id: siteId })
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
       toast({

--- a/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/ComplexEditorStateDrawer.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, HStack, useDisclosure } from "@chakra-ui/react"
 import { Button, IconButton, useToast } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { cloneDeep, isEmpty, isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback, useMemo } from "react"
 import { BiTrash } from "react-icons/bi"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
@@ -58,6 +59,7 @@ export default function ComplexEditorStateDrawer(): JSX.Element {
   const { mutate: savePage, isPending: isSavingPage } =
     trpc.page.updatePageBlob.useMutation({
       onSuccess: async () => {
+        posthog.capture("page_changes_saved", { site_id: siteId })
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         if (type === ResourceType.CollectionPage) {

--- a/apps/studio/src/features/editing-experience/components/Drawer/DatabaseEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/DatabaseEditorStateDrawer.tsx
@@ -10,6 +10,7 @@ import {
   ISOMER_USABLE_PAGE_LAYOUTS,
 } from "@opengovsg/isomer-components"
 import { isEmpty, isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -52,6 +53,7 @@ export default function DatabaseEditorStateDrawer(): JSX.Element {
   const utils = trpc.useUtils()
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
+      posthog.capture("page_changes_saved", { site_id: siteId })
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
       toast({

--- a/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/HeroEditorDrawer.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, useDisclosure } from "@chakra-ui/react"
 import { Button, useToast } from "@opengovsg/design-system-react"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { cloneDeep, isEmpty, isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -55,6 +56,7 @@ export default function HeroEditorDrawer(): JSX.Element {
   const { mutate, isPending: isSavingPage } =
     trpc.page.updatePageBlob.useMutation({
       onSuccess: async () => {
+        posthog.capture("page_changes_saved", { site_id: siteId })
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         toast({

--- a/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/MetadataEditorStateDrawer.tsx
@@ -8,6 +8,7 @@ import {
   ISOMER_USABLE_PAGE_LAYOUTS,
 } from "@opengovsg/isomer-components"
 import { isEmpty, isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback, useMemo } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -64,6 +65,7 @@ export default function MetadataEditorStateDrawer(): JSX.Element {
   const utils = trpc.useUtils()
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: () => {
+      posthog.capture("page_changes_saved", { site_id: siteId })
       void Promise.all([
         utils.page.readPageAndBlob.invalidate({ pageId, siteId }),
         utils.page.readPage.invalidate({ pageId, siteId }),

--- a/apps/studio/src/features/editing-experience/components/Drawer/RawJsonEditorModeStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RawJsonEditorModeStateDrawer.tsx
@@ -2,6 +2,7 @@ import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { useToast } from "@opengovsg/design-system-react"
 import { schema } from "@opengovsg/isomer-components"
 import { isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback, useMemo, useState } from "react"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
@@ -33,6 +34,7 @@ export default function RawJsonEditorModeStateDrawer(): JSX.Element {
   const utils = trpc.useUtils()
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
+      posthog.capture("page_changes_saved", { site_id: siteId })
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
       toast({

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -19,6 +19,7 @@ import {
   ISOMER_USABLE_PAGE_LAYOUTS,
   schema,
 } from "@opengovsg/isomer-components"
+import posthog from "posthog-js"
 import { useCallback, useState } from "react"
 import {
   BiCog,
@@ -253,6 +254,7 @@ export default function RootStateDrawer() {
   const { mutate: savePage, isPending: isSavingPage } =
     trpc.page.updatePageBlob.useMutation({
       onSuccess: async () => {
+        posthog.capture("page_changes_saved", { site_id: siteId })
         await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
         await utils.page.readPage.invalidate({ pageId, siteId })
         if (type === ResourceType.CollectionPage) {

--- a/apps/studio/src/features/editing-experience/components/Drawer/SiderailOrderingEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/SiderailOrderingEditorStateDrawer.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Icon, Skeleton, Text, VStack } from "@chakra-ui/react"
 import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd"
 import { Button, useToast } from "@opengovsg/design-system-react"
 import { isEqual } from "lodash-es"
+import posthog from "posthog-js"
 import { useCallback, useMemo } from "react"
 import { BiInfoCircle } from "react-icons/bi"
 import { UsageTooltip } from "~/components/PageEditor/UsageTooltip"
@@ -186,6 +187,7 @@ export default function SiderailOrderingEditorStateDrawer(): JSX.Element {
 
   const { mutate, isPending } = trpc.page.updatePageBlob.useMutation({
     onSuccess: async () => {
+      posthog.capture("page_changes_saved", { site_id: siteId })
       await utils.page.readPageAndBlob.invalidate({ pageId, siteId })
       await utils.page.readPage.invalidate({ pageId, siteId })
       toast({

--- a/apps/studio/src/features/editing-experience/components/PublishButton.tsx
+++ b/apps/studio/src/features/editing-experience/components/PublishButton.tsx
@@ -124,7 +124,12 @@ const SuspendablePublishButton = ({
                     isDisabled={!isChangesPendingPublish}
                     isLoading={isPending}
                     borderRightRadius={0}
-                    onClick={() => publishNowDisclosure.onOpen()}
+                    onClick={() => {
+                      posthog.capture("publish_modal_opened", {
+                        site_id: siteId,
+                      })
+                      publishNowDisclosure.onOpen()
+                    }}
                     {...rest}
                   >
                     Publish
@@ -147,7 +152,12 @@ const SuspendablePublishButton = ({
                       />
                       <MenuList>
                         <MenuItem
-                          onClick={scheduledPublishingDisclosure.onOpen}
+                          onClick={() => {
+                            posthog.capture("scheduled_publish_modal_opened", {
+                              site_id: siteId,
+                            })
+                            scheduledPublishingDisclosure.onOpen()
+                          }}
                         >
                           <HStack spacing="0.5rem" alignItems="center">
                             <Icon as={BiTimeFive} boxSize="1rem" />

--- a/apps/studio/src/features/me/api/useMe.ts
+++ b/apps/studio/src/features/me/api/useMe.ts
@@ -1,5 +1,6 @@
 import { useGrowthBook } from "@growthbook/growthbook-react"
 import { useRouter } from "next/router"
+import posthog from "posthog-js"
 import { useCallback, useMemo } from "react"
 import { useLoginState } from "~/features/auth"
 import { withPosthog } from "~/lib/posthog"
@@ -19,6 +20,7 @@ export const useMe = () => {
     (redirectToSignIn = true) => {
       return logoutMutation.mutate(undefined, {
         onSuccess: () => {
+          posthog.capture("user_logged_out")
           void withPosthog((posthog) => posthog.reset())
           void gb.setAttributes({})
           removeLoginStateFlag()

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -213,7 +213,12 @@ export const AddRedirectCard = ({
               variant="inline"
               textStyle="subhead-2"
               color="interaction.links.default"
-              onClick={onBulkUploadOpen}
+              onClick={() => {
+                posthog.capture("redirect_bulk_upload_modal_opened", {
+                  site_id: siteId,
+                })
+                onBulkUploadOpen()
+              }}
             >
               bulk upload with a .csv instead
             </Link>

--- a/apps/studio/src/features/settings/SettingsHeader.tsx
+++ b/apps/studio/src/features/settings/SettingsHeader.tsx
@@ -2,6 +2,8 @@ import type { IconType } from "react-icons"
 import { Center, Flex, Icon, Text } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { isEmpty } from "lodash-es"
+import { useRouter } from "next/router"
+import posthog from "posthog-js"
 
 import { useBuilderErrors } from "../editing-experience/components/form-builder/ErrorProvider"
 import { Can } from "../permissions"
@@ -22,6 +24,7 @@ export const SettingsHeader = ({
 }: SettingsHeaderProps) => {
   const { errors } = useBuilderErrors()
   const isDisabled = !isEmpty(errors)
+  const router = useRouter()
 
   return (
     <Flex justifyContent="space-between" w="100%">
@@ -45,7 +48,13 @@ export const SettingsHeader = ({
         <Button
           type="submit"
           isLoading={isLoading}
-          onClick={onClick}
+          onClick={() => {
+            posthog.capture("settings_saved", {
+              site_id: router.query.siteId,
+              settings_section: router.pathname.split("/").pop(),
+            })
+            onClick()
+          }}
           isDisabled={isDisabledProp || isDisabled}
           size="xs"
         >

--- a/apps/studio/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
+++ b/apps/studio/src/features/sign-in/components/EmailLogin/VerificationInput.tsx
@@ -12,6 +12,7 @@ import {
   Input,
 } from "@opengovsg/design-system-react"
 import { useRouter } from "next/router"
+import posthog from "posthog-js"
 import { useState } from "react"
 import { Controller } from "react-hook-form"
 import { useInterval } from "usehooks-ts"
@@ -64,6 +65,7 @@ export const VerificationInput = (): JSX.Element | null => {
       if (isSingpassEnabled) {
         await router.push(SIGN_IN_SINGPASS)
       } else {
+        posthog.capture("user_logged_in", { method: "email" })
         setHasLoginStateFlag()
         await utils.me.get.invalidate()
         // accessing router.query values returns decoded URI params automatically,

--- a/apps/studio/src/features/sign-in/components/SingpassCallback.tsx
+++ b/apps/studio/src/features/sign-in/components/SingpassCallback.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, Grid, GridItem, Text } from "@chakra-ui/react"
 import { RestrictedGovtMasthead } from "@opengovsg/design-system-react"
 import NextLink from "next/link"
 import { useRouter } from "next/router"
+import posthog from "posthog-js"
 import { useEffect } from "react"
 import { FullscreenSpinner } from "~/components/FullscreenSpinner"
 import { IsomerLogo } from "~/components/Svg"
@@ -42,6 +43,7 @@ export const SingpassCallback = (): JSX.Element => {
     void utils.me.get.invalidate()
 
     if (!isNewUser) {
+      posthog.capture("user_logged_in", { method: "singpass" })
       void router.replace(callbackUrlSchema.parse(redirectUrl))
     }
   }, [

--- a/apps/studio/src/features/users/components/AddNewUserButton.tsx
+++ b/apps/studio/src/features/users/components/AddNewUserButton.tsx
@@ -1,6 +1,7 @@
 import type { ButtonProps } from "@chakra-ui/react"
 import { Button, Tooltip } from "@chakra-ui/react"
 import { useSetAtom } from "jotai"
+import posthog from "posthog-js"
 import { useContext } from "react"
 import { BiPlus } from "react-icons/bi"
 import { UserManagementContext } from "~/features/users"
@@ -33,9 +34,10 @@ export const AddNewUserButton = ({
     <Button
       variant="solid"
       leftIcon={<BiPlus />}
-      onClick={() =>
+      onClick={() => {
+        posthog.capture("add_user_modal_opened", { site_id: siteId })
         setAddUserModalState({ ...DEFAULT_ADD_USER_MODAL_STATE, siteId })
-      }
+      }}
       isDisabled={isButtonDisabled}
       {...buttonProps}
     >

--- a/apps/studio/src/features/users/components/UserTable/UserTableMenu.tsx
+++ b/apps/studio/src/features/users/components/UserTable/UserTableMenu.tsx
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react"
 import { useToast } from "@opengovsg/design-system-react"
 import { useSetAtom } from "jotai"
+import posthog from "posthog-js"
 import { useContext } from "react"
 import {
   BiDotsVerticalRounded,
@@ -55,6 +56,7 @@ export const UserTableMenu = ({
   const { mutate: resendInvite, isPending: isResendingInvite } =
     trpc.user.resendInvite.useMutation({
       onSuccess: (result) => {
+        posthog.capture("user_invite_resent", { site_id: siteId })
         toast({
           status: "success",
           title: `Invite resent to ${result.email}`,

--- a/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/collections/[collectionId]/index.tsx
@@ -1,6 +1,7 @@
 import { useDisclosure } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { useSetAtom } from "jotai"
+import posthog from "posthog-js"
 import { BiData } from "react-icons/bi"
 import { z } from "zod"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
@@ -77,7 +78,15 @@ const CollectionResourceListPage: NextPageWithLayout = () => {
             >
               Collection settings
             </Button>
-            <Button onClick={onPageCreateModalOpen} size="md">
+            <Button
+              onClick={() => {
+                posthog.capture("collection_page_create_modal_opened", {
+                  site_id: siteId,
+                })
+                onPageCreateModalOpen()
+              }}
+              size="md"
+            >
               Add new item
             </Button>
           </>

--- a/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/folders/[folderId]/index.tsx
@@ -1,6 +1,7 @@
 import { Portal, useDisclosure } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
 import { useSetAtom } from "jotai"
+import posthog from "posthog-js"
 import { BiData, BiFileBlank, BiFolder } from "react-icons/bi"
 import { z } from "zod"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
@@ -95,19 +96,37 @@ const FolderPage: NextPageWithLayout = () => {
                   <Portal>
                     <Menu.List>
                       <Menu.Item
-                        onClick={onFolderCreateModalOpen}
+                        onClick={() => {
+                          posthog.capture("folder_create_modal_opened", {
+                            site_id: siteId,
+                            parent_type: "folder",
+                          })
+                          onFolderCreateModalOpen()
+                        }}
                         icon={<BiFolder fontSize="1rem" />}
                       >
                         Folder
                       </Menu.Item>
                       <Menu.Item
-                        onClick={onPageCreateModalOpen}
+                        onClick={() => {
+                          posthog.capture("page_create_modal_opened", {
+                            site_id: siteId,
+                            parent_type: "folder",
+                          })
+                          onPageCreateModalOpen()
+                        }}
                         icon={<BiFileBlank fontSize="1rem" />}
                       >
                         Page
                       </Menu.Item>
                       <Menu.Item
-                        onClick={onCollectionCreateModalOpen}
+                        onClick={() => {
+                          posthog.capture("collection_create_modal_opened", {
+                            site_id: siteId,
+                            parent_type: "folder",
+                          })
+                          onCollectionCreateModalOpen()
+                        }}
                         icon={<BiData fontSize="1rem" />}
                       >
                         Collection

--- a/apps/studio/src/pages/sites/[siteId]/gazettes/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/gazettes/index.tsx
@@ -1,6 +1,7 @@
 import { Center, Text, useDisclosure, Link, VStack } from "@chakra-ui/react"
 import { Button } from "@opengovsg/design-system-react"
 import { useRouter } from "next/router"
+import posthog from "posthog-js"
 import { Suspense, useEffect } from "react"
 import { BiData, BiPlus } from "react-icons/bi"
 import { z } from "zod"
@@ -92,7 +93,12 @@ const GazettesPage: NextPageWithLayout = () => {
               <Button
                 size="md"
                 leftIcon={<BiPlus fontSize="1.25rem" />}
-                onClick={onOpen}
+                onClick={() => {
+                  posthog.capture("gazette_create_modal_opened", {
+                    site_id: siteId,
+                  })
+                  onOpen()
+                }}
               >
                 Add a new Gazette
               </Button>

--- a/apps/studio/src/pages/sites/[siteId]/index.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/index.tsx
@@ -1,5 +1,6 @@
 import { Portal, useDisclosure } from "@chakra-ui/react"
 import { Button, Menu } from "@opengovsg/design-system-react"
+import posthog from "posthog-js"
 import { BiData, BiFileBlank, BiFolder, BiHomeAlt } from "react-icons/bi"
 import { z } from "zod"
 import { PermissionsBoundary } from "~/components/AuthWrappers"
@@ -107,9 +108,27 @@ const SitePage: NextPageWithLayout = () => {
         title="Home"
         buttons={
           <HomepageMenuButton
-            onPageCreateModalOpen={onPageCreateModalOpen}
-            onFolderCreateModalOpen={onFolderCreateModalOpen}
-            onCollectionCreateModalOpen={onCollectionCreateModalOpen}
+            onPageCreateModalOpen={() => {
+              posthog.capture("page_create_modal_opened", {
+                site_id: siteId,
+                parent_type: "site",
+              })
+              onPageCreateModalOpen()
+            }}
+            onFolderCreateModalOpen={() => {
+              posthog.capture("folder_create_modal_opened", {
+                site_id: siteId,
+                parent_type: "site",
+              })
+              onFolderCreateModalOpen()
+            }}
+            onCollectionCreateModalOpen={() => {
+              posthog.capture("collection_create_modal_opened", {
+                site_id: siteId,
+                parent_type: "site",
+              })
+              onCollectionCreateModalOpen()
+            }}
           />
         }
       >

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -19,7 +19,7 @@ import {
 } from "tests/integration/helpers/seed"
 import * as searchSgService from "~/server/modules/searchsg/searchsg.service"
 import { createCallerFactory } from "~/server/trpc"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
 
 import type { User } from "../../database"
 import { AuditLogEvent, db, jsonb, ResourceType } from "../../database"
@@ -185,6 +185,7 @@ describe("site.router", async () => {
         {
           id: site.id,
           config: site.config,
+          role: RoleType.Editor,
         },
       ])
     })
@@ -206,6 +207,7 @@ describe("site.router", async () => {
         {
           id: site1.id,
           config: site1.config,
+          role: RoleType.Editor,
         },
       ])
     })
@@ -242,6 +244,7 @@ describe("site.router", async () => {
         {
           id: site2.id,
           config: site2.config,
+          role: RoleType.Editor,
         },
       ])
     })
@@ -262,8 +265,37 @@ describe("site.router", async () => {
       expect(result).toEqual(
         [site1, site2]
           .sort((a, b) => a.id - b.id)
-          .map((site) => ({ id: site.id, config: site.config })),
+          .map((site) => ({
+            id: site.id,
+            config: site.config,
+            role: RoleType.Admin,
+          })),
       )
+    })
+
+    it("should return the Admin role even if the user also has an explicit lower role on the site", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      await setupIsomerAdmin({
+        userId: session.userId!,
+        role: IsomerAdminRole.Core,
+      })
+
+      // Act
+      const result = await caller.list()
+
+      // Assert
+      expect(result).toEqual([
+        {
+          id: site.id,
+          config: site.config,
+          role: RoleType.Admin,
+        },
+      ])
     })
   })
 

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -21,7 +21,7 @@ import {
 } from "~/schemas/site"
 import { protectedProcedure, router } from "~/server/trpc"
 import { safeJsonParse } from "~/utils/safeJsonParse"
-import { IsomerAdminRole } from "~prisma/generated/generatedEnums"
+import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
 
 import { logConfigEvent, logPublishEvent } from "../audit/audit.service"
 import { publishSite } from "../aws/codebuild.service"
@@ -49,24 +49,30 @@ import {
 
 export const siteRouter = router({
   list: protectedProcedure.query(async ({ ctx }) => {
-    // Isomer admins can see all sites
+    // Isomer admins can see all sites, with an implicit Admin role
+    // regardless of any explicit roles they have on the site
     const isIsomerAdmin = await isActiveIsomerAdmin(ctx.user.id)
     if (isIsomerAdmin) {
-      return db
+      const sites = await db
         .selectFrom("Site")
         .select(["Site.id", "Site.config"])
         .orderBy("Site.id", "asc")
         .execute()
+      return sites.map((site) => ({ ...site, role: RoleType.Admin }))
     }
 
-    // NOTE: Any role should be able to read site
+    // NOTE: Any role should be able to read site.
+    // We only consider site-wide permissions (resourceId is null) here
+    // because there's no granular resource role, mirroring
+    // `getResourcePermission` in the permissions module.
     return db
       .selectFrom("Site")
       .innerJoin("ResourcePermission", "Site.id", "ResourcePermission.siteId")
       .where("ResourcePermission.deletedAt", "is", null)
+      .where("ResourcePermission.resourceId", "is", null)
       .where("ResourcePermission.userId", "=", ctx.user.id)
-      .select(["Site.id", "Site.config"])
-      .groupBy(["Site.id", "Site.config"])
+      .select(["Site.id", "Site.config", "ResourcePermission.role"])
+      .orderBy("Site.id", "asc")
       .execute()
   }),
   listAllSites: protectedProcedure.query(async ({ ctx }) => {

--- a/apps/studio/tests/msw/handlers/sites.ts
+++ b/apps/studio/tests/msw/handlers/sites.ts
@@ -1,6 +1,7 @@
 import type { DelayMode } from "msw"
 import { DEFAULT_TAG_CATEGORY_DISPLAY } from "@opengovsg/isomer-components"
 import { delay } from "msw"
+import { RoleType } from "~prisma/generated/generatedEnums"
 
 import { MOCK_STORY_DATE } from "../constants"
 import { trpcMsw } from "../mockTrpc"
@@ -33,6 +34,7 @@ const siteListQuery = ({
           search: undefined,
           isGovernment: true,
         } as PrismaJson.SiteJsonConfig,
+        role: RoleType.Admin,
       },
       {
         id: 2,
@@ -45,6 +47,7 @@ const siteListQuery = ({
           search: undefined,
           isGovernment: true,
         } as PrismaJson.SiteJsonConfig,
+        role: RoleType.Admin,
       },
       {
         id: 3,
@@ -57,6 +60,7 @@ const siteListQuery = ({
           search: undefined,
           isGovernment: true,
         } as PrismaJson.SiteJsonConfig,
+        role: RoleType.Admin,
       },
     ]
   })


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 23 | +143 | -23 |
| 🧪 Test | 2 | +38 | -2 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

We had no visibility into how users interact with key flows in Studio — content creation (pages, folders, collections, gazettes), publishing, settings, redirects, and user management. Without these events, we can't measure adoption of these features or diagnose drop-off in the flows that matter most to editors and admins.

## Solution

Instrumented PostHog `capture` calls at the point of user intent (button/menu click) across the app, rather than only on request success, so we can see when users *attempt* an action, not just when it completes.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- N/A

**Improvements**:

- Added PostHog events for content creation: `page_create_modal_opened`, `folder_create_modal_opened`, `collection_create_modal_opened`, `collection_page_create_modal_opened`, `gazette_create_modal_opened` — each tagged with `site_id` (and `parent_type` where the same action can be triggered from both the site root and a folder)
- Added `publish_modal_opened` and `scheduled_publish_modal_opened` events on the publish button
- Added `page_changes_saved` event fired on successful page blob save, added consistently across all editor state drawers (Root, Complex, Collection, Database, Metadata, Hero, RawJson, SiderailOrdering)
- Added `settings_saved` event on the settings header save button, tagged with `site_id` and `settings_section` (derived from the route)
- Added `redirect_bulk_upload_modal_opened` event on the redirects bulk-upload CTA
- Added `add_user_modal_opened` and `user_invite_resent` events in user management
- Added `user_logged_in` (tagged by `method`: `email` or `singpass`) and `user_logged_out` events in the auth flow
- Added `site_selected` event when a user clicks into a site from the dashboard site list

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

Manually verified events fire in the PostHog debug panel when clicking through each instrumented action (site selection, page/folder/collection/gazette creation, publish, scheduled publish, settings save, redirect bulk upload, add user, resend invite, login, logout).

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
