### PR TITLE
fix(components): reset query params between Storybook stories

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -130,6 +130,19 @@ const MockDateDecorator: Decorator = (Story) => {
   return <Story />
 }
 
+// Storybook's preview iframe is a single persistent document — switching
+// stories re-renders the story tree in place rather than reloading the
+// page, so anything a previous story's `play()` wrote via `history` (e.g.
+// `useQueryParams`' `?filters=...`) is still on `window.location` when the
+// next story mounts. Reset the search string per story so filter/query
+// state never leaks across stories, the same way `MockDateDecorator`
+// isolates `Date`.
+const ResetQueryParamsDecorator: Decorator = (Story) => {
+  window.history.replaceState({}, "", window.location.pathname)
+
+  return <Story />
+}
+
 export const decorators: Decorator[] = [
   withThemeByDataAttribute({
     themes: {
@@ -139,6 +152,7 @@ export const decorators: Decorator[] = [
   }),
   LayoutDecorator,
   MockDateDecorator,
+  ResetQueryParamsDecorator,
 ]
 
 export default preview


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 1 | +14 | -0 |
| 🧪 Test | 0 | +0 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Storybook's preview iframe is a single persistent document — switching stories re-renders the story tree in place rather than reloading the page. Any story whose `play()` function writes to `window.location` via `history` (e.g. `useQueryParams`' `?filters=...`) leaves that query string in place for the next story that mounts, so filter/query state leaks across unrelated stories depending on run order.

## Solution

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- None.

**Bug Fixes**:

- Add a `ResetQueryParamsDecorator` to `packages/components/.storybook/preview.tsx` that clears `window.location`'s search string (via `history.replaceState`) before every story renders — the same pattern `MockDateDecorator` already uses to isolate `Date` per story.

## Before & After Screenshots

Not applicable — internal Storybook test-isolation fix, no visual change to any story.

## Tests

**Manual Verification Steps**:

- [ ] Run `pnpm storybook` in `packages/components`
- [ ] Open a story that sets query params via `useQueryParams` (e.g. a `Filter`/`Collection` story with an interaction test), let it run, then switch to a different, unrelated story — confirm the URL's query string has been reset and the new story doesn't inherit the previous story's filter state

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a global Storybook decorator that clears query parameters before each story renders, preventing URL-backed filter state from leaking between stories.
- Resets the preview iframe URL with `history.replaceState`.
- Registers the reset alongside the existing global layout, theme, and date decorators.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable defects identified in the Storybook isolation change.

The reset runs before each story, removes leaked query state without adding history entries, and does not interfere with current story-level URL setup or any existing hash/history-state dependency.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/.storybook/preview.tsx | Adds a narrowly scoped Storybook query-parameter reset with no concrete correctness or compatibility issue identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(components): reset query params betw..."](https://github.com/opengovsg/isomer/commit/fa9df499c71c0261fd83124b9fc822d2e5e8ef54) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54080343)</sub>

<!-- /greptile_comment -->