### PR TITLE
[Hero] Add image fit variant to large image hero

### DIFF
--- a/packages/components/src/interfaces/complex/Hero.ts
+++ b/packages/components/src/interfaces/complex/Hero.ts
@@ -4,6 +4,7 @@ import type { IsomerSiteProps } from "~/types"
 import { Type } from "@sinclair/typebox"
 import { omit } from "lodash-es"
 import { IMAGE_ACCEPTED_MIME_TYPE_MAPPING } from "~/constants/image"
+import { HeroImageFitSchema } from "~/schemas/internal"
 import { LINK_HREF_PATTERN, NON_EMPTY_STRING_REGEX } from "~/utils/validation"
 
 import { ARRAY_RADIO_FORMAT } from "../format"
@@ -143,6 +144,7 @@ const HeroLargeImageSchema = Type.Composite(
         default: HERO_STYLE.largeImage,
       }),
       backgroundUrl: BackgroundUrlSchema,
+      imageFit: Type.Optional(HeroImageFitSchema),
     }),
     HeroBaseSchema,
     CallToActionsSchema,

--- a/packages/components/src/schemas/internal/imageFitSchema.ts
+++ b/packages/components/src/schemas/internal/imageFitSchema.ts
@@ -30,3 +30,7 @@ export const InfoCardsImageFitSchema = generateImageFitSchema({
   title: "Image display",
   description: `Select "Resize image to fit" only if the image has a white background.`,
 })
+
+export const HeroImageFitSchema = generateImageFitSchema({
+  title: "Image display",
+})

--- a/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/Hero.stories.tsx
@@ -106,6 +106,14 @@ export const LargeImage: Story = {
   },
 }
 
+export const LargeImageFit: Story = {
+  args: {
+    ...LargeImage.args,
+    variant: "largeImage",
+    imageFit: "contain",
+  },
+}
+
 export const Floating: Story = {
   args: {
     site: generateSiteConfig(),

--- a/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/HeroLargeImage.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/HeroLargeImage.tsx
@@ -13,6 +13,7 @@ export const HeroLargeImage = ({
   secondaryButtonLabel,
   secondaryButtonUrl,
   backgroundUrl,
+  imageFit,
   site,
 }: HeroLargeImageProps) => {
   return (
@@ -62,6 +63,7 @@ export const HeroLargeImage = ({
       <ImageContainer
         imageSrc={backgroundUrl}
         imageAlt=""
+        imageFit={imageFit}
         assetsBaseUrl={site.assetsBaseUrl}
       />
     </section>

--- a/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
@@ -60,7 +60,13 @@ export const ImageContainer = ({
   }, [])
 
   return (
-    <div className="relative w-full">
+    <div
+      className={
+        imageFit === IMAGE_FIT.Content
+          ? "relative w-full px-6 md:px-10"
+          : "relative w-full"
+      }
+    >
       <ImageClient
         ref={imageRef}
         src={imageSrc}
@@ -68,7 +74,7 @@ export const ImageContainer = ({
         width="100%"
         className={
           imageFit === IMAGE_FIT.Content
-            ? "mx-auto block h-auto max-h-[31.25rem] w-auto max-w-full"
+            ? "mx-auto block h-auto max-h-[31.25rem] w-auto max-w-full rounded-lg"
             : "aspect-square max-h-[60rem] w-full object-cover object-center md:aspect-[2/1]"
         }
         assetsBaseUrl={assetsBaseUrl}

--- a/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import type { ImageClientProps } from "~/interfaces"
+import type { HeroLargeImageProps } from "~/interfaces/complex/Hero"
 import { useEffect, useRef, useState } from "react"
+import { IMAGE_FIT } from "~/interfaces/constants"
 
 import { ImageClient } from "../../../internal/ImageClient"
 import { ScrollForMoreButton } from "./ScrollForMoreButton"
@@ -9,6 +11,7 @@ import { ScrollForMoreButton } from "./ScrollForMoreButton"
 interface ImageContainerProps {
   imageSrc: ImageClientProps["src"]
   imageAlt: ImageClientProps["alt"]
+  imageFit?: HeroLargeImageProps["imageFit"]
   assetsBaseUrl: ImageClientProps["assetsBaseUrl"]
 }
 
@@ -18,6 +21,7 @@ const SCROLL_THRESHOLD = 120
 export const ImageContainer = ({
   imageSrc,
   imageAlt,
+  imageFit = IMAGE_FIT.Cover,
   assetsBaseUrl,
 }: ImageContainerProps) => {
   const imageRef = useRef<HTMLImageElement>(null)
@@ -62,7 +66,11 @@ export const ImageContainer = ({
         src={imageSrc}
         alt={imageAlt}
         width="100%"
-        className="aspect-square max-h-[60rem] w-full object-cover object-center md:aspect-[2/1]"
+        className={
+          imageFit === IMAGE_FIT.Content
+            ? "mx-auto block h-auto max-h-[31.25rem] w-auto max-w-full"
+            : "aspect-square max-h-[60rem] w-full object-cover object-center md:aspect-[2/1]"
+        }
         assetsBaseUrl={assetsBaseUrl}
         lazyLoading={false} // hero is always above the fold
       />

--- a/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
+++ b/packages/components/src/templates/next/components/complex/Hero/HeroLargeImage/ImageContainer.tsx
@@ -63,7 +63,7 @@ export const ImageContainer = ({
     <div
       className={
         imageFit === IMAGE_FIT.Content
-          ? "relative w-full px-6 md:px-10"
+          ? "relative w-full md:px-10"
           : "relative w-full"
       }
     >
@@ -74,7 +74,7 @@ export const ImageContainer = ({
         width="100%"
         className={
           imageFit === IMAGE_FIT.Content
-            ? "mx-auto block h-auto max-h-[31.25rem] w-auto max-w-full rounded-lg"
+            ? "aspect-square max-h-[60rem] w-full object-cover object-center md:mx-auto md:block md:aspect-auto md:h-auto md:max-h-[31.25rem] md:w-auto md:max-w-full md:rounded-lg"
             : "aspect-square max-h-[60rem] w-full object-cover object-center md:aspect-[2/1]"
         }
         assetsBaseUrl={assetsBaseUrl}


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 4 | +24 | -2 |
| 🧪 Test | 1 | +8 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

We're going through Streamline. Schools tend to have hero banners often where they have a custom artwork that represents their school. We've received a user feedback and have witnessed many websites look not so ideal with the heavy gradient.  

Closes [ISOM-2510]

## Solution

Adds a image-fit: contain; variant to the large image hero banner option.

https://github.com/user-attachments/assets/099469c9-a18e-4068-9546-649a3cd80eb2

**Breaking Changes**

<!-- Does this PR contain any backward incompatible changes? If so, what are they and should there be special considerations for release? -->

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [ x] No - this PR is backwards compatible

**Improvements**:

- Added an image-fit variant to the Large Image hero variant.
- The image caps at 500px height, so placing a portrait image won't make the hero too long vertically.

## Tests

<!-- What tests should be run to confirm functionality? -->

**Manual Verification Steps**:

<!-- Checklist of steps for the release deployer to manually verify that the PR functionality works correctly. Each step should be actionable and specific. -->

- [ ] Step 1: Go to the Homepage > Hero banner.
- [ ] Step 2: Choose large image. Choose 'Resize image to fit' option.
- [ ] Step 3: Try adding images in different dimensions. The full image should always be visible.
