### PR TITLE
docs: improve Copilot reviews and refresh repository guidance

### DIFF
--- a/.claude/skills/feature-implement/SKILL.md
+++ b/.claude/skills/feature-implement/SKILL.md
@@ -36,7 +36,8 @@ Particular files to re-read every time:
 - `apps/studio/src/server/CLAUDE.md` if touching the server
 - `apps/studio/src/features/CLAUDE.md` if touching a feature
 - `packages/components/CLAUDE.md` if touching the published-site renderer
-- `apps/studio/prisma/CLAUDE.md` if touching the schema
+- `packages/db/prisma/CLAUDE.md` if touching the schema or migrations
+- `apps/studio/prisma/CLAUDE.md` if touching Studio seed data, JSON-column types, or one-off data scripts
 
 ### 3. Stack the work
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,32 @@
+# Isomer code review instructions
+
+Use these instructions when reviewing changes in this repository. More specific
+rules are applied from `.github/instructions/*.instructions.md` based on the
+changed file.
+
+## Findings
+
+- Report an issue only when a changed line creates a concrete correctness,
+  security, data-integrity, or compatibility problem, or breaks an explicit
+  repository invariant with a named maintenance or rollout consequence. Name
+  the triggering input or caller and the observable consequence.
+- Do not report formatting, import ordering, lint, or type errors already
+  enforced by CI unless the change disables or bypasses that enforcement. Do
+  not present a stylistic preference as a defect.
+- Respect the terminology and invariants in the nearest `CONTEXT.md` and in
+  current, non-superseded decisions under `docs/adr/`. When reporting a
+  conflict, identify the exact invariant and explain how the changed behavior
+  violates it.
+- At a boundary between Studio, the database, shared packages, build tooling,
+  and published sites, identify the exact producer, consumer, or persisted
+  historical shape that the change breaks. Do not speculate about an unnamed
+  caller.
+- Recommend a test only when you can name the changed behavior that is
+  uncovered and the assertion that would fail before the fix.
+
+## Stacked pull requests
+
+- Review every pull request against its actual base as an independently
+  mergeable and revertible change. A non-default base may represent a stacked
+  pull request. Do not assume that another pull request will repair a
+  regression in the current diff.

--- a/.github/instructions/configuration.instructions.md
+++ b/.github/instructions/configuration.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: ".env.example,apps/studio/.env.example,apps/studio/src/env.mjs,**/package.json,pnpm-workspace.yaml,pnpm-lock.yaml,**/turbo.json,.github/workflows/**/*,.github/actions/**/*,tooling/build/**/*"
+---
+
+# Configuration review instructions
+
+- For a new Studio environment variable, verify the Zod server or client
+  schema, the explicit `processEnv` mapping in `apps/studio/src/env.mjs`, the
+  relevant example environment file, and every build or runtime deployment
+  surface that must provide it. Report the exact missing consumer rather than
+  requesting propagation everywhere.
+- Never expose a secret through a `NEXT_PUBLIC_` variable, client bundle,
+  public build argument, workflow output, or log. Client variables must be
+  intentionally public and declared in the client schema.
+- Use `catalog:` for shared external dependencies declared in
+  `pnpm-workspace.yaml` and `workspace:*` for internal workspace packages.
+  Preserve documented compatibility pins unless all named consumers are
+  migrated in the same rollout.
+- Require `pnpm-lock.yaml` to match dependency manifest changes. Do not report
+  findings in a mechanically updated lockfile unless they reveal a concrete
+  manifest, integrity, platform, or lifecycle-script problem.
+- When changing package scripts, Turbo tasks, or GitHub workflows, identify the
+  affected workspace or CI/deployment caller and ensure its command, inputs,
+  outputs, and required environment remain connected.

