### PR TITLE
fix: retry failed document ingestion jobs

### DIFF
--- a/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
+++ b/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
@@ -393,13 +393,13 @@ describe("schedulePushDocumentJobHandler", async () => {
       // Act
       await schedulePushDocumentJobHandler()
 
-      // Assert — saveObjects not called, but job row still deleted.
+      // Assert — saveObjects was not called, so the job remains for retry.
       expect(algoliaLib.saveObjectsToSearchIndex).not.toHaveBeenCalled()
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(0)
+      expect(remaining).toHaveLength(1)
     })
 
     it("isolates failures: one bad resource does not prevent others from being saved", async () => {
@@ -453,12 +453,53 @@ describe("schedulePushDocumentJobHandler", async () => {
 
       // Assert — saveObjects was called twice (once per resource).
       expect(algoliaLib.saveObjectsToSearchIndex).toHaveBeenCalledTimes(2)
-      // Both rows cleaned up regardless.
+      // Only the successfully pushed row is cleaned up; the failed row is
+      // retained for the next tick.
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(0)
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.resourceId).toBe(String(badId))
+    })
+
+    it("preserves a job that is rescheduled while Algolia ingestion is in flight", async () => {
+      // Arrange
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/rescheduled/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const rescheduledAt = addMinutes(FIXED_NOW, 30)
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      vi.mocked(algoliaLib.saveObjectsToSearchIndex).mockImplementation(
+        async () => {
+          await db
+            .updateTable("PushDocumentJob")
+            .set({ scheduledAt: rescheduledAt })
+            .where("resourceId", "=", String(resourceId))
+            .execute()
+        },
+      )
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — cleanup must not delete the updated schedule.
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(remaining.scheduledAt).toEqual(rescheduledAt)
     })
 
     it("dispatches a resource that was already published (publishing cron won the race)", async () => {
@@ -643,13 +684,12 @@ describe("schedulePushDocumentJobHandler", async () => {
       // Assert — Algolia and SearchSG both skipped (no valid documents).
       expect(algoliaLib.saveObjectsToSearchIndex).not.toHaveBeenCalled()
       expect(global.fetch).not.toHaveBeenCalled()
-      // Row still cleaned up — the worker treats malformed content as a
-      // permanent failure for that row, not a transient error.
+      // The malformed row was not pushed, so it remains for retry.
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(0)
+      expect(remaining).toHaveLength(1)
     })
   })
 
@@ -719,6 +759,116 @@ describe("schedulePushDocumentJobHandler", async () => {
           ContentDisposition: `inline; filename="Document Title.pdf"`,
         }),
       )
