### PR TITLE
fix(redirects): hide write controls from non-admins, polish wildcard hint

### DIFF
--- a/apps/studio/src/features/settings/Redirects/RedirectManagementContext.tsx
+++ b/apps/studio/src/features/settings/Redirects/RedirectManagementContext.tsx
@@ -1,0 +1,81 @@
+import type { PropsWithChildren } from "react"
+import type { RedirectManagementAbility } from "~/server/modules/permissions/permissions.type"
+import { Ability } from "@casl/ability"
+import { createContext, useContext, useMemo } from "react"
+import { buildRedirectManagementPermissions } from "~/server/modules/permissions/permissions.util"
+import { trpc } from "~/utils/trpc"
+
+interface RedirectManagement {
+  ability: RedirectManagementAbility | Ability
+  // Whether the roles behind `ability` are still loading, or failed to load.
+  // Both leave `ability` permitting nothing, which is indistinguishable from a
+  // genuine read-only role unless the consumer can tell them apart — so it is
+  // surfaced rather than collapsed into the ability.
+  isPending: boolean
+  isError: boolean
+}
+
+export const RedirectManagementContext = createContext<RedirectManagement>({
+  // A dummy ability that permits nothing, so a consumer mounted outside the
+  // provider falls back to read-only rather than to full access.
+  ability: new Ability(),
+  isPending: false,
+  isError: false,
+})
+
+interface RedirectManagementProviderProps {
+  siteId: number
+}
+
+// Reads the same site-wide roles query the other permission providers use, so
+// it costs no extra request — React Query serves it from the shared cache.
+export const RedirectManagementProvider = ({
+  siteId,
+  children,
+}: PropsWithChildren<RedirectManagementProviderProps>) => {
+  const {
+    data: roles,
+    isPending,
+    isError,
+  } = trpc.resource.getRolesFor.useQuery({
+    siteId,
+    resourceId: null,
+  })
+
+  const value = useMemo(
+    () => ({
+      ability: roles
+        ? buildRedirectManagementPermissions(roles)
+        : new Ability(),
+      isPending,
+      isError,
+    }),
+    [roles, isPending, isError],
+  )
+
+  return (
+    <RedirectManagementContext.Provider value={value}>
+      {children}
+    </RedirectManagementContext.Provider>
+  )
+}
+
+interface UseRedirectManagementResult {
+  // Whether the current user may add or remove redirects. The server enforces
+  // the same rule on `redirect.create` / `redirect.bulkCreate` /
+  // `redirect.delete`; this only decides whether we offer the controls at all.
+  // False while the roles are unknown, so callers must check `isPending` and
+  // `isError` before presenting the page as read-only.
+  canManageRedirects: boolean
+  isPending: boolean
+  isError: boolean
+}
+
+export const useRedirectManagement = (): UseRedirectManagementResult => {
+  const { ability, isPending, isError } = useContext(RedirectManagementContext)
+  return {
+    canManageRedirects: ability.can("manage", "RedirectManagement"),
+    isPending,
+    isError,
+  }
+}

