### PR TITLE
feat(studio): unpublish folder/collection (Lite, no-cascade)

### DIFF
--- a/apps/studio/src/schemas/collection.ts
+++ b/apps/studio/src/schemas/collection.ts
@@ -10,6 +10,11 @@ import { resourceOrderByOptions } from "./resource"
 
 export type CollectionLinkProps = Static<typeof LinkRefPageSchema>
 
+export const unpublishCollectionSchema = z.object({
+  resourceId: z.number().min(1),
+  siteId: z.number().min(1),
+})
+
 // NOTE: zod's internal date schema uses `YYYY-MM-DD` but our format is
 // dd/MM/yyyy. Hence, we will run a 2 way conversion from
 // our format -> zod then zod -> our format

--- a/apps/studio/src/schemas/folder.ts
+++ b/apps/studio/src/schemas/folder.ts
@@ -34,6 +34,11 @@ export const readFolderSchema = z
   })
   .merge(offsetPaginationSchema)
 
+export const unpublishFolderSchema = z.object({
+  resourceId: z.number().min(1),
+  siteId: z.number().min(1),
+})
+
 const baseFolderSchema = z.object({
   resourceId: z.string(),
   siteId: z.string(),

--- a/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
+++ b/apps/studio/src/server/modules/collection/__tests__/collection.router.test.ts
@@ -18,6 +18,7 @@ import {
   setupEditorPermissions,
   setupFolder,
   setupPageResource,
+  setupPublisherPermissions,
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
@@ -1233,6 +1234,107 @@ describe("collection.router", async () => {
         .where("id", "=", collection.id)
         .executeTakeFirst()
       expect(result).toMatchObject(expected!)
+    })
+  })
+
+  describe("unpublishCollection", () => {
+    it("should throw 401 if not logged in", async () => {
+      const result = unauthedCaller.unpublishCollection({
+        siteId: 1,
+        resourceId: 1,
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user does not have unpublish access", async () => {
+      const { site, collection } = await setupCollection()
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const result = caller.unpublishCollection({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw if the collection's IndexPage is not currently published", async () => {
+      const { site, collection } = await setupCollection()
+      await setupPageResource({
+        siteId: site.id,
+        parentId: collection.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Draft,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const result = caller.unpublishCollection({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "This page is not currently published",
+        }),
+      )
+    })
+
+    it("should unpublish the collection's IndexPage, leaving the collection's own row untouched", async () => {
+      // Arrange
+      const { site, collection } = await setupCollection()
+      const { page: indexPage } = await setupPageResource({
+        siteId: site.id,
+        parentId: collection.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.unpublishCollection({
+        siteId: site.id,
+        resourceId: Number(collection.id),
+      })
+
+      // Assert — the IndexPage is unpublished
+      const updatedIndexPage = await db
+        .selectFrom("Resource")
+        .where("id", "=", indexPage.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(updatedIndexPage.publishedVersionId).toBeNull()
+      expect(updatedIndexPage.state).toEqual(ResourceState.Draft)
+      expect(updatedIndexPage.draftBlobId).not.toBeNull()
+
+      // Assert — the Collection's own row is untouched
+      const updatedCollection = await db
+        .selectFrom("Resource")
+        .where("id", "=", collection.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(updatedCollection.publishedVersionId).toBeNull()
+      expect(updatedCollection.state).toEqual(ResourceState.Draft)
     })
   })
 

--- a/apps/studio/src/server/modules/collection/collection.router.ts
+++ b/apps/studio/src/server/modules/collection/collection.router.ts
@@ -2,6 +2,7 @@ import type { UnwrapTagged } from "type-fest"
 import { TRPCError } from "@trpc/server"
 import { get, pick } from "lodash-es"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
+import { ENABLE_CODEBUILD_JOBS } from "~/lib/growthbook"
 import {
   countTagOptionsUsageSchema,
   createCollectionSchema,
@@ -10,6 +11,7 @@ import {
   getCollectionTagsSchema,
   readCollectionSchema,
   readLinkSchema,
+  unpublishCollectionSchema,
 } from "~/schemas/collection"
 import { readFolderSchema } from "~/schemas/folder"
 import { createCollectionPageSchema } from "~/schemas/page"
@@ -32,6 +34,7 @@ import {
   getBlobOfResource,
   getSiteResourceById,
   publishResource,
+  unpublishPageResource,
   updateBlobById,
 } from "../resource/resource.service"
 import { validateUserPermissionsForSite } from "../site/site.service"
@@ -66,6 +69,26 @@ export const collectionRouter = router({
       }
       return resource
     }),
+  unpublishCollection: protectedProcedure
+    .input(unpublishCollectionSchema)
+    .mutation(
+      async ({ ctx: { user, gb, logger }, input: { siteId, resourceId } }) => {
+        await bulkValidateUserPermissionsForResources({
+          siteId,
+          action: "unpublish",
+          userId: user.id,
+        })
+        await unpublishPageResource({
+          logger,
+          siteId,
+          resourceId: String(resourceId),
+          userId: user.id,
+          sitePublish: {
+            enableCodebuildJobs: gb.isOn(ENABLE_CODEBUILD_JOBS),
+          },
+        })
+      },
+    ),
   create: protectedProcedure
     .input(createCollectionSchema)
     .mutation(

--- a/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
+++ b/apps/studio/src/server/modules/folder/__tests__/folder.router.test.ts
@@ -13,6 +13,7 @@ import {
   setupEditorPermissions,
   setupFolder,
   setupPageResource,
+  setupPublisherPermissions,
   setupSite,
   setupUser,
 } from "tests/integration/helpers/seed"
@@ -436,6 +437,116 @@ describe("folder.router", async () => {
         .where("id", "=", folder.id)
         .executeTakeFirst()
       expect(result).toEqual(expected)
+    })
+  })
+
+  describe("unpublishFolder", () => {
+    it("should throw 401 if not logged in", async () => {
+      const result = unauthedCaller.unpublishFolder({
+        siteId: 1,
+        resourceId: 1,
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({ code: "UNAUTHORIZED" }),
+      )
+    })
+
+    it("should throw 403 if user does not have unpublish access", async () => {
+      const { site, folder } = await setupFolder()
+      await setupEditorPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const result = caller.unpublishFolder({
+        siteId: site.id,
+        resourceId: Number(folder.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "FORBIDDEN",
+          message:
+            "You do not have sufficient permissions to perform this action",
+        }),
+      )
+    })
+
+    it("should throw if the folder's IndexPage is not currently published", async () => {
+      const { site, folder } = await setupFolder()
+      await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Draft,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      const result = caller.unpublishFolder({
+        siteId: site.id,
+        resourceId: Number(folder.id),
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "This page is not currently published",
+        }),
+      )
+    })
+
+    it("should unpublish the folder's IndexPage, leaving the folder's own row untouched", async () => {
+      // Arrange
+      const { site, folder } = await setupFolder()
+      const { page: indexPage } = await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Published,
+        userId: session.userId,
+      })
+      await setupPublisherPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      await caller.unpublishFolder({
+        siteId: site.id,
+        resourceId: Number(folder.id),
+      })
+
+      // Assert — the IndexPage is unpublished
+      const updatedIndexPage = await db
+        .selectFrom("Resource")
+        .where("id", "=", indexPage.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(updatedIndexPage.publishedVersionId).toBeNull()
+      expect(updatedIndexPage.state).toEqual(ResourceState.Draft)
+      expect(updatedIndexPage.draftBlobId).not.toBeNull()
+
+      // Assert — the Folder's own row is untouched (it never had a
+      // publishedVersionId to begin with)
+      const updatedFolder = await db
+        .selectFrom("Resource")
+        .where("id", "=", folder.id)
+        .selectAll()
+        .executeTakeFirstOrThrow()
+      expect(updatedFolder.publishedVersionId).toBeNull()
+      expect(updatedFolder.state).toEqual(ResourceState.Draft)
+
+      // Assert — audited against the IndexPage, not the folder
+      const auditLogs = await db
+        .selectFrom("AuditLog")
+        .where("eventType", "=", AuditLogEvent.Unpublish)
+        .selectAll()
+        .execute()
+      expect(auditLogs.length).toEqual(1)
     })
   })
 

--- a/apps/studio/src/server/modules/folder/folder.router.ts
+++ b/apps/studio/src/server/modules/folder/folder.router.ts
@@ -1,13 +1,17 @@
 import { TRPCError } from "@trpc/server"
 import { get, pick } from "lodash-es"
 import { INDEX_PAGE_PERMALINK } from "~/constants/sitemap"
-import { IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY } from "~/lib/growthbook"
+import {
+  ENABLE_CODEBUILD_JOBS,
+  IS_ADVANCED_REDIRECTS_ENABLED_FEATURE_KEY,
+} from "~/lib/growthbook"
 import {
   createFolderSchema,
   editFolderSchema,
   getIndexpageSchema,
   listChildPagesSchema,
   readFolderSchema,
+  unpublishFolderSchema,
 } from "~/schemas/folder"
 import { protectedProcedure, router } from "~/server/trpc"
 
@@ -27,6 +31,7 @@ import {
   getResourceFullPermalink,
   hasPublishedDescendant,
   publishResource,
+  unpublishPageResource,
 } from "../resource/resource.service"
 import { defaultFolderSelect } from "./folder.select"
 
@@ -201,6 +206,26 @@ export const folderRouter = router({
 
       return data
     }),
+  unpublishFolder: protectedProcedure
+    .input(unpublishFolderSchema)
+    .mutation(
+      async ({ ctx: { user, gb, logger }, input: { siteId, resourceId } }) => {
+        await bulkValidateUserPermissionsForResources({
+          siteId,
+          action: "unpublish",
+          userId: user.id,
+        })
+        await unpublishPageResource({
+          logger,
+          siteId,
+          resourceId: String(resourceId),
+          userId: user.id,
+          sitePublish: {
+            enableCodebuildJobs: gb.isOn(ENABLE_CODEBUILD_JOBS),
+          },
+        })
+      },
+    ),
   editFolder: protectedProcedure
     .input(editFolderSchema)
     .mutation(

--- a/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
+++ b/apps/studio/src/server/modules/resource/__tests__/resource.router.test.ts
@@ -3008,32 +3008,55 @@ describe("resource.router", async () => {
       expect(actual).not.toBeUndefined()
     })
 
-    it("should still allow deleting a published folder (no unpublish path yet)", async () => {
+    it("should block deleting a folder whose IndexPage is still published", async () => {
+      // Arrange — the folder's own row never carries a publishedVersionId;
+      // it's the child IndexPage that's actually live.
+      const { site, folder } = await setupFolder({})
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+
+      // Act
+      const result = caller.delete({
+        resourceId: folder.id,
+        siteId: site.id,
+      })
+
+      // Assert
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "This page must be unpublished before it can be deleted",
+        }),
+      )
+      const actual = await db
+        .selectFrom("Resource")
+        .where("id", "=", folder.id)
+        .executeTakeFirst()
+      expect(actual).not.toBeUndefined()
+    })
+
+    it("should allow deleting a folder whose IndexPage is not published", async () => {
       // Arrange
       const { site, folder } = await setupFolder({})
       await setupAdminPermissions({
         userId: session.userId,
         siteId: site.id,
       })
-      const blob = await setupBlob()
-      const version = await db
-        .insertInto("Version")
-        .values({
-          versionNum: 1,
-          resourceId: folder.id,
-          blobId: blob.id,
-          publishedBy: session.userId as string,
-        })
-        .returning("id")
-        .executeTakeFirstOrThrow()
-      await db
-        .updateTable("Resource")
-        .where("id", "=", folder.id)
-        .set({
-          state: ResourceState.Published,
-          publishedVersionId: version.id,
-        })
-        .execute()
+      await setupPageResource({
+        siteId: site.id,
+        parentId: folder.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Draft,
+      })
 
       // Act
       const result = await caller.delete({
@@ -3048,6 +3071,38 @@ describe("resource.router", async () => {
         .where("id", "=", folder.id)
         .executeTakeFirst()
       expect(actual).toBeUndefined()
+    })
+
+    it("should block deleting a collection whose IndexPage is still published", async () => {
+      const { site, collection } = await setupCollection({})
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+      await setupPageResource({
+        siteId: site.id,
+        parentId: collection.id,
+        resourceType: ResourceType.IndexPage,
+        state: ResourceState.Published,
+        userId: session.userId ?? undefined,
+      })
+
+      const result = caller.delete({
+        resourceId: collection.id,
+        siteId: site.id,
+      })
+
+      await expect(result).rejects.toThrow(
+        new TRPCError({
+          code: "BAD_REQUEST",
+          message: "This page must be unpublished before it can be deleted",
+        }),
+      )
+      const actual = await db
+        .selectFrom("Resource")
+        .where("id", "=", collection.id)
+        .executeTakeFirst()
+      expect(actual).not.toBeUndefined()
     })
 
     it("should soft-delete redirects pointing to the deleted page", async () => {

--- a/apps/studio/src/server/modules/resource/resource.router.ts
+++ b/apps/studio/src/server/modules/resource/resource.router.ts
@@ -754,17 +754,25 @@ export const resourceRouter = router({
         }
 
         // A live page must be unpublished before it can be deleted, so its
-        // removal is always preceded by an audited Unpublish event.
-        // TODO: Folders and Collections have no unpublish path yet (open
-        // design item), so they're exempt from this guard for now — deleting
-        // a published folder/collection today skips the Unpublish audit
-        // event that pages get. Revisit once folder/collection unpublish is
-        // designed.
-        if (
-          before.publishedVersionId !== null &&
-          before.type !== ResourceType.Folder &&
-          before.type !== ResourceType.Collection
-        ) {
+        // removal is always preceded by an audited Unpublish event. Folder
+        // and Collection rows never carry their own publishedVersionId —
+        // their live content is their child IndexPage's — so check that
+        // instead of the container's own (always-null) field.
+        const isLive =
+          before.type === ResourceType.Folder ||
+          before.type === ResourceType.Collection
+            ? (
+                await tx
+                  .selectFrom("Resource")
+                  .where("Resource.parentId", "=", resourceId)
+                  .where("Resource.siteId", "=", Number(siteId))
+                  .where("Resource.type", "=", ResourceType.IndexPage)
+                  .select("Resource.publishedVersionId")
+                  .executeTakeFirst()
+              )?.publishedVersionId != null
+            : before.publishedVersionId !== null
+
+        if (isLive) {
           throw new TRPCError({
             code: "BAD_REQUEST",
             message: "This page must be unpublished before it can be deleted",

--- a/apps/studio/src/server/modules/resource/resource.service.ts
+++ b/apps/studio/src/server/modules/resource/resource.service.ts
@@ -1376,6 +1376,12 @@ export const unpublishPageResource = async ({
   userId,
   sitePublish,
 }: UnpublishPageResourceArgs) => {
+  // For a Folder/Collection `resourceId`, this is resolved to the child
+  // IndexPage once `fullResource` is fetched below — that's the resource
+  // actually being unpublished. Declared here so the post-transaction
+  // `publishSite` call below can reference the correct id.
+  let targetResourceId = resourceId
+
   await db.transaction().execute(async (tx) => {
     const fullResource = await getFullPageById(tx, {
       resourceId: Number(resourceId),
@@ -1416,9 +1422,11 @@ export const unpublishPageResource = async ({
           .executeTakeFirstOrThrow()
       ).id
 
+    targetResourceId = fullResource.id
+
     await updatePageById(
       {
-        id: Number(resourceId),
+        id: Number(targetResourceId),
         siteId,
         publishedVersionId: null,
         draftBlobId,
@@ -1446,7 +1454,7 @@ export const unpublishPageResource = async ({
       siteId,
       codebuildJob: sitePublish.enableCodebuildJobs
         ? {
-            resourceWithUserIds: [{ resourceId, userId }],
+            resourceWithUserIds: [{ resourceId: targetResourceId, userId }],
             isScheduled: false,
           }
         : undefined,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 6 | +88 | -14 |
| 🧪 Test | 3 | +288 | -20 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Summary
- Adds `unpublishFolder`/`unpublishCollection` mutations. `FolderMeta`/`CollectionMeta` hold no renderable content — the actual live content for a `Folder`/`Collection` is its child `IndexPage`, which `unpublishPageResource` already resolves to via `getFullPageById`'s existing redirect. No cascade to other children.
- Fixes `unpublishPageResource` to write against the redirect-resolved resource id (`fullResource.id`) rather than the caller's raw id — previously, calling it with a Folder/Collection id would read the IndexPage's content but write to the container's own row, silently leaving the real live IndexPage untouched.
- Fixes the delete guard (`resource.router.ts`) to check the child IndexPage's `publishedVersionId` for `Folder`/`Collection` deletes, replacing the previous exemption which checked the container's own (always-null) field and so never actually blocked anything.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors (pre-existing unrelated warnings only)
- [x] New unit tests: `unpublishFolder`/`unpublishCollection` happy path, 401, 403, precondition-failed
- [x] Updated delete-guard tests: blocks folder/collection delete while IndexPage is live, allows once unpublished (replaces a stale test that asserted the old, incorrect behavior)
- [ ] Manual verification that the parent's index-listing query correctly drops the folder/collection once unpublished (believed already correct via existing `state = Published` filter in `getLocalisedSitemap`, not independently verified in this PR)

Stacked on `pr3-unpublish-service`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)