### PR TITLE
feat: allow Isomer Admins to export audit logs

### DIFF
--- a/apps/studio/src/server/modules/audit/__tests__/audit.router.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/audit.router.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   setupAdminPermissions,
   setupEditorPermissions,
+  setupIsomerAdmin,
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
@@ -74,6 +75,7 @@ describe("audit.router", async () => {
     await resetTables(
       "AuditLogExportRequest",
       "AuditLog",
+      "IsomerAdmin",
       "ResourcePermission",
       "Site",
       "User",
@@ -152,6 +154,28 @@ describe("audit.router", async () => {
           before: null,
           after: { auditLogDateRange, reportType: "Access" },
         },
+      })
+    })
+
+    it("should allow an Isomer Admin without a site permission to request an export", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupIsomerAdmin({ userId: session.userId! })
+
+      // Act
+      const result = await caller.createExportRequest({
+        siteId: site.id,
+        month: VALID_MONTH,
+        reportType: "Access",
+      })
+
+      // Assert
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        siteId: site.id,
+        userId: session.userId,
+        reportType: "Access",
+        status: "Pending",
       })
     })
 

--- a/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
+++ b/apps/studio/src/server/modules/audit/__tests__/auditLogExport.processor.test.ts
@@ -1,6 +1,7 @@
 import { resetTables } from "tests/integration/helpers/db"
 import {
   setupAdminPermissions,
+  setupIsomerAdmin,
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
@@ -145,6 +146,7 @@ describe("auditLogExport processor", () => {
   beforeEach(async () => {
     await resetTables(
       "AuditLogExportRequest",
+      "IsomerAdmin",
       "ResourcePermission",
       "User",
       "Site",
@@ -217,6 +219,28 @@ describe("auditLogExport processor", () => {
     // requests compare against the range end to qualify this row for reuse.
     // Its value is captured BEFORE the report query, not at delivery.
     expect(updated.completedAt).not.toBeNull()
+  })
+
+  it("processes an Isomer Admin request without a site permission", async () => {
+    // Arrange
+    const { site } = await setupSite()
+    const admin = await setupUser({ email: "isomer-admin@open.gov.sg" })
+    await setupIsomerAdmin({ userId: admin.id })
+    const request = await seedRequest({
+      siteId: site.id,
+      userId: admin.id,
+      reportType: "Access",
+    })
+
+    // Act
+    await processPendingAuditLogExports()
+
+    // Assert
+    expect(mockUploadAuditLogExport).toHaveBeenCalledTimes(1)
+    expect(mockSendAuditLogExportReadyEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientEmail: admin.email }),
+    )
+    expect((await getRequest(request.id)).status).toBe("Done")
   })
 
   it("marks the row Done BEFORE sending the ready email, so the emailed token is already live", async () => {

--- a/apps/studio/src/server/modules/audit/auditLogExport.service.ts
+++ b/apps/studio/src/server/modules/audit/auditLogExport.service.ts
@@ -26,7 +26,8 @@ import { AuditLogExportStatus } from "~prisma/generated/generatedEnums"
 
 import type { BaseLogger } from "@isomer/logging"
 
-import { AuditLogExportReportType, db } from "../database"
+import { AuditLogExportReportType, db, RoleType } from "../database"
+import { getResourcePermission } from "../permissions/permissions.service"
 import { logAuditLogExportEvent } from "./audit.service"
 import {
   accessReportQuery,
@@ -405,22 +406,20 @@ export const processAuditLogExportRequest = async (
     .select(["id", "name", "config"])
     .executeTakeFirstOrThrow()
 
-  const user = await db
-    .selectFrom("User")
-    .innerJoin("ResourcePermission", "ResourcePermission.userId", "User.id")
-    .where("User.id", "=", request.userId)
-    .where("User.deletedAt", "is", null)
-    .where("ResourcePermission.userId", "=", request.userId)
-    .where("ResourcePermission.role", "=", "Admin")
-    .where("ResourcePermission.siteId", "=", site.id)
-    .where("ResourcePermission.deletedAt", "is", null)
-    .select(["User.id", "User.email"])
-    .executeTakeFirst()
+  const [user, roles] = await Promise.all([
+    db
+      .selectFrom("User")
+      .where("User.id", "=", request.userId)
+      .where("User.deletedAt", "is", null)
+      .select(["User.id", "User.email"])
+      .executeTakeFirst(),
+    getResourcePermission({ userId: request.userId, siteId: site.id }),
+  ])
+  const isAdmin = roles.some(({ role }) => role === RoleType.Admin)
 
-  // NOTE: Early return - this is technically not a failure
-  // because it means that the user has been removed from the site
-  // as an admin between the job creation and fulfillment time
-  if (!user) {
+  // NOTE: Early return - the requester no longer exists or lost their
+  // effective Admin access between request creation and fulfillment.
+  if (!user || !isAdmin) {
     logger.warn(
       { requestId, userId: request.userId },
       "User no longer exists or is not an admin",

--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -1560,31 +1560,37 @@ describe("validateUserIsSiteAdmin", () => {
   })
 
   it("should allow a Site Admin", async () => {
+    // Arrange
     const user = await setupUser({ email: "site-admin@example.com" })
     const { site } = await setupSite()
     await setupAdminPermissions({ userId: user.id, siteId: site.id })
 
+    // Act & Assert
     await expect(
       validateUserIsSiteAdmin({ userId: user.id, siteId: site.id }),
     ).resolves.toBe(true)
   })
 
   it("should allow an active Isomer Admin without a site permission", async () => {
+    // Arrange
     const user = await setupUser({ email: "isomer-admin@example.com" })
     const { site } = await setupSite()
     await setupIsomerAdmin({ userId: user.id })
 
+    // Act & Assert
     await expect(
       validateUserIsSiteAdmin({ userId: user.id, siteId: site.id }),
     ).resolves.toBe(true)
   })
 
   it("should reject an expired Isomer Admin without a site permission", async () => {
+    // Arrange
     const user = await setupUser({ email: "expired-admin@example.com" })
     const { site } = await setupSite()
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
     await setupIsomerAdmin({ userId: user.id, expiry: yesterday })
 
+    // Act & Assert
     await expect(
       validateUserIsSiteAdmin({ userId: user.id, siteId: site.id }),
     ).rejects.toMatchObject({ code: "FORBIDDEN" })

--- a/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
+++ b/apps/studio/src/server/modules/permissions/__tests__/permissions.service.test.ts
@@ -24,6 +24,7 @@ import {
   isActiveIsomerAdmin,
   validatePermissionsForManagingUsers,
   validateUserIsIsomerAdmin,
+  validateUserIsSiteAdmin,
 } from "../permissions.service"
 import { CRUD_ACTIONS } from "../permissions.type"
 import {
@@ -1550,6 +1551,43 @@ describe("validateUserIsIsomerAdmin", () => {
           "You do not have sufficient permissions to perform this action",
       }),
     )
+  })
+})
+
+describe("validateUserIsSiteAdmin", () => {
+  beforeEach(async () => {
+    await resetTables("IsomerAdmin", "ResourcePermission", "User", "Site")
+  })
+
+  it("should allow a Site Admin", async () => {
+    const user = await setupUser({ email: "site-admin@example.com" })
+    const { site } = await setupSite()
+    await setupAdminPermissions({ userId: user.id, siteId: site.id })
+
+    await expect(
+      validateUserIsSiteAdmin({ userId: user.id, siteId: site.id }),
+    ).resolves.toBe(true)
+  })
+
+  it("should allow an active Isomer Admin without a site permission", async () => {
+    const user = await setupUser({ email: "isomer-admin@example.com" })
+    const { site } = await setupSite()
+    await setupIsomerAdmin({ userId: user.id })
+
+    await expect(
+      validateUserIsSiteAdmin({ userId: user.id, siteId: site.id }),
+    ).resolves.toBe(true)
+  })
+
+  it("should reject an expired Isomer Admin without a site permission", async () => {
+    const user = await setupUser({ email: "expired-admin@example.com" })
+    const { site } = await setupSite()
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    await setupIsomerAdmin({ userId: user.id, expiry: yesterday })
+
+    await expect(
+      validateUserIsSiteAdmin({ userId: user.id, siteId: site.id }),
+    ).rejects.toMatchObject({ code: "FORBIDDEN" })
   })
 })
 

--- a/apps/studio/src/server/modules/permissions/permissions.service.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.service.ts
@@ -342,20 +342,17 @@ export const validateUserIsSiteAdmin = async ({
   userId,
   siteId,
 }: ValidateUserIsSiteAdminProps) => {
-  const _ = await db
-    .selectFrom("ResourcePermission")
-    .where("role", "=", "Admin")
-    .where("ResourcePermission.userId", "=", userId)
-    .where("ResourcePermission.siteId", "=", siteId)
-    .where("ResourcePermission.deletedAt", "is", null)
-    .select(["role"])
-    .executeTakeFirstOrThrow(() => {
-      throw new TRPCError({
-        code: "FORBIDDEN",
-        message:
-          "You do not have sufficient permissions to perform this action",
-      })
+  // Use the shared permission lookup so platform-level Isomer Admins inherit
+  // every capability guarded as Site Admin-only. This also keeps expiry and
+  // soft-deletion handling consistent with the rest of the permission system.
+  const roles = await getResourcePermission({ userId, siteId })
+
+  if (!roles.some(({ role }) => role === RoleType.Admin)) {
+    throw new TRPCError({
+      code: "FORBIDDEN",
+      message: "You do not have sufficient permissions to perform this action",
     })
+  }
 
   return true
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +26 | -30 |
| 🧪 Test | 3 | +92 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Isomer Admins without a site-specific Admin permission cannot request or receive audit log exports.

## Solution

Use the shared effective-role lookup for both request authorization and background-job revalidation, preserving expiry and soft-deletion behavior.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Centralize audit-export Admin checks on the existing effective permission abstraction

**Bug Fixes**:

- Allow active Isomer Admins to request and receive audit log exports without site-specific permissions
- Continue rejecting expired Isomer Admins and unauthorized users

## Before & After Screenshots

No visual changes.

## Tests

- `pnpm --dir apps/studio exec dotenv -e .env.test -- vitest run src/server/modules/permissions/__tests__/permissions.service.test.ts src/server/modules/audit/__tests__/audit.router.test.ts src/server/modules/audit/__tests__/auditLogExport.processor.test.ts`
- `pnpm --dir apps/studio typecheck`
- Focused type-aware lint and formatting checks

**Manual Verification Steps**:

- [ ] Sign in as an active Isomer Admin without a site-specific permission
- [ ] Request an audit log export from the site settings
- [ ] Verify the export reaches Done and the ready email is sent

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change allows active Isomer Admins to request audit-log exports without a site-specific permission, while rechecking effective Admin access before an export is generated. Expired platform-admin access remains excluded by the shared permission lookup.

## T-Rex validation blocked
The focused Studio authorization suite could not start because the required Testcontainers PostgreSQL and MockPass services need a Docker-compatible container runtime. The `docker` tool is not installed, and Vitest stopped in global setup before collecting or running the request, expiry, revocation, or export-processing tests.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No actionable defect was identified in the changed authorization flow.

There are no final review findings. The focused integration suite could not execute because its required container runtime is unavailable, so the authorization paths were not exercised in this environment.

**Files Needing Attention:** No files require changes based on this review; rerun the focused audit and permission integration tests in an environment with Docker-compatible Testcontainers support.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Studio integration command targeting the permissions, audit-router, and export-processor tests was run directly and through a saved script.
- Vitest exited during global setup because Testcontainers could not find a working container runtime and Docker is not installed, so PostgreSQL and MockPass never started and no tests were collected or executed.
- The blocker condition was confirmed: no working container runtime is available and docker is not installed, and the captured command output plus the exact focused test script were uploaded for review.

<a href="https://app.greptile.com/trex/runs/18422040/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["test: follow Arrange Act Assert conventi..."](https://github.com/opengovsg/isomer/commit/b69150cd241dd087241d1afc37658ce98652ee5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51050141)</sub>

<!-- /greptile_comment -->