--- a/apps/studio/src/features/settings/Redirects/__tests__/RedirectsSettings.browser.test.tsx
+++ b/apps/studio/src/features/settings/Redirects/__tests__/RedirectsSettings.browser.test.tsx
@@ -1,0 +1,179 @@
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { theme } from "~/theme"
+import { RoleType } from "~prisma/generated/generatedEnums"
+
+import { RedirectsSettings } from ".."
+import { WILDCARD_HINT } from "../constants"
+
+const SITE_ID = 42
+
+// ~/env.mjs validates `process.env` at module scope, which is a ReferenceError
+// under Browser Mode's real-browser runtime. The page picker reaches it via
+// ~/utils/resources for a link prefix that never renders here.
+vi.mock("~/env.mjs", () => ({
+  env: { NEXT_PUBLIC_APP_URL: "http://localhost:3000" },
+}))
+
+// The wildcard hint and the bulk-upload entry point only render with advanced
+// redirects on, which is the state these assertions are about.
+vi.mock("~/hooks/useIsAdvancedRedirectsEnabled", () => ({
+  useIsAdvancedRedirectsEnabled: () => true,
+}))
+
+const REDIRECT_ROW = {
+  id: "1",
+  source: "/old-news",
+  destination: "https://www.example.gov.sg",
+  publishedAt: new Date("2026-01-01T00:00:00Z"),
+}
+
+// What the site-wide roles query answers with. RedirectManagementProvider turns
+// this into the ability under test, so these cases run through the real CASL
+// rules rather than an ability injected past them. `undefined` roles stand for
+// the query not having resolved, which pairs with isPending/isError below.
+let currentRoles: { role: RoleType }[] | undefined = []
+let rolesQueryState = { isPending: false, isError: false }
+
+// The table's reads and every write the card/modal owns. None of them is what
+// this test covers — the question is purely which controls a role is shown — so
+// stub the tRPC surface with the minimum both branches touch on render.
+vi.mock("~/utils/trpc", () => {
+  const noop = vi.fn()
+  return {
+    trpc: {
+      useUtils: () => ({ redirect: { invalidate: noop } }),
+      resource: {
+        getRolesFor: {
+          useQuery: () => ({ data: currentRoles, ...rolesQueryState }),
+        },
+      },
+      redirect: {
+        list: { useQuery: () => ({ data: [REDIRECT_ROW], isLoading: false }) },
+        count: { useQuery: () => ({ data: 1, isLoading: false }) },
+        resolveReferences: { useQuery: () => ({ data: [] }) },
+        create: { useMutation: () => ({ mutate: noop, isPending: false }) },
+        delete: { useMutation: () => ({ mutate: noop, isPending: false }) },
+        bulkValidate: { useMutation: () => ({ mutateAsync: noop }) },
+        bulkCreate: {
+          useMutation: () => ({ mutateAsync: noop, isPending: false }),
+        },
+      },
+    },
+  }
+})
+
+const renderRedirects = () =>
+  render(
+    <ThemeProvider theme={theme}>
+      <RedirectsSettings siteId={SITE_ID} />
+    </ThemeProvider>,
+  )
+
+const renderAs = (role: RoleType) => {
+  currentRoles = [{ role }]
+  return renderRedirects()
+}
+
+const DELETE_LABEL = `Delete redirect for ${REDIRECT_ROW.source}`
+const PERMISSION_ERROR = /We couldn't check your permissions/
+
+describe("RedirectsSettings", () => {
+  beforeEach(() => {
+    currentRoles = []
+    rolesQueryState = { isPending: false, isError: false }
+  })
+
+  it("shows the add-redirect card, bulk upload and delete to a site admin", () => {
+    // Arrange / Act
+    renderAs(RoleType.Admin)
+
+    // Assert
+    expect(screen.queryByText("Add new redirects")).not.toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "bulk upload with a .csv instead" }),
+    ).not.toBeNull()
+    expect(screen.queryByLabelText(DELETE_LABEL)).not.toBeNull()
+  })
+
+  it("hides every write control from a non-admin, who still sees the table", () => {
+    // Arrange / Act — the server rejects create/delete for anyone but a site
+    // admin, so a non-admin must not be handed inputs, a .csv template, or a
+    // delete button whose submit can only come back FORBIDDEN.
+    renderAs(RoleType.Editor)
+
+    // Assert
+    expect(screen.queryByText("Add new redirects")).toBeNull()
+    expect(
+      screen.queryByRole("button", { name: "bulk upload with a .csv instead" }),
+    ).toBeNull()
+    expect(screen.queryByLabelText(DELETE_LABEL)).toBeNull()
+    expect(screen.queryByText(REDIRECT_ROW.source)).not.toBeNull()
+  })
+
+  it("keeps rows the same height whether or not the delete column renders", () => {
+    // Arrange — dropping the delete column takes away the 2.5rem IconButton
+    // that sets the row height, so without a pinned height a non-admin's rows
+    // come out visibly shorter than the same table shown to an admin. Real
+    // layout, hence Browser Mode.
+    const rowHeightsFor = (role: RoleType) => {
+      const { unmount } = renderAs(role)
+      const heights = Array.from(document.querySelectorAll("tbody tr")).map(
+        (row) => row.getBoundingClientRect().height,
+      )
+      unmount()
+      return heights
+    }
+
+    // Act
+    const adminHeights = rowHeightsFor(RoleType.Admin)
+    const editorHeights = rowHeightsFor(RoleType.Editor)
+
+    // Assert
+    expect(adminHeights.length).toBeGreaterThan(0)
+    expect(editorHeights).toEqual(adminHeights)
+  })
+
+  it("does not present the page as read-only while the roles are still loading", () => {
+    // Arrange — an unresolved roles query leaves the ability permitting
+    // nothing, which must not be shown as a settled "you can't do this": an
+    // admin would be told they lack access and then contradicted a moment
+    // later.
+    currentRoles = undefined
+    rolesQueryState = { isPending: true, isError: false }
+
+    // Act
+    renderRedirects()
+
+    // Assert: no write controls yet, but no read-only page either — the table
+    // holds its loading state rather than committing to a column set.
+    expect(screen.queryByText("Add new redirects")).toBeNull()
+    expect(screen.queryByLabelText(DELETE_LABEL)).toBeNull()
+    expect(screen.queryByText(PERMISSION_ERROR)).toBeNull()
+    expect(document.querySelector(".chakra-skeleton")).not.toBeNull()
+  })
+
+  it("says so when the roles query fails instead of silently going read-only", () => {
+    // Arrange
+    currentRoles = undefined
+    rolesQueryState = { isPending: false, isError: true }
+
+    // Act
+    renderRedirects()
+
+    // Assert
+    expect(screen.queryByText(PERMISSION_ERROR)).not.toBeNull()
+    expect(screen.queryByText("Add new redirects")).toBeNull()
+    expect(screen.queryByLabelText(DELETE_LABEL)).toBeNull()
+  })
+
+  it("describes the wildcard in terms of folders and collections, not sections", () => {
+    // Arrange / Act
+    renderAs(RoleType.Admin)
+
+    // Assert
+    expect(screen.queryByText(WILDCARD_HINT)).not.toBeNull()
+    expect(WILDCARD_HINT).not.toContain("section")
+  })
+})

