### PR TITLE
feat(studio): make dashboard table rows fully clickable

### DIFF
--- a/apps/studio/src/components/Datatable/Datatable.browser.test.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.browser.test.tsx
@@ -1,0 +1,94 @@
+import { LinkOverlay } from "@chakra-ui/react"
+import { ThemeProvider } from "@opengovsg/design-system-react"
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table"
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+import { theme } from "~/theme"
+
+import { Datatable } from "./Datatable"
+
+interface RowData {
+  title: string
+}
+
+const columnsHelper = createColumnHelper<RowData>()
+const columns = [
+  columnsHelper.accessor("title", {
+    header: "Title",
+    cell: ({ getValue }) => (
+      <LinkOverlay href="/test-page" sx={{ position: "static" }}>
+        {getValue()}
+      </LinkOverlay>
+    ),
+  }),
+]
+
+const LinkedRowTable = ({
+  data = [{ title: "Test page" }],
+}: {
+  data?: RowData[]
+}) => {
+  const instance = useReactTable({
+    columns,
+    data,
+    getCoreRowModel: getCoreRowModel(),
+  })
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Datatable isRowLink instance={instance} />
+    </ThemeProvider>
+  )
+}
+
+describe("Datatable linked rows", () => {
+  afterEach(cleanup)
+
+  it("uses a native link overlay while preserving valid table markup", () => {
+    render(<LinkedRowTable />)
+
+    const link = screen.getByRole("link", { name: "Test page" })
+    const row = link.closest("tr")
+
+    expect(row).not.toBeNull()
+    if (!row) throw new Error("Expected link to be inside a table row")
+
+    expect(row.parentElement?.tagName).toBe("TBODY")
+    expect(link.getAttribute("href")).toBe("/test-page")
+    expect(getComputedStyle(row).position).toBe("relative")
+    expect(getComputedStyle(row).cursor).toBe("pointer")
+    expect(getComputedStyle(link).position).toBe("static")
+
+    const overlayStyles = getComputedStyle(link, "::before")
+    const rowBounds = row.getBoundingClientRect()
+    expect(overlayStyles.position).toBe("absolute")
+    expect(Number.parseFloat(overlayStyles.width)).toBeCloseTo(
+      rowBounds.width,
+      0,
+    )
+    expect(
+      Math.abs(Number.parseFloat(overlayStyles.height) - rowBounds.height),
+    ).toBeLessThanOrEqual(1)
+  })
+
+  it("keeps the row styles that the Table theme applies to Tr", () => {
+    // Arrange / Act
+    render(<LinkedRowTable data={[{ title: "First" }, { title: "Last" }]} />)
+
+    const [, ...bodyRows] = screen.getAllByRole("row")
+    const [firstRow, lastRow] = bodyRows.map((row) => getComputedStyle(row))
+
+    // Assert
+    // The last row drops its divider so it doesn't double up on the
+    // container border.
+    expect(firstRow?.borderBottomWidth).toBe("1px")
+    expect(lastRow?.borderBottomWidth).toBe("0px")
+    // body-2 typography.
+    expect(firstRow?.fontSize).toBe("14px")
+    expect(firstRow?.lineHeight).toBe("20px")
+  })
+})

