### PR TITLE
📆 feat(tooling): thread dateTagged through publishing pipeline

### DIFF
--- a/tooling/build/scripts/publishing/index.ts
+++ b/tooling/build/scripts/publishing/index.ts
@@ -159,6 +159,7 @@ async function main() {
           category: resource.content.page.category,
           tags: resource.content.page.tags,
           tagged: resource.content.page.tagged,
+          dateTagged: resource.content.page.dateTagged,
           date: resource.content.page.date,
           image: resource.content.page.image,
           firstImage: getResourceFirstImage(resource),

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "catalog:aws-sdk",
+    "@opengovsg/isomer-components": "workspace:*",
     "dotenv": "catalog:",
     "pg": "catalog:pg",
     "tsx": "catalog:"

--- a/tooling/build/scripts/publishing/package.json
+++ b/tooling/build/scripts/publishing/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "catalog:aws-sdk",
-    "@opengovsg/isomer-components": "workspace:*",
     "dotenv": "catalog:",
     "pg": "catalog:pg",
     "tsx": "catalog:"

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -20,6 +20,12 @@ interface Tagged {
   id: string
 }
 
+interface DateTagged {
+  id: string
+  date: string
+  endDate?: string
+}
+
 type TagCategory = Tagged & {
   options: Tagged[]
 }
@@ -52,6 +58,7 @@ export type SitemapEntry = Pick<
   children?: SitemapEntry[]
   tags?: Tag[]
   tagged?: Tagged[]
+  dateTagged?: DateTagged[]
   collectionPagePageProps?: CollectionPagePageProps
 }
 

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -1,3 +1,4 @@
+import type { DateTaggedItem } from "@opengovsg/isomer-components"
 import type { Resource as DbResource } from "~generated/selectableTypes"
 
 import type { PAGE_RESOURCE_TYPES } from "./constants"