--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -1,0 +1,25 @@
+---
+applyTo: "packages/db/prisma/schema.prisma,packages/db/prisma.config.ts,packages/db/prisma/migrations/**/*,packages/db/prisma/custom/**/*,packages/db/prisma/generate.cts,packages/db/src/generated/**/*,apps/studio/prisma/types.ts"
+---
+
+# Database review instructions
+
+- Migrations run before new application code. Require the previous deployed
+  application version and queued jobs to continue working after each migration
+  in the pull request.
+- Stage incompatible changes. Add required columns as nullable, backfill, and
+  tighten later. Rename or type-change columns by adding the replacement,
+  migrating or dual-writing, switching readers, and removing the old column in
+  a later rollout.
+- Flag `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, `TRUNCATE`, destructive data
+  rewrites, or Prisma-generated drop-and-add renames unless the pull request
+  contains an explicit rollout plan and human approval.
+- On large tables, require indexes to be created with
+  `CREATE INDEX CONCURRENTLY` through the custom-migration workflow so writes
+  are not locked.
+- After `schema.prisma` changes, require the committed Kysely outputs under
+  `packages/db/src/generated/` to be regenerated. Do not recommend hand edits
+  to generated files.
+- Keep JSON fields' `@kyselyType` annotations aligned with
+  `apps/studio/prisma/types.ts`; report the exact generated or runtime type that
+  becomes inconsistent.

--- a/.github/instructions/published-sites.instructions.md
+++ b/.github/instructions/published-sites.instructions.md
@@ -1,0 +1,24 @@
+---
+applyTo: "packages/components/src/**/*,tooling/template/**/*"
+---
+
+# Published-site compatibility review instructions
+
+- Treat stored site JSON and already-published content as historical inputs
+  that must continue to render. Schema and interface additions must be
+  optional. Do not remove a field or change its type until producers and stored
+  data have completed a migration-first rollout.
+- Preserve the boundary: Studio produces typed, schema-valid content and
+  `packages/components` renders it. Published components must not import
+  Studio code, call Studio APIs, depend on Studio-private symbols, or branch on
+  Studio-internal feature flags.
+- Keep the base published render paths server-renderable. Network-driven or
+  browser-only behavior must be isolated in an explicit client hook or nested
+  client component and must not execute during server rendering. Do not add
+  top-level access to `window`, `document`, `localStorage`, or similar APIs in
+  server-rendered modules.
+- When changing a public schema, interface, type, constant, or component,
+  verify that it is exported through the package's public entry point and that
+  current Studio and template consumers remain compatible.
+- Flag a compatibility problem only when you can identify the old content
+  shape or concrete consumer that fails.

--- a/.github/instructions/studio-server.instructions.md
+++ b/.github/instructions/studio-server.instructions.md
@@ -1,0 +1,27 @@
+---
+applyTo: "apps/studio/src/server/**/*.ts,apps/studio/src/pages/api/**/*.ts"
+---
+
+# Studio server review instructions
+
+- Require the appropriate authorization check in the router or API handler
+  before calling a service, writing to the database, publishing, or causing an
+  external side effect. A valid session proves authentication, not permission
+  for the requested site or resource.
+- Use `protectedProcedure` by default. `publicProcedure` and
+  `webhookProcedure` are valid only for deliberately unauthenticated or
+  API-key-authenticated callers. Do not accept ad hoc authentication middleware
+  in individual routers.
+- For every state-changing resource mutation, require the audit event and the
+  write to use the same database transaction. Audit deltas must contain the
+  actual persisted before and after values, rather than request input assumed
+  to match the database.
+- Require `.meta({ rateLimitOptions: ... })` for user-triggered procedures that
+  call external services such as email, S3, or Singpass.
+- Do not return raw database errors, caught `error.message` values, request
+  data, stack traces, credentials, or other sensitive internal details to
+  clients. Log server details with the request logger and return an appropriate
+  generic `TRPCError` or HTTP response.
+- Validate external input with the relevant Zod schema before it reaches
+  business logic. Keep tRPC routers focused on input, authorization, and
+  service orchestration rather than placing business logic in the callback.

--- a/.github/instructions/ui-accessibility.instructions.md
+++ b/.github/instructions/ui-accessibility.instructions.md
@@ -1,0 +1,23 @@
+---
+applyTo: "apps/studio/src/**/*.tsx,packages/components/src/**/*.tsx"
+---
+
+# UI accessibility review instructions
+
+- Every changed interactive control must be keyboard reachable and operable
+  and must expose an accessible name. Prefer native elements and the existing
+  Chakra UI or React Aria primitives over recreating their behavior.
+- Flag click handlers on non-interactive elements when there is no equivalent
+  keyboard interaction, focusability, and semantic role.
+- Icon-only controls need a meaningful accessible name. Decorative icons must
+  be hidden from assistive technology when adjacent text already supplies the
+  name.
+- Images conveying content need meaningful alternative text; decorative images
+  use an empty `alt` value. Do not duplicate surrounding text in alt text
+  without adding information.
+- Do not rely on color alone to communicate state, errors, selection, or
+  required actions. Preserve visible keyboard focus and sufficient non-text
+  contrast for controls and state indicators.
+- Report an accessibility finding only when the changed interaction creates a
+  concrete keyboard, screen-reader, focus, naming, or perception failure; do
+  not request redundant ARIA where native semantics are already sufficient.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm dev:e2e          # Start dev server + run E2E tests
 # From apps/studio
 pnpm test:unit        # Run Vitest unit tests
 pnpm test:watch       # Watch mode for unit tests
-pnpm exec playwright test tests/e2e/specific-test.spec.ts  # Run single E2E test
+pnpm exec playwright test tests/e2e/specific.test.ts       # Run single E2E test
 pnpm test:unit -- src/path/to/test.test.ts                 # Run single unit test
 ```
 
