### PR TITLE
feat: Add preview hover -> editor sidebar cross-highlighting

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/BaseBlock.tsx
@@ -18,6 +18,7 @@ export type BaseBlockProps = {
     description: string
   }
   isHidden?: boolean
+  isHighlighted?: boolean
 } & (
   | {
       icon: IconType
@@ -40,6 +41,7 @@ export const BaseBlock = ({
   onMouseLeave,
   invalidProps,
   isHidden,
+  isHighlighted,
 }: BaseBlockProps): JSX.Element | null => {
   const actualDraggableProps = draggableProps ?? {}
 
@@ -86,7 +88,9 @@ export const BaseBlock = ({
       w="100%"
       borderRadius="6px"
       border="1px solid"
-      borderColor="base.divider.medium"
+      borderColor={
+        isHighlighted ? "interaction.main-subtle.hover" : "base.divider.medium"
+      }
       transitionProperty="common"
       transitionDuration="normal"
       aria-invalid={!!invalidProps}
@@ -106,7 +110,7 @@ export const BaseBlock = ({
         bg: "utility.feedback.critical-subtle",
         borderColor: "utility.feedback.critical",
       }}
-      bg="white"
+      bg={isHighlighted ? "interaction.muted.main.hover" : "white"}
       py={variant === "vertical" ? "1.25rem" : "0.75rem"}
       px={variant === "vertical" ? "1.25rem" : "0.75rem"}
       flexDirection="row"

--- a/apps/studio/src/features/editing-experience/components/Block/DraggableBlock.tsx
+++ b/apps/studio/src/features/editing-experience/components/Block/DraggableBlock.tsx
@@ -31,7 +31,7 @@ export const DraggableBlock = ({
   invalidProps,
   isHidden,
 }: DraggableBlockProps): JSX.Element => {
-  const { setHoveredBlockIndex } = useEditorDrawerContext()
+  const { hoveredBlockIndex, setHoveredBlockIndex } = useEditorDrawerContext()
 
   useEffect(() => {
     // If this row unmounts while hovered (e.g. clicking it navigates the
@@ -75,6 +75,7 @@ export const DraggableBlock = ({
           >
             <BaseBlock
               isHidden={isHidden}
+              isHighlighted={hoveredBlockIndex === index}
               onClick={onClick}
               onMouseEnter={() => setHoveredBlockIndex(index)}
               onMouseLeave={() => setHoveredBlockIndex(null)}

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.browser.test.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.browser.test.tsx
@@ -1,0 +1,76 @@
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { useState } from "react"
+import Frame from "react-frame-component"
+import { afterEach, describe, expect, it } from "vitest"
+import { theme } from "~/theme"
+
+import { DiscardChangesModal } from "../DiscardChangesModal"
+
+const SKIP_LABEL = "Skip to main content"
+
+const Harness = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Frame title="preview">
+        <a href="#content">{SKIP_LABEL}</a>
+        <button type="button" onClick={() => setIsOpen(true)}>
+          Edit
+        </button>
+        <div id="content">Main</div>
+      </Frame>
+      <DiscardChangesModal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        onDiscard={() => setIsOpen(false)}
+        returnFocusOnClose={false}
+        blockScrollOnMount={false}
+        lockFocusAcrossFrames={false}
+      />
+    </ThemeProvider>
+  )
+}
+
+describe("DiscardChangesModal preview iframe focus", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("does not focus Skip to main content when the dialog closes", async () => {
+    // Arrange
+    render(<Harness />)
+    const iframe = await screen.findByTitle("preview")
+    const iframeDocument = (iframe as HTMLIFrameElement).contentDocument
+    expect(iframeDocument).not.toBeNull()
+
+    const editButton = await waitFor(() => {
+      const button = iframeDocument!.querySelector("button")
+      expect(button).not.toBeNull()
+      return button!
+    })
+
+    // Act
+    fireEvent.click(editButton)
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Go back to editing" }),
+    )
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("dialog", {
+          name: /Are you sure you want to discard your changes/i,
+        }),
+      ).not.toBeInTheDocument()
+    })
+    expect(iframeDocument!.activeElement?.textContent).not.toBe(SKIP_LABEL)
+  })
+})

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.stories.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/nextjs"
+import { Box } from "@chakra-ui/react"
+
+import { DiscardChangesModal } from "./DiscardChangesModal"
+
+const meta: Meta<typeof DiscardChangesModal> = {
+  title: "Components/DiscardChangesModal",
+  component: DiscardChangesModal,
+  decorators: [
+    (storyFn) => (
+      <Box w="100%" h="100vh">
+        {storyFn()}
+      </Box>
+    ),
+  ],
+  parameters: {
+    layout: "fullscreen",
+    chromatic: { delay: 200 },
+  },
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+    onDiscard: () => undefined,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof DiscardChangesModal>
+
+export const Default: Story = {}

--- a/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
+++ b/apps/studio/src/features/editing-experience/components/DiscardChangesModal/DiscardChangesModal.tsx
@@ -1,3 +1,4 @@
+import type { ModalProps } from "@chakra-ui/react"
 import {
   HStack,
   Modal,
@@ -10,7 +11,10 @@ import {
 } from "@chakra-ui/react"
 import { Button, ModalCloseButton } from "@opengovsg/design-system-react"
 
-interface DiscardChangesModalProps {
+interface DiscardChangesModalProps extends Pick<
+  ModalProps,
+  "returnFocusOnClose" | "blockScrollOnMount" | "lockFocusAcrossFrames"
+> {
   isOpen: boolean
   onClose: () => void
   onDiscard: () => void
@@ -20,9 +24,10 @@ export const DiscardChangesModal = ({
   isOpen,
   onClose,
   onDiscard,
+  ...modalProps
 }: DiscardChangesModalProps): JSX.Element => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal isOpen={isOpen} onClose={onClose} {...modalProps}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader pr="4.5rem">

--- a/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/RootStateDrawer.tsx
@@ -46,6 +46,7 @@ import { IsomerAdminRole, ResourceType } from "~prisma/generated/generatedEnums"
 
 import { TYPE_TO_ICON } from "../../constants"
 import { pageSchema } from "../../schema"
+import { getDrawerStateForBlock } from "../../utils/getDrawerStateForBlock"
 import { getIsHeroFirstBlock } from "../../utils/getIsHeroFirstBlock"
 import { ActivateRawJsonEditorMode } from "../ActivateRawJsonEditorMode"
 import { BaseBlock } from "../Block/BaseBlock"
@@ -625,16 +626,17 @@ export default function RootStateDrawer() {
                                         draggableId={`${block.type}-${index}`}
                                         index={index}
                                         onClick={() => {
-                                          // TODO: we should automatically do this probably?
-                                          const nextState =
+                                          const savedBlock =
                                             savedPageState.content[index]
-                                              ?.type === "prose"
-                                              ? "nativeEditor"
-                                              : "complexEditor"
                                           // NOTE: SNAPSHOT
-                                          selectBlock(index, {
-                                            state: nextState,
-                                          })
+                                          selectBlock(
+                                            index,
+                                            savedBlock
+                                              ? getDrawerStateForBlock(
+                                                  savedBlock,
+                                                )
+                                              : { state: "complexEditor" },
+                                          )
                                         }}
                                         invalidProps={
                                           invalidBlockIndexes.has(index)

--- a/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
@@ -10,12 +10,7 @@ interface BlockHighlightOverlayProps {
   width: number
   height: number
   label?: string
-  // When true, fades the overlay out — used for the lingering flash shown
-  // after a click-to-scroll, as opposed to the hover highlight which just
-  // tracks the cursor at full opacity.
   isFading?: boolean
-  // Edit button, placed inside the top-right corner rather than outside it —
-  // outside would sit past the block's DOM bounds and trigger a mouseout.
   onEditClick?: () => void
 }
 

--- a/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
@@ -14,13 +14,8 @@ interface BlockHighlightOverlayProps {
   // after a click-to-scroll, as opposed to the hover highlight which just
   // tracks the cursor at full opacity.
   isFading?: boolean
-  // Renders an "Edit" button beside the label. Sits inside the box's
-  // top-right corner (rather than fully outside it) since the hover overlay
-  // only stays mounted while the cursor stays within the block's own DOM
-  // bounds — anything positioned outside that area would cause a
-  // `mouseout` the moment the cursor reaches it, clearing the highlight
-  // (and the button) before it could be clicked. Accepted trade-off: this
-  // can shadow a sliver of the block's own interactive content in that corner.
+  // Edit button, placed inside the top-right corner rather than outside it —
+  // outside would sit past the block's DOM bounds and trigger a mouseout.
   onEditClick?: () => void
 }
 

--- a/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/BlockHighlightOverlay.tsx
@@ -1,5 +1,8 @@
 import { useToken } from "@chakra-ui/react"
+import { BiPencil } from "react-icons/bi"
 import { BLOCK_FLASH_FADE_DURATION_MS } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
+
+const PILL_HEIGHT = "20px"
 
 interface BlockHighlightOverlayProps {
   top: number
@@ -11,6 +14,14 @@ interface BlockHighlightOverlayProps {
   // after a click-to-scroll, as opposed to the hover highlight which just
   // tracks the cursor at full opacity.
   isFading?: boolean
+  // Renders an "Edit" button beside the label. Sits inside the box's
+  // top-right corner (rather than fully outside it) since the hover overlay
+  // only stays mounted while the cursor stays within the block's own DOM
+  // bounds — anything positioned outside that area would cause a
+  // `mouseout` the moment the cursor reaches it, clearing the highlight
+  // (and the button) before it could be clicked. Accepted trade-off: this
+  // can shadow a sliver of the block's own interactive content in that corner.
+  onEditClick?: () => void
 }
 
 export const BlockHighlightOverlay = ({
@@ -20,12 +31,17 @@ export const BlockHighlightOverlay = ({
   height,
   label,
   isFading = false,
+  onEditClick,
 }: BlockHighlightOverlayProps): JSX.Element => {
-  const [outlineColor, overlayBgColor, labelColor] = useToken("colors", [
-    "interaction.main.default",
-    "interaction.tinted.main.active",
-    "base.content.inverse",
-  ])
+  const [outlineColor, overlayBgColor, labelColor, canvasColor] = useToken(
+    "colors",
+    [
+      "interaction.main.default",
+      "interaction.tinted.main.active",
+      "base.content.inverse",
+      "base.canvas.default",
+    ],
+  )
   const [spacing2px, spacing8px] = useToken("space", ["0.5", "2"])
   const [labelBorderRadius] = useToken("radii", ["md"])
   const [labelFontSize] = useToken("fontSizes", ["xs"])
@@ -48,21 +64,62 @@ export const BlockHighlightOverlay = ({
         transition: `opacity ${BLOCK_FLASH_FADE_DURATION_MS}ms ease-out`,
       }}
     >
-      {label && (
+      {(label ?? onEditClick) && (
         <div
+          data-isomer-preview-toolbar
           style={{
             position: "absolute",
             top: 0,
             right: 0,
-            padding: `${spacing2px} ${spacing8px}`,
-            fontSize: labelFontSize,
-            lineHeight: labelLineHeight,
-            color: labelColor,
-            backgroundColor: outlineColor,
-            borderRadius: `0 0 0 ${labelBorderRadius}`,
+            display: "flex",
+            alignItems: "stretch",
+            height: PILL_HEIGHT,
+            pointerEvents: onEditClick ? "auto" : "none",
           }}
         >
-          {label}
+          {onEditClick && (
+            <button
+              type="button"
+              onClick={onEditClick}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "4px",
+                height: PILL_HEIGHT,
+                boxSizing: "border-box",
+                padding: `0 ${spacing8px}`,
+                fontSize: labelFontSize,
+                lineHeight: labelLineHeight,
+                color: outlineColor,
+                backgroundColor: canvasColor,
+                border: `1px solid ${outlineColor}`,
+                borderRadius: `0 0 0 ${labelBorderRadius}`,
+                cursor: "pointer",
+              }}
+            >
+              <BiPencil size={12} />
+              Edit
+            </button>
+          )}
+          {label && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                height: PILL_HEIGHT,
+                padding: `0 ${spacing8px}`,
+                fontSize: labelFontSize,
+                lineHeight: labelLineHeight,
+                color: labelColor,
+                backgroundColor: outlineColor,
+                borderRadius: onEditClick
+                  ? `0 0 ${labelBorderRadius} 0`
+                  : `0 0 0 ${labelBorderRadius}`,
+              }}
+            >
+              {label}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,7 +1,8 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
-import { Box } from "@chakra-ui/react"
-import { merge } from "lodash-es"
-import { useCallback } from "react"
+import type { DrawerState } from "~/types/editorDrawer"
+import { Box, useDisclosure } from "@chakra-ui/react"
+import { isEqual, merge } from "lodash-es"
+import { useCallback, useState } from "react"
 import { createPortal } from "react-dom"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useBlockFlashHighlight } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
@@ -12,10 +13,16 @@ import { getDrawerStateForBlock } from "~/features/editing-experience/utils/getD
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
 
+import { DiscardChangesModal } from "../DiscardChangesModal"
 import { BlockHighlightOverlay } from "./BlockHighlightOverlay"
 import { LoadingPreview } from "./LoadingPreview"
 import PreviewWithCustomSitemap from "./PreviewWithCustomSitemap"
 import { ViewportContainer } from "./ViewportContainer"
+
+interface PendingBlockSelection {
+  index: number
+  drawerState: DrawerState
+}
 
 const LoadingState = (): JSX.Element => {
   return (
@@ -37,6 +44,9 @@ const LoadingState = (): JSX.Element => {
 const SuspendableEditPagePreview = (): JSX.Element => {
   const {
     previewPageState,
+    setPreviewPageState,
+    savedPageState,
+    currActiveIdx,
     pageId,
     updatedAt,
     siteId,
@@ -49,6 +59,14 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     iframeDocument,
     setIframeDocument,
   } = useEditorDrawerContext()
+
+  const {
+    isOpen: isDiscardChangesModalOpen,
+    onOpen: onDiscardChangesModalOpen,
+    onClose: onDiscardChangesModalClose,
+  } = useDisclosure()
+  const [pendingBlockSelection, setPendingBlockSelection] =
+    useState<PendingBlockSelection | null>(null)
 
   const [siteMap] = trpc.site.getLocalisedSitemap.useSuspenseQuery({
     siteId,
@@ -80,8 +98,49 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     if (hoveredBlockIndex === null) return
     const block = previewPageState.content[hoveredBlockIndex]
     if (!block) return
-    selectBlock(hoveredBlockIndex, getDrawerStateForBlock(block))
-  }, [hoveredBlockIndex, previewPageState.content, selectBlock])
+    const nextDrawerState = getDrawerStateForBlock(block)
+
+    const hasUnsavedChanges = !isEqual(previewPageState, savedPageState)
+    if (hasUnsavedChanges && hoveredBlockIndex !== currActiveIdx) {
+      setPendingBlockSelection({
+        index: hoveredBlockIndex,
+        drawerState: nextDrawerState,
+      })
+      onDiscardChangesModalOpen()
+      return
+    }
+    selectBlock(hoveredBlockIndex, nextDrawerState)
+  }, [
+    hoveredBlockIndex,
+    previewPageState,
+    savedPageState,
+    currActiveIdx,
+    selectBlock,
+    onDiscardChangesModalOpen,
+  ])
+
+  const handleDiscardChangesModalClose = useCallback(() => {
+    setPendingBlockSelection(null)
+    onDiscardChangesModalClose()
+  }, [onDiscardChangesModalClose])
+
+  const handleDiscardChanges = useCallback(() => {
+    setPreviewPageState(savedPageState)
+    onDiscardChangesModalClose()
+    if (pendingBlockSelection) {
+      selectBlock(
+        pendingBlockSelection.index,
+        pendingBlockSelection.drawerState,
+      )
+      setPendingBlockSelection(null)
+    }
+  }, [
+    savedPageState,
+    setPreviewPageState,
+    onDiscardChangesModalClose,
+    pendingBlockSelection,
+    selectBlock,
+  ])
 
   const { rect: flashRect, label: flashLabel } = useBlockHighlight({
     iframeDocument,
@@ -140,6 +199,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
           />,
           iframeDocument.body,
         )}
+      <DiscardChangesModal
+        isOpen={isDiscardChangesModalOpen}
+        onClose={handleDiscardChangesModalClose}
+        onDiscard={handleDiscardChanges}
+      />
     </ViewportContainer>
   )
 }

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -166,52 +166,56 @@ const SuspendableEditPagePreview = (): JSX.Element => {
   })
 
   return (
-    <ViewportContainer siteId={siteId} callback={handleIframeMount}>
-      <PreviewWithCustomSitemap
-        {...merge(previewPageState, { page: { title } })}
-        siteId={siteId}
-        permalink={permalink}
-        lastModified={updatedAt.toISOString()}
-        version="0.1.0"
-        siteMap={siteMap}
-      />
-      {/* Use a positioned overlay rather than styling the block directly —
-      a background colour would paint behind the block's own content
-      (invisible over opaque images/video), and an outline drawn on the
-      block itself can only sit inside or across its edge, overlapping
-      its content either way. */}
-      {iframeDocument &&
-        highlightRect &&
-        createPortal(
-          <BlockHighlightOverlay
-            {...highlightRect}
-            label={highlightLabel}
-            onEditClick={handleEditClick}
-          />,
-          iframeDocument.body,
-        )}
-      {/* Deliberately rendered even when it overlaps the hover overlay above
-      (e.g. clicking a block you're already hovering) — the flash's hold/fade
-      timer starts at click time regardless of render state, so gating this
-      on hover would let the timer run out before the block stops being
-      hovered, cutting the flash short or skipping it entirely. Overlapping
-      the identical hover overlay is visually a no-op. */}
-      {iframeDocument &&
-        flashRect &&
-        createPortal(
-          <BlockHighlightOverlay
-            {...flashRect}
-            label={flashLabel}
-            isFading={isFlashFading}
-          />,
-          iframeDocument.body,
-        )}
+    <>
+      <ViewportContainer siteId={siteId} callback={handleIframeMount}>
+        <PreviewWithCustomSitemap
+          {...merge(previewPageState, { page: { title } })}
+          siteId={siteId}
+          permalink={permalink}
+          lastModified={updatedAt.toISOString()}
+          version="0.1.0"
+          siteMap={siteMap}
+        />
+        {/* Use a positioned overlay rather than styling the block directly —
+        a background colour would paint behind the block's own content
+        (invisible over opaque images/video), and an outline drawn on the
+        block itself can only sit inside or across its edge, overlapping
+        its content either way. */}
+        {iframeDocument &&
+          highlightRect &&
+          createPortal(
+            <BlockHighlightOverlay
+              {...highlightRect}
+              label={highlightLabel}
+              onEditClick={handleEditClick}
+            />,
+            iframeDocument.body,
+          )}
+        {/* Deliberately rendered even when it overlaps the hover overlay above
+        (e.g. clicking a block you're already hovering) — the flash's hold/fade
+        timer starts at click time regardless of render state, so gating this
+        on hover would let the timer run out before the block stops being
+        hovered, cutting the flash short or skipping it entirely. Overlapping
+        the identical hover overlay is visually a no-op. */}
+        {iframeDocument &&
+          flashRect &&
+          createPortal(
+            <BlockHighlightOverlay
+              {...flashRect}
+              label={flashLabel}
+              isFading={isFlashFading}
+            />,
+            iframeDocument.body,
+          )}
+      </ViewportContainer>
+      {/* Outside the preview iframe: Chakra portals into ownerDocument.body,
+          and the iframe only loads site CSS, so the dialog would be unstyled. */}
       <DiscardChangesModal
         isOpen={isDiscardChangesModalOpen}
         onClose={handleDiscardChangesModalClose}
         onDiscard={handleDiscardChanges}
       />
-    </ViewportContainer>
+    </>
   )
 }
 

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,5 +1,4 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
-import type { DrawerState } from "~/types/editorDrawer"
 import { Box, useDisclosure } from "@chakra-ui/react"
 import { isEqual, merge } from "lodash-es"
 import { useCallback, useState } from "react"
@@ -21,7 +20,6 @@ import { ViewportContainer } from "./ViewportContainer"
 
 interface PendingBlockSelection {
   index: number
-  drawerState: DrawerState
 }
 
 const LoadingState = (): JSX.Element => {
@@ -102,10 +100,7 @@ const SuspendableEditPagePreview = (): JSX.Element => {
 
     const hasUnsavedChanges = !isEqual(previewPageState, savedPageState)
     if (hasUnsavedChanges && hoveredBlockIndex !== currActiveIdx) {
-      setPendingBlockSelection({
-        index: hoveredBlockIndex,
-        drawerState: nextDrawerState,
-      })
+      setPendingBlockSelection({ index: hoveredBlockIndex })
       onDiscardChangesModalOpen()
       return
     }
@@ -128,10 +123,17 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     setPreviewPageState(savedPageState)
     onDiscardChangesModalClose()
     if (pendingBlockSelection) {
-      selectBlock(
-        pendingBlockSelection.index,
-        pendingBlockSelection.drawerState,
-      )
+      // Re-derive the target block from the just-restored saved content —
+      // the pending selection's index came from hovering the discarded
+      // preview, whose structure (and therefore block types/positions) may
+      // no longer match `savedPageState` after add/remove/reorder edits.
+      const restoredBlock = savedPageState.content[pendingBlockSelection.index]
+      if (restoredBlock) {
+        selectBlock(
+          pendingBlockSelection.index,
+          getDrawerStateForBlock(restoredBlock),
+        )
+      }
       setPendingBlockSelection(null)
     }
   }, [

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,7 +1,7 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box } from "@chakra-ui/react"
 import { merge } from "lodash-es"
-import { useCallback } from "react"
+import { useCallback, useEffect } from "react"
 import { createPortal } from "react-dom"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useBlockFlashHighlight } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
@@ -40,6 +40,7 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     permalink,
     title,
     hoveredBlockIndex,
+    setHoveredBlockIndex,
     flashBlockIndex,
     setFlashBlockIndex,
     iframeDocument,
@@ -57,6 +58,53 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     },
     [setIframeDocument],
   )
+
+  useEffect(() => {
+    if (!iframeDocument) return
+
+    // Resolve which block (if any) a mouse event target belongs to by
+    // walking up to the direct child of the shared content-blocks container.
+    const resolveBlockIndex = (target: EventTarget | null): number | null => {
+      const container = iframeDocument.querySelector(
+        "[data-isomer-content-blocks]",
+      )
+      if (!container) return null
+
+      let node = target as Node | null
+      while (node && node.parentElement !== container) {
+        node = node.parentElement
+      }
+      if (!(node instanceof HTMLElement)) return null
+
+      const index = Array.prototype.indexOf.call(container.children, node)
+      return index === -1 ? null : index
+    }
+
+    const handleMouseOver = (event: MouseEvent) => {
+      const index = resolveBlockIndex(event.target)
+      if (index !== null) setHoveredBlockIndex(index)
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const container = iframeDocument.querySelector(
+        "[data-isomer-content-blocks]",
+      )
+      if (!container) return
+
+      const related = event.relatedTarget as Node | null
+      if (!related || !container.contains(related)) {
+        setHoveredBlockIndex(null)
+      }
+    }
+
+    iframeDocument.addEventListener("mouseover", handleMouseOver)
+    iframeDocument.addEventListener("mouseout", handleMouseOut)
+
+    return () => {
+      iframeDocument.removeEventListener("mouseover", handleMouseOver)
+      iframeDocument.removeEventListener("mouseout", handleMouseOut)
+    }
+  }, [iframeDocument, setHoveredBlockIndex])
 
   const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({
     iframeDocument,

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -74,7 +74,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
       while (node && node.parentElement !== container) {
         node = node.parentElement
       }
-      if (!(node instanceof HTMLElement)) return null
+      // NOTE: Deliberately not `instanceof HTMLElement` — react-frame-component
+      // portals content into the iframe's own document, so DOM nodes there are
+      // instances of the iframe's own HTMLElement global, not this window's.
+      // `instanceof` checks against the parent realm's class silently fail.
+      if (!node) return null
 
       const index = Array.prototype.indexOf.call(container.children, node)
       return index === -1 ? null : index

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -21,6 +21,7 @@ import { ViewportContainer } from "./ViewportContainer"
 
 interface PendingBlockSelection {
   block: IsomerSchema["content"][number]
+  index: number
 }
 
 const LoadingState = (): JSX.Element => {
@@ -66,6 +67,8 @@ const SuspendableEditPagePreview = (): JSX.Element => {
   } = useDisclosure()
   const [pendingBlockSelection, setPendingBlockSelection] =
     useState<PendingBlockSelection | null>(null)
+  const [hoveredBlockElement, setHoveredBlockElement] =
+    useState<HTMLElement | null>(null)
 
   const [siteMap] = trpc.site.getLocalisedSitemap.useSuspenseQuery({
     siteId,
@@ -83,11 +86,13 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     iframeDocument,
     previewPageState.content,
     setHoveredBlockIndex,
+    setHoveredBlockElement,
   )
 
   const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({
     iframeDocument,
     hoveredBlockIndex,
+    hoveredBlockElement,
     content: previewPageState.content,
   })
 
@@ -101,7 +106,7 @@ const SuspendableEditPagePreview = (): JSX.Element => {
 
     const hasUnsavedChanges = !isEqual(previewPageState, savedPageState)
     if (hasUnsavedChanges && hoveredBlockIndex !== currActiveIdx) {
-      setPendingBlockSelection({ block })
+      setPendingBlockSelection({ block, index: hoveredBlockIndex })
       onDiscardChangesModalOpen()
       return
     }
@@ -124,9 +129,14 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     setPreviewPageState(savedPageState)
     onDiscardChangesModalClose()
     if (pendingBlockSelection) {
-      const idx = savedPageState.content.findIndex((b) =>
-        isEqual(b, pendingBlockSelection.block),
-      )
+      const { block, index } = pendingBlockSelection
+      let idx = savedPageState.content.findIndex((b) => isEqual(b, block))
+      if (idx === -1) {
+        const savedBlock = savedPageState.content[index]
+        if (savedBlock?.type === block.type) {
+          idx = index
+        }
+      }
       if (idx !== -1) {
         const restoredBlock = savedPageState.content[idx]
         if (restoredBlock) {

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -62,7 +62,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     [setIframeDocument],
   )
 
-  usePreviewHoverDetection(iframeDocument, setHoveredBlockIndex)
+  usePreviewHoverDetection(
+    iframeDocument,
+    previewPageState.content,
+    setHoveredBlockIndex,
+  )
 
   const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({
     iframeDocument,

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -67,8 +67,6 @@ const SuspendableEditPagePreview = (): JSX.Element => {
   } = useDisclosure()
   const [pendingBlockSelection, setPendingBlockSelection] =
     useState<PendingBlockSelection | null>(null)
-  const [hoveredBlockElement, setHoveredBlockElement] =
-    useState<HTMLElement | null>(null)
 
   const [siteMap] = trpc.site.getLocalisedSitemap.useSuspenseQuery({
     siteId,
@@ -86,13 +84,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     iframeDocument,
     previewPageState.content,
     setHoveredBlockIndex,
-    setHoveredBlockElement,
   )
 
   const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({
     iframeDocument,
     hoveredBlockIndex,
-    hoveredBlockElement,
     content: previewPageState.content,
   })
 

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,11 +1,14 @@
 import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box } from "@chakra-ui/react"
 import { merge } from "lodash-es"
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 import { createPortal } from "react-dom"
 import { useEditorDrawerContext } from "~/contexts/EditorDrawerContext"
 import { useBlockFlashHighlight } from "~/features/editing-experience/hooks/useBlockFlashHighlight"
 import { useBlockHighlight } from "~/features/editing-experience/hooks/useBlockHighlight"
+import { usePreviewHoverDetection } from "~/features/editing-experience/hooks/usePreviewHoverDetection"
+import { useSelectBlock } from "~/features/editing-experience/hooks/useSelectBlock"
+import { getDrawerStateForBlock } from "~/features/editing-experience/utils/getDrawerStateForBlock"
 import { withSuspense } from "~/hocs/withSuspense"
 import { trpc } from "~/utils/trpc"
 
@@ -59,62 +62,22 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     [setIframeDocument],
   )
 
-  useEffect(() => {
-    if (!iframeDocument) return
-
-    // Resolve which block (if any) a mouse event target belongs to by
-    // walking up to the direct child of the shared content-blocks container.
-    const resolveBlockIndex = (target: EventTarget | null): number | null => {
-      const container = iframeDocument.querySelector(
-        "[data-isomer-content-blocks]",
-      )
-      if (!container) return null
-
-      let node = target as Node | null
-      while (node && node.parentElement !== container) {
-        node = node.parentElement
-      }
-      // NOTE: Deliberately not `instanceof HTMLElement` — react-frame-component
-      // portals content into the iframe's own document, so DOM nodes there are
-      // instances of the iframe's own HTMLElement global, not this window's.
-      // `instanceof` checks against the parent realm's class silently fail.
-      if (!node) return null
-
-      const index = Array.prototype.indexOf.call(container.children, node)
-      return index === -1 ? null : index
-    }
-
-    const handleMouseOver = (event: MouseEvent) => {
-      const index = resolveBlockIndex(event.target)
-      if (index !== null) setHoveredBlockIndex(index)
-    }
-
-    const handleMouseOut = (event: MouseEvent) => {
-      const container = iframeDocument.querySelector(
-        "[data-isomer-content-blocks]",
-      )
-      if (!container) return
-
-      const related = event.relatedTarget as Node | null
-      if (!related || !container.contains(related)) {
-        setHoveredBlockIndex(null)
-      }
-    }
-
-    iframeDocument.addEventListener("mouseover", handleMouseOver)
-    iframeDocument.addEventListener("mouseout", handleMouseOut)
-
-    return () => {
-      iframeDocument.removeEventListener("mouseover", handleMouseOver)
-      iframeDocument.removeEventListener("mouseout", handleMouseOut)
-    }
-  }, [iframeDocument, setHoveredBlockIndex])
+  usePreviewHoverDetection(iframeDocument, setHoveredBlockIndex)
 
   const { rect: highlightRect, label: highlightLabel } = useBlockHighlight({
     iframeDocument,
     hoveredBlockIndex,
     content: previewPageState.content,
   })
+
+  const selectBlock = useSelectBlock()
+
+  const handleEditClick = useCallback(() => {
+    if (hoveredBlockIndex === null) return
+    const block = previewPageState.content[hoveredBlockIndex]
+    if (!block) return
+    selectBlock(hoveredBlockIndex, getDrawerStateForBlock(block))
+  }, [hoveredBlockIndex, previewPageState.content, selectBlock])
 
   const { rect: flashRect, label: flashLabel } = useBlockHighlight({
     iframeDocument,
@@ -150,7 +113,11 @@ const SuspendableEditPagePreview = (): JSX.Element => {
       {iframeDocument &&
         highlightRect &&
         createPortal(
-          <BlockHighlightOverlay {...highlightRect} label={highlightLabel} />,
+          <BlockHighlightOverlay
+            {...highlightRect}
+            label={highlightLabel}
+            onEditClick={handleEditClick}
+          />,
           iframeDocument.body,
         )}
       {/* Deliberately rendered even when it overlaps the hover overlay above

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -1,3 +1,4 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { IframeCallbackFnProps } from "~/types/dom"
 import { Box, useDisclosure } from "@chakra-ui/react"
 import { isEqual, merge } from "lodash-es"
@@ -19,7 +20,7 @@ import PreviewWithCustomSitemap from "./PreviewWithCustomSitemap"
 import { ViewportContainer } from "./ViewportContainer"
 
 interface PendingBlockSelection {
-  index: number
+  block: IsomerSchema["content"][number]
 }
 
 const LoadingState = (): JSX.Element => {
@@ -100,7 +101,7 @@ const SuspendableEditPagePreview = (): JSX.Element => {
 
     const hasUnsavedChanges = !isEqual(previewPageState, savedPageState)
     if (hasUnsavedChanges && hoveredBlockIndex !== currActiveIdx) {
-      setPendingBlockSelection({ index: hoveredBlockIndex })
+      setPendingBlockSelection({ block })
       onDiscardChangesModalOpen()
       return
     }
@@ -123,16 +124,14 @@ const SuspendableEditPagePreview = (): JSX.Element => {
     setPreviewPageState(savedPageState)
     onDiscardChangesModalClose()
     if (pendingBlockSelection) {
-      // Re-derive the target block from the just-restored saved content —
-      // the pending selection's index came from hovering the discarded
-      // preview, whose structure (and therefore block types/positions) may
-      // no longer match `savedPageState` after add/remove/reorder edits.
-      const restoredBlock = savedPageState.content[pendingBlockSelection.index]
-      if (restoredBlock) {
-        selectBlock(
-          pendingBlockSelection.index,
-          getDrawerStateForBlock(restoredBlock),
-        )
+      const idx = savedPageState.content.findIndex((b) =>
+        isEqual(b, pendingBlockSelection.block),
+      )
+      if (idx !== -1) {
+        const restoredBlock = savedPageState.content[idx]
+        if (restoredBlock) {
+          selectBlock(idx, getDrawerStateForBlock(restoredBlock))
+        }
       }
       setPendingBlockSelection(null)
     }

--- a/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
+++ b/apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
@@ -209,11 +209,16 @@ const SuspendableEditPagePreview = (): JSX.Element => {
           )}
       </ViewportContainer>
       {/* Outside the preview iframe: Chakra portals into ownerDocument.body,
-          and the iframe only loads site CSS, so the dialog would be unstyled. */}
+          and the iframe only loads site CSS, so the dialog would be unstyled.
+          Do not restore focus or lock scroll into the iframe — that focuses
+          "Skip to main content" and jumps the preview to the top. */}
       <DiscardChangesModal
         isOpen={isDiscardChangesModalOpen}
         onClose={handleDiscardChangesModalClose}
         onDiscard={handleDiscardChanges}
+        returnFocusOnClose={false}
+        blockScrollOnMount={false}
+        lockFocusAcrossFrames={false}
       />
     </>
   )

--- a/apps/studio/src/features/editing-experience/constants.ts
+++ b/apps/studio/src/features/editing-experience/constants.ts
@@ -67,6 +67,7 @@ export const LEFT_EDITOR_AFTER_EDITING_EVENT = "left-editor-after-editing"
 
 // Shared by getBlockElement.ts and usePreviewHoverDetection.ts.
 export const CONTENT_BLOCKS_SELECTOR = "[data-isomer-content-blocks]"
+export const CONTENT_BLOCK_INDEX_ATTR = "data-isomer-content-index"
 export type ContentEditSurveyEvent =
   | typeof PUBLISHED_AFTER_EDITING_EVENT
   | typeof LEFT_EDITOR_AFTER_EDITING_EVENT

--- a/apps/studio/src/features/editing-experience/constants.ts
+++ b/apps/studio/src/features/editing-experience/constants.ts
@@ -64,6 +64,9 @@ export const TYPE_TO_ICON: Record<
 
 export const PUBLISHED_AFTER_EDITING_EVENT = "published-after-editing"
 export const LEFT_EDITOR_AFTER_EDITING_EVENT = "left-editor-after-editing"
+
+// Shared by getBlockElement.ts and usePreviewHoverDetection.ts.
+export const CONTENT_BLOCKS_SELECTOR = "[data-isomer-content-blocks]"
 export type ContentEditSurveyEvent =
   | typeof PUBLISHED_AFTER_EDITING_EVENT
   | typeof LEFT_EDITOR_AFTER_EDITING_EVENT

--- a/apps/studio/src/features/editing-experience/constants.ts
+++ b/apps/studio/src/features/editing-experience/constants.ts
@@ -65,7 +65,6 @@ export const TYPE_TO_ICON: Record<
 export const PUBLISHED_AFTER_EDITING_EVENT = "published-after-editing"
 export const LEFT_EDITOR_AFTER_EDITING_EVENT = "left-editor-after-editing"
 
-// Shared by getBlockElement.ts and usePreviewHoverDetection.ts.
 export const CONTENT_BLOCKS_SELECTOR = "[data-isomer-content-blocks]"
 export const CONTENT_BLOCK_INDEX_ATTR = "data-isomer-content-index"
 export type ContentEditSurveyEvent =

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -1,37 +1,33 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
+import type { BlockHighlightRect } from "~/features/editing-experience/utils/getBlockElement"
 import { getComponentSchema } from "@opengovsg/isomer-components"
 import { useEffect, useState } from "react"
 import { PROSE_COMPONENT_NAME } from "~/constants/formBuilder"
-import { getBlockElement } from "~/features/editing-experience/utils/getBlockElement"
-
-interface HighlightRect {
-  top: number
-  left: number
-  width: number
-  height: number
-}
+import {
+  getBlockElements,
+  getBlockHighlightRect,
+} from "~/features/editing-experience/utils/getBlockElement"
 
 interface UseBlockHighlightParams {
   iframeDocument: Document | null
   hoveredBlockIndex: number | null
-  hoveredBlockElement?: HTMLElement | null
   content: IsomerSchema["content"]
 }
 
 interface UseBlockHighlightReturn {
-  rect: HighlightRect | null
+  rect: BlockHighlightRect | null
   label: string | undefined
 }
 
 // Computes where (and what) to render for the currently hovered block's
-// highlight overlay in the preview iframe.
+// highlight overlay in the preview iframe. Multi-node blocks (e.g. prose)
+// share one overlay covering every stamped node.
 export const useBlockHighlight = ({
   iframeDocument,
   hoveredBlockIndex,
-  hoveredBlockElement,
   content,
 }: UseBlockHighlightParams): UseBlockHighlightReturn => {
-  const [rect, setRect] = useState<HighlightRect | null>(null)
+  const [rect, setRect] = useState<BlockHighlightRect | null>(null)
 
   useEffect(() => {
     if (hoveredBlockIndex === null || !iframeDocument) {
@@ -39,40 +35,32 @@ export const useBlockHighlight = ({
       return
     }
 
-    const blockEl =
-      hoveredBlockElement ?? getBlockElement(iframeDocument, hoveredBlockIndex)
+    const blockEls = getBlockElements(iframeDocument, hoveredBlockIndex)
 
-    if (!blockEl) {
+    if (blockEls.length === 0) {
       setRect(null)
       return
     }
 
     const updateRect = () => {
-      const scrollX = iframeDocument.defaultView?.scrollX ?? 0
-      const scrollY = iframeDocument.defaultView?.scrollY ?? 0
-      const domRect = blockEl.getBoundingClientRect()
-
-      setRect({
-        top: domRect.top + scrollY,
-        left: domRect.left + scrollX,
-        width: domRect.width,
-        height: domRect.height,
-      })
+      setRect(getBlockHighlightRect(iframeDocument, hoveredBlockIndex) ?? null)
     }
 
     updateRect()
 
     // Interacting with the block itself (e.g. expanding an Accordion) can
     // change its size without the hover target ever changing, so the rect
-    // would otherwise go stale until the next mouseover/mouseout. Watch the
-    // hovered block directly rather than re-querying on every layout change.
+    // would otherwise go stale until the next mouseover/mouseout. Watch every
+    // stamped node — a prose block is several siblings, not one wrapper.
     const resizeObserver = new ResizeObserver(updateRect)
-    resizeObserver.observe(blockEl)
+    for (const el of blockEls) {
+      resizeObserver.observe(el)
+    }
 
     return () => {
       resizeObserver.disconnect()
     }
-  }, [hoveredBlockIndex, hoveredBlockElement, iframeDocument, content])
+  }, [hoveredBlockIndex, iframeDocument, content])
 
   const block =
     hoveredBlockIndex !== null ? content[hoveredBlockIndex] : undefined

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -14,6 +14,7 @@ interface HighlightRect {
 interface UseBlockHighlightParams {
   iframeDocument: Document | null
   hoveredBlockIndex: number | null
+  hoveredBlockElement?: HTMLElement | null
   content: IsomerSchema["content"]
 }
 
@@ -27,6 +28,7 @@ interface UseBlockHighlightReturn {
 export const useBlockHighlight = ({
   iframeDocument,
   hoveredBlockIndex,
+  hoveredBlockElement,
   content,
 }: UseBlockHighlightParams): UseBlockHighlightReturn => {
   const [rect, setRect] = useState<HighlightRect | null>(null)
@@ -37,7 +39,8 @@ export const useBlockHighlight = ({
       return
     }
 
-    const blockEl = getBlockElement(iframeDocument, hoveredBlockIndex)
+    const blockEl =
+      hoveredBlockElement ?? getBlockElement(iframeDocument, hoveredBlockIndex)
 
     if (!blockEl) {
       setRect(null)
@@ -69,7 +72,7 @@ export const useBlockHighlight = ({
     return () => {
       resizeObserver.disconnect()
     }
-  }, [hoveredBlockIndex, iframeDocument, content])
+  }, [hoveredBlockIndex, hoveredBlockElement, iframeDocument, content])
 
   const block =
     hoveredBlockIndex !== null ? content[hoveredBlockIndex] : undefined

--- a/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useBlockHighlight.ts
@@ -37,7 +37,7 @@ export const useBlockHighlight = ({
       return
     }
 
-    const blockEl = getBlockElement(iframeDocument, content, hoveredBlockIndex)
+    const blockEl = getBlockElement(iframeDocument, hoveredBlockIndex)
 
     if (!blockEl) {
       setRect(null)

--- a/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
+++ b/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
@@ -1,12 +1,17 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
+import type { Dispatch, SetStateAction } from "react"
 import { useEffect } from "react"
-import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
+import {
+  CONTENT_BLOCK_INDEX_ATTR,
+  CONTENT_BLOCKS_SELECTOR,
+} from "~/features/editing-experience/constants"
 import { getContentIndexFromElement } from "~/features/editing-experience/utils/getBlockElement"
 
 export const usePreviewHoverDetection = (
   iframeDocument: Document | null,
   content: IsomerSchema["content"],
   setHoveredBlockIndex: (index: number | null) => void,
+  setHoveredBlockElement?: Dispatch<SetStateAction<HTMLElement | null>>,
 ): void => {
   useEffect(() => {
     if (!iframeDocument) return
@@ -16,10 +21,14 @@ export const usePreviewHoverDetection = (
     const handleMouseOver = (event: MouseEvent) => {
       container ??= iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
 
-      const contentIndex = getContentIndexFromElement(
-        event.target as Element | null,
+      const target = event.target as Element | null
+      const contentIndex = getContentIndexFromElement(target)
+      if (contentIndex === null) return
+
+      setHoveredBlockIndex(contentIndex)
+      setHoveredBlockElement?.(
+        target?.closest<HTMLElement>(`[${CONTENT_BLOCK_INDEX_ATTR}]`) ?? null,
       )
-      if (contentIndex !== null) setHoveredBlockIndex(contentIndex)
     }
 
     const handleMouseOut = (event: MouseEvent) => {
@@ -46,6 +55,7 @@ export const usePreviewHoverDetection = (
       }
 
       setHoveredBlockIndex(null)
+      setHoveredBlockElement?.(null)
     }
 
     iframeDocument.addEventListener("mouseover", handleMouseOver)
@@ -55,5 +65,5 @@ export const usePreviewHoverDetection = (
       iframeDocument.removeEventListener("mouseover", handleMouseOver)
       iframeDocument.removeEventListener("mouseout", handleMouseOut)
     }
-  }, [iframeDocument, content, setHoveredBlockIndex])
+  }, [iframeDocument, content, setHoveredBlockIndex, setHoveredBlockElement])
 }

--- a/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
+++ b/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
@@ -1,17 +1,12 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
-import type { Dispatch, SetStateAction } from "react"
 import { useEffect } from "react"
-import {
-  CONTENT_BLOCK_INDEX_ATTR,
-  CONTENT_BLOCKS_SELECTOR,
-} from "~/features/editing-experience/constants"
+import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
 import { getContentIndexFromElement } from "~/features/editing-experience/utils/getBlockElement"
 
 export const usePreviewHoverDetection = (
   iframeDocument: Document | null,
   content: IsomerSchema["content"],
   setHoveredBlockIndex: (index: number | null) => void,
-  setHoveredBlockElement?: Dispatch<SetStateAction<HTMLElement | null>>,
 ): void => {
   useEffect(() => {
     if (!iframeDocument) return
@@ -21,14 +16,10 @@ export const usePreviewHoverDetection = (
     const handleMouseOver = (event: MouseEvent) => {
       container ??= iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
 
-      const target = event.target as Element | null
-      const contentIndex = getContentIndexFromElement(target)
-      if (contentIndex === null) return
-
-      setHoveredBlockIndex(contentIndex)
-      setHoveredBlockElement?.(
-        target?.closest<HTMLElement>(`[${CONTENT_BLOCK_INDEX_ATTR}]`) ?? null,
+      const contentIndex = getContentIndexFromElement(
+        event.target as Element | null,
       )
+      if (contentIndex !== null) setHoveredBlockIndex(contentIndex)
     }
 
     const handleMouseOut = (event: MouseEvent) => {
@@ -55,7 +46,6 @@ export const usePreviewHoverDetection = (
       }
 
       setHoveredBlockIndex(null)
-      setHoveredBlockElement?.(null)
     }
 
     iframeDocument.addEventListener("mouseover", handleMouseOver)
@@ -65,5 +55,5 @@ export const usePreviewHoverDetection = (
       iframeDocument.removeEventListener("mouseover", handleMouseOver)
       iframeDocument.removeEventListener("mouseout", handleMouseOut)
     }
-  }, [iframeDocument, content, setHoveredBlockIndex, setHoveredBlockElement])
+  }, [iframeDocument, content, setHoveredBlockIndex])
 }

--- a/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
+++ b/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
@@ -3,10 +3,6 @@ import { useEffect } from "react"
 import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
 import { getContentIndexFromElement } from "~/features/editing-experience/utils/getBlockElement"
 
-// Tracks which block the cursor is over inside the preview iframe (the
-// reverse of hovering a sidebar row). Hand-rolled instead of usehooks-ts's
-// `useEventListener`, which only re-subscribes on `element` ref identity
-// change, not `.current` change — misses `iframeDocument` going null -> set.
 export const usePreviewHoverDetection = (
   iframeDocument: Document | null,
   content: IsomerSchema["content"],
@@ -37,17 +33,11 @@ export const usePreviewHoverDetection = (
         )
         const toIndex = getContentIndexFromElement(related as Element | null)
 
-        // Moving between elements inside the same block (e.g. prose items).
         if (fromIndex !== null && fromIndex === toIndex) return
-
-        // Another block inside the container — mouseover will update the index.
         if (container.contains(related)) return
 
-        // The hover toolbar is portaled as a sibling of the content container,
-        // not a descendant, so moving onto it fires mouseout with
-        // `relatedTarget` outside the block — that would unmount the toolbar
-        // mid-hover and loop (block reappears -> synthetic mouseover -> repeat).
-        // Treat entering the toolbar as staying within the block.
+        // The edit toolbar is portaled outside the content container; treat
+        // moving onto it as staying within the hovered block.
         const relatedElement = related as Element | null
         const enteredToolbar = relatedElement?.closest?.(
           "[data-isomer-preview-toolbar]",

--- a/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
+++ b/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
@@ -1,0 +1,85 @@
+import { useEffect } from "react"
+
+const CONTENT_BLOCKS_SELECTOR = "[data-isomer-content-blocks]"
+
+// Resolve which block (if any) a mouse event target belongs to by walking up
+// to the direct child of the shared content-blocks container.
+const resolveBlockIndex = (
+  container: Element,
+  target: EventTarget | null,
+): number | null => {
+  let node = target as Node | null
+  while (node && node.parentElement !== container) {
+    node = node.parentElement
+  }
+  // NOTE: Deliberately not `instanceof HTMLElement` — react-frame-component
+  // portals content into the iframe's own document, so DOM nodes there are
+  // instances of the iframe's own HTMLElement global, not this window's.
+  // `instanceof` checks against the parent realm's class silently fail.
+  if (!node) return null
+
+  const index = Array.prototype.indexOf.call(container.children, node)
+  return index === -1 ? null : index
+}
+
+// Tracks which block the cursor is over inside the preview iframe, so the
+// sidebar can mirror the highlight (the reverse of hovering a sidebar row to
+// highlight the preview). Hand-rolled rather than usehooks-ts's
+// `useEventListener`: that hook only re-subscribes when its `element` ref's
+// *identity* changes, not when `.current` does — since `iframeDocument`
+// starts `null` and is only set once the iframe finishes mounting, it would
+// permanently miss the real target and fall back to `window`.
+export const usePreviewHoverDetection = (
+  iframeDocument: Document | null,
+  setHoveredBlockIndex: (index: number | null) => void,
+): void => {
+  useEffect(() => {
+    if (!iframeDocument) return
+
+    const handleMouseOver = (event: MouseEvent) => {
+      const container = iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
+      if (!container) return
+
+      const index = resolveBlockIndex(container, event.target)
+      if (index !== null) setHoveredBlockIndex(index)
+    }
+
+    const handleMouseOut = (event: MouseEvent) => {
+      const container = iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
+      if (!container) return
+
+      const related = event.relatedTarget as Node | null
+      if (related && container.contains(related)) return
+
+      // The hover toolbar (Edit button + label pill) is portaled directly
+      // into `iframeDocument.body` as a sibling of the content-blocks
+      // container, not a descendant of it — see BlockHighlightOverlay.tsx.
+      // Moving the cursor onto the toolbar therefore fires `mouseout` on the
+      // block with `relatedTarget` outside `container`, which would clear
+      // the highlight and unmount the toolbar out from under the cursor.
+      // That exposes the block underneath again, the browser re-runs hit
+      // testing, and a synthetic `mouseover` fires without real cursor
+      // movement — restarting the cycle as an infinite flicker loop. Treat
+      // entering the toolbar the same as staying within the block.
+      // NOTE: Deliberately not `instanceof Element` — see the note above
+      // about react-frame-component portaling into the iframe's own
+      // document; `instanceof` against the parent realm's class silently
+      // fails here too.
+      const relatedElement = event.relatedTarget as Element | null
+      const enteredToolbar = relatedElement?.closest?.(
+        "[data-isomer-preview-toolbar]",
+      )
+      if (enteredToolbar) return
+
+      setHoveredBlockIndex(null)
+    }
+
+    iframeDocument.addEventListener("mouseover", handleMouseOver)
+    iframeDocument.addEventListener("mouseout", handleMouseOut)
+
+    return () => {
+      iframeDocument.removeEventListener("mouseover", handleMouseOver)
+      iframeDocument.removeEventListener("mouseout", handleMouseOut)
+    }
+  }, [iframeDocument, setHoveredBlockIndex])
+}

--- a/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
+++ b/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
@@ -1,26 +1,7 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { useEffect } from "react"
 import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
-import { getContentIndexFromDomIndex } from "~/features/editing-experience/utils/getBlockElement"
-
-// Walks up to the direct child of the content-blocks container and returns
-// its DOM position — a raw DOM index, not a `content` array index (hidden
-// childrenpages blocks aren't rendered; see getBlockElement.ts for the map).
-const resolveDomBlockIndex = (
-  container: Element,
-  target: EventTarget | null,
-): number | null => {
-  let node = target as Node | null
-  while (node && node.parentElement !== container) {
-    node = node.parentElement
-  }
-  // Not `instanceof HTMLElement`: react-frame-component portals into the
-  // iframe's own document, whose nodes belong to a different realm.
-  if (!node) return null
-
-  const index = Array.prototype.indexOf.call(container.children, node)
-  return index === -1 ? null : index
-}
+import { getContentIndexFromElement } from "~/features/editing-experience/utils/getBlockElement"
 
 // Tracks which block the cursor is over inside the preview iframe (the
 // reverse of hovering a sidebar row). Hand-rolled instead of usehooks-ts's
@@ -34,17 +15,14 @@ export const usePreviewHoverDetection = (
   useEffect(() => {
     if (!iframeDocument) return
 
-    // Cached across events rather than re-queried per mouseover/mouseout.
     let container = iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
 
     const handleMouseOver = (event: MouseEvent) => {
       container ??= iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
-      if (!container) return
 
-      const domIndex = resolveDomBlockIndex(container, event.target)
-      if (domIndex === null) return
-
-      const contentIndex = getContentIndexFromDomIndex(content, domIndex)
+      const contentIndex = getContentIndexFromElement(
+        event.target as Element | null,
+      )
       if (contentIndex !== null) setHoveredBlockIndex(contentIndex)
     }
 
@@ -53,19 +31,29 @@ export const usePreviewHoverDetection = (
       if (!container) return
 
       const related = event.relatedTarget as Node | null
-      if (related && container.contains(related)) return
+      if (related) {
+        const fromIndex = getContentIndexFromElement(
+          event.target as Element | null,
+        )
+        const toIndex = getContentIndexFromElement(related as Element | null)
 
-      // The hover toolbar is portaled as a sibling of `container`, not a
-      // descendant, so moving onto it fires mouseout with `relatedTarget`
-      // outside `container` — that would unmount the toolbar mid-hover and
-      // loop (block reappears -> synthetic mouseover -> repeat). Treat
-      // entering the toolbar as staying within the block.
-      // Not `instanceof Element` — see the cross-realm note above.
-      const relatedElement = event.relatedTarget as Element | null
-      const enteredToolbar = relatedElement?.closest?.(
-        "[data-isomer-preview-toolbar]",
-      )
-      if (enteredToolbar) return
+        // Moving between elements inside the same block (e.g. prose items).
+        if (fromIndex !== null && fromIndex === toIndex) return
+
+        // Another block inside the container — mouseover will update the index.
+        if (container.contains(related)) return
+
+        // The hover toolbar is portaled as a sibling of the content container,
+        // not a descendant, so moving onto it fires mouseout with
+        // `relatedTarget` outside the block — that would unmount the toolbar
+        // mid-hover and loop (block reappears -> synthetic mouseover -> repeat).
+        // Treat entering the toolbar as staying within the block.
+        const relatedElement = related as Element | null
+        const enteredToolbar = relatedElement?.closest?.(
+          "[data-isomer-preview-toolbar]",
+        )
+        if (enteredToolbar) return
+      }
 
       setHoveredBlockIndex(null)
     }

--- a/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
+++ b/apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts
@@ -1,10 +1,12 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { useEffect } from "react"
+import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
+import { getContentIndexFromDomIndex } from "~/features/editing-experience/utils/getBlockElement"
 
-const CONTENT_BLOCKS_SELECTOR = "[data-isomer-content-blocks]"
-
-// Resolve which block (if any) a mouse event target belongs to by walking up
-// to the direct child of the shared content-blocks container.
-const resolveBlockIndex = (
+// Walks up to the direct child of the content-blocks container and returns
+// its DOM position — a raw DOM index, not a `content` array index (hidden
+// childrenpages blocks aren't rendered; see getBlockElement.ts for the map).
+const resolveDomBlockIndex = (
   container: Element,
   target: EventTarget | null,
 ): number | null => {
@@ -12,59 +14,53 @@ const resolveBlockIndex = (
   while (node && node.parentElement !== container) {
     node = node.parentElement
   }
-  // NOTE: Deliberately not `instanceof HTMLElement` — react-frame-component
-  // portals content into the iframe's own document, so DOM nodes there are
-  // instances of the iframe's own HTMLElement global, not this window's.
-  // `instanceof` checks against the parent realm's class silently fail.
+  // Not `instanceof HTMLElement`: react-frame-component portals into the
+  // iframe's own document, whose nodes belong to a different realm.
   if (!node) return null
 
   const index = Array.prototype.indexOf.call(container.children, node)
   return index === -1 ? null : index
 }
 
-// Tracks which block the cursor is over inside the preview iframe, so the
-// sidebar can mirror the highlight (the reverse of hovering a sidebar row to
-// highlight the preview). Hand-rolled rather than usehooks-ts's
-// `useEventListener`: that hook only re-subscribes when its `element` ref's
-// *identity* changes, not when `.current` does — since `iframeDocument`
-// starts `null` and is only set once the iframe finishes mounting, it would
-// permanently miss the real target and fall back to `window`.
+// Tracks which block the cursor is over inside the preview iframe (the
+// reverse of hovering a sidebar row). Hand-rolled instead of usehooks-ts's
+// `useEventListener`, which only re-subscribes on `element` ref identity
+// change, not `.current` change — misses `iframeDocument` going null -> set.
 export const usePreviewHoverDetection = (
   iframeDocument: Document | null,
+  content: IsomerSchema["content"],
   setHoveredBlockIndex: (index: number | null) => void,
 ): void => {
   useEffect(() => {
     if (!iframeDocument) return
 
+    // Cached across events rather than re-queried per mouseover/mouseout.
+    let container = iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
+
     const handleMouseOver = (event: MouseEvent) => {
-      const container = iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
+      container ??= iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
       if (!container) return
 
-      const index = resolveBlockIndex(container, event.target)
-      if (index !== null) setHoveredBlockIndex(index)
+      const domIndex = resolveDomBlockIndex(container, event.target)
+      if (domIndex === null) return
+
+      const contentIndex = getContentIndexFromDomIndex(content, domIndex)
+      if (contentIndex !== null) setHoveredBlockIndex(contentIndex)
     }
 
     const handleMouseOut = (event: MouseEvent) => {
-      const container = iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
+      container ??= iframeDocument.querySelector(CONTENT_BLOCKS_SELECTOR)
       if (!container) return
 
       const related = event.relatedTarget as Node | null
       if (related && container.contains(related)) return
 
-      // The hover toolbar (Edit button + label pill) is portaled directly
-      // into `iframeDocument.body` as a sibling of the content-blocks
-      // container, not a descendant of it — see BlockHighlightOverlay.tsx.
-      // Moving the cursor onto the toolbar therefore fires `mouseout` on the
-      // block with `relatedTarget` outside `container`, which would clear
-      // the highlight and unmount the toolbar out from under the cursor.
-      // That exposes the block underneath again, the browser re-runs hit
-      // testing, and a synthetic `mouseover` fires without real cursor
-      // movement — restarting the cycle as an infinite flicker loop. Treat
-      // entering the toolbar the same as staying within the block.
-      // NOTE: Deliberately not `instanceof Element` — see the note above
-      // about react-frame-component portaling into the iframe's own
-      // document; `instanceof` against the parent realm's class silently
-      // fails here too.
+      // The hover toolbar is portaled as a sibling of `container`, not a
+      // descendant, so moving onto it fires mouseout with `relatedTarget`
+      // outside `container` — that would unmount the toolbar mid-hover and
+      // loop (block reappears -> synthetic mouseover -> repeat). Treat
+      // entering the toolbar as staying within the block.
+      // Not `instanceof Element` — see the cross-realm note above.
       const relatedElement = event.relatedTarget as Element | null
       const enteredToolbar = relatedElement?.closest?.(
         "[data-isomer-preview-toolbar]",
@@ -81,5 +77,5 @@ export const usePreviewHoverDetection = (
       iframeDocument.removeEventListener("mouseover", handleMouseOver)
       iframeDocument.removeEventListener("mouseout", handleMouseOut)
     }
-  }, [iframeDocument, setHoveredBlockIndex])
+  }, [iframeDocument, content, setHoveredBlockIndex])
 }

--- a/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
+++ b/apps/studio/src/features/editing-experience/hooks/useSelectBlock.ts
@@ -11,7 +11,6 @@ export const useSelectBlock = () => {
     setDrawerState,
     setFlashBlockIndex,
     iframeDocument,
-    previewPageState,
   } = useEditorDrawerContext()
 
   return useCallback(
@@ -21,16 +20,9 @@ export const useSelectBlock = () => {
       setFlashBlockIndex(index)
       scrollToBlockElement({
         iframeDocument,
-        content: previewPageState.content,
         index,
       })
     },
-    [
-      setCurrActiveIdx,
-      setDrawerState,
-      setFlashBlockIndex,
-      iframeDocument,
-      previewPageState,
-    ],
+    [setCurrActiveIdx, setDrawerState, setFlashBlockIndex, iframeDocument],
   )
 }

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
@@ -5,7 +5,7 @@ import { CONTENT_BLOCK_INDEX_ATTR } from "../../constants"
 import { getBlockElement, getContentIndexFromElement } from "../getBlockElement"
 
 const renderContainer = (
-  blocks: Array<{ contentIndex: number; tag?: string }>,
+  blocks: { contentIndex: number; tag?: string }[],
 ): HTMLElement => {
   const container = document.createElement("div")
   container.setAttribute("data-isomer-content-blocks", "")
@@ -44,15 +44,9 @@ describe("getBlockElement / getContentIndexFromElement", () => {
     })
 
     it("maps a stamped DOM node back to the same content index", () => {
-      expect(
-        getContentIndexFromElement(container?.children[0] as Element),
-      ).toBe(0)
-      expect(
-        getContentIndexFromElement(container?.children[1] as Element),
-      ).toBe(1)
-      expect(
-        getContentIndexFromElement(container?.children[2] as Element),
-      ).toBe(2)
+      expect(getContentIndexFromElement(container!.children[0]!)).toBe(0)
+      expect(getContentIndexFromElement(container!.children[1]!)).toBe(1)
+      expect(getContentIndexFromElement(container!.children[2]!)).toBe(2)
     })
   })
 
@@ -75,21 +69,13 @@ describe("getBlockElement / getContentIndexFromElement", () => {
     })
 
     it("maps every DOM node belonging to prose back to the prose content index", () => {
-      expect(
-        getContentIndexFromElement(container?.children[0] as Element),
-      ).toBe(0)
-      expect(
-        getContentIndexFromElement(container?.children[1] as Element),
-      ).toBe(0)
-      expect(
-        getContentIndexFromElement(container?.children[2] as Element),
-      ).toBe(0)
+      expect(getContentIndexFromElement(container!.children[0]!)).toBe(0)
+      expect(getContentIndexFromElement(container!.children[1]!)).toBe(0)
+      expect(getContentIndexFromElement(container!.children[2]!)).toBe(0)
     })
 
     it("maps the DOM node after prose back to the following content index", () => {
-      expect(
-        getContentIndexFromElement(container?.children[3] as Element),
-      ).toBe(1)
+      expect(getContentIndexFromElement(container!.children[3]!)).toBe(1)
     })
   })
 

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
@@ -1,25 +1,26 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
-import {
-  getBlockElement,
-  getContentIndexFromDomIndex,
-} from "../getBlockElement"
+import { CONTENT_BLOCK_INDEX_ATTR } from "../../constants"
+import { getBlockElement, getContentIndexFromElement } from "../getBlockElement"
 
-// Mirrors packages/components' rendering rules well enough to exercise the
-// index math: each content block becomes one or more direct children of
-// `[data-isomer-content-blocks]`, in order.
-const renderContainer = (domChildTags: string[]): HTMLElement => {
+const renderContainer = (
+  blocks: Array<{ contentIndex: number; tag?: string }>,
+): HTMLElement => {
   const container = document.createElement("div")
   container.setAttribute("data-isomer-content-blocks", "")
-  domChildTags.forEach((tag) => {
-    container.appendChild(document.createElement(tag))
+
+  blocks.forEach(({ contentIndex, tag = "div" }) => {
+    const el = document.createElement(tag)
+    el.setAttribute(CONTENT_BLOCK_INDEX_ATTR, String(contentIndex))
+    container.appendChild(el)
   })
+
   document.body.appendChild(container)
   return container
 }
 
-describe("getBlockElement / getContentIndexFromDomIndex", () => {
+describe("getBlockElement / getContentIndexFromElement", () => {
   let container: HTMLElement | null = null
 
   afterEach(() => {
@@ -29,85 +30,83 @@ describe("getBlockElement / getContentIndexFromDomIndex", () => {
 
   describe("blocks that render as a single DOM node", () => {
     beforeEach(() => {
-      container = renderContainer(["div", "div", "div"])
+      container = renderContainer([
+        { contentIndex: 0 },
+        { contentIndex: 1 },
+        { contentIndex: 2 },
+      ])
     })
 
-    it("maps content index to the DOM child at the same position", () => {
-      const content = [
-        { type: "hero" },
-        { type: "image" },
-        { type: "callout" },
-      ] as unknown as IsomerSchema["content"]
-
-      expect(getBlockElement(document, content, 0)).toBe(container?.children[0])
-      expect(getBlockElement(document, content, 1)).toBe(container?.children[1])
-      expect(getBlockElement(document, content, 2)).toBe(container?.children[2])
+    it("maps content index to the stamped DOM node", () => {
+      expect(getBlockElement(document, 0)).toBe(container?.children[0])
+      expect(getBlockElement(document, 1)).toBe(container?.children[1])
+      expect(getBlockElement(document, 2)).toBe(container?.children[2])
     })
 
-    it("maps a DOM index back to the same content index", () => {
-      const content = [
-        { type: "hero" },
-        { type: "image" },
-        { type: "callout" },
-      ] as unknown as IsomerSchema["content"]
-
-      expect(getContentIndexFromDomIndex(content, 0)).toBe(0)
-      expect(getContentIndexFromDomIndex(content, 1)).toBe(1)
-      expect(getContentIndexFromDomIndex(content, 2)).toBe(2)
+    it("maps a stamped DOM node back to the same content index", () => {
+      expect(
+        getContentIndexFromElement(container?.children[0] as Element),
+      ).toBe(0)
+      expect(
+        getContentIndexFromElement(container?.children[1] as Element),
+      ).toBe(1)
+      expect(
+        getContentIndexFromElement(container?.children[2] as Element),
+      ).toBe(2)
     })
   })
 
   describe("a multi-item prose block preceding another block", () => {
     beforeEach(() => {
-      // prose block -> 3 sibling <p> elements, then the image block -> 1 <div>
-      container = renderContainer(["p", "p", "p", "div"])
+      container = renderContainer([
+        { contentIndex: 0, tag: "p" },
+        { contentIndex: 0, tag: "p" },
+        { contentIndex: 0, tag: "p" },
+        { contentIndex: 1, tag: "div" },
+      ])
     })
 
-    const content = [
-      {
-        type: "prose",
-        content: [
-          { type: "paragraph" },
-          { type: "paragraph" },
-          { type: "paragraph" },
-        ],
-      },
-      { type: "image" },
-    ] as unknown as IsomerSchema["content"]
-
-    it("resolves the prose block to its first DOM child, not a shifted one", () => {
-      expect(getBlockElement(document, content, 0)).toBe(container?.children[0])
+    it("resolves the prose block to its first stamped DOM node", () => {
+      expect(getBlockElement(document, 0)).toBe(container?.children[0])
     })
 
-    it("resolves the block after prose to the DOM child after all of prose's items", () => {
-      expect(getBlockElement(document, content, 1)).toBe(container?.children[3])
+    it("resolves the block after prose to its stamped DOM node", () => {
+      expect(getBlockElement(document, 1)).toBe(container?.children[3])
     })
 
-    it("maps every DOM child belonging to prose back to the prose content index", () => {
-      expect(getContentIndexFromDomIndex(content, 0)).toBe(0)
-      expect(getContentIndexFromDomIndex(content, 1)).toBe(0)
-      expect(getContentIndexFromDomIndex(content, 2)).toBe(0)
+    it("maps every DOM node belonging to prose back to the prose content index", () => {
+      expect(
+        getContentIndexFromElement(container?.children[0] as Element),
+      ).toBe(0)
+      expect(
+        getContentIndexFromElement(container?.children[1] as Element),
+      ).toBe(0)
+      expect(
+        getContentIndexFromElement(container?.children[2] as Element),
+      ).toBe(0)
     })
 
-    it("maps the DOM child after prose back to the following content index", () => {
-      expect(getContentIndexFromDomIndex(content, 3)).toBe(1)
+    it("maps the DOM node after prose back to the following content index", () => {
+      expect(
+        getContentIndexFromElement(container?.children[3] as Element),
+      ).toBe(1)
     })
   })
 
-  describe("a hidden childrenpages block", () => {
+  describe("a block that renders no DOM nodes", () => {
     beforeEach(() => {
-      container = renderContainer(["div"])
+      container = renderContainer([{ contentIndex: 1 }])
     })
 
-    it("is skipped entirely and never reaches the DOM", () => {
+    it("returns undefined for a content index with no stamped node", () => {
       const content = [
-        { type: "childrenpages", isHidden: true },
+        { type: "childrenpages", isHidden: false },
         { type: "image" },
       ] as unknown as IsomerSchema["content"]
 
-      expect(getBlockElement(document, content, 0)).toBeUndefined()
-      expect(getBlockElement(document, content, 1)).toBe(container?.children[0])
-      expect(getContentIndexFromDomIndex(content, 0)).toBe(1)
+      expect(content).toHaveLength(2)
+      expect(getBlockElement(document, 0)).toBeUndefined()
+      expect(getBlockElement(document, 1)).toBe(container?.children[0])
     })
   })
 })

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
@@ -2,7 +2,12 @@ import type { IsomerSchema } from "@opengovsg/isomer-components"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
 
 import { CONTENT_BLOCK_INDEX_ATTR } from "../../constants"
-import { getBlockElement, getContentIndexFromElement } from "../getBlockElement"
+import {
+  getBlockElement,
+  getBlockElements,
+  getBlockHighlightRect,
+  getContentIndexFromElement,
+} from "../getBlockElement"
 
 const renderContainer = (
   blocks: { contentIndex: number; tag?: string }[],
@@ -13,6 +18,8 @@ const renderContainer = (
   blocks.forEach(({ contentIndex, tag = "div" }) => {
     const el = document.createElement(tag)
     el.setAttribute(CONTENT_BLOCK_INDEX_ATTR, String(contentIndex))
+    el.style.width = "200px"
+    el.style.height = "40px"
     container.appendChild(el)
   })
 
@@ -38,15 +45,34 @@ describe("getBlockElement / getContentIndexFromElement", () => {
     })
 
     it("maps content index to the stamped DOM node", () => {
+      // Arrange / Act / Assert
       expect(getBlockElement(document, 0)).toBe(container?.children[0])
       expect(getBlockElement(document, 1)).toBe(container?.children[1])
       expect(getBlockElement(document, 2)).toBe(container?.children[2])
     })
 
     it("maps a stamped DOM node back to the same content index", () => {
+      // Arrange / Act / Assert
       expect(getContentIndexFromElement(container!.children[0]!)).toBe(0)
       expect(getContentIndexFromElement(container!.children[1]!)).toBe(1)
       expect(getContentIndexFromElement(container!.children[2]!)).toBe(2)
+    })
+
+    it("highlights the stamped DOM node bounds", () => {
+      // Arrange
+      const el = container!.children[1] as HTMLElement
+      const bounds = el.getBoundingClientRect()
+
+      // Act
+      const rect = getBlockHighlightRect(document, 1)
+
+      // Assert
+      expect(rect).toEqual({
+        top: bounds.top + window.scrollY,
+        left: bounds.left + window.scrollX,
+        width: bounds.width,
+        height: bounds.height,
+      })
     })
   })
 
@@ -61,21 +87,56 @@ describe("getBlockElement / getContentIndexFromElement", () => {
     })
 
     it("resolves the prose block to its first stamped DOM node", () => {
+      // Arrange / Act / Assert
       expect(getBlockElement(document, 0)).toBe(container?.children[0])
     })
 
+    it("returns every stamped DOM node belonging to the prose block", () => {
+      // Arrange / Act
+      const elements = getBlockElements(document, 0)
+
+      // Assert
+      expect(elements).toEqual([
+        container?.children[0],
+        container?.children[1],
+        container?.children[2],
+      ])
+    })
+
     it("resolves the block after prose to its stamped DOM node", () => {
+      // Arrange / Act / Assert
       expect(getBlockElement(document, 1)).toBe(container?.children[3])
     })
 
     it("maps every DOM node belonging to prose back to the prose content index", () => {
+      // Arrange / Act / Assert
       expect(getContentIndexFromElement(container!.children[0]!)).toBe(0)
       expect(getContentIndexFromElement(container!.children[1]!)).toBe(0)
       expect(getContentIndexFromElement(container!.children[2]!)).toBe(0)
     })
 
     it("maps the DOM node after prose back to the following content index", () => {
+      // Arrange / Act / Assert
       expect(getContentIndexFromElement(container!.children[3]!)).toBe(1)
+    })
+
+    it("highlights the union of every stamped node, not only the first", () => {
+      // Arrange
+      const first = container!.children[0]!.getBoundingClientRect()
+      const last = container!.children[2]!.getBoundingClientRect()
+
+      // Act
+      const rect = getBlockHighlightRect(document, 0)
+
+      // Assert
+      expect(rect).toEqual({
+        top: first.top + window.scrollY,
+        left: Math.min(first.left, last.left) + window.scrollX,
+        width:
+          Math.max(first.right, last.right) - Math.min(first.left, last.left),
+        height: last.bottom - first.top,
+      })
+      expect(rect!.height).toBeGreaterThan(first.height)
     })
   })
 
@@ -85,13 +146,16 @@ describe("getBlockElement / getContentIndexFromElement", () => {
     })
 
     it("returns undefined for a content index with no stamped node", () => {
+      // Arrange
       const content = [
         { type: "childrenpages", isHidden: false },
         { type: "image" },
       ] as unknown as IsomerSchema["content"]
 
+      // Act / Assert
       expect(content).toHaveLength(2)
       expect(getBlockElement(document, 0)).toBeUndefined()
+      expect(getBlockHighlightRect(document, 0)).toBeUndefined()
       expect(getBlockElement(document, 1)).toBe(container?.children[0])
     })
   })

--- a/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
+++ b/apps/studio/src/features/editing-experience/utils/__tests__/getBlockElement.browser.test.ts
@@ -1,0 +1,113 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  getBlockElement,
+  getContentIndexFromDomIndex,
+} from "../getBlockElement"
+
+// Mirrors packages/components' rendering rules well enough to exercise the
+// index math: each content block becomes one or more direct children of
+// `[data-isomer-content-blocks]`, in order.
+const renderContainer = (domChildTags: string[]): HTMLElement => {
+  const container = document.createElement("div")
+  container.setAttribute("data-isomer-content-blocks", "")
+  domChildTags.forEach((tag) => {
+    container.appendChild(document.createElement(tag))
+  })
+  document.body.appendChild(container)
+  return container
+}
+
+describe("getBlockElement / getContentIndexFromDomIndex", () => {
+  let container: HTMLElement | null = null
+
+  afterEach(() => {
+    container?.remove()
+    container = null
+  })
+
+  describe("blocks that render as a single DOM node", () => {
+    beforeEach(() => {
+      container = renderContainer(["div", "div", "div"])
+    })
+
+    it("maps content index to the DOM child at the same position", () => {
+      const content = [
+        { type: "hero" },
+        { type: "image" },
+        { type: "callout" },
+      ] as unknown as IsomerSchema["content"]
+
+      expect(getBlockElement(document, content, 0)).toBe(container?.children[0])
+      expect(getBlockElement(document, content, 1)).toBe(container?.children[1])
+      expect(getBlockElement(document, content, 2)).toBe(container?.children[2])
+    })
+
+    it("maps a DOM index back to the same content index", () => {
+      const content = [
+        { type: "hero" },
+        { type: "image" },
+        { type: "callout" },
+      ] as unknown as IsomerSchema["content"]
+
+      expect(getContentIndexFromDomIndex(content, 0)).toBe(0)
+      expect(getContentIndexFromDomIndex(content, 1)).toBe(1)
+      expect(getContentIndexFromDomIndex(content, 2)).toBe(2)
+    })
+  })
+
+  describe("a multi-item prose block preceding another block", () => {
+    beforeEach(() => {
+      // prose block -> 3 sibling <p> elements, then the image block -> 1 <div>
+      container = renderContainer(["p", "p", "p", "div"])
+    })
+
+    const content = [
+      {
+        type: "prose",
+        content: [
+          { type: "paragraph" },
+          { type: "paragraph" },
+          { type: "paragraph" },
+        ],
+      },
+      { type: "image" },
+    ] as unknown as IsomerSchema["content"]
+
+    it("resolves the prose block to its first DOM child, not a shifted one", () => {
+      expect(getBlockElement(document, content, 0)).toBe(container?.children[0])
+    })
+
+    it("resolves the block after prose to the DOM child after all of prose's items", () => {
+      expect(getBlockElement(document, content, 1)).toBe(container?.children[3])
+    })
+
+    it("maps every DOM child belonging to prose back to the prose content index", () => {
+      expect(getContentIndexFromDomIndex(content, 0)).toBe(0)
+      expect(getContentIndexFromDomIndex(content, 1)).toBe(0)
+      expect(getContentIndexFromDomIndex(content, 2)).toBe(0)
+    })
+
+    it("maps the DOM child after prose back to the following content index", () => {
+      expect(getContentIndexFromDomIndex(content, 3)).toBe(1)
+    })
+  })
+
+  describe("a hidden childrenpages block", () => {
+    beforeEach(() => {
+      container = renderContainer(["div"])
+    })
+
+    it("is skipped entirely and never reaches the DOM", () => {
+      const content = [
+        { type: "childrenpages", isHidden: true },
+        { type: "image" },
+      ] as unknown as IsomerSchema["content"]
+
+      expect(getBlockElement(document, content, 0)).toBeUndefined()
+      expect(getBlockElement(document, content, 1)).toBe(container?.children[0])
+      expect(getContentIndexFromDomIndex(content, 0)).toBe(1)
+    })
+  })
+})

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -3,8 +3,6 @@ import {
   CONTENT_BLOCKS_SELECTOR,
 } from "~/features/editing-experience/constants"
 
-// Blocks stamp `data-isomer-content-index` at render time so we don't have to
-// guess how many DOM nodes each block type occupies.
 export const getBlockElement = (
   iframeDocument: Document | null,
   index: number | null,

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -3,11 +3,16 @@ import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants
 
 // packages/components' renderPageContent filters out hidden childrenpages
 // blocks before rendering, so a hidden childrenpages block never reaches the
-// DOM and every block after it is shifted up by one. Mirror that filter here
-// so we can translate a `content` index into the matching DOM child index.
-const isHiddenChildrenPagesBlock = (
-  block: IsomerSchema["content"][number],
-): boolean => block.type === "childrenpages" && !!block.isHidden
+// DOM. Prose blocks are the other special case: Prose.tsx renders each
+// content item (paragraph, heading, list, ...) as its own top-level DOM
+// sibling instead of a single wrapper, so a prose block occupies as many
+// direct DOM children as it has content items. Mirror both here so we can
+// translate a `content` index into the matching DOM child index.
+const getDomSpan = (block: IsomerSchema["content"][number]): number => {
+  if (block.type === "childrenpages" && block.isHidden) return 0
+  if (block.type === "prose") return block.content?.length ?? 0
+  return 1
+}
 
 // Blocks aren't individually wrapped (that broke the `first:mt-*`-style
 // spacing most block components use), so instead we index directly into
@@ -22,21 +27,19 @@ export const getBlockElement = (
   }
 
   const block = content[index]
-  if (!block || isHiddenChildrenPagesBlock(block)) {
+  if (!block || getDomSpan(block) === 0) {
     return undefined
   }
 
-  const visibleIndex = content
+  const domIndex = content
     .slice(0, index)
-    .filter((b) => !isHiddenChildrenPagesBlock(b)).length
+    .reduce((sum, b) => sum + getDomSpan(b), 0)
 
   const contentBlocksContainer = iframeDocument.querySelector(
     CONTENT_BLOCKS_SELECTOR,
   )
 
-  return contentBlocksContainer?.children[visibleIndex] as
-    | HTMLElement
-    | undefined
+  return contentBlocksContainer?.children[domIndex] as HTMLElement | undefined
 }
 
 // Inverse of getBlockElement: DOM child index -> `content` array index.
@@ -44,12 +47,13 @@ export const getContentIndexFromDomIndex = (
   content: IsomerSchema["content"],
   domIndex: number,
 ): number | null => {
-  let visibleIndex = 0
+  let cursor = 0
   for (let i = 0; i < content.length; i++) {
     const block = content[i]
-    if (!block || isHiddenChildrenPagesBlock(block)) continue
-    if (visibleIndex === domIndex) return i
-    visibleIndex++
+    if (!block) continue
+    const span = getDomSpan(block)
+    if (domIndex < cursor + span) return i
+    cursor += span
   }
   return null
 }

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -1,4 +1,5 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
+import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
 
 // packages/components' renderPageContent filters out hidden childrenpages
 // blocks before rendering, so a hidden childrenpages block never reaches the
@@ -30,10 +31,25 @@ export const getBlockElement = (
     .filter((b) => !isHiddenChildrenPagesBlock(b)).length
 
   const contentBlocksContainer = iframeDocument.querySelector(
-    "[data-isomer-content-blocks]",
+    CONTENT_BLOCKS_SELECTOR,
   )
 
   return contentBlocksContainer?.children[visibleIndex] as
     | HTMLElement
     | undefined
+}
+
+// Inverse of getBlockElement: DOM child index -> `content` array index.
+export const getContentIndexFromDomIndex = (
+  content: IsomerSchema["content"],
+  domIndex: number,
+): number | null => {
+  let visibleIndex = 0
+  for (let i = 0; i < content.length; i++) {
+    const block = content[i]
+    if (!block || isHiddenChildrenPagesBlock(block)) continue
+    if (visibleIndex === domIndex) return i
+    visibleIndex++
+  }
+  return null
 }

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -11,9 +11,11 @@ export const getBlockElement = (
     return undefined
   }
 
-  return iframeDocument.querySelector(
-    `${CONTENT_BLOCKS_SELECTOR} [${CONTENT_BLOCK_INDEX_ATTR}="${index}"]`,
-  ) as HTMLElement | undefined
+  return (
+    iframeDocument.querySelector<HTMLElement>(
+      `${CONTENT_BLOCKS_SELECTOR} [${CONTENT_BLOCK_INDEX_ATTR}="${index}"]`,
+    ) ?? undefined
+  )
 }
 
 export const getContentIndexFromElement = (

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -1,59 +1,29 @@
-import type { IsomerSchema } from "@opengovsg/isomer-components"
-import { CONTENT_BLOCKS_SELECTOR } from "~/features/editing-experience/constants"
+import {
+  CONTENT_BLOCK_INDEX_ATTR,
+  CONTENT_BLOCKS_SELECTOR,
+} from "~/features/editing-experience/constants"
 
-// packages/components' renderPageContent filters out hidden childrenpages
-// blocks before rendering, so a hidden childrenpages block never reaches the
-// DOM. Prose blocks are the other special case: Prose.tsx renders each
-// content item (paragraph, heading, list, ...) as its own top-level DOM
-// sibling instead of a single wrapper, so a prose block occupies as many
-// direct DOM children as it has content items. Mirror both here so we can
-// translate a `content` index into the matching DOM child index.
-const getDomSpan = (block: IsomerSchema["content"][number]): number => {
-  if (block.type === "childrenpages" && block.isHidden) return 0
-  if (block.type === "prose") return block.content?.length ?? 0
-  return 1
-}
-
-// Blocks aren't individually wrapped (that broke the `first:mt-*`-style
-// spacing most block components use), so instead we index directly into
-// the children of the shared content container.
+// Blocks stamp `data-isomer-content-index` at render time so we don't have to
+// guess how many DOM nodes each block type occupies.
 export const getBlockElement = (
   iframeDocument: Document | null,
-  content: IsomerSchema["content"],
   index: number | null,
 ): HTMLElement | undefined => {
   if (index === null || !iframeDocument) {
     return undefined
   }
 
-  const block = content[index]
-  if (!block || getDomSpan(block) === 0) {
-    return undefined
-  }
-
-  const domIndex = content
-    .slice(0, index)
-    .reduce((sum, b) => sum + getDomSpan(b), 0)
-
-  const contentBlocksContainer = iframeDocument.querySelector(
-    CONTENT_BLOCKS_SELECTOR,
-  )
-
-  return contentBlocksContainer?.children[domIndex] as HTMLElement | undefined
+  return iframeDocument.querySelector(
+    `${CONTENT_BLOCKS_SELECTOR} [${CONTENT_BLOCK_INDEX_ATTR}="${index}"]`,
+  ) as HTMLElement | undefined
 }
 
-// Inverse of getBlockElement: DOM child index -> `content` array index.
-export const getContentIndexFromDomIndex = (
-  content: IsomerSchema["content"],
-  domIndex: number,
+export const getContentIndexFromElement = (
+  element: Element | null,
 ): number | null => {
-  let cursor = 0
-  for (let i = 0; i < content.length; i++) {
-    const block = content[i]
-    if (!block) continue
-    const span = getDomSpan(block)
-    if (domIndex < cursor + span) return i
-    cursor += span
-  }
-  return null
+  const marked = element?.closest?.(`[${CONTENT_BLOCK_INDEX_ATTR}]`)
+  if (!marked) return null
+
+  const contentIndex = Number(marked.getAttribute(CONTENT_BLOCK_INDEX_ATTR))
+  return Number.isNaN(contentIndex) ? null : contentIndex
 }

--- a/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/getBlockElement.ts
@@ -3,19 +3,66 @@ import {
   CONTENT_BLOCKS_SELECTOR,
 } from "~/features/editing-experience/constants"
 
+export interface BlockHighlightRect {
+  top: number
+  left: number
+  width: number
+  height: number
+}
+
+export const getBlockElements = (
+  iframeDocument: Document | null,
+  index: number | null,
+): HTMLElement[] => {
+  if (index === null || !iframeDocument) {
+    return []
+  }
+
+  return Array.from(
+    iframeDocument.querySelectorAll<HTMLElement>(
+      `${CONTENT_BLOCKS_SELECTOR} [${CONTENT_BLOCK_INDEX_ATTR}="${index}"]`,
+    ),
+  )
+}
+
 export const getBlockElement = (
   iframeDocument: Document | null,
   index: number | null,
 ): HTMLElement | undefined => {
-  if (index === null || !iframeDocument) {
+  return getBlockElements(iframeDocument, index)[0]
+}
+
+export const getBlockHighlightRect = (
+  iframeDocument: Document | null,
+  index: number | null,
+): BlockHighlightRect | undefined => {
+  const elements = getBlockElements(iframeDocument, index)
+  if (elements.length === 0 || !iframeDocument) {
     return undefined
   }
 
-  return (
-    iframeDocument.querySelector<HTMLElement>(
-      `${CONTENT_BLOCKS_SELECTOR} [${CONTENT_BLOCK_INDEX_ATTR}="${index}"]`,
-    ) ?? undefined
-  )
+  const scrollX = iframeDocument.defaultView?.scrollX ?? 0
+  const scrollY = iframeDocument.defaultView?.scrollY ?? 0
+
+  let top = Infinity
+  let left = Infinity
+  let right = -Infinity
+  let bottom = -Infinity
+
+  for (const el of elements) {
+    const r = el.getBoundingClientRect()
+    top = Math.min(top, r.top)
+    left = Math.min(left, r.left)
+    right = Math.max(right, r.right)
+    bottom = Math.max(bottom, r.bottom)
+  }
+
+  return {
+    top: top + scrollY,
+    left: left + scrollX,
+    width: right - left,
+    height: bottom - top,
+  }
 }
 
 export const getContentIndexFromElement = (

--- a/apps/studio/src/features/editing-experience/utils/getDrawerStateForBlock.ts
+++ b/apps/studio/src/features/editing-experience/utils/getDrawerStateForBlock.ts
@@ -1,8 +1,7 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { DrawerState } from "~/types/editorDrawer"
 
-// Mirrors the block-type -> editor-drawer-state mapping every "click a block"
-// entry point needs (sidebar row click, preview edit button, ...).
+// Shared block-type -> editor-drawer-state mapping for every click-a-block entry point.
 export const getDrawerStateForBlock = (
   block: IsomerSchema["content"][number],
 ): DrawerState => {

--- a/apps/studio/src/features/editing-experience/utils/getDrawerStateForBlock.ts
+++ b/apps/studio/src/features/editing-experience/utils/getDrawerStateForBlock.ts
@@ -1,7 +1,6 @@
 import type { IsomerSchema } from "@opengovsg/isomer-components"
 import type { DrawerState } from "~/types/editorDrawer"
 
-// Shared block-type -> editor-drawer-state mapping for every click-a-block entry point.
 export const getDrawerStateForBlock = (
   block: IsomerSchema["content"][number],
 ): DrawerState => {

--- a/apps/studio/src/features/editing-experience/utils/getDrawerStateForBlock.ts
+++ b/apps/studio/src/features/editing-experience/utils/getDrawerStateForBlock.ts
@@ -1,0 +1,16 @@
+import type { IsomerSchema } from "@opengovsg/isomer-components"
+import type { DrawerState } from "~/types/editorDrawer"
+
+// Mirrors the block-type -> editor-drawer-state mapping every "click a block"
+// entry point needs (sidebar row click, preview edit button, ...).
+export const getDrawerStateForBlock = (
+  block: IsomerSchema["content"][number],
+): DrawerState => {
+  if (block.type === "hero") {
+    return { state: "heroEditor" }
+  }
+  if (block.type === "prose") {
+    return { state: "nativeEditor" }
+  }
+  return { state: "complexEditor" }
+}

--- a/apps/studio/src/features/editing-experience/utils/index.ts
+++ b/apps/studio/src/features/editing-experience/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./createTableSelectionBorderPlugin"
 export * from "./getBlockElement"
 export * from "./getDgsIdFromString"
+export * from "./getDrawerStateForBlock"
 export * from "./getHtmlWithRelativeReferenceLinks"
 export * from "./getSelectedCellBorderClasses"
 export * from "./scrollToBlockElement"

--- a/apps/studio/src/features/editing-experience/utils/scrollToBlockElement.ts
+++ b/apps/studio/src/features/editing-experience/utils/scrollToBlockElement.ts
@@ -1,18 +1,14 @@
-import type { IsomerSchema } from "@opengovsg/isomer-components"
-
 import { getBlockElement } from "./getBlockElement"
 
 interface ScrollToBlockElementParams {
   iframeDocument: Document | null
-  content: IsomerSchema["content"]
   index: number | null
 }
 
 export const scrollToBlockElement = ({
   iframeDocument,
-  content,
   index,
 }: ScrollToBlockElementParams): void => {
-  const blockEl = getBlockElement(iframeDocument, content, index)
+  const blockEl = getBlockElement(iframeDocument, index)
   blockEl?.scrollIntoView({ behavior: "smooth", block: "nearest" })
 }

--- a/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
+++ b/packages/components/src/templates/next/components/complex/Accordion/Accordion.tsx
@@ -4,6 +4,10 @@ import { BiMinus, BiPlus } from "react-icons/bi"
 import { tv } from "~/lib/tv"
 import { focusVisibleHighlight } from "~/utils/tailwind"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { Prose } from "../../native/Prose"
 
 const summaryStyle = tv({
@@ -24,16 +28,23 @@ const createAccordionStyles = tv({
 const accordionStyles = createAccordionStyles()
 
 interface AccordionProps
-  extends BaseAccordionProps, VariantProps<typeof createAccordionStyles> {}
+  extends
+    BaseAccordionProps,
+    ContentBlockIndexProps,
+    VariantProps<typeof createAccordionStyles> {}
 
 export const Accordion = ({
   summary,
   details,
   site,
   headingLevel,
+  contentBlockIndex,
 }: AccordionProps) => {
   return (
-    <details className={accordionStyles.details()}>
+    <details
+      className={accordionStyles.details()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <summary className={summaryStyle()}>
         {summary}
         <BiMinus

--- a/packages/components/src/templates/next/components/complex/AntiScamDisclaimerBanner/AntiScamDisclaimerBanner.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/AntiScamDisclaimerBanner/AntiScamDisclaimerBanner.stories.tsx
@@ -11,9 +11,6 @@ const meta: Meta<typeof AntiScamDisclaimerBanner> = {
     layout: "fullscreen",
     chromatic: withChromaticModes(["mobile", "tablet", "desktop"]),
   },
-  args: {
-    type: "antiscambanner",
-  },
 }
 
 export default meta

--- a/packages/components/src/templates/next/components/complex/AntiScamDisclaimerBanner/AntiScamDisclaimerBanner.tsx
+++ b/packages/components/src/templates/next/components/complex/AntiScamDisclaimerBanner/AntiScamDisclaimerBanner.tsx
@@ -1,14 +1,21 @@
 import { BiError } from "react-icons/bi"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
 
-export const AntiScamDisclaimerBanner = () => {
+export const AntiScamDisclaimerBanner = ({
+  contentBlockIndex,
+}: ContentBlockIndexProps) => {
   return (
     <div
       className={`${ComponentContent} w-full rounded-lg bg-base-canvas px-5 py-12 md:px-6 lg:w-fit lg:max-w-full lg:py-16`}
       role="region"
       aria-label="Anti-scam notice"
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       <div className="flex flex-col gap-5 lg:flex-row lg:items-start">
         <div className="flex size-11 shrink-0 items-center justify-center rounded-full bg-utility-feedback-warning-faint">

--- a/packages/components/src/templates/next/components/complex/Audio/Audio.tsx
+++ b/packages/components/src/templates/next/components/complex/Audio/Audio.tsx
@@ -1,9 +1,20 @@
 import type { AudioProps } from "~/interfaces"
 import { isApplePodcastUrl, isValidAudioEmbedUrl } from "~/utils/validation"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 
-export const Audio = ({ title, url, shouldLazyLoad = true }: AudioProps) => {
+type AudioRenderProps = AudioProps & ContentBlockIndexProps
+
+export const Audio = ({
+  title,
+  url,
+  shouldLazyLoad = true,
+  contentBlockIndex,
+}: AudioRenderProps) => {
   if (!isValidAudioEmbedUrl(url)) {
     return <></>
   }
@@ -12,7 +23,10 @@ export const Audio = ({ title, url, shouldLazyLoad = true }: AudioProps) => {
     const isEpisode = new URL(url).searchParams.has("i")
     const heightPx = isEpisode ? 175 : 450
     return (
-      <section className={`${ComponentContent} mt-7 first:mt-0`}>
+      <section
+        className={`${ComponentContent} mt-7 first:mt-0`}
+        {...contentBlockIndexAttr(contentBlockIndex)}
+      >
         {/* Apple Podcast: show 450px, episode 175px; 10px radius; 100% width */}
         <div
           className="w-full overflow-hidden rounded-[10px]"
@@ -35,7 +49,10 @@ export const Audio = ({ title, url, shouldLazyLoad = true }: AudioProps) => {
   }
 
   return (
-    <section className={`${ComponentContent} mt-7 first:mt-0`}>
+    <section
+      className={`${ComponentContent} mt-7 first:mt-0`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       {/* Spotify: 152px default embed height */}
       <div className="h-[152px] w-full overflow-hidden rounded-[12px]">
         <iframe

--- a/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.tsx
+++ b/packages/components/src/templates/next/components/complex/Blockquote/Blockquote.tsx
@@ -3,6 +3,10 @@ import { BiSolidQuoteAltLeft } from "react-icons/bi"
 import { tv } from "~/lib/tv"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { ImageClient } from "../../internal/ImageClient"
 
@@ -47,6 +51,8 @@ const createBlockquoteStyles = tv({
   },
 })
 
+type BlockquoteRenderProps = BlockquoteProps & ContentBlockIndexProps
+
 export const Blockquote = ({
   quote,
   source,
@@ -55,7 +61,8 @@ export const Blockquote = ({
   layout,
   shouldLazyLoad,
   site,
-}: BlockquoteProps) => {
+  contentBlockIndex,
+}: BlockquoteRenderProps) => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const variants = {
     layout: simplifiedLayout,
@@ -63,7 +70,10 @@ export const Blockquote = ({
   const compoundStyles = createBlockquoteStyles(variants)
 
   return (
-    <section className={compoundStyles.outerContainer()}>
+    <section
+      className={compoundStyles.outerContainer()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.innerContainer()}>
         <div className={compoundStyles.quoteContainer()}>
           <div className={compoundStyles.openApostrophe()} aria-hidden>

--- a/packages/components/src/templates/next/components/complex/Button/Button.tsx
+++ b/packages/components/src/templates/next/components/complex/Button/Button.tsx
@@ -1,12 +1,18 @@
 import type { ButtonProps } from "~/interfaces"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { LinkButton } from "../../internal/LinkButton"
 
 const ALIGNMENT_STYLES = {
   left: "justify-start",
   center: "justify-center",
 } as const
+
+type ButtonRenderProps = ButtonProps & ContentBlockIndexProps
 
 export const Button = ({
   alignment,
@@ -15,12 +21,14 @@ export const Button = ({
   secondaryButtonLabel,
   secondaryButtonUrl,
   site,
-}: ButtonProps) => {
+  contentBlockIndex,
+}: ButtonRenderProps) => {
   const hasSecondaryCTA = !!secondaryButtonLabel && !!secondaryButtonUrl
 
   return (
     <div
       className={`flex flex-wrap items-center gap-5 [&:not(:first-child)]:mt-7 ${ALIGNMENT_STYLES[alignment]}`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       <LinkButton
         href={getReferenceLinkHref(

--- a/packages/components/src/templates/next/components/complex/Callout/Callout.tsx
+++ b/packages/components/src/templates/next/components/complex/Callout/Callout.tsx
@@ -4,6 +4,10 @@ import { BiCheckCircle, BiError, BiErrorCircle } from "react-icons/bi"
 import { DEFAULT_CALLOUT_VARIANT } from "~/interfaces/complex/Callout"
 import { tv } from "~/lib/tv"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { Prose } from "../../native/Prose"
 
 const CALLOUT_CONFIG: Record<
@@ -66,17 +70,25 @@ const calloutStyles = tv({
   },
 })
 
+type CalloutRenderProps = CalloutProps & ContentBlockIndexProps
+
 export const Callout = ({
   content,
   site,
   headingLevel,
   variant = DEFAULT_CALLOUT_VARIANT,
-}: CalloutProps) => {
+  contentBlockIndex,
+}: CalloutRenderProps) => {
   const { icon: Icon, label } = CALLOUT_CONFIG[variant]
   const styles = calloutStyles({ variant, hasIcon: !!Icon })
 
   return (
-    <div className={styles.container()} role="group" aria-label={label}>
+    <div
+      className={styles.container()}
+      role="group"
+      aria-label={label}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       {Icon && <Icon aria-hidden className={styles.icon()} />}
       <div className={styles.content()} tabIndex={0}>
         <Prose {...content} site={site} headingLevel={headingLevel} />

--- a/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
+++ b/packages/components/src/templates/next/components/complex/ChildrenPages/ChildrenPages.tsx
@@ -9,6 +9,10 @@ import { getNodeFromSiteMap } from "~/utils/getNodeFromSiteMap"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { groupFocusVisibleHighlight } from "~/utils/tailwind"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { ImageClient } from "../../internal/ImageClient"
 import { Link } from "../../internal/Link"
@@ -34,7 +38,8 @@ interface ChildpageLayoutProps
       | "maxColumns"
       | "headingLevel"
     >,
-    Pick<ImageClientProps, "assetsBaseUrl"> {
+    Pick<ImageClientProps, "assetsBaseUrl">,
+    ContentBlockIndexProps {
   childpages: Childpage[]
   fallback: Required<NonNullable<IsomerSitemap["image"]>>
 }
@@ -49,6 +54,7 @@ const BoxLayout = ({
   maxColumns = "2",
   imageFit = "cover",
   headingLevel,
+  contentBlockIndex,
 }: ChildpageLayoutProps) => {
   return (
     <div
@@ -57,6 +63,7 @@ const BoxLayout = ({
         variant: "default",
         class: "[&:not(:first-child)]:mt-7",
       })}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       {childpages.map(({ title, description, url, image }, idx) => {
         if (showThumbnail) {
@@ -155,11 +162,15 @@ const RowLayout = ({
   shouldLazyLoad,
   site,
   imageFit,
+  contentBlockIndex,
 }: ChildpageLayoutProps): JSX.Element => {
   const styles = createRowStyles()
 
   return (
-    <div className={styles.container()}>
+    <div
+      className={styles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       {childpages.map(({ title, description, url, image }, idx) => {
         const renderedImage = image?.src ? image : fallback
 
@@ -218,6 +229,8 @@ const RowLayout = ({
   )
 }
 
+type ChildrenPagesRenderProps = ChildrenPagesProps & ContentBlockIndexProps
+
 export const ChildrenPages = ({
   childrenPagesOrdering = [],
   permalink,
@@ -229,7 +242,8 @@ export const ChildrenPages = ({
   maxColumns = "2",
   imageFit = IMAGE_FIT.Cover,
   headingLevel,
-}: ChildrenPagesProps) => {
+  contentBlockIndex,
+}: ChildrenPagesRenderProps) => {
   const currentPageNode = getNodeFromSiteMap(site.siteMap, permalink)
 
   if (!currentPageNode?.children) {
@@ -260,6 +274,7 @@ export const ChildrenPages = ({
         maxColumns={maxColumns}
         imageFit={imageFit}
         headingLevel={headingLevel}
+        contentBlockIndex={contentBlockIndex}
       />
     )
   }
@@ -279,6 +294,7 @@ export const ChildrenPages = ({
       site={site}
       imageFit={imageFit}
       headingLevel={headingLevel}
+      contentBlockIndex={contentBlockIndex}
     />
   )
 }

--- a/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.tsx
+++ b/packages/components/src/templates/next/components/complex/CollectionBlock/CollectionBlock.tsx
@@ -10,6 +10,10 @@ import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { getResourceIdFromReferenceLink } from "~/utils/getResourceIdFromReferenceLink"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { ImageClient } from "../../internal/ImageClient"
 import { Link } from "../../internal/Link"
@@ -151,15 +155,20 @@ interface CollectionBlockSkeletonProps {
   title: string
   description: string
   headingLevel: number
+  contentBlockIndex?: number
 }
 const CollectionBlockSkeleton = ({
   title,
   description,
   headingLevel,
+  contentBlockIndex,
 }: CollectionBlockSkeletonProps) => {
   const TitleTag = getHeadingTag(headingLevel)
   return (
-    <section className={compoundStyles.container()}>
+    <section
+      className={compoundStyles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.headingContainer()}>
         <TitleTag className={compoundStyles.headingTitle()}>{title}</TitleTag>
         <p>{description}</p>
@@ -167,6 +176,8 @@ const CollectionBlockSkeleton = ({
     </section>
   )
 }
+
+type CollectionBlockRenderProps = CollectionBlockProps & ContentBlockIndexProps
 
 export const CollectionBlock = ({
   site,
@@ -178,7 +189,8 @@ export const CollectionBlock = ({
   buttonLabel,
   shouldLazyLoad,
   headingLevel,
-}: CollectionBlockProps): JSX.Element => {
+  contentBlockIndex,
+}: CollectionBlockRenderProps): JSX.Element => {
   const collectionId = getResourceIdFromReferenceLink(collectionReferenceLink)
 
   // This happens when no collection is selected yet on Studio when the user just added the block
@@ -188,6 +200,7 @@ export const CollectionBlock = ({
         title="No collection selected"
         description="Choose a collection to display its content."
         headingLevel={headingLevel}
+        contentBlockIndex={contentBlockIndex}
       />
     )
   }
@@ -212,7 +225,10 @@ export const CollectionBlock = ({
   const TitleTag = getHeadingTag(headingLevel)
 
   return (
-    <section className={compoundStyles.container()}>
+    <section
+      className={compoundStyles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.headingContainer()}>
         <TitleTag className={compoundStyles.headingTitle()}>
           {customTitle ?? collectionParent.title}

--- a/packages/components/src/templates/next/components/complex/ContactInformation/ContactInformation.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/ContactInformation.tsx
@@ -3,13 +3,18 @@ import { omit } from "lodash-es"
 import { DATA_SOURCE_TYPE } from "~/interfaces/integration"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
+import { type ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { DgsContactInformation } from "./DgsContactInformation"
 import { NativeContactInformation } from "./NativeContactInformation"
 
+type ContactInformationRenderProps = ContactInformationProps &
+  ContentBlockIndexProps
+
 export const ContactInformation = ({
   dataSource,
+  contentBlockIndex,
   ...rest
-}: ContactInformationProps) => {
+}: ContactInformationRenderProps) => {
   const uiProps = {
     ...omit(rest, ["url", "site"]),
     referenceLinkHref: getReferenceLinkHref(
@@ -21,15 +26,31 @@ export const ContactInformation = ({
 
   // For backward compatibility, where dataSource is not provided,
   if (!dataSource) {
-    return <NativeContactInformation {...uiProps} />
+    return (
+      <NativeContactInformation
+        {...uiProps}
+        contentBlockIndex={contentBlockIndex}
+      />
+    )
   }
 
   const { type } = dataSource
   switch (type) {
     case DATA_SOURCE_TYPE.native:
-      return <NativeContactInformation {...uiProps} />
+      return (
+        <NativeContactInformation
+          {...uiProps}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case DATA_SOURCE_TYPE.dgs:
-      return <DgsContactInformation dataSource={dataSource} {...uiProps} />
+      return (
+        <DgsContactInformation
+          dataSource={dataSource}
+          {...uiProps}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     default:
       const _exhaustiveCheck: never = type
       return _exhaustiveCheck

--- a/packages/components/src/templates/next/components/complex/ContactInformation/DgsContactInformation/DgsContactInformation.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/DgsContactInformation/DgsContactInformation.tsx
@@ -12,12 +12,17 @@ import { transformDgsField, useDgsData } from "~/hooks/useDgsData"
 import { InjectableContactInformationKeys } from "~/interfaces/complex/ContactInformation/constants"
 import { safeJsonParse } from "~/utils/safeJsonParse"
 
+import { type ContentBlockIndexProps } from "../../../../render/contentBlockIndex"
 import { ContactInformationUI } from "../components"
+
+type DgsContactInformationRenderProps = DgsContactInformationProps &
+  ContentBlockIndexProps
 
 export const DgsContactInformation = ({
   dataSource: { resourceId, filters },
+  contentBlockIndex,
   ...rest
-}: DgsContactInformationProps) => {
+}: DgsContactInformationRenderProps) => {
   const params = useMemo(
     () => ({
       resourceId,
@@ -40,6 +45,7 @@ export const DgsContactInformation = ({
         methods={[]} // not needed for loading state but its required prop
         {...pick(rest, "type", "layout", "headingLevel")}
         acceptHtmlTags
+        contentBlockIndex={contentBlockIndex}
       />
     )
   }
@@ -52,14 +58,21 @@ export const DgsContactInformation = ({
     return null
   }
 
-  return <DgsTransformedContactInformation {...rest} record={record} />
+  return (
+    <DgsTransformedContactInformation
+      {...rest}
+      record={record}
+      contentBlockIndex={contentBlockIndex}
+    />
+  )
 }
 
 export const DgsTransformedContactInformation = ({
   record,
   isLoading,
+  contentBlockIndex,
   ...rest
-}: DgsTransformedContactInformationProps) => {
+}: DgsTransformedContactInformationProps & ContentBlockIndexProps) => {
   const title = transformDgsField(
     rest.title,
     record,
@@ -88,6 +101,7 @@ export const DgsTransformedContactInformation = ({
       type={rest.type}
       layout={rest.layout}
       headingLevel={rest.headingLevel}
+      contentBlockIndex={contentBlockIndex}
       {...omit(rest, InjectableContactInformationKeys)}
       acceptHtmlTags
     />

--- a/packages/components/src/templates/next/components/complex/ContactInformation/NativeContactInformation/NativeContactInformation.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/NativeContactInformation/NativeContactInformation.tsx
@@ -1,10 +1,17 @@
 import type { NativeContactInformationProps } from "~/interfaces/complex/ContactInformation/ContactInformation"
 
+import { type ContentBlockIndexProps } from "../../../../render/contentBlockIndex"
 import { ContactInformationUI } from "../components"
+
+type NativeContactInformationRenderProps = NativeContactInformationProps &
+  ContentBlockIndexProps
 
 export const NativeContactInformation = ({
   dataSource: _dataSource,
+  contentBlockIndex,
   ...rest
-}: NativeContactInformationProps) => {
-  return <ContactInformationUI {...rest} />
+}: NativeContactInformationRenderProps) => {
+  return (
+    <ContactInformationUI {...rest} contentBlockIndex={contentBlockIndex} />
+  )
 }

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/ContactInformationUI.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/ContactInformationUI.tsx
@@ -1,10 +1,13 @@
 import type { ContactInformationUIProps } from "~/interfaces"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
+import { type ContentBlockIndexProps } from "../../../../render/contentBlockIndex"
 import { DefaultContactInformationUI } from "./DefaultContactInformationUI"
 import { HomepageContactInformationUI } from "./HomepageContactInformationUI"
 
-export const ContactInformationUI = (props: ContactInformationUIProps) => {
+export const ContactInformationUI = (
+  props: ContactInformationUIProps & ContentBlockIndexProps,
+) => {
   const simplifiedLayout = getTailwindVariantLayout(props.layout)
 
   switch (simplifiedLayout) {

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/DefaultContactInformationUI.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/DefaultContactInformationUI.tsx
@@ -2,6 +2,10 @@ import type { ContactInformationUIProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../../internal/BaseParagraph"
 import { LinkButton } from "../../../internal/LinkButton"
 import {
@@ -38,7 +42,8 @@ export const DefaultContactInformationUI = ({
   isLoading,
   acceptHtmlTags = false,
   headingLevel,
-}: ContactInformationUIProps) => {
+  contentBlockIndex,
+}: ContactInformationUIProps & ContentBlockIndexProps) => {
   const compoundStyles = createDefaultContactInformationStyles({
     isLoading,
   })
@@ -62,7 +67,10 @@ export const DefaultContactInformationUI = ({
   const descriptionText = isLoading ? "" : (description ?? "")
 
   return (
-    <section className={compoundStyles.screenWideOuterContainer()}>
+    <section
+      className={compoundStyles.screenWideOuterContainer()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.container()}>
         <div className={compoundStyles.titleAndDescriptionContainer()}>
           {(title || isLoading) && (

--- a/packages/components/src/templates/next/components/complex/ContactInformation/components/HomepageContactInformationUI.tsx
+++ b/packages/components/src/templates/next/components/complex/ContactInformation/components/HomepageContactInformationUI.tsx
@@ -2,6 +2,10 @@ import type { ContactInformationUIProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../../internal/BaseParagraph"
 import { LinkButton } from "../../../internal/LinkButton"
 import {
@@ -91,6 +95,9 @@ type NumberOfContactMethods =
 
 const MAX_CONTACT_METHODS_FOR_HOMEPAGE = 3
 
+type HomepageContactInformationUIRenderProps = ContactInformationUIProps &
+  ContentBlockIndexProps
+
 export const HomepageContactInformationUI = ({
   whitelistedMethods,
   title,
@@ -101,7 +108,8 @@ export const HomepageContactInformationUI = ({
   isLoading,
   acceptHtmlTags = false,
   headingLevel,
-}: ContactInformationUIProps) => {
+  contentBlockIndex,
+}: HomepageContactInformationUIRenderProps) => {
   const TitleTag = getHeadingTag(headingLevel)
   const filteredMethods = filterContactMethods({ methods, whitelistedMethods })
 
@@ -147,7 +155,10 @@ export const HomepageContactInformationUI = ({
   const descriptionText = isLoading ? "" : (description ?? "")
 
   return (
-    <section className={compoundStyles.screenWideOuterContainer()}>
+    <section
+      className={compoundStyles.screenWideOuterContainer()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.container()}>
         <div className={compoundStyles.titleAndDescriptionContainer()}>
           {(title || isLoading) && (

--- a/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
+++ b/packages/components/src/templates/next/components/complex/Contentpic/Contentpic.tsx
@@ -2,6 +2,10 @@ import type { VariantProps } from "tailwind-variants"
 import type { ContentpicProps as BaseContentpicProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ImageClient } from "../../internal/ImageClient"
 import { Prose } from "../../native/Prose"
 
@@ -20,6 +24,7 @@ const compoundStyles = contentpicStyles()
 interface ContentpicProps
   extends
     Omit<BaseContentpicProps, "type">,
+    ContentBlockIndexProps,
     VariantProps<typeof contentpicStyles> {}
 
 export const Contentpic = ({
@@ -29,9 +34,13 @@ export const Contentpic = ({
   site,
   shouldLazyLoad = true,
   headingLevel,
+  contentBlockIndex,
 }: ContentpicProps): JSX.Element => {
   return (
-    <div className={compoundStyles.container()}>
+    <div
+      className={compoundStyles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <ImageClient
         src={imageSrc}
         alt={imageAlt || ""}

--- a/packages/components/src/templates/next/components/complex/DynamicComponentList/DynamicComponentList.tsx
+++ b/packages/components/src/templates/next/components/complex/DynamicComponentList/DynamicComponentList.tsx
@@ -5,6 +5,7 @@ import type { DynamicComponentListProps } from "~/interfaces"
 import { useMemo } from "react"
 import { useDgsData } from "~/hooks/useDgsData"
 
+import { type ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { DgsTransformedContactInformation } from "../ContactInformation"
 
 // We do not know how many records will be returned
@@ -16,7 +17,8 @@ export const DynamicComponentList = ({
   component,
   layout,
   headingLevel,
-}: DynamicComponentListProps) => {
+  contentBlockIndex,
+}: DynamicComponentListProps & ContentBlockIndexProps) => {
   const params = useMemo(
     () => ({
       resourceId,
@@ -52,6 +54,7 @@ export const DynamicComponentList = ({
           layout={layout}
           isLoading={isLoading}
           headingLevel={headingLevel}
+          contentBlockIndex={contentBlockIndex}
         />
       ))
 

--- a/packages/components/src/templates/next/components/complex/DynamicDataBanner/DynamicDataBanner.tsx
+++ b/packages/components/src/templates/next/components/complex/DynamicDataBanner/DynamicDataBanner.tsx
@@ -2,8 +2,15 @@ import type { DynamicDataBannerProps } from "~/interfaces"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { getTextAsHtml } from "~/utils/getTextAsHtml"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../internal/BaseParagraph"
 import { DynamicDataBannerClient } from "./DynamicDataBannerClient"
+
+type DynamicDataBannerRenderProps = DynamicDataBannerProps &
+  ContentBlockIndexProps
 
 export const DynamicDataBanner = ({
   apiEndpoint,
@@ -13,7 +20,8 @@ export const DynamicDataBanner = ({
   label,
   errorMessage,
   site,
-}: DynamicDataBannerProps) => {
+  contentBlockIndex,
+}: DynamicDataBannerRenderProps) => {
   return (
     <DynamicDataBannerClient
       apiEndpoint={apiEndpoint}
@@ -21,6 +29,7 @@ export const DynamicDataBanner = ({
       data={data}
       url={getReferenceLinkHref(url, site.siteMapArray, site.assetsBaseUrl)}
       label={label}
+      contentBlockIndex={contentBlockIndex}
       errorMessageBaseParagraph={
         <BaseParagraph
           content={getTextAsHtml({

--- a/packages/components/src/templates/next/components/complex/DynamicDataBanner/DynamicDataBanner.tsx
+++ b/packages/components/src/templates/next/components/complex/DynamicDataBanner/DynamicDataBanner.tsx
@@ -2,10 +2,7 @@ import type { DynamicDataBannerProps } from "~/interfaces"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { getTextAsHtml } from "~/utils/getTextAsHtml"
 
-import {
-  contentBlockIndexAttr,
-  type ContentBlockIndexProps,
-} from "../../../render/contentBlockIndex"
+import type { ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../internal/BaseParagraph"
 import { DynamicDataBannerClient } from "./DynamicDataBannerClient"
 

--- a/packages/components/src/templates/next/components/complex/DynamicDataBanner/DynamicDataBannerClient.tsx
+++ b/packages/components/src/templates/next/components/complex/DynamicDataBanner/DynamicDataBannerClient.tsx
@@ -7,6 +7,10 @@ import { DYNAMIC_DATA_BANNER_NUMBER_OF_DATA } from "~/interfaces/complex/Dynamic
 import { tv } from "~/lib/tv"
 import { twMerge } from "~/lib/twMerge"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
 import { getSingaporeDateLong, getSingaporeDateYYYYMMDD } from "./utils"
@@ -43,9 +47,10 @@ const compoundStyles = createDynamicDataBannerStyles()
 type DynamicDataBannerClientProps = Omit<
   DynamicDataBannerProps,
   "type" | "site" | "errorMessage"
-> & {
-  errorMessageBaseParagraph?: React.ReactNode
-}
+> &
+  ContentBlockIndexProps & {
+    errorMessageBaseParagraph?: React.ReactNode
+  }
 
 const DynamicDataBannerUI = ({
   title,
@@ -53,9 +58,10 @@ const DynamicDataBannerUI = ({
   url,
   label,
   errorMessageBaseParagraph,
+  contentBlockIndex,
 }: Pick<
   DynamicDataBannerClientProps,
-  "title" | "label" | "url" | "errorMessageBaseParagraph"
+  "title" | "label" | "url" | "errorMessageBaseParagraph" | "contentBlockIndex"
 > & {
   data: { label: string; value?: string }[]
 }) => {
@@ -74,7 +80,10 @@ const DynamicDataBannerUI = ({
 
   if (errorMessageBaseParagraph) {
     return (
-      <div className={compoundStyles.screenWideOuterContainer()}>
+      <div
+        className={compoundStyles.screenWideOuterContainer()}
+        {...contentBlockIndexAttr(contentBlockIndex)}
+      >
         <div className={compoundStyles.errorMessageContainer()}>
           <BiError className={compoundStyles.errorIcon()} />
           {errorMessageBaseParagraph}
@@ -84,7 +93,10 @@ const DynamicDataBannerUI = ({
   }
 
   return (
-    <div className={compoundStyles.screenWideOuterContainer()}>
+    <div
+      className={compoundStyles.screenWideOuterContainer()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.outerContainer()}>
         <div className={compoundStyles.basicInfoContainer()}>
           {!!title && <div className={compoundStyles.title()}>{title}</div>}
@@ -130,6 +142,7 @@ export const DynamicDataBannerClient = ({
   url,
   label,
   errorMessageBaseParagraph,
+  contentBlockIndex,
 }: DynamicDataBannerClientProps) => {
   const [isLoading, setLoading] = useState(true)
   const [isError, setError] = useState(false)
@@ -165,12 +178,20 @@ export const DynamicDataBannerClient = ({
         url={url}
         label={label}
         errorMessageBaseParagraph={errorMessageBaseParagraph}
+        contentBlockIndex={contentBlockIndex}
       />
     )
   }
 
   if (data.length !== DYNAMIC_DATA_BANNER_NUMBER_OF_DATA)
-    return <DynamicDataBannerUI data={[]} url={url} label={label} />
+    return (
+      <DynamicDataBannerUI
+        data={[]}
+        url={url}
+        label={label}
+        contentBlockIndex={contentBlockIndex}
+      />
+    )
 
   return (
     <DynamicDataBannerUI
@@ -181,6 +202,7 @@ export const DynamicDataBannerClient = ({
       }))}
       url={url}
       label={label}
+      contentBlockIndex={contentBlockIndex}
     />
   )
 }

--- a/packages/components/src/templates/next/components/complex/FormSG/FormSG.tsx
+++ b/packages/components/src/templates/next/components/complex/FormSG/FormSG.tsx
@@ -1,16 +1,30 @@
 import type { FormSGProps } from "~/interfaces"
 import { isValidFormSGEmbedUrl } from "~/utils/validation"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../internal/BaseParagraph"
 import { ComponentContent } from "../../internal/customCssClass"
 
-export const FormSG = ({ title, url, shouldLazyLoad = true }: FormSGProps) => {
+type FormSGRenderProps = FormSGProps & ContentBlockIndexProps
+
+export const FormSG = ({
+  title,
+  url,
+  shouldLazyLoad = true,
+  contentBlockIndex,
+}: FormSGRenderProps) => {
   if (!isValidFormSGEmbedUrl(url)) {
     return <></>
   }
 
   return (
-    <section className={`${ComponentContent} mt-7 first:mt-0`}>
+    <section
+      className={`${ComponentContent} mt-7 first:mt-0`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <BaseParagraph
         content={`If the form below doesn't load, <a href="${url}" target="_blank">open it in a new window</a>.`}
         className="prose-body-base pb-2 pt-1 text-base-content opacity-90"

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.tsx
@@ -1,13 +1,16 @@
 import type { HeroProps } from "~/interfaces/complex/Hero"
 import { HERO_STYLE } from "~/interfaces/complex/Hero"
 
+import { type ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { HeroBlock } from "./HeroBlock"
 import { HeroFloating } from "./HeroFloating"
 import { HeroGradient } from "./HeroGradient"
 import { HeroLargeImage } from "./HeroLargeImage"
 import { HeroSearchbar } from "./HeroSearchbar"
 
-export const Hero = (props: HeroProps) => {
+type HeroRenderProps = HeroProps & ContentBlockIndexProps
+
+export const Hero = (props: HeroRenderProps) => {
   const { variant } = props
   switch (variant) {
     case HERO_STYLE.gradient:

--- a/packages/components/src/templates/next/components/complex/Hero/HeroBlock.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroBlock.tsx
@@ -2,6 +2,10 @@ import type { HeroBlockProps } from "~/interfaces/complex/Hero"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ImageClient } from "../../internal/ImageClient"
 import { LinkButton } from "../../internal/LinkButton/LinkButton"
 
@@ -20,6 +24,8 @@ const HERO_THEME_MAPPINGS = {
   },
 } as const
 
+type HeroBlockRenderProps = HeroBlockProps & ContentBlockIndexProps
+
 export const HeroBlock = ({
   title,
   subtitle,
@@ -31,14 +37,18 @@ export const HeroBlock = ({
   site,
   theme = "default",
   headingLevel,
-}: HeroBlockProps) => {
+  contentBlockIndex,
+}: HeroBlockRenderProps) => {
   const heroColour = HERO_THEME_MAPPINGS.hero[theme]
   const heroTextColour = HERO_THEME_MAPPINGS.text[theme]
   const heroButton = HERO_THEME_MAPPINGS.button[theme]
   const Tag = getHeadingTag(headingLevel)
 
   return (
-    <section className="flex min-h-[15rem] flex-col sm:min-h-[22.5rem] lg:min-h-[31.25rem] lg:flex-row">
+    <section
+      className="flex min-h-[15rem] flex-col sm:min-h-[22.5rem] lg:min-h-[31.25rem] lg:flex-row"
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div
         className={`flex flex-row ${heroColour} px-6 pb-12 pt-11 md:px-10 lg:w-1/2 lg:justify-end lg:pl-10 lg:pr-8`}
       >

--- a/packages/components/src/templates/next/components/complex/Hero/HeroFloating.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroFloating.tsx
@@ -2,6 +2,10 @@ import type { HeroFloatingProps } from "~/interfaces/complex/Hero"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { ImageClient } from "../../internal/ImageClient"
 import { LinkButton } from "../../internal/LinkButton/LinkButton"
@@ -25,6 +29,8 @@ const HERO_THEME_MAPPINGS = {
   },
 } as const
 
+type HeroFloatingRenderProps = HeroFloatingProps & ContentBlockIndexProps
+
 export const HeroFloating = ({
   title,
   subtitle,
@@ -36,7 +42,8 @@ export const HeroFloating = ({
   site,
   theme = "default",
   headingLevel,
-}: HeroFloatingProps) => {
+  contentBlockIndex,
+}: HeroFloatingRenderProps) => {
   const heroColour = HERO_THEME_MAPPINGS.hero[theme]
   const heroTitleColour = HERO_THEME_MAPPINGS.title[theme]
   const heroSubtitleColour = HERO_THEME_MAPPINGS.subtitle[theme]
@@ -47,6 +54,7 @@ export const HeroFloating = ({
     <section
       // we have !px-0, sm:!px-0 and md:!px-0 to override the default px from ComponentContent
       className={`${ComponentContent} flex w-full flex-col items-center !px-0 pb-12 pt-6 sm:!px-0 md:!px-0 md:pb-24 md:pt-16 lg:items-start lg:!px-10`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       {/* Image with aspect ratio and max height */}
       <div className="lg:flex lg:w-full lg:justify-end">

--- a/packages/components/src/templates/next/components/complex/Hero/HeroGradient.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroGradient.tsx
@@ -2,9 +2,15 @@ import type { HeroGradientProps } from "~/interfaces/complex/Hero"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { ImageClient } from "../../internal/ImageClient"
 import { LinkButton } from "../../internal/LinkButton/LinkButton"
+
+type HeroGradientRenderProps = HeroGradientProps & ContentBlockIndexProps
 
 export const HeroGradient = ({
   title,
@@ -16,10 +22,14 @@ export const HeroGradient = ({
   backgroundUrl,
   site,
   headingLevel,
-}: HeroGradientProps) => {
+  contentBlockIndex,
+}: HeroGradientRenderProps) => {
   const Tag = getHeadingTag(headingLevel)
   return (
-    <section className="relative flex min-h-[15rem] sm:min-h-[22.5rem] lg:min-h-[31.25rem]">
+    <section
+      className="relative flex min-h-[15rem] sm:min-h-[22.5rem] lg:min-h-[31.25rem]"
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div
         className="absolute inset-0 min-h-[15rem] min-w-full overflow-hidden sm:min-h-[22.5rem] lg:min-h-[31.25rem]"
         style={{ contain: "layout" }}

--- a/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/HeroLargeImage.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/HeroLargeImage.tsx
@@ -2,9 +2,15 @@ import type { HeroLargeImageProps } from "~/interfaces/complex/Hero"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../../render/contentBlockIndex"
 import { ComponentContent } from "../../../internal/customCssClass"
 import { LinkButton } from "../../../internal/LinkButton/LinkButton"
 import { ImageContainer } from "./ImageContainer"
+
+type HeroLargeImageRenderProps = HeroLargeImageProps & ContentBlockIndexProps
 
 export const HeroLargeImage = ({
   title,
@@ -16,10 +22,14 @@ export const HeroLargeImage = ({
   backgroundUrl,
   site,
   headingLevel,
-}: HeroLargeImageProps) => {
+  contentBlockIndex,
+}: HeroLargeImageRenderProps) => {
   const Tag = getHeadingTag(headingLevel)
   return (
-    <section className="flex w-full flex-col">
+    <section
+      className="flex w-full flex-col"
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       {/* Text and button container */}
       <div
         className={`mx-auto flex w-full flex-col gap-6 px-6 pb-12 pt-10 md:gap-9 lg:pb-16 lg:pt-12 ${ComponentContent}`}

--- a/packages/components/src/templates/next/components/complex/Hero/HeroSearchbar/HeroSearchbar.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroSearchbar/HeroSearchbar.tsx
@@ -1,15 +1,24 @@
 import type { HeroSearchbarProps } from "~/interfaces/complex/Hero"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../../render/contentBlockIndex"
 import { ImageClient } from "../../../internal/ImageClient"
 import { SearchbarContent } from "./SearchbarContent"
 
-export const HeroSearchbar = (props: HeroSearchbarProps) => {
-  const { backgroundUrl, site } = props
+type HeroSearchbarRenderProps = HeroSearchbarProps & ContentBlockIndexProps
+
+export const HeroSearchbar = (props: HeroSearchbarRenderProps) => {
+  const { backgroundUrl, site, contentBlockIndex } = props
 
   if (backgroundUrl) {
     // Stacking (back to front): background image (no z-index) → overlay (before:z-10) → content (z-20).
     return (
-      <section className="relative flex w-full flex-col justify-center text-base-content-inverse before:absolute before:inset-0 before:z-10 before:bg-[#182236] before:opacity-80 md:min-h-80 lg:min-h-96">
+      <section
+        className="relative flex w-full flex-col justify-center text-base-content-inverse before:absolute before:inset-0 before:z-10 before:bg-[#182236] before:opacity-80 md:min-h-80 lg:min-h-96"
+        {...contentBlockIndexAttr(contentBlockIndex)}
+      >
         <div
           className="absolute inset-0 min-w-full overflow-hidden md:min-h-80 lg:min-h-96"
           style={{ contain: "layout" }}
@@ -38,6 +47,7 @@ export const HeroSearchbar = (props: HeroSearchbarProps) => {
             // Very slightly diagonal gradient going from the right-top-ish (white) to the left-bottom-ish (brand canvas color)
             "linear-gradient(275deg, #FFF 6.27%, var(--color-brand-canvas-default) 100%)",
         }}
+        {...contentBlockIndexAttr(contentBlockIndex)}
       >
         <SearchbarContent {...props} />
       </section>

--- a/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
+++ b/packages/components/src/templates/next/components/complex/Iframe/Iframe.tsx
@@ -1,6 +1,10 @@
 import type { IframeProps } from "~/interfaces"
 import { getSanitizedIframeWithTitle } from "~/utils/getSanitizedIframeWithTitle"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 
 // Sets the appropriate padding for the iframe based on the URL
@@ -26,6 +30,8 @@ const getPaddingForEmbed = (url: string | null) => {
   return "pt-[56.25%]"
 }
 
+type IframeRenderProps = IframeProps & ContentBlockIndexProps
+
 /**
  * @deprecated Replaced with individual website embed components
  */
@@ -33,7 +39,8 @@ export const Iframe = ({
   title,
   content,
   shouldLazyLoad = true,
-}: IframeProps) => {
+  contentBlockIndex,
+}: IframeRenderProps) => {
   const sanitizedIframe = getSanitizedIframeWithTitle(content, title)
 
   if (!sanitizedIframe) {
@@ -45,7 +52,10 @@ export const Iframe = ({
   const iframeUrl = sanitizedIframe.getAttribute("src")
 
   return (
-    <section className={`mt-7 first:mt-0 ${ComponentContent}`}>
+    <section
+      className={`mt-7 first:mt-0 ${ComponentContent}`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div
         className={`relative w-full overflow-hidden ${getPaddingForEmbed(
           iframeUrl,

--- a/packages/components/src/templates/next/components/complex/Image/Image.tsx
+++ b/packages/components/src/templates/next/components/complex/Image/Image.tsx
@@ -1,6 +1,10 @@
 import type { ImageProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ImageClient } from "../../internal/ImageClient"
 
 const createImageStyles = tv({
@@ -34,6 +38,8 @@ const getSizeWidth = (size: ImageProps["size"]) => {
   }
 }
 
+type ImageRenderProps = ImageProps & ContentBlockIndexProps
+
 export const Image = ({
   src,
   alt,
@@ -41,9 +47,13 @@ export const Image = ({
   size,
   site,
   shouldLazyLoad = true,
-}: ImageProps) => {
+  contentBlockIndex,
+}: ImageRenderProps) => {
   return (
-    <div className={compoundStyles.container()}>
+    <div
+      className={compoundStyles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <ImageClient
         src={src}
         alt={alt}

--- a/packages/components/src/templates/next/components/complex/ImageGallery/ImageGallery.tsx
+++ b/packages/components/src/templates/next/components/complex/ImageGallery/ImageGallery.tsx
@@ -1,10 +1,13 @@
 import type { ImageGalleryProps } from "~/interfaces/complex/ImageGallery"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 
+import { type ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { ImageGalleryClient } from "./ImageGalleryClient"
 
-export const ImageGallery = (props: ImageGalleryProps) => {
-  const { site, images, ...rest } = props
+type ImageGalleryRenderProps = ImageGalleryProps & ContentBlockIndexProps
+
+export const ImageGallery = (props: ImageGalleryRenderProps) => {
+  const { site, images, contentBlockIndex, ...rest } = props
 
   const processedImages = images.map((image) => ({
     ...image,
@@ -18,6 +21,7 @@ export const ImageGallery = (props: ImageGalleryProps) => {
     <ImageGalleryClient
       assetsBaseUrl={site.assetsBaseUrl}
       images={processedImages}
+      contentBlockIndex={contentBlockIndex}
       {...rest}
     />
   )

--- a/packages/components/src/templates/next/components/complex/ImageGallery/ImageGalleryClient.tsx
+++ b/packages/components/src/templates/next/components/complex/ImageGallery/ImageGalleryClient.tsx
@@ -5,6 +5,10 @@ import { useCallback, useMemo, useRef, useState, useTransition } from "react"
 import { useBreakpoint } from "~/hooks/useBreakpoint"
 import { tv } from "~/lib/tv"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ImageClient } from "../../internal/ImageClient"
 import { LEFT_ARROW_SVG, RIGHT_ARROW_SVG } from "./assets"
 import { getEndingPreviewIndices, getPreviewIndices } from "./utils"
@@ -45,11 +49,15 @@ const createImagePreviewStyles = tv({
 
 const compoundStyles = createImagePreviewStyles()
 
+type ImageGalleryClientRenderProps = ImageGalleryClientProps &
+  ContentBlockIndexProps
+
 export const ImageGalleryClient = ({
   images,
   assetsBaseUrl,
   shouldLazyLoad,
-}: ImageGalleryClientProps) => {
+  contentBlockIndex,
+}: ImageGalleryClientRenderProps) => {
   const [currentIndex, setCurrentIndex] = useState(0)
   const [isPending, startTransition] = useTransition()
 
@@ -175,6 +183,7 @@ export const ImageGalleryClient = ({
       className="mt-6 w-full first:mt-0"
       role="region"
       aria-label="Image gallery"
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       {/* Main Slideshow */}
       <div className="relative h-[17rem] w-full overflow-hidden border bg-white sm:h-[28.5rem]">

--- a/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCards/InfoCards.tsx
@@ -9,6 +9,10 @@ import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { LinkButton } from "../../internal/LinkButton"
 import { compoundStyles } from "./common"
 import {
@@ -16,6 +20,8 @@ import {
   InfoCardWithFullImage,
   InfoCardWithImage,
 } from "./components"
+
+type InfoCardsRenderProps = InfoCardsProps & ContentBlockIndexProps
 
 export const InfoCards = ({
   id,
@@ -30,7 +36,8 @@ export const InfoCards = ({
   site,
   shouldLazyLoad,
   headingLevel,
-}: InfoCardsProps): JSX.Element => {
+  contentBlockIndex,
+}: InfoCardsRenderProps): JSX.Element => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const cardVariant =
     variant === CARDS_WITH_FULL_IMAGES
@@ -97,6 +104,7 @@ export const InfoCards = ({
     <section
       id={id}
       className={compoundStyles.container({ layout: simplifiedLayout })}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       {(title || subtitle) && (
         <div

--- a/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
+++ b/packages/components/src/templates/next/components/complex/InfoCols/InfoCols.tsx
@@ -9,6 +9,10 @@ import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 import { groupFocusVisibleHighlight } from "~/utils/tailwind"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Link } from "../../internal/Link"
 
@@ -151,6 +155,8 @@ const InfoBoxes = ({
   )
 }
 
+type InfoColsRenderProps = InfoColsProps & ContentBlockIndexProps
+
 export const InfoCols = ({
   id,
   title,
@@ -159,12 +165,17 @@ export const InfoCols = ({
   layout,
   site,
   headingLevel,
-}: InfoColsProps) => {
+  contentBlockIndex,
+}: InfoColsRenderProps) => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const Tag = getHeadingTag(headingLevel)
 
   return (
-    <section id={id} className={compoundStyles.section()}>
+    <section
+      id={id}
+      className={compoundStyles.section()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div
         className={compoundStyles.outerContainer({ layout: simplifiedLayout })}
       >

--- a/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
+++ b/packages/components/src/templates/next/components/complex/Infobar/Infobar.tsx
@@ -5,6 +5,10 @@ import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { LinkButton } from "../../internal/LinkButton"
 
@@ -85,6 +89,8 @@ export const createInfobarStyles = tv({
   },
 })
 
+type InfobarRenderProps = InfobarProps & ContentBlockIndexProps
+
 export const Infobar = ({
   variant,
   title,
@@ -96,7 +102,8 @@ export const Infobar = ({
   layout,
   site,
   headingLevel,
-}: InfobarProps) => {
+  contentBlockIndex,
+}: InfobarRenderProps) => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const Tag = getHeadingTag(headingLevel)
   const hasPrimaryCTA = !!buttonLabel && !!buttonUrl
@@ -114,7 +121,10 @@ export const Infobar = ({
       : "default"
 
   return (
-    <section className={styles.screenWideOuterContainer()}>
+    <section
+      className={styles.screenWideOuterContainer()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={styles.outerContainer()}>
         <div className={styles.innerContainer()}>
           <div className={styles.headingContainer()}>

--- a/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/Infopic.tsx
@@ -2,16 +2,20 @@ import { InfopicVariants } from "~/interfaces/complex/Infopic"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 
 import type { InfopicProps } from "./types"
+import { type ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { BlockInfopic } from "./components/BlockInfopic"
 import { FullInfopic } from "./components/FullInfopic"
+
+type InfopicRenderProps = InfopicProps & ContentBlockIndexProps
 
 export const Infopic = ({
   imageSrc,
   site,
   // NOTE: We need to set a default value here for back-compat
   variant = InfopicVariants.Block.value,
+  contentBlockIndex,
   ...rest
-}: InfopicProps): JSX.Element => {
+}: InfopicRenderProps): JSX.Element => {
   const imgSrc =
     isExternalUrl(imageSrc) || site.assetsBaseUrl === undefined
       ? imageSrc
@@ -19,9 +23,23 @@ export const Infopic = ({
 
   switch (variant) {
     case InfopicVariants.Block.value:
-      return <BlockInfopic {...rest} site={site} imageSrc={imgSrc} />
+      return (
+        <BlockInfopic
+          {...rest}
+          site={site}
+          imageSrc={imgSrc}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case InfopicVariants.Full.value:
-      return <FullInfopic {...rest} site={site} imageSrc={imgSrc} />
+      return (
+        <FullInfopic
+          {...rest}
+          site={site}
+          imageSrc={imgSrc}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     default:
       const missingVariant: never = variant
       return missingVariant

--- a/packages/components/src/templates/next/components/complex/Infopic/components/BlockInfopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/components/BlockInfopic.tsx
@@ -3,6 +3,10 @@ import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
 import type { InfopicProps } from "../types"
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../../render/contentBlockIndex"
 import { ImageClient } from "../../../internal/ImageClient"
 import { LinkButton } from "../../../internal/LinkButton"
 import { infopicStyles } from "../common"
@@ -19,7 +23,8 @@ export const BlockInfopic = ({
   shouldLazyLoad,
   site,
   headingLevel,
-}: Omit<InfopicProps, "variant">) => {
+  contentBlockIndex,
+}: Omit<InfopicProps, "variant"> & ContentBlockIndexProps) => {
   const Tag = getHeadingTag(headingLevel)
   const compoundStyles = infopicStyles({
     isTextOnRight,
@@ -29,7 +34,11 @@ export const BlockInfopic = ({
   const hasLinkButton = !!buttonLabel && !!buttonUrl
 
   return (
-    <section id={id} className={compoundStyles.container()}>
+    <section
+      id={id}
+      className={compoundStyles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={compoundStyles.content()}>
         <Tag className={compoundStyles.title()}>{title}</Tag>
         <p className={compoundStyles.description()}>{description}</p>

--- a/packages/components/src/templates/next/components/complex/Infopic/components/FullInfopic.tsx
+++ b/packages/components/src/templates/next/components/complex/Infopic/components/FullInfopic.tsx
@@ -3,6 +3,10 @@ import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 
 import type { InfopicProps } from "../types"
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../../render/contentBlockIndex"
 import { LinkButton } from "../../../internal/LinkButton"
 import { infopicStyles } from "../common"
 
@@ -19,7 +23,8 @@ export const FullInfopic = ({
   isTextOnRight,
   site,
   headingLevel,
-}: FullInfopicProps) => {
+  contentBlockIndex,
+}: FullInfopicProps & ContentBlockIndexProps) => {
   const Tag = getHeadingTag(headingLevel)
   const compoundStyles = infopicStyles({
     isTextOnRight,
@@ -36,6 +41,7 @@ export const FullInfopic = ({
         backgroundPosition: "center",
       }}
       id={id}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       <div className={compoundStyles.overlay()}>
         <div

--- a/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
+++ b/packages/components/src/templates/next/components/complex/KeyStatistics/KeyStatistics.tsx
@@ -4,6 +4,10 @@ import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getReferenceLinkHref } from "~/utils/getReferenceLinkHref"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { LinkButton } from "../../internal/LinkButton"
 
@@ -59,6 +63,8 @@ const createKeyStatisticsStyles = tv({
 
 const compoundStyles = createKeyStatisticsStyles()
 
+type KeyStatisticsRenderProps = KeyStatisticsProps & ContentBlockIndexProps
+
 export const KeyStatistics = ({
   id,
   title,
@@ -68,7 +74,8 @@ export const KeyStatistics = ({
   layout,
   site,
   headingLevel,
-}: KeyStatisticsProps) => {
+  contentBlockIndex,
+}: KeyStatisticsRenderProps) => {
   const noOfItems = Math.min(MAX_ITEMS, statistics.length) as NoOfItemVariants
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const TitleTag = getHeadingTag(headingLevel)
@@ -78,6 +85,7 @@ export const KeyStatistics = ({
     <section
       id={id}
       className={compoundStyles.container({ layout: simplifiedLayout })}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       <TitleTag className={compoundStyles.title()}>{title}</TitleTag>
 

--- a/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
+++ b/packages/components/src/templates/next/components/complex/LogoCloud/LogoCloud.tsx
@@ -1,6 +1,10 @@
 import type { LogoCloudProps } from "~/interfaces/complex/LogoCloud"
 import { tv } from "~/lib/tv"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { ImageClient } from "../../internal/ImageClient"
 
@@ -15,14 +19,20 @@ const createLogoCloudStyles = tv({
 })
 const compoundStyles = createLogoCloudStyles()
 
+type LogoCloudRenderProps = LogoCloudProps & ContentBlockIndexProps
+
 export const LogoCloud = ({
   images: baseImages,
   title,
   site: { assetsBaseUrl },
   shouldLazyLoad = true,
-}: LogoCloudProps) => {
+  contentBlockIndex,
+}: LogoCloudRenderProps) => {
   return (
-    <div className={compoundStyles.container()}>
+    <div
+      className={compoundStyles.container()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       {title && <p className={compoundStyles.title()}>{title}</p>}
       <div className={compoundStyles.logoContainer()}>
         {baseImages.map(({ src, alt }) => (

--- a/packages/components/src/templates/next/components/complex/Map/Map.tsx
+++ b/packages/components/src/templates/next/components/complex/Map/Map.tsx
@@ -2,6 +2,10 @@ import type { MapProps } from "~/interfaces"
 import { tv } from "~/lib/tv"
 import { isValidMapEmbedUrl, isValidOGPMapsEmbedUrl } from "~/utils/validation"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../internal/BaseParagraph"
 import { ComponentContent } from "../../internal/customCssClass"
 
@@ -21,7 +25,14 @@ const createMapStyles = tv({
   },
 })
 
-export const Map = ({ title, url, shouldLazyLoad = true }: MapProps) => {
+type MapRenderProps = MapProps & ContentBlockIndexProps
+
+export const Map = ({
+  title,
+  url,
+  shouldLazyLoad = true,
+  contentBlockIndex,
+}: MapRenderProps) => {
   if (!isValidMapEmbedUrl(url)) {
     return <></>
   }
@@ -33,7 +44,10 @@ export const Map = ({ title, url, shouldLazyLoad = true }: MapProps) => {
   })
 
   return (
-    <section className={compoundStyles.outerContainer()}>
+    <section
+      className={compoundStyles.outerContainer()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       {isOgpMapsEmbed && (
         <BaseParagraph
           content={`You can also view the map below on <a href="${url}">Maps.gov.sg</a>.`}

--- a/packages/components/src/templates/next/components/complex/Steps/Steps.tsx
+++ b/packages/components/src/templates/next/components/complex/Steps/Steps.tsx
@@ -3,6 +3,10 @@ import { tv } from "~/lib/tv"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getTailwindVariantLayout } from "~/utils/getTailwindVariantLayout"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { Step } from "./Step"
 
@@ -42,6 +46,8 @@ const createStepsStyles = tv({
 
 const styles = createStepsStyles()
 
+type StepsRenderProps = StepsProps & ContentBlockIndexProps
+
 export const Steps = ({
   id,
   title,
@@ -51,13 +57,18 @@ export const Steps = ({
   layout,
   site,
   headingLevel,
-}: StepsProps) => {
+  contentBlockIndex,
+}: StepsRenderProps) => {
   const simplifiedLayout = getTailwindVariantLayout(layout)
   const TitleTag = getHeadingTag(headingLevel)
   const hasTwo = steps.length === 2
 
   return (
-    <section id={id} className={styles.section()}>
+    <section
+      id={id}
+      className={styles.section()}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div className={styles.outerContainer({ layout: simplifiedLayout })}>
         <div className={styles.innerContainer()}>
           <div className={styles.header({ layout: simplifiedLayout })}>

--- a/packages/components/src/templates/next/components/complex/Video/Video.tsx
+++ b/packages/components/src/templates/next/components/complex/Video/Video.tsx
@@ -1,6 +1,10 @@
 import type { VideoProps } from "~/interfaces"
 import { isValidVideoUrl, VALID_VIDEO_DOMAINS } from "~/utils/validation"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ComponentContent } from "../../internal/customCssClass"
 import { LiteVimeoEmbed } from "./LiteVimeoEmbed"
 import { LiteYouTubeEmbed } from "./LiteYouTubeEmbed"
@@ -50,7 +54,14 @@ const parseVideo = (url: string): ParsedVideo | null => {
   }
 }
 
-export const Video = ({ title, url, shouldLazyLoad = true }: VideoProps) => {
+type VideoRenderProps = VideoProps & ContentBlockIndexProps
+
+export const Video = ({
+  title,
+  url,
+  shouldLazyLoad = true,
+  contentBlockIndex,
+}: VideoRenderProps) => {
   const parsedVideo = parseVideo(url)
   if (!parsedVideo) return null
 
@@ -101,7 +112,10 @@ export const Video = ({ title, url, shouldLazyLoad = true }: VideoProps) => {
   }
 
   return (
-    <section className={`${ComponentContent} mt-7 first:mt-0`}>
+    <section
+      className={`${ComponentContent} mt-7 first:mt-0`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <div
         className={isPortrait ? "mx-auto w-full max-w-[20.3125rem]" : "w-full"}
       >

--- a/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
+++ b/packages/components/src/templates/next/components/internal/BaseParagraph/BaseParagraph.tsx
@@ -4,6 +4,10 @@ import { ALLOWED_TAG_LIST, Interweave } from "interweave"
 import { twMerge } from "~/lib/twMerge"
 import { isExternalUrl } from "~/utils/isExternalUrl"
 
+import {
+  CONTENT_BLOCK_INDEX_ATTR,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { Link } from "../Link"
 
 // This will be tree-shaken out of client bundles
@@ -26,7 +30,8 @@ export const BaseParagraph = ({
   allowedTags,
   className,
   attrs,
-}: BaseParagraphProps) => {
+  contentBlockIndex,
+}: BaseParagraphProps & ContentBlockIndexProps) => {
   const transform = (node: HTMLElement, children: Node[]): React.ReactNode => {
     if (node.tagName.toLocaleLowerCase() === "a") {
       const href = node.getAttribute("href") ?? undefined
@@ -52,6 +57,9 @@ export const BaseParagraph = ({
       allowList={allowedTags ?? ALLOWED_TAG_LIST_WITHOUT_SPAN}
       attributes={{
         ...(attrs?.dir && { dir: attrs.dir }),
+        ...(contentBlockIndex !== undefined && {
+          [CONTENT_BLOCK_INDEX_ATTR]: contentBlockIndex,
+        }),
       }}
       className={twMerge(
         `[&:not(:first-child)]:mt-6 [&:not(:last-child)]:mb-6 [&_a]:text-link [&_a]:underline [&_a]:outline-none visited:[&_a]:text-link-visited hover:[&_a]:text-link-hover focus-visible:[&_a]:bg-utility-highlight focus-visible:[&_a]:text-base-content-strong focus-visible:[&_a]:decoration-transparent focus-visible:[&_a]:shadow-focus-visible focus-visible:[&_a]:transition-none`,

--- a/packages/components/src/templates/next/components/native/Divider/Divider.tsx
+++ b/packages/components/src/templates/next/components/native/Divider/Divider.tsx
@@ -1,5 +1,17 @@
 import type { DividerProps } from "~/interfaces"
 
-export const Divider = ({}: DividerProps) => {
-  return <hr className="my-6 bg-divider-medium" />
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
+
+export const Divider = ({
+  contentBlockIndex,
+}: DividerProps & ContentBlockIndexProps) => {
+  return (
+    <hr
+      className="my-6 bg-divider-medium"
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    />
+  )
 }

--- a/packages/components/src/templates/next/components/native/Heading/Heading.tsx
+++ b/packages/components/src/templates/next/components/native/Heading/Heading.tsx
@@ -2,6 +2,11 @@ import type { HeadingProps } from "~/interfaces"
 import { getHeadingTag } from "~/utils/getHeadingTag"
 import { getTextAsHtml } from "~/utils/getTextAsHtml"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
+
 // `level` only selects the visual style/font size below — it no longer
 // determines the rendered tag. The tag comes from `headingLevel`, computed
 // by the renderer from this heading's actual position in the page, so a
@@ -12,13 +17,15 @@ export const Heading = ({
   content,
   site,
   headingLevel,
-}: Omit<HeadingProps, "type">) => {
+  contentBlockIndex,
+}: Omit<HeadingProps, "type"> & ContentBlockIndexProps) => {
   const Tag = getHeadingTag(headingLevel)
   const textContent = getTextAsHtml({
     site,
     content,
     shouldHideEmptyHardBreak: true,
   })
+  const blockIndexAttr = contentBlockIndexAttr(contentBlockIndex)
 
   if (level === 2) {
     return (
@@ -26,6 +33,7 @@ export const Heading = ({
         id={id}
         className="prose-display-sm text-base-content-strong [&:not(:first-child)]:mt-14 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
+        {...blockIndexAttr}
       >
         {textContent}
       </Tag>
@@ -37,6 +45,7 @@ export const Heading = ({
         id={id}
         className="prose-display-xs text-base-content-strong [&:not(:first-child)]:mt-9 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
+        {...blockIndexAttr}
       >
         {textContent}
       </Tag>
@@ -48,6 +57,7 @@ export const Heading = ({
         id={id}
         className="prose-title-md-semibold text-base-content-strong [&:not(:first-child)]:mt-8 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
+        {...blockIndexAttr}
       >
         {textContent}
       </Tag>
@@ -59,6 +69,7 @@ export const Heading = ({
         id={id}
         className="prose-headline-lg-semibold text-base-content-strong [&:not(:first-child)]:mt-7 [&:not(:last-child)]:mb-6"
         dir={dir ?? undefined}
+        {...blockIndexAttr}
       >
         {textContent}
       </Tag>
@@ -69,6 +80,7 @@ export const Heading = ({
       id={id}
       className="prose-headline-base-semibold text-base-content-strong [&:not(:first-child)]:mt-6 [&:not(:last-child)]:mb-6"
       dir={dir ?? undefined}
+      {...blockIndexAttr}
     >
       {textContent}
     </Tag>

--- a/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
+++ b/packages/components/src/templates/next/components/native/OrderedList/OrderedList.tsx
@@ -1,5 +1,9 @@
 import type { OrderedListProps } from "~/interfaces"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ListItem } from "../ListItem"
 
 const getOrderedListType = (level?: number) => {
@@ -18,7 +22,8 @@ export const OrderedList = ({
   content,
   level,
   site,
-}: OrderedListProps) => {
+  contentBlockIndex,
+}: OrderedListProps & ContentBlockIndexProps) => {
   return (
     // Nested sublists (level set) use `mt-3` to match the item rhythm (`my-3`
     // on ListItem). Top-level lists keep `mt-6` because preceding blocks like
@@ -26,6 +31,7 @@ export const OrderedList = ({
     <ol
       className={`${level ? "mt-3" : "mt-6"} ps-9 marker:text-base-content ${getOrderedListType(level)}`}
       start={attrs?.start}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       {content.map((item, index) => (
         <ListItem key={index} {...item} level={level} site={site} />

--- a/packages/components/src/templates/next/components/native/Prose/Prose.tsx
+++ b/packages/components/src/templates/next/components/native/Prose/Prose.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react"
 import type { ProseProps } from "~/interfaces"
 import { getTextAsHtml } from "~/utils/getTextAsHtml"
 
+import { type ContentBlockIndexProps } from "../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../internal/BaseParagraph"
 import { Divider } from "../Divider"
 import { Heading } from "../Heading"
@@ -9,27 +10,42 @@ import { OrderedList } from "../OrderedList"
 import { Table } from "../Table"
 import { UnorderedList } from "../UnorderedList"
 
+type ProseRenderProps = ProseProps & ContentBlockIndexProps
+
 const ProseComponent = ({
   component,
   site,
   shouldStripContentHtmlTags,
   headingLevel,
+  contentBlockIndex,
 }: {
   component: NonNullable<ProseProps["content"]>[number]
-} & Pick<
-  ProseProps,
-  "site" | "shouldStripContentHtmlTags" | "headingLevel"
->): JSX.Element => {
+} & Pick<ProseProps, "site" | "shouldStripContentHtmlTags" | "headingLevel"> &
+  ContentBlockIndexProps): JSX.Element => {
   switch (component.type) {
     case "divider":
-      return <Divider {...component} />
+      return <Divider {...component} contentBlockIndex={contentBlockIndex} />
     case "heading":
-      return <Heading {...component} site={site} headingLevel={headingLevel} />
+      return (
+        <Heading
+          {...component}
+          contentBlockIndex={contentBlockIndex}
+          site={site}
+          headingLevel={headingLevel}
+        />
+      )
     case "orderedList":
-      return <OrderedList {...component} site={site} />
+      return (
+        <OrderedList
+          {...component}
+          contentBlockIndex={contentBlockIndex}
+          site={site}
+        />
+      )
     case "paragraph":
       return (
         <BaseParagraph
+          contentBlockIndex={contentBlockIndex}
           content={getTextAsHtml({
             site,
             content: component.content,
@@ -40,9 +56,21 @@ const ProseComponent = ({
         />
       )
     case "table":
-      return <Table {...component} site={site} />
+      return (
+        <Table
+          {...component}
+          contentBlockIndex={contentBlockIndex}
+          site={site}
+        />
+      )
     case "unorderedList":
-      return <UnorderedList {...component} site={site} />
+      return (
+        <UnorderedList
+          {...component}
+          contentBlockIndex={contentBlockIndex}
+          site={site}
+        />
+      )
   }
 }
 
@@ -51,7 +79,8 @@ export const Prose = ({
   site,
   shouldStripContentHtmlTags = false,
   headingLevel,
-}: ProseProps) => {
+  contentBlockIndex,
+}: ProseRenderProps) => {
   if (!content) {
     return <></>
   }
@@ -65,6 +94,7 @@ export const Prose = ({
           site={site}
           shouldStripContentHtmlTags={shouldStripContentHtmlTags}
           headingLevel={headingLevel}
+          contentBlockIndex={contentBlockIndex}
         />
       ))}
     </>

--- a/packages/components/src/templates/next/components/native/Table/Table.tsx
+++ b/packages/components/src/templates/next/components/native/Table/Table.tsx
@@ -2,6 +2,10 @@ import type { TableProps } from "~/interfaces"
 import { useId } from "react"
 import { tv } from "~/lib/tv"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { BaseParagraph } from "../../internal/BaseParagraph"
 import { Divider } from "../Divider"
 import { OrderedList } from "../OrderedList"
@@ -29,12 +33,20 @@ const tableCellStyles = tv({
   },
 })
 
-export const Table = ({ attrs: { caption }, content, site }: TableProps) => {
+export const Table = ({
+  attrs: { caption },
+  content,
+  site,
+  contentBlockIndex,
+}: TableProps & ContentBlockIndexProps) => {
   const tableDescriptionId = useId()
   const layout = resolveTableLayout(content)
 
   return (
-    <div className="flex flex-col gap-4 [&:not(:first-child)]:mt-7">
+    <div
+      className="flex flex-col gap-4 [&:not(:first-child)]:mt-7"
+      {...contentBlockIndexAttr(contentBlockIndex)}
+    >
       <BaseParagraph
         id={tableDescriptionId}
         content={caption}

--- a/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
+++ b/packages/components/src/templates/next/components/native/UnorderedList/UnorderedList.tsx
@@ -1,5 +1,9 @@
 import type { UnorderedListProps } from "~/interfaces"
 
+import {
+  contentBlockIndexAttr,
+  type ContentBlockIndexProps,
+} from "../../../render/contentBlockIndex"
 import { ListItem } from "../ListItem"
 
 const getUnorderedListType = (level?: number) => {
@@ -13,13 +17,19 @@ const getUnorderedListType = (level?: number) => {
   }
 }
 
-export const UnorderedList = ({ content, level, site }: UnorderedListProps) => {
+export const UnorderedList = ({
+  content,
+  level,
+  site,
+  contentBlockIndex,
+}: UnorderedListProps & ContentBlockIndexProps) => {
   return (
     // Nested sublists (level set) use `mt-3` to match the item rhythm (`my-3`
     // on ListItem). Top-level lists keep `mt-6` because preceding blocks like
     // Table or Callout have no bottom margin to collapse over a smaller value.
     <ul
       className={`${level ? "mt-3" : "mt-6"} ps-9 marker:text-base-content ${getUnorderedListType(level)}`}
+      {...contentBlockIndexAttr(contentBlockIndex)}
     >
       {content.map((item, index) => (
         <ListItem key={index} {...item} level={level} site={site} />

--- a/packages/components/src/templates/next/render/contentBlockIndex.ts
+++ b/packages/components/src/templates/next/render/contentBlockIndex.ts
@@ -1,0 +1,12 @@
+export const CONTENT_BLOCK_INDEX_ATTR = "data-isomer-content-index" as const
+
+export type ContentBlockIndexProps = {
+  contentBlockIndex?: number
+}
+
+export const contentBlockIndexAttr = (
+  contentBlockIndex?: number,
+): Partial<Record<typeof CONTENT_BLOCK_INDEX_ATTR, number>> =>
+  contentBlockIndex === undefined
+    ? {}
+    : { [CONTENT_BLOCK_INDEX_ATTR]: contentBlockIndex }

--- a/packages/components/src/templates/next/render/contentBlockIndex.ts
+++ b/packages/components/src/templates/next/render/contentBlockIndex.ts
@@ -1,6 +1,6 @@
 export const CONTENT_BLOCK_INDEX_ATTR = "data-isomer-content-index" as const
 
-export type ContentBlockIndexProps = {
+export interface ContentBlockIndexProps {
   contentBlockIndex?: number
 }
 

--- a/packages/components/src/templates/next/render/renderComponent.tsx
+++ b/packages/components/src/templates/next/render/renderComponent.tsx
@@ -198,7 +198,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "map":

--- a/packages/components/src/templates/next/render/renderComponent.tsx
+++ b/packages/components/src/templates/next/render/renderComponent.tsx
@@ -49,8 +49,6 @@ export const renderComponent = ({
   component,
   ...rest
 }: RenderComponentProps) => {
-  const contentBlockIndex = contentIndex
-
   switch (component.type) {
     case "logocloud":
       return (
@@ -58,7 +56,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "accordion":
@@ -67,14 +65,14 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "antiscambanner":
       return (
         <AntiScamDisclaimerBanner
           key={elementKey}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "blockquote":
@@ -83,7 +81,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "button":
@@ -92,7 +90,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "callout":
@@ -101,7 +99,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "contentpic":
@@ -110,7 +108,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "formsg":
@@ -119,7 +117,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "hero":
@@ -128,7 +126,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "iframe":
@@ -137,7 +135,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "image":
@@ -146,7 +144,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "infobar":
@@ -155,7 +153,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "infocards":
@@ -164,7 +162,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "infocols":
@@ -173,7 +171,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "infopic":
@@ -182,7 +180,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "keystatistics":
@@ -191,7 +189,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "steps":
@@ -209,7 +207,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "childrenpages":
@@ -218,7 +216,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "prose":
@@ -227,7 +225,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
           shouldStripContentHtmlTags
         />
       )
@@ -237,7 +235,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "video":
@@ -246,7 +244,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "dynamicdatabanner":
@@ -255,7 +253,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
 
@@ -265,7 +263,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "imagegallery":
@@ -274,7 +272,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "contactinformation":
@@ -283,7 +281,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     case "dynamiccomponentlist":
@@ -292,7 +290,7 @@ export const renderComponent = ({
           key={elementKey}
           {...component}
           {...rest}
-          contentBlockIndex={contentBlockIndex}
+          contentBlockIndex={contentIndex}
         />
       )
     default:

--- a/packages/components/src/templates/next/render/renderComponent.tsx
+++ b/packages/components/src/templates/next/render/renderComponent.tsx
@@ -34,6 +34,7 @@ import { Prose } from "../components/native/Prose"
 
 interface RenderComponentProps {
   elementKey?: number
+  contentIndex: number
   component: IsomerComponent
   layout: IsomerPageLayoutType
   site: IsomerSiteProps
@@ -44,74 +45,256 @@ interface RenderComponentProps {
 
 export const renderComponent = ({
   elementKey,
+  contentIndex,
   component,
   ...rest
 }: RenderComponentProps) => {
+  const contentBlockIndex = contentIndex
+
   switch (component.type) {
     case "logocloud":
-      return <LogoCloud key={elementKey} {...component} {...rest} />
+      return (
+        <LogoCloud
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "accordion":
-      return <Accordion key={elementKey} {...component} {...rest} />
+      return (
+        <Accordion
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "antiscambanner":
       return (
-        <AntiScamDisclaimerBanner key={elementKey} {...component} {...rest} />
+        <AntiScamDisclaimerBanner
+          key={elementKey}
+          contentBlockIndex={contentBlockIndex}
+        />
       )
     case "blockquote":
-      return <Blockquote key={elementKey} {...component} {...rest} />
+      return (
+        <Blockquote
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "button":
-      return <Button key={elementKey} {...component} {...rest} />
+      return (
+        <Button
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "callout":
-      return <Callout key={elementKey} {...component} {...rest} />
+      return (
+        <Callout
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "contentpic":
-      return <Contentpic key={elementKey} {...component} {...rest} />
+      return (
+        <Contentpic
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "formsg":
-      return <FormSG key={elementKey} {...component} {...rest} />
+      return (
+        <FormSG
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "hero":
-      return <Hero key={elementKey} {...component} {...rest} />
+      return (
+        <Hero
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "iframe":
-      return <Iframe key={elementKey} {...component} {...rest} />
+      return (
+        <Iframe
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "image":
-      return <Image key={elementKey} {...component} {...rest} />
+      return (
+        <Image
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "infobar":
-      return <Infobar key={elementKey} {...component} {...rest} />
+      return (
+        <Infobar
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "infocards":
-      return <InfoCards key={elementKey} {...component} {...rest} />
+      return (
+        <InfoCards
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "infocols":
-      return <InfoCols key={elementKey} {...component} {...rest} />
+      return (
+        <InfoCols
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "infopic":
-      return <Infopic key={elementKey} {...component} {...rest} />
+      return (
+        <Infopic
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "keystatistics":
-      return <KeyStatistics key={elementKey} {...component} {...rest} />
+      return (
+        <KeyStatistics
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "steps":
-      return <Steps key={elementKey} {...component} {...rest} />
+      return (
+        <Steps
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "map":
-      return <Map key={elementKey} {...component} {...rest} />
+      return (
+        <Map
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "childrenpages":
-      return <ChildrenPages key={elementKey} {...component} {...rest} />
+      return (
+        <ChildrenPages
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "prose":
       return (
         <Prose
           key={elementKey}
           {...component}
           {...rest}
+          contentBlockIndex={contentBlockIndex}
           shouldStripContentHtmlTags
         />
       )
     case "audio":
-      return <Audio key={elementKey} {...component} {...rest} />
+      return (
+        <Audio
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "video":
-      return <Video key={elementKey} {...component} {...rest} />
+      return (
+        <Video
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "dynamicdatabanner":
-      return <DynamicDataBanner key={elementKey} {...component} {...rest} />
+      return (
+        <DynamicDataBanner
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
 
     case "collectionblock":
-      return <CollectionBlock key={elementKey} {...component} {...rest} />
+      return (
+        <CollectionBlock
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "imagegallery":
-      return <ImageGallery key={elementKey} {...component} {...rest} />
+      return (
+        <ImageGallery
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "contactinformation":
-      return <ContactInformation key={elementKey} {...component} {...rest} />
+      return (
+        <ContactInformation
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     case "dynamiccomponentlist":
-      return <DynamicComponentList key={elementKey} {...component} {...rest} />
+      return (
+        <DynamicComponentList
+          key={elementKey}
+          {...component}
+          {...rest}
+          contentBlockIndex={contentBlockIndex}
+        />
+      )
     default:
       const _: never = component
       return <></>

--- a/packages/components/src/templates/next/render/renderPageContent.ts
+++ b/packages/components/src/templates/next/render/renderPageContent.ts
@@ -22,19 +22,20 @@ export const renderPageContent = ({
   headingLevel,
   ...rest
 }: RenderPageContentParams) => {
-  // Filter out hidden childrenpages blocks
-  const visibleContent = content.filter((component) =>
-    component.type === "childrenpages" ? !component.isHidden : true,
-  )
+  const visibleContent = content
+    .map((component, contentIndex) => ({ component, contentIndex }))
+    .filter(({ component }) =>
+      component.type === "childrenpages" ? !component.isHidden : true,
+    )
 
   // Find index of first component with image
-  const firstImageIndex = visibleContent.findIndex((component) =>
+  const firstImageIndex = visibleContent.findIndex(({ component }) =>
     doesComponentHaveImage({ component }),
   )
 
   let isInfopicTextOnRight = false
 
-  return visibleContent.map((component, index) => {
+  return visibleContent.map(({ component, contentIndex }, index) => {
     // Lazy load components with images that appear after the first image.
     // We assume that only the first image component will be visible above the fold,
     // while subsequent components should be lazy loaded to enhance the Lighthouse performance score.
@@ -54,6 +55,7 @@ export const renderPageContent = ({
       }
       return renderComponent({
         elementKey: index,
+        contentIndex,
         component: formattedComponent,
         shouldLazyLoad,
         headingLevel: currentHeadingLevel,
@@ -64,6 +66,7 @@ export const renderPageContent = ({
 
     return renderComponent({
       elementKey: index,
+      contentIndex,
       component,
       shouldLazyLoad,
       headingLevel: currentHeadingLevel,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 64 | +1225 | -266 |
| 🧪 Test | 4 | +268 | -3 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

<!-- What problem are you trying to solve? What issue does this close? -->

N/A — no tracked issue. Stacked on top of #3140 (editor → preview hover highlighting). This PR adds the reverse direction: hovering a block in the live preview should highlight the corresponding row in the editor sidebar.

## Solution

Hovering a block in the preview iframe now highlights the corresponding row in the sidebar (`RootStateDrawer`), reusing the same `hoveredBlockIndex` state introduced in #3140 — so hovering either side lights up both the preview overlay and the sidebar row.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Hovering a block in the live preview iframe highlights the corresponding row in the sidebar block list.

**Improvements**:

- `EditPagePreview.tsx` attaches a single delegated `mouseover`/`mouseout` listener on the iframe's document, walking up from the event target to the direct child of the shared `[data-isomer-content-blocks]` container (introduced in #3140) to resolve which block is hovered.
- `BaseBlock.tsx` gained a new `isHighlighted` prop, applying the same colours as its existing native `_hover` state but driven externally (via `hoveredBlockIndex === index`) rather than requiring the mouse to be directly over the row — since the trigger can now come from the preview side instead.

**Bug Fixes**:

- Fixed a cross-realm `instanceof` bug found during implementation: `react-frame-component` portals content into the iframe's own document, so DOM nodes there are instances of the iframe's own `HTMLElement` global, not the parent window's. An `instanceof HTMLElement` check in the block-resolution logic was silently failing for every element (the preceding walk-up loop already guarantees the node is either `null` or the correct match, so the check was simplified to a plain null check).

## Before & After Screenshots

https://github.com/user-attachments/assets/c13eba81-15f4-40d1-987b-71bd2547f05a

## Tests

**Manual Verification Steps**:

- [ ] Open a page in the Studio editor with several different block types.
- [ ] Hover each block directly in the preview iframe — confirm the corresponding row in the left sidebar highlights (background/border change), matching the row you'd click to edit that block.
- [ ] Move the mouse off a preview block — confirm the sidebar row highlight clears.
- [ ] Confirm hovering a sidebar row still highlights the preview as before (existing #3140 behaviour is unaffected).
- [ ] Move the mouse quickly between adjacent blocks in the preview — confirm the sidebar highlight tracks correctly without getting stuck on a previous block.
- [ ] Test on a page using a different layout (e.g. an Index/Collection page, a Database page) to confirm detection still works there.









<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds bidirectional hover highlighting and preview-side block editing by stamping content indices throughout the shared renderer.
- Adds delegated preview hover detection and sidebar highlighting.
- Adds an Edit toolbar with discard-before-navigation handling.
- Replaces positional DOM mapping with renderer-provided block-index attributes.
</details>


<details><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not yet safe to merge because multi-item prose highlights the wrong region and discard recovery can still open the wrong duplicate block or drop the requested selection.

The marker lookup returns only the first DOM node for a multi-root prose block, while the previously reported discard-identity issue remains because selection recovery still relies on findIndex(isEqual).

**Files Needing Attention:** apps/studio/src/features/editing-experience/utils/getBlockElement.ts and apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/studio/src/features/editing-experience/components/preview/EditPagePreview.tsx | Adds preview-side editing and discard recovery, but value equality still cannot reliably preserve block identity. |
| apps/studio/src/features/editing-experience/utils/getBlockElement.ts | Marker-based lookup fixes positional offsets but resolves only the first DOM element for multi-root blocks. |
| apps/studio/src/features/editing-experience/hooks/usePreviewHoverDetection.ts | Delegates iframe hover tracking through stamped block indices and handles toolbar transitions. |
| packages/components/src/templates/next/render/renderPageContent.ts | Preserves original content indices while filtering hidden child-page blocks and forwards them into rendering. |
| packages/components/src/templates/next/components/native/Prose/Prose.tsx | Stamps every prose sibling with one block index, exposing the first-match overlay limitation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant User
  participant Preview
  participant HoverState
  participant Sidebar
  participant Editor
  User->>Preview: Hover rendered block
  Preview->>HoverState: Resolve stamped content index
  HoverState-->>Preview: Position highlight and Edit toolbar
  HoverState-->>Sidebar: Highlight matching row
  User->>Preview: Click Edit
  Preview->>Editor: Select block or request discard
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233141%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3141&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Futils%2FgetBlockElement.ts%3A14-16%0A**Prose%20highlight%20uses%20first%20item**%0A%0AWhen%20a%20prose%20block%20contains%20multiple%20rendered%20items%20and%20the%20user%20hovers%20a%20later%20item%2C%20every%20item%20has%20the%20same%20content%20index%20but%20%60querySelector%60%20returns%20only%20the%20first%20match.%20The%20highlight%20and%20Edit%20toolbar%20therefore%20appear%20over%20the%20first%20prose%20item%20instead%20of%20the%20content%20being%20hovered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3141&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Futils%2FgetBlockElement.ts%3A14-16%0A**Prose%20highlight%20uses%20first%20item**%0A%0AWhen%20a%20prose%20block%20contains%20multiple%20rendered%20items%20and%20the%20user%20hovers%20a%20later%20item%2C%20every%20item%20has%20the%20same%20content%20index%20but%20%60querySelector%60%20returns%20only%20the%20first%20match.%20The%20highlight%20and%20Edit%20toolbar%20therefore%20appear%20over%20the%20first%20prose%20item%20instead%20of%20the%20content%20being%20hovered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3141&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fpreview-hover-highlight-reverse%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpreview-hover-highlight-reverse%22.%0A%0A%23%23%23%20Issue%201%0Aapps%2Fstudio%2Fsrc%2Ffeatures%2Fediting-experience%2Futils%2FgetBlockElement.ts%3A14-16%0A**Prose%20highlight%20uses%20first%20item**%0A%0AWhen%20a%20prose%20block%20contains%20multiple%20rendered%20items%20and%20the%20user%20hovers%20a%20later%20item%2C%20every%20item%20has%20the%20same%20content%20index%20but%20%60querySelector%60%20returns%20only%20the%20first%20match.%20The%20highlight%20and%20Edit%20toolbar%20therefore%20appear%20over%20the%20first%20prose%20item%20instead%20of%20the%20content%20being%20hovered.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
apps/studio/src/features/editing-experience/utils/getBlockElement.ts:14-16
**Prose highlight uses first item**

When a prose block contains multiple rendered items and the user hovers a later item, every item has the same content index but `querySelector` returns only the first match. The highlight and Edit toolbar therefore appear over the first prose item instead of the content being hovered.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["chore: trim redundant comments and alias..."](https://github.com/opengovsg/isomer/commit/a21b8f791388a69284a910e48a24aa162410d45a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54263826)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Page authoring experience](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/page-authoring.md)
- Knowledge Base — [Site rendering components](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/site-rendering-components.md)

<!-- /greptile_comment -->