@@ -18,12 +19,6 @@ interface Tag {
 interface Tagged {
   label: string
   id: string
-}
-
-interface DateTagged {
-  id: string
-  date: string
-  endDate?: string
 }
 
 type TagCategory = Tagged & {
@@ -58,7 +53,7 @@ export type SitemapEntry = Pick<
   children?: SitemapEntry[]
   tags?: Tag[]
   tagged?: Tagged[]
-  dateTagged?: DateTagged[]
+  dateTagged?: DateTaggedItem[]
   collectionPagePageProps?: CollectionPagePageProps
 }
 

--- a/tooling/build/scripts/publishing/types.ts
+++ b/tooling/build/scripts/publishing/types.ts
@@ -1,4 +1,3 @@
-import type { DateTaggedItem } from "@opengovsg/isomer-components"
 import type { Resource as DbResource } from "~generated/selectableTypes"
 
 import type { PAGE_RESOURCE_TYPES } from "./constants"
@@ -19,6 +18,12 @@ interface Tag {
 interface Tagged {
   label: string
   id: string
+}
+
+interface DateTagged {
+  id: string
+  date: string
+  endDate?: string
 }
 
 type TagCategory = Tagged & {
@@ -53,7 +58,7 @@ export type SitemapEntry = Pick<
   children?: SitemapEntry[]
   tags?: Tag[]
   tagged?: Tagged[]
-  dateTagged?: DateTaggedItem[]
+  dateTagged?: DateTagged[]
   collectionPagePageProps?: CollectionPagePageProps
 }
 


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 2 | +8 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The static-site publishing pipeline builds a sitemap entry per resource for the published site; it needs to carry `dateTagged` values through so published collection/article pages can render date filters and status pills (added in earlier PRs of this stack).

**PR 5 of 5 (final)**, stacked on `feat/date-filters-studio`. Stack: 1 `feat/date-filters-schema` → 2 `feat/date-filters-components-ui` → 3 `feat/date-filters-growthbook` → 4 `feat/date-filters-studio` → **5 (this PR)**.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- `tooling/build/scripts/publishing/types.ts` — add `DateTagged` interface and `dateTagged?: DateTagged[]` to `SitemapEntry`.
- `tooling/build/scripts/publishing/index.ts` — pass `resource.content.page.dateTagged` through into the generated sitemap entry.

**Improvements**:

- None.

**Bug Fixes**:

- None.

## Before & After Screenshots

Not applicable — build-script/data change, no visual output of its own.

## Tests

**Manual Verification Steps**:

- [ ] Run the publishing script locally (`pnpm build:template` or the equivalent publish script) against a site with a collection date filter configured and confirm the generated sitemap output includes a `dateTagged` array for the tagged pages
- [ ] Confirm pages without any date filter still publish correctly (no `dateTagged`/empty array, no errors)


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR threads article date-tag metadata from stored page content into generated sitemap entries and adds a corresponding publisher-side type.

- Populated date-tag arrays are preserved by the existing JSON serialization path.
- Pages without date tags remain backward compatible because the property is optional.
- The publishing-side type should reuse the canonical sitemap metadata type, and the new output behavior needs regression coverage.
- Under the repository risk taxonomy, changes under `tooling/**` are classified as high risk and require human review.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

The forwarding logic appears behaviorally sound, but the explicit type-reuse requirement must be satisfied before merging; publishing regression coverage should also be added.

Optional and populated metadata serialize correctly, with no runtime or security failure established. The remaining findings concern a duplicated contract that can drift from the canonical sitemap type and missing coverage for the new publishing behavior.

**Files Needing Attention:** tooling/build/scripts/publishing/types.ts; tooling/build/scripts/publishing/index.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| tooling/build/scripts/publishing/index.ts | Forwards optional page date-tag metadata into each generated sitemap entry, but lacks publishing-test coverage. |
| tooling/build/scripts/publishing/types.ts | Adds the publisher-side date-tag field using a duplicate, less precise type instead of the canonical schema-derived type. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A["Stored page content<br/>page.dateTagged"] --> B["Publishing resource mapper"]
  B --> C["SitemapEntry.dateTagged"]
  C --> D["JSON.stringify"]
  D --> E["Published sitemap.json"]
  E --> F["IsomerSitemap consumer"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20opengovsg%2Fisomer%20PR%20%233159%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=opengovsg%2Fisomer&pr=3159&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2Ftypes.ts%3A23-27%0A**Duplicate%20date-tag%20contract**%0A%0AThis%20interface%20duplicates%20the%20canonical%20exported%20%60DateTaggedItem%60%20used%20by%20%60IsomerSitemap%60%20and%20is%20already%20less%20precise%20because%20it%20accepts%20arbitrary%20strings%20instead%20of%20the%20schema-derived%20UUID%20and%20date%20types.%20This%20violates%20the%20repository%20directive%20to%20reuse%20an%20existing%20schema%20or%20type%20with%20the%20same%20domain%20behavior%20and%20allows%20the%20publishing%20contract%20to%20drift%20from%20its%20consumer.%20This%20requirement%20must%20be%20satisfied%20before%20merging%3B%20reuse%20%60DateTaggedItem%60%20or%20derive%20the%20field%20from%20%60ArticlePagePageProps%5B%22dateTagged%22%5D%60.%0A%0A%23%23%23%20Issue%202%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2Findex.ts%3A162%0A**Date-tag%20forwarding%20is%20untested**%0A%0AThe%20publishing%20integration%20test%20and%20its%20seed%20data%20do%20not%20exercise%20this%20new%20field%2C%20so%20there%20is%20no%20regression%20protection%20confirming%20that%20%60dateTagged%60%20reaches%20the%20generated%20%60sitemap.json%60%20unchanged.%20A%20later%20mapping%20refactor%20could%20silently%20drop%20or%20alter%20this%20metadata%20without%20failing%20a%20test.%20Add%20a%20tagged%20page%20to%20the%20existing%20publishing%20seed%20and%20assert%20that%20its%20complete%20date%20range%20appears%20in%20the%20generated%20entry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer&pr=3159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2Ftypes.ts%3A23-27%0A**Duplicate%20date-tag%20contract**%0A%0AThis%20interface%20duplicates%20the%20canonical%20exported%20%60DateTaggedItem%60%20used%20by%20%60IsomerSitemap%60%20and%20is%20already%20less%20precise%20because%20it%20accepts%20arbitrary%20strings%20instead%20of%20the%20schema-derived%20UUID%20and%20date%20types.%20This%20violates%20the%20repository%20directive%20to%20reuse%20an%20existing%20schema%20or%20type%20with%20the%20same%20domain%20behavior%20and%20allows%20the%20publishing%20contract%20to%20drift%20from%20its%20consumer.%20This%20requirement%20must%20be%20satisfied%20before%20merging%3B%20reuse%20%60DateTaggedItem%60%20or%20derive%20the%20field%20from%20%60ArticlePagePageProps%5B%22dateTagged%22%5D%60.%0A%0A%23%23%23%20Issue%202%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2Findex.ts%3A162%0A**Date-tag%20forwarding%20is%20untested**%0A%0AThe%20publishing%20integration%20test%20and%20its%20seed%20data%20do%20not%20exercise%20this%20new%20field%2C%20so%20there%20is%20no%20regression%20protection%20confirming%20that%20%60dateTagged%60%20reaches%20the%20generated%20%60sitemap.json%60%20unchanged.%20A%20later%20mapping%20refactor%20could%20silently%20drop%20or%20alter%20this%20metadata%20without%20failing%20a%20test.%20Add%20a%20tagged%20page%20to%20the%20existing%20publishing%20seed%20and%20assert%20that%20its%20complete%20date%20range%20appears%20in%20the%20generated%20entry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=3159&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/conductor?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22opengovsg%2Fisomer%22%20on%20the%20existing%20branch%20%22feat%2Fdate-filters-publishing%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fdate-filters-publishing%22.%0A%0A%23%23%23%20Issue%201%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2Ftypes.ts%3A23-27%0A**Duplicate%20date-tag%20contract**%0A%0AThis%20interface%20duplicates%20the%20canonical%20exported%20%60DateTaggedItem%60%20used%20by%20%60IsomerSitemap%60%20and%20is%20already%20less%20precise%20because%20it%20accepts%20arbitrary%20strings%20instead%20of%20the%20schema-derived%20UUID%20and%20date%20types.%20This%20violates%20the%20repository%20directive%20to%20reuse%20an%20existing%20schema%20or%20type%20with%20the%20same%20domain%20behavior%20and%20allows%20the%20publishing%20contract%20to%20drift%20from%20its%20consumer.%20This%20requirement%20must%20be%20satisfied%20before%20merging%3B%20reuse%20%60DateTaggedItem%60%20or%20derive%20the%20field%20from%20%60ArticlePagePageProps%5B%22dateTagged%22%5D%60.%0A%0A%23%23%23%20Issue%202%0Atooling%2Fbuild%2Fscripts%2Fpublishing%2Findex.ts%3A162%0A**Date-tag%20forwarding%20is%20untested**%0A%0AThe%20publishing%20integration%20test%20and%20its%20seed%20data%20do%20not%20exercise%20this%20new%20field%2C%20so%20there%20is%20no%20regression%20protection%20confirming%20that%20%60dateTagged%60%20reaches%20the%20generated%20%60sitemap.json%60%20unchanged.%20A%20later%20mapping%20refactor%20could%20silently%20drop%20or%20alter%20this%20metadata%20without%20failing%20a%20test.%20Add%20a%20tagged%20page%20to%20the%20existing%20publishing%20seed%20and%20assert%20that%20its%20complete%20date%20range%20appears%20in%20the%20generated%20entry.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=opengovsg%2Fisomer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"><img alt="Fix All in Conductor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInConductor.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tooling/build/scripts/publishing/types.ts:23-27
**Duplicate date-tag contract**

This interface duplicates the canonical exported `DateTaggedItem` used by `IsomerSitemap` and is already less precise because it accepts arbitrary strings instead of the schema-derived UUID and date types. This violates the repository directive to reuse an existing schema or type with the same domain behavior and allows the publishing contract to drift from its consumer. This requirement must be satisfied before merging; reuse `DateTaggedItem` or derive the field from `ArticlePagePageProps["dateTagged"]`.

### Issue 2
tooling/build/scripts/publishing/index.ts:162
**Date-tag forwarding is untested**

The publishing integration test and its seed data do not exercise this new field, so there is no regression protection confirming that `dateTagged` reaches the generated `sitemap.json` unchanged. A later mapping refactor could silently drop or alter this metadata without failing a test. Add a tagged page to the existing publishing seed and assert that its complete date range appears in the generated entry.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: undo unrelate change"](https://github.com/opengovsg/isomer/commit/6df23fd80acf3f0002c4cb2ffb04499df5c04ddc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62244216)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - # Isomer review rules    Apply the same standards ... ([source](https://app.greptile.com/opengovsg/-/custom-context?memory=fd2ee0a5-1a6a-4898-86da-1b53c321a5ad))

<!-- /greptile_comment -->

## /show-me to help explain what this PR does

This PR only wires the already-stored `dateTagged` field into the static-site sitemap output — nothing upstream (schema, UI, GrowthBook) changes here.

```text
tooling/build/scripts/publishing/
├── types.ts   # + local `DateTagged` interface, + `dateTagged?: DateTagged[]` on SitemapEntry
└── index.ts   # + one line copying resource.content.page.dateTagged into the built sitemap entry
```

```diff
 // types.ts
+interface DateTagged {
+  id: string
+  date: string
+  endDate?: string
+}

 export type SitemapEntry = Pick<Resource, "id" | "title" | "permalink" | "type"> & {
   ...
   tagged?: Tagged[]
+  dateTagged?: DateTagged[]
   collectionPagePageProps?: CollectionPagePageProps
 }
```

```diff
 // index.ts — inside the per-resource sitemapEntry builder
   tagged: resource.content.page.tagged,
+  dateTagged: resource.content.page.dateTagged,
   date: resource.content.page.date,
```

Why a local `DateTagged` interface instead of importing `DateTaggedItem` from `@opengovsg/isomer-components`: the branch tried that first (`refactor(publishing): reuse DateTaggedItem from isomer-components`) then reverted it in the final commit (`refactor(publishing): remove dependency on isomer-components`) so the publishing tool doesn't take on a runtime dependency on the components package just for a type.