@@ -57,7 +57,7 @@ pnpm clean            # Clean build artifacts
 ## Architecture
 
 ### Monorepo Structure
-- `apps/studio` - Main Next.js 15 application (CMS/site builder)
+- `apps/studio` - Main Next.js 16 application (CMS/site builder)
 - `packages/components` - Reusable component library (@opengovsg/isomer-components)
 - `packages/pgboss` - Job queue wrapper (@isomer/pgboss)
 - `tooling/*` - Shared configs (TypeScript, Oxlint, Storybook)
@@ -73,7 +73,7 @@ pnpm clean            # Clean build artifacts
 - `theme/` - Chakra UI theme configuration
 
 ### Key Technologies
-- **Framework**: Next.js 15, React 18
+- **Framework**: Next.js 16, React 18
 - **API**: tRPC for type-safe client-server communication
 - **Database**: PostgreSQL with Prisma ORM
 - **Styling**: Tailwind CSS + Chakra UI
@@ -84,9 +84,10 @@ pnpm clean            # Clean build artifacts
 - **Formatting**: Oxfmt
 
 ### Database
-- Schema: `apps/studio/prisma/schema.prisma`
-- Migrations: `apps/studio/prisma/migrations/`
-- Custom migrations: `apps/studio/prisma/custom/`
+- Schema: `packages/db/prisma/schema.prisma`
+- Migrations: `packages/db/prisma/migrations/`
+- Custom migrations: `packages/db/prisma/custom/`
+- Generated Kysely types: `packages/db/src/generated/`
 
 ## Testing Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm dev:e2e          # Start dev server + run E2E tests
 # From apps/studio
 pnpm test:unit        # Run Vitest unit tests
 pnpm test:watch       # Watch mode for unit tests
-pnpm exec playwright test tests/e2e/specific.test.ts       # Run single E2E test
+pnpm exec playwright test tests/e2e/smoke.test.ts          # Run single E2E test
 pnpm test:unit -- src/path/to/test.test.ts                 # Run single unit test
 ```
 

--- a/apps/studio/.storybook/main.ts
+++ b/apps/studio/.storybook/main.ts
@@ -35,8 +35,8 @@ const config: StorybookConfig = {
     reactDocgen: "react-docgen-typescript",
   },
 
-  // Force Storybook to use the same React version as the app, as it defaults
-  // to using React 19 when using Next.js 15. We require React 18 due to
+  // Force Storybook to use the same React version as the app, rather than its
+  // React 19 default. We require React 18 due to
   // react-input-mask used by OGP's design system, which uses findDOMNode which
   // has been removed in React 19.
   // Ref: https://github.com/storybookjs/storybook/issues/30646

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -163,7 +163,7 @@ pnpm test:unit -- src/path/to/file.test.ts   # single file
 ```bash
 pnpm setup:test                                           # start Docker services first
 pnpm test:e2e
-pnpm exec playwright test tests/e2e/specific.spec.ts      # single test
+pnpm exec playwright test tests/e2e/specific.test.ts      # single test
 ```
 
 - Requires `pnpm setup:test` (containerized PostgreSQL + MockPass)

--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -163,7 +163,7 @@ pnpm test:unit -- src/path/to/file.test.ts   # single file
 ```bash
 pnpm setup:test                                           # start Docker services first
 pnpm test:e2e
