### PR TITLE
chore: add posthog host to script src to allwo loading config

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -62,6 +62,7 @@ const ContentSecurityPolicy = `
     https://open.spotify.com
     https://js-cdn.music.apple.com
     ${env.NEXT_PUBLIC_POSTHOG_ASSETS_HOST ?? ""}
+    ${env.NEXT_PUBLIC_POSTHOG_HOST ?? ""}
     ${env.NEXT_PUBLIC_APP_ENV === "preview" ? "https://vercel.live" : ""}
     ;
   style-src


### PR DESCRIPTION
we need to add this host into `script-src` to allow for posthog to load config
<img width="1258" height="883" alt="image" src="https://github.com/user-attachments/assets/1d361c5f-36b6-4005-893d-6713e6f68443" />
