### PR TITLE
chore: Generalize Collection results count from "articles" to "items"

### DIFF
--- a/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/Collection.stories.tsx
@@ -231,7 +231,7 @@ export const YearFilterSelectNotSpecified: Story = {
     const screen = within(canvasElement)
     await userEvent.click(screen.getByText(/Not specified/i))
 
-    const resultsHeader = await screen.findAllByText(/3 articles/)
+    const resultsHeader = await screen.findAllByText(/3 items/)
     await expect(resultsHeader.length).toBe(1)
   },
 }

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -64,9 +64,7 @@ export const CollectionResults = ({
       <div className="flex w-full flex-col justify-between gap-x-6 gap-y-2 md:flex-row">
         <div className="flex h-full w-full items-center gap-3">
           <p className="prose-headline-lg-regular text-base-content-medium">
-            {appliedFilters.length > 0 || searchValue !== ""
-              ? `${filteredCount} article${filteredCount === 1 ? "" : "s"}`
-              : `${filteredCount} article${filteredCount === 1 ? "" : "s"}`}
+            {`${filteredCount} item${filteredCount === 1 ? "" : "s"}`}
             {searchValue !== "" && (
               <>
                 {" "}

--- a/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
+++ b/packages/components/src/templates/next/layouts/Collection/CollectionResults.tsx
@@ -54,7 +54,7 @@ export const CollectionResults = ({
   if (totalCount === 0) {
     return (
       <p className="prose-body-base py-32 text-center text-base-content">
-        There are no articles here.
+        There are no items here.
       </p>
     )
   }
@@ -98,8 +98,7 @@ export const CollectionResults = ({
       ) : (
         <div className="flex flex-col gap-1 py-32 text-center text-content">
           <p className="prose-body-base">
-            We couldn’t find any articles. Try different search terms or
-            filters.
+            We couldn’t find any items. Try different search terms or filters.
           </p>
           <button
             className="prose-headline-base-medium mx-auto w-fit text-link underline-offset-4 hover:underline"


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +3 | -6 |
| 🧪 Test | 1 | +1 | -1 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Collections can contain pages, links, and files — not just articles. This updates the published Collection layout to use `items` consistently in the results header and empty states.

## Changes

- `CollectionResults.tsx`: Change the count label at the top of the results list from `article(s)` to `item(s)`, and remove a redundant ternary where both branches were identical.
- `CollectionResults.tsx`: Update empty-state copy (`There are no items here.` and `We couldn't find any items.`) to match.
- `Collection.stories.tsx`: Update the Storybook interaction test to match the new copy.

## Test plan

- [x] Updated Storybook interaction assertion for filtered results count
- [ ] Verify Collection page shows `N items` at the top when browsing unfiltered results
- [ ] Verify filtered/search results still show `N items for "query"` correctly
- [ ] Verify empty collection shows `There are no items here.`
- [ ] Verify no search/filter matches show `We couldn't find any items.`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3844bd12-e6c7-4f2c-88e3-cc1c7388f6ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3844bd12-e6c7-4f2c-88e3-cc1c7388f6ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