-pnpm exec playwright test tests/e2e/specific.test.ts      # single test
+pnpm exec playwright test tests/e2e/smoke.test.ts         # single test
 ```
 
 - Requires `pnpm setup:test` (containerized PostgreSQL + MockPass)

--- a/apps/studio/prisma/CLAUDE.md
+++ b/apps/studio/prisma/CLAUDE.md
@@ -1,101 +1,52 @@
-# Prisma + migrations (`apps/studio/prisma`)
+# Studio database support (`apps/studio/prisma`)
 
-The Prisma schema is the source of truth for the database. Migrations apply atomically against production via the `migrate:<env>` flow in the root `README.md`. Mistakes here are expensive — a bad migration can lock tables, drop data, or block deploys.
+This directory contains Studio-owned database support files. The Prisma schema,
+migrations, custom migrations, and generated database types live in
+`packages/db/`; see `packages/db/prisma/CLAUDE.md` before changing them.
 
 ## Layout
 
-```
+```text
 prisma/
-├── schema.prisma           # The schema. Generator targets: prisma-client-js, prisma-json-types-generator, prisma-kysely.
-├── migrations/             # Prisma-managed migrations (timestamp-prefixed folders).
-│   └── <ts>_<name>/migration.sql
-├── custom/                 # Hand-authored SQL applied via the custom migration mechanism.
-│   ├── install.ts          # Roller that splices custom SQL into the next migration.
-│   └── migration.sql       # Accumulated custom statements awaiting the next dev migration.
-├── generated/              # Kysely + Prisma JSON types (generated). Do not edit.
-├── scripts/                # Ad-hoc data scripts (run manually, not by migrate).
-├── seed.ts                 # Seed data for local dev.
-└── types.ts                # JSON column TS types — referenced from schema via `prisma-json-types-generator`.
+├── types.ts       # Precise PrismaJson types used by Studio
+├── seed.ts        # Local-development seed data
+└── scripts/       # Manually run data and administration scripts
 ```
 
-## Generators — what runs at `pnpm generate`
+## JSON-column types
 
-| Generator                     | Output                                       | Why                                           |
-| ----------------------------- | -------------------------------------------- | --------------------------------------------- |
-| `prisma-client-js`            | `node_modules/.prisma/client`                | Default Prisma client used by legacy queries. |
-| `prisma-json-types-generator` | Types for `Json` columns                     | Reads from `prisma/types.ts`.                 |
-| `prisma-kysely`               | `prisma/generated/generatedTypes.ts` + enums | Kysely DB types — preferred for new queries.  |
-
-After any schema change, run `pnpm generate` and commit the regenerated `prisma/generated/` files.
-
-## Workflow — adding a new migration
-
-1. Edit `schema.prisma`.
-2. From `apps/studio/`: `pnpm migrate:dev`. Name the migration descriptively (`add_<table>_<reason>`).
-3. Inspect the generated `migration.sql` — Prisma sometimes generates destructive operations (drops, renames) when a non-destructive one would do.
-4. Run `pnpm generate` to refresh the Kysely + JSON types.
-5. Commit:
-   - `prisma/schema.prisma`
-   - `prisma/migrations/<ts>_<name>/migration.sql`
-   - `prisma/generated/*`
-6. Update `apps/studio/prisma/types.ts` if you added/changed a JSON column.
-
-## Custom migrations
-
-The `custom/` folder lets you ship hand-written SQL (triggers, partial indexes, RLS) that Prisma's introspection cannot express. Statements in `custom/migration.sql` get merged into the next Prisma migration by `custom/install.ts`.
-
-Use this for:
-
-- Triggers and stored procedures.
-- Partial / expression indexes that Prisma can't express.
-- Data backfills attached to a schema change.
-
-Do **not** use this to bypass Prisma's tracked migration history. Every change must still land in a tracked migration folder.
-
-## Rules
-
-### Backward-compatible by default
-
-- Migrations run before the new app code is deployed. The old code must still work against the new schema during the window.
-- New required columns: add as nullable, backfill, then tighten in a follow-up migration.
-- Column renames: add new, dual-write, drop old — three migrations, not one.
-- Type changes: add a new column with the new type, migrate data, swap in code, drop old.
-
-### One migration per PR
-
-- A PR that touches the schema should land its migration alone, or as the only schema-change PR in a Graphite stack.
-- Migrations that change schema in a non-backward-compatible way **must not** be stacked with app code changes that depend on them — they ship in their own PR and merge first.
-
-### No destructive ops without explicit approval
-
-- `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, `TRUNCATE` require an explicit approving reviewer in the PR description.
-- The agent must refuse to ship a destructive migration without a human picking the approach.
-
-### Indexes
-
-- New indexes on large tables should use `CREATE INDEX CONCURRENTLY` via a custom migration. Prisma's default `CREATE INDEX` will lock writes.
-- An index that supports a new query path lands in the same PR as the query.
-
-### JSON columns
-
-- The TS type for each JSON column lives in `prisma/types.ts` and is picked up by `prisma-json-types-generator`. Update both together.
+- `types.ts` is the precise `PrismaJson` namespace declaration used by Studio.
+  Keep it aligned with JSON fields and `/// @kyselyType(...)` annotations in
+  `packages/db/prisma/schema.prisma`.
+- `packages/db/src/prisma-json-types.d.ts` intentionally contains loose stubs
+  so `@isomer/db` can type-check without depending on Studio or
+  `@opengovsg/isomer-components`. Do not replace those stubs with Studio types.
+- After changing a JSON-column shape or the database schema, run
+  `pnpm --filter @isomer/db generate` from the repository root and commit the
+  regenerated files under `packages/db/src/generated/`.
 
 ## Seeding
 