+    })
+
+    it("deletes only rows successfully included in the SearchSG batch", async () => {
+      // Arrange
+      const { resourceId: goodId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/good/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const { resourceId: badId, ref: badRef } =
+        await seedDocumentReadyForIngestion({
+          parentTitle: "Notices2",
+          ref: "/bad/gazette.pdf",
+          category: "Government Gazettes",
+          publishedBy: user.id,
+        })
+
+      await db
+        .insertInto("PushDocumentJob")
+        .values([
+          {
+            resourceId: String(goodId),
+            scheduledAt: FIXED_NOW,
+            scheduledBy: user.id,
+          },
+          {
+            resourceId: String(badId),
+            scheduledAt: FIXED_NOW,
+            scheduledBy: user.id,
+          },
+        ])
+        .execute()
+
+      vi.mocked(s3Lib.getBlob).mockImplementation((_bucket, key) => {
+        if (key === badRef.slice(1)) {
+          return Promise.reject(new Error("S3 error"))
+        }
+        return Promise.resolve(new Uint8Array([1, 2, 3]))
+      })
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — the successful document was pushed and removed from the
+      // queue, while the failed row remains for the next tick.
+      const ingestCall = vi
+        .mocked(global.fetch)
+        .mock.calls.find(([u]) => urlToString(u).includes("/documents"))
+      expect(ingestCall).toBeDefined()
+      const ingestBody = ingestCall![1]?.body as string
+      const body = JSON.parse(ingestBody) as {
+        documentsToAdd: Record<string, unknown>[]
+      }
+      expect(body.documentsToAdd).toHaveLength(1)
+
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .execute()
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.resourceId).toBe(String(badId))
+    })
+
+    it("preserves a job that is rescheduled while SearchSG ingestion is in flight", async () => {
+      // Arrange
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/rescheduled/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const rescheduledAt = addMinutes(FIXED_NOW, 30)
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      vi.mocked(global.fetch).mockImplementation(async (input) => {
+        const u = urlToString(input)
+        if (u.endsWith("/v1/auth/token")) {
+          return new Response(
+            JSON.stringify({ accessToken: "test-token", tokenType: "Bearer" }),
+            { status: 200 },
+          )
+        }
+        if (u.includes("/documents")) {
+          await db
+            .updateTable("PushDocumentJob")
+            .set({ scheduledAt: rescheduledAt })
+            .where("resourceId", "=", String(resourceId))
+            .execute()
+          return new Response("{}", { status: 200 })
+        }
+        throw new Error(`Unexpected fetch: ${u}`)
+      })
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — cleanup must not delete the updated schedule.
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(remaining.scheduledAt).toEqual(rescheduledAt)
     })
 
     it("skips rows scheduled for the future", async () => {

--- a/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
+++ b/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
@@ -384,13 +384,13 @@ describe("schedulePushDocumentJobHandler", async () => {
       // Act
       await schedulePushDocumentJobHandler()
 
-      // Assert — saveObjects not called, but job row still deleted.
+      // Assert — saveObjects was not called, so the job remains for retry.
       expect(algoliaLib.saveObjectsToSearchIndex).not.toHaveBeenCalled()
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(0)
+      expect(remaining).toHaveLength(1)
     })
 
     it("isolates failures: one bad resource does not prevent others from being saved", async () => {
@@ -444,12 +444,53 @@ describe("schedulePushDocumentJobHandler", async () => {
 
       // Assert — saveObjects was called twice (once per resource).
       expect(algoliaLib.saveObjectsToSearchIndex).toHaveBeenCalledTimes(2)
-      // Both rows cleaned up regardless.
+      // Only the successfully pushed row is cleaned up; the failed row is
+      // retained for the next tick.
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(0)
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.resourceId).toBe(String(badId))
+    })
+
+    it("preserves a job that is rescheduled while Algolia ingestion is in flight", async () => {
+      // Arrange
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/rescheduled/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const rescheduledAt = addMinutes(FIXED_NOW, 30)
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      vi.mocked(algoliaLib.saveObjectsToSearchIndex).mockImplementation(
+        async () => {
+          await db
+            .updateTable("PushDocumentJob")
+            .set({ scheduledAt: rescheduledAt })
+            .where("resourceId", "=", String(resourceId))
+            .execute()
+        },
+      )
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — cleanup must not delete the updated schedule.
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(remaining.scheduledAt).toEqual(rescheduledAt)
     })
 
     it("dispatches a resource that was already published (publishing cron won the race)", async () => {
@@ -634,13 +675,12 @@ describe("schedulePushDocumentJobHandler", async () => {
       // Assert — Algolia and SearchSG both skipped (no valid documents).
       expect(algoliaLib.saveObjectsToSearchIndex).not.toHaveBeenCalled()
       expect(global.fetch).not.toHaveBeenCalled()
-      // Row still cleaned up — the worker treats malformed content as a
-      // permanent failure for that row, not a transient error.
+      // The malformed row was not pushed, so it remains for retry.
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(0)
+      expect(remaining).toHaveLength(1)
     })
   })
 
@@ -702,6 +742,116 @@ describe("schedulePushDocumentJobHandler", async () => {
       // S3 + PDF parser were each invoked exactly once.
       expect(s3Lib.getBlob).toHaveBeenCalledTimes(1)
       expect(gazetteService.parseFullTextFromPDF).toHaveBeenCalledTimes(1)
+    })
+
+    it("deletes only rows successfully included in the SearchSG batch", async () => {
+      // Arrange
+      const { resourceId: goodId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/good/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const { resourceId: badId, ref: badRef } =
+        await seedDocumentReadyForIngestion({
+          parentTitle: "Notices2",
+          ref: "/bad/gazette.pdf",
+          category: "Government Gazettes",
+          publishedBy: user.id,
+        })
+
+      await db
+        .insertInto("PushDocumentJob")
+        .values([
+          {
+            resourceId: String(goodId),
+            scheduledAt: FIXED_NOW,
+            scheduledBy: user.id,
+          },
+          {
+            resourceId: String(badId),
+            scheduledAt: FIXED_NOW,
+            scheduledBy: user.id,
+          },
+        ])
+        .execute()
+
+      vi.mocked(s3Lib.getBlob).mockImplementation((_bucket, key) => {
+        if (key === badRef.slice(1)) {
+          return Promise.reject(new Error("S3 error"))
+        }
+        return Promise.resolve(new Uint8Array([1, 2, 3]))
+      })
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — the successful document was pushed and removed from the
+      // queue, while the failed row remains for the next tick.
+      const ingestCall = vi
+        .mocked(global.fetch)
+        .mock.calls.find(([u]) => urlToString(u).includes("/documents"))
+      expect(ingestCall).toBeDefined()
+      const ingestBody = ingestCall![1]?.body as string
+      const body = JSON.parse(ingestBody) as {
+        documentsToAdd: Record<string, unknown>[]
+      }
+      expect(body.documentsToAdd).toHaveLength(1)
+
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .execute()
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.resourceId).toBe(String(badId))
+    })
+
+    it("preserves a job that is rescheduled while SearchSG ingestion is in flight", async () => {
+      // Arrange
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/rescheduled/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      const rescheduledAt = addMinutes(FIXED_NOW, 30)
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      vi.mocked(global.fetch).mockImplementation(async (input) => {
+        const u = urlToString(input)
+        if (u.endsWith("/v1/auth/token")) {
+          return new Response(
+            JSON.stringify({ accessToken: "test-token", tokenType: "Bearer" }),
+            { status: 200 },
+          )
+        }
+        if (u.includes("/documents")) {
+          await db
+            .updateTable("PushDocumentJob")
+            .set({ scheduledAt: rescheduledAt })
+            .where("resourceId", "=", String(resourceId))
+            .execute()
+          return new Response("{}", { status: 200 })
+        }
+        throw new Error(`Unexpected fetch: ${u}`)
+      })
+
+      // Act
+      await schedulePushDocumentJobHandler()
+
+      // Assert — cleanup must not delete the updated schedule.
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(remaining.scheduledAt).toEqual(rescheduledAt)
     })
 
     it("skips rows scheduled for the future", async () => {

--- a/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
+++ b/apps/studio/src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts
@@ -372,7 +372,7 @@ describe("schedulePushDocumentJobHandler", async () => {
       expect(records[0]).toMatchObject({ notificationNum: "12345" })
     })
 
-    it("skips save when PDF text is empty (no records built)", async () => {
+    it("drops an empty PDF job after three failed attempts", async () => {
       // Arrange
       vi.spyOn(gazetteService, "parseFullTextFromPDF").mockResolvedValue("")
       const { resourceId } = await seedDocumentReadyForIngestion({
@@ -393,13 +393,28 @@ describe("schedulePushDocumentJobHandler", async () => {
       // Act
       await schedulePushDocumentJobHandler()
 
-      // Assert — saveObjects was not called, so the job remains for retry.
+      // Assert — the first two failures are retained for retry.
       expect(algoliaLib.saveObjectsToSearchIndex).not.toHaveBeenCalled()
+      const firstAttempt = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(firstAttempt.attempts).toBe(1)
+
+      await schedulePushDocumentJobHandler()
+      const secondAttempt = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(secondAttempt.attempts).toBe(2)
+
+      // The third failure exhausts the job instead of retrying forever.
+      await schedulePushDocumentJobHandler()
       const remaining = await db
         .selectFrom("PushDocumentJob")
         .selectAll()
         .execute()
-      expect(remaining).toHaveLength(1)
+      expect(remaining).toHaveLength(0)
     })
 
     it("isolates failures: one bad resource does not prevent others from being saved", async () => {
@@ -461,6 +476,7 @@ describe("schedulePushDocumentJobHandler", async () => {
         .execute()
       expect(remaining).toHaveLength(1)
       expect(remaining[0]?.resourceId).toBe(String(badId))
+      expect(remaining[0]?.attempts).toBe(1)
     })
 
     it("preserves a job that is rescheduled while Algolia ingestion is in flight", async () => {
@@ -635,6 +651,7 @@ describe("schedulePushDocumentJobHandler", async () => {
         .selectAll()
         .execute()
       expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.attempts).toBe(0)
     })
 
     it("logs and skips a row whose blob content does not match the expected shape", async () => {
@@ -690,6 +707,7 @@ describe("schedulePushDocumentJobHandler", async () => {
         .selectAll()
         .execute()
       expect(remaining).toHaveLength(1)
+      expect(remaining[0]?.attempts).toBe(1)
     })
   })
 
@@ -821,6 +839,117 @@ describe("schedulePushDocumentJobHandler", async () => {
         .execute()
       expect(remaining).toHaveLength(1)
       expect(remaining[0]?.resourceId).toBe(String(badId))
+      expect(remaining[0]?.attempts).toBe(1)
+    })
+
+    it("bounds each SearchSG tick and processes duplicate-resource jobs", async () => {
+      // Arrange — one more row than the per-tick batch size also proves that
+      // duplicate jobs for a resource are not collapsed by the source query.
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/backlog/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      await db
+        .insertInto("PushDocumentJob")
+        .values(
+          Array.from({ length: 21 }, () => ({
+            resourceId: String(resourceId),
+            scheduledAt: FIXED_NOW,
+            scheduledBy: user.id,
+          })),
+        )
+        .execute()
+
+      // Act — the first tick processes only the bounded batch.
+      await schedulePushDocumentJobHandler()
+
+      // Assert
+      const afterFirstTick = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .execute()
+      expect(afterFirstTick).toHaveLength(1)
+
+      await schedulePushDocumentJobHandler()
+      const afterSecondTick = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .execute()
+      expect(afterSecondTick).toHaveLength(0)
+
+      const ingestBatchSizes = vi
+        .mocked(global.fetch)
+        .mock.calls.filter(([u]) => urlToString(u).includes("/documents"))
+        .map(([, init]) => {
+          const body = JSON.parse(init?.body as string) as {
+            documentsToAdd: Record<string, unknown>[]
+          }
+          return body.documentsToAdd.length
+        })
+      expect(ingestBatchSizes).toEqual([20, 1])
+    })
+
+    it("drops a SearchSG job after three failed ingestion attempts", async () => {
+      // Arrange
+      const { resourceId } = await seedDocumentReadyForIngestion({
+        parentTitle: "Notices",
+        ref: "/failed/gazette.pdf",
+        category: "Government Gazettes",
+        publishedBy: user.id,
+      })
+      await db
+        .insertInto("PushDocumentJob")
+        .values({
+          resourceId: String(resourceId),
+          scheduledAt: FIXED_NOW,
+          scheduledBy: user.id,
+        })
+        .execute()
+
+      vi.mocked(global.fetch).mockImplementation((input) => {
+        const u = urlToString(input)
+        if (u.endsWith("/v1/auth/token")) {
+          return Promise.resolve(
+            new Response(
+              JSON.stringify({
+                accessToken: "test-token",
+                tokenType: "Bearer",
+              }),
+              { status: 200 },
+            ),
+          )
+        }
+        if (u.includes("/documents")) {
+          return Promise.resolve(
+            new Response("SearchSG unavailable", { status: 503 }),
+          )
+        }
+        return Promise.reject(new Error(`Unexpected fetch: ${u}`))
+      })
+
+      // Act + Assert — failures are persisted and capped.
+      await schedulePushDocumentJobHandler()
+      const firstAttempt = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(firstAttempt.attempts).toBe(1)
+
+      await schedulePushDocumentJobHandler()
+      const secondAttempt = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(secondAttempt.attempts).toBe(2)
+
+      await schedulePushDocumentJobHandler()
+      const remaining = await db
+        .selectFrom("PushDocumentJob")
+        .selectAll()
+        .execute()
+      expect(remaining).toHaveLength(0)
     })
 
     it("preserves a job that is rescheduled while SearchSG ingestion is in flight", async () => {

--- a/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
+++ b/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
@@ -20,12 +20,17 @@ import { registerPgbossJob } from "@isomer/pgboss"
 const JOB_NAME = "schedule-push-document"
 const CRON_SCHEDULE = "* * * * *" // every minute
 const SEARCHSG_CONTENT_LENGTH = 50000
+// Retain transient failures, but discard a poison job after three attempts.
+const MAX_ATTEMPTS = 3
+// Bound extraction, external requests, and cleanup-query size for each tick.
+const BATCH_SIZE = 20
 
 const logger = createBaseLogger({ path: "cron:schedulePushDocumentJob" })
 
 interface ProcessedJob {
   jobId: string
   scheduledAt: Date
+  attempts: number
 }
 
 const pushDocumentContentSchema = z.object({
@@ -186,8 +191,9 @@ export const schedulePushDocumentJobHandler = async () => {
       .leftJoin("Blob as PublishedBlob", "PublishedBlob.id", "Version.blobId")
       .leftJoin("Blob as DraftBlob", "DraftBlob.id", "Resource.draftBlobId")
       .where("PushDocumentJob.scheduledAt", "<=", scheduledAtCutoff)
-      .distinctOn("Resource.id")
-      .orderBy("Resource.id")
+      .orderBy("PushDocumentJob.scheduledAt")
+      .orderBy("PushDocumentJob.id")
+      .limit(BATCH_SIZE)
       .select([
         (eb) =>
           eb.fn
@@ -198,6 +204,7 @@ export const schedulePushDocumentJobHandler = async () => {
         "Resource.parentId",
         "PushDocumentJob.id as jobId",
         "PushDocumentJob.scheduledAt",
+        "PushDocumentJob.attempts",
       ])
       .execute()
 
@@ -207,11 +214,17 @@ export const schedulePushDocumentJobHandler = async () => {
         async ({
           jobId,
           scheduledAt,
+          attempts,
           resourceId,
           title,
           parentId,
           content,
         }) => {
+          const job = {
+            jobId,
+            scheduledAt,
+            attempts: attempts ?? 0,
+          }
           try {
             const extracted = await extractResourceData({
               resourceId,
@@ -219,14 +232,13 @@ export const schedulePushDocumentJobHandler = async () => {
               title,
               content,
             })
-            if (extracted === null) return null
+            if (extracted === null) return { job, document: null }
 
             const { ref, pdfTextContent, subcategoryLabel, parsedPage } =
               extracted
 
             return {
-              jobId,
-              scheduledAt,
+              job,
               document: {
                 // SearchSG dedupes on documentId, so derive a stable id from the
                 // S3 key + resourceId. Re-uploads of the same key produce the
@@ -242,20 +254,33 @@ export const schedulePushDocumentJobHandler = async () => {
             }
           } catch (error) {
             logger.error({ error, resourceId }, "Failed to process document")
-            return null
+            return { job, document: null }
           }
         },
       )
 
       const resolvedDocuments = await Promise.all(documentPromises)
       const processedDocuments = resolvedDocuments.filter(
-        (result): result is ProcessedJob & { document: PushDocument } =>
-          result !== null,
+        (result): result is { job: ProcessedJob; document: PushDocument } =>
+          result.document !== null,
       )
       const documents = processedDocuments.map(({ document }) => document)
+      const failedJobs = resolvedDocuments
+        .filter(({ document }) => document === null)
+        .map(({ job }) => job)
 
-      await pushDocumentsForIngestion(documents)
-      await deleteProcessedJobs(processedDocuments)
+      await recordFailedJobs(failedJobs)
+      try {
+        await pushDocumentsForIngestion(documents)
+      } catch (error) {
+        logger.error(
+          { error, count: processedDocuments.length },
+          "Failed to push SearchSG document batch",
+        )
+        await recordFailedJobs(processedDocuments.map(({ job }) => job))
+        return
+      }
+      await deleteProcessedJobs(processedDocuments.map(({ job }) => job))
       logger.info(
         { count: documents.length, documents },
         "Completed schedule push document job (SearchSG)",
@@ -271,11 +296,18 @@ export const schedulePushDocumentJobHandler = async () => {
       for (const {
         jobId,
         scheduledAt,
+        attempts,
         resourceId,
         title,
         parentId,
         content,
       } of scheduledResources) {
+        const job = {
+          jobId,
+          scheduledAt,
+          attempts: attempts ?? 0,
+        }
+        let succeeded = false
         try {
           const extracted = await extractResourceData({
             resourceId,
@@ -283,7 +315,9 @@ export const schedulePushDocumentJobHandler = async () => {
             title,
             content,
           })
-          if (extracted === null) continue
+          if (extracted === null) {
+            continue
+          }
 
           const {
             objectGroup,
@@ -313,7 +347,8 @@ export const schedulePushDocumentJobHandler = async () => {
           }
 
           await saveObjectsToSearchIndex(records)
-          processedJobs.push({ jobId, scheduledAt })
+          processedJobs.push(job)
+          succeeded = true
           savedCount++
           logger.info({ resourceId, count: records.length }, "Saved to Algolia")
         } catch (error) {
@@ -321,6 +356,10 @@ export const schedulePushDocumentJobHandler = async () => {
             { error, resourceId },
             "Failed to process document for Algolia",
           )
+        } finally {
+          if (!succeeded) {
+            await recordFailedJobs([job])
+          }
         }
       }
 
@@ -340,14 +379,64 @@ const deleteProcessedJobs = async (jobs: ProcessedJob[]) => {
 
   // A user can reschedule the same row while external ingestion is in flight.
   // Match the selected timestamp as well as the id so the updated job survives.
-  await db
-    .deleteFrom("PushDocumentJob")
-    .where((eb) =>
-      eb.or(
-        jobs.map(({ jobId, scheduledAt }) =>
-          eb.and([eb("id", "=", jobId), eb("scheduledAt", "=", scheduledAt)]),
+  for (let offset = 0; offset < jobs.length; offset += BATCH_SIZE) {
+    const batch = jobs.slice(offset, offset + BATCH_SIZE)
+    await db
+      .deleteFrom("PushDocumentJob")
+      .where((eb) =>
+        eb.or(
+          batch.map(({ jobId, scheduledAt }) =>
+            eb.and([eb("id", "=", jobId), eb("scheduledAt", "=", scheduledAt)]),
+          ),
         ),
-      ),
+      )
+      .execute()
+  }
+}
+
+const recordFailedJobs = async (jobs: ProcessedJob[]) => {
+  if (jobs.length === 0) return
+
+  const exhaustedJobs: ProcessedJob[] = []
+  const retryableJobsByAttempt = new Map<number, ProcessedJob[]>()
+
+  for (const job of jobs) {
+    const nextAttempt = job.attempts + 1
+    if (nextAttempt >= MAX_ATTEMPTS) {
+      exhaustedJobs.push(job)
+      continue
+    }
+
+    const retryableJobs = retryableJobsByAttempt.get(nextAttempt) ?? []
+    retryableJobs.push(job)
+    retryableJobsByAttempt.set(nextAttempt, retryableJobs)
+  }
+
+  for (const [attempts, retryableJobs] of retryableJobsByAttempt) {
+    for (let offset = 0; offset < retryableJobs.length; offset += BATCH_SIZE) {
+      const batch = retryableJobs.slice(offset, offset + BATCH_SIZE)
+      await db
+        .updateTable("PushDocumentJob")
+        .set({ attempts, updatedAt: new Date() })
+        .where((eb) =>
+          eb.or(
+            batch.map(({ jobId, scheduledAt }) =>
+              eb.and([
+                eb("id", "=", jobId),
+                eb("scheduledAt", "=", scheduledAt),
+              ]),
+            ),
+          ),
+        )
+        .execute()
+    }
+  }
+
+  if (exhaustedJobs.length > 0) {
+    logger.error(
+      { jobIds: exhaustedJobs.map(({ jobId }) => jobId) },
+      "Dropping document ingestion jobs after maximum attempts",
     )
-    .execute()
+    await deleteProcessedJobs(exhaustedJobs)
+  }
 }

--- a/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
+++ b/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
@@ -22,6 +22,11 @@ const SEARCHSG_CONTENT_LENGTH = 50000
 
 const logger = createBaseLogger({ path: "cron:schedulePushDocumentJob" })
 
+interface ProcessedJob {
+  jobId: string
+  scheduledAt: Date
+}
+
 const pushDocumentContentSchema = z.object({
   page: z.object({
     ref: z.string(),
@@ -186,6 +191,7 @@ export const schedulePushDocumentJobHandler = async () => {
         "Resource.title",
         "Resource.id as resourceId",
         "Resource.parentId",
+        "PushDocumentJob.id as jobId",
         "PushDocumentJob.scheduledAt",
       ])
       .execute()
@@ -193,7 +199,14 @@ export const schedulePushDocumentJobHandler = async () => {
     if (useSearchSg) {
       // --- SearchSG path (flag ON) ---
       const documentPromises = scheduledResources.map(
-        async ({ scheduledAt, resourceId, title, parentId, content }) => {
+        async ({
+          jobId,
+          scheduledAt,
+          resourceId,
+          title,
+          parentId,
+          content,
+        }) => {
           try {
             const extracted = await extractResourceData({
               resourceId,
@@ -206,16 +219,20 @@ export const schedulePushDocumentJobHandler = async () => {
               extracted
 
             return {
-              // SearchSG dedupes on documentId, so derive a stable id from the
-              // S3 key + resourceId. Re-uploads of the same key produce the
-              // same id, avoiding duplicate search hits.
-              documentId: generateDocumentId(ref, String(resourceId)),
-              content: pdfTextContent.slice(0, SEARCHSG_CONTENT_LENGTH),
-              title,
-              url: encodeURI(`https://${env.S3_GAZETTE_DOMAIN_NAME}${ref}`),
-              date: scheduledAt.toISOString(),
-              categories: subcategoryLabel ? [subcategoryLabel] : [],
-              contentType: parsedPage.category,
+              jobId,
+              scheduledAt,
+              document: {
+                // SearchSG dedupes on documentId, so derive a stable id from the
+                // S3 key + resourceId. Re-uploads of the same key produce the
+                // same id, avoiding duplicate search hits.
+                documentId: generateDocumentId(ref, String(resourceId)),
+                content: pdfTextContent.slice(0, SEARCHSG_CONTENT_LENGTH),
+                title,
+                url: encodeURI(`https://${env.S3_GAZETTE_DOMAIN_NAME}${ref}`),
+                date: scheduledAt.toISOString(),
+                categories: subcategoryLabel ? [subcategoryLabel] : [],
+                contentType: parsedPage.category,
+              },
             }
           } catch (error) {
             logger.error({ error, resourceId }, "Failed to process document")
@@ -225,12 +242,14 @@ export const schedulePushDocumentJobHandler = async () => {
       )
 
       const resolvedDocuments = await Promise.all(documentPromises)
-      const documents = resolvedDocuments.filter(
-        (document): document is PushDocument => document !== null,
+      const processedDocuments = resolvedDocuments.filter(
+        (result): result is ProcessedJob & { document: PushDocument } =>
+          result !== null,
       )
+      const documents = processedDocuments.map(({ document }) => document)
 
       await pushDocumentsForIngestion(documents)
-      await deleteProcessedJobs(scheduledAtCutoff)
+      await deleteProcessedJobs(processedDocuments)
       logger.info(
         { count: documents.length, documents },
         "Completed schedule push document job (SearchSG)",
@@ -238,11 +257,13 @@ export const schedulePushDocumentJobHandler = async () => {
     } else {
       // --- Algolia path (flag OFF, default) ---
       let savedCount = 0
+      const processedJobs: ProcessedJob[] = []
       // NOTE: This is deliberate done using a `for .. await` loop
       // to avoid running into rate-limits with Algolia. DO NOT
       // change this to a `map` as it might cause the publish to fail
       // due to the records not being ingested by Algolia
       for (const {
+        jobId,
         scheduledAt,
         resourceId,
         title,
@@ -285,6 +306,7 @@ export const schedulePushDocumentJobHandler = async () => {
           }
 
           await saveObjectsToSearchIndex(records)
+          processedJobs.push({ jobId, scheduledAt })
           savedCount++
           logger.info({ resourceId, count: records.length }, "Saved to Algolia")
         } catch (error) {
@@ -295,7 +317,7 @@ export const schedulePushDocumentJobHandler = async () => {
         }
       }
 
-      await deleteProcessedJobs(scheduledAtCutoff)
+      await deleteProcessedJobs(processedJobs)
       logger.info(
         { count: savedCount, attempted: scheduledResources.length },
         "Completed schedule push document job (Algolia)",
@@ -306,12 +328,19 @@ export const schedulePushDocumentJobHandler = async () => {
   }
 }
 
-// Drop every job whose scheduledAt has passed, regardless of per-row push
-// outcome — failed rows are logged above and not retried in-band, matching
-// the existing schedule-publishing semantics.
-const deleteProcessedJobs = async (scheduledAtCutoff: Date) => {
+const deleteProcessedJobs = async (jobs: ProcessedJob[]) => {
+  if (jobs.length === 0) return
+
+  // A user can reschedule the same row while external ingestion is in flight.
+  // Match the selected timestamp as well as the id so the updated job survives.
   await db
     .deleteFrom("PushDocumentJob")
-    .where("scheduledAt", "<=", scheduledAtCutoff)
+    .where((eb) =>
+      eb.or(
+        jobs.map(({ jobId, scheduledAt }) =>
+          eb.and([eb("id", "=", jobId), eb("scheduledAt", "=", scheduledAt)]),
+        ),
+      ),
+    )
     .execute()
 }

--- a/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
+++ b/apps/studio/src/server/cron/jobs/schedulePushDocumentJob.ts
@@ -23,6 +23,11 @@ const SEARCHSG_CONTENT_LENGTH = 50000
 
 const logger = createBaseLogger({ path: "cron:schedulePushDocumentJob" })
 
+interface ProcessedJob {
+  jobId: string
+  scheduledAt: Date
+}
+
 const pushDocumentContentSchema = z.object({
   page: z.object({
     ref: z.string(),
@@ -191,6 +196,7 @@ export const schedulePushDocumentJobHandler = async () => {
         "Resource.title",
         "Resource.id as resourceId",
         "Resource.parentId",
+        "PushDocumentJob.id as jobId",
         "PushDocumentJob.scheduledAt",
       ])
       .execute()
@@ -198,7 +204,14 @@ export const schedulePushDocumentJobHandler = async () => {
     if (useSearchSg) {
       // --- SearchSG path (flag ON) ---
       const documentPromises = scheduledResources.map(
-        async ({ scheduledAt, resourceId, title, parentId, content }) => {
+        async ({
+          jobId,
+          scheduledAt,
+          resourceId,
+          title,
+          parentId,
+          content,
+        }) => {
           try {
             const extracted = await extractResourceData({
               resourceId,
@@ -212,16 +225,20 @@ export const schedulePushDocumentJobHandler = async () => {
               extracted
 
             return {
-              // SearchSG dedupes on documentId, so derive a stable id from the
-              // S3 key + resourceId. Re-uploads of the same key produce the
-              // same id, avoiding duplicate search hits.
-              documentId: generateDocumentId(ref, String(resourceId)),
-              content: pdfTextContent.slice(0, SEARCHSG_CONTENT_LENGTH),
-              title,
-              url: encodeURI(`https://${env.S3_GAZETTE_DOMAIN_NAME}${ref}`),
-              date: scheduledAt.toISOString(),
-              categories: subcategoryLabel ? [subcategoryLabel] : [],
-              contentType: parsedPage.category,
+              jobId,
+              scheduledAt,
+              document: {
+                // SearchSG dedupes on documentId, so derive a stable id from the
+                // S3 key + resourceId. Re-uploads of the same key produce the
+                // same id, avoiding duplicate search hits.
+                documentId: generateDocumentId(ref, String(resourceId)),
+                content: pdfTextContent.slice(0, SEARCHSG_CONTENT_LENGTH),
+                title,
+                url: encodeURI(`https://${env.S3_GAZETTE_DOMAIN_NAME}${ref}`),
+                date: scheduledAt.toISOString(),
+                categories: subcategoryLabel ? [subcategoryLabel] : [],
+                contentType: parsedPage.category,
+              },
             }
           } catch (error) {
             logger.error({ error, resourceId }, "Failed to process document")
@@ -231,12 +248,14 @@ export const schedulePushDocumentJobHandler = async () => {
       )
 
       const resolvedDocuments = await Promise.all(documentPromises)
-      const documents = resolvedDocuments.filter(
-        (document): document is PushDocument => document !== null,
+      const processedDocuments = resolvedDocuments.filter(
+        (result): result is ProcessedJob & { document: PushDocument } =>
+          result !== null,
       )
+      const documents = processedDocuments.map(({ document }) => document)
 
       await pushDocumentsForIngestion(documents)
-      await deleteProcessedJobs(scheduledAtCutoff)
+      await deleteProcessedJobs(processedDocuments)
       logger.info(
         { count: documents.length, documents },
         "Completed schedule push document job (SearchSG)",
@@ -244,11 +263,13 @@ export const schedulePushDocumentJobHandler = async () => {
     } else {
       // --- Algolia path (flag OFF, default) ---
       let savedCount = 0
+      const processedJobs: ProcessedJob[] = []
       // NOTE: This is deliberate done using a `for .. await` loop
       // to avoid running into rate-limits with Algolia. DO NOT
       // change this to a `map` as it might cause the publish to fail
       // due to the records not being ingested by Algolia
       for (const {
+        jobId,
         scheduledAt,
         resourceId,
         title,
@@ -292,6 +313,7 @@ export const schedulePushDocumentJobHandler = async () => {
           }
 
           await saveObjectsToSearchIndex(records)
+          processedJobs.push({ jobId, scheduledAt })
           savedCount++
           logger.info({ resourceId, count: records.length }, "Saved to Algolia")
         } catch (error) {
@@ -302,7 +324,7 @@ export const schedulePushDocumentJobHandler = async () => {
         }
       }
 
-      await deleteProcessedJobs(scheduledAtCutoff)
+      await deleteProcessedJobs(processedJobs)
       logger.info(
         { count: savedCount, attempted: scheduledResources.length },
         "Completed schedule push document job (Algolia)",
@@ -313,12 +335,19 @@ export const schedulePushDocumentJobHandler = async () => {
   }
 }
 
-// Drop every job whose scheduledAt has passed, regardless of per-row push
-// outcome — failed rows are logged above and not retried in-band, matching
-// the existing schedule-publishing semantics.
-const deleteProcessedJobs = async (scheduledAtCutoff: Date) => {
+const deleteProcessedJobs = async (jobs: ProcessedJob[]) => {
+  if (jobs.length === 0) return
+
+  // A user can reschedule the same row while external ingestion is in flight.
+  // Match the selected timestamp as well as the id so the updated job survives.
   await db
     .deleteFrom("PushDocumentJob")
-    .where("scheduledAt", "<=", scheduledAtCutoff)
+    .where((eb) =>
+      eb.or(
+        jobs.map(({ jobId, scheduledAt }) =>
+          eb.and([eb("id", "=", jobId), eb("scheduledAt", "=", scheduledAt)]),
+        ),
+      ),
+    )
     .execute()
 }

--- a/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
+++ b/apps/studio/src/server/modules/gazette/__tests__/gazette.router.test.ts
@@ -584,6 +584,48 @@ describe("gazette.router", async () => {
       expect(after.scheduledAt).toEqual(PAST_DATE)
     })
 
+    it("resets document ingestion attempts when a gazette is rescheduled", async () => {
+      // Arrange
+      const { site, collection } = await seedToppanWithCollection()
+      const { gazetteId } = await caller.create({
+        siteId: site.id,
+        collectionId: Number(collection.id),
+        title: "Retrying Gazette",
+        permalink: crypto.randomUUID(),
+        ref: "/1/abc/retrying.pdf",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: PAST_DATE,
+      })
+      await db
+        .updateTable("PushDocumentJob")
+        .set({ attempts: 2 })
+        .where("resourceId", "=", String(gazetteId))
+        .execute()
+      const rescheduledAt = subMinutes(PAST_DATE, 1)
+
+      // Act
+      await caller.update({
+        siteId: site.id,
+        gazetteId: Number(gazetteId),
+        title: "Retrying Gazette",
+        category: "Government Gazette",
+        date: "30/04/2026",
+        tagged: ["sub-1"],
+        scheduledAt: rescheduledAt,
+      })
+
+      // Assert
+      const pushJob = await db
+        .selectFrom("PushDocumentJob")
+        .where("resourceId", "=", String(gazetteId))
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(pushJob.scheduledAt).toEqual(rescheduledAt)
+      expect(pushJob.attempts).toBe(0)
+    })
+
     it("rejects update when changing to a file ID that already exists", async () => {
       // Arrange
       const { site, collection } = await seedToppanWithCollection()

--- a/apps/studio/src/server/modules/gazette/gazette.router.ts
+++ b/apps/studio/src/server/modules/gazette/gazette.router.ts
@@ -583,6 +583,7 @@ export const gazetteRouter = router({
                 .set({
                   scheduledAt,
                   scheduledBy: user.id,
+                  attempts: 0,
                 })
                 .where("resourceId", "=", String(gazetteId))
                 .where("resourceId", "in", (eb) =>

--- a/packages/db/prisma/migrations/20260825000000_add_push_document_job_attempts/migration.sql
+++ b/packages/db/prisma/migrations/20260825000000_add_push_document_job_attempts/migration.sql
@@ -1,0 +1,2 @@
+-- AddColumn
+ALTER TABLE "PushDocumentJob" ADD COLUMN "attempts" INTEGER DEFAULT 0;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -362,6 +362,8 @@ model PushDocumentJob {
   scheduledAt DateTime
   scheduledBy String
   scheduler   User     @relation(fields: [scheduledBy], references: [id], onDelete: Restrict)
+  // Nullable for backwards-compatible rollout; new and migrated rows default to zero.
+  attempts Int? @default(0)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt

--- a/packages/db/src/generated/generatedTypes.ts
+++ b/packages/db/src/generated/generatedTypes.ts
@@ -104,6 +104,7 @@ export interface PushDocumentJob {
   resourceId: string
   scheduledAt: Timestamp
   scheduledBy: string
+  attempts: Generated<number | null>
   createdAt: Generated<Timestamp>
   updatedAt: Generated<Timestamp>
 }


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +152 | -29 |
| 🧪 Test | 2 | +328 | -7 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 1 | +1 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Document ingestion jobs were deleted after transient Algolia or SearchSG failures, preventing retries; cleanup could also remove a concurrently rescheduled job or overflow on a large queue.

Closes ISOM-2478

## Solution

Process at most 20 scheduled jobs per tick, persist up to three processing attempts, and delete successful or exhausted rows only when both their ID and original schedule timestamp still match. Process duplicate jobs deterministically, and reset the retry counter when a gazette is rescheduled.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Bound queue selection, external ingestion batches, and cleanup predicates to 20 jobs per tick.
- Persist retry attempts with a backwards-compatible nullable database column.

**Bug Fixes**:

- Retain failed jobs for retry and discard poison jobs after the third failed attempt.
- Preserve jobs rescheduled while ingestion is in flight.
- Process every queued row instead of dropping duplicate resource jobs through `distinctOn`.

## Before & After Screenshots

Not applicable; this is a background job change.

## Tests

- `pnpm --filter isomer-studio exec dotenv -e .env.test -- vitest run src/server/cron/jobs/__test__/schedulePushDocumentJob.test.ts src/server/modules/gazette/__tests__/gazette.router.test.ts`
- `pnpm run lint && pnpm run lint:ws`
- `pnpm run format`
- `pnpm run typecheck`

**Manual Verification Steps**:

- [ ] Trigger transient Algolia and SearchSG failures and confirm each job is retried up to three attempts.
- [ ] Reschedule a job while ingestion is in progress and confirm the updated job remains queued with its attempt count reset.
- [ ] Queue more than 20 jobs, including duplicate resources, and confirm they drain across bounded cron ticks.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/99429059-323a-4b64-a57b-654f43da3adc)
