### PR TITLE
feat(studio): validate and normalize AskGov widget input

### DIFF
--- a/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
+++ b/apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx
@@ -82,7 +82,11 @@ const IntegrationsSettingsPage: NextPageWithLayout = () => {
 
   const updateSiteIntegrationsMutation =
     trpc.site.updateSiteIntegrations.useMutation({
-      onSuccess: async () => {
+      onSuccess: async (updatedSite) => {
+        setComplexIntegrationSettings({
+          askgov: updatedSite.config.askgov,
+          vica: updatedSite.config.vica,
+        })
         toast({
           ...SETTINGS_TOAST_MESSAGES.success,
           status: "success",

--- a/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
+++ b/apps/studio/src/server/modules/site/__tests__/site.router.test.ts
@@ -571,6 +571,30 @@ describe("site.router", async () => {
         .executeTakeFirstOrThrow()
       expect(updatedSite.name).toEqual(MOCK_SITE_NAME)
     })
+    it("should normalize an AskGov URL when updating the site config", async () => {
+      // Arrange
+      const { site } = await setupSite()
+      await setupAdminPermissions({
+        userId: session.userId,
+        siteId: site.id,
+      })
+
+      // Act
+      const result = await caller.updateSiteConfig({
+        siteName: MOCK_SITE_NAME,
+        logoUrl: MOCK_LOGO_URL,
+        url: "https://www.isomer.gov.sg",
+        theme: "isomer-next",
+        siteId: site.id,
+        askgov: {
+          "data-agency":
+            "https://www.ask.gov.sg/mha/questions/question-id?from=widget",
+        },
+      })
+
+      // Assert
+      expect(result.askgov).toEqual({ "data-agency": "mha" })
+    })
     it("should generate an audit log entry", async () => {
       // Arrange
       const { site } = await setupSite()
@@ -899,6 +923,41 @@ describe("site.router", async () => {
       // Assert
       expect(result.config).toEqual(MOCK_INTEGRATION_DATA)
     })
+    it.each([
+      {
+        input: "http://ask.gov.sg/mom/?topic=employment#contact",
+        expected: "mom",
+        description: "URL",
+      },
+      {
+        input: "www.ask.gov.sg/help/questions/question-id",
+        expected: "help",
+        description: "scheme-less URL",
+      },
+      { input: "mha", expected: "mha", description: "ID" },
+    ])(
+      "should store an AskGov $description as the agency ID when updating site integrations",
+      async ({ input, expected }) => {
+        // Arrange
+        const { site } = await setupSite()
+        await setupAdminPermissions({
+          userId: session.userId,
+          siteId: site.id,
+        })
+
+        // Act
+        const result = await caller.updateSiteIntegrations({
+          data: {
+            ...MOCK_INTEGRATION_DATA,
+            askgov: { "data-agency": input },
+          },
+          siteId: site.id,
+        })
+
+        // Assert
+        expect(result.config.askgov).toEqual({ "data-agency": expected })
+      },
+    )
     it("should generate an audit log entry", async () => {
       // Arrange
       const { site } = await setupSite()

--- a/apps/studio/src/server/modules/site/site.router.ts
+++ b/apps/studio/src/server/modules/site/site.router.ts
@@ -42,6 +42,7 @@ import {
   getNotification,
   getSiteConfig,
   getSiteTheme,
+  normalizeAskgovConfig,
   resolveEgazetteAlgoliaSearchConfig,
   setSiteNotification,
   validateUserPermissionsForSite,
@@ -136,21 +137,29 @@ export const siteRouter = router({
         .executeTakeFirstOrThrow()
 
       const { config } = site
+      const normalizedConfig = normalizeAskgovConfig({ ...rest, siteName })
 
       const updatedConfig = await db.transaction().execute(async (tx) => {
         // Preserve the existing clientId from DB - only admins can update it via setSiteConfigByAdmin
         const searchConfig =
-          rest.search?.type === "searchSG" && config.search?.type === "searchSG"
-            ? { ...rest.search, clientId: config.search.clientId }
+          normalizedConfig.search?.type === "searchSG" &&
+          config.search?.type === "searchSG"
+            ? {
+                ...normalizedConfig.search,
+                clientId: config.search.clientId,
+              }
             : // egazette-algolia is admin-managed; site admins cannot switch
               // to/from it or tamper with its Algolia credentials.
-              resolveEgazetteAlgoliaSearchConfig(config.search, rest.search)
+              resolveEgazetteAlgoliaSearchConfig(
+                config.search,
+                normalizedConfig.search,
+              )
 
         const updatedSite = await tx
           .updateTable("Site")
           .set({
             name: siteName,
-            config: jsonb({ ...rest, siteName, search: searchConfig }),
+            config: jsonb({ ...normalizedConfig, search: searchConfig }),
           })
           .where("id", "=", siteId)
           .returningAll()
@@ -201,6 +210,7 @@ export const siteRouter = router({
         .where("id", "=", ctx.user.id)
         .selectAll()
         .executeTakeFirstOrThrow()
+      const normalizedData = normalizeAskgovConfig(data)
 
       return await db.transaction().execute(async (tx) => {
         const site = await tx
@@ -214,7 +224,7 @@ export const siteRouter = router({
         // a site admin from switching back to localSearch once SearchSG is set.
         if (
           site.config.search?.type === "searchSG" &&
-          data.search?.type === "localSearch"
+          normalizedData.search?.type === "localSearch"
         ) {
           throw new TRPCError({
             code: "BAD_REQUEST",
@@ -227,12 +237,12 @@ export const siteRouter = router({
         // it or tamper with its Algolia credentials.
         const search = resolveEgazetteAlgoliaSearchConfig(
           site.config.search,
-          data.search,
+          normalizedData.search,
         )
 
         const updatedSite = await tx
           .updateTable("Site")
-          .set({ config: jsonb({ ...data, search }) })
+          .set({ config: jsonb({ ...normalizedData, search }) })
           .where("id", "=", siteId)
           .returningAll()
           .executeTakeFirstOrThrow()

--- a/apps/studio/src/server/modules/site/site.service.ts
+++ b/apps/studio/src/server/modules/site/site.service.ts
@@ -1,5 +1,6 @@
 import type { IsomerSiteConfigProps } from "@opengovsg/isomer-components"
 import type { Notification } from "~/schemas/site"
+import { getAskgovIdFromString } from "@opengovsg/isomer-components"
 import { TRPCError } from "@trpc/server"
 import { ResourceState, ResourceType } from "~/server/modules/database"
 
@@ -43,6 +44,29 @@ export const validateUserPermissionsForSite = async ({
 type SiteSearchConfig = IsomerSiteConfigProps["search"]
 
 const EGAZETTE_ALGOLIA_SEARCH_TYPE = "egazette-algolia"
+
+export const normalizeAskgovConfig = (
+  config: IsomerSiteConfigProps,
+): IsomerSiteConfigProps => {
+  if (!config.askgov) return config
+
+  const agencyId = getAskgovIdFromString(config.askgov["data-agency"])
+
+  if (agencyId === null) {
+    throw new TRPCError({
+      code: "BAD_REQUEST",
+      message: "Invalid AskGov ID or URL",
+    })
+  }
+
+  return {
+    ...config,
+    askgov: {
+      ...config.askgov,
+      "data-agency": agencyId,
+    },
+  }
+}
 
 /**
  * The `egazette-algolia` search variant carries Algolia connection details

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -12,6 +12,7 @@ export {
   createChildrenPagesComparator,
   formatBytes,
   DGS_REQUEST_MAX_BYTES,
+  getAskgovIdFromString,
 } from "./utils"
 export * from "./schemas"
 export * from "./types"

--- a/packages/components/src/interfaces/internal/Askgov.ts
+++ b/packages/components/src/interfaces/internal/Askgov.ts
@@ -2,12 +2,25 @@ import type { Static } from "@sinclair/typebox"
 import type { IsomerSiteProps } from "~/types"
 import { Type } from "@sinclair/typebox"
 
+// Accepts existing IDs such as `mha`, plus AskGov URLs with or without an
+// HTTP(S) scheme, for example `https://ask.gov.sg/mha` and
+// `www.ask.gov.sg/mha/questions/123`. The ID branch remains free-form but
+// excludes URL-like values and all AskGov subdomains so only `ask.gov.sg` and
+// `www.ask.gov.sg` can use the URL form. Root URLs without an ID are rejected.
+const ASKGOV_DOMAIN_PATTERN = "(?:[A-Za-z0-9-]+\\.)*ask\\.gov\\.sg"
+const ASKGOV_HOST_PATTERN = "(?:www\\.)?ask\\.gov\\.sg"
+const ASKGOV_ID_OR_URL_PATTERN = `^(?:(?!${ASKGOV_DOMAIN_PATTERN}(?:[./?#]|$)|.*://).+|(?:https?://)?${ASKGOV_HOST_PATTERN}/[^/?#]+.*)$`
+
 export const AskgovSchema = Type.Object(
   {
     "data-agency": Type.String({
       title: "AskGov ID",
       description:
         'This is what comes after ask.gov.sg. For example, for https://ask.gov.sg/help, "help" is the ID.',
+      pattern: ASKGOV_ID_OR_URL_PATTERN,
+      errorMessage: {
+        pattern: "must be an ID or a valid ask.gov.sg URL",
+      },
     }),
     "data-topic": Type.Optional(
       Type.String({

--- a/packages/components/src/interfaces/internal/Askgov.ts
+++ b/packages/components/src/interfaces/internal/Askgov.ts
@@ -1,15 +1,7 @@
 import type { Static } from "@sinclair/typebox"
 import type { IsomerSiteProps } from "~/types"
 import { Type } from "@sinclair/typebox"
-
-// Accepts existing IDs such as `mha`, plus AskGov URLs with or without an
-// HTTP(S) scheme, for example `https://ask.gov.sg/mha` and
-// `www.ask.gov.sg/mha/questions/123`. The ID branch remains free-form but
-// excludes URL-like values and all AskGov subdomains so only `ask.gov.sg` and
-// `www.ask.gov.sg` can use the URL form. Root URLs without an ID are rejected.
-const ASKGOV_DOMAIN_PATTERN = "(?:[A-Za-z0-9-]+\\.)*ask\\.gov\\.sg"
-const ASKGOV_HOST_PATTERN = "(?:www\\.)?ask\\.gov\\.sg"
-const ASKGOV_ID_OR_URL_PATTERN = `^(?:(?!${ASKGOV_DOMAIN_PATTERN}(?:[./?#]|$)|.*://).+|(?:https?://)?${ASKGOV_HOST_PATTERN}/[^/?#]+.*)$`
+import { ASKGOV_ID_OR_URL_REGEX } from "~/utils/validation"
 
 export const AskgovSchema = Type.Object(
   {
@@ -17,7 +9,7 @@ export const AskgovSchema = Type.Object(
       title: "AskGov ID",
       description:
         'This is what comes after ask.gov.sg. For example, for https://ask.gov.sg/help, "help" is the ID.',
-      pattern: ASKGOV_ID_OR_URL_PATTERN,
+      pattern: ASKGOV_ID_OR_URL_REGEX,
       errorMessage: {
         pattern: "must be an ID or a valid ask.gov.sg URL",
       },

--- a/packages/components/src/interfaces/internal/__tests__/Askgov.test.ts
+++ b/packages/components/src/interfaces/internal/__tests__/Askgov.test.ts
@@ -1,42 +1,67 @@
 import { Value } from "@sinclair/typebox/value"
 import { describe, expect, it } from "vitest"
+import { getAskgovIdFromString } from "~/utils/getAskgovIdFromString"
 
 import { AskgovSchema } from "../Askgov"
 
 const isValidAgencyInput = (value: string) =>
   Value.Check(AskgovSchema, { "data-agency": value })
 
+const ACCEPTED = [
+  "mha",
+  "help2",
+  "agency_id",
+  " mha ",
+  "https://ask.gov.sg/mha",
+  "http://ask.gov.sg/mha/",
+  "https://www.ask.gov.sg/help/questions/question-id",
+  "HTTPS://WWW.ASK.GOV.SG/mha",
+  "ask.gov.sg/mha",
+  "www.ask.gov.sg/help/questions/question-id",
+  "  https://ask.gov.sg/mha  ",
+]
+
+const REJECTED = [
+  "",
+  "   ",
+  "custom/agency",
+  "example.com/mha",
+  "https://example.com/mha",
+  "https://ask.gov.sg",
+  "https://ask.gov.sg/",
+  "https://www.ask.gov.sg?topic=scams",
+  "https://staging.ask.gov.sg/mha",
+  "https://foo.www.ask.gov.sg/mha",
+  "https://ask.gov.sg.example.com/mha",
+  "ask.gov.sg",
+  "www.ask.gov.sg/",
+  "staging.ask.gov.sg/mha",
+  "foo.www.ask.gov.sg/mha",
+  "ask.gov.sg.example.com/mha",
+  "ftp://ask.gov.sg/mha",
+  "https://",
+]
+
 describe("AskgovSchema", () => {
-  it.each([
-    "mha",
-    "custom/agency",
-    "https://ask.gov.sg/mha",
-    "http://ask.gov.sg/mha/",
-    "https://www.ask.gov.sg/help/questions/question-id",
-    "ask.gov.sg/mha",
-    "www.ask.gov.sg/help/questions/question-id",
-  ])("accepts %j", (value) => {
+  it.each(ACCEPTED)("accepts %j", (value) => {
     expect(isValidAgencyInput(value)).toBe(true)
   })
 
-  it.each([
-    "https://ask.gov.sg",
-    "https://ask.gov.sg/",
-    "https://www.ask.gov.sg?topic=scams",
-    "https://staging.ask.gov.sg/mha",
-    "https://foo.www.ask.gov.sg/mha",
-    "https://ask.gov.sg.example.com/mha",
-    "https://example.com/mha",
-    "ask.gov.sg",
-    "www.ask.gov.sg/",
-    "staging.ask.gov.sg/mha",
-    "foo.www.ask.gov.sg/mha",
-    "ask.gov.sg.example.com/mha",
-    "ftp://ask.gov.sg/mha",
-    "https://",
-  ])("rejects %j", (value) => {
+  it.each(REJECTED)("rejects %j", (value) => {
     expect(isValidAgencyInput(value)).toBe(false)
   })
+
+  // The schema gates what a user can save and `getAskgovIdFromString` decides
+  // what gets stored, so the two have to agree on every input or the mutation
+  // rejects a value the form accepted.
+  it.each([...ACCEPTED, ...REJECTED])(
+    "agrees with getAskgovIdFromString on %j",
+    (value) => {
+      expect(isValidAgencyInput(value)).toBe(
+        getAskgovIdFromString(value) !== null,
+      )
+    },
+  )
 
   it("provides the AskGov-specific validation message", () => {
     expect(AskgovSchema.properties["data-agency"]).toMatchObject({

--- a/packages/components/src/interfaces/internal/__tests__/Askgov.test.ts
+++ b/packages/components/src/interfaces/internal/__tests__/Askgov.test.ts
@@ -1,0 +1,48 @@
+import { Value } from "@sinclair/typebox/value"
+import { describe, expect, it } from "vitest"
+
+import { AskgovSchema } from "../Askgov"
+
+const isValidAgencyInput = (value: string) =>
+  Value.Check(AskgovSchema, { "data-agency": value })
+
+describe("AskgovSchema", () => {
+  it.each([
+    "mha",
+    "custom/agency",
+    "https://ask.gov.sg/mha",
+    "http://ask.gov.sg/mha/",
+    "https://www.ask.gov.sg/help/questions/question-id",
+    "ask.gov.sg/mha",
+    "www.ask.gov.sg/help/questions/question-id",
+  ])("accepts %j", (value) => {
+    expect(isValidAgencyInput(value)).toBe(true)
+  })
+
+  it.each([
+    "https://ask.gov.sg",
+    "https://ask.gov.sg/",
+    "https://www.ask.gov.sg?topic=scams",
+    "https://staging.ask.gov.sg/mha",
+    "https://foo.www.ask.gov.sg/mha",
+    "https://ask.gov.sg.example.com/mha",
+    "https://example.com/mha",
+    "ask.gov.sg",
+    "www.ask.gov.sg/",
+    "staging.ask.gov.sg/mha",
+    "foo.www.ask.gov.sg/mha",
+    "ask.gov.sg.example.com/mha",
+    "ftp://ask.gov.sg/mha",
+    "https://",
+  ])("rejects %j", (value) => {
+    expect(isValidAgencyInput(value)).toBe(false)
+  })
+
+  it("provides the AskGov-specific validation message", () => {
+    expect(AskgovSchema.properties["data-agency"]).toMatchObject({
+      errorMessage: {
+        pattern: "must be an ID or a valid ask.gov.sg URL",
+      },
+    })
+  })
+})

--- a/packages/components/src/utils/__tests__/getAskgovIdFromString.test.ts
+++ b/packages/components/src/utils/__tests__/getAskgovIdFromString.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest"
 import { getAskgovIdFromString } from "../getAskgovIdFromString"
 
 describe("getAskgovIdFromString", () => {
-  it.each(["mha", "custom/agency", " agency-id "])(
+  it.each(["mha", "help2", "agency_id", "agency-id"])(
     "returns the plain ID %j unchanged",
     (agencyId) => {
       expect(getAskgovIdFromString(agencyId)).toBe(agencyId)
@@ -20,18 +20,31 @@ describe("getAskgovIdFromString", () => {
     ["ask.gov.sg/mha", "mha"],
     ["www.ask.gov.sg/help/questions/question-id", "help"],
     ["ASK.GOV.SG/MHA?topic=scams#contact", "MHA"],
+    // A nested URL in the query string is part of the ignored remainder
+    ["ask.gov.sg/mha?next=https://example.com", "mha"],
   ])("extracts %j as %j", (value, expected) => {
     expect(getAskgovIdFromString(value)).toBe(expected)
   })
 
   it.each([
+    [" mha ", "mha"],
+    ["  https://ask.gov.sg/mha  ", "mha"],
+  ])("trims %j to %j", (value, expected) => {
+    expect(getAskgovIdFromString(value)).toBe(expected)
+  })
+
+  it.each([
+    "",
+    "   ",
+    "custom/agency",
+    "example.com/mha",
+    "https://example.com/mha",
     "https://ask.gov.sg",
     "https://ask.gov.sg/",
     "https://www.ask.gov.sg?topic=scams",
     "https://staging.ask.gov.sg/mha",
     "https://foo.www.ask.gov.sg/mha",
     "https://ask.gov.sg.example.com/mha",
-    "https://example.com/mha",
     "ask.gov.sg",
     "www.ask.gov.sg/",
     "staging.ask.gov.sg/mha",

--- a/packages/components/src/utils/__tests__/getAskgovIdFromString.test.ts
+++ b/packages/components/src/utils/__tests__/getAskgovIdFromString.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { getAskgovIdFromString } from "../getAskgovIdFromString"
+
+describe("getAskgovIdFromString", () => {
+  it.each(["mha", "custom/agency", " agency-id "])(
+    "returns the plain ID %j unchanged",
+    (agencyId) => {
+      expect(getAskgovIdFromString(agencyId)).toBe(agencyId)
+    },
+  )
+
+  it.each([
+    ["https://ask.gov.sg/mha", "mha"],
+    ["http://ask.gov.sg/mom/", "mom"],
+    ["https://www.ask.gov.sg/ogp", "ogp"],
+    ["http://www.ask.gov.sg/help/questions/question-id", "help"],
+    ["https://ask.gov.sg/mha?topic=scams#contact", "mha"],
+    ["HTTPS://WWW.ASK.GOV.SG/MHA/questions/question-id", "MHA"],
+    ["ask.gov.sg/mha", "mha"],
+    ["www.ask.gov.sg/help/questions/question-id", "help"],
+    ["ASK.GOV.SG/MHA?topic=scams#contact", "MHA"],
+  ])("extracts %j as %j", (value, expected) => {
+    expect(getAskgovIdFromString(value)).toBe(expected)
+  })
+
+  it.each([
+    "https://ask.gov.sg",
+    "https://ask.gov.sg/",
+    "https://www.ask.gov.sg?topic=scams",
+    "https://staging.ask.gov.sg/mha",
+    "https://foo.www.ask.gov.sg/mha",
+    "https://ask.gov.sg.example.com/mha",
+    "https://example.com/mha",
+    "ask.gov.sg",
+    "www.ask.gov.sg/",
+    "staging.ask.gov.sg/mha",
+    "foo.www.ask.gov.sg/mha",
+    "ask.gov.sg.example.com/mha",
+    "ftp://ask.gov.sg/mha",
+    "https://",
+  ])("rejects %j", (value) => {
+    expect(getAskgovIdFromString(value)).toBeNull()
+  })
+})

--- a/packages/components/src/utils/getAskgovIdFromString.ts
+++ b/packages/components/src/utils/getAskgovIdFromString.ts
@@ -1,0 +1,33 @@
+const ASKGOV_HOSTNAMES = new Set(["ask.gov.sg", "www.ask.gov.sg"])
+const SCHEMELESS_ASKGOV_DOMAIN_PATTERN =
+  /^(?:[a-z0-9-]+\.)*ask\.gov\.sg(?:[./?#]|$)/i
+
+/**
+ * Returns an AskGov agency ID unchanged, or extracts it from a supported URL.
+ * URL inputs must use HTTP(S), have an accepted hostname, and include the
+ * agency ID as the first path segment.
+ */
+export const getAskgovIdFromString = (value: string): string | null => {
+  const valueToParse = value.includes("://")
+    ? value
+    : SCHEMELESS_ASKGOV_DOMAIN_PATTERN.test(value)
+      ? `https://${value}`
+      : null
+
+  if (!valueToParse) return value
+
+  try {
+    const url = new URL(valueToParse)
+
+    if (
+      !["http:", "https:"].includes(url.protocol) ||
+      !ASKGOV_HOSTNAMES.has(url.hostname)
+    ) {
+      return null
+    }
+
+    return url.pathname.split("/")[1] || null
+  } catch {
+    return null
+  }
+}

--- a/packages/components/src/utils/getAskgovIdFromString.ts
+++ b/packages/components/src/utils/getAskgovIdFromString.ts
@@ -1,33 +1,16 @@
-const ASKGOV_HOSTNAMES = new Set(["ask.gov.sg", "www.ask.gov.sg"])
-const SCHEMELESS_ASKGOV_DOMAIN_PATTERN =
-  /^(?:[a-z0-9-]+\.)*ask\.gov\.sg(?:[./?#]|$)/i
+import { ASKGOV_AGENCY_ID_REGEX, ASKGOV_URL_REGEX } from "./validation"
+
+const AGENCY_ID = new RegExp(`^${ASKGOV_AGENCY_ID_REGEX}$`)
+const ASKGOV_URL = new RegExp(`^${ASKGOV_URL_REGEX}$`)
 
 /**
- * Returns an AskGov agency ID unchanged, or extracts it from a supported URL.
- * URL inputs must use HTTP(S), have an accepted hostname, and include the
- * agency ID as the first path segment.
+ * Normalises an AskGov agency ID or an ask.gov.sg link down to the bare agency
+ * ID that the widget script expects, or `null` if the value is neither.
  */
 export const getAskgovIdFromString = (value: string): string | null => {
-  const valueToParse = value.includes("://")
-    ? value
-    : SCHEMELESS_ASKGOV_DOMAIN_PATTERN.test(value)
-      ? `https://${value}`
-      : null
+  const trimmed = value.trim()
 
-  if (!valueToParse) return value
+  if (AGENCY_ID.test(trimmed)) return trimmed
 
-  try {
-    const url = new URL(valueToParse)
-
-    if (
-      !["http:", "https:"].includes(url.protocol) ||
-      !ASKGOV_HOSTNAMES.has(url.hostname)
-    ) {
-      return null
-    }
-
-    return url.pathname.split("/")[1] || null
-  } catch {
-    return null
-  }
+  return ASKGOV_URL.exec(trimmed)?.[1] ?? null
 }

--- a/packages/components/src/utils/index.ts
+++ b/packages/components/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { getBreadcrumbFromSiteMap } from "./getBreadcrumbFromSiteMap"
 export { getFormattedDate } from "./getFormattedDate"
+export { getAskgovIdFromString } from "./getAskgovIdFromString"
 export { getNodeFromSiteMap } from "./getNodeFromSiteMap"
 export { getParsedDate } from "./getParsedDate"
 export { getReferenceLinkHref } from "./getReferenceLinkHref"

--- a/packages/components/src/utils/validation.ts
+++ b/packages/components/src/utils/validation.ts
@@ -232,6 +232,43 @@ export const TRIMMED_NON_EMPTY_STRING_REGEX = "^\\S(.*\\S)?$"
 // ❌ "d_ab_c" (contains underscore after prefix)
 export const DGS_ID_STRING_REGEX = "^d_[a-zA-Z0-9]+$"
 
+// An AskGov agency ID is the first path segment of an ask.gov.sg link — `mha` in
+// https://ask.gov.sg/mha/questions/123 — and that bare ID is what the widget
+// script expects. Agencies routinely paste the whole link instead, so the field
+// accepts either form and `getAskgovIdFromString` normalises a link down to the
+// ID. The scheme and host spell their casing out as character classes rather
+// than using the `i` flag: this pattern is also used as a JSON schema `pattern`,
+// which ajv compiles with the `u` flag only, and the schema and the extractor
+// have to accept exactly the same inputs.
+const ASKGOV_SCHEME_REGEX = "(?:[Hh][Tt][Tt][Pp][Ss]?://)?"
+const ASKGOV_HOST_REGEX =
+  "(?:[Ww][Ww][Ww]\\.)?[Aa][Ss][Kk]\\.[Gg][Oo][Vv]\\.[Ss][Gg]"
+
+// ✅ "mha"
+// ✅ "help2"
+// ❌ "custom/agency" (an ID has no path separators)
+// ❌ "ask.gov.sg" (an ID has no dots)
+// ❌ "" (empty string)
+export const ASKGOV_AGENCY_ID_REGEX = "[A-Za-z0-9_-]+"
+
+// Captures the agency ID. Whatever follows it — further path segments, a query
+// string or a fragment — is ignored, so links to a specific question or topic
+// resolve to the same agency ID.
+// ✅ "https://ask.gov.sg/mha"
+// ✅ "http://www.ask.gov.sg/help/questions/question-id?from=widget"
+// ✅ "ask.gov.sg/mha" (scheme is optional)
+// ✅ "HTTPS://WWW.ASK.GOV.SG/mha" (scheme and host are case-insensitive)
+// ❌ "https://ask.gov.sg/" (no agency ID)
+// ❌ "https://staging.ask.gov.sg/mha" (only ask.gov.sg and www.ask.gov.sg)
+// ❌ "example.com/mha" (not an AskGov host)
+// ❌ "ftp://ask.gov.sg/mha" (only HTTP(S))
+export const ASKGOV_URL_REGEX = `${ASKGOV_SCHEME_REGEX}${ASKGOV_HOST_REGEX}/(${ASKGOV_AGENCY_ID_REGEX})(?:[/?#].*)?`
+
+// Either of the two above. Surrounding whitespace is tolerated so that a value
+// pasted with a stray space is not rejected outright; `getAskgovIdFromString`
+// trims it off before the ID is stored.
+export const ASKGOV_ID_OR_URL_REGEX = `^\\s*(?:${ASKGOV_AGENCY_ID_REGEX}|${ASKGOV_URL_REGEX})\\s*$`
+
 // Matches Google tag IDs across the formats observed in the wild:
 //   GTM-XXXXXX  — Google Tag Manager containers (official)
 //   G-XXXXXX    — Google Analytics 4 measurement IDs (officially loaded via gtag.js, not GTM,


### PR DESCRIPTION
<!-- pr-diff-breakdown:start -->
### 📊 PR diff breakdown

| Bucket | Files | +Lines | -Lines |
|---|---|---|---|
| ⚙️ App | 8 | +106 | -8 |
| 🧪 Test | 3 | +190 | -0 |
| 📄 Doc | 0 | +0 | -0 |
| 🚫 Ignore | 0 | +0 | -0 |
<!-- pr-diff-breakdown:end -->

## Problem

The AskGov ID field in Site settings → Integrations accepted any string. It expects only the agency ID (e.g. `mha`), but agencies commonly paste the full URL from their browser address bar (e.g. `https://ask.gov.sg/mha/questions/123`). That value was stored verbatim and spread straight onto the widget element as `data-agency`, so the AskGov script silently failed to load on the published site.

Closes ISOM-2340

## Solution

Validate the field at the schema level so only a bare ID or an `ask.gov.sg` URL is accepted, and normalize accepted URLs down to the agency ID on the server before the site config is persisted, so the stored value is always in the form the widget script expects.

**Breaking Changes**

- [x] Yes - this PR contains breaking changes
  - The new `pattern` on `data-agency` applies to the whole `SiteConfigSchema`, which `updateSiteConfig` validates in full. The Name and agency and Logo settings pages both submit the entire stored config, so a site whose existing `data-agency` does not match the pattern will fail to save on those pages with a generic validation error until the value is corrected on the Integrations page. A stored value fails if it is an empty string, a bare `https://ask.gov.sg` root URL, a URL on any other host, or anything other than a slug (`[A-Za-z0-9_-]+`) once URLs are excluded. Publishing is unaffected — `SiteConfigSchema` is not validated in the build pipeline. Please run `SELECT id, config->'askgov'->>'data-agency' FROM "Site" WHERE config->'askgov' IS NOT NULL;` before release and normalize any offending rows.
- [ ] No - this PR is backwards compatible

**Features**:

- `getAskgovIdFromString` in `@opengovsg/isomer-components` returns a plain agency ID unchanged and extracts the ID from an ask.gov.sg link, returning `null` for anything else.

**Improvements**:

- The AskGov ID field now rejects unsupported input with the message "must be an ID or a valid ask.gov.sg URL". Subdomains (e.g. `staging.ask.gov.sg`), other hosts (e.g. `example.com/mha`), non-HTTP(S) schemes, and root URLs with no agency ID are all rejected.
- `updateSiteConfig` and `updateSiteIntegrations` normalize the AskGov config before writing, so a pasted URL is stored as the bare agency ID.
- The schema `pattern` and the extractor are both derived from one set of constants in `utils/validation.ts`, alongside the other validation patterns in the package. A unit test asserts the two agree on every input in the fixture, so the form cannot accept a value the mutation then rejects. The scheme and host match case-insensitively and surrounding whitespace is trimmed.

**Bug Fixes**:

- Pasting an AskGov URL into the ID field no longer produces a broken widget on the published site.
- The Integrations form now resets from the mutation response after saving, so the field shows the normalized ID instead of leaving the typed URL on screen with the page stuck in an unsaved state.

## Before & After Screenshots

No layout changes. The only visual differences are the inline validation error on unsupported input, and the field showing the normalized agency ID after a successful save.

**BEFORE**:

<!-- [insert screenshot here] -->

**AFTER**:

<!-- [insert screenshot here] -->

## Tests

Unit tests cover the schema pattern (`packages/components/src/interfaces/internal/__tests__/Askgov.test.ts`) and the ID extraction helper (`packages/components/src/utils/__tests__/getAskgovIdFromString.test.ts`), including accepted IDs, accepted URL forms with and without a scheme, and rejected hosts, schemes and root URLs. tRPC router tests cover normalization through both `updateSiteConfig` and `updateSiteIntegrations`.

**Manual Verification Steps**:

- [ ] Go to Site settings → Integrations, enable AskGov, enter `https://ask.gov.sg/mha/questions/question-id?from=widget` and save. Confirm the success toast appears and the field then shows `mha`.
- [ ] Reload the page and confirm the field still shows `mha`, and that the Save button is disabled (no unsaved changes).
- [ ] Enter a bare ID such as `mha` and save. Confirm it is stored unchanged.
- [ ] Enter `https://ask.gov.sg` and confirm the inline error "must be an ID or a valid ask.gov.sg URL" appears and Save is disabled. Repeat with `https://staging.ask.gov.sg/mha` and `https://example.com/mha`.
- [ ] Publish the site and confirm the AskGov widget loads and opens on the published page.
- [ ] On a site that already has AskGov configured, save the Name and agency page and the Logo page, and confirm both still succeed.

**New scripts**:

- None

**New dependencies**:

- None

**New dev dependencies**:

- None

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR validates AskGov integration values and normalizes supported AskGov URLs to agency IDs before persistence.
- Adds shared schema patterns and an AskGov ID extraction utility.
- Normalizes AskGov configuration through both site-update mutations.
- Resets the integrations form from the normalized mutation response.
- Adds schema, utility, and router coverage for accepted, rejected, and normalized inputs.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/components/src/utils/validation.ts | Defines matching case-insensitive patterns for bare AskGov IDs and supported AskGov URLs. |
| packages/components/src/utils/getAskgovIdFromString.ts | Trims valid input and extracts the first AskGov URL path segment as the agency ID. |
| packages/components/src/interfaces/internal/Askgov.ts | Applies the shared AskGov validation pattern and field-specific error message. |
| apps/studio/src/server/modules/site/site.service.ts | Normalizes AskGov configuration and rejects values that cannot produce an agency ID. |
| apps/studio/src/server/modules/site/site.router.ts | Applies normalization before persisting configuration through both affected update procedures. |
| apps/studio/src/pages/sites/[siteId]/settings/integrations.tsx | Resets integration form state from the normalized server response after a successful save. |
| packages/components/CLAUDE.md | Corrects the documented test convention to match the package’s existing `.test.ts` usage. |

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor(components): derive AskGov vali..."](https://github.com/opengovsg/isomer/commit/09060109e3b20ee510a875b2abcebb132c46c7a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54225309)</sub>

<!-- /greptile_comment -->