### PR TITLE
fix(studio): key incrementVersion off Version history, not publishedVersionId

### DIFF
--- a/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
+++ b/apps/studio/src/server/modules/version/__tests__/version.service.test.ts
@@ -1,0 +1,101 @@
+import { resetTables } from "tests/integration/helpers/db"
+import {
+  setupBlob,
+  setupPageResource,
+  setupUser,
+} from "tests/integration/helpers/seed"
+import { ResourceType } from "~prisma/generated/prisma/client"
+
+import { db, ResourceState } from "../../database"
+import { incrementVersion } from "../version.service"
+
+describe("version.service", () => {
+  beforeEach(async () => {
+    await resetTables("Resource", "Version", "Blob", "User", "Site")
+  })
+
+  describe("incrementVersion", () => {
+    it("should return null if there is no draft to publish", async () => {
+      // Arrange
+      const user = await setupUser({})
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+
+      // Act
+      const result = await db.transaction().execute((tx) =>
+        incrementVersion({
+          siteId: site.id,
+          resourceId: page.id,
+          userId: user.id,
+          tx,
+        }),
+      )
+
+      // Assert
+      expect(result).toBeNull()
+    })
+
+    it("should start version numbering at 1 for a page that has never been published", async () => {
+      // Arrange
+      const user = await setupUser({})
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Draft,
+        userId: user.id,
+      })
+
+      // Act
+      const result = await db.transaction().execute((tx) =>
+        incrementVersion({
+          siteId: site.id,
+          resourceId: page.id,
+          userId: user.id,
+          tx,
+        }),
+      )
+
+      // Assert
+      expect(result?.previousVersion).toBeNull()
+      expect(result?.newVersion.versionNum).toEqual(1)
+    })
+
+    it("should continue version numbering from Version history even after publishedVersionId has been cleared (unpublish)", async () => {
+      // Arrange
+      const user = await setupUser({})
+      const { site, page } = await setupPageResource({
+        resourceType: ResourceType.Page,
+        state: ResourceState.Published,
+        userId: user.id,
+      })
+      // Simulate an unpublish: publishedVersionId is cleared but the
+      // Version history (versionNum 1) remains untouched.
+      const newDraftBlob = await setupBlob()
+      await db
+        .updateTable("Resource")
+        .where("id", "=", page.id)
+        .set({
+          publishedVersionId: null,
+          draftBlobId: newDraftBlob.id,
+          state: ResourceState.Draft,
+        })
+        .execute()
+
+      // Act
+      const result = await db.transaction().execute((tx) =>
+        incrementVersion({
+          siteId: site.id,
+          resourceId: page.id,
+          userId: user.id,
+          tx,
+        }),
+      )
+
+      // Assert
+      expect(result?.previousVersion?.versionNum).toEqual(1)
+      expect(result?.newVersion.versionNum).toEqual(2)
+    })
+  })
+})

--- a/apps/studio/src/server/modules/version/version.service.ts
+++ b/apps/studio/src/server/modules/version/version.service.ts
@@ -4,7 +4,6 @@ import { ResourceState } from "~prisma/generated/generatedEnums"
 import { type DB } from "~prisma/generated/generatedTypes"
 
 import type { SafeKysely, Transaction } from "../database"