--- a/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/AddRedirectCard.tsx
@@ -32,6 +32,7 @@ import { useZodForm } from "~/lib/form"
 import { normalizeRedirectSource, redirectKind } from "~/schemas/redirect"
 
 import { useCreateRedirect } from "../api"
+import { WILDCARD_HINT } from "../constants"
 import { addRedirectSchema, type AddRedirectInput } from "../types"
 import { BulkUploadRedirectsModal } from "./BulkUploadRedirectsModal"
 import { SelectDestinationPageModal } from "./SelectDestinationPageModal"
@@ -254,11 +255,17 @@ export const AddRedirectCard = ({
             />
           </InputGroup>
           <FormErrorMessage>{errors.source?.message}</FormErrorMessage>
+          {/* The design system's helper text sits flush against the field
+              (theme sets `mt: 0`), which reads as part of the input when placed
+              below it — space it off the box. This has to go through `sx`, not
+              an `mt` prop: the design system's wrapper merges the theme's
+              helperText styles into `sx`, and Chakra's `sx` outranks style
+              props, so an `mt` prop is silently dropped. Colour and font size
+              come from the theme (base.content.medium, body-2) for the same
+              reason. */}
           {isAdvancedRedirectsEnabled && !errors.source && (
-            <FormHelperText fontSize="xs" color="base.content.medium">
-              {wildcardPreview
-                ? `e.g. ${wildcardPreview}`
-                : "Add /* at the end to redirect a whole section (e.g. /old-news/*)."}
+            <FormHelperText sx={{ mt: "0.75rem" }}>
+              {wildcardPreview ? `e.g. ${wildcardPreview}` : WILDCARD_HINT}
             </FormHelperText>
           )}
         </FormControl>

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsEmptyPlaceholder.tsx
@@ -3,12 +3,20 @@ import { Link } from "@opengovsg/design-system-react"
 
 import { REDIRECTS_SUPPORT_LINK } from "../constants"
 
+interface RedirectsEmptyPlaceholderProps {
+  // The table drops its delete column for a user who can't delete, so the
+  // placeholder is told how many columns to span rather than assuming.
+  colSpan: number
+}
+
 // Shown in place of table rows when a site has no redirects yet. Unlike the
 // generic EmptyTablePlaceholder, this points users to the redirects guide.
-export const RedirectsEmptyPlaceholder = (): JSX.Element => {
+export const RedirectsEmptyPlaceholder = ({
+  colSpan,
+}: RedirectsEmptyPlaceholderProps): JSX.Element => {
   return (
     <Tr>
-      <Td colSpan={4} border="none">
+      <Td colSpan={colSpan} border="none">
         <Flex align="center" justify="center" py="8.5rem">
           <Stack align="center" spacing="0.5rem" textAlign="center">
             <Text textStyle="subhead-1" color="base.content.default">

--- a/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
+++ b/apps/studio/src/features/settings/Redirects/components/RedirectsTable.tsx
@@ -44,6 +44,7 @@ import {
   useListRedirects,
   useResolveRedirectReferences,
 } from "../api"
+import { useRedirectManagement } from "../RedirectManagementContext"
 import {
   formatAddedAt,
   getDestinationDisplay,
@@ -64,6 +65,16 @@ const MISSING_PAGE_LABEL = "Page no longer exists"
 // specific segment visible ("/promo/really-long…/end.html") instead of losing
 // the tail to a plain end-ellipsis.
 const TRUNCATION_TAIL_LENGTH = 10
+
+// Body rows are pinned to this height so they don't depend on which columns are
+// rendered. The delete IconButton (2.5rem) is what sets the row height for a
+// site admin; without that column, rows for everyone else would come out ~20px
+// shorter. That's 2.5rem plus the theme's 0.5rem vertical cell padding top and
+// bottom — and one more pixel for the collapsed row border, which the cell's
+// border-box height has to cover too. Without that pixel the button no longer
+// fits and the delete cell alone grows 1px, putting the two views back out of
+// step.
+const ROW_HEIGHT = "calc(3.5rem + 1px)"
 
 const splitForMiddleTruncation = (value: string) => {
   const splitAt = Math.max(0, value.length - TRUNCATION_TAIL_LENGTH)
@@ -281,9 +292,13 @@ function SourceCell({ source }: { source: string }): JSX.Element {
   )
 }
 
+// The delete column is only built for a user who may actually delete — deleting
+// is site-admin-only server-side, so showing the button to anyone else only
+// yields a FORBIDDEN toast.
 const getColumns = (
   onDeleteClick: (row: RedirectRow) => void,
   infoByDestination: Map<string, ResolvedDestination>,
+  canDelete: boolean,
 ) => [
   columnsHelper.accessor("source", {
     minSize: 250,
@@ -330,26 +345,36 @@ const getColumns = (
       </Text>
     ),
   }),
-  columnsHelper.display({
-    id: "delete",
-    size: 80,
-    enableSorting: false,
-    header: () => (
-      <TableHeader textStyle="subhead-2" color="base.content.medium">
-        <VisuallyHidden>Actions</VisuallyHidden>
-      </TableHeader>
-    ),
-    cell: ({ row }) => (
-      <IconButton
-        aria-label={`Delete redirect for ${row.original.source}`}
-        icon={<BiTrash />}
-        variant="clear"
-        colorScheme="critical"
-        size="sm"
-        onClick={() => onDeleteClick(row.original)}
-      />
-    ),
-  }),
+  ...(canDelete
+    ? [
+        columnsHelper.display({
+          id: "delete",
+          size: 80,
+          enableSorting: false,
+          header: () => (
+            <TableHeader textStyle="subhead-2" color="base.content.medium">
+              <VisuallyHidden>Actions</VisuallyHidden>
+            </TableHeader>
+          ),
+          // The button is inline-flex, so on a text baseline it claims a hair
+          // more than its own 2.5rem and rounds the row up past ROW_HEIGHT.
+          // A flex wrapper takes it out of the line box, keeping this row
+          // exactly as tall as one without the column.
+          cell: ({ row }) => (
+            <Box display="flex" alignItems="center" h="2.5rem">
+              <IconButton
+                aria-label={`Delete redirect for ${row.original.source}`}
+                icon={<BiTrash />}
+                variant="clear"
+                colorScheme="critical"
+                size="sm"
+                onClick={() => onDeleteClick(row.original)}
+              />
+            </Box>
+          ),
+        }),
+      ]
+    : []),
 ]
 
 interface RedirectsTableProps {
@@ -359,6 +384,11 @@ interface RedirectsTableProps {
 export const RedirectsTable = ({
   siteId,
 }: RedirectsTableProps): JSX.Element => {
+  // While the roles are unknown we can't tell whether the delete column
+  // belongs, so the table stays in its loading state rather than rendering a
+  // column set it may have to change a moment later.
+  const { canManageRedirects: canDelete, isPending: isPermissionPending } =
+    useRedirectManagement()
   const toast = useToast(BRIEF_TOAST_SETTINGS)
   const { mutate: deleteRedirect, isPending } = useDeleteRedirect()
   // Newest redirects first, matching the design's default sort on "Added"
@@ -421,8 +451,8 @@ export const RedirectsTable = ({
   }, [resolvedDestinations])
 
   const columns = useMemo(
-    () => getColumns(setRedirectToDelete, infoByDestination),
-    [infoByDestination],
+    () => getColumns(setRedirectToDelete, infoByDestination, canDelete),
+    [infoByDestination, canDelete],
   )
 
   // Changing the sort order reshuffles rows across pages, so jump back to
@@ -476,10 +506,17 @@ export const RedirectsTable = ({
       <Datatable
         pagination
         totalRowCount={totalRowCount}
-        isFetching={isLoading || isCountLoading}
-        emptyPlaceholder={<RedirectsEmptyPlaceholder />}
+        isFetching={isLoading || isCountLoading || isPermissionPending}
+        emptyPlaceholder={
+          <RedirectsEmptyPlaceholder colSpan={columns.length} />
+        }
         instance={tableInstance}
-        sx={{ tableLayout: "fixed" }}
+        sx={{
+          tableLayout: "fixed",
+          // The empty-state cell spans every column and sets its own height, so
+          // it's left out — it's the only body cell carrying a colspan.
+          "tbody td:not([colspan])": { height: ROW_HEIGHT },
+        }}
       />
       <DeleteRedirectModal
         redirect={redirectToDelete}

--- a/apps/studio/src/features/settings/Redirects/constants.ts
+++ b/apps/studio/src/features/settings/Redirects/constants.ts
@@ -1,2 +1,8 @@
 export const REDIRECTS_SUPPORT_LINK =
   "https://support.isomer.gov.sg/en/articles/15897348-redirections"
+
+// Hint under the source field explaining the wildcard. Says "folder or
+// collection" rather than "section": "section" isn't a term the CMS uses
+// anywhere else, so it doesn't map onto anything users see in their site tree.
+export const WILDCARD_HINT =
+  "Add /* at the end to redirect all pages within a folder or collection (e.g. /old-news/*)."

--- a/apps/studio/src/features/settings/Redirects/index.tsx
+++ b/apps/studio/src/features/settings/Redirects/index.tsx
@@ -1,23 +1,64 @@
-import { Stack } from "@chakra-ui/react"
+import { Skeleton, Stack } from "@chakra-ui/react"
+import { Infobox } from "@opengovsg/design-system-react"
 
 import { AddRedirectCard } from "./components/AddRedirectCard"
 import { RedirectsHeader } from "./components/RedirectsHeader"
 import { RedirectsTable } from "./components/RedirectsTable"
+import {
+  RedirectManagementProvider,
+  useRedirectManagement,
+} from "./RedirectManagementContext"
 
 interface RedirectsSettingsProps {
   siteId: number
 }
 
-export const RedirectsSettings = ({
+// Roughly the height of the add-redirect card, so the table doesn't jump when
+// the roles land and the real card takes its place.
+const ADD_CARD_SKELETON_HEIGHT = "13rem"
+
+// The add-redirect card only appears once we know the user may use it. Until
+// then the answer is unknown, not "no" — showing the read-only page straight
+// away would tell an admin they lack access and then contradict itself.
+const AddRedirectSection = ({
+  siteId,
+}: RedirectsSettingsProps): JSX.Element => {
+  const { canManageRedirects, isPending, isError } = useRedirectManagement()
+
+  if (isPending) {
+    return <Skeleton height={ADD_CARD_SKELETON_HEIGHT} borderRadius="0.5rem" />
+  }
+
+  if (isError) {
+    return (
+      <Infobox variant="warning" size="sm">
+        We couldn't check your permissions, so adding and removing redirects is
+        unavailable. Refresh the page to try again.
+      </Infobox>
+    )
+  }
+
+  return canManageRedirects ? <AddRedirectCard siteId={siteId} /> : <></>
+}
+
+const RedirectsSettingsContent = ({
   siteId,
 }: RedirectsSettingsProps): JSX.Element => (
   <Stack spacing="1.5rem" px="2rem" py="1.5rem" w="full">
     <RedirectsHeader />
 
     <Stack spacing="1.25rem">
-      <AddRedirectCard siteId={siteId} />
+      <AddRedirectSection siteId={siteId} />
 
       <RedirectsTable siteId={siteId} />
     </Stack>
   </Stack>
+)
+
+export const RedirectsSettings = ({
+  siteId,
+}: RedirectsSettingsProps): JSX.Element => (
+  <RedirectManagementProvider siteId={siteId}>
+    <RedirectsSettingsContent siteId={siteId} />
+  </RedirectManagementProvider>
 )

--- a/apps/studio/src/server/modules/permissions/permissions.type.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.type.ts
@@ -23,6 +23,15 @@ export type UserManagementActions = (typeof _USER_MANAGEMENT_ACTIONS)[number]
 type UserManagementTuple = [UserManagementActions, "UserManagement"]
 export type UserManagementAbility = Ability<UserManagementTuple>
 
+// Redirects are site-wide: any role may read the table, only Admins may add or
+// remove. Same shape as UserManagement today, but kept as its own subject so
+// the two can diverge without one silently changing the other.
+const _REDIRECT_MANAGEMENT_ACTIONS = ["read", "manage"] as const
+export type RedirectManagementActions =
+  (typeof _REDIRECT_MANAGEMENT_ACTIONS)[number]
+type RedirectManagementTuple = [RedirectManagementActions, "RedirectManagement"]
+export type RedirectManagementAbility = Ability<RedirectManagementTuple>
+
 export interface PermissionsProps {
   userId: string
   siteId: number

--- a/apps/studio/src/server/modules/permissions/permissions.util.ts
+++ b/apps/studio/src/server/modules/permissions/permissions.util.ts
@@ -1,4 +1,7 @@
-import type { UserManagementAbility } from "~/server/modules/permissions/permissions.type"
+import type {
+  RedirectManagementAbility,
+  UserManagementAbility,
+} from "~/server/modules/permissions/permissions.type"
 import { AbilityBuilder, createMongoAbility } from "@casl/ability"
 import { RoleType } from "~prisma/generated/generatedEnums"
 
@@ -36,6 +39,27 @@ export const buildPermissionsForResource = (
       builder.can("publish", "Resource")
       return
   }
+}
+
+// Mirrors the server's gate on the redirect router: `list`/`count` need only
+// read access to the site, while `create`, `bulkCreate` and `delete` check
+// create/delete on Site, which only an Admin holds.
+export const buildRedirectManagementPermissions = (
+  roles: { role: RoleType }[],
+) => {
+  const builder = new AbilityBuilder<RedirectManagementAbility>(
+    createMongoAbility,
+  )
+
+  if (roles.length > 0) {
+    builder.can("read", "RedirectManagement")
+  }
+
+  if (roles.some(({ role }) => role === RoleType.Admin)) {
+    builder.can("manage", "RedirectManagement")
+  }
+
+  return builder.build({ detectSubjectType: () => "RedirectManagement" })
 }
 
 export const buildUserManagementPermissions = (roles: { role: RoleType }[]) => {

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -1540,6 +1540,48 @@ describe("redirect.router", async () => {
         { reference: "/folder", permalink: null, warn: true },
       ])
     })
+
+    it("terminates for a folder whose subtree contains a parent-chain cycle", async () => {
+      // Arrange — nothing creates a cycle today (moving a folder into its own
+      // descendant is rejected), but a malformed chain must not be able to spin
+      // the permalink walk forever: the folder and its child point at each
+      // other, so following parents alternates between them without end.
+      // Reached by id through a stored reference, which skips the path walk a
+      // cycle would otherwise fail.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: null,
+      })
+      const { folder: child } = await setupFolder({
+        siteId,
+        permalink: "child",
+        parentId: folder.id,
+      })
+      await db
+        .updateTable("Resource")
+        .set({ parentId: child.id })
+        .where("id", "=", folder.id)
+        .execute()
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: [`[resource:${siteId}:${folder.id}]`],
+      })
+
+      // Assert — the point is that it returns at all rather than hanging, and
+      // still warns because nothing inside is published. The permalink is left
+      // unasserted: a cyclic chain has no meaningful path, so pinning whatever
+      // the walk salvages would only lock in nonsense.
+      expect(result).toHaveLength(1)
+      expect(result[0]?.warn).toBe(true)
+    })
   })
 
   describe("delete", () => {

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -964,7 +964,10 @@ export const getResourceFullPermalinks = async (
         .where("Resource.siteId", "=", siteId)
         .where("Resource.id", "in", resourceIds.map(String))
         .select(["Resource.id", "Resource.permalink", "Resource.parentId"])
-        .unionAll((fb) =>
+        // `union` (not `unionAll`) dedupes rows so a malformed parent chain
+        // with a cycle can't drive the recursion forever, matching
+        // getResourcePermalinkTree and withResourceSubtree above.
+        .union((fb) =>
           fb
             // Recursive case: walk up to each node's parent
             .selectFrom("Resource")
@@ -999,12 +1002,17 @@ export const getResourceFullPermalinks = async (
   const result = new Map<number, string>()
   for (const resourceId of resourceIds) {
     const segments: string[] = []
+    // The query above terminates on a cyclic chain, but the walk it feeds would
+    // still loop between the cycle's members forever — stop at the first id
+    // seen twice.
+    const visited = new Set<string>()
     let currentId: string | null = String(resourceId)
     while (currentId !== null) {
       const node = nodeById.get(currentId)
-      if (node === undefined) {
+      if (node === undefined || visited.has(currentId)) {
         break
       }
+      visited.add(currentId)
       segments.push(node.permalink)
       currentId = node.parentId
     }

--- a/apps/studio/src/stories/Page/SettingsPage/AuditLog.stories.tsx
+++ b/apps/studio/src/stories/Page/SettingsPage/AuditLog.stories.tsx
@@ -89,6 +89,11 @@ export const ExportRequested: Story = {
     await userEvent.click(screen.getByRole("button", { name: "Export log" }), {
       pointerEventsCheck: 0,
     })
-    await expect(await screen.findByText("Export requested")).toBeVisible()
+    // Presence, not a one-shot toBeVisible. BRIEF_TOAST_SETTINGS gives the
+    // toast a 3s duration and it is removed ~200ms after that, so on a loaded
+    // CI machine it can begin tearing down between the find and the assertion —
+    // leaving an emptied node that fails the visibility check even though the
+    // toast did appear.
+    await screen.findByText("Export requested")
   },
 }


### PR DESCRIPTION
> The folder destination-warning fix that was originally part of this PR has moved to #3124, stacked on top of this one.

## Problem

Three issues raised in the "Bulk upload & wildcard redirects" dogfooding session, plus two robustness problems found while fixing them.

1. **Editors saw redirect controls they cannot use.** `redirect.create` / `redirect.delete` require `create`/`delete` on `Site`, which only site admins hold. The settings page rendered the add-redirect form, the bulk-upload link, the `.csv` template and the row delete button to everyone, so a non-admin could fill in the form and download the template only to be met with `FORBIDDEN` on submit.
2. **"Section" is not a term the CMS uses.** The wildcard hint read "redirect a whole section", which does not map onto anything in the site tree.
3. **The wildcard hint sat flush against the input**, reading as part of the field rather than as a caption.
4. **A malformed `Resource.parentId` chain could hang a request.** `getResourceFullPermalinks` recursed with `unionAll` and the in-memory ancestor walk it feeds had no visited guard, so a redirect destination stored as a `[resource:...]` reference pointing into a cycle hung `resolveReferences` outright.
5. **A flaky audit-log story** was failing Chromatic on this branch.

Closes N/A — items 1–3 were raised on the dogfooding feedback board rather than as GitHub issues.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Improvements**:

- The add-redirect card and the delete column render only for site admins, gated on a `RedirectManagement` ability of their own rather than borrowing `UserManagement`. The two resolve the same way today, but they are separate concerns and a named context says what the check means. Read access still sees the full table.
- The roles query behind that gate turned "loading" and "failed" into an empty ability, which is indistinguishable from a genuine read-only role — so an admin saw a read-only page transiently on load, and permanently on failure, with nothing explaining why. The context now surfaces `isPending` and `isError`: a skeleton while roles load, an explicit message when they fail.
- Table rows are pinned to a fixed height, so dropping the delete column no longer makes a non-admin's rows about 20px shorter than an admin's.
- The wildcard hint now reads "Add /\* at the end to redirect all pages within a folder or collection (e.g. /old-news/\*)", spaced off the input to match the label-to-input gap. The spacing has to go through `sx`: the design system's `FormHelperText` merges the theme's `helperText` styles into `sx`, and Chakra's `sx` outranks style props, so an `mt` prop was being silently dropped.

**Bug Fixes**:

- `getResourceFullPermalinks` is now cycle-safe on both counts — the CTE uses `union` and the ancestor walk stops at the first id seen twice, matching `getResourcePermalinkTree` and `withResourceSubtree`, which already dedupe for this reason. Nothing creates a cycle today (moving a folder into its own descendant is rejected), so this is defence against malformed data.
- The audit-log `ExportRequested` story asserted `toBeVisible()` on a toast with a 3s duration immediately after finding it, so on a loaded CI machine the toast could begin tearing down between the find and the assertion. It now asserts presence only, matching the convention already used for the same reason in `Redirects.stories.tsx`. That story is unrelated to this branch — it only started being snapshotted here because the permissions util changed, pulling it into Chromatic's TurboSnap set.

## Before & After Screenshots

**BEFORE**: every role saw the "Add new redirects" card, the bulk-upload link and the per-row delete icons; the wildcard hint read "redirect a whole section" and sat flush against the input.

**AFTER**: non-admins see only the redirects table, at the same row height an admin sees; admins see the card, with a skeleton while permissions load. The hint reads "all pages within a folder or collection" with a 0.75rem gap above it.

## Tests

`RedirectsSettings.browser.test.tsx` covers the admin and non-admin views, the hint copy, row-height parity between the two roles, and the roles-query loading and error states. It runs in Browser Mode because it asserts real layout, and because the design system's CJS `FormHelperText` and Chakra's ESM `FormControl` resolve to different module instances under jsdom. `redirect.router.test.ts` adds a test proving a cyclic parent chain terminates instead of hanging.

**Manual Verification Steps**:

- [ ] As a **site admin**, open Settings → Redirects. Confirm the "Add new redirects" card, the "bulk upload with a .csv instead" link and the per-row delete icons are all present.
- [ ] As an **Editor or Publisher** on the same site, open the same page. Confirm the add card, the bulk-upload link and the entire delete column are gone, and that the table still lists every redirect.
- [ ] Compare the two views and confirm the table rows are the same height.
- [ ] Reload as an admin on a slow connection (throttle in devtools) and confirm a skeleton appears where the add card goes, rather than the page briefly presenting itself as read-only.
- [ ] With `is-advanced-redirects-enabled` on, confirm the hint under "When someone visits" reads "Add /* at the end to redirect all pages within a folder or collection (e.g. /old-news/*)" and has a clear gap above it.
- [ ] Confirm adding and deleting a redirect as a site admin still works end to end.

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The redirect-management update adds clearer permission-state handling and safer resource traversal for redirect resolution.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Initial state verified: Admin roles load successfully and the Redirects page shows a Delete control for /old-news.
- After attempting a background refetch, the Admin roles are retained but the page displays that adding/removing redirects is unavailable, while the Delete redirect for /old-news remains rendered.
- The evaluation confirms the P2 hypothesis based on the after-state observations.

<a href="https://app.greptile.com/trex/runs/18445923/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["test(audit-log): stop the export story r..."](https://github.com/opengovsg/isomer/commit/ce42b21a1a9124a4166e098a617b62763e495543) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51082155)</sub>

<!-- /greptile_comment -->