--- a/apps/studio/src/components/Datatable/Datatable.tsx
+++ b/apps/studio/src/components/Datatable/Datatable.tsx
@@ -3,6 +3,7 @@ import type { Row, Table as ReactTable } from "@tanstack/react-table"
 import {
   Box,
   Flex,
+  LinkBox,
   Spinner,
   Table,
   Tbody,
@@ -28,6 +29,8 @@ interface DatatableProps<D> extends TableProps {
   emptyPlaceholder?: React.ReactElement
   overflow?: LayoutProps["overflow"]
   onRowClick?: (row: Row<D>) => void
+  /** Render each row as a LinkBox for a descendant LinkOverlay. */
+  isRowLink?: boolean
 }
 
 export const Datatable = <T extends object>({
@@ -38,6 +41,7 @@ export const Datatable = <T extends object>({
   emptyPlaceholder,
   overflow = "auto",
   onRowClick,
+  isRowLink,
   ...tableProps
 }: DatatableProps<T>): JSX.Element => {
   const { rows } = instance.getRowModel()
@@ -111,12 +115,19 @@ export const Datatable = <T extends object>({
           <Tbody>
             {rows.length === 0 && emptyPlaceholder}
             {rows.map((row) => {
+              const RowComponent = isRowLink ? LinkBox : Tr
+
               return (
-                <Tr
+                <RowComponent
+                  as={isRowLink ? "tr" : undefined}
                   key={row.id}
                   borderBottomWidth="1px"
+                  // LinkBox rows don't pick up the Table theme's `tr` styles,
+                  // so restate the ones we rely on here.
+                  _last={{ borderBottomWidth: 0 }}
+                  textStyle="body-2"
                   _hover={{ bgColor: "interaction.muted.main.hover" }}
-                  cursor={onRowClick ? "pointer" : undefined}
+                  cursor={onRowClick || isRowLink ? "pointer" : undefined}
                   onClick={() => onRowClick?.(row)}
                 >
                   {row.getVisibleCells().map((cell) => {
@@ -129,7 +140,7 @@ export const Datatable = <T extends object>({
                       </Td>
                     )
                   })}
-                </Tr>
+                </RowComponent>
               )
             })}
           </Tbody>

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTable.tsx
@@ -138,6 +138,7 @@ export const CollectionTable = ({
 
       <Datatable
         pagination
+        isRowLink
         isFetching={isFetching || isCountLoading}
         emptyPlaceholder={
           <EmptyTablePlaceholder

--- a/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/CollectionTable/CollectionTableMenu.tsx
@@ -50,6 +50,8 @@ export const CollectionTableMenu = ({
         colorScheme="neutral"
         icon={<BiDotsHorizontalRounded />}
         variant="clear"
+        position="relative"
+        zIndex={1}
       />
       <Portal>
         <MenuList>

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTable.tsx
@@ -135,6 +135,7 @@ export const ResourceTable = ({
 
       <Datatable
         pagination
+        isRowLink
         emptyPlaceholder={
           <EmptyTablePlaceholder
             entityName="page"

--- a/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/ResourceTableMenu.tsx
@@ -85,6 +85,8 @@ export const ResourceTableMenu = ({
         colorScheme="neutral"
         icon={<BiDotsHorizontalRounded />}
         variant="clear"
+        position="relative"
+        zIndex={1}
       />
       <Portal>
         <MenuList minWidth="8rem">

--- a/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
+++ b/apps/studio/src/features/dashboard/components/ResourceTable/TitleCell.tsx
@@ -1,6 +1,14 @@
 import type { IconType } from "react-icons"
-import { Badge, HStack, Icon, Text, Tooltip, VStack } from "@chakra-ui/react"
-import { Link } from "@opengovsg/design-system-react"
+import {
+  Badge,
+  HStack,
+  Icon,
+  LinkOverlay,
+  Text,
+  Tooltip,
+  useStyleConfig,
+  VStack,
+} from "@chakra-ui/react"
 import { format } from "date-fns"
 import NextLink from "next/link"
 import { useMemo } from "react"
@@ -25,6 +33,11 @@ export const TitleCell = ({
   id,
   scheduledAt,
 }: TitleCellProps): JSX.Element => {
+  const linkStyles = useStyleConfig("Link", {
+    colorScheme: "neutral",
+    variant: "standalone",
+  })
+
   const linkToResource: string = useMemo(() => {
     return getLinkToResource({ resourceId: id, siteId, type })
   }, [id, siteId, type])
@@ -32,6 +45,9 @@ export const TitleCell = ({
   const ResourceTypeIcon: IconType = useMemo(() => {
     return getIcon(type)
   }, [type])
+  const scheduledAtLabel = scheduledAt
+    ? format(scheduledAt, "MMMM d, yyyy h:mm a")
+    : undefined
 
   return (
     <HStack align="center" spacing="0.625rem">
@@ -42,28 +58,31 @@ export const TitleCell = ({
       />
       <VStack spacing="0.25rem" align="start">
         <HStack align="center" spacing="0.5rem">
-          <Link
+          <LinkOverlay
             as={NextLink}
             href={linkToResource}
             title={title}
-            textStyle="subhead-2"
             noOfLines={1}
-            p="0"
-            variant="standalone"
-            colorScheme="neutral"
+            sx={{
+              ...linkStyles,
+              position: "static",
+              p: 0,
+              textStyle: "subhead-2",
+            }}
           >
             {title}
-          </Link>
-          {scheduledAt && (
-            <Tooltip
-              label={format(scheduledAt, "MMMM d, yyyy h:mm a")}
-              placement="bottom"
-              hasArrow
-            >
+          </LinkOverlay>
+          {scheduledAtLabel && (
+            <Tooltip label={scheduledAtLabel} placement="bottom" hasArrow>
               <Badge
+                as={NextLink}
+                href={linkToResource}
+                aria-label={`${title} is scheduled for ${scheduledAtLabel}`}
                 bgColor="utility.feedback.info-subtle"
                 color="utility.feedback.info"
                 cursor="pointer"
+                position="relative"
+                zIndex={1}
               >
                 <HStack spacing="0.25rem" align="center">
                   <Icon as={BiTimeFive} boxSize="0.75rem" />


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 6 | +53 | -17 |
| 🧪 Test | 1 | +94 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

Closes [ISOM-2482](https://linear.app/ogp/issue/ISOM-2482/studio-dashboard-make-folder-page-and-collection-table-rows-fully).

Dashboard users could only open folders, pages, collections, and collection items by clicking their titles, leaving most of each table row inactive.

## Solution

Dashboard rows now use native link overlays that preserve browser link behavior while keeping valid table markup, existing row styling, scheduled-status tooltips, and independently interactive action menus.

**Breaking Changes**

- [ ] Yes - this PR contains breaking changes
  - Details ...
- [x] No - this PR is backwards compatible

**Features**:

- None.

**Improvements**:

- Makes folder, page, collection, and collection-item rows fully clickable.
- Supports keyboard focus, context menus, middle-click, and modifier-click through native links.

**Bug Fixes**:

- Keeps kebab menus and scheduled badges above the row link overlay.
- Preserves table typography and last-row divider styling for linked rows.

## Before & After Screenshots

**AFTER**:

https://github.com/user-attachments/assets/e6ea5f8c-af8c-4a1b-bf50-3d7f3127fefe


## Tests

- `CI=1 pnpm --filter isomer-studio exec vitest run --project browser src/components/Datatable/Datatable.browser.test.tsx`
- Targeted formatting and type-aware lint checks for all changed files.
- Full Studio typecheck remains blocked by unrelated existing errors outside the changed files.

**Manual Verification Steps**:

- [ ] Click whitespace in folder, page, and collection rows and confirm each item opens.
- [ ] Click whitespace in collection-item rows and confirm each item opens.
- [ ] Modifier-click or middle-click a row and confirm it can open in a new tab.
- [ ] Open the kebab menu with pointer and keyboard controls, then run an action without navigating the row.

**New scripts**:

- None.

**New dependencies**:

- None.

**New dev dependencies**:

- None.
