### PR TITLE
feat: Add hover and click-to-scroll highlighting between block editor and preview

### DIFF
--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -11,6 +11,11 @@ import { type DrawerState } from "~/types/editorDrawer"
 interface PreviewInteractionState {
   hoveredBlockIndex: number | null
   setHoveredBlockIndex: Dispatch<SetStateAction<number | null>>
+  // Block to flash-highlight in the preview after a click-to-scroll — decoupled
+  // from `hoveredBlockIndex` since selecting a block can unmount its hover
+  // source (e.g. switching drawer state) well before the scroll settles.
+  flashBlockIndex: number | null
+  setFlashBlockIndex: Dispatch<SetStateAction<number | null>>
   iframeDocument: Document | null
   setIframeDocument: Dispatch<SetStateAction<Document | null>>
 }
@@ -74,6 +79,7 @@ export function EditorDrawerProvider({
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(
     null,
   )
+  const [flashBlockIndex, setFlashBlockIndex] = useState<number | null>(null)
   const [iframeDocument, setIframeDocument] = useState<Document | null>(null)
 
   const setPreviewPageState = useCallback(
@@ -108,6 +114,8 @@ export function EditorDrawerProvider({
         setAddedBlockIndex,
         hoveredBlockIndex,
         setHoveredBlockIndex,
+        flashBlockIndex,
+        setFlashBlockIndex,
         iframeDocument,
         setIframeDocument,
         type,

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -22,6 +22,8 @@ interface DrawerContextType extends Pick<
   setModifiedAssets: Dispatch<SetStateAction<ModifiedAsset[]>>
   addedBlockIndex: number | null
   setAddedBlockIndex: Dispatch<SetStateAction<number | null>>
+  hoveredBlockIndex: number | null
+  setHoveredBlockIndex: Dispatch<SetStateAction<number | null>>
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -59,6 +61,9 @@ export function EditorDrawerProvider({
   // Holding state for images/files that have been modified in the page
   const [modifiedAssets, setModifiedAssets] = useState<ModifiedAsset[]>([])
   const [addedBlockIndex, setAddedBlockIndex] = useState<number | null>(null)
+  const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(
+    null,
+  )
 
   const setPreviewPageState = useCallback(
     (previewPageState: SetStateAction<IsomerSchema>) => {
@@ -90,6 +95,8 @@ export function EditorDrawerProvider({
         setModifiedAssets,
         addedBlockIndex,
         setAddedBlockIndex,
+        hoveredBlockIndex,
+        setHoveredBlockIndex,
         type,
         permalink,
         siteId,

--- a/apps/studio/src/contexts/EditorDrawerContext.tsx
+++ b/apps/studio/src/contexts/EditorDrawerContext.tsx
@@ -6,10 +6,22 @@ import { createContext, useCallback, useContext, useState } from "react"
 import { flushSync } from "react-dom"
 import { type DrawerState } from "~/types/editorDrawer"
 
-interface DrawerContextType extends Pick<
-  EditorDrawerProviderProps,
-  "type" | "permalink" | "siteId" | "pageId" | "updatedAt" | "title"
-> {
+// Preview-iframe interaction state: which block is hovered/active in the
+// editor, and a reference to the preview iframe's document to act on it.
+interface PreviewInteractionState {
+  hoveredBlockIndex: number | null
+  setHoveredBlockIndex: Dispatch<SetStateAction<number | null>>
+  iframeDocument: Document | null
+  setIframeDocument: Dispatch<SetStateAction<Document | null>>
+}
+
+interface DrawerContextType
+  extends
+    PreviewInteractionState,
+    Pick<
+      EditorDrawerProviderProps,
+      "type" | "permalink" | "siteId" | "pageId" | "updatedAt" | "title"
+    > {
   currActiveIdx: number
   setCurrActiveIdx: (currActiveIdx: number) => void
   drawerState: DrawerState
@@ -22,8 +34,6 @@ interface DrawerContextType extends Pick<
   setModifiedAssets: Dispatch<SetStateAction<ModifiedAsset[]>>
   addedBlockIndex: number | null
   setAddedBlockIndex: Dispatch<SetStateAction<number | null>>
-  hoveredBlockIndex: number | null
-  setHoveredBlockIndex: Dispatch<SetStateAction<number | null>>
 }
 const EditorDrawerContext = createContext<DrawerContextType | null>(null)
 
@@ -64,6 +74,7 @@ export function EditorDrawerProvider({
   const [hoveredBlockIndex, setHoveredBlockIndex] = useState<number | null>(
     null,
   )
+  const [iframeDocument, setIframeDocument] = useState<Document | null>(null)
 
   const setPreviewPageState = useCallback(
     (previewPageState: SetStateAction<IsomerSchema>) => {
@@ -97,6 +108,8 @@ export function EditorDrawerProvider({
         setAddedBlockIndex,
         hoveredBlockIndex,
         setHoveredBlockIndex,
+        iframeDocument,
+        setIframeDocument,
         type,
         permalink,
         siteId,

--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -11,6 +11,8 @@ export type BaseBlockProps = {
   variant?: "horizontal" | "vertical"
   containerProps?: StackProps
   onClick?: () => void
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
   draggableProps?: DraggableProvidedDragHandleProps | null
   invalidProps?: {
     description: string
@@ -34,6 +36,8 @@ export const BaseBlock = ({
   draggableProps,
   containerProps,
   onClick,
+  onMouseEnter,
+  onMouseLeave,
   invalidProps,
   isHidden,
 }: BaseBlockProps): JSX.Element | null => {
@@ -109,6 +113,8 @@ export const BaseBlock = ({
       align={variant === "vertical" ? "flex-start" : "center"}
       textAlign="start"
       onClick={onClick}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
       {...actualDraggableProps}
       {...containerProps}
     >

--- a/apps/studio/src/features/editing-experience/components/Block/DraggableBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/DraggableBlock.tsx
@@ -5,8 +5,9 @@ import {
   getComponentSchema,
   renderComponentPreviewText,
 } from "@opengovsg/isomer-components"
-import { useMemo } from "react"
+import { useEffect, useMemo } from "react"
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 
 import type { BaseBlockProps } from "./BaseBlock"
 import { TYPE_TO_ICON } from "../../constants"
@@ -30,6 +31,17 @@ export const DraggableBlock = ({
   invalidProps,
   isHidden,
 }: DraggableBlockProps): JSX.Element => {
+  const { setHoveredBlockIndex } = useEditorDrawerContext()
+
+  useEffect(() => {
+    // If this row unmounts while hovered (e.g. clicking it navigates the
+    // drawer away, or the block is deleted), no `mouseleave` fires — clear
+    // the hover state directly so the preview highlight doesn't get stuck.
+    return () => {
+      setHoveredBlockIndex((prev) => (prev === index ? null : prev))
+    }
+  }, [index, setHoveredBlockIndex])
+
   const icon = TYPE_TO_ICON[block.type]
 
   const blockComponentName = useMemo(() => {
@@ -64,6 +76,8 @@ export const DraggableBlock = ({
             <BaseBlock
               isHidden={isHidden}
               onClick={onClick}
+              onMouseEnter={() => setHoveredBlockIndex(index)}
+              onMouseLeave={() => setHoveredBlockIndex(null)}
               dragHandle={
                 <BaseBlockDragHandle
                   isDragging={isDragging}

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -36,6 +36,7 @@ import { BlockEditingPlaceholder } from "~/components/Svg"
 import { BRIEF_TOAST_SETTINGS } from "~/constants/toast"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { CanManageCollectionFilters } from "~/features/editing-experience/hooks/canManageCollectionFilters"
+import { useSelectBlock } from "~/features/editing-experience/hooks/useSelectBlock"
 import { useIsUserIsomerAdmin } from "~/hooks/useIsUserIsomerAdmin"
 import { useNewCollectionTagsManagement } from "~/hooks/useNewCollectionTagsManagement"
 import { useQueryParse } from "~/hooks/useQueryParse"
@@ -85,8 +86,8 @@ const FIXED_BLOCK_CONTENT: Record<string, FixedBlockContent> = {
 }
 
 const FixedBlock = () => {
-  const { setCurrActiveIdx, setDrawerState, previewPageState } =
-    useEditorDrawerContext()
+  const { setDrawerState, previewPageState } = useEditorDrawerContext()
+  const selectBlock = useSelectBlock()
   const pageLayout = previewPageState.layout
   const isHeroFixedBlock = getIsHeroFirstBlock(pageLayout, previewPageState)
   const isNewCollectionTagsManagementEnabled = useNewCollectionTagsManagement()
@@ -97,10 +98,7 @@ const FixedBlock = () => {
     const isValid = validateHeroComponentFn(fixedBlock)
     return (
       <BaseBlock
-        onClick={() => {
-          setCurrActiveIdx(0)
-          setDrawerState({ state: "heroEditor" })
-        }}
+        onClick={() => selectBlock(0, { state: "heroEditor" })}
         label="Hero banner"
         description="Title, subtitle, and Call-to-Action"
         icon={TYPE_TO_ICON.hero}
@@ -120,10 +118,9 @@ const FixedBlock = () => {
       <>
         <BaseBlock
           variant="vertical"
-          onClick={() => {
-            setCurrActiveIdx(0)
-            setDrawerState({ state: "collectionEditor", type: "display" })
-          }}
+          onClick={() =>
+            selectBlock(0, { state: "collectionEditor", type: "display" })
+          }
           label="Collection display"
           description="Customise the Collection’s Summary, Layout, Sorting logic, and Thumbnail."
           icon={BiCog}
@@ -131,10 +128,9 @@ const FixedBlock = () => {
         <CanManageCollectionFilters>
           <BaseBlock
             variant="vertical"
-            onClick={() => {
-              setCurrActiveIdx(0)
-              setDrawerState({ state: "collectionEditor", type: "filter" })
-            }}
+            onClick={() =>
+              selectBlock(0, { state: "collectionEditor", type: "filter" })
+            }
             label="Filters"
             description="Define and manage filters for this Collection."
             icon={BiSlider}
@@ -147,10 +143,9 @@ const FixedBlock = () => {
   if (pageLayout === ISOMER_USABLE_PAGE_LAYOUTS.Collection) {
     return (
       <BaseBlock
-        onClick={() => {
-          setCurrActiveIdx(0)
-          setDrawerState({ state: "collectionEditor", type: "display" })
-        }}
+        onClick={() =>
+          selectBlock(0, { state: "collectionEditor", type: "display" })
+        }
         label="Collection settings"
         description="Summary, style, categories and sorting"
         icon={BiPin}
@@ -201,12 +196,12 @@ export default function RootStateDrawer() {
   const {
     type,
     setDrawerState,
-    setCurrActiveIdx,
     savedPageState,
     setSavedPageState,
     previewPageState,
     setPreviewPageState,
   } = useEditorDrawerContext()
+  const selectBlock = useSelectBlock()
   const [isPreviewingIndexPage, setIsPreviewingIndexPage] = useState(false)
   const {
     isOpen: isConfirmConvertIndexPageModalOpen,
@@ -630,7 +625,6 @@ export default function RootStateDrawer() {
                                         draggableId={`${block.type}-${index}`}
                                         index={index}
                                         onClick={() => {
-                                          setCurrActiveIdx(index)
                                           // TODO: we should automatically do this probably?
                                           const nextState =
                                             savedPageState.content[index]
@@ -638,7 +632,9 @@ export default function RootStateDrawer() {
                                               ? "nativeEditor"
                                               : "complexEditor"
                                           // NOTE: SNAPSHOT
-                                          setDrawerState({ state: nextState })
+                                          selectBlock(index, {
+                                            state: nextState,
+                                          })
                                         }}
                                         invalidProps={
                                           invalidBlockIndexes.has(index)

--- a/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
@@ -1,3 +1,4 @@
+import { useToken } from "@chakra-ui/react"
 import { BLOCK_FLASH_FADE_DURATION_MS } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
 
 interface BlockHighlightOverlayProps {
@@ -20,6 +21,16 @@ export const BlockHighlightOverlay = ({
   label,
   isFading = false,
 }: BlockHighlightOverlayProps): JSX.Element => {
+  const [outlineColor, overlayBgColor, labelColor] = useToken("colors", [
+    "interaction.main.default",
+    "interaction.tinted.main.active",
+    "base.content.inverse",
+  ])
+  const [spacing2px, spacing8px] = useToken("space", ["0.5", "2"])
+  const [labelBorderRadius] = useToken("radii", ["md"])
+  const [labelFontSize] = useToken("fontSizes", ["xs"])
+  const [labelLineHeight] = useToken("lineHeights", ["base"])
+
   return (
     <div
       style={{
@@ -28,9 +39,9 @@ export const BlockHighlightOverlay = ({
         left,
         width,
         height,
-        outline: "2px solid #2164DA",
-        outlineOffset: "2px",
-        backgroundColor: "rgba(33, 100, 218, 0.12)",
+        outline: `${spacing2px} solid ${outlineColor}`,
+        outlineOffset: spacing2px,
+        backgroundColor: overlayBgColor,
         pointerEvents: "none",
         zIndex: 9999,
         opacity: isFading ? 0 : 1,
@@ -43,12 +54,12 @@ export const BlockHighlightOverlay = ({
             position: "absolute",
             top: 0,
             right: 0,
-            padding: "2px 8px",
-            fontSize: "12px",
-            lineHeight: 1.5,
-            color: "white",
-            backgroundColor: "#2164DA",
-            borderRadius: "0 0 0 6px",
+            padding: `${spacing2px} ${spacing8px}`,
+            fontSize: labelFontSize,
+            lineHeight: labelLineHeight,
+            color: labelColor,
+            backgroundColor: outlineColor,
+            borderRadius: `0 0 0 ${labelBorderRadius}`,
           }}
         >
           {label}

--- a/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
@@ -1,0 +1,50 @@
+interface BlockHighlightOverlayProps {
+  top: number
+  left: number
+  width: number
+  height: number
+  label?: string
+}
+
+export const BlockHighlightOverlay = ({
+  top,
+  left,
+  width,
+  height,
+  label,
+}: BlockHighlightOverlayProps): JSX.Element => {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top,
+        left,
+        width,
+        height,
+        outline: "2px solid #2164DA",
+        outlineOffset: "2px",
+        backgroundColor: "rgba(33, 100, 218, 0.12)",
+        pointerEvents: "none",
+        zIndex: 9999,
+      }}
+    >
+      {label && (
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            padding: "2px 8px",
+            fontSize: "12px",
+            lineHeight: 1.5,
+            color: "white",
+            backgroundColor: "#2164DA",
+            borderRadius: "0 0 0 6px",
+          }}
+        >
+          {label}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
@@ -1,9 +1,15 @@
+import { BLOCK_FLASH_FADE_DURATION_MS } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
+
 interface BlockHighlightOverlayProps {
   top: number
   left: number
   width: number
   height: number
   label?: string
+  // When true, fades the overlay out — used for the lingering flash shown
+  // after a click-to-scroll, as opposed to the hover highlight which just
+  // tracks the cursor at full opacity.
+  isFading?: boolean
 }
 
 export const BlockHighlightOverlay = ({
@@ -12,6 +18,7 @@ export const BlockHighlightOverlay = ({
   width,
   height,
   label,
+  isFading = false,
 }: BlockHighlightOverlayProps): JSX.Element => {
   return (
     <div
@@ -26,6 +33,8 @@ export const BlockHighlightOverlay = ({
         backgroundColor: "rgba(33, 100, 218, 0.12)",
         pointerEvents: "none",
         zIndex: 9999,
+        opacity: isFading ? 0 : 1,
+        transition: `opacity ${BLOCK_FLASH_FADE_DURATION_MS}ms ease-out`,
       }}
     >
       {label && (

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,5 +1,7 @@
+import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box } from "@chakra-ui/react"
 import { merge } from "lodash-es"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
@@ -26,16 +28,82 @@ const LoadingState = (): JSX.Element => {
 }
 
 const SuspendableEditPagePreview = (): JSX.Element => {
-  const { previewPageState, pageId, updatedAt, siteId, permalink, title } =
-    useEditorDrawerContext()
+  const {
+    previewPageState,
+    pageId,
+    updatedAt,
+    siteId,
+    permalink,
+    title,
+    hoveredBlockIndex,
+  } = useEditorDrawerContext()
 
   const [siteMap] = trpc.site.getLocalisedSitemap.useSuspenseQuery({
     siteId,
     resourceId: pageId,
   })
 
+  const [iframeDocument, setIframeDocument] = useState<Document | null>(null)
+  const overlayElRef = useRef<HTMLDivElement | null>(null)
+
+  const handleIframeMount = useCallback(
+    ({ document }: IframeCallbackFnProps) => {
+      setIframeDocument(document ?? null)
+    },
+    [],
+  )
+
+  useEffect(() => {
+    // Clear any previously-applied highlight overlay
+    overlayElRef.current?.remove()
+    overlayElRef.current = null
+
+    if (hoveredBlockIndex !== null && iframeDocument) {
+      // Blocks aren't individually wrapped (that broke the `first:mt-*`-style
+      // spacing most block components use), so instead we index directly
+      // into the children of the shared content container.
+      const contentBlocksContainer = iframeDocument.querySelector(
+        "[data-isomer-content-blocks]",
+      )
+      const blockEl = contentBlocksContainer?.children[hoveredBlockIndex] as
+        | HTMLElement
+        | undefined
+
+      if (blockEl) {
+        // Use a positioned overlay rather than styling the block directly —
+        // a background colour would paint behind the block's own content
+        // (invisible over opaque images/video), and an outline drawn on the
+        // block itself can only sit inside or across its edge, overlapping
+        // its content either way.
+        const scrollX = iframeDocument.defaultView?.scrollX ?? 0
+        const scrollY = iframeDocument.defaultView?.scrollY ?? 0
+        const rect = blockEl.getBoundingClientRect()
+
+        const overlay = iframeDocument.createElement("div")
+        overlay.style.position = "absolute"
+        overlay.style.top = `${rect.top + scrollY}px`
+        overlay.style.left = `${rect.left + scrollX}px`
+        overlay.style.width = `${rect.width}px`
+        overlay.style.height = `${rect.height}px`
+        overlay.style.outline = "2px solid #2164DA"
+        overlay.style.outlineOffset = "2px"
+        overlay.style.backgroundColor = "rgba(33, 100, 218, 0.12)"
+        overlay.style.pointerEvents = "none"
+        overlay.style.zIndex = "9999"
+
+        iframeDocument.body.appendChild(overlay)
+        overlayElRef.current = overlay
+      }
+    }
+
+    return () => {
+      overlayElRef.current?.remove()
+      overlayElRef.current = null
+    }
+  }, [hoveredBlockIndex, iframeDocument])
+
   return (
-    <ViewportContainer siteId={siteId}>
+    <ViewportContainer siteId={siteId} callback={handleIframeMount}>
       <PreviewWithCustomSitemap
         {...merge(previewPageState, { page: { title } })}
         siteId={siteId}

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,7 +1,7 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box } from "@chakra-ui/react"
 import { merge } from "lodash-es"
-import { useCallback, useState } from "react"
+import { useCallback } from "react"
 import { createPortal } from "react-dom"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useBlockHighlight } from "~/features/editing-experience/hooks/useBlockHighlight"
@@ -39,6 +39,8 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     permalink,
     title,
     hoveredBlockIndex,
+    iframeDocument,
+    setIframeDocument,
   } = useEditorDrawerContext()
 
   const [siteMap] = trpc.site.getLocalisedSitemap.useSuspenseQuery({
@@ -46,13 +48,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     resourceId: pageId,
   })
 
-  const [iframeDocument, setIframeDocument] = useState<Document | null>(null)
-
   const handleIframeMount = useCallback(
     ({ document }: IframeCallbackFnProps) => {
       setIframeDocument(document ?? null)
     },
-    [],
+    [setIframeDocument],
   )
 
   const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,13 +1,14 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box } from "@chakra-ui/react"
-import { getComponentSchema } from "@opengovsg/isomer-components"
 import { merge } from "lodash-es"
-import { useCallback, useEffect, useRef, useState } from "react"
-import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
+import { useCallback, useState } from "react"
+import { createPortal } from "react-dom"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { useBlockHighlight } from "~/features/editing-experience/hooks/useBlockHighlight"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
 
+import { BlockHighlightOverlay } from "./BlockHighlightOverlay"
 import { LoadingPreview } from "./LoadingPreview"
 import PreviewWithCustomSitemap from "./PreviewWithCustomSitemap"
 import { ViewportContainer } from "./ViewportContainer"
@@ -46,7 +47,6 @@ const SuspendableEditPagePreview = (): JSX.Element => {
   })
 
   const [iframeDocument, setIframeDocument] = useState<Document | null>(null)
-  const overlayElRef = useRef<HTMLDivElement | null>(null)
 
   const handleIframeMount = useCallback(
     ({ document }: IframeCallbackFnProps) => {
@@ -55,76 +55,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     [],
   )
 
-  useEffect(() => {
-    // Clear any previously-applied highlight overlay
-    overlayElRef.current?.remove()
-    overlayElRef.current = null
-
-    if (hoveredBlockIndex !== null && iframeDocument) {
-      // Blocks aren't individually wrapped (that broke the `first:mt-*`-style
-      // spacing most block components use), so instead we index directly
-      // into the children of the shared content container.
-      const contentBlocksContainer = iframeDocument.querySelector(
-        "[data-isomer-content-blocks]",
-      )
-      const blockEl = contentBlocksContainer?.children[hoveredBlockIndex] as
-        | HTMLElement
-        | undefined
-
-      if (blockEl) {
-        // Use a positioned overlay rather than styling the block directly —
-        // a background colour would paint behind the block's own content
-        // (invisible over opaque images/video), and an outline drawn on the
-        // block itself can only sit inside or across its edge, overlapping
-        // its content either way.
-        const scrollX = iframeDocument.defaultView?.scrollX ?? 0
-        const scrollY = iframeDocument.defaultView?.scrollY ?? 0
-        const rect = blockEl.getBoundingClientRect()
-
-        const overlay = iframeDocument.createElement("div")
-        overlay.style.position = "absolute"
-        overlay.style.top = `${rect.top + scrollY}px`
-        overlay.style.left = `${rect.left + scrollX}px`
-        overlay.style.width = `${rect.width}px`
-        overlay.style.height = `${rect.height}px`
-        overlay.style.outline = "2px solid #2164DA"
-        overlay.style.outlineOffset = "2px"
-        overlay.style.backgroundColor = "rgba(33, 100, 218, 0.12)"
-        overlay.style.pointerEvents = "none"
-        overlay.style.zIndex = "9999"
-
-        const block = previewPageState.content[hoveredBlockIndex]
-        if (block) {
-          const blockComponentName =
-            block.type === "prose"
-              ? PROSE_COMPONENT_NAME
-              : (getComponentSchema({ component: block.type }).title ??
-                "Unknown")
-
-          const label = iframeDocument.createElement("div")
-          label.textContent = blockComponentName
-          label.style.position = "absolute"
-          label.style.top = "0"
-          label.style.right = "0"
-          label.style.padding = "2px 8px"
-          label.style.fontSize = "12px"
-          label.style.lineHeight = "1.5"
-          label.style.color = "white"
-          label.style.backgroundColor = "#2164DA"
-          label.style.borderRadius = "0 0 0 6px"
-          overlay.appendChild(label)
-        }
-
-        iframeDocument.body.appendChild(overlay)
-        overlayElRef.current = overlay
-      }
-    }
-
-    return () => {
-      overlayElRef.current?.remove()
-      overlayElRef.current = null
-    }
-  }, [hoveredBlockIndex, iframeDocument, previewPageState])
+  const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({
+    iframeDocument,
+    hoveredBlockIndex,
+    content: previewPageState.content,
+  })
 
   return (
     <ViewportContainer siteId={siteId} callback={handleIframeMount}>
@@ -136,6 +71,17 @@ const SuspendableEditPagePreview = (): JSX.Element => {
         version="0.1.0"
         siteMap={siteMap}
       />
+      {/* Use a positioned overlay rather than styling the block directly —
+      a background colour would paint behind the block's own content
+      (invisible over opaque images/video), and an outline drawn on the
+      block itself can only sit inside or across its edge, overlapping
+      its content either way. */}
+      {iframeDocument &&
+        highlightRect &&
+        createPortal(
+          <BlockHighlightOverlay {...highlightRect} label={highlightLabel} />,
+          iframeDocument.body,
+        )}
     </ViewportContainer>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -4,6 +4,7 @@ import { merge } from "lodash-es"
 import { useCallback } from "react"
 import { createPortal } from "react-dom"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { useBlockFlashHighlight } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
 import { useBlockHighlight } from "~/features/editing-experience/hooks/useBlockHighlight"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
@@ -39,6 +40,8 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     permalink,
     title,
     hoveredBlockIndex,
+    flashBlockIndex,
+    setFlashBlockIndex,
     iframeDocument,
     setIframeDocument,
   } = useEditorDrawerContext()
@@ -61,6 +64,22 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     content: previewPageState.content,
   })
 
+  const { rect: flashRect, label: flashLabel } = useBlockHighlight({
+    iframeDocument,
+    hoveredBlockIndex: flashBlockIndex,
+    content: previewPageState.content,
+  })
+
+  const handleFlashEnd = useCallback(
+    () => setFlashBlockIndex(null),
+    [setFlashBlockIndex],
+  )
+
+  const { isFading: isFlashFading } = useBlockFlashHighlight({
+    flashBlockIndex,
+    onFlashEnd: handleFlashEnd,
+  })
+
   return (
     <ViewportContainer siteId={siteId} callback={handleIframeMount}>
       <PreviewWithCustomSitemap
@@ -80,6 +99,22 @@ const SuspendableEditPagePreview = (): JSX.Element => {
         highlightRect &&
         createPortal(
           <BlockHighlightOverlay {...highlightRect} label={highlightLabel} />,
+          iframeDocument.body,
+        )}
+      {/* Deliberately rendered even when it overlaps the hover overlay above
+      (e.g. clicking a block you're already hovering) — the flash's hold/fade
+      timer starts at click time regardless of render state, so gating this
+      on hover would let the timer run out before the block stops being
+      hovered, cutting the flash short or skipping it entirely. Overlapping
+      the identical hover overlay is visually a no-op. */}
+      {iframeDocument &&
+        flashRect &&
+        createPortal(
+          <BlockHighlightOverlay
+            {...flashRect}
+            label={flashLabel}
+            isFading={isFlashFading}
+          />,
           iframeDocument.body,
         )}
     </ViewportContainer>

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,7 +1,9 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box } from "@chakra-ui/react"
+import { getComponentSchema } from "@opengovsg/isomer-components"
 import { merge } from "lodash-es"
 import { useCallback, useEffect, useRef, useState } from "react"
+import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
@@ -91,6 +93,28 @@ const SuspendableEditPagePreview = (): JSX.Element => {
         overlay.style.pointerEvents = "none"
         overlay.style.zIndex = "9999"
 
+        const block = previewPageState.content[hoveredBlockIndex]
+        if (block) {
+          const blockComponentName =
+            block.type === "prose"
+              ? PROSE_COMPONENT_NAME
+              : (getComponentSchema({ component: block.type }).title ??
+                "Unknown")
+
+          const label = iframeDocument.createElement("div")
+          label.textContent = blockComponentName
+          label.style.position = "absolute"
+          label.style.top = "0"
+          label.style.right = "0"
+          label.style.padding = "2px 8px"
+          label.style.fontSize = "12px"
+          label.style.lineHeight = "1.5"
+          label.style.color = "white"
+          label.style.backgroundColor = "#2164DA"
+          label.style.borderRadius = "0 0 0 6px"
+          overlay.appendChild(label)
+        }
+
         iframeDocument.body.appendChild(overlay)
         overlayElRef.current = overlay
       }
@@ -100,7 +124,7 @@ const SuspendableEditPagePreview = (): JSX.Element => {
       overlayElRef.current?.remove()
       overlayElRef.current = null
     }
-  }, [hoveredBlockIndex, iframeDocument])
+  }, [hoveredBlockIndex, iframeDocument, previewPageState])
 
   return (
     <ViewportContainer siteId={siteId} callback={handleIframeMount}>

--- a/apps/studio/src/features/editing-experience/hooks/useBlockFlashHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockFlashHighlight.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react"
+
+const FLASH_HOLD_DURATION_MS = 400
+const FLASH_FADE_DURATION_MS = 900
+
+export const BLOCK_FLASH_FADE_DURATION_MS = FLASH_FADE_DURATION_MS
+
+interface UseBlockFlashHighlightParams {
+  flashBlockIndex: number | null
+  onFlashEnd: () => void
+}
+
+interface UseBlockFlashHighlightReturn {
+  isFading: boolean
+}
+
+// Drives the timing for the click-to-scroll flash highlight: hold at full
+// opacity so the fade is noticeable, then fade out and clear the flash state.
+export const useBlockFlashHighlight = ({
+  flashBlockIndex,
+  onFlashEnd,
+}: UseBlockFlashHighlightParams): UseBlockFlashHighlightReturn => {
+  const [isFading, setIsFading] = useState(false)
+
+  useEffect(() => {
+    if (flashBlockIndex === null) {
+      setIsFading(false)
+      return
+    }
+
+    setIsFading(false)
+    const fadeTimeout = setTimeout(
+      () => setIsFading(true),
+      FLASH_HOLD_DURATION_MS,
+    )
+    const endTimeout = setTimeout(
+      onFlashEnd,
+      FLASH_HOLD_DURATION_MS + FLASH_FADE_DURATION_MS,
+    )
+
+    return () => {
+      clearTimeout(fadeTimeout)
+      clearTimeout(endTimeout)
+    }
+    // oxlint-disable-next-line react-hooks/exhaustive-deps
+  }, [flashBlockIndex])
+
+  return { isFading }
+}

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -2,6 +2,7 @@ import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { useEffect, useState } from "react"
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
+import { getBlockElement } from "~/features/editing-experience/utils/getBlockElement"
 
 interface HighlightRect {
   top: number
@@ -36,15 +37,7 @@ export const useBlockHighlight = ({
       return
     }
 
-    // Blocks aren't individually wrapped (that broke the `first:mt-*`-style
-    // spacing most block components use), so instead we index directly
-    // into the children of the shared content container.
-    const contentBlocksContainer = iframeDocument.querySelector(
-      "[data-isomer-content-blocks]",
-    )
-    const blockEl = contentBlocksContainer?.children[hoveredBlockIndex] as
-      | HTMLElement
-      | undefined
+    const blockEl = getBlockElement(iframeDocument, hoveredBlockIndex)
 
     if (!blockEl) {
       setRect(null)

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -51,16 +51,31 @@ export const useBlockHighlight = ({
       return
     }
 
-    const scrollX = iframeDocument.defaultView?.scrollX ?? 0
-    const scrollY = iframeDocument.defaultView?.scrollY ?? 0
-    const domRect = blockEl.getBoundingClientRect()
+    const updateRect = () => {
+      const scrollX = iframeDocument.defaultView?.scrollX ?? 0
+      const scrollY = iframeDocument.defaultView?.scrollY ?? 0
+      const domRect = blockEl.getBoundingClientRect()
 
-    setRect({
-      top: domRect.top + scrollY,
-      left: domRect.left + scrollX,
-      width: domRect.width,
-      height: domRect.height,
-    })
+      setRect({
+        top: domRect.top + scrollY,
+        left: domRect.left + scrollX,
+        width: domRect.width,
+        height: domRect.height,
+      })
+    }
+
+    updateRect()
+
+    // Interacting with the block itself (e.g. expanding an Accordion) can
+    // change its size without the hover target ever changing, so the rect
+    // would otherwise go stale until the next mouseover/mouseout. Watch the
+    // hovered block directly rather than re-querying on every layout change.
+    const resizeObserver = new ResizeObserver(updateRect)
+    resizeObserver.observe(blockEl)
+
+    return () => {
+      resizeObserver.disconnect()
+    }
   }, [hoveredBlockIndex, iframeDocument])
 
   const block =

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -1,0 +1,76 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+import { getComponentSchema } from "@opengovsg/isomer-components"
+import { useEffect, useState } from "react"
+import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
+
+interface HighlightRect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+interface UseBlockHighlightParams {
+  iframeDocument: Document | null
+  hoveredBlockIndex: number | null
+  content: IsomerSchema["content"]
+}
+
+interface UseBlockHighlightReturn {
+  rect: HighlightRect | null
+  label: string | undefined
+}
+
+// Computes where (and what) to render for the currently hovered block's
+// highlight overlay in the preview iframe.
+export const useBlockHighlight = ({
+  iframeDocument,
+  hoveredBlockIndex,
+  content,
+}: UseBlockHighlightParams): UseBlockHighlightReturn => {
+  const [rect, setRect] = useState<HighlightRect | null>(null)
+
+  useEffect(() => {
+    if (hoveredBlockIndex === null || !iframeDocument) {
+      setRect(null)
+      return
+    }
+
+    // Blocks aren't individually wrapped (that broke the `first:mt-*`-style
+    // spacing most block components use), so instead we index directly
+    // into the children of the shared content container.
+    const contentBlocksContainer = iframeDocument.querySelector(
+      "[data-isomer-content-blocks]",
+    )
+    const blockEl = contentBlocksContainer?.children[hoveredBlockIndex] as
+      | HTMLElement
+      | undefined
+
+    if (!blockEl) {
+      setRect(null)
+      return
+    }
+
+    const scrollX = iframeDocument.defaultView?.scrollX ?? 0
+    const scrollY = iframeDocument.defaultView?.scrollY ?? 0
+    const domRect = blockEl.getBoundingClientRect()
+
+    setRect({
+      top: domRect.top + scrollY,
+      left: domRect.left + scrollX,
+      width: domRect.width,
+      height: domRect.height,
+    })
+  }, [hoveredBlockIndex, iframeDocument])
+
+  const block =
+    hoveredBlockIndex !== null ? content[hoveredBlockIndex] : undefined
+
+  const label = block
+    ? block.type === "prose"
+      ? PROSE_COMPONENT_NAME
+      : (getComponentSchema({ component: block.type }).title ?? "Unknown")
+    : undefined
+
+  return { rect, label }
+}

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -37,7 +37,7 @@ export const useBlockHighlight = ({
       return
     }
 
-    const blockEl = getBlockElement(iframeDocument, hoveredBlockIndex)
+    const blockEl = getBlockElement(iframeDocument, content, hoveredBlockIndex)
 
     if (!blockEl) {
       setRect(null)
@@ -69,7 +69,7 @@ export const useBlockHighlight = ({
     return () => {
       resizeObserver.disconnect()
     }
-  }, [hoveredBlockIndex, iframeDocument])
+  }, [hoveredBlockIndex, iframeDocument, content])
 
   const block =
     hoveredBlockIndex !== null ? content[hoveredBlockIndex] : undefined

--- a/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react"
+import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
+import { scrollToBlockElement } from "~/features/editing-experience/utils/scrollToBlockElement"
+import { type DrawerState } from "~/types/editorDrawer"
+
+// Marks a block as active, switches the drawer to its editor, and scrolls
+// the preview to it — the combination every "click a block" handler needs.
+export const useSelectBlock = () => {
+  const { setCurrActiveIdx, setDrawerState, iframeDocument } =
+    useEditorDrawerContext()
+
+  return useCallback(
+    (index: number, drawerState: DrawerState) => {
+      setCurrActiveIdx(index)
+      setDrawerState(drawerState)
+      scrollToBlockElement(iframeDocument, index)
+    },
+    [setCurrActiveIdx, setDrawerState, iframeDocument],
+  )
+}

--- a/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
@@ -6,15 +6,19 @@ import { type DrawerState } from "~/types/editorDrawer"
 // Marks a block as active, switches the drawer to its editor, and scrolls
 // the preview to it — the combination every "click a block" handler needs.
 export const useSelectBlock = () => {
-  const { setCurrActiveIdx, setDrawerState, iframeDocument } =
+  const { setCurrActiveIdx, setDrawerState, iframeDocument, previewPageState } =
     useEditorDrawerContext()
 
   return useCallback(
     (index: number, drawerState: DrawerState) => {
       setCurrActiveIdx(index)
       setDrawerState(drawerState)
-      scrollToBlockElement(iframeDocument, index)
+      scrollToBlockElement({
+        iframeDocument,
+        content: previewPageState.content,
+        index,
+      })
     },
-    [setCurrActiveIdx, setDrawerState, iframeDocument],
+    [setCurrActiveIdx, setDrawerState, iframeDocument, previewPageState],
   )
 }

--- a/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
@@ -6,19 +6,31 @@ import { type DrawerState } from "~/types/editorDrawer"
 // Marks a block as active, switches the drawer to its editor, and scrolls
 // the preview to it — the combination every "click a block" handler needs.
 export const useSelectBlock = () => {
-  const { setCurrActiveIdx, setDrawerState, iframeDocument, previewPageState } =
-    useEditorDrawerContext()
+  const {
+    setCurrActiveIdx,
+    setDrawerState,
+    setFlashBlockIndex,
+    iframeDocument,
+    previewPageState,
+  } = useEditorDrawerContext()
 
   return useCallback(
     (index: number, drawerState: DrawerState) => {
       setCurrActiveIdx(index)
       setDrawerState(drawerState)
+      setFlashBlockIndex(index)
       scrollToBlockElement({
         iframeDocument,
         content: previewPageState.content,
         index,
       })
     },
-    [setCurrActiveIdx, setDrawerState, iframeDocument, previewPageState],
+    [
+      setCurrActiveIdx,
+      setDrawerState,
+      setFlashBlockIndex,
+      iframeDocument,
+      previewPageState,
+    ],
   )
 }

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -1,0 +1,17 @@
+// Blocks aren't individually wrapped (that broke the `first:mt-*`-style
+// spacing most block components use), so instead we index directly into
+// the children of the shared content container.
+export const getBlockElement = (
+  iframeDocument: Document | null,
+  index: number | null,
+): HTMLElement | undefined => {
+  if (index === null || !iframeDocument) {
+    return undefined
+  }
+
+  const contentBlocksContainer = iframeDocument.querySelector(
+    "[data-isomer-content-blocks]",
+  )
+
+  return contentBlocksContainer?.children[index] as HTMLElement | undefined
+}

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -1,17 +1,39 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+
+// packages/components' renderPageContent filters out hidden childrenpages
+// blocks before rendering, so a hidden childrenpages block never reaches the
+// DOM and every block after it is shifted up by one. Mirror that filter here
+// so we can translate a `content` index into the matching DOM child index.
+const isHiddenChildrenPagesBlock = (
+  block: IsomerSchema["content"][number],
+): boolean => block.type === "childrenpages" && !!block.isHidden
+
 // Blocks aren't individually wrapped (that broke the `first:mt-*`-style
 // spacing most block components use), so instead we index directly into
 // the children of the shared content container.
 export const getBlockElement = (
   iframeDocument: Document | null,
+  content: IsomerSchema["content"],
   index: number | null,
 ): HTMLElement | undefined => {
   if (index === null || !iframeDocument) {
     return undefined
   }
 
+  const block = content[index]
+  if (!block || isHiddenChildrenPagesBlock(block)) {
+    return undefined
+  }
+
+  const visibleIndex = content
+    .slice(0, index)
+    .filter((b) => !isHiddenChildrenPagesBlock(b)).length
+
   const contentBlocksContainer = iframeDocument.querySelector(
     "[data-isomer-content-blocks]",
   )
 
-  return contentBlocksContainer?.children[index] as HTMLElement | undefined
+  return contentBlocksContainer?.children[visibleIndex] as
+    | HTMLElement
+    | undefined
 }

--- a/apps/studio/src/features/editing-experience/utils/index.ts
+++ b/apps/studio/src/features/editing-experience/utils/index.ts
@@ -1,4 +1,6 @@
 export * from "./createTableSelectionBorderPlugin"
+export * from "./getBlockElement"
 export * from "./getDgsIdFromString"
 export * from "./getHtmlWithRelativeReferenceLinks"
 export * from "./getSelectedCellBorderClasses"
+export * from "./scrollToBlockElement"

--- a/apps/studio/src/features/editing-experience/utils/scrollToBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/scrollToBlockElement.ts
@@ -1,9 +1,18 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+
 import { getBlockElement } from "./getBlockElement"
 
-export const scrollToBlockElement = (
-  iframeDocument: Document | null,
-  index: number | null,
-): void => {
-  const blockEl = getBlockElement(iframeDocument, index)
+interface ScrollToBlockElementParams {
+  iframeDocument: Document | null
+  content: IsomerSchema["content"]
+  index: number | null
+}
+
+export const scrollToBlockElement = ({
+  iframeDocument,
+  content,
+  index,
+}: ScrollToBlockElementParams): void => {
+  const blockEl = getBlockElement(iframeDocument, content, index)
   blockEl?.scrollIntoView({ behavior: "smooth", block: "nearest" })
 }

--- a/apps/studio/src/features/editing-experience/utils/scrollToBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/scrollToBlockElement.ts
@@ -1,0 +1,9 @@
+import { getBlockElement } from "./getBlockElement"
+
+export const scrollToBlockElement = (
+  iframeDocument: Document | null,
+  index: number | null,
+): void => {
+  const blockEl = getBlockElement(iframeDocument, index)
+  blockEl?.scrollIntoView({ behavior: "smooth", block: "nearest" })
+}

--- a/packages/components/src/templates/next/layouts/Article/Article.tsx
+++ b/packages/components/src/templates/next/layouts/Article/Article.tsx
@@ -46,7 +46,10 @@ export const ArticleLayout = ({
         />
 
         <div className="mx-auto w-full gap-10 pb-20">
-          <div className="w-full overflow-x-auto break-words lg:max-w-[660px]">
+          <div
+            className="w-full overflow-x-auto break-words lg:max-w-[660px]"
+            data-isomer-content-blocks
+          >
             {renderPageContent({
               site,
               layout,

--- a/packages/components/src/templates/next/layouts/Content/Content.tsx
+++ b/packages/components/src/templates/next/layouts/Content/Content.tsx
@@ -59,7 +59,7 @@ export const ContentLayout = ({
           {tableOfContents.length > 1 && (
             <TableOfContents items={tableOfContents} />
           )}
-          <div>
+          <div data-isomer-content-blocks>
             {renderPageContent({
               content: transformedContent,
               layout,

--- a/packages/components/src/templates/next/layouts/Database/Database.tsx
+++ b/packages/components/src/templates/next/layouts/Database/Database.tsx
@@ -50,7 +50,7 @@ export const DatabaseLayout = ({
             {tableOfContents.length > 1 && (
               <TableOfContents items={tableOfContents} />
             )}
-            <div>
+            <div data-isomer-content-blocks>
               {renderPageContent({
                 content: transformedContent,
                 layout,

--- a/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
+++ b/packages/components/src/templates/next/layouts/Homepage/Homepage.tsx
@@ -15,6 +15,7 @@ export const HomepageLayout = ({
         // ComponentContent = "component-content" (customCssClass.ts) is imported by all Homepage components,
         // but cannot be used here as tailwind does not support dynamic class names
         className={`break-words [&_.component-content]:mx-auto [&_.component-content]:max-w-screen-xl [&_.component-content]:px-6 [&_.component-content]:md:px-10`}
+        data-isomer-content-blocks
       >
         {renderPageContent({
           content,

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -15,7 +15,7 @@ const createIndexPageLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 break-words lg:col-span-8",
+    content: "col-span-12 flex flex-col gap-16 break-words lg:col-span-8",
   },
 })
 

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -15,7 +15,7 @@ const createIndexPageLayoutStyles = tv({
     container:
       "mx-auto grid max-w-screen-xl grid-cols-12 px-6 py-12 md:px-10 md:py-16 lg:gap-10",
     siderailContainer: "relative col-span-3 hidden lg:block",
-    content: "col-span-12 flex flex-col gap-16 break-words lg:col-span-8",
+    content: "col-span-12 flex flex-col gap-14 break-words lg:col-span-8",
   },
 })
 

--- a/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
+++ b/packages/components/src/templates/next/layouts/IndexPage/IndexPage.tsx
@@ -64,14 +64,16 @@ export const IndexPageLayout = ({
           {tableOfContents.length > 1 && (
             <TableOfContents items={tableOfContents} />
           )}
-          {renderPageContent({
-            content: transformedContent,
-            layout,
-            site,
-            permalink: page.permalink,
-            // ContentPageHeader above already owns the page's h1.
-            headingLevel: 2,
-          })}
+          <div data-isomer-content-blocks>
+            {renderPageContent({
+              content: transformedContent,
+              layout,
+              site,
+              permalink: page.permalink,
+              // ContentPageHeader above already owns the page's h1.
+              headingLevel: 2,
+            })}
+          </div>
         </div>
       </div>
     </Skeleton>


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 17 | +462 | -41 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

N/A — no tracked issue. This is a POC exploring cross-highlighting between the page editor's block list (sidebar) and the live preview iframe. Today, hovering or clicking a block row in the sidebar gives no indication of which rendered element it corresponds to in the preview, making it hard to map the editing UI to the actual page output, especially on pages with many similar-looking blocks or after clicking a row scrolls the preview somewhere off-screen.

Also closes https://linear.app/ogp/issue/ISOM-2498/studio-editing-preview-doesnt-scroll-to-block-being-edited-in-studio

## Solution

<!-- How did you solve the problem? -->

Hovering a block row in the sidebar highlights the corresponding block in the live preview iframe with an outline + tint overlay. Clicking a block row scrolls the preview to that block and briefly flashes the same highlight (held at full opacity, then faded out) so the click-to-scroll destination is visually confirmed even when the row isn't currently hovered. This PR only covers editor → preview highlighting; preview → editor (hovering the iframe to highlight the sidebar) is out of scope for this POC.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Hovering a block row in the sidebar (`RootStateDrawer`) highlights the corresponding block in the live preview iframe with an outline + background tint.
- Clicking a block row scrolls the preview to that block and flashes the same highlight overlay (holds briefly, then fades out over ~900ms), giving visual confirmation of which block was selected.

**Improvements**:

- `packages/components` layouts (`Content`, `Article`, `Homepage`, `Database`, `IndexPage`) now render a `data-isomer-content-blocks` marker on the single container that wraps all page-content blocks, giving Studio a stable, positional way to address an individual block's DOM node (`container.children[index]`) without wrapping blocks individually — wrapping each block would have broken the `first:mt-*`/`not(:first-child)`-style spacing most block components rely on for the gaps between them.
- The highlight itself is rendered as a separate positioned overlay element (absolutely positioned over the block's bounding box) rather than styled directly onto the block — a `background-color` on the block would paint behind opaque content like images, and an `outline` on the block itself would overlap its own content or edge depending on offset direction.
- `getBlockElement`/`scrollToBlockElement` now account for hidden `childrenpages` blocks, which `packages/components`' render path filters out of the DOM entirely — without this, a content index after a hidden block would resolve to the wrong DOM child.
- New `useSelectBlock` hook centralizes the "mark active, switch drawer state, scroll preview to it, and trigger the flash" sequence, replacing the duplicated `setCurrActiveIdx` + `setDrawerState` pairs previously scattered across `RootStateDrawer`'s click handlers.
- `EditorDrawerContext` gained `hoveredBlockIndex`/`setHoveredBlockIndex` and `flashBlockIndex`/`setFlashBlockIndex` state. The flash index is deliberately decoupled from the hover index — clicking a block can unmount its hover source (e.g. switching drawer state) well before the scroll and flash finish.
- The hover state is cleared when a sidebar row unmounts (not just on `mouseleave`) — clicking a row navigates the drawer away before a `mouseleave` can fire, which previously left the preview highlight stuck.

**Bug Fixes**:

- N/A (new functionality)

## Before & After Screenshots

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

https://github.com/user-attachments/assets/22711a6a-4abd-40bc-99b2-50b87d1164d8

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

- [ ] Open a page in the Studio editor with several different block types (e.g. Hero, Callout, Image Gallery, Map, Accordion).
- [ ] Hover each block row in the left sidebar list — confirm the corresponding block in the preview iframe is highlighted with a blue outline + tint, and that the outline sits around the block rather than overlapping its content.
- [ ] Confirm the spacing/gaps between blocks in the preview are unchanged from before this PR (i.e. no visual regression to block spacing).
- [ ] Move the mouse off a sidebar row — confirm the highlight in the preview disappears.
- [ ] Hover a sidebar row, then click it (opening that block's settings panel) — confirm the preview scrolls to that block and the highlight flashes (holds briefly, then fades) rather than staying stuck.
- [ ] Click a block row without hovering it first — confirm the preview still scrolls to it and flashes the highlight.
- [ ] Hover a sidebar row, then delete that block — confirm the highlight clears rather than staying stuck on a now-nonexistent block.
- [ ] On a page with a hidden "Child pages" block earlier in the content list, hover/click a block after it — confirm the highlight lands on the correct block (verifies the hidden-block index mapping).
- [ ] Test on a page using a different layout (e.g. an Index/Collection page, a Database page) to confirm highlighting still works there.
- [ ] Spot-check a published (non-Studio) page render is unaffected (the `data-isomer-content-blocks` attribute is inert on published sites — it carries no styling or behavior).



<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds editor-to-preview block highlighting and click-to-scroll feedback while preserving positional mapping across layouts and hidden child-page blocks.
- Adds shared hover, flash, and iframe-document state to the editor context.
- Adds overlay positioning, flash timing, block lookup, and scroll-selection utilities.
- Marks page-content containers across supported component layouts.
- Replaces the overlay’s previously hardcoded colors and dimensions with shared theme tokens.
</details>


<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx | The prior hardcoded overlay and label colors and dimensions are now sourced from Chakra theme tokens. |
| apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx | Integrates hover and flash overlays into the iframe document through portals. |
| apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts | Resolves block geometry and keeps overlay bounds synchronized through ResizeObserver. |
| apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts | Centralizes block selection, drawer navigation, preview scrolling, and flash activation. |
| apps/studio/src/features/editing-experience/utils/getBlockElement.ts | Maps editor content indexes to rendered children while excluding hidden child-page blocks. |
| packages/components/src/templates/next/layouts/Content/Content.tsx | Marks the rendered content-block container for positional lookup from Studio. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant E as Editor block row
  participant C as Editor context
  participant P as Preview iframe
  participant O as Highlight overlay
  E->>C: Hover block index
  C->>P: Resolve rendered child
  P->>O: Render highlight at block bounds
  E->>C: Select block index
  C->>P: Scroll block into view
  C->>O: Hold and fade flash highlight
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(IndexPage): match ToC-to-content gap..."](https://github.com/opengovsg/isomer/commit/acb37915c926420c4d884f7aeaf8dd00142b6898) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54218609)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Page authoring experience](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/page-authoring.md)
- Knowledge Base — [Site rendering components](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/site-rendering-components.md)
- Knowledge Base — [Component rendering engine](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/component-rendering-engine.md)
</details>


<!-- /greptile_comment -->