### PR TITLE
feat(export-import): migrate redirects

### DIFF
--- a/tooling/export-import/index.ts
+++ b/tooling/export-import/index.ts
@@ -74,7 +74,10 @@ const unstudioifySite = async (sourceSiteId: number) => {
   const allJsonFiles = fs
     .readdirSync(path.join(process.cwd(), "temp"), { recursive: true })
     .filter(
-      (file) => (file as string).endsWith(".json") && file !== "sitemap.json"
+      (file) =>
+        (file as string).endsWith(".json") &&
+        file !== "sitemap.json" &&
+        file !== "redirects.json"
     ) as string[];
 
   for (const file of allJsonFiles) {
@@ -225,6 +228,10 @@ const main = async () => {
   await execFile("mv", [
     path.join(exportDir, "sitemap.json"),
     path.join(tempDir, "sitemap.json"),
+  ]);
+  await execFile("mv", [
+    path.join(exportDir, "redirects.json"),
+    path.join(tempDir, "redirects.json"),
   ]);
 
   // Step 2: Export the assets from the S3 bucket

--- a/tooling/export-import/migrate.ts
+++ b/tooling/export-import/migrate.ts
@@ -22,6 +22,11 @@ interface Resource {
   blobId: number | null;
 }
 
+interface Redirect {
+  source: string;
+  destination: string;
+}
+
 dotenv.config();
 
 export async function migrate(
@@ -29,8 +34,14 @@ export async function migrate(
   sourceSiteId: number,
   destinationSiteId: number
 ) {
+  const redirects = readRedirects();
   await seedDatabase(client, destinationSiteId);
-  await studioifySite(client, sourceSiteId, destinationSiteId);
+  const resourcesMap = await studioifySite(
+    client,
+    sourceSiteId,
+    destinationSiteId
+  );
+  await importRedirects(client, destinationSiteId, redirects, resourcesMap);
 }
 
 async function seedDatabase(client: Client, siteId: number) {
@@ -303,6 +314,61 @@ async function importFooter(client: Client, siteId: number) {
   );
 }
 
+function readRedirects(): Redirect[] {
+  const redirectsPath = path.join(process.cwd(), "temp", "redirects.json");
+  return parseRedirects(JSON.parse(fs.readFileSync(redirectsPath, "utf-8")));
+}
+
+async function importRedirects(
+  client: Client,
+  siteId: number,
+  redirects: Redirect[],
+  resourcesMap: Record<string, Resource>
+) {
+  console.log("Importing redirects");
+  const studioifiedRedirects = redirects.map((redirect) => ({
+    ...redirect,
+    destination: studioifyRedirectDestination(
+      redirect.destination,
+      siteId,
+      resourcesMap
+    ),
+  }));
+
+  if (studioifiedRedirects.length > 0) {
+    await client.query(
+      `INSERT INTO public."Redirect" ("siteId", source, destination)
+       SELECT $1, redirect.source, redirect.destination
+       FROM jsonb_to_recordset($2::jsonb)
+         AS redirect(source text, destination text)
+       ON CONFLICT ("siteId", source) DO UPDATE
+       SET destination = EXCLUDED.destination,
+           "deletedAt" = NULL,
+           "createdAt" = CURRENT_TIMESTAMP`,
+      [siteId, JSON.stringify(studioifiedRedirects)]
+    );
+  }
+}
+
+function parseRedirects(value: unknown): Redirect[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every(
+      (redirect): redirect is Redirect =>
+        typeof redirect === "object" &&
+        redirect !== null &&
+        "source" in redirect &&
+        typeof redirect.source === "string" &&
+        "destination" in redirect &&
+        typeof redirect.destination === "string"
+    )
+  ) {
+    throw new Error("Exported redirects.json has an invalid format");
+  }
+
+  return value;
+}
+
 async function studioifySite(
   client: Client,
   sourceSiteId: number,
@@ -353,6 +419,7 @@ async function studioifySite(
     resourcesMap
   );
   await updateSiteConfig(client, destinationSiteId, updatedSiteConfig);
+  return resourcesMap;
 }
 
 async function getResourceMapping(client: Client, siteId: number) {
@@ -500,6 +567,20 @@ function studioifyContent(
   newContent = newContent.replace(regex, `/${destinationSiteId}/$1/`);
 
   return newContent;
+}
+
+function studioifyRedirectDestination(
+  destination: string,
+  destinationSiteId: number,
+  resourcesMap: Record<string, Pick<Resource, "id">>
+): string {
+  const resource = resourcesMap[destination];
+
+  if (!resource) {
+    return destination;
+  }
+
+  return `[resource:${String(destinationSiteId)}:${String(resource.id)}]`;
 }
 
 function getProperTitle(slug: string) {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +90 | -2 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The export-import script leaves the generated `redirects.json` behind, so Redirects table entries are not migrated to the destination site.

Closes N/A

## Solution

Move the already-unstudioified `redirects.json` into the temporary export bundle, validate its shape, studioify matching internal destinations using destination resource IDs, and upsert the Redirect rows into the destination site.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Migrate live Redirects table entries between environments.

**Improvements**:

- Preserve Page references for internal destinations while leaving literal paths and external URLs unchanged.
- Revive matching soft-deleted destination rows during migration.

**Bug Fixes**:

- Include the existing redirect export artifact in the import flow.

## Before & After Screenshots

**BEFORE**:

N/A — tooling-only change.

**AFTER**:

N/A — tooling-only change.

## Tests

TypeScript check: `pnpm --filter @isomer/export-import exec tsc --noEmit -p tsconfig.json`

**Manual Verification Steps**:

- [ ] Export a site containing internal-path and external-URL Redirects.
- [ ] Import it into another environment and confirm the Redirects table contains the same Sources and Destinations.
- [ ] Confirm internal Page destinations reference destination-site resource IDs.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change includes redirects in export bundles and restores their destination references on import. Importing a redirect whose source path already exists as a live redirect on the destination site replaces the configured destination and resets its creation time. Preserve live destination-site redirects and only restore matching soft-deleted records before merging.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until redirect imports stop modifying existing live redirects.

A database harness exercised the production-equivalent conflict statement against a seeded live redirect and confirmed both the destination replacement and creation-time reset.

**Files Needing Attention:** tooling/export-import/migrate.ts, specifically the redirect upsert conflict branch at lines 344-347.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A finding-comment-proof for a P1 redirect-conflict finding was produced and linked to a validation script.
- The pre-action Live Redirect state was captured to establish the baseline before the import conflict action.
- The post-action Live Redirect state was captured to show the result after applying the import conflict action.
- A general-contract-validation-proof was produced, confirming that the live redirect changed from /live-destination (original 2020 timestamp) to /imported-destination with a new timestamp, all assertions passed, and noting severity: P1.

<a href="https://app.greptile.com/trex/runs/18637782/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Redirect import overwrites an existing live redirect**

   - **Bug**
     - For a pre-existing live Redirect with the same `(siteId, source)`, the import upsert executes its `DO UPDATE` branch and changes `destination` to the imported value. It also assigns `createdAt = CURRENT_TIMESTAMP`; `deletedAt = NULL` is a no-op for an already live row but is still unconditionally assigned.
   - **Cause**
     - The `ON CONFLICT ("siteId", source) DO UPDATE` branch has no predicate distinguishing soft-deleted rows from live rows and directly assigns `destination`, `deletedAt`, and `createdAt`. The schema's unconditional unique index on `(siteId, source)` guarantees that the existing live row conflicts.
   - **Fix**
     - Restrict the conflict update to soft-deleted rows, for example add `WHERE public."Redirect"."deletedAt" IS NOT NULL` to the conflict action, and avoid assigning `createdAt` on update. This preserves live redirects while allowing a deleted redirect to be restored if that is intended.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233129%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3129&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atooling%2Fexport-import%2Fmigrate.ts%3A344-347%0A**Live%20redirects%20are%20overwritten**%0A%0AThe%20conflict%20action%20runs%20for%20an%20already-live%20%60%28siteId%2C%20source%29%60%20redirect%20as%20well%20as%20for%20a%20soft-deleted%20one.%20Importing%20a%20bundle%20can%20therefore%20replace%20the%20destination%20configured%20on%20the%20destination%20site%20and%20reset%20that%20redirect's%20creation%20time.%20Restrict%20this%20update%20to%20rows%20with%20a%20non-null%20%60deletedAt%60%2C%20and%20do%20not%20update%20%60createdAt%60%2C%20so%20import%20restores%20deleted%20redirects%20without%20silently%20changing%20live%20routing%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atooling%2Fexport-import%2Fmigrate.ts%3A344-347%0A**Live%20redirects%20are%20overwritten**%0A%0AThe%20conflict%20action%20runs%20for%20an%20already-live%20%60%28siteId%2C%20source%29%60%20redirect%20as%20well%20as%20for%20a%20soft-deleted%20one.%20Importing%20a%20bundle%20can%20therefore%20replace%20the%20destination%20configured%20on%20the%20destination%20site%20and%20reset%20that%20redirect's%20creation%20time.%20Restrict%20this%20update%20to%20rows%20with%20a%20non-null%20%60deletedAt%60%2C%20and%20do%20not%20update%20%60createdAt%60%2C%20so%20import%20restores%20deleted%20redirects%20without%20silently%20changing%20live%20routing%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3129&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22bridgetown%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bridgetown%22.%0A%0A%23%23%23%20Issue%201%0Atooling%2Fexport-import%2Fmigrate.ts%3A344-347%0A**Live%20redirects%20are%20overwritten**%0A%0AThe%20conflict%20action%20runs%20for%20an%20already-live%20%60%28siteId%2C%20source%29%60%20redirect%20as%20well%20as%20for%20a%20soft-deleted%20one.%20Importing%20a%20bundle%20can%20therefore%20replace%20the%20destination%20configured%20on%20the%20destination%20site%20and%20reset%20that%20redirect's%20creation%20time.%20Restrict%20this%20update%20to%20rows%20with%20a%20non-null%20%60deletedAt%60%2C%20and%20do%20not%20update%20%60createdAt%60%2C%20so%20import%20restores%20deleted%20redirects%20without%20silently%20changing%20live%20routing%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tooling/export-import/migrate.ts:344-347
**Live redirects are overwritten**

The conflict action runs for an already-live `(siteId, source)` redirect as well as for a soft-deleted one. Importing a bundle can therefore replace the destination configured on the destination site and reset that redirect's creation time. Restrict this update to rows with a non-null `deletedAt`, and do not update `createdAt`, so import restores deleted redirects without silently changing live routing behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(export-import): migrate redirects"](https://github.com/opengovsg/isomer/commit/7258f91c410a54f61f3e207ecf82a32bbd378878) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52842062)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->