### PR TITLE
📆 feat(studio): add is-date-filters-enabled growthbook flag

### DIFF
--- a/apps/studio/src/hooks/useDateFiltersEnabled.ts
+++ b/apps/studio/src/hooks/useDateFiltersEnabled.ts
@@ -1,0 +1,11 @@
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import {
+  IS_DATE_FILTERS_ENABLED_FEATURE_KEY,
+  IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+} from "~/lib/growthbook"
+
+export const useDateFiltersEnabled = () =>
+  useFeatureValue<boolean>(
+    IS_DATE_FILTERS_ENABLED_FEATURE_KEY,
+    IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+  )

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -22,10 +22,8 @@ export const ENABLE_SEARCHSG_GAZETTE_INGESTION =
   "enable-searchsg-gazette-ingestion"
 
 // Gates the "Date filter" option when adding a new collection tag filter.
-// TODO: flip IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE to false once
-// this key is set up in GrowthBook.
 export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY = "is-date-filters-enabled"
-export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
+export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = false
 
 export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 

--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ -21,6 +21,12 @@ export const IS_AUDIT_LOG_ENABLED_FEATURE_KEY = "is-audit-log-enabled"
 export const ENABLE_SEARCHSG_GAZETTE_INGESTION =
   "enable-searchsg-gazette-ingestion"
 
+// Gates the "Date filter" option when adding a new collection tag filter.
+// TODO: flip IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE to false once
+// this key is set up in GrowthBook.
+export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY = "is-date-filters-enabled"
+export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
+
 export const IS_SINGPASS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = true
 
 interface GetIsSingpassEnabledProps {


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +15 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The date-filter admin UI (next PR in this stack) should ship behind a feature flag so it can be enabled per-environment rather than going live for every editor the moment it merges.

**PR 3 of 5**, stacked on `feat/date-filter-collection-wiring`. Stack: 1 `feat/date-filters-schema` → 2 `feat/date-filter-collection-wiring` → **3 (this PR)** → 4 `feat/date-filters-studio` → 5 `feat/date-filters-publishing`.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- Add `IS_DATE_FILTERS_ENABLED_FEATURE_KEY` (`is-date-filters-enabled`) to `apps/studio/src/lib/growthbook.ts`, with a fallback value of `true` until the key is set up in GrowthBook (see the `TODO` comment in the diff).
- Add `useDateFiltersEnabled` hook that reads the flag.

**Improvements**:

- None.

**Bug Fixes**:

- None.

## Before & After Screenshots

Not applicable — the flag and hook have no consumers in this PR; they're wired up in the next PR (`feat/date-filters-studio`).

## Tests

No user-visible behavior changes yet (unused flag/hook).

**Manual Verification Steps**:

- [ ] `pnpm typecheck` passes for `apps/studio`
- [ ] Confirm `is-date-filters-enabled` doesn't collide with an existing GrowthBook key name

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62009298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a><a href="https://app.greptile.com/opengovsg/-/pull-requests/opengovsg/isomer/3157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptileDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1"><img alt="View in Greptile" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewInGreptile.svg?v=1" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge because it is additive, currently inert, and follows established feature-flag conventions.

<details><summary><h3>Summary</h3></summary>

- The flag defaults to disabled, following the repository’s existing dark-launch pattern.
- The hook uses the established `useFeatureValue<boolean>` convention.
- The change is additive and reversible, making it low risk under the repository risk taxonomy.
</details>

<!-- /greptile_comment -->

## /show-me to help explain what this PR does

This PR adds one new GrowthBook flag and a thin hook wrapping it — nothing else. It has zero consumers yet; that happens in the next stacked PR (`feat/date-filters-studio`).

```mermaid
flowchart LR
    subgraph "growthbook.ts (edited)"
        K["IS_DATE_FILTERS_ENABLED_FEATURE_KEY\n= 'is-date-filters-enabled'"]
        V["IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE\n= false"]
    end
    subgraph "useDateFiltersEnabled.ts (new)"
        H["useDateFiltersEnabled()\n= useFeatureValue(K, V)"]
    end
    GB["GrowthBook SDK\n(useFeatureValue)"] --> H
    K --> H
    V --> H
    H -.->|"no callers in this PR"| C["date-filter admin UI\n(next PR: feat/date-filters-studio)"]

    style C stroke-dasharray: 5 5
```

```
apps/studio/src/
├── lib/
│   └── growthbook.ts              # +4 lines: new flag key + fallback constant, next to IS_AUDIT_LOG_ENABLED_FEATURE_KEY
└── hooks/
    └── useDateFiltersEnabled.ts   # +11 lines, new file: thin useFeatureValue wrapper, same shape as useIsSingpassEnabled.ts
```

```diff
--- a/apps/studio/src/lib/growthbook.ts
+++ b/apps/studio/src/lib/growthbook.ts
@@ export const IS_AUDIT_LOG_ENABLED_FEATURE_KEY = "is-audit-log-enabled"
+// Gates the "Date filter" option when adding a new collection tag filter.
+export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY = "is-date-filters-enabled"
+export const IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE = false

--- /dev/null
+++ b/apps/studio/src/hooks/useDateFiltersEnabled.ts
+import { useFeatureValue } from "@growthbook/growthbook-react"
+import {
+  IS_DATE_FILTERS_ENABLED_FEATURE_KEY,
+  IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+} from "~/lib/growthbook"
+
+export const useDateFiltersEnabled = () =>
+  useFeatureValue<boolean>(
+    IS_DATE_FILTERS_ENABLED_FEATURE_KEY,
+    IS_DATE_FILTERS_ENABLED_FEATURE_KEY_FALLBACK_VALUE,
+  )
```

That's the entire diff — 2 files, +15/-0. Defaults to `false` (off) until the flag is created in GrowthBook, matching the existing dark-launch pattern used by `IS_SINGPASS_ENABLED_FEATURE_KEY`.
