### PR TITLE
fix(studio): update to renamed @opengovsg/validators package

### DIFF
--- a/apps/studio/next.config.mjs
+++ b/apps/studio/next.config.mjs
@@ -166,7 +166,7 @@ const config = {
     "@isomer/logging",
     "@isomer/pgboss",
     "@sinclair/typebox",
-    "@opengovsg/starter-kitty-validators",
+    "@opengovsg/validators",
   ],
   images: {
     remotePatterns: env.NEXT_PUBLIC_S3_ASSETS_DOMAIN_NAME

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -85,7 +85,7 @@
     "@jsonforms/react": "catalog:jsonforms",
     "@opengovsg/design-system-react": "catalog:",
     "@opengovsg/isomer-components": "workspace:*",
-    "@opengovsg/starter-kitty-validators": "catalog:",
+    "@opengovsg/validators": "catalog:",
     "@paralleldrive/cuid2": "catalog:",
     "@prisma/adapter-pg": "catalog:prisma",
     "@sinclair/typebox": "catalog:",

--- a/apps/studio/src/schemas/url.ts
+++ b/apps/studio/src/schemas/url.ts
@@ -1,4 +1,4 @@
-import { UrlValidator } from "@opengovsg/starter-kitty-validators"
+import { UrlValidator } from "@opengovsg/validators"
 import { z } from "zod"
 import { DASHBOARD } from "~/lib/routes"
 import { getBaseUrl } from "~/utils/getBaseUrl"

--- a/apps/studio/src/schemas/user.ts
+++ b/apps/studio/src/schemas/user.ts
@@ -1,4 +1,4 @@
-import { createEmailSchema } from "@opengovsg/starter-kitty-validators/email"
+import { createEmailSchema } from "@opengovsg/validators/email"
 import { z } from "zod"
 import { IsomerAdminRole, RoleType } from "~prisma/generated/generatedEnums"
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,7 +110,7 @@ catalogs:
     '@opengovsg/design-system-react':
       specifier: ^1.31.0
       version: 1.34.0
-    '@opengovsg/starter-kitty-validators':
+    '@opengovsg/validators':
       specifier: ^1.4.1
       version: 1.4.1
     '@paralleldrive/cuid2':
@@ -754,7 +754,7 @@ importers:
       '@opengovsg/isomer-components':
         specifier: workspace:*
         version: link:../../packages/components
-      '@opengovsg/starter-kitty-validators':
+      '@opengovsg/validators':
         specifier: 'catalog:'
         version: 1.4.1(zod@4.4.3)
       '@paralleldrive/cuid2':
@@ -4812,17 +4812,14 @@ packages:
       '@openfeature/core': ^1.10.0
 
   '@opengovsg/design-system-react@1.34.0':
-    resolution: {integrity: sha512-ceNcFsHq7wSBlvfexFbjzAKehWRQyzmT40jhbVmnPZiI8xwOqB3o6Hb2VuKXRiU3yRIDx/4DI20nr5ZlGstNHw==}
+    resolution: {integrity: sha512-ceNcFsHq7wSBlvfexFbjzAKehWRQyzmT40jhbVmnPZiI8xwOqB3o6Hb2VuKXRiU3yRIDx/4DI20nr5ZlGstNHw==, tarball: https://npm.pkg.github.com/download/@opengovsg/design-system-react/1.34.0/d029e0ec2ab44883840ebb79cc2c3106ed91f91a}
     peerDependencies:
       '@chakra-ui/react': ^2.10.5
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  '@opengovsg/starter-kitty-validators@1.4.1':
-    resolution: {integrity: sha512-fq6+ytBixRhnmSSfXpJU14Yi9xzRNXKmsbxHns13OtVZRknBTTjjvlPe4JLve+K0sLaYqgGijKsh11aDzsSe7A==}
-    deprecated: |-
-      Renamed to @opengovsg/validators. Please
-        migrate: npm i @opengovsg/validators
+  '@opengovsg/validators@1.4.1':
+    resolution: {integrity: sha512-Wnn8M8WsMLS8x3zf9pALUUBn2NILMGcBO03K0xzmGqw4FmJe/NwPA39Pnkeni4eGv5UKdQlbCk7TiRZGuwvF2w==, tarball: https://npm.pkg.github.com/download/@opengovsg/validators/1.4.1/4beed28b09c629f74e6c668e227521aea83862a2}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -16111,7 +16108,7 @@ snapshots:
       - prop-types
       - supports-color
 
-  '@opengovsg/starter-kitty-validators@1.4.1(zod@4.4.3)':
+  '@opengovsg/validators@1.4.1(zod@4.4.3)':
     dependencies:
       email-addresses: 5.0.0
       zod: 4.4.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4812,14 +4812,14 @@ packages:
       '@openfeature/core': ^1.10.0
 
   '@opengovsg/design-system-react@1.34.0':
-    resolution: {integrity: sha512-ceNcFsHq7wSBlvfexFbjzAKehWRQyzmT40jhbVmnPZiI8xwOqB3o6Hb2VuKXRiU3yRIDx/4DI20nr5ZlGstNHw==, tarball: https://npm.pkg.github.com/download/@opengovsg/design-system-react/1.34.0/d029e0ec2ab44883840ebb79cc2c3106ed91f91a}
+    resolution: {integrity: sha512-ceNcFsHq7wSBlvfexFbjzAKehWRQyzmT40jhbVmnPZiI8xwOqB3o6Hb2VuKXRiU3yRIDx/4DI20nr5ZlGstNHw==}
     peerDependencies:
       '@chakra-ui/react': ^2.10.5
       react: ^18.2.0
       react-dom: ^18.2.0
 
   '@opengovsg/validators@1.4.1':
-    resolution: {integrity: sha512-Wnn8M8WsMLS8x3zf9pALUUBn2NILMGcBO03K0xzmGqw4FmJe/NwPA39Pnkeni4eGv5UKdQlbCk7TiRZGuwvF2w==, tarball: https://npm.pkg.github.com/download/@opengovsg/validators/1.4.1/4beed28b09c629f74e6c668e227521aea83862a2}
+    resolution: {integrity: sha512-Wnn8M8WsMLS8x3zf9pALUUBn2NILMGcBO03K0xzmGqw4FmJe/NwPA39Pnkeni4eGv5UKdQlbCk7TiRZGuwvF2w==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4812,14 +4812,14 @@ packages:
       '@openfeature/core': ^1.10.0
 
   '@opengovsg/design-system-react@1.34.0':
-    resolution: {integrity: sha512-ceNcFsHq7wSBlvfexFbjzAKehWRQyzmT40jhbVmnPZiI8xwOqB3o6Hb2VuKXRiU3yRIDx/4DI20nr5ZlGstNHw==}
+    resolution: {integrity: sha512-ceNcFsHq7wSBlvfexFbjzAKehWRQyzmT40jhbVmnPZiI8xwOqB3o6Hb2VuKXRiU3yRIDx/4DI20nr5ZlGstNHw==, tarball: https://npm.pkg.github.com/download/@opengovsg/design-system-react/1.34.0/d029e0ec2ab44883840ebb79cc2c3106ed91f91a}
     peerDependencies:
       '@chakra-ui/react': ^2.10.5
       react: ^18.2.0
       react-dom: ^18.2.0
 
   '@opengovsg/validators@1.4.1':
-    resolution: {integrity: sha512-Wnn8M8WsMLS8x3zf9pALUUBn2NILMGcBO03K0xzmGqw4FmJe/NwPA39Pnkeni4eGv5UKdQlbCk7TiRZGuwvF2w==}
+    resolution: {integrity: sha512-Wnn8M8WsMLS8x3zf9pALUUBn2NILMGcBO03K0xzmGqw4FmJe/NwPA39Pnkeni4eGv5UKdQlbCk7TiRZGuwvF2w==, tarball: https://npm.pkg.github.com/download/@opengovsg/validators/1.4.1/4beed28b09c629f74e6c668e227521aea83862a2}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4819,7 +4819,7 @@ packages:
       react-dom: ^18.2.0
 
   '@opengovsg/validators@1.4.1':
-    resolution: {integrity: sha512-Wnn8M8WsMLS8x3zf9pALUUBn2NILMGcBO03K0xzmGqw4FmJe/NwPA39Pnkeni4eGv5UKdQlbCk7TiRZGuwvF2w==}
+    resolution: {integrity: sha512-jynSts9f51gG2CP3vApgtIVx/GTE/5DanWDN7UnISyjDIfjT1mpoit43Mxl9UAxh5UwjLrfcJxKJHQHPj7A9QA==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,7 +85,7 @@ catalog:
   "@octokit/rest": ^22.0.0
   "@inquirer/prompts": ^8.5.2
   "@opengovsg/design-system-react": ^1.31.0
-  "@opengovsg/starter-kitty-validators": ^1.4.1
+  "@opengovsg/validators": ^1.4.1
   "@paralleldrive/cuid2": ^3.3.0
   "@sinclair/typebox": ^0.33.24
   "@tanstack/react-table": ^8.21.2


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 5 | +5 | -5 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 1 | +5 | -8 |
<!-- pr-diff-breakdown:end -->

## Problem

`pnpm install` fails for anyone on a fresh clone/lockfile with:

```
GET https://npm.pkg.github.com/@opengovsg/starter-kitty-validators/-/starter-kitty-validators-1.4.1.tgz: Not Found - 404
```

`@opengovsg/starter-kitty-validators` was renamed to `@opengovsg/validators` upstream in [opengovsg/starter-kitty#100](https://github.com/opengovsg/starter-kitty/pull/100). Our catalog pin (`^1.4.1`) predates the rename, so it's asking the registry for a scoped package name that no longer resolves — installs are broken for the whole team until this is updated.

## Solution

Update every reference from the old scoped name to the new one:

- `pnpm-workspace.yaml` catalog entry
- `apps/studio/package.json` dependency entry
- The two import sites: `src/schemas/url.ts` (`UrlValidator`) and `src/schemas/user.ts` (`createEmailSchema` from the `/email` subpath)
- Regenerated `pnpm-lock.yaml`

No API surface changed upstream as part of the rename — same exports, same subpaths — so this is a pure find-and-replace with no behavioral change.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- None

**Bug Fixes**:

- Fixes broken `pnpm install` caused by the upstream package rename of `@opengovsg/starter-kitty-validators` → `@opengovsg/validators`

## Tests

**Manual Verification Steps**:

- [ ] Run `pnpm install` from a clean state and confirm it completes with no `ERR_PNPM_FETCH_404`/`ERR_PNPM_FETCH_403` errors
- [ ] Start the app and exercise a flow that uses `UrlValidator` (e.g. entering a redirect/webhook URL in site settings) — confirm validation still behaves as before
- [ ] Exercise a flow that uses the email schema (e.g. inviting/adding a user by email) — confirm validation still behaves as before

**New scripts**:

- None

**New dependencies**:

- None (rename only, same underlying package)

**New dev dependencies**:

- None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Studio now references the renamed `@opengovsg/validators` package for URL and email validation, updates its Next.js transpilation list, and refreshes the workspace lockfile. The current validators checksum matches the npm registry tarball, and a frozen, scripts-disabled Studio installation completes without an integrity error.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No accepted blocking findings remain after the frozen installation and registry checksum checks completed successfully.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the downloaded validators tarball checksum against the lockfile integrity value and confirmed a match.
- Completed a frozen pnpm install for the studio workspace, which finished with 'Already up to date' and reported no tarball integrity errors.
- Compiled the validation summary noting identical checksums, the successful frozen install, and the referenced project lines that justify the validation results.

<a href="https://app.greptile.com/trex/runs/18279770/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: correct stale integrity hash for @o..."](https://github.com/opengovsg/isomer/commit/266f33a0b7084c4ef8ab839fb49dfa9f31d400f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52124958)</sub>

<!-- /greptile_comment -->