-import { db } from "../database"
 import { getPageById, updatePageById } from "../resource/resource.service"
 
 interface Version {
@@ -20,12 +19,25 @@ const defaultVersionSelect: SelectExpression<DB, "Version">[] = [
   "Version.publishedAt",
 ]
 
-const getVersionById = ({ versionId }: { versionId: string }) =>
-  db
+/**
+ * Get the most recent Version for a resource, by versionNum, regardless of
+ * whether it is the resource's currently published version. This must be
+ * keyed off Version history rather than Resource.publishedVersionId, since
+ * the latter is cleared on unpublish but the version history is not.
+ */
+const getLatestVersionByResourceId = ({
+  tx,
+  resourceId,
+}: {
+  tx: SafeKysely
+  resourceId: string
+}) =>
+  tx
     .selectFrom("Version")
-    .where("Version.id", "=", versionId)
+    .where("Version.resourceId", "=", resourceId)
     .select(defaultVersionSelect)
-    .executeTakeFirstOrThrow()
+    .orderBy("Version.versionNum", "desc")
+    .executeTakeFirst()
 
 const createVersion = async (
   db: SafeKysely,
@@ -88,11 +100,13 @@ export const incrementVersion = async ({
 
   let newVersionNum = 1
   let previousVersion: Version | null = null
-  if (page.publishedVersionId) {
-    previousVersion = await getVersionById({
-      versionId: page.publishedVersionId,
-    })
-    newVersionNum = previousVersion.versionNum + 1
+  const latestVersion = await getLatestVersionByResourceId({
+    tx,
+    resourceId,
+  })
+  if (latestVersion) {
+    previousVersion = latestVersion
+    newVersionNum = latestVersion.versionNum + 1
   }
 
   // Create the new version

--- a/packages/db/prisma/custom/migration.sql
+++ b/packages/db/prisma/custom/migration.sql
@@ -17,3 +17,12 @@ DROP INDEX "User_email_deletedAt_key";
 CREATE UNIQUE INDEX IF NOT EXISTS "User_email_deletedAt_key" ON "User"("email", "deletedAt") NULLS NOT DISTINCT;
 
 ---------------------------------
+
+---------------------------------
+-- Non-locking index to look up a resource's latest Version by resourceId,
+-- ordered by versionNum. Version can grow large, so this is created
+-- CONCURRENTLY instead of via a normal Prisma migration.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Version_resourceId_versionNum_idx" ON "Version"("resourceId", "versionNum");
+
+---------------------------------

--- a/packages/db/prisma/migrations/20260811090000_custom_migration/migration.sql
+++ b/packages/db/prisma/migrations/20260811090000_custom_migration/migration.sql
@@ -1,0 +1,8 @@
+---------------------------------
+-- Non-locking index to look up a resource's latest Version by resourceId,
+-- ordered by versionNum. Version can grow large, so this is created
+-- CONCURRENTLY instead of via a normal Prisma migration.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Version_resourceId_versionNum_idx" ON "Version"("resourceId", "versionNum");
+
+---------------------------------

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -47,6 +47,8 @@ model Version {
   publisher   User       @relation(fields: [publishedBy], references: [id])
 
   updatedAt DateTime @default(now()) @updatedAt
+
+  @@index([resourceId, versionNum])
 }
 
 model Resource {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +43 | -10 |
| 🧪 Test | 1 | +101 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

`incrementVersion` (`apps/studio/src/server/modules/version/version.service.ts`) derives the previous version and next `versionNum` from `Resource.publishedVersionId`. This works today because `publishedVersionId` is only ever cleared by... nothing — there's currently no way to un-publish a page.

We're about to add an unpublish action that clears `publishedVersionId` while leaving `draftBlobId`/Version history untouched (so the draft the user was working on isn't lost). Once that lands, republishing an unpublished page would hit `incrementVersion`, see `publishedVersionId === null`, and reset `newVersionNum` to `1` — silently colliding with/orphaning the existing Version history for that resource.

## Solution

- Add `getLatestVersionByResourceId`, which looks up the most recent `Version` row for a resource by `versionNum`, independent of `Resource.publishedVersionId`.
- `incrementVersion` now derives `previousVersion`/`newVersionNum` from Version history via this helper instead of `publishedVersionId`.
- Add a `CREATE INDEX CONCURRENTLY` on `Version(resourceId, versionNum)` (via the custom migration mechanism, since Version can grow large) to keep this lookup cheap.

No behavior change for any page that has never been unpublished — for those, "latest Version" and "Version pointed to by publishedVersionId" are always the same row.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- Fixes version-numbering collision/orphaning that would occur once unpublish (clearing `publishedVersionId`) ships, by keying `incrementVersion` off Version history instead.

## Tests

- Added `apps/studio/src/server/modules/version/__tests__/version.service.test.ts`:
  - `incrementVersion` returns `null` when there's no draft to publish.
  - Version numbering starts at 1 for a never-published page.
  - Version numbering continues correctly (`versionNum` 2, `previousVersion` = versionNum 1) even after `publishedVersionId` has been cleared, simulating an unpublish.
- Verified the new regression test fails against the pre-fix code (`newVersionNum` resets to 1) and passes with the fix.
- Full unit suite (`pnpm test:unit`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)