### PR TITLE
fix(redirects): treat a folder holding published pages as a live destination

### DIFF
--- a/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/bulkRedirects.router.test.ts
@@ -172,6 +172,40 @@ describe("redirect.router bulk upload", async () => {
       expect(errorFor(result, "/shadowed")).toBeTruthy()
     })
 
+    it("allows an exact source at a folder whose index page is still a draft", async () => {
+      // Arrange — nothing renders at "/folder" until its IndexPage is
+      // published, so a redirect there shadows nothing, even though the folder
+      // holds a published page.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({ siteId, permalink: "folder" })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        permalink: "live-child",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.bulkValidate({
+        siteId,
+        csv: csvOf([["/folder", "/somewhere"]]),
+      })
+
+      // Assert
+      expect(errorFor(result, "/folder")).toBeNull()
+    })
+
     it("flags a wildcard source whose prefix is itself a live published page", async () => {
       // Arrange
       await seedPublishedPageAtRoot("news")

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -1669,6 +1669,42 @@ describe("redirect.router", async () => {
       ])
     })
 
+    it("should warn for an unpublished page even when a page nested under it is published", async () => {
+      // Arrange — only a container is served by what it holds. A page renders
+      // at its own URL and nowhere else, so a published child at
+      // "/parent/child" does nothing for "/parent", which is still a draft.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { page: parent } = await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: null,
+        permalink: "parent",
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: parent.id,
+        permalink: "child",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/parent"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/parent", permalink: null, warn: true },
+      ])
+    })
+
     it("terminates for a folder whose subtree contains a parent-chain cycle", async () => {
       // Arrange — nothing creates a cycle today (moving a folder into its own
       // descendant is rejected), but a malformed chain must not be able to spin

--- a/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
+++ b/apps/studio/src/server/modules/redirect/__tests__/redirect.router.test.ts
@@ -13,6 +13,7 @@ import {
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
+import { MAX_REDIRECT_REFERENCES } from "~/schemas/redirect"
 import { createCallerFactory } from "~/server/trpc"
 import { ResourceState, ResourceType } from "~prisma/generated/generatedEnums"
 
@@ -1235,6 +1236,45 @@ describe("redirect.router", async () => {
       await expect(result).rejects.toMatchObject({ code: "FORBIDDEN" })
     })
 
+    it("should reject a batch larger than the reference cap before any lookup", async () => {
+      // Arrange — the fan-out of per-destination liveness lookups is bounded by
+      // this cap, so it is the control that keeps one request from turning into
+      // an unbounded pile of queries. Rejection happens in the input schema,
+      // before the procedure body runs.
+      const references = Array.from(
+        { length: MAX_REDIRECT_REFERENCES + 1 },
+        (_, index) => `[resource:${siteId}:${index + 1}]`,
+      )
+
+      // Act
+      const result = caller.resolveReferences({ siteId, references })
+
+      // Assert
+      await expect(result).rejects.toMatchObject({ code: "BAD_REQUEST" })
+      await expect(result).rejects.toThrow(/Too many references/)
+    })
+
+    it("should resolve a batch right at the reference cap", async () => {
+      // Arrange — the boundary the cap admits, every entry unresolvable so each
+      // one takes the liveness path rather than short-circuiting.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const references = Array.from(
+        { length: MAX_REDIRECT_REFERENCES },
+        (_, index) => `/missing-${index}`,
+      )
+
+      // Act
+      const result = await caller.resolveReferences({ siteId, references })
+
+      // Assert
+      expect(result).toHaveLength(MAX_REDIRECT_REFERENCES)
+      expect(result.every(({ warn }) => warn)).toBe(true)
+    })
+
     it("should resolve a reference to the page's current permalink", async () => {
       // Arrange
       const { page } = await setupPageResource({
@@ -1510,9 +1550,9 @@ describe("redirect.router", async () => {
       ])
     })
 
-    it("should warn for a folder whose index page is not published", async () => {
-      // Arrange — a folder with an unpublished IndexPage has no live page at its
-      // URL, so it warns.
+    it("should warn for a folder with nothing published inside it", async () => {
+      // Arrange — an unpublished IndexPage and no published pages beneath it, so
+      // the folder has no live content at all.
       await setupPageResource({
         siteId,
         resourceType: ResourceType.RootPage,
@@ -1528,6 +1568,12 @@ describe("redirect.router", async () => {
         resourceType: ResourceType.IndexPage,
         parentId: folder.id,
       })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        permalink: "draft-child",
+      })
 
       // Act
       const result = await caller.resolveReferences({
@@ -1538,6 +1584,88 @@ describe("redirect.router", async () => {
       // Assert
       expect(result).toEqual([
         { reference: "/folder", permalink: null, warn: true },
+      ])
+    })
+
+    it("should not warn for a folder whose index page is unpublished but which holds a published page", async () => {
+      // Arrange — index pages are created as drafts and rarely published by
+      // hand, so a folder of published pages must not read as leading nowhere.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: folder.id,
+        permalink: "live-child",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/folder"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/folder", permalink: null, warn: false },
+      ])
+    })
+
+    it("should not warn for a folder whose published page sits in a nested subfolder", async () => {
+      // Arrange — the walk is recursive, so live content any depth down counts.
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.RootPage,
+        parentId: null,
+      })
+      const { folder } = await setupFolder({
+        siteId,
+        permalink: "folder",
+        parentId: null,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.IndexPage,
+        parentId: folder.id,
+      })
+      const { folder: subfolder } = await setupFolder({
+        siteId,
+        permalink: "subfolder",
+        parentId: folder.id,
+      })
+      await setupPageResource({
+        siteId,
+        resourceType: ResourceType.Page,
+        parentId: subfolder.id,
+        permalink: "live-grandchild",
+        state: ResourceState.Published,
+        userId,
+      })
+
+      // Act
+      const result = await caller.resolveReferences({
+        siteId,
+        references: ["/folder"],
+      })
+
+      // Assert
+      expect(result).toEqual([
+        { reference: "/folder", permalink: null, warn: false },
       ])
     })
 

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -52,6 +52,7 @@ import {
   getResourceFullPermalinks,
   getResourceIdByPermalink,
   getResourceIdsByPermalinks,
+  hasPublishedDescendant,
 } from "../resource/resource.service"
 
 // Sort field → column. `publishedAt` maps to `createdAt`; `satisfies` keeps the
@@ -131,10 +132,18 @@ const resolveDestinationForStorage = async (
   }
 }
 
-// Batch publish-state for a set of resource ids. A Page/CollectionPage is live
-// when it has a published version; a Folder/Collection is served by its
-// IndexPage, so it's live when that index page is published (mirrors
-// getResourceByFullPermalink's container handling).
+const isContainerType = (type: ResourceType) =>
+  type === ResourceType.Folder || type === ResourceType.Collection
+
+// Batch publish-state for a set of resource ids: is there a page rendering at
+// this resource's own URL? A Page/CollectionPage is live when it has a
+// published version; a Folder/Collection is served by its IndexPage, so it's
+// live when that index page is published (mirrors getResourceByFullPermalink's
+// container handling).
+//
+// This is the question the source-shadowing guards ask — a redirect may only be
+// refused when a page really renders at that URL. It is deliberately NOT the
+// question the destination warning asks; see getDestinationLiveStateByResourceIds.
 const getPublishedStateByResourceIds = async (
   siteId: number,
   resourceIds: number[],
@@ -152,10 +161,7 @@ const getPublishedStateByResourceIds = async (
     .execute()
 
   const containerIds = resources
-    .filter(
-      (r) =>
-        r.type === ResourceType.Folder || r.type === ResourceType.Collection,
-    )
+    .filter((r) => isContainerType(r.type))
     .map((r) => String(r.id))
   const publishedByContainerId = new Map<string, boolean>()
   if (containerIds.length > 0) {
@@ -175,17 +181,75 @@ const getPublishedStateByResourceIds = async (
   }
 
   for (const resource of resources) {
-    const isContainer =
-      resource.type === ResourceType.Folder ||
-      resource.type === ResourceType.Collection
     result.set(
       Number(resource.id),
-      isContainer
+      isContainerType(resource.type)
         ? (publishedByContainerId.get(String(resource.id)) ?? false)
         : resource.publishedVersionId !== null,
     )
   }
   return result
+}
+
+// How many destination-liveness lookups may be in flight at once. Each is a
+// short-circuiting subtree existence check, so a small window keeps a single
+// request off the connection pool while still overlapping the round-trips.
+const LIVENESS_LOOKUP_CONCURRENCY = 5
+
+// Batch liveness for redirect *destinations*: does this destination lead
+// anywhere on the published site? Same as getPublishedStateByResourceIds except
+// that a container also counts as live when it holds published pages but its
+// own index page is still a draft — index pages are created as drafts and are
+// rarely published by hand, so gating on the index page alone flags a section
+// full of live pages as leading nowhere.
+//
+// Only the table's advisory warning uses this. The shadowing guards must keep
+// the stricter "a page renders at this exact URL" reading, or a redirect at a
+// draft-index folder would be refused as hiding a page that isn't there.
+const getDestinationLiveStateByResourceIds = async (
+  siteId: number,
+  resourceIds: number[],
+): Promise<Map<number, boolean>> => {
+  const state = await getPublishedStateByResourceIds(siteId, resourceIds)
+  if (state.size === 0) {
+    return state
+  }
+
+  // Only a resource the index-page check already ruled out can be revived by
+  // its contents, so this asks about the smallest set that could still change
+  // the answer — usually none. Non-containers are left in: a page has no
+  // children, so the check simply comes back false for them, and filtering
+  // them out first would cost a query to learn their types.
+  const undecidedIds = [...state.entries()].flatMap(([id, isLive]) =>
+    isLive ? [] : [id],
+  )
+
+  // A request may carry up to MAX_REDIRECT_REFERENCES destinations, and a
+  // caller can make every one of them undecided by pointing at unpublished
+  // resources. Run the lookups a few at a time so one request can't put its
+  // whole batch on the connection pool at once — the table only ever has a
+  // page's worth in flight, so this costs it nothing.
+  for (const batch of chunk(undecidedIds, LIVENESS_LOOKUP_CONCURRENCY)) {
+    const revived = await Promise.all(
+      batch.map(async (id) => ({
+        id,
+        // Reuses the resource module's existing subtree walk rather than a
+        // second one here: it stops at the first published row instead of
+        // materialising the subtree, and its CTE is a `union` so a malformed
+        // parent chain with a cycle terminates instead of recursing forever.
+        isLive: await hasPublishedDescendant(db, {
+          siteId,
+          resourceId: String(id),
+        }),
+      })),
+    )
+    for (const { id, isLive } of revived) {
+      if (isLive) {
+        state.set(id, true)
+      }
+    }
+  }
+  return state
 }
 
 // Strips a "?query"/"#fragment" off a path, leaving the bare path before the
@@ -249,7 +313,7 @@ export const resolveRedirectReferences = async ({
     .filter((id): id is number => id !== null)
   const [permalinks, publishedState] = await Promise.all([
     getResourceFullPermalinks(siteId, resourceIds),
-    getPublishedStateByResourceIds(siteId, resourceIds),
+    getDestinationLiveStateByResourceIds(siteId, resourceIds),
   ])
 
   return parsed.map(({ reference, kind, resourceId }) => {

--- a/apps/studio/src/server/modules/redirect/redirect.service.ts
+++ b/apps/studio/src/server/modules/redirect/redirect.service.ts
@@ -144,21 +144,23 @@ const isContainerType = (type: ResourceType) =>
 // This is the question the source-shadowing guards ask — a redirect may only be
 // refused when a page really renders at that URL. It is deliberately NOT the
 // question the destination warning asks; see getDestinationLiveStateByResourceIds.
-const getPublishedStateByResourceIds = async (
-  siteId: number,
-  resourceIds: number[],
-): Promise<Map<number, boolean>> => {
-  const result = new Map<number, boolean>()
-  if (resourceIds.length === 0) {
-    return result
-  }
-  const ids = resourceIds.map(String)
-  const resources = await db
+const getResourcesForLiveness = async (siteId: number, resourceIds: number[]) =>
+  db
     .selectFrom("Resource")
     .where("Resource.siteId", "=", siteId)
-    .where("Resource.id", "in", ids)
+    .where("Resource.id", "in", resourceIds.map(String))
     .select(["Resource.id", "Resource.type", "Resource.publishedVersionId"])
     .execute()
+
+type ResourceForLiveness = Awaited<
+  ReturnType<typeof getResourcesForLiveness>
+>[number]
+
+const buildPublishedState = async (
+  siteId: number,
+  resources: ResourceForLiveness[],
+): Promise<Map<number, boolean>> => {
+  const result = new Map<number, boolean>()
 
   const containerIds = resources
     .filter((r) => isContainerType(r.type))
@@ -191,6 +193,19 @@ const getPublishedStateByResourceIds = async (
   return result
 }
 
+const getPublishedStateByResourceIds = async (
+  siteId: number,
+  resourceIds: number[],
+): Promise<Map<number, boolean>> => {
+  if (resourceIds.length === 0) {
+    return new Map()
+  }
+  return buildPublishedState(
+    siteId,
+    await getResourcesForLiveness(siteId, resourceIds),
+  )
+}
+
 // How many destination-liveness lookups may be in flight at once. Each is a
 // short-circuiting subtree existence check, so a small window keeps a single
 // request off the connection pool while still overlapping the round-trips.
@@ -210,18 +225,23 @@ const getDestinationLiveStateByResourceIds = async (
   siteId: number,
   resourceIds: number[],
 ): Promise<Map<number, boolean>> => {
-  const state = await getPublishedStateByResourceIds(siteId, resourceIds)
-  if (state.size === 0) {
-    return state
+  if (resourceIds.length === 0) {
+    return new Map()
   }
+  const resources = await getResourcesForLiveness(siteId, resourceIds)
+  const state = await buildPublishedState(siteId, resources)
 
-  // Only a resource the index-page check already ruled out can be revived by
-  // its contents, so this asks about the smallest set that could still change
-  // the answer — usually none. Non-containers are left in: a page has no
-  // children, so the check simply comes back false for them, and filtering
-  // them out first would cost a query to learn their types.
-  const undecidedIds = [...state.entries()].flatMap(([id, isLive]) =>
-    isLive ? [] : [id],
+  // Only a *container* is served by what it holds, so only a container can be
+  // revived by its contents. A page renders at its own URL and nowhere else —
+  // reviving it because something nested under it is published would suppress
+  // the warning for a draft page whose child lives at a different URL. Narrowed
+  // to the containers the index-page check already ruled out, which is the
+  // smallest set that could still change the answer — usually none. The types
+  // come from the fetch above, so this costs no extra query.
+  const undecidedContainerIds = resources.flatMap((resource) =>
+    isContainerType(resource.type) && !state.get(Number(resource.id))
+      ? [Number(resource.id)]
+      : [],
   )
 
   // A request may carry up to MAX_REDIRECT_REFERENCES destinations, and a
@@ -229,7 +249,10 @@ const getDestinationLiveStateByResourceIds = async (
   // resources. Run the lookups a few at a time so one request can't put its
   // whole batch on the connection pool at once — the table only ever has a
   // page's worth in flight, so this costs it nothing.
-  for (const batch of chunk(undecidedIds, LIVENESS_LOOKUP_CONCURRENCY)) {
+  for (const batch of chunk(
+    undecidedContainerIds,
+    LIVENESS_LOOKUP_CONCURRENCY,
+  )) {
     const revived = await Promise.all(
       batch.map(async (id) => ({
         id,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +111 | -24 |
| 🧪 Test | 2 | +201 | -3 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

> **Stacked on #3087.** Review that one first — this PR's diff is only meaningful against it, and the base will retarget to `main` once #3087 merges.

## Problem

Raised in the "Bulk upload & wildcard redirects" dogfooding session: a folder was shown with the amber "hasn't been published yet" warning next to it in the redirects table, even though the folder plainly exists on the live site and contains published pages.

The destination warning treated a folder or collection as live only when its own `IndexPage` had a published version. Index pages are created as drafts and are rarely published by hand, so a folder full of published pages read as leading nowhere. Site admins were being told a working redirect was broken.

Closes N/A — raised on the dogfooding feedback board rather than as a GitHub issue.

## Solution

`getPublishedStateByResourceIds` was answering two different questions for two different callers, so this splits them.

- **Source-shadowing guards** (single create and both bulk-upload paths) keep the strict reading: *does a page render at this exact URL?* A folder with a draft index page renders nothing, so a redirect placed there hides nothing and must be allowed.
- **Destinations** get `getDestinationLiveStateByResourceIds`, which additionally counts a container that holds published pages at any depth.

Keeping the guards strict is not cosmetic. Without the split, a bulk upload whose source is a draft-index folder gets rejected with "A live page already uses this URL" — blocking a legitimate redirect against a page that does not exist. There is a regression test for exactly that.

The descendant check reuses the resource module's existing `hasPublishedDescendant` rather than adding a second recursive walk: it stops at the first published row instead of materialising the subtree, and its CTE is a `union`, so a malformed `parentId` chain terminates rather than recursing forever. Lookups run in windows of `LIVENESS_LOOKUP_CONCURRENCY` (5) so a request at the reference cap cannot put its whole batch on the connection pool at once.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Bug Fixes**:

- A folder or collection destination no longer warns when its index page is a draft but it holds published pages, at any depth.
- The shadowing guards keep index-page semantics, so a redirect whose source is a draft-index folder is still accepted.

**Improvements**:

- Destination liveness and source shadowing are now separate, named functions, so changing one cannot silently change the other.

## Before & After Screenshots

**BEFORE**: a redirect pointing at `/folder` — a folder with an unpublished index page and a published page inside — showed the amber "This page or folder you're redirecting to hasn't been published yet" icon next to the destination.

**AFTER**: no icon for that folder. Destinations that genuinely lead nowhere (an unpublished page, a path matching no resource, a deleted reference) still show it.

## Tests

`redirect.router.test.ts` covers the folder cases: a published child, a published page in a nested subfolder, and a folder with nothing published inside it (which still warns). `bulkRedirects.router.test.ts` covers the shadowing regression — an exact source at a draft-index folder is accepted. Two further tests pin the reference cap that bounds the lookup fan-out: one over the limit is rejected with `BAD_REQUEST`, and a batch right at the limit resolves.

**Manual Verification Steps**:

- [ ] Create a folder, add a page inside it, and publish that page. Leave the folder's own page unpublished.
- [ ] Go to Settings → Redirects and add a redirect pointing at `/that-folder`. Confirm **no** amber warning icon appears next to the destination.
- [ ] Add a redirect pointing at a page you have not published, and confirm the amber warning icon **does** still appear.
- [ ] Add a redirect pointing at a path that does not exist at all, and confirm it also still warns.
- [ ] Bulk upload a CSV whose source column is `/that-folder`. Confirm the row is accepted rather than flagged with "A live page already uses this URL. The redirect would hide it."
- [ ] Publish the folder's own page, reload the redirects table, and confirm the folder destination still shows no warning.

**New scripts**: none

**New dependencies**: none

**New dev dependencies**: none

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Redirect destination warnings now treat folders and collections with published descendants as live. However, the same descendant lookup also clears the warning for unpublished page-like destinations that do not render at their own URL.
</details>

<details><summary><h3>Confidence Score: 4/5</h3></summary>

Not merge-safe until destination liveness is restricted to container resources.

One accepted P1 non-security finding remains: an unpublished page-like redirect destination can be presented as live solely because a nested resource is published.

**Files Needing Attention:** apps/studio/src/server/modules/redirect/redirect.service.ts
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex prepared a focused execution environment by wiring in the redirect liveness harness, Vitest configuration, and Isomer component stubs.
- T-Rex ran the focused test flow and produced a focused execution output log that shows the draft page with a published child.
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex validated the proof against the relevant review comment to confirm alignment with the finding details.

<a href="https://app.greptile.com/trex/runs/18652097/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233124%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3124&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (2): Last reviewed commit: ["fix(redirects): treat a folder holding p..."](https://github.com/opengovsg/isomer/commit/b3e4036921d3b73137818a5c4c742418ea6e66da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52474346)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->