### PR TITLE
fix(components): prevent duplicate search focus outline

### DIFF
--- a/packages/components/.storybook/main.ts
+++ b/packages/components/.storybook/main.ts
@@ -17,34 +17,6 @@ const config: StorybookConfig = {
   },
 
   staticDirs: ["../public", "./assets"],
-
-  viteFinal: (config) => {
-    // Workaround for a rolldown (Vite 8 bundler) codegen bug: with
-    // strictExecutionOrder (force-enabled by @storybook/builder-vite),
-    // circular value-imports among src/{types,interfaces,schemas} make
-    // rolldown emit lazily-initialised (__esm-wrapped) modules whose
-    // cross-chunk bindings (e.g. typebox's `Type`) are never imported,
-    // throwing "ReferenceError: Type is not defined" at runtime. Disable it
-    // via a post-enforced plugin (builder-vite re-enables it in a pre plugin
-    // config hook, which runs after viteFinal). Only affects the Storybook
-    // build; the published package build uses tsc and is unaffected.
-    config.plugins ??= []
-    config.plugins.push({
-      name: "isomer:disable-strict-execution-order",
-      enforce: "post",
-      config: (cfg) => {
-        const output = (
-          cfg.build as
-            | { rolldownOptions?: { output?: Record<string, unknown> } }
-            | undefined
-        )?.rolldownOptions?.output
-        if (output && !Array.isArray(output)) {
-          output.strictExecutionOrder = false
-        }
-      },
-    })
-    return config
-  },
 }
 
 export default config

--- a/packages/components/src/templates/next/components/internal/Search.browser.test.tsx
+++ b/packages/components/src/templates/next/components/internal/Search.browser.test.tsx
@@ -7,10 +7,21 @@ describe("SearchField", () => {
   it("uses only the field group focus indicator", () => {
     const { getByRole } = render(<SearchField aria-label="Search" />)
     const input = getByRole("searchbox")
+    const fieldGroup = input.parentElement
+
+    expect(fieldGroup).not.toBeNull()
+    if (!fieldGroup) {
+      throw new Error("Expected the search input to have a field group")
+    }
+
+    const unfocusedBoxShadow = getComputedStyle(fieldGroup).boxShadow
 
     fireEvent.focus(input)
 
-    expect(getComputedStyle(input).outlineColor).toBe("rgba(0, 0, 0, 0)")
-    expect(getComputedStyle(input.parentElement!).boxShadow).not.toBe("none")
+    expect(["transparent", "rgba(0, 0, 0, 0)"]).toContain(
+      getComputedStyle(input).outlineColor,
+    )
+    expect(fieldGroup.className).toContain("shadow-utility-feedback-info")
+    expect(getComputedStyle(fieldGroup).boxShadow).not.toBe(unfocusedBoxShadow)
   })
 })

--- a/packages/components/src/templates/next/components/internal/Search.browser.test.tsx
+++ b/packages/components/src/templates/next/components/internal/Search.browser.test.tsx
@@ -1,0 +1,16 @@
+import { fireEvent, render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { SearchField } from "./Search"
+
+describe("SearchField", () => {
+  it("uses only the field group focus indicator", () => {
+    const { getByRole } = render(<SearchField aria-label="Search" />)
+    const input = getByRole("searchbox")
+
+    fireEvent.focus(input)
+
+    expect(getComputedStyle(input).outlineColor).toBe("rgba(0, 0, 0, 0)")
+    expect(getComputedStyle(input.parentElement!).boxShadow).not.toBe("none")
+  })
+})

--- a/packages/components/src/templates/next/components/internal/Search.tsx
+++ b/packages/components/src/templates/next/components/internal/Search.tsx
@@ -13,7 +13,7 @@ import { twMerge } from "~/lib/twMerge"
 import { IconButton } from "./IconButton"
 
 const inputStyles = tv({
-  base: "prose-body-base min-w-0 flex-1 bg-white text-base-content outline outline-0 placeholder:text-interaction-support-placeholder disabled:text-interaction-support-placeholder",
+  base: "prose-body-base min-w-0 flex-1 bg-white text-base-content outline-none placeholder:text-interaction-support-placeholder disabled:text-interaction-support-placeholder",
 })
 
 const fieldGroupStyles = tv({


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +1 | -29 |
| 🧪 Test | 1 | +27 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The SearchableTable search input can show the browser focus outline alongside the field-group focus indicator, and the components Storybook build fails during story extraction because its preview globals execute out of order.

Closes: N/A

## Solution

Use the single `outline-none` utility for the nested input, add robust browser coverage for the focused field-group indicator, and remove the obsolete Storybook execution-order override so the preview runtime initializes its globals before consumers.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- Cross-browser regression coverage for search-field focus styling
- Reliable static Storybook preview initialization

**Bug Fixes**:

- Remove the duplicate visible focus outline from the search input
- Prevent the Storybook preview-errors module from being read before initialization

## Before & After Screenshots

**BEFORE**:

- Not available

**AFTER**:

- Not available

## Tests

- `CI=1 pnpm --filter @opengovsg/isomer-components exec vitest run --project browser src/templates/next/components/internal/Search.browser.test.tsx --reporter=verbose`
- `pnpm --filter @opengovsg/isomer-components exec storybook build --output-dir /tmp/isomer-storybook-strict --stats-json`
- Loaded all 386 generated stories in Chromium with zero uncaught errors
- `pnpm --filter @opengovsg/isomer-components format`
- `pnpm --filter @opengovsg/isomer-components lint`
- `pnpm --filter @opengovsg/isomer-components typecheck`

**Manual Verification Steps**:

- [ ] Open a native SearchableTable and focus its search input
- [ ] Confirm that only one focus indicator appears around the field group
- [ ] Confirm that search and clear interactions still work

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None
