### PR TITLE
fix(studio): align publishing table headers

### DIFF
--- a/apps/studio/src/pages/godmode/publishing.tsx
+++ b/apps/studio/src/pages/godmode/publishing.tsx
@@ -96,8 +96,8 @@ const GodModePublishingPage: NextPageWithLayout = () => {
         <Table variant="simple">
           <Thead>
             <Tr>
-              <Th>Site Name</Th>
               <Th>Site ID</Th>
+              <Th>Site Name</Th>
               <Th>CodeBuild ID</Th>
               <Th>Actions</Th>
             </Tr>


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +1 | -1 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The publishing table labels did not match the displayed site ID and site name values.

Closes N/A

## Solution

Swapped the Site ID and Site Name headers so they align with the existing data columns.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Publishing table headers now accurately identify the displayed columns.

**Bug Fixes**:

- Corrected the Site ID and Site Name header order.

## Before & After Screenshots

**BEFORE**:

Not captured; this is a text-only header correction.

**AFTER**:

Not captured; this is a text-only header correction.

## Tests

`git diff --check` passed.

**Manual Verification Steps**:

- [ ] Open God Mode > Publishing.
- [ ] Confirm the first two headers read Site ID, then Site Name.
- [ ] Confirm each header matches its displayed value.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.