-- `prisma/seed.ts` is for local dev only — it must be idempotent (re-running should produce the same state).
-- Tests use their own setup, not the seed file.
+- `seed.ts` is for local development only. It must be idempotent: rerunning it
+  should produce the same state.
+- Tests use their own setup and fixtures, not the development seed.
+- Run it from `apps/studio` with `pnpm db:seed` after local services and
+  migrations are ready.
 
-## Scripts (`prisma/scripts/`)
+## One-off scripts
 
-- One-off data scripts (rename a column, normalise a value across rows) live here.
-- Each script must be idempotent and dry-runnable.
-- Scripts are **not** run by `migrate:<env>` — they're executed manually and recorded in the PR description.
+- Put manual data and administration scripts under `scripts/`.
+- Make scripts idempotent and dry-runnable where the operation allows it.
+- Scripts are not run by the migration workflow. Record the command, target
+  environment, and outcome in the pull request or operational runbook.
+- Pair with another engineer before running a script against production.
+- Use the environment and tunnel instructions in `scripts/README.md`.
 
 ## Anti-patterns the agent should refuse
 
-- Combining a schema change with un-related app code in one migration PR.
-- A `DROP COLUMN` / `DROP TABLE` in the same migration that adds its replacement.
-- New required columns without a backfill + two-phase rollout.
-- Editing files under `prisma/generated/` by hand.
-- Skipping `pnpm generate` after a schema change.
-- A non-idempotent script in `prisma/scripts/`.
+- Editing the database schema or migrations in this directory instead of
+  `packages/db/prisma/`.
+- Changing a JSON-column schema without updating `types.ts` and regenerating
+  `packages/db/src/generated/`.
+- Adding a non-idempotent seed or destructive one-off script without an
+  explicit operational plan and human review.

--- a/apps/studio/src/server/CLAUDE.md
+++ b/apps/studio/src/server/CLAUDE.md
@@ -65,7 +65,7 @@ Never write your own auth middleware in a router. If you need a new auth shape, 
 - Kysely (`db`) is the default. Prefer it for new queries.
 - Prisma (`ctx.prisma`) is used for legacy queries and where Kysely lacks parity.
 - Mix in one router only when necessary, and prefer one transaction owner per mutation.
-- Migrations and schema live under `apps/studio/prisma/` — see `apps/studio/prisma/CLAUDE.md`.
+- Migrations and schema live under `packages/db/prisma/` — see `packages/db/prisma/CLAUDE.md`. Studio-owned seed data, JSON-column types, and one-off scripts remain under `apps/studio/prisma/`.
 
 ## Testing
 

