### PR TITLE
fix: gate cron workers on deployed runtime flag

### DIFF
--- a/.aws/deploy/task-definition.json
+++ b/.aws/deploy/task-definition.json
@@ -26,6 +26,10 @@
         {
           "name": "NODE_ENV",
           "value": "production"
+        },
+        {
+          "name": "ENABLE_CRON_WORKERS",
+          "value": "true"
         }
       ],
       "linuxParameters": {

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@
 # Prisma supports the native connection string format for PostgreSQL, MySQL, SQLite, SQL Server, MongoDB and CockroachDB.
 # See the documentation for all the connection string options: https://pris.ly/d/connection-strings
 DATABASE_URL=postgres://root:root@localhost:5432/app
+# Cron workers are disabled by default. Opt in only when using a local database.
+ENABLE_CRON_WORKERS=false
 
 # Auth settings
 # =============

--- a/apps/studio/src/env.mjs
+++ b/apps/studio/src/env.mjs
@@ -71,6 +71,7 @@ const server = z
   .object({
     DATABASE_URL: z.string().url(),
     CI: z.coerce.boolean().default(false),
+    ENABLE_CRON_WORKERS: z.stringbool().optional().default(false),
     NODE_ENV: z.enum(["development", "test", "production"]),
     OTP_EXPIRY: z.coerce.number().positive().optional().default(600),
     // WARNING: Setting this bypasses OTP security. For preview environments only — never set in staging or production.
@@ -150,6 +151,7 @@ const processEnv = {
   DATABASE_URL: process.env.DATABASE_URL,
   DD_DELETION_EMAIL: process.env.DD_DELETION_EMAIL,
   CI: process.env.CI,
+  ENABLE_CRON_WORKERS: process.env.ENABLE_CRON_WORKERS,
   NODE_ENV: process.env.NODE_ENV,
   OTP_EXPIRY: process.env.OTP_EXPIRY,
   POSTMAN_API_KEY: process.env.POSTMAN_API_KEY,

--- a/apps/studio/src/instrumentation.ts
+++ b/apps/studio/src/instrumentation.ts
@@ -11,8 +11,7 @@ export async function register() {
     // oxlint-disable-next-line node/no-process-env
     initTracer({ service: process.env.DD_SERVICE ?? "isomer-next" })
 
-    // Skip cron on Vercel preview (serverless — no persistent process)
-    if (env.NEXT_PUBLIC_APP_ENV !== "preview") {
+    if (env.ENABLE_CRON_WORKERS) {
       // Import only if runtime is nodejs. This avoids running it on the browser, build time etc.
       const { initializeCronJobs, stopCronJobs } = await import("~/server/cron")
       await initializeCronJobs()
@@ -24,6 +23,8 @@ export async function register() {
       }
       process.on("SIGTERM", gracefulShutdown)
       process.on("SIGINT", gracefulShutdown)
+    } else {
+      console.log("Cron workers are disabled")
     }
   }
 }

--- a/apps/studio/src/server/cron/index.ts
+++ b/apps/studio/src/server/cron/index.ts
@@ -1,3 +1,5 @@
+import { env } from "~/env.mjs"
+
 import { createBaseLogger } from "../../lib/logger"
 import { auditLogExportJob } from "./jobs/auditLogExportJob"
 import { deactivateInactiveUsersJob } from "./jobs/deactivateInactiveUsersJob"
@@ -11,6 +13,11 @@ const logger = createBaseLogger({ path: "cron:index" })
 const cronJobs: { stop: () => void }[] = []
 
 export const initializeCronJobs = async () => {
+  if (!env.ENABLE_CRON_WORKERS) {
+    logger.info("Cron workers are disabled. Skipping initialization.")
+    return
+  }
+
   logger.info("Initializing cron jobs...")
 
   // Initialize and track all cron jobs

--- a/packages/pgboss/.env.test
+++ b/packages/pgboss/.env.test
@@ -1,4 +1,5 @@
 # PostgreSQL connection string for test database, bind to port 5431 to avoid conflict with other services
 DATABASE_URL=postgres://root:root@localhost:5431/test
+ENABLE_CRON_WORKERS=true
 CI=true
 PINO_LOG_LEVEL=silent

--- a/packages/pgboss/README.md
+++ b/packages/pgboss/README.md
@@ -11,6 +11,9 @@ Internal wrapper around `pg-boss` for PostgreSQL-backed background job schedulin
 
 Default timezone is `Asia/Singapore`.
 
+Workers and schedules are registered only when `ENABLE_CRON_WORKERS=true`. The
+flag defaults to `false`; opt in locally only when connected to a local database.
+
 ## Commands
 
 ```bash

--- a/packages/pgboss/src/__test__/client.test.ts
+++ b/packages/pgboss/src/__test__/client.test.ts
@@ -6,6 +6,7 @@ import { type BaseLogger, pino } from "@isomer/logging"
 
 import type { GlobalWithPgBoss } from ".."
 import { registerPgbossJob } from ".."
+import { env } from "../env"
 
 const logger: BaseLogger = pino({ level: "silent" })
 
@@ -17,9 +18,27 @@ describe("client", () => {
     globalForPgboss.registeredPgbossJobs = new Set<string>()
   })
   afterEach(() => {
+    env.ENABLE_CRON_WORKERS = true
     vi.restoreAllMocks()
   })
   describe("registerPgbossJob", () => {
+    it("does not start PgBoss or register a job when cron workers are disabled", async () => {
+      env.ENABLE_CRON_WORKERS = false
+      const handler = vi.fn().mockResolvedValue(undefined)
+
+      const { stop } = await registerPgbossJob(
+        logger,
+        "disabled-job",
+        "* * * * *",
+        handler,
+      )
+
+      expect(globalForPgboss.pgBoss).toBeUndefined()
+      expect(globalForPgboss.registeredPgbossJobs).toEqual(new Set())
+      expect(handler).not.toHaveBeenCalled()
+      expect(stop()).toBeUndefined()
+    })
+
     it("creates queue, registers worker, and schedules job", async () => {
       const handler = vi.fn().mockResolvedValue(undefined)
 

--- a/packages/pgboss/src/client.ts
+++ b/packages/pgboss/src/client.ts
@@ -36,6 +36,11 @@ export const registerPgbossJob = async (
   scheduleOptions: ScheduleOptions = {},
   heartbeatOptions?: HeartbeatOptions,
 ) => {
+  if (!env.ENABLE_CRON_WORKERS) {
+    logger.warn(`PgBoss job ${jobName} is disabled. Skipping registration.`)
+    return { stop: () => undefined }
+  }
+
   const boss = await getPgbossClient(logger)
   if (globalForPgboss.registeredPgbossJobs.has(jobName)) {
     logger.warn(
@@ -80,6 +85,8 @@ export const registerPgbossJob = async (
 }
 
 export const stopAllPgbossJobs = async (logger: BaseLogger): Promise<void> => {
+  if (!env.ENABLE_CRON_WORKERS) return
+
   const boss = await getPgbossClient(logger)
   try {
     await boss.stop({ graceful: true })

--- a/packages/pgboss/src/env.ts
+++ b/packages/pgboss/src/env.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 
 const envSchema = z.object({
   DATABASE_URL: z.string().url(),
+  ENABLE_CRON_WORKERS: z.stringbool().optional().default(false),
   NODE_ENV: z
     .enum(["development", "test", "production"])
     .default("development"),

--- a/turbo.json
+++ b/turbo.json
@@ -8,6 +8,7 @@
   "globalEnv": [
     "NODE_ENV",
     "DATABASE_URL",
+    "ENABLE_CRON_WORKERS",
     "CI",
     "SESSION_SECRET",
     "NEXT_PUBLIC_S3_REGION",


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 9 | +29 | -3 |
| 🧪 Test | 1 | +19 | -0 |
| 📄 Doc | 1 | +3 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Resolves [ISOM-2480](https://linear.app/ogp/issue/ISOM-2480/gate-pg-boss-cron-startup-on-the-production-runtime-environment). Studio currently starts pg-boss workers whenever the app boots outside preview, allowing a local process connected to a deployed database to register and consume production jobs.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Add a validated `ENABLE_CRON_WORKERS` flag that defaults to `false`, document the local opt-in, and set it explicitly on the deployed ECS Studio container.
- Guard cron startup at the Next.js instrumentation, Studio initializer, and pg-boss registration boundaries.

**Bug Fixes**:

- Prevent Studio processes without the deployed-runtime flag from starting pg-boss, registering schedules, or consuming cron jobs.

## Before & After Screenshots

**BEFORE**:

Not applicable; this is a server runtime change.

**AFTER**:

Not applicable; this is a server runtime change.

## Tests

- `pnpm --filter @isomer/pgboss test:unit`
- `pnpm --filter @isomer/pgboss typecheck`
- `pnpm --filter isomer-studio typecheck`
- `pnpm --filter @isomer/pgboss lint`
- `pnpm --filter isomer-studio lint`
- `pnpm --filter @isomer/pgboss format`
- `pnpm --filter isomer-studio format`

**Manual Verification Steps**:

- [ ] Start Studio without `ENABLE_CRON_WORKERS`; verify startup logs report that cron workers are disabled and no pg-boss schedules or workers are registered.
- [ ] Start Studio against a local database with `ENABLE_CRON_WORKERS=true`; verify the cron jobs initialize and register normally.
- [ ] Deploy the ECS task definition and verify the Studio container receives `ENABLE_CRON_WORKERS=true` and cron jobs initialize successfully.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change makes background cron processing explicitly opt-in. Local Studio processes default to leaving workers disabled, while the deployed ECS task definition enables them.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: no blocking failure remains.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The harness explicitly exercised ENABLE\_CRON\_WORKERS=false against Studio instrumentation and PgBoss registration, including an enabled path with a client double asserting queue/work/schedule registration.
- The first runner invocation was rejected because the Studio Vitest config only includes src/\*\*/\*.test.\*, prompting the harness relocation.
- The relocated normal Studio runner was blocked before tests by Testcontainers due to the absence of a Docker/container runtime.
- An isolated config then allowed Studio imports but failed mandatory Studio environment validation because the required test environment was not loaded.
- Infrastructure-enabled PgBoss validation could not be run because Docker and PostgreSQL tooling were absent, and there was no listener on the package test database port 5431.

<a href="https://app.greptile.com/trex/runs/18451276/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: gate cron worker startup on explici..."](https://github.com/opengovsg/isomer/commit/f6015609dda876ac409415cc5222ed6553c22ead) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52470974)</sub>

<!-- /greptile_comment -->