### PR TITLE
perf(studio): memoize collection metadata schema/validator

### DIFF
--- a/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
+++ b/apps/studio/src/features/editing-experience/components/Drawer/CollectionEditorStateDrawer.tsx
@@ -90,13 +90,22 @@ export default function CollectionEditorStateDrawer(): JSX.Element {
     }
   }, [drawerStateType, canManageFilters])
 
-  const metadataSchema = getScopedSchema({
-    layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
-    scope: "page",
-    ...schemaFields,
-  })
-  const validateFn =
-    ajv.compile<Static<ReturnType<typeof getLayoutPageSchema>>>(metadataSchema)
+  const metadataSchema = useMemo(
+    () =>
+      getScopedSchema({
+        layout: ISOMER_USABLE_PAGE_LAYOUTS.Collection,
+        scope: "page",
+        ...schemaFields,
+      }),
+    [schemaFields],
+  )
+  const validateFn = useMemo(
+    () =>
+      ajv.compile<Static<ReturnType<typeof getLayoutPageSchema>>>(
+        metadataSchema,
+      ),
+    [metadataSchema],
+  )
 
   const handleSaveChanges = useCallback(() => {
     const hadNoTagsBefore = !(savedPageState.page as CollectionPagePageProps)


### PR DESCRIPTION
## Problem

\`CollectionEditorStateDrawer\` recomputes \`metadataSchema\` (via \`getScopedSchema\`) and \`validateFn\` (via \`ajv.compile\`) directly in the render body, with no memoization — so both are rebuilt from scratch on every render, even ones unrelated to this schema.

Caught while investigating a flaky Chromatic/Storybook issue in a follow-up PR.

## Solution

Memoize \`metadataSchema\` on \`schemaFields\` (already memoized) and \`validateFn\` on \`metadataSchema\`, so both keep a stable reference across renders that don't actually change which fields are in scope.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None

**Improvements**:

- \`metadataSchema\`/\`validateFn\` in \`CollectionEditorStateDrawer\` are now memoized instead of recomputed on every render, avoiding redundant \`getScopedSchema\`/\`ajv.compile\` calls.

**Bug Fixes**:

- None

## Tests

Existing Storybook stories under \`Pages/Edit Page/Collection Index Page/New Experience\` continue to pass.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None