--- a/docs/ai-workflow.md
+++ b/docs/ai-workflow.md
@@ -83,11 +83,11 @@ For an agent to read a frame reliably:
 
 ## PR review
 
-There is no automated review bot. Risk tiering and review grading are done via the `pr-review` skill, which reads `docs/risk-taxonomy.md` (file-glob rules, reversibility modifiers, hot paths) and diffs the current branch against `main`. It posts a single informational comment — it never approves, requests changes, or merges.
+Automated review has two separate roles. GitHub Copilot code review can leave code findings on pull requests, guided by the repository-wide `.github/copilot-instructions.md` and scoped rules under `.github/instructions/`. The `pr-review` skill handles repository-specific risk tiering and review grading: it reads `docs/risk-taxonomy.md` (file-glob rules, reversibility modifiers, hot paths), diffs the current branch against `main`, and posts a single informational comment. It never approves, requests changes, or merges.
 
 For a full human-authority review (the typical "review this PR" ask), use the `review-pr` skill instead; `pr-review` is for automation-style grading only.
 
-All PRs require human approval before merge, regardless of risk tier.
+All PRs require human approval before merge, regardless of automated findings or risk tier.
 
 ## GitHub PR conventions
 

--- a/docs/risk-taxonomy.md
+++ b/docs/risk-taxonomy.md
@@ -98,8 +98,8 @@ There is no bot that submits an actual GitHub APPROVE review — the `pr-review`
 
 1. The PR touches no file outside the `risk:low` globs.
 2. CI is green (lint, typecheck, build, tests).
-3. Code review (human, since there is no automated code-review skill) surfaces no blocking issues.
-4. Security review (human, since there is no automated security-review skill) surfaces no blocking issues.
+3. Any automated code-review findings, including GitHub Copilot findings when a review runs, are resolved or explicitly dismissed as non-blocking.
+4. Human code and security review surfaces no blocking issues.
 5. The PR does not change `package.json` scripts, `engines`, `pnpm.overrides`, or workspace dependencies.
 6. No reversibility modifier applies (external side-effects, row mutations, pgboss handler removal/rename/payload change, S3 object deletions).
 

--- a/docs/risk-taxonomy.md
+++ b/docs/risk-taxonomy.md
@@ -18,8 +18,10 @@ Match top-down — the first matching glob wins for that file. The PR's tier is 
 
 ### `risk:high`
 
-- `apps/studio/prisma/migrations/**`
-- `apps/studio/prisma/schema.prisma`
+- `packages/db/prisma/migrations/**`
+- `packages/db/prisma/schema.prisma`
+- `packages/db/prisma/custom/**`
+- `packages/db/prisma.config.ts`
 - `apps/studio/src/server/modules/auth/**`
 - `apps/studio/src/server/modules/permissions/**`
 - `apps/studio/src/server/modules/audit/**`
@@ -70,6 +72,7 @@ Server-side logic, data contracts, and shared libraries — things where a bug c
 - `packages/components/src/templates/**`
 - `packages/components/src/schemas/**`
 - `packages/components/src/engine/**`
+- `packages/db/src/**`, `packages/db/prisma/generate.cts`
 - `packages/pgboss/**`, `packages/redis/**`, `packages/logging/**`, `packages/validators/**` — exception: removing/renaming a pgboss job handler or changing its payload type triggers the reversibility modifier and bumps to risk:high
 
 ### `risk:low`

--- a/packages/components/CLAUDE.md
+++ b/packages/components/CLAUDE.md
@@ -109,7 +109,7 @@ src/
 ## Tests
 
 - Visual + behavioural tests via Storybook.
-- Unit tests (`.spec.ts`) for utilities and engine code.
+- Unit tests (`.test.ts` / `.test.tsx`) for utilities and engine code.
 - Snapshot tests are discouraged except for the JSON Schema itself.
 
 ## Anti-patterns the agent should refuse

--- a/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
+++ b/packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx
@@ -4,7 +4,8 @@
 
 export const PreloadHelper = ({ href }: { href: string }) => {
   // TODO: replace with ReactDom.preconnect and ReactDom.dnsPrefetch
-  // However, note that they are only available in React 19 which is not yet supported by Next.js
+  // They are only available in React 19, while this repository remains on
+  // React 18 because some design-system dependencies still use findDOMNode.
   // Ref: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#resource-hints
   return (
     <>

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -2,4 +2,4 @@
 
 Shared database layer for the Isomer monorepo. Owns the Prisma schema, generated Kysely types, and the `createDb()` Kysely factory consumed by `apps/studio` and tooling scripts.
 
-This package is being assembled progressively. See `docs/superpowers/specs/2026-06-02-extract-db-package-design.md` for the migration plan.
+See `prisma/CLAUDE.md` for the schema, migration, and generated-type workflow.

--- a/packages/db/prisma/CLAUDE.md
+++ b/packages/db/prisma/CLAUDE.md
@@ -1,0 +1,109 @@
+# Prisma schema and migrations (`packages/db/prisma`)
+
+The Prisma schema is the source of truth for the database. Migrations run
+before new application code is deployed, so mistakes here can lock tables,
+drop data, or make the old application version fail during rollout.
+
+## Layout
+
+```text
+packages/db/
+├── prisma/
+│   ├── schema.prisma       # Database schema
+│   ├── migrations/         # Prisma-managed, timestamped migrations
+│   ├── custom/             # Hand-authored SQL and its installer
+│   ├── generate.cts        # Post-processes generated Kysely types
+│   └── generated/prisma/   # Generated Prisma client; gitignored
+└── src/
+    ├── generated/          # Generated Kysely types and enums; committed
+    └── prisma-json-types.d.ts
+```
+
+Studio's precise JSON-column types, development seed, and one-off data scripts
+remain under `apps/studio/prisma/`; see that directory's `CLAUDE.md` when they
+are part of the change.
+
+## Generated outputs
+
+Running `pnpm --filter @isomer/db generate` produces:
+
+| Generator / step      | Output                                                                        | Commit?        |
+| --------------------- | ----------------------------------------------------------------------------- | -------------- |
+| Prisma client         | `packages/db/prisma/generated/prisma/`                                        | No; gitignored |
+| `prisma-kysely`       | `packages/db/src/generated/generatedTypes.ts` and `generatedEnums.ts`         | Yes            |
+| `prisma/generate.cts` | `packages/db/src/generated/selectableTypes.ts` and unsupported-column patches | Yes            |
+
+Do not edit generated files by hand. After every schema change, regenerate and
+commit all changes under `packages/db/src/generated/`.
+
+## Adding a migration
+
+1. Edit `packages/db/prisma/schema.prisma`.
+2. From `apps/studio`, run `pnpm migrate:dev` and give the migration a
+   descriptive name. Equivalently, run the filtered `@isomer/db` migration
+   command from the repository root.
+3. Inspect the generated `migration.sql`; Prisma may express a rename as a
+   destructive drop and add.
+4. Run `pnpm --filter @isomer/db generate` from the repository root.
+5. Commit the schema, the new migration directory, and changes under
+   `packages/db/src/generated/`.
+6. If a JSON column changed, update `apps/studio/prisma/types.ts` in the same
+   change.
+
+## Custom migrations
+
+Use `packages/db/prisma/custom/migration.sql` for database objects Prisma cannot
+express, such as triggers, stored procedures, partial indexes, or data
+backfills tied to a schema change. Run
+`pnpm --filter @isomer/db migrate:custom` to copy new statements into a tracked
+timestamped migration.
+
+Do not use custom SQL to bypass Prisma's migration history. Every production
+change must still be present under `packages/db/prisma/migrations/`.
+
+## Rules
+
+### Backward-compatible by default
+
+- The old application version must continue to work after the migration runs.
+- Add required columns as nullable, backfill them, then tighten the constraint
+  in a follow-up migration.
+- Rename columns by adding the replacement, dual-writing or migrating data,
+  switching readers, and dropping the old column only after rollout.
+- Change a column type by adding a new column and migrating callers; do not
+  rewrite it in place when old code or queued jobs can still use it.
+
+### Isolate schema changes
+
+- Keep one schema-change concern per pull request.
+- A non-backward-compatible migration must land separately before application
+  code that depends on it; do not hide the dependency inside a Graphite stack.
+
+### Destructive operations require explicit approval
+
+- `DROP TABLE`, `DROP COLUMN`, `ALTER TYPE`, and `TRUNCATE` require explicit
+  human approval recorded in the pull request.
+- Do not combine removal of an old field with addition of its replacement in a
+  single rollout migration.
+
+### Indexes
+
+- Create indexes on large tables with `CREATE INDEX CONCURRENTLY` through a
+  custom migration so writes are not locked.
+- Land an index that supports a new query path with that query change.
+
+### JSON columns
+
+- Keep each JSON field's `/// @kyselyType(...)` annotation in `schema.prisma`
+  aligned with `apps/studio/prisma/types.ts`.
+- Regenerate the committed Kysely types after changing either side of the
+  contract.
+
+## Anti-patterns the agent should refuse
+
+- A destructive migration without an explicit rollout plan and approval.
+- A new required column without a backfill and staged rollout.
+- Hand-editing files under `packages/db/src/generated/` or
+  `packages/db/prisma/generated/`.
+- Skipping generation after a schema change.
+- Putting Studio seed data or one-off administration scripts in `packages/db`.


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 8 | +159 | -3 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 10 | +167 | -102 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Copilot reviews lacked repository-specific, high-signal conventions, while existing engineering guidance referenced stale framework versions, test naming, and database locations.

Closes N/A

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
- [x] No - this PR is backwards compatible

**Features**:

- Add repository-wide and path-specific Copilot review instructions for Studio server code, database changes, published sites, configuration, and accessibility.

**Improvements**:

- Document evidence-based findings, current-base review behavior for stacked PRs, compatibility checks, and noise reduction.
- Split database guidance between the shared database package and Studio-owned support files, and update the risk taxonomy and workflow documentation.

**Bug Fixes**:

- Correct stale Next.js, Playwright, React, database-path, and generated-type references.

## Before & After Screenshots

**BEFORE**: N/A - documentation and review configuration only.

**AFTER**: N/A - documentation and review configuration only.

## Tests

- `git diff --check origin/main...`
- Formatting check for changed instruction and guidance files
- `pnpm --filter isomer-studio lint` (passes with existing warnings)
- `pnpm --filter @opengovsg/isomer-components lint` (passes with existing warnings)

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds repository-wide and path-specific Copilot review guidance and refreshes documentation for the current framework, database-package layout, testing conventions, and human-review workflow.

- Separates Copilot code findings from repository-specific risk grading while preserving mandatory human review and approval.
- Adds scoped instructions for configuration, database, published-site, Studio-server, and accessibility changes.
- Updates database ownership and generated-type guidance for `packages/db`.
- Refreshes Next.js, React, Playwright, and test-file references.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported contradiction is resolved in the current documentation.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/ai-workflow.md | Clarifies the separate roles of Copilot review, risk grading, and human-authority review while retaining mandatory human approval. |
| docs/risk-taxonomy.md | Updates database risk paths and resolves the prior contradiction by accounting for automated findings alongside required human code and security review. |
| .github/copilot-instructions.md | Adds evidence-based repository-wide instructions for concrete, low-noise Copilot review findings. |
| .github/instructions/database.instructions.md | Adds scoped migration compatibility, destructive-operation, indexing, and generated-type review guidance. |
| packages/db/prisma/CLAUDE.md | Documents the shared database package’s schema, migration, custom SQL, and generated-output workflows. |
| apps/studio/prisma/CLAUDE.md | Narrows Studio database guidance to JSON types, seed data, and one-off scripts after schema ownership moved to `packages/db`. |
| packages/components/src/templates/next/components/internal/utils/PreloadHelper.tsx | Refreshes a comment to accurately explain why the repository remains on React 18 without changing runtime behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: address review feedback"](https://github.com/opengovsg/isomer/commit/ced17755895e60a7c7e690042f2ddc37d7bc0d55) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53295765)</sub>

**Context used:**

- Knowledge Base — [@isomer/db package](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/db-package.md)
- Knowledge Base — [@opengovsg/isomer-components](https://app.greptile.com/opengovsg/-/custom-context/knowledge-base/opengovsg/isomer/-/docs/components-package.md)

<!-- /greptile_comment -->

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/3c982b2f-b23c-411b-9194-81d8f